### PR TITLE
Release train: add `release finish` promote + close-out scripts

### DIFF
--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -268,6 +268,21 @@ git push   # or open a PR if main is protected / the fix needs review on main
 
 When the hard gates pass for a specific RC, promote **that** RC. Do not re-cut from `main`.
 
+**Scripted path (recommended).** `script/release-finish promote X.Y.Z` orchestrates this whole step:
+it runs `git fetch`, asserts you are on `release/X.Y.Z` with a clean tree, verifies the tip equals the
+accepted RC tag (`git diff --stat vX.Y.Z.rc.N` is empty), prompts you to collapse the rc CHANGELOG, then
+asks for explicit confirmation before running `bundle exec rake release[X.Y.Z]`. It wraps — does not
+replace — the rake promotion guards (`stable_release_branch_allowed?`,
+`ensure_release_branch_promotes_tagged_rc!`). Preview the exact commands first with `--dry-run`:
+
+```bash
+script/release-finish promote 17.0.0 --dry-run   # prints every command, executes nothing
+script/release-finish promote 17.0.0             # runs it, with a confirmation before rake release
+```
+
+By default it resolves the highest `v17.0.0.rc.N` tag as the accepted RC; pass `--rc-tag v17.0.0.rc.3`
+to pin a specific one. The manual equivalent the script runs is below.
+
 ```bash
 git fetch origin
 git checkout release/17.0.0
@@ -312,6 +327,24 @@ be re-spun, and an explicit human sign-off on the promotion itself (see
 and publish phase `final` for the release line during the promotion freeze.
 
 ### 5. Close out the release line
+
+**Scripted path (recommended).** `script/release-finish close-out X.Y.Z` orchestrates this step: it runs
+`git fetch`, asserts you are on `main` with a clean tree, shows the real `script/release-forward-port`
+dry-run plan, then asks for explicit confirmation before applying the forward-port and, separately,
+before deleting the release branch on the remote. It shells out to the existing
+`script/release-forward-port` interface (it does not re-implement forward-porting), so the same plan,
+skips, and `MANUAL` handling described in step 3 apply. Preview everything first with `--dry-run`:
+
+```bash
+git fetch origin
+git checkout main
+git pull --rebase
+script/release-finish close-out 17.0.0 --dry-run   # prints commands + the real forward-port plan
+script/release-finish close-out 17.0.0             # applies, with confirmations before each outward op
+# Then `git push` the forward-ported commits to main (or open a PR if main is protected).
+```
+
+The manual equivalent the script wraps is below.
 
 ```bash
 # After v17.0.0 is published and the GitHub release exists:

--- a/script/release-finish
+++ b/script/release-finish
@@ -1,0 +1,448 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "open3"
+
+# Orchestrates the release-train runbook's steps 4 (promote) and 5 (close out),
+# wrapping the existing rake promotion guards (`stable_release_branch_allowed?`,
+# `ensure_release_branch_promotes_tagged_rc!`) and the existing
+# `script/release-forward-port` interface with confirmations and a dry-run mode.
+#
+# See internal/contributor-info/release-train-runbook.md steps 4-5 and
+# internal/contributor-info/release-train-automation-design.md (PR 4).
+#
+# Two subcommands, because each phase is a deliberate, separately-confirmed step
+# in the release line and must not run unattended back-to-back:
+#
+#   promote    Step 4: promote the accepted RC at the release-branch tip to the
+#              final tag, in place (no re-cut from main). Verifies the tip equals
+#              the accepted RC tag, collapses the rc->stable CHANGELOG, then runs
+#              `bundle exec rake release[X.Y.Z]` (the rake guards enforce the
+#              dangerous tag/version safety; this script does not re-implement it).
+#   close-out  Step 5: forward-port remaining release-branch commits to main via
+#              `script/release-forward-port` (dry-run, then apply on confirmation),
+#              then delete the ephemeral release branch on origin.
+#
+# The dangerous outward operations (`rake release`, `git push --delete`) are each
+# gated behind an explicit confirmation and are printed-only under --dry-run.
+# rubocop:disable Metrics/ClassLength
+class ReleaseFinish
+  STABLE_VERSION = /\A\d+\.\d+\.\d+\z/
+  SUBCOMMANDS = %w[promote close-out].freeze
+  # Resolve the sibling forward-port helper relative to this script so close-out
+  # works regardless of the current directory (the runbook runs from repo root,
+  # but the throwaway-repo tests run from a temp checkout).
+  FORWARD_PORT_SCRIPT = File.expand_path("release-forward-port", __dir__)
+
+  class UsageError < StandardError; end
+  class GitError < StandardError; end
+  class AbortError < StandardError; end
+
+  def initialize(argv)
+    @argv = argv.dup
+    @options = {
+      dry_run: false,
+      assume_yes: false,
+      version: nil,
+      rc_tag: nil,
+      remote: "origin"
+    }
+    @parser = build_parser
+  end
+
+  def run
+    subcommand = parse_options!
+
+    case subcommand
+    when "promote" then promote
+    when "close-out" then close_out
+    else
+      raise UsageError, "unknown subcommand: #{subcommand.inspect}"
+    end
+  rescue OptionParser::ParseError, UsageError => e
+    warn "ERROR: #{e.message}"
+    warn @parser
+    2
+  rescue AbortError => e
+    warn "Aborted: #{e.message}"
+    1
+  rescue GitError => e
+    warn "ERROR: #{e.message}"
+    1
+  end
+
+  private
+
+  # ---------------------------------------------------------------------------
+  # Option parsing
+  # ---------------------------------------------------------------------------
+
+  def parse_options!
+    argv = @argv.dup
+    subcommand = argv.shift
+    if subcommand.nil? || %w[-h --help].include?(subcommand)
+      puts @parser
+      exit 0
+    end
+    raise UsageError, "unknown subcommand: #{subcommand.inspect}" unless SUBCOMMANDS.include?(subcommand)
+
+    @parser.parse!(argv)
+
+    @options[:version] ||= argv.shift
+    raise UsageError, "too many arguments: #{argv.join(' ')}" unless argv.empty?
+
+    validate_version!
+    subcommand
+  end
+
+  def validate_version!
+    version = @options[:version]
+    raise UsageError, "version X.Y.Z is required (e.g. release-finish promote 17.0.0)" if version.nil? || version.empty?
+    return if version.match?(STABLE_VERSION)
+
+    raise UsageError, "version must be a stable X.Y.Z (got #{version.inspect}); pass the final target, not an rc"
+  end
+
+  def build_parser
+    OptionParser.new do |parser|
+      parser.banner = usage_banner
+
+      parser.on("--version VERSION", "Final target version X.Y.Z (also positional)") do |version|
+        @options[:version] = version
+      end
+      parser.on("--rc-tag TAG", "Accepted RC tag to verify the tip against (default: highest vX.Y.Z.rc.N)") do |tag|
+        @options[:rc_tag] = tag
+      end
+      parser.on("--remote NAME", "Remote for fetch and branch deletion (default: origin)") do |remote|
+        @options[:remote] = remote
+      end
+      parser.on("--dry-run", "Print the exact commands without executing any of them") do
+        @options[:dry_run] = true
+      end
+      parser.on("--yes", "Skip interactive confirmations (still honors --dry-run)") do
+        @options[:assume_yes] = true
+      end
+      parser.on("-h", "--help", "Show this help") do
+        puts parser
+        exit 0
+      end
+    end
+  end
+
+  def usage_banner
+    <<~BANNER
+      Usage: script/release-finish promote   X.Y.Z [--rc-tag vX.Y.Z.rc.N] [--dry-run] [--yes]
+             script/release-finish close-out X.Y.Z [--remote origin] [--dry-run] [--yes]
+
+      Orchestrates the release-train runbook steps 4 (promote) and 5 (close out).
+
+        promote    Verify the release/X.Y.Z tip equals the accepted RC tag, collapse the
+                   rc->stable CHANGELOG, then run `bundle exec rake release[X.Y.Z]`.
+        close-out  Forward-port remaining commits to main via #{FORWARD_PORT_SCRIPT},
+                   then delete release/X.Y.Z on the remote.
+
+      The rake promotion guards enforce the dangerous tag/version safety; this script
+      adds dry-run, confirmations, and on/at-release/clean-tree guards around them.
+    BANNER
+  end
+
+  # ---------------------------------------------------------------------------
+  # promote (step 4)
+  # ---------------------------------------------------------------------------
+
+  def promote
+    version = @options.fetch(:version)
+    release_branch = "release/#{version}"
+
+    section "Promote #{version} (runbook step 4)"
+    run_or_print("git", "fetch", @options.fetch(:remote))
+    ensure_on_release_branch!(release_branch)
+    ensure_clean_worktree!
+
+    rc_tag = resolve_rc_tag!(version)
+    ensure_tip_matches_rc_tag!(rc_tag)
+
+    collapse_changelog_to_stable
+    run_release_task!(version, release_branch, rc_tag)
+
+    finish_dry_run_notice
+    0
+  end
+
+  def resolve_rc_tag!(version)
+    explicit = @options[:rc_tag]
+    if explicit
+      ensure_tag_exists!(explicit)
+      return explicit
+    end
+
+    tag = highest_rc_tag(version)
+    raise AbortError, "no vX.Y.Z.rc.N tag found for #{version}; pass --rc-tag explicitly" if tag.nil?
+
+    puts "Resolved accepted RC tag: #{tag} (highest rc tag for #{version})."
+    tag
+  end
+
+  def highest_rc_tag(version)
+    tags = git_lines("tag", "--list", "v#{version}.rc.*")
+    tags
+      .map { |tag| [rc_index(tag), tag] }
+      .reject { |index, _tag| index.nil? }
+      .max_by { |index, _tag| index }
+      &.last
+  end
+
+  def rc_index(tag)
+    match = tag.match(/\.rc\.(\d+)\z/)
+    match && match[1].to_i
+  end
+
+  def ensure_tip_matches_rc_tag!(rc_tag)
+    # The runbook check: `git diff --stat <rc_tag>` against the working tree must
+    # be empty (no drift since the accepted RC). HEAD is already the branch tip.
+    diff = git("diff", "--stat", rc_tag).strip
+    return if diff.empty?
+
+    raise AbortError, <<~ERROR.strip
+      release tip has drifted from the accepted RC tag #{rc_tag}.
+      `git diff --stat #{rc_tag}` is not empty:
+
+      #{diff}
+
+      The final must be the accepted RC promoted in place (no re-cut). Reset the
+      branch to the RC tip or cut a new RC and re-validate before promoting.
+    ERROR
+  end
+
+  def collapse_changelog_to_stable
+    section "Collapse rc CHANGELOG sections into the final ### [#{@options.fetch(:version)}] section"
+    if @options[:dry_run]
+      puts "DRY RUN: would collapse the rc CHANGELOG sections into ### [#{@options.fetch(:version)}]:"
+      puts indent("/update-changelog release   # or: bundle exec rake \"update_changelog[release]\"")
+      return
+    end
+
+    puts "Run the changelog collapse now, before the release task tags the final:"
+    puts indent("/update-changelog release")
+    puts indent("(equivalently: bundle exec rake \"update_changelog[release]\")")
+    puts
+    return if confirm?("Has the rc->stable CHANGELOG collapse been applied and committed?")
+
+    raise AbortError, "collapse the rc CHANGELOG into the final section, commit it, then re-run promote"
+  end
+
+  def run_release_task!(version, release_branch, rc_tag)
+    section "Promote: bundle exec rake release[#{version}]"
+    puts "This tags v#{version} and publishes. The rake guards (stable_release_branch_allowed?,"
+    puts "ensure_release_branch_promotes_tagged_rc!) validate the #{release_branch} tip against #{rc_tag}."
+
+    confirm_outward!(
+      "Run `bundle exec rake \"release[#{version}]\"` now (tags v#{version} and publishes)?",
+      "bundle exec rake \"release[#{version}]\""
+    )
+    run_or_print("bundle", "exec", "rake", "release[#{version}]")
+  end
+
+  # ---------------------------------------------------------------------------
+  # close-out (step 5)
+  # ---------------------------------------------------------------------------
+
+  def close_out
+    version = @options.fetch(:version)
+    release_branch = "release/#{version}"
+    source = "#{@options.fetch(:remote)}/#{release_branch}"
+
+    section "Close out #{version} (runbook step 5)"
+    run_or_print("git", "fetch", @options.fetch(:remote))
+    ensure_on_main!
+    ensure_clean_worktree!
+
+    forward_port_to_main!(source)
+    delete_release_branch!(release_branch)
+
+    finish_dry_run_notice
+    0
+  end
+
+  def forward_port_to_main!(source)
+    section "Forward-port remaining #{source} commits to main"
+    # Always show the REAL plan: release-forward-port --dry-run is read-only (no
+    # checkout, no cherry-pick), so running it even under our own --dry-run gives
+    # the operator the actual forward-port preview rather than a bare command.
+    puts "Dry-run plan first (delegates to #{FORWARD_PORT_SCRIPT}; it skips rc bumps and already-ported fixes):"
+    unless system(FORWARD_PORT_SCRIPT, "--source", source, "--target", "main", "--dry-run")
+      raise GitError, "#{FORWARD_PORT_SCRIPT} --dry-run failed; cannot preview the forward-port plan"
+    end
+
+    if @options[:dry_run]
+      puts
+      puts "DRY RUN: the plan above is read-only; the apply step (forward-port without --dry-run) was skipped."
+      return
+    end
+
+    unless confirm?("Apply the forward-port plan above onto main?")
+      raise AbortError, "review the plan and re-run close-out when ready to forward-port"
+    end
+
+    forwarded = system(FORWARD_PORT_SCRIPT, "--source", source, "--target", "main")
+    return if forwarded
+
+    raise AbortError,
+          "#{FORWARD_PORT_SCRIPT} did not complete (conflict or MANUAL item). Resolve per the runbook, " \
+          "then re-run close-out; the helper is idempotent and the branch deletion below was not run."
+  end
+
+  def delete_release_branch!(release_branch)
+    remote = @options.fetch(:remote)
+    section "Delete the ephemeral branch #{release_branch} on #{remote} (tags are the durable record)"
+
+    confirm_outward!(
+      "Delete #{release_branch} on #{remote} now? Tags persist; this only removes the branch.",
+      "git push #{remote} --delete #{release_branch}"
+    )
+    run_or_print("git", "push", remote, "--delete", release_branch)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shared guards
+  # ---------------------------------------------------------------------------
+
+  def ensure_on_release_branch!(release_branch)
+    branch = current_branch
+    return if branch == release_branch
+
+    raise AbortError, <<~ERROR.strip
+      not on #{release_branch} (current branch: #{branch.empty? ? 'detached HEAD' : branch}).
+      Promote runs from the release branch itself:
+        git checkout #{release_branch}
+    ERROR
+  end
+
+  def ensure_on_main!
+    branch = current_branch
+    return if branch == "main"
+
+    raise AbortError, <<~ERROR.strip
+      not on main (current branch: #{branch.empty? ? 'detached HEAD' : branch}).
+      Close-out forward-ports onto main:
+        git checkout main && git pull --rebase
+    ERROR
+  end
+
+  def ensure_clean_worktree!
+    return if git("status", "--porcelain").strip.empty?
+
+    raise AbortError, "working tree is not clean; commit, stash, or discard local changes before continuing"
+  end
+
+  def ensure_tag_exists!(tag)
+    return if tag_exists?(tag)
+
+    raise AbortError, "RC tag #{tag} does not exist locally; fetch tags or pass an existing --rc-tag"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Confirmation + execution helpers
+  # ---------------------------------------------------------------------------
+
+  # Confirm before an outward/destructive op, then let the caller's run_or_print
+  # do the single canonical print/exec. Under --dry-run there is nothing to
+  # confirm (run_or_print prints the command). With --yes, skip the prompt.
+  # Otherwise require an interactive y/N, aborting on "no" or when no TTY is
+  # available, so the script never runs an outward op unattended.
+  def confirm_outward!(question, command)
+    return if @options[:dry_run]
+    return if confirm?(question)
+
+    raise AbortError, "declined: #{command}"
+  end
+
+  def confirm?(question)
+    return true if @options[:assume_yes]
+
+    unless $stdin.tty?
+      raise AbortError, "#{question} (no TTY for confirmation; re-run with --yes to proceed or --dry-run to preview)"
+    end
+
+    $stdout.print("#{question} [y/N] ")
+    $stdout.flush
+    answer = $stdin.gets
+    return false if answer.nil?
+
+    answer.strip.casecmp?("y") || answer.strip.casecmp?("yes")
+  end
+
+  # Run a command, or print it under --dry-run. Read-only setup (git fetch, the
+  # forward-port dry-run) flows through here so dry-run prints the full recipe.
+  def run_or_print(*command)
+    if @options[:dry_run]
+      puts "DRY RUN: would run: #{command.join(' ')}"
+      return
+    end
+
+    puts "+ #{command.join(' ')}"
+    return if system(*command)
+
+    raise GitError, "command failed: #{command.join(' ')}"
+  end
+
+  def finish_dry_run_notice
+    return unless @options[:dry_run]
+
+    puts
+    puts "DRY RUN: nothing was executed; no tags, pushes, releases, or branch deletions occurred."
+  end
+
+  # ---------------------------------------------------------------------------
+  # Output helpers
+  # ---------------------------------------------------------------------------
+
+  def section(title)
+    puts
+    puts "== #{title} =="
+  end
+
+  def indent(text)
+    text.lines.map { |line| "    #{line}" }.join
+  end
+
+  # ---------------------------------------------------------------------------
+  # Git helpers (mirroring script/release-forward-port's non-prompting wrappers)
+  # ---------------------------------------------------------------------------
+
+  def current_branch
+    git("rev-parse", "--abbrev-ref", "HEAD").strip
+  end
+
+  def tag_exists?(tag)
+    _stdout, _stderr, status = capture_git("rev-parse", "--verify", "--quiet", "refs/tags/#{tag}")
+    status.success?
+  end
+
+  def git_lines(*)
+    git(*).lines.map(&:strip).reject(&:empty?)
+  end
+
+  def git(*args)
+    stdout, stderr, status = capture_git(*args)
+    raise GitError, git_error(args, stdout, stderr, status) unless status.success?
+
+    stdout
+  end
+
+  def capture_git(*)
+    git_env = { "GIT_TERMINAL_PROMPT" => "0", "GIT_PAGER" => "cat" }
+    Open3.capture3(git_env, "git", *)
+  end
+
+  def git_error(args, stdout, stderr, status)
+    message = ["git #{args.join(' ')} failed with status #{status.exitstatus}"]
+    message << stderr.strip unless stderr.strip.empty?
+    message << stdout.strip unless stdout.strip.empty?
+    message.join(": ")
+  end
+end
+# rubocop:enable Metrics/ClassLength
+
+exit ReleaseFinish.new(ARGV).run if $PROGRAM_NAME == __FILE__

--- a/script/release-finish
+++ b/script/release-finish
@@ -54,11 +54,10 @@ class ReleaseFinish
   def run
     subcommand = parse_options!
 
+    # parse_options! has already validated subcommand is one of SUBCOMMANDS.
     case subcommand
     when "promote" then promote
     when "close-out" then close_out
-    else
-      raise UsageError, "unknown subcommand: #{subcommand.inspect}"
     end
   rescue OptionParser::ParseError, UsageError => e
     warn "ERROR: #{e.message}"
@@ -199,8 +198,23 @@ class ReleaseFinish
   end
 
   def ensure_tip_matches_rc_tag!(rc_tag)
-    # The runbook check: `git diff --stat <rc_tag>` against the working tree must
-    # be empty (no drift since the accepted RC). HEAD is already the branch tip.
+    # Two checks, because `git diff --stat` compares TREES: an empty or
+    # metadata-only commit layered on top of the accepted RC has the same tree
+    # and would pass the diff alone. First require HEAD to be the exact tagged
+    # commit (identity), then keep the tree check as defense in depth.
+    head_sha = git("rev-parse", "--verify", "HEAD").strip
+    tag_sha = peeled_tag_sha(rc_tag)
+    unless head_sha == tag_sha
+      raise AbortError, <<~ERROR.strip
+        release tip is not the accepted RC commit #{rc_tag}.
+          HEAD:   #{head_sha}
+          #{rc_tag}: #{tag_sha}
+        Even an empty or metadata-only commit on top of the RC breaks the
+        "promote in place, no re-cut" invariant. Reset the branch to the RC tip
+        (git reset --hard #{rc_tag}) or cut and validate a new RC before promoting.
+      ERROR
+    end
+
     diff = git("diff", "--stat", rc_tag).strip
     return if diff.empty?
 
@@ -251,15 +265,17 @@ class ReleaseFinish
   def close_out
     version = @options.fetch(:version)
     release_branch = "release/#{version}"
-    source = "#{@options.fetch(:remote)}/#{release_branch}"
+    remote = @options.fetch(:remote)
+    source = "#{remote}/#{release_branch}"
 
     section "Close out #{version} (runbook step 5)"
-    run_or_print("git", "fetch", @options.fetch(:remote))
+    run_or_print("git", "fetch", remote)
     ensure_on_main!
+    ensure_local_main_matches_remote!(remote)
     ensure_clean_worktree!
 
     forward_port_to_main!(source)
-    delete_release_branch!(release_branch)
+    delete_release_branch!(release_branch, remote)
 
     finish_dry_run_notice
     0
@@ -293,9 +309,21 @@ class ReleaseFinish
           "then re-run close-out; the helper is idempotent and the branch deletion below was not run."
   end
 
-  def delete_release_branch!(release_branch)
-    remote = @options.fetch(:remote)
+  def delete_release_branch!(release_branch, remote)
     section "Delete the ephemeral branch #{release_branch} on #{remote} (tags are the durable record)"
+
+    if @options[:dry_run]
+      puts "DRY RUN: would verify the forward-ported commits are on #{remote}/main, then run:"
+      run_or_print("git", "push", remote, "--delete", release_branch)
+      return
+    end
+
+    # SAFETY: never delete the source branch while its forward-ported commits
+    # exist only on LOCAL main. close-out applies the cherry-picks locally but
+    # deliberately does not push main (main may be protected), so the operator
+    # must push first. Re-fetch and verify local main is now on origin/main
+    # before allowing the delete.
+    ensure_forward_port_durable_on_remote!(remote)
 
     confirm_outward!(
       "Delete #{release_branch} on #{remote} now? Tags persist; this only removes the branch.",
@@ -330,6 +358,48 @@ class ReleaseFinish
     ERROR
   end
 
+  # Require local main to equal the freshly-fetched remote main before
+  # forward-porting, so the cherry-picks never land on a stale or diverged main.
+  def ensure_local_main_matches_remote!(remote)
+    local = git("rev-parse", "main").strip
+    remote_main = "#{remote}/main"
+    upstream = git("rev-parse", remote_main).strip
+    return if local == upstream
+
+    raise AbortError, <<~ERROR.strip
+      local main is not in sync with #{remote_main}
+        local:  #{local}
+        remote: #{upstream}
+      Sync before forward-porting so the cherry-picks land on current main:
+        git checkout main && git pull --rebase
+    ERROR
+  end
+
+  # SAFETY GATE for the branch delete: the forward-port applies cherry-picks to
+  # LOCAL main but close-out never pushes main itself (main may be protected), so
+  # the operator must push (or merge the forward-port PR) first. Re-fetch and
+  # require local main — which carries those cherry-picks — to be reachable from
+  # the remote main. If the operator has not pushed, local main holds commits
+  # absent from #{remote}/main and this aborts, making it impossible to delete
+  # the source branch while its unique forward-ported commits exist only locally.
+  # (Cherry-picks get new SHAs, so this checks the pushed local-main tip, not the
+  # original release-branch commit identities, which are never ancestors of main
+  # under the trunk-based -x model.)
+  def ensure_forward_port_durable_on_remote!(remote)
+    run_or_print("git", "fetch", remote)
+    remote_main = "#{remote}/main"
+    local_main = git("rev-parse", "main").strip
+    return if commit_reachable_from?(local_main, remote_main)
+
+    raise AbortError, <<~ERROR.strip
+      the forward-ported commits on local main are not yet on #{remote_main}.
+      Push main before deleting the source branch — its unique commits would
+      otherwise be lost (tags do not preserve the forward-port onto main):
+        git push   # or merge the forward-port PR into main
+      Then re-run: script/release-finish close-out #{@options.fetch(:version)}
+    ERROR
+  end
+
   def ensure_clean_worktree!
     return if git("status", "--porcelain").strip.empty?
 
@@ -353,9 +423,8 @@ class ReleaseFinish
   # available, so the script never runs an outward op unattended.
   def confirm_outward!(question, command)
     return if @options[:dry_run]
-    return if confirm?(question)
 
-    raise AbortError, "declined: #{command}"
+    raise AbortError, "declined: #{command}" unless confirm?(question)
   end
 
   def confirm?(question)
@@ -417,6 +486,17 @@ class ReleaseFinish
 
   def tag_exists?(tag)
     _stdout, _stderr, status = capture_git("rev-parse", "--verify", "--quiet", "refs/tags/#{tag}")
+    status.success?
+  end
+
+  # The commit a tag points at, dereferencing annotated tags (^{}) so the value
+  # is a commit SHA comparable to a branch HEAD.
+  def peeled_tag_sha(tag)
+    git("rev-parse", "--verify", "#{tag}^{commit}").strip
+  end
+
+  def commit_reachable_from?(commit, ref)
+    _stdout, _stderr, status = capture_git("merge-base", "--is-ancestor", commit, ref)
     status.success?
   end
 

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# Test harness for script/release-finish. Requires bash and git. Run with
+# `bash script/release-finish-test.bash`.
+#
+# Every case runs against a throwaway `mktemp -d` git repo and exercises only the
+# dry-run output and the guard/abort paths. NOTHING here runs a real release,
+# branch deletion, or push: promote stops at the rake-release confirmation under
+# dry-run, and close-out only invokes the forward-port DRY-RUN plan plus printed
+# branch-deletion. The harness never adds a network remote.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_FINISH="$SCRIPT_DIR/release-finish"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+FAILURES=()
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$CURRENT_TEST: $message")
+  if [ -n "${SUBSHELL_FAILURES_FILE:-}" ]; then
+    printf '%s\n' "$CURRENT_TEST: $message" >> "$SUBSHELL_FAILURES_FILE"
+  fi
+  echo "  FAIL: $message" >&2
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      fail "$label: expected to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*)
+      fail "$label: expected NOT to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+    *) ;;
+  esac
+}
+
+assert_status() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-status}"
+  if [ "$expected" != "$actual" ]; then
+    fail "$label: expected exit $expected, got $actual"
+    return 1
+  fi
+}
+
+run_test() {
+  local test_fn="$1"
+  CURRENT_TEST="$test_fn"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $test_fn"
+
+  local tmpdir before_failed had_errexit=false subshell_failures
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/release-finish-test.XXXXXX")"
+  subshell_failures="$tmpdir/failures.log"
+  : > "$subshell_failures"
+  before_failed="$TESTS_FAILED"
+
+  case "$-" in
+    *e*) had_errexit=true ;;
+  esac
+
+  set +e
+  (
+    set -uo pipefail
+    SUBSHELL_FAILURES_FILE="$subshell_failures"
+    export SUBSHELL_FAILURES_FILE
+    cd "$tmpdir" || exit 1
+    "$test_fn"
+  )
+  local rc=$?
+  if [ "$had_errexit" = true ]; then
+    set -e
+  fi
+
+  if [ -s "$subshell_failures" ]; then
+    while IFS= read -r failure_line; do
+      [ -n "$failure_line" ] || continue
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      FAILURES+=("$failure_line")
+    done < "$subshell_failures"
+  fi
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
+    echo "  FAIL: subshell exited $rc" >&2
+  fi
+}
+
+# Build a throwaway repo that looks like a release line: main with a version
+# file, a release/X.Y.Z branch carrying a fix and a vX.Y.Z.rc.N tag, and a local
+# "origin" remote that is a SEPARATE throwaway clone in the same tmp tree, so
+# `git fetch origin` and the forward-port `origin/release/X.Y.Z` ref resolve with
+# no network. The remote is a local bare repo: a real `git push` would only ever
+# touch that throwaway, never a network remote — and these tests never reach an
+# unguarded push anyway.
+setup_release_repo() {
+  local origin_dir="$PWD/origin.git"
+  git init -q --bare "$origin_dir"
+
+  git init -q -b main work
+  cd work || exit 1
+  git config user.email test@example.com
+  git config user.name "Release Finish Test"
+  git remote add origin "$origin_dir"
+
+  mkdir -p react_on_rails/lib/react_on_rails
+  printf 'module ReactOnRails\n  VERSION = "1.0.0"\nend\n' > react_on_rails/lib/react_on_rails/version.rb
+  printf 'core\n' > app.txt
+  printf '## [Unreleased]\n\n## [1.0.0.rc.0]\n- Fix something\n' > CHANGELOG.md
+  git add .
+  git commit -qm "beta work"
+  git push -q origin main
+
+  git checkout -q -b release/1.0.0
+  printf 'fix\n' > fix.txt
+  git add .
+  git commit -qm "Fix SSR regression"
+  git tag v1.0.0.rc.0
+  git push -q origin release/1.0.0
+
+  # Refresh remote-tracking refs (origin/main, origin/release/1.0.0) so the
+  # forward-port dry-run resolves the source even when our own --dry-run prints
+  # the `git fetch` instead of running it.
+  git fetch -q origin
+  # Leave the operator checked out on the release branch (promote's starting point).
+}
+
+# Run release-finish with stdin closed (no TTY), capturing combined output.
+# Returns the exit status in RF_STATUS and output in RF_OUT.
+run_rf() {
+  RF_OUT="$(ruby "$RELEASE_FINISH" "$@" </dev/null 2>&1)"
+  RF_STATUS=$?
+}
+
+# --- promote: happy-path dry-run -------------------------------------------
+
+test_promote_dry_run_prints_commands_and_runs_nothing() {
+  setup_release_repo
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 0 "$RF_STATUS" "promote dry-run status"
+  assert_contains "$RF_OUT" "Promote 1.0.0 (runbook step 4)" "promote dry-run"
+  assert_contains "$RF_OUT" "Resolved accepted RC tag: v1.0.0.rc.0" "promote dry-run"
+  assert_contains "$RF_OUT" 'DRY RUN: would run: bundle exec rake release[1.0.0]' "promote dry-run"
+  assert_contains "$RF_OUT" "update-changelog release" "promote dry-run"
+  assert_contains "$RF_OUT" "nothing was executed" "promote dry-run"
+}
+
+# The dry-run must never tag, publish, or otherwise mutate the repo.
+test_promote_dry_run_does_not_execute_release() {
+  setup_release_repo
+  local head_before
+  head_before="$(git rev-parse HEAD)"
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 0 "$RF_STATUS" "promote dry-run no-op status"
+  # Dry-run prints the fetch rather than running it (no real outward git ops).
+  assert_contains "$RF_OUT" "DRY RUN: would run: git fetch origin" "promote dry-run should not really fetch"
+  # No new v1.0.0 (final) tag, and HEAD unchanged.
+  if git rev-parse -q --verify refs/tags/v1.0.0 >/dev/null 2>&1; then
+    fail "promote dry-run created the final tag v1.0.0"
+  fi
+  assert_status "$head_before" "$(git rev-parse HEAD)" "promote dry-run HEAD unchanged"
+}
+
+# --- promote: explicit rc tag ----------------------------------------------
+
+test_promote_accepts_explicit_rc_tag() {
+  setup_release_repo
+  run_rf promote 1.0.0 --rc-tag v1.0.0.rc.0 --dry-run
+
+  assert_status 0 "$RF_STATUS" "promote explicit rc-tag status"
+  assert_contains "$RF_OUT" 'DRY RUN: would run: bundle exec rake release[1.0.0]' "promote explicit rc-tag"
+}
+
+# --- promote: guard — wrong branch -----------------------------------------
+
+test_promote_aborts_when_not_on_release_branch() {
+  setup_release_repo
+  git checkout -q main
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 1 "$RF_STATUS" "promote wrong-branch status"
+  assert_contains "$RF_OUT" "not on release/1.0.0" "promote wrong-branch"
+  assert_not_contains "$RF_OUT" "rake release[1.0.0]" "promote wrong-branch should stop before release"
+}
+
+# --- promote: guard — drifted tip ------------------------------------------
+
+test_promote_aborts_when_tip_drifted_from_rc_tag() {
+  setup_release_repo
+  # Add a commit after the rc tag so the tip no longer matches v1.0.0.rc.0.
+  printf 'drift\n' > drift.txt
+  git add .
+  git commit -qm "post-rc drift"
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 1 "$RF_STATUS" "promote drift status"
+  assert_contains "$RF_OUT" "has drifted from the accepted RC tag v1.0.0.rc.0" "promote drift"
+  assert_not_contains "$RF_OUT" "would run: bundle exec rake release" "promote drift should stop before release"
+}
+
+# --- promote: guard — dirty tree -------------------------------------------
+
+test_promote_aborts_on_dirty_worktree() {
+  setup_release_repo
+  printf 'dirty\n' >> fix.txt
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 1 "$RF_STATUS" "promote dirty status"
+  assert_contains "$RF_OUT" "working tree is not clean" "promote dirty"
+}
+
+# --- promote: guard — missing rc tag ---------------------------------------
+
+test_promote_aborts_when_no_rc_tag_found() {
+  setup_release_repo
+  git tag -d v1.0.0.rc.0 >/dev/null
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 1 "$RF_STATUS" "promote missing-tag status"
+  assert_contains "$RF_OUT" "no vX.Y.Z.rc.N tag found for 1.0.0" "promote missing-tag"
+}
+
+test_promote_aborts_when_explicit_rc_tag_absent() {
+  setup_release_repo
+  run_rf promote 1.0.0 --rc-tag v1.0.0.rc.9 --dry-run
+
+  assert_status 1 "$RF_STATUS" "promote bad explicit tag status"
+  assert_contains "$RF_OUT" "v1.0.0.rc.9 does not exist" "promote bad explicit tag"
+}
+
+# Highest rc index wins when several rc tags exist.
+test_promote_selects_highest_rc_tag() {
+  setup_release_repo
+  git tag v1.0.0.rc.1
+  git tag v1.0.0.rc.2
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 0 "$RF_STATUS" "promote highest-rc status"
+  assert_contains "$RF_OUT" "Resolved accepted RC tag: v1.0.0.rc.2" "promote highest-rc"
+}
+
+# --- promote: confirmation safety (no --yes, no TTY) ------------------------
+
+# Without --dry-run and without a TTY, an outward op (the rake release) must NOT
+# run: confirm? aborts because there is no TTY and --yes was not given. This is
+# the guard that keeps `rake release` from ever firing unattended.
+test_promote_without_tty_and_without_yes_aborts_before_release() {
+  setup_release_repo
+  run_rf promote 1.0.0
+
+  assert_status 1 "$RF_STATUS" "promote no-tty status"
+  assert_contains "$RF_OUT" "no TTY for confirmation" "promote no-tty"
+  # Real promotion never happened: no final tag.
+  if git rev-parse -q --verify refs/tags/v1.0.0 >/dev/null 2>&1; then
+    fail "promote without TTY created the final tag v1.0.0"
+  fi
+}
+
+# --- close-out: happy-path dry-run -----------------------------------------
+
+test_close_out_dry_run_prints_plan_and_runs_nothing() {
+  setup_release_repo
+  git checkout -q main
+  run_rf close-out 1.0.0 --dry-run
+
+  assert_status 0 "$RF_STATUS" "close-out dry-run status"
+  assert_contains "$RF_OUT" "Close out 1.0.0 (runbook step 5)" "close-out dry-run"
+  # The real forward-port DRY-RUN plan is shown (it resolves origin/release/1.0.0).
+  assert_contains "$RF_OUT" "Release forward-port plan" "close-out dry-run"
+  assert_contains "$RF_OUT" "PICK" "close-out dry-run picks the fix"
+  assert_contains "$RF_OUT" 'DRY RUN: would run: git push origin --delete release/1.0.0' "close-out dry-run"
+  assert_contains "$RF_OUT" "nothing was executed" "close-out dry-run"
+}
+
+# The forward-port plan must exclude rc version-bump style commits; here it only
+# picks the real fix, never the branch deletion is executed.
+test_close_out_dry_run_does_not_delete_branch() {
+  setup_release_repo
+  git checkout -q main
+  run_rf close-out 1.0.0 --dry-run
+
+  assert_status 0 "$RF_STATUS" "close-out no-delete status"
+  # origin ref for the release branch is still present after a dry-run.
+  if ! git rev-parse -q --verify refs/remotes/origin/release/1.0.0 >/dev/null 2>&1; then
+    fail "close-out dry-run removed the origin release ref"
+  fi
+}
+
+# --- close-out: guard — not on main ----------------------------------------
+
+test_close_out_aborts_when_not_on_main() {
+  setup_release_repo
+  # Still on release/1.0.0 from setup.
+  run_rf close-out 1.0.0 --dry-run
+
+  assert_status 1 "$RF_STATUS" "close-out wrong-branch status"
+  assert_contains "$RF_OUT" "not on main" "close-out wrong-branch"
+}
+
+# --- close-out: guard — dirty tree -----------------------------------------
+
+test_close_out_aborts_on_dirty_worktree() {
+  setup_release_repo
+  git checkout -q main
+  printf 'dirty\n' >> app.txt
+  run_rf close-out 1.0.0 --dry-run
+
+  assert_status 1 "$RF_STATUS" "close-out dirty status"
+  assert_contains "$RF_OUT" "working tree is not clean" "close-out dirty"
+}
+
+# --- shared: argument validation -------------------------------------------
+
+test_rejects_rc_version_argument() {
+  setup_release_repo
+  run_rf promote 1.0.0.rc.1 --dry-run
+
+  assert_status 2 "$RF_STATUS" "rc-version-arg status"
+  assert_contains "$RF_OUT" "version must be a stable X.Y.Z" "rc-version-arg"
+}
+
+test_rejects_missing_version() {
+  setup_release_repo
+  run_rf promote --dry-run
+
+  assert_status 2 "$RF_STATUS" "missing-version status"
+  assert_contains "$RF_OUT" "version X.Y.Z is required" "missing-version"
+}
+
+test_rejects_unknown_subcommand() {
+  setup_release_repo
+  run_rf ship 1.0.0
+
+  assert_status 2 "$RF_STATUS" "unknown-subcommand status"
+  assert_contains "$RF_OUT" "unknown subcommand" "unknown-subcommand"
+}
+
+test_help_exits_zero() {
+  setup_release_repo
+  run_rf --help
+
+  assert_status 0 "$RF_STATUS" "help status"
+  assert_contains "$RF_OUT" "Orchestrates the release-train runbook steps 4" "help"
+}
+
+run_test test_promote_dry_run_prints_commands_and_runs_nothing
+run_test test_promote_dry_run_does_not_execute_release
+run_test test_promote_accepts_explicit_rc_tag
+run_test test_promote_aborts_when_not_on_release_branch
+run_test test_promote_aborts_when_tip_drifted_from_rc_tag
+run_test test_promote_aborts_on_dirty_worktree
+run_test test_promote_aborts_when_no_rc_tag_found
+run_test test_promote_aborts_when_explicit_rc_tag_absent
+run_test test_promote_selects_highest_rc_tag
+run_test test_promote_without_tty_and_without_yes_aborts_before_release
+run_test test_close_out_dry_run_prints_plan_and_runs_nothing
+run_test test_close_out_dry_run_does_not_delete_branch
+run_test test_close_out_aborts_when_not_on_main
+run_test test_close_out_aborts_on_dirty_worktree
+run_test test_rejects_rc_version_argument
+run_test test_rejects_missing_version
+run_test test_rejects_unknown_subcommand
+run_test test_help_exits_zero
+
+echo
+echo "release-finish tests: $TESTS_RUN run, $TESTS_FAILED failed"
+
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  printf '\nFailures:\n' >&2
+  printf '  - %s\n' "${FAILURES[@]}" >&2
+  exit 1
+fi

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Test harness for script/release-finish. Requires bash and git. Run with
+# Test harness for script/release-finish. Requires bash, git, and ruby (the
+# script under test is a Ruby program, invoked via `ruby`). Run with
 # `bash script/release-finish-test.bash`.
 #
 # Every case runs against a throwaway `mktemp -d` git repo and exercises only the

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -64,6 +64,31 @@ assert_status() {
   fi
 }
 
+# General string equality (used for SHA / ref comparisons, where assert_status's
+# "expected exit N" wording would be misleading).
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-value}"
+  if [ "$expected" != "$actual" ]; then
+    fail "$label: expected '$expected', got '$actual'"
+    return 1
+  fi
+}
+
+# Initialize a git repo on a `main` branch portably. `git init -b main` needs
+# Git >= 2.28; on older Git it silently creates `master`, which would make the
+# later `main` assertions fail confusingly. Fall back to creating the branch
+# explicitly so the harness works on any supported Git.
+git_init_main() {
+  local dir="$1"
+  if git init -q -b main "$dir" 2>/dev/null; then
+    return 0
+  fi
+  git init -q "$dir"
+  git -C "$dir" symbolic-ref HEAD refs/heads/main
+}
+
 run_test() {
   local test_fn="$1"
   CURRENT_TEST="$test_fn"
@@ -120,7 +145,7 @@ setup_release_repo() {
   local origin_dir="$PWD/origin.git"
   git init -q --bare "$origin_dir"
 
-  git init -q -b main work
+  git_init_main work
   cd work || exit 1
   git config user.email test@example.com
   git config user.name "Release Finish Test"
@@ -183,7 +208,7 @@ test_promote_dry_run_does_not_execute_release() {
   if git rev-parse -q --verify refs/tags/v1.0.0 >/dev/null 2>&1; then
     fail "promote dry-run created the final tag v1.0.0"
   fi
-  assert_status "$head_before" "$(git rev-parse HEAD)" "promote dry-run HEAD unchanged"
+  assert_equal "$head_before" "$(git rev-parse HEAD)" "promote dry-run HEAD unchanged"
 }
 
 # --- promote: explicit rc tag ----------------------------------------------
@@ -212,15 +237,33 @@ test_promote_aborts_when_not_on_release_branch() {
 
 test_promote_aborts_when_tip_drifted_from_rc_tag() {
   setup_release_repo
-  # Add a commit after the rc tag so the tip no longer matches v1.0.0.rc.0.
+  # Add a content commit after the rc tag so the tip no longer matches v1.0.0.rc.0
+  # (different commit AND different tree). The identity check fires first.
   printf 'drift\n' > drift.txt
   git add .
   git commit -qm "post-rc drift"
   run_rf promote 1.0.0 --dry-run
 
   assert_status 1 "$RF_STATUS" "promote drift status"
-  assert_contains "$RF_OUT" "has drifted from the accepted RC tag v1.0.0.rc.0" "promote drift"
+  assert_contains "$RF_OUT" "is not the accepted RC commit v1.0.0.rc.0" "promote drift"
   assert_not_contains "$RF_OUT" "would run: bundle exec rake release" "promote drift should stop before release"
+}
+
+# #3: an EMPTY (or metadata-only) commit layered on top of the RC has the SAME
+# tree, so `git diff --stat <rc_tag>` is empty and would pass the tree check
+# alone. The commit-identity check must still abort: HEAD != the rc tag's SHA.
+test_promote_aborts_on_empty_commit_atop_rc_despite_equal_tree() {
+  setup_release_repo
+  git commit -q --allow-empty -m "empty commit on top of the RC"
+  # Sanity: the tree is unchanged vs the rc tag (the gap the old check missed).
+  if [ -n "$(git diff --stat v1.0.0.rc.0)" ]; then
+    fail "fixture invalid: expected an empty tree diff vs the rc tag"
+  fi
+  run_rf promote 1.0.0 --dry-run
+
+  assert_status 1 "$RF_STATUS" "promote empty-commit status"
+  assert_contains "$RF_OUT" "is not the accepted RC commit v1.0.0.rc.0" "promote empty-commit message"
+  assert_not_contains "$RF_OUT" "would run: bundle exec rake release" "promote empty-commit stops before release"
 }
 
 # --- promote: guard — dirty tree -------------------------------------------
@@ -311,6 +354,95 @@ test_close_out_dry_run_does_not_delete_branch() {
   fi
 }
 
+# Simulate the operator having forward-ported the fix onto main AND pushed it,
+# so origin/main carries the cherry-pick. This is the precondition the durable
+# branch-delete gate requires. Leaves the checkout on a synced local main.
+push_forward_port_to_origin_main() {
+  git checkout -q main
+  git cherry-pick -x "$(git rev-parse release/1.0.0)" >/dev/null 2>&1
+  git push -q origin main
+  git fetch -q origin
+}
+
+# --- close-out: real apply (--yes, no TTY) deletes the branch ---------------
+
+# #5 coverage: the --yes non-dry-run path must proceed through confirm_outward!
+# WITHOUT a TTY (no prompt, no abort) and actually perform the outward ops. Here
+# the forward-port was already pushed to the throwaway local origin, so the
+# durability gate passes and the branch is deleted on that local bare origin
+# only (never a network remote).
+test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  # Branch exists on origin before close-out.
+  if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "precondition: release branch should exist on origin"
+  fi
+
+  run_rf close-out 1.0.0 --yes
+
+  assert_status 0 "$RF_STATUS" "close-out --yes status"
+  # The fix was already pushed to origin/main, so the forward-port helper sees it
+  # as already-ported (a no-op). What matters for #5: --yes proceeded through
+  # confirm_outward! with NO TTY (no "no TTY" abort, no prompt) and actually ran
+  # the outward delete.
+  assert_not_contains "$RF_OUT" "no TTY for confirmation" "close-out --yes should not stop on TTY"
+  assert_contains "$RF_OUT" "+ git push origin --delete release/1.0.0" "close-out --yes deleted branch"
+  # The branch is actually gone from the (local bare) origin.
+  if git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "close-out --yes did not delete the release branch on origin"
+  fi
+}
+
+# --- close-out: P1 durability gate — refuse delete if main not pushed -------
+
+# #1: a single close-out run forward-ports the fix onto LOCAL main but never
+# pushes main itself. The fix now exists only locally, so the durable-delete gate
+# MUST abort before deleting the source branch (otherwise the commit is lost).
+# Local main starts in sync with origin/main, so the stale-main guard passes and
+# control reaches the durability gate the in-run cherry-pick triggers.
+test_close_out_refuses_delete_when_forward_port_only_local() {
+  setup_release_repo
+  git checkout -q main   # local main == origin/main (synced by setup's fetch)
+
+  run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out local-only status"
+  # The forward-port DID apply locally...
+  assert_contains "$RF_OUT" "Forward-port complete" "close-out local-only applied the pick"
+  # ...but the gate refused the delete because main was not pushed.
+  assert_contains "$RF_OUT" "not yet on origin/main" "close-out local-only message"
+  assert_not_contains "$RF_OUT" "git push origin --delete" "close-out local-only must not delete"
+  # Critical: the branch still exists on origin (its unique commits are safe).
+  if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "durability gate deleted the release branch while commits were only local"
+  fi
+}
+
+# --- close-out: P1 stale-main guard ----------------------------------------
+
+# #2: local main behind origin/main must abort before forward-porting, so the
+# cherry-picks never land on a stale main.
+test_close_out_aborts_when_local_main_behind_origin() {
+  setup_release_repo
+  # Advance origin/main past local main via a second clone-less push.
+  git checkout -q main
+  local synced_main
+  synced_main="$(git rev-parse main)"
+  # Create a commit, push it to origin, then move local main back so it is stale.
+  printf 'newer\n' > newer.txt
+  git add .
+  git commit -qm "later main work"
+  git push -q origin main
+  git reset -q --hard "$synced_main"   # local main now behind origin/main
+  git fetch -q origin
+
+  run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out stale-main status"
+  assert_contains "$RF_OUT" "local main is not in sync" "close-out stale-main message"
+}
+
 # --- close-out: guard — not on main ----------------------------------------
 
 test_close_out_aborts_when_not_on_main() {
@@ -373,6 +505,7 @@ run_test test_promote_dry_run_does_not_execute_release
 run_test test_promote_accepts_explicit_rc_tag
 run_test test_promote_aborts_when_not_on_release_branch
 run_test test_promote_aborts_when_tip_drifted_from_rc_tag
+run_test test_promote_aborts_on_empty_commit_atop_rc_despite_equal_tree
 run_test test_promote_aborts_on_dirty_worktree
 run_test test_promote_aborts_when_no_rc_tag_found
 run_test test_promote_aborts_when_explicit_rc_tag_absent
@@ -380,6 +513,9 @@ run_test test_promote_selects_highest_rc_tag
 run_test test_promote_without_tty_and_without_yes_aborts_before_release
 run_test test_close_out_dry_run_prints_plan_and_runs_nothing
 run_test test_close_out_dry_run_does_not_delete_branch
+run_test test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed
+run_test test_close_out_refuses_delete_when_forward_port_only_local
+run_test test_close_out_aborts_when_local_main_behind_origin
 run_test test_close_out_aborts_when_not_on_main
 run_test test_close_out_aborts_on_dirty_worktree
 run_test test_rejects_rc_version_argument


### PR DESCRIPTION
## What & why

PR 4 of 4 in the **release-train automation** series (design spec in #4255).

Scripts the runbook's final two steps — promote the last good RC to the stable release, and close out the line — so the manual git/tag dance becomes a guarded, dry-runnable `release finish`.

## Changes

- new `script/release-finish` with two subcommands (each phase is a deliberate, separately-confirmed step):
  - `promote X.Y.Z`: assert on/at `release/X.Y.Z` + clean tree → resolve the accepted RC tag (highest `vX.Y.Z.rc.N`, or `--rc-tag`) → verify the tip equals it (`git diff --stat` empty) → prompt for the rc→stable CHANGELOG collapse → run `bundle exec rake release[X.Y.Z]` after confirmation. The dangerous tag/version logic stays in the existing rake guards (`stable_release_branch_allowed?`, `ensure_release_branch_promotes_tagged_rc!`).
  - `close-out X.Y.Z`: assert on `main` + clean tree → show the **real** `release-forward-port --dry-run` plan → apply on confirmation → `git push --delete release/X.Y.Z` on a separate confirmation.
- `script/release-finish-test.bash`: new harness (18 cases).
- `internal/contributor-info/release-train-runbook.md`: steps 4–5 reference the script (step 1 untouched — owned by #4255).

Safety: `--dry-run` prints every command and executes nothing (wins over `--yes`); outward ops (`rake release`, branch delete) each require an explicit confirmation and abort without a TTY unless `--yes`; a forward-port conflict aborts close-out **before** the branch delete. Forward-port is invoked via the existing `script/release-forward-port` interface (resolved via `__dir__`), independent of PR 3's internals.

## Validation

- `bash script/release-finish-test.bash`: `18 run, 0 failed` (throwaway `mktemp -d` repos with a local bare origin; covers both dry-runs plus wrong-branch / drifted-tip / dirty-tree / missing-rc-tag / bad-version / no-TTY abort paths — never a real release/push/delete).
- `bundle exec rubocop script/release-finish`: `no offenses detected`.
- `prettier@3.6.2 --check` (runbook): clean.

## Notes

- No changelog entry: release automation tooling (no-entry category).
- `close-out` deliberately does not push the forward-ported commits to `main` (may be protected) — the runbook instructs the operator to push or open a PR, matching how step 5 already worked.
- Touches runbook steps 4–5; #4255 touches step 1 — clean rebase expected (different sections).

Confidence note: high. New script never executes a real release/delete/push without explicit confirmation; 18 cases cover dry-run + every guard/abort path; wraps (doesn't re-implement) the audited rake promotion guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new release helper to promote the last good RC to final and to close out the release line.
  * Includes dry-run previews, explicit RC selection, confirmation gating, and safer branch/worktree validations.

* **Documentation**
  * Expanded the release runbook with recommended scripted workflows for promotion and close-out.

* **Tests**
  * Added a dedicated test harness covering success, option handling, safety aborts, argument validation, and dry-run/non-mutation guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->