### PR TITLE
Fix release forward-port post-merge review findings

### DIFF
--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -116,6 +116,15 @@ RSpec.describe "script/release-forward-port" do
     [base_sha, feature_sha, merge_sha]
   end
 
+  def configure_external_diff(repo)
+    external_diff_path = File.join(repo, "external-diff.sh")
+    File.write(external_diff_path, "#!/bin/sh\nprintf '%s --- Text\\n' \"$1\"\n")
+    File.chmod(0o755, external_diff_path)
+    git(repo, "add", "external-diff.sh")
+    git(repo, "commit", "--no-gpg-sign", "-m", "Configure external diff helper")
+    git(repo, "config", "diff.external", external_diff_path)
+  end
+
   it "dry-runs the forward-port plan without changing the target branch" do
     with_release_repo do |repo|
       rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
@@ -318,6 +327,26 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips no-footer target patches that rename the source path" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      git(repo, "mv", "app.txt", "renamed file.txt")
+      write_file(repo, "renamed file.txt", "base\nrelease fix\n")
+      commit_all(repo, "Rename and apply release fix manually")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "renamed file.txt"))).to eq("base\nrelease fix\n")
+    end
+  end
+
   it "does not skip a no-footer cherry-pick that was later reverted" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
@@ -358,6 +387,39 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(reapplied_count)
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+    end
+  end
+
+  it "skips no-footer manual reapplications after source-sha reverts and target renames" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      git(repo, "cherry-pick", fix_sha)
+      git(repo, "mv", "app.txt", "renamed file.txt")
+      commit_all(repo, "Rename target file")
+      write_file(repo, "renamed file.txt", "base\n")
+      git(repo, "add", "renamed file.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually after rename",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      write_file(repo, "renamed file.txt", "base\nrelease fix\n")
+      commit_all(repo, "Reapply release fix manually after rename")
+      reapplied_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(reapplied_count)
+      expect(File.read(File.join(repo, "renamed file.txt"))).to eq("base\nrelease fix\n")
     end
   end
 
@@ -1059,6 +1121,85 @@ RSpec.describe "script/release-forward-port" do
       git(repo, "commit", "--no-gpg-sign", "-m", "Merge side reapply with manual fix")
       restored_count = git(repo, "rev-list", "--count", "main").strip
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(second_stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(restored_count)
+    end
+  end
+
+  it "picks source-sha reverts that remove a renamed target path" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      git(repo, "mv", "app.txt", "renamed.txt")
+      commit_all(repo, "Rename target file")
+      write_file(repo, "renamed.txt", "base\n")
+      git(repo, "add", "renamed.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually after rename",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      reverted_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "renamed.txt"))).to eq("base\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(second_stdout).not_to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(reverted_count)
+    end
+  end
+
+  it "skips source-sha reverts superseded by merge-only reapplications after target renames" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      git(repo, "checkout", "-b", "side-reapply")
+      write_file(repo, "side.txt", "side branch marker\n")
+      commit_all(repo, "Prepare side branch")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "app.txt", "base\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      git(repo, "mv", "app.txt", "renamed file.txt")
+      commit_all(repo, "Rename target file")
+      git(repo, "merge", "--no-ff", "--no-commit", "side-reapply")
+      write_file(repo, "renamed file.txt", "base\nrelease fix\n")
+      git(repo, "add", "renamed file.txt")
+      git(repo, "commit", "--no-gpg-sign", "-m", "Merge side reapply with renamed manual fix")
+      configure_external_diff(repo)
+      restored_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "renamed file.txt"))).to eq("base\nrelease fix\n")
 
       second_stdout, second_stderr, second_status =
         run_script(repo, "--source", "release/1.0.1", "--target", "main")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -1187,6 +1187,22 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "keeps empty stable version bump commits manual" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      git(repo, "commit", "--allow-empty", "--no-gpg-sign", "-m", "Bump version to 1.0.1")
+      stable_bump_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("stable release version bump commit")
+      expect(stdout).not_to include("empty commit; cherry-picking would only create a no-op commit")
+    end
+  end
+
   it "skips an -x cherry-pick restored by reverting its revert" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -1307,6 +1307,27 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "checks out the target branch before completing acknowledged manual-only plans" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1]\n- Final notes\n")
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+
+      git(repo, "checkout", "main")
+      git(repo, "checkout", "-b", "operator-notes")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--ack-manual", stable_bump_sha)
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("ACK-MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("Checking out main")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip).to eq("main")
+    end
+  end
+
   it "picks version bumps when the target prerelease label is unknown" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -7,6 +7,8 @@ require "tmpdir"
 require_relative "spec_helper"
 
 release_forward_port_script = File.expand_path("../../../script/release-forward-port", __dir__)
+# Guard against re-loading when this spec file is required more than once. The
+# helper constant is defined only by script/release-forward-port.
 load release_forward_port_script unless defined?(ReleaseForwardPort)
 
 RSpec.describe "script/release-forward-port" do
@@ -182,6 +184,35 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "does not require a clean worktree or checkout target for a no-op normal run" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "feature-work")
+      write_file(repo, "scratch.txt", "local notes\n")
+
+      stdout, stderr, status = run_script(repo, "--source", "main", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("No commits found in main..main.")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip).to eq("feature-work")
+      expect(File.read(File.join(repo, "scratch.txt"))).to eq("local notes\n")
+    end
+  end
+
+  it "rejects no-op normal runs while a cherry-pick is in progress" do
+    with_release_repo do |repo|
+      git_dir = git(repo, "rev-parse", "--git-dir").strip
+      File.write(File.join(repo, git_dir, "CHERRY_PICK_HEAD"), git(repo, "rev-parse", "HEAD"))
+
+      stdout, stderr, status = run_script(repo, "--source", "main", "--target", "main")
+
+      expect(status).not_to be_success
+      expect(stdout).to include("No commits found in main..main.")
+      expect(stdout).not_to include("Nothing to cherry-pick")
+      expect(stderr).to include("a cherry-pick is already in progress")
+    end
+  end
+
   it "skips initially empty release commits before cherry-picking" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
@@ -306,6 +337,56 @@ RSpec.describe "script/release-forward-port" do
 
       latest_commit_body = git(repo, "log", "-1", "--format=%B")
       expect(latest_commit_body).to include("(cherry picked from commit #{fix_sha})")
+    end
+  end
+
+  it "skips no-footer manual reapplications after source-sha reverts" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      git(repo, "cherry-pick", fix_sha)
+      git(repo, "revert", "--no-edit", fix_sha)
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      commit_all(repo, "Reapply release fix manually")
+      reapplied_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(reapplied_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+    end
+  end
+
+  it "skips live patches after empty source-sha reverts" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      git(repo, "cherry-pick", fix_sha)
+      git(
+        repo,
+        "commit",
+        "--allow-empty",
+        "--no-gpg-sign",
+        "-m",
+        "Record empty source revert",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
     end
   end
 
@@ -469,6 +550,35 @@ RSpec.describe "script/release-forward-port" do
       expect(second_stdout).to include("Nothing to cherry-pick")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
       expect(File.read(File.join(repo, "app.txt"))).to eq("base updated on main\nrelease fix\n")
+    end
+  end
+
+  it "skips -x cherry-picks after unrelated target merges are reverted" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      git(repo, "checkout", "-b", "unrelated-main-work")
+      write_file(repo, "notes.txt", "unrelated target work\n")
+      commit_all(repo, "Add unrelated target notes")
+      git(repo, "checkout", "main")
+      git(repo, "merge", "--no-ff", "unrelated-main-work", "-m", "Merge unrelated target work")
+      unrelated_merge_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "revert", "-m", "1", "--no-edit", unrelated_merge_sha)
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(second_stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
     end
   end
 
@@ -737,6 +847,280 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "does not skip an -x cherry-pick when the source commit was later reverted on target" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      git(repo, "revert", "--no-commit", fix_sha)
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      source_revert_body = git(repo, "log", "-1", "--format=%B")
+      expect(source_revert_body).to include("Undo release regression manually")
+      expect(source_revert_body).to include("This reverts commit #{fix_sha}.")
+      reverted_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(second_stdout).not_to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+      expect(git(repo, "rev-list", "--count", "main").strip.to_i).to eq(reverted_count.to_i + 1)
+
+      repicked_count = git(repo, "rev-list", "--count", "main").strip
+      third_stdout, third_stderr, third_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(third_status).to be_success, third_stderr
+      expect(third_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(third_stdout).to include("Nothing to cherry-pick")
+      expect(third_stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(repicked_count)
+    end
+  end
+
+  it "does not trust -x evidence after conflict-resolved source-sha reverts" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      write_file(repo, "app.txt", "base updated on main\nrelease fix\n")
+      commit_all(repo, "Adjust target context around release fix")
+
+      _stdout, _stderr, revert_status =
+        Open3.capture3(git_env, "git", "revert", "--no-commit", fix_sha, chdir: repo)
+      expect(revert_status).not_to be_success
+      write_file(repo, "app.txt", "base updated on main\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression after context update",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(stdout).not_to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base updated on main\n")
+    end
+  end
+
+  it "skips source-sha reverts superseded by merged no-footer reapplications" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      base_sha = git(repo, "rev-list", "--max-parents=0", "HEAD").strip
+      git(repo, "checkout", "-b", "side-reapply", base_sha)
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      commit_all(repo, "Independently reapply release fix")
+
+      git(repo, "checkout", "main")
+      git(repo, "revert", "--no-commit", fix_sha)
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      git(repo, "merge", "--no-ff", "side-reapply", "-m", "Merge independent reapply")
+      restored_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(second_stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(restored_count)
+    end
+  end
+
+  it "skips source-sha reverts superseded by merged conflict-resolved -x reapplications" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "release branch\n")
+      fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "app.txt", "main branch\n")
+      commit_all(repo, "Change same line on main")
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).not_to be_success
+      expect(first_stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(first_stderr).to include("Cherry-pick failed for #{fix_sha}")
+      write_file(repo, "app.txt", "main branch\nrelease branch\n")
+      git(repo, "add", "app.txt")
+      git(repo, "-c", "core.editor=true", "cherry-pick", "--continue")
+
+      git(repo, "checkout", "-b", "side-reapply", "main~1")
+      write_file(repo, "side.txt", "side branch marker\n")
+      commit_all(repo, "Prepare side branch")
+      _stdout, _stderr, side_status =
+        Open3.capture3(git_env, "git", "cherry-pick", "-x", fix_sha, chdir: repo)
+      expect(side_status).not_to be_success
+      write_file(repo, "app.txt", "main branch\nrelease branch\n")
+      git(repo, "add", "app.txt")
+      git(repo, "-c", "core.editor=true", "cherry-pick", "--continue")
+
+      git(repo, "checkout", "main")
+      _stdout, _stderr, revert_status =
+        Open3.capture3(git_env, "git", "revert", "--no-commit", fix_sha, chdir: repo)
+      expect(revert_status).not_to be_success
+      write_file(repo, "app.txt", "main branch\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+
+      _stdout, _stderr, merge_status =
+        Open3.capture3(git_env, "git", "merge", "--no-ff", "side-reapply", "-m", "Merge side reapply", chdir: repo)
+      unless merge_status.success?
+        write_file(repo, "app.txt", "main branch\nrelease branch\n")
+        git(repo, "add", "app.txt")
+        git(repo, "commit", "--no-gpg-sign", "-m", "Merge side reapply")
+      end
+      restored_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("main branch\nrelease branch\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(second_stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(restored_count)
+    end
+  end
+
+  it "does not treat -x side commits merged with ours as source-revert supersession" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      base_sha = git(repo, "rev-parse", "main~1").strip
+      git(repo, "checkout", "-b", "side-reapply", base_sha)
+      write_file(repo, "side.txt", "side branch marker\n")
+      commit_all(repo, "Prepare side branch")
+      git(repo, "cherry-pick", "-x", fix_sha)
+
+      git(repo, "checkout", "main")
+      git(repo, "revert", "--no-commit", fix_sha)
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      git(repo, "merge", "--no-ff", "-s", "ours", "side-reapply", "-m", "Merge side but keep reverted content")
+      reverted_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(second_stdout).not_to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+      expect(git(repo, "rev-list", "--count", "main").strip.to_i).to eq(reverted_count.to_i + 1)
+    end
+  end
+
+  it "ignores source-sha reverts merged with ours when the target kept the fix" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      git(repo, "checkout", "-b", "side-revert")
+      git(repo, "revert", "--no-edit", fix_sha)
+      git(repo, "checkout", "main")
+      git(repo, "merge", "--no-ff", "-s", "ours", "side-revert", "-m", "Merge side revert but keep fix")
+      kept_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(second_stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(kept_count)
+    end
+  end
+
+  it "keeps stable version bumps manual after source-sha reverts" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "target.txt", "target-only work\n")
+      commit_all(repo, "Advance target branch")
+      git(repo, "cherry-pick", stable_bump_sha)
+      git(repo, "revert", "--no-edit", stable_bump_sha)
+      restored_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "react_on_rails/lib/react_on_rails/version.rb"))).to include("1.0.0")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("stable release version bump commit")
+      expect(stdout).not_to include("PICK #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(restored_count)
+      expect(File.read(File.join(repo, "react_on_rails/lib/react_on_rails/version.rb"))).to include("1.0.0")
+    end
+  end
+
   it "skips an -x cherry-pick restored by reverting its revert" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)
@@ -818,6 +1202,26 @@ RSpec.describe "script/release-forward-port" do
       expect(stderr).to include("--ack-manual #{stable_bump_sha}")
       expect(stdout).not_to include("Forward-port complete")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
+  it "requires a clean worktree before completing acknowledged manual-only plans" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1]\n- Final notes\n")
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1]\n- Manually copied final notes\n")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--ack-manual", stable_bump_sha)
+
+      expect(status).not_to be_success
+      expect(stdout).to include("ACK-MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).not_to include("Nothing to cherry-pick")
+      expect(stderr).to include("working tree is not clean")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -1030,6 +1030,72 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips source-sha reverts superseded by merge-only reapplications" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      git(repo, "checkout", "-b", "side-reapply")
+      write_file(repo, "side.txt", "side branch marker\n")
+      commit_all(repo, "Prepare side branch")
+
+      git(repo, "checkout", "main")
+      git(repo, "revert", "--no-commit", fix_sha)
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Undo release regression manually",
+        "-m",
+        "This reverts commit #{fix_sha}."
+      )
+      git(repo, "merge", "--no-ff", "--no-commit", "side-reapply")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      git(repo, "add", "app.txt")
+      git(repo, "commit", "--no-gpg-sign", "-m", "Merge side reapply with manual fix")
+      restored_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(second_stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(restored_count)
+    end
+  end
+
+  it "skips side-merged -x reapplications when the target renamed the changed file before merge" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      git(repo, "checkout", "-b", "side-reapply", "main")
+      git(repo, "cherry-pick", "-x", fix_sha)
+
+      git(repo, "checkout", "main")
+      git(repo, "mv", "app.txt", "renamed.txt")
+      commit_all(repo, "Rename target file")
+      git(repo, "merge", "--no-ff", "side-reapply", "-m", "Merge side reapply after rename")
+      merged_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "renamed.txt"))).to eq("base\nrelease fix\n")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(File.read(File.join(repo, "renamed.txt"))).to eq("base\nrelease fix\n")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(merged_count)
+    end
+  end
+
   it "does not treat -x side commits merged with ours as source-revert supersession" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -85,6 +85,8 @@ class ReleaseForwardPort
       return 0
     end
 
+    return finish_no_action_plan(plan) unless actionable_plan?(plan)
+
     ensure_clean_worktree!
     checkout_target!(target)
     # This final expression is the process exit status.
@@ -99,6 +101,12 @@ class ReleaseForwardPort
   end
 
   private
+
+  def finish_no_action_plan(plan)
+    acknowledged_manual_entries?(plan) ? ensure_clean_worktree! : ensure_no_cherry_pick_in_progress!
+    puts "\nNothing to cherry-pick."
+    0
+  end
 
   def parse_options!
     argv = @argv.dup
@@ -192,11 +200,14 @@ class ReleaseForwardPort
     special_reason = special_skip_reason(sha, subject, target, target_version)
     return special_reason if special_reason
 
-    return "already forward-ported to #{target} via cherry-pick -x evidence with no later target revert" if
-      already_forward_ported_with_x?(sha, target)
-
     return "empty commit; cherry-picking would only create a no-op commit on #{target}" if
       patch_id_for_commit(sha) == EMPTY_PATCH_ID
+
+    return active_source_revert_skip_reason(subject, target, target_version) if
+      source_standard_revert_on_target?(sha, target)
+
+    return "already forward-ported to #{target} via cherry-pick -x evidence with no later target revert" if
+      already_forward_ported_with_x?(sha, target)
 
     # Origin was reverted on target: the fix was applied and then undone, so
     # re-apply it even if git cherry reports a patch match.
@@ -207,6 +218,15 @@ class ReleaseForwardPort
       return "patch already exists on #{target} according to target history with no later standard revert"
     end
 
+    version_bump_skip_reason(subject, target, target_version)
+  end
+
+  def active_source_revert_skip_reason(subject, target, target_version)
+    # A target-side `git revert <source-sha>` names the release commit rather
+    # than the earlier target cherry-pick, so do not trust either -x footer or
+    # patch-equivalence evidence while that source revert is still active.
+    # Version-bump guards still win because reapplying release-only version files
+    # to the target branch is never an automatic forward-port.
     version_bump_skip_reason(subject, target, target_version)
   end
 
@@ -339,11 +359,9 @@ class ReleaseForwardPort
 
   def already_forward_ported_with_x?(sha, target)
     return true if source_cherry_pick_origin_on_target?(sha, target)
+    return false if source_standard_revert_on_target?(sha, target)
 
-    footer = format(CHERRY_PICK_FOOTER_FORMAT, sha)
-    # This history search can false-positive if a later target commit quotes the
-    # footer verbatim. The runbook documents that boundary for release operators.
-    forwarded_shas = git_lines("log", target, "--fixed-strings", "--grep", footer, "--format=%H")
+    forwarded_shas = forwarded_shas_with_x(sha, target)
     return false if forwarded_shas.empty?
 
     # True if at least one copy of the cherry-pick is still live on the target.
@@ -360,6 +378,61 @@ class ReleaseForwardPort
   def source_cherry_pick_origin_reverted_on_target?(sha, target)
     origin_sha = cherry_pick_origin(sha)
     origin_sha && commit_on_target?(origin_sha, target) && !target_commit_live_on_target?(origin_sha, target)
+  end
+
+  def source_standard_revert_on_target?(sha, target)
+    active_revert_shas =
+      standard_revert_shas_on_target(sha, target)
+      .reject { |revert_sha| standard_revert_on_target?(revert_sha, target) }
+      .select { |revert_sha| target_commit_live_on_target?(revert_sha, target) }
+      .select { |revert_sha| revert_changes_source_paths?(revert_sha, sha) }
+    return false if active_revert_shas.empty?
+
+    active_revert_shas.any? do |revert_sha|
+      !source_revert_superseded_on_target?(sha, target, revert_sha)
+    end
+  end
+
+  def revert_changes_source_paths?(revert_sha, sha)
+    paths = changed_paths_for_commit(sha)
+    return false if paths.empty?
+
+    commit_changes_paths?(revert_sha, paths)
+  end
+
+  def source_revert_superseded_on_target?(sha, target, revert_sha)
+    source_reapplied_with_x_after_revert?(sha, target, revert_sha) ||
+      source_reapplied_without_x_after_revert?(sha, target, revert_sha)
+  end
+
+  def source_reapplied_with_x_after_revert?(sha, target, revert_sha)
+    forwarded_shas_with_x(sha, target).any? do |forwarded_sha|
+      target_commit_introduced_after_revert?(forwarded_sha, target, revert_sha) &&
+        target_commit_live_on_target?(forwarded_sha, target)
+    end
+  end
+
+  def source_reapplied_without_x_after_revert?(sha, target, revert_sha)
+    source_patch_id = patch_id_for_commit(sha)
+
+    patch_equivalent_target_candidates(sha, target).any? do |target_sha|
+      patch_id_for_commit(target_sha) == source_patch_id &&
+        target_commit_introduced_after_revert?(target_sha, target, revert_sha) &&
+        target_commit_live_on_target?(target_sha, target)
+    end
+  end
+
+  def target_commit_introduced_after_revert?(sha, target, revert_sha)
+    commit_descends_from?(sha, revert_sha) ||
+      target_merge_descendants(sha, target).any? { |merge_sha| commit_descends_from?(merge_sha, revert_sha) }
+  end
+
+  def forwarded_shas_with_x(sha, target)
+    footer = format(CHERRY_PICK_FOOTER_FORMAT, sha)
+    # This history search can false-positive if a later target commit quotes the
+    # footer verbatim. The live-target check by callers mitigates reverted target
+    # copies; the runbook documents the remaining quoted-footer boundary.
+    git_lines("log", target, "--fixed-strings", "--grep", footer, "--format=%H")
   end
 
   def reverted_commit_live_on_target?(sha, target)
@@ -413,13 +486,22 @@ class ReleaseForwardPort
   end
 
   def target_commit_live_on_target?(sha, target)
-    !standard_revert_on_target?(sha, target) && !target_commit_reverted_through_merge?(sha, target)
+    return false if standard_revert_on_target?(sha, target)
+    return false if target_commit_reverted_through_merge?(sha, target)
+
+    commit_on_first_parent?(sha, target) || target_merge_descendants(sha, target).any?
+  end
+
+  def commit_on_first_parent?(sha, target)
+    @first_parent_commits ||= {}
+    @first_parent_commits[target] ||= git_lines("rev-list", "--first-parent", target).to_h { |commit| [commit, true] }
+    @first_parent_commits[target].key?(sha)
   end
 
   def target_commit_reverted_through_merge?(sha, target)
-    # Intentionally conservative: if any merge that included this commit was
-    # reverted, treat the commit as not live. Re-picking a present change is
-    # safer than skipping a release fix that the target tree no longer has.
+    # Only merge reverts that introduced this commit can make it non-live. Later
+    # unrelated merges often descend from already-forward-ported fixes through
+    # first-parent history; their reverts should not make an older fix look absent.
     @target_merge_revert_cache ||= {}
     cache_key = [sha, target]
     return @target_merge_revert_cache.fetch(cache_key) if @target_merge_revert_cache.key?(cache_key)
@@ -429,17 +511,57 @@ class ReleaseForwardPort
   end
 
   def target_merge_descendants(sha, target)
-    git_lines("log", target, "--merges", "--ancestry-path", "#{sha}..#{target}", "--format=%H")
+    git_lines("log", target, "--merges", "--ancestry-path", "#{sha}..#{target}", "--format=%H").select do |merge_sha|
+      merge_introduces_commit?(merge_sha, sha)
+    end
+  end
+
+  def merge_introduces_commit?(merge_sha, sha)
+    parents = git("rev-list", "--parents", "-n", "1", merge_sha).split.drop(1)
+    return false if parents.length < 2
+
+    first_parent, *merged_side_parents = parents
+    return false if commit_descends_from?(first_parent, sha)
+    return false unless merged_side_parents.any? { |parent| commit_descends_from?(parent, sha) }
+
+    merge_changes_commit_paths?(first_parent, merge_sha, sha)
+  end
+
+  def merge_changes_commit_paths?(first_parent, merge_sha, sha)
+    paths = changed_paths_for_commit(sha)
+    return false if paths.empty?
+
+    diff_changes_paths?(first_parent, merge_sha, paths)
+  end
+
+  def commit_changes_paths?(commit_sha, paths)
+    parents = git("rev-list", "--parents", "-n", "1", commit_sha).split.drop(1)
+    return false if parents.empty?
+
+    diff_changes_paths?(parents.first, commit_sha, paths)
+  end
+
+  def diff_changes_paths?(from_ref, to_ref, paths)
+    args = ["diff", "--quiet", from_ref, to_ref, "--", *paths]
+    stdout, stderr, status = capture_git(*args)
+    return true if status.exitstatus == 1
+    raise GitError, git_error(args, stdout, stderr, status) unless status.success?
+
+    false
   end
 
   def patch_equivalent_target_candidates(sha, target)
-    paths = git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+    paths = changed_paths_for_commit(sha)
     return [] if paths.empty?
 
     # This path-history walk can be broad for high-churn files, but it only runs
     # for no-footer patch-equivalent candidates after git cherry marks a commit
     # equivalent. Normal helper reruns use the faster -x footer path.
     git_lines("log", target, "--format=%H", "--no-merges", "--", *paths)
+  end
+
+  def changed_paths_for_commit(sha)
+    git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
   end
 
   def patch_id_for_commit(sha)
@@ -596,13 +718,17 @@ class ReleaseForwardPort
   end
 
   def ensure_clean_worktree!
-    if cherry_pick_in_progress?
-      raise GitError, "a cherry-pick is already in progress; run git cherry-pick --continue or --abort first"
-    end
+    ensure_no_cherry_pick_in_progress!
 
     return if git("status", "--porcelain").strip.empty?
 
     raise GitError, "working tree is not clean; commit, stash, or discard local changes before normal mode"
+  end
+
+  def ensure_no_cherry_pick_in_progress!
+    return unless cherry_pick_in_progress?
+
+    raise GitError, "a cherry-pick is already in progress; run git cherry-pick --continue or --abort first"
   end
 
   def ensure_local_target_branch!(target)
@@ -650,6 +776,10 @@ class ReleaseForwardPort
 
   def actionable_plan?(plan)
     plan.any? { |entry| entry.action == :pick || (entry.manual? && !acknowledged_manual_entry?(entry)) }
+  end
+
+  def acknowledged_manual_entries?(plan)
+    plan.any? { |entry| entry.manual? && acknowledged_manual_entry?(entry) }
   end
 
   def remaining_picks(plan, index)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -636,7 +636,7 @@ class ReleaseForwardPort
   end
 
   def renamed_target_path_pairs_from_ref(from_ref, first_parent, source_paths)
-    git_lines("diff", "--name-status", "--find-renames", from_ref, first_parent).filter_map do |line|
+    git_lines("diff", "--name-status", "--find-renames=20%", from_ref, first_parent).filter_map do |line|
       status, old_path, new_path = line.split("\t", 3)
       [old_path, new_path] if status.start_with?("R") && new_path && source_paths.key?(old_path)
     end

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -85,7 +85,7 @@ class ReleaseForwardPort
       return 0
     end
 
-    return finish_no_action_plan(plan) unless actionable_plan?(plan)
+    return finish_no_action_plan(plan, target) unless actionable_plan?(plan)
 
     ensure_clean_worktree!
     checkout_target!(target)
@@ -102,8 +102,14 @@ class ReleaseForwardPort
 
   private
 
-  def finish_no_action_plan(plan)
-    acknowledged_manual_entries?(plan) ? ensure_clean_worktree! : ensure_no_cherry_pick_in_progress!
+  def finish_no_action_plan(plan, target)
+    if acknowledged_manual_entries?(plan)
+      ensure_clean_worktree!
+      checkout_target!(target)
+    else
+      ensure_no_cherry_pick_in_progress!
+    end
+
     puts "\nNothing to cherry-pick."
     0
   end

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -226,8 +226,8 @@ class ReleaseForwardPort
   end
 
   def patch_equivalent_skip_reason(sha, target, patch_equivalent_commits)
-    return unless patch_equivalent_commits[sha] &&
-                  patch_equivalent_commit_present_on_target?(sha, target)
+    return unless patch_equivalent_commits[sha] || target_has_renamed_source_paths?(target, sha)
+    return unless patch_equivalent_commit_present_on_target?(sha, target)
 
     "patch already exists on #{target} according to target history with no later standard revert"
   end
@@ -404,10 +404,13 @@ class ReleaseForwardPort
   end
 
   def revert_changes_source_paths?(revert_sha, sha)
-    paths = changed_paths_for_commit(sha)
+    parents = git("rev-list", "--parents", "-n", "1", revert_sha).split.drop(1)
+    return false if parents.empty?
+
+    paths = source_paths_for_target_diff(parents.first, sha)
     return false if paths.empty?
 
-    commit_changes_paths?(revert_sha, paths)
+    diff_changes_paths?(parents.first, revert_sha, paths)
   end
 
   def source_revert_superseded_on_target?(sha, target, revert_sha)
@@ -427,9 +430,9 @@ class ReleaseForwardPort
     source_patch_id = patch_id_for_commit(sha)
 
     patch_equivalent_target_candidates(sha, target).any? do |target_sha|
-      patch_id_for_commit(target_sha) == source_patch_id &&
-        target_commit_introduced_after_revert?(target_sha, target, revert_sha) &&
-        target_commit_live_on_target?(target_sha, target)
+      target_commit_introduced_after_revert?(target_sha, target, revert_sha) &&
+        target_commit_live_on_target?(target_sha, target) &&
+        patch_id_for_target_candidate(target_sha, sha) == source_patch_id
     end
   end
 
@@ -451,10 +454,10 @@ class ReleaseForwardPort
     return if parents.length < 2
 
     first_parent = parents.first
-    paths = source_paths_for_target_diff(first_parent, sha)
-    return if paths.empty?
+    target_to_source_paths = target_to_source_path_map(first_parent, sha)
+    return if target_to_source_paths.empty?
 
-    patch_id_for_diff(first_parent, merge_sha, paths)
+    patch_id_for_diff(first_parent, merge_sha, target_to_source_paths.keys, target_to_source_paths:)
   end
 
   def target_commit_introduced_after_revert?(sha, target, revert_sha)
@@ -516,7 +519,8 @@ class ReleaseForwardPort
     source_patch_id = patch_id_for_commit(sha)
 
     patch_equivalent_target_candidates(sha, target).any? do |target_sha|
-      patch_id_for_commit(target_sha) == source_patch_id && target_commit_live_on_target?(target_sha, target)
+      patch_id_for_target_candidate(target_sha, sha) == source_patch_id &&
+        target_commit_live_on_target?(target_sha, target)
     end
   end
 
@@ -569,13 +573,6 @@ class ReleaseForwardPort
     diff_changes_paths?(first_parent, merge_sha, paths)
   end
 
-  def commit_changes_paths?(commit_sha, paths)
-    parents = git("rev-list", "--parents", "-n", "1", commit_sha).split.drop(1)
-    return false if parents.empty?
-
-    diff_changes_paths?(parents.first, commit_sha, paths)
-  end
-
   def diff_changes_paths?(from_ref, to_ref, paths)
     args = ["diff", "--quiet", from_ref, to_ref, "--", *paths]
     stdout, stderr, status = capture_git(*args)
@@ -586,30 +583,63 @@ class ReleaseForwardPort
   end
 
   def patch_equivalent_target_candidates(sha, target)
-    paths = changed_paths_for_commit(sha)
+    paths = source_paths_for_target_diff(target, sha)
     return [] if paths.empty?
 
     # This path-history walk can be broad for high-churn files, but it only runs
     # for no-footer patch-equivalent candidates after git cherry marks a commit
-    # equivalent. Normal helper reruns use the faster -x footer path.
+    # equivalent or when target-side renames need a path-aware fallback. Normal
+    # helper reruns use the faster -x footer path.
     git_lines("log", target, "--format=%H", "--no-merges", "--", *paths)
   end
 
-  def source_paths_for_target_diff(first_parent, sha)
-    paths = changed_paths_for_commit(sha)
-    return [] if paths.empty?
-
-    (paths + renamed_target_paths_for_source_paths(first_parent, sha, paths)).uniq
+  def target_has_renamed_source_paths?(target, sha)
+    (source_paths_for_target_diff(target, sha) - changed_paths_for_commit(sha)).any?
   end
 
-  def renamed_target_paths_for_source_paths(first_parent, sha, paths)
-    merge_base = git("merge-base", first_parent, sha).strip
-    source_paths = paths.to_h { |path| [path, true] }
+  def patch_id_for_target_candidate(target_sha, source_sha)
+    parents = git("rev-list", "--parents", "-n", "1", target_sha).split.drop(1)
+    return patch_id_for_commit(target_sha) if parents.empty?
 
-    git_lines("diff", "--name-status", "--find-renames", merge_base, first_parent).filter_map do |line|
+    target_to_source_paths = target_to_source_path_map(target_sha, source_sha)
+    patch_id_for_commit(target_sha, target_to_source_paths:)
+  end
+
+  def source_paths_for_target_diff(first_parent, sha)
+    target_to_source_path_map(first_parent, sha).keys
+  end
+
+  def target_to_source_path_map(first_parent, sha)
+    paths = changed_paths_for_commit(sha)
+    return {} if paths.empty?
+
+    path_map = paths.to_h { |path| [path, path] }
+    renamed_target_path_pairs_for_source_paths(first_parent, sha, paths).each do |source_path, target_path|
+      path_map[target_path] = source_path
+    end
+
+    path_map
+  end
+
+  def renamed_target_path_pairs_for_source_paths(first_parent, sha, paths)
+    @renamed_target_path_pairs_cache ||= {}
+    cache_key = [first_parent, sha]
+    return @renamed_target_path_pairs_cache.fetch(cache_key) if @renamed_target_path_pairs_cache.key?(cache_key)
+
+    source_paths = paths.to_h { |path| [path, true] }
+    rename_base_refs = [git("merge-base", first_parent, sha).strip, sha].uniq
+
+    @renamed_target_path_pairs_cache[cache_key] =
+      rename_base_refs.flat_map do |from_ref|
+        renamed_target_path_pairs_from_ref(from_ref, first_parent, source_paths)
+      end.uniq
+  end
+
+  def renamed_target_path_pairs_from_ref(from_ref, first_parent, source_paths)
+    git_lines("diff", "--name-status", "--find-renames", from_ref, first_parent).filter_map do |line|
       status, old_path, new_path = line.split("\t", 3)
-      new_path if status.start_with?("R") && new_path && source_paths.key?(old_path)
-    end.uniq
+      [old_path, new_path] if status.start_with?("R") && new_path && source_paths.key?(old_path)
+    end
   end
 
   def changed_paths_for_commit(sha)
@@ -617,17 +647,109 @@ class ReleaseForwardPort
     @changed_paths_cache[sha] ||= git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
   end
 
-  def patch_id_for_commit(sha)
+  def patch_id_for_commit(sha, target_to_source_paths: {})
     # git show --format= emits diff-only output. git patch-id still hashes the
     # hunk content and emits a commit field we discard; the first token is the
     # content hash used for comparisons.
-    patch = git("show", "--format=", "--full-index", "--find-renames", sha).b
+    patch =
+      git(
+        "show",
+        "--no-ext-diff",
+        "--format=",
+        "--full-index",
+        rename_detection_option(target_to_source_paths),
+        sha
+      ).b
+    patch = normalize_patch_paths(patch, target_to_source_paths)
     patch_id_for_patch(patch, sha)
   end
 
-  def patch_id_for_diff(from_ref, to_ref, paths)
-    patch = git("diff", "--full-index", "--find-renames", from_ref, to_ref, "--", *paths).b
+  def patch_id_for_diff(from_ref, to_ref, paths, target_to_source_paths: {})
+    patch =
+      git(
+        "diff",
+        "--no-ext-diff",
+        "--full-index",
+        rename_detection_option(target_to_source_paths),
+        from_ref,
+        to_ref,
+        "--",
+        *paths
+      ).b
+    patch = normalize_patch_paths(patch, target_to_source_paths)
     patch_id_for_patch(patch, "#{from_ref}..#{to_ref}")
+  end
+
+  def rename_detection_option(target_to_source_paths)
+    return "--find-renames=20%" if target_to_source_paths.any? { |target_path, source_path| target_path != source_path }
+
+    "--find-renames"
+  end
+
+  def normalize_patch_paths(patch, target_to_source_paths)
+    changed_paths = target_to_source_paths.reject { |target_path, source_path| target_path == source_path }
+    return patch if changed_paths.empty?
+
+    patch.each_line.map { |line| normalize_patch_path_line(line, changed_paths) }.join.b
+  end
+
+  def normalize_patch_path_line(line, target_to_source_paths)
+    return normalize_patch_diff_header(line, target_to_source_paths) if line.start_with?("diff --git ")
+    return normalize_prefixed_patch_path_line(line, target_to_source_paths) if line.start_with?("--- ", "+++ ")
+
+    normalize_unprefixed_patch_path_line(line, target_to_source_paths)
+  end
+
+  def normalize_patch_diff_header(line, target_to_source_paths)
+    trailing_newline = line.end_with?("\n") ? "\n" : ""
+    header = line.delete_prefix("diff --git ").delete_suffix("\n")
+
+    sorted_paths = target_to_source_paths.sort_by { |target_path, _source_path| -target_path.length }
+    sorted_paths.each do |target_path, source_path|
+      next if target_path == source_path
+
+      mapped_headers = [
+        "a/#{target_path} b/#{target_path}",
+        "a/#{source_path} b/#{target_path}"
+      ]
+      next unless mapped_headers.include?(header)
+
+      return "diff --git a/#{source_path} b/#{source_path}#{trailing_newline}"
+    end
+
+    line
+  end
+
+  def normalize_prefixed_patch_path_line(line, target_to_source_paths)
+    trailing_newline = line.end_with?("\n") ? "\n" : ""
+    prefix = line[0, 4]
+    path, separator, metadata = line[4..].delete_suffix("\n").partition("\t")
+    return line if path == "/dev/null"
+
+    normalized_path = normalize_prefixed_patch_path(path, path[0, 2], target_to_source_paths)
+    "#{prefix}#{normalized_path}#{separator}#{metadata}#{trailing_newline}"
+  end
+
+  def normalize_unprefixed_patch_path_line(line, target_to_source_paths)
+    return "" if line.start_with?("similarity index ", "dissimilarity index ")
+
+    path_headers = ["rename from ", "rename to ", "copy from ", "copy to "]
+    path_header = path_headers.find { |header| line.start_with?(header) }
+    return line unless path_header
+
+    trailing_newline = line.end_with?("\n") ? "\n" : ""
+    path = line.delete_prefix(path_header).delete_suffix("\n")
+    return "" if path_header.start_with?("rename ") &&
+                 (target_to_source_paths.key?(path) || target_to_source_paths.value?(path))
+
+    "#{path_header}#{target_to_source_paths.fetch(path, path)}#{trailing_newline}"
+  end
+
+  def normalize_prefixed_patch_path(path, prefix, target_to_source_paths)
+    return path unless path.start_with?(prefix)
+
+    target_path = path.delete_prefix(prefix)
+    "#{prefix}#{target_to_source_paths.fetch(target_path, target_path)}"
   end
 
   def patch_id_for_patch(patch, label)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -402,7 +402,8 @@ class ReleaseForwardPort
 
   def source_revert_superseded_on_target?(sha, target, revert_sha)
     source_reapplied_with_x_after_revert?(sha, target, revert_sha) ||
-      source_reapplied_without_x_after_revert?(sha, target, revert_sha)
+      source_reapplied_without_x_after_revert?(sha, target, revert_sha) ||
+      source_reapplied_by_merge_after_revert?(sha, target, revert_sha)
   end
 
   def source_reapplied_with_x_after_revert?(sha, target, revert_sha)
@@ -420,6 +421,30 @@ class ReleaseForwardPort
         target_commit_introduced_after_revert?(target_sha, target, revert_sha) &&
         target_commit_live_on_target?(target_sha, target)
     end
+  end
+
+  def source_reapplied_by_merge_after_revert?(sha, target, revert_sha)
+    source_patch_id = patch_id_for_commit(sha)
+
+    target_first_parent_merges_after(revert_sha, target).any? do |merge_sha|
+      target_commit_live_on_target?(merge_sha, target) &&
+        patch_id_for_merge_source_paths(merge_sha, sha) == source_patch_id
+    end
+  end
+
+  def target_first_parent_merges_after(sha, target)
+    git_lines("log", target, "--first-parent", "--merges", "#{sha}..#{target}", "--format=%H")
+  end
+
+  def patch_id_for_merge_source_paths(merge_sha, sha)
+    parents = git("rev-list", "--parents", "-n", "1", merge_sha).split.drop(1)
+    return if parents.length < 2
+
+    first_parent = parents.first
+    paths = source_paths_for_target_diff(first_parent, sha)
+    return if paths.empty?
+
+    patch_id_for_diff(first_parent, merge_sha, paths)
   end
 
   def target_commit_introduced_after_revert?(sha, target, revert_sha)
@@ -528,7 +553,7 @@ class ReleaseForwardPort
   end
 
   def merge_changes_commit_paths?(first_parent, merge_sha, sha)
-    paths = changed_paths_for_commit(sha)
+    paths = source_paths_for_target_diff(first_parent, sha)
     return false if paths.empty?
 
     diff_changes_paths?(first_parent, merge_sha, paths)
@@ -560,6 +585,23 @@ class ReleaseForwardPort
     git_lines("log", target, "--format=%H", "--no-merges", "--", *paths)
   end
 
+  def source_paths_for_target_diff(first_parent, sha)
+    paths = changed_paths_for_commit(sha)
+    return [] if paths.empty?
+
+    (paths + renamed_target_paths_for_source_paths(first_parent, sha, paths)).uniq
+  end
+
+  def renamed_target_paths_for_source_paths(first_parent, sha, paths)
+    merge_base = git("merge-base", first_parent, sha).strip
+    source_paths = paths.to_h { |path| [path, true] }
+
+    git_lines("diff", "--name-status", "--find-renames", merge_base, first_parent).filter_map do |line|
+      status, old_path, new_path = line.split("\t", 3)
+      new_path if status.start_with?("R") && new_path && source_paths.key?(old_path)
+    end.uniq
+  end
+
   def changed_paths_for_commit(sha)
     git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
   end
@@ -569,12 +611,21 @@ class ReleaseForwardPort
     # hunk content and emits a commit field we discard; the first token is the
     # content hash used for comparisons.
     patch = git("show", "--format=", "--full-index", "--find-renames", sha).b
+    patch_id_for_patch(patch, sha)
+  end
+
+  def patch_id_for_diff(from_ref, to_ref, paths)
+    patch = git("diff", "--full-index", "--find-renames", from_ref, to_ref, "--", *paths).b
+    patch_id_for_patch(patch, "#{from_ref}..#{to_ref}")
+  end
+
+  def patch_id_for_patch(patch, label)
     # Empty commits carry no file changes; cherry-picking them would only create
     # a no-op commit, so treat the patch as already present.
     return EMPTY_PATCH_ID if empty_patch?(patch)
 
     stdout, stderr, status = capture_git("patch-id", "--stable", stdin_data: patch)
-    raise GitError, "#{git_error(['patch-id', '--stable'], stdout, stderr, status)} for #{sha}" unless status.success?
+    raise GitError, "#{git_error(['patch-id', '--stable'], stdout, stderr, status)} for #{label}" unless status.success?
 
     patch_id = stdout.split.first
     return hunkless_patch_id(patch) if patch_id.nil?

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -200,6 +200,9 @@ class ReleaseForwardPort
     special_reason = special_skip_reason(sha, subject, target, target_version)
     return special_reason if special_reason
 
+    version_bump_reason = version_bump_skip_reason(subject, target, target_version)
+    return version_bump_reason if version_bump_reason
+
     return "empty commit; cherry-picking would only create a no-op commit on #{target}" if
       patch_id_for_commit(sha) == EMPTY_PATCH_ID
 
@@ -213,12 +216,14 @@ class ReleaseForwardPort
     # re-apply it even if git cherry reports a patch match.
     return if source_cherry_pick_origin_reverted_on_target?(sha, target)
 
-    if patch_equivalent_commits[sha] &&
-       patch_equivalent_commit_present_on_target?(sha, target)
-      return "patch already exists on #{target} according to target history with no later standard revert"
-    end
+    patch_equivalent_skip_reason(sha, target, patch_equivalent_commits)
+  end
 
-    version_bump_skip_reason(subject, target, target_version)
+  def patch_equivalent_skip_reason(sha, target, patch_equivalent_commits)
+    return unless patch_equivalent_commits[sha] &&
+                  patch_equivalent_commit_present_on_target?(sha, target)
+
+    "patch already exists on #{target} according to target history with no later standard revert"
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)
@@ -383,7 +388,6 @@ class ReleaseForwardPort
   def source_standard_revert_on_target?(sha, target)
     active_revert_shas =
       standard_revert_shas_on_target(sha, target)
-      .reject { |revert_sha| standard_revert_on_target?(revert_sha, target) }
       .select { |revert_sha| target_commit_live_on_target?(revert_sha, target) }
       .select { |revert_sha| revert_changes_source_paths?(revert_sha, sha) }
     return false if active_revert_shas.empty?
@@ -603,7 +607,8 @@ class ReleaseForwardPort
   end
 
   def changed_paths_for_commit(sha)
-    git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+    @changed_paths_cache ||= {}
+    @changed_paths_cache[sha] ||= git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
   end
 
   def patch_id_for_commit(sha)


### PR DESCRIPTION
## Why

Follow-up to #4181 / #4162. PR #4181 is already merged, but post-merge review surfaced release-forward-port edge cases that could make the helper report the wrong plan or fail during an otherwise idempotent closeout run.

This PR keeps the original release-forward-port design and fixes the review findings without broad release-process redesign.

## What Changed

- Preserve no-op normal-mode behavior while still rejecting an in-progress cherry-pick.
- Require ACK-MANUAL-only normal runs to have a clean worktree and check out the target branch before reporting completion.
- Treat target-side `git revert <source-sha>` commits as active only when the revert itself is live on the target and changes the source commit paths.
- Treat no-footer and merge-only reapplications as superseding source-sha reverts when the target restores the source patch.
- Expand patch/liveness checks through target-side renames before deciding that side-merged or manually reapplied evidence is absent.
- Normalize target-side renamed patch paths back to source paths for patch-id comparison, while ignoring external diff drivers.
- Avoid treating side-branch commits that are merely reachable through `-s ours`/non-introducing merges as live target evidence.
- Keep stable version bump safeguards ahead of empty-commit and source-revert re-pick logic.
- Cache changed-path lookups during a planning run.
- Add focused regression coverage for the #4181 and #4261 review findings, including renamed target paths and no-footer reapplications.

## Addresses #4181 Review Threads

- `PRRT_kwDOAnNnU86MJ3kt`: no-op normal mode no longer checks out the target or rejects dirty worktrees when there is truly nothing to do, while still rejecting active cherry-picks.
- `PRRT_kwDOAnNnU86MJ3wG`: the quoted `-x` footer boundary is documented at the helper call site.
- `PRRT_kwDOAnNnU86MJ35H`: the spec load guard now explains why the script is loaded conditionally.
- `PRRT_kwDOAnNnU86MJ4fS`: reverted unrelated target merges no longer make older forward-ported fixes look absent.
- `PRRT_kwDOAnNnU86MJ4fb`: source-SHA reverts now force a re-pick only when the revert is live and not superseded.

## Addresses #4261 Review Threads

- `PRRT_kwDOAnNnU86MxWi4`: target-side renames are included when checking whether a side merge introduced a source commit's paths.
- `PRRT_kwDOAnNnU86MxWmF`: merge-only reapplications after source-sha reverts are recognized when the merge diff restores the source patch.
- `PRRT_kwDOAnNnU86MxX5_`: stable version bump guards run before empty-commit skipping, preserving the `MANUAL` gate.
- `PRRT_kwDOAnNnU86MxX6l`: the redundant pre-filter was removed; `target_commit_live_on_target?` remains the single liveness gate.
- `PRRT_kwDOAnNnU86MxX6_`: changed-path lookups are memoized per planning run.
- `PRRT_kwDOAnNnU86MxaW8`: ACK-MANUAL-only normal runs now verify a clean worktree and check out the target branch before completing.
- `PRRT_kwDOAnNnU86MxbRY`: source-SHA revert checks use rename-aware target paths, so a revert that removes a renamed target path is still treated as active.
- `PRRT_kwDOAnNnU86MxckF`: merge-only and no-footer patch comparisons normalize target renamed paths back to source paths and bypass external diff drivers.

## Validation

- `ruby -c script/release-forward-port && ruby -c react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb && git diff --check`
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/release_forward_port_script_spec.rb` - 65 examples, 0 failures
- `cd react_on_rails && env GIT_TEST_FORCE_SIGNING_FALLBACK=1 bundle exec rspec spec/react_on_rails/release_forward_port_script_spec.rb` - 65 examples, 0 failures
- `BUNDLE_GEMFILE="$(git rev-parse --show-toplevel)/Gemfile" bundle exec rubocop script/release-forward-port react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb` - no offenses
- `script/ci-changes-detector origin/main` - routes RSpec tests + CI infrastructure/full optimized suite, no benchmarks
- pre-commit hook - trailing newline, RuboCop, autofix checks passed
- pre-push hook - branch Ruby lint and markdown-link routing passed
- `codex review --uncommitted` was run in bounded passes. It surfaced target-rename edge cases; those were fixed with regressions. The final retry timed out after exploratory reads, with no final finding list.

## Merge Rationale

This is a narrow post-merge hardening PR for the release forward-port helper after #4181. It reduces release-closeout risk by fixing known false-skip/false-pick cases, preserving manual handling for stable version bumps, and improving path/revert classification around side merges and target-side renames. The change is limited to `script/release-forward-port` and its spec, and every accepted review finding has targeted local regression coverage.

## Confidence Note

- Validated: syntax, whitespace, RuboCop, normal helper spec, forced-signing helper spec, CI detector, pre-commit hooks, pre-push hooks, optimized hosted CI, current-head review-thread triage, strict merge ledger.
- Evidence: branch head `68ef83ced`; hosted CI all green including `rspec-package-tests (4.0, latest, generators)` after 40m39s; CodeRabbit approved; `claude-review` passed; unresolved review threads count 0; `script/pr-merge-ledger 4261 --strict --changelog-classification not_user_visible --finding-dispositions <P2 not_applicable map> --pretty` returned `complete_allowed: true`.
- UNKNOWN: none.
- Residual risk: helper history classification remains conservative for unusual manually edited histories; late review cleanup-only/performance nits were auto-deferred to avoid restarting the final-candidate gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `release-forward-port` handling for “no actionable work”: it now exits cleanly with **“Nothing to cherry-pick.”** and avoids unnecessary checks.
  * Tightened safety around dirty worktrees/cherry-pick-in-progress, and refined skip decisions for active revert/reapply scenarios (including more reliable treatment of `-x` evidence and rename cases).
  * Updated acknowledged manual flows to require a **clean worktree** and ensure the **target branch is checked out**.
* **Tests**
  * Expanded coverage for no-op runs, revert/reapply/rename edge cases, and `-x` evidence/supersession behavior across dry-run and revert-during-merge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

