### PR TITLE
Release train: ci-changes-detector classifies release-tooling paths (skip full matrix)

### DIFF
--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -464,6 +464,29 @@ while IFS= read -r file; do
       PRO_LINT_CONFIG_CHANGED=true
       ;;
 
+    # Release tooling (rake release tasks + their helper scripts). The ONLY
+    # automated coverage for these paths is the release rspec suite
+    # (react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb and
+    # release_forward_port_script_spec.rb), so route them to RSPEC_CHANGED rather
+    # than the CI-infrastructure arm below. That arm's catch-all-equivalent
+    # behavior set RUN_GENERATORS=true, which makes required-pr-gate force the
+    # full hosted matrix (Generator/Playwright/Integration/JS) — none of which
+    # exercise release tooling (see script/ci-required-hosted-gate). This arm is
+    # deliberately NOT generator-/JS-sensitive: it sets no GENERATORS_CHANGED or
+    # JS_CHANGED, so run_generators / run_js_tests stay false and hosted CI is
+    # optional rather than gate-forced. It must precede the script/* CI-infra arm
+    # (which would otherwise swallow script/release-*) and follow the more
+    # specific source/spec arms above. Sets no BENCH_* flag: release tooling is
+    # never shipped in the gem and cannot move runtime performance.
+    rakelib/release.rake|script/release-forward-port|script/release-forward-port-test.bash|script/release-finish|script/release-finish-test.bash)
+      DOCS_ONLY=false
+      if source_file_comment_only_change "$file"; then
+        SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        RSPEC_CHANGED=true
+      fi
+      ;;
+
     # CI infrastructure files (scripts, workflows, CI configs).
     # These change HOW the suite runs but never the gem/package runtime, so they
     # trigger the full TEST suite to validate the change (see the CI_INFRA_CHANGED

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -77,6 +77,7 @@ PRO_DUMMY_CHANGED=false
 PRO_NODE_RENDERER_CHANGED=false
 UNCATEGORIZED_CHANGED=false
 CI_INFRA_CHANGED=false
+RELEASE_TOOLING_CHANGED=false
 SOURCE_COMMENT_ONLY_CHANGED=false
 PRO_SOURCE_COMMENT_ONLY_CHANGED=false
 # Benchmark relevance, tracked separately from the test-selection flags above.
@@ -467,23 +468,32 @@ while IFS= read -r file; do
     # Release tooling (rake release tasks + their helper scripts). The ONLY
     # automated coverage for these paths is the release rspec suite
     # (react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb and
-    # release_forward_port_script_spec.rb), so route them to RSPEC_CHANGED rather
-    # than the CI-infrastructure arm below. That arm's catch-all-equivalent
-    # behavior set RUN_GENERATORS=true, which makes required-pr-gate force the
-    # full hosted matrix (Generator/Playwright/Integration/JS) — none of which
-    # exercise release tooling (see script/ci-required-hosted-gate). This arm is
+    # release_forward_port_script_spec.rb), so route them to RSPEC_CHANGED (runs
+    # those specs) plus RELEASE_TOOLING_CHANGED (runs rubocop) rather than the
+    # CI-infrastructure arm below. That arm's catch-all-equivalent behavior set
+    # RUN_GENERATORS=true, which makes required-pr-gate force the full hosted
+    # matrix (Generator/Playwright/Integration/JS) — none of which exercise
+    # release tooling (see script/ci-required-hosted-gate). This arm is
     # deliberately NOT generator-/JS-sensitive: it sets no GENERATORS_CHANGED or
     # JS_CHANGED, so run_generators / run_js_tests stay false and hosted CI is
-    # optional rather than gate-forced. It must precede the script/* CI-infra arm
+    # optional rather than gate-forced. RELEASE_TOOLING_CHANGED only drives
+    # RUN_LINT (release tooling is Ruby/Bash that rubocop covers); it is kept
+    # separate from RSPEC_CHANGED so the lint trigger does not leak to unrelated
+    # core/Pro spec-only changes. It must precede the script/* CI-infra arm
     # (which would otherwise swallow script/release-*) and follow the more
     # specific source/spec arms above. Sets no BENCH_* flag: release tooling is
     # never shipped in the gem and cannot move runtime performance.
+    # NOTE: the bare `script/release` stub (a 3-line `echo "See rake -D release"`)
+    # is intentionally NOT listed here — it has no release-spec coverage, so it
+    # stays in the script/* CI-infra arm below rather than claiming a test suite
+    # that does not exercise it.
     rakelib/release.rake|script/release-forward-port|script/release-forward-port-test.bash|script/release-finish|script/release-finish-test.bash)
       DOCS_ONLY=false
       if source_file_comment_only_change "$file"; then
         SOURCE_COMMENT_ONLY_CHANGED=true
       else
         RSPEC_CHANGED=true
+        RELEASE_TOOLING_CHANGED=true
       fi
       ;;
 
@@ -654,6 +664,14 @@ fi
 # only need lint here. The benchmarks_changed output drives the benchmark
 # workflow's script-validation step.
 if [ "$BENCHMARKS_CHANGED" = true ]; then
+  RUN_LINT=true
+fi
+
+# Release tooling (rakelib/release.rake + script/release-* helpers) is Ruby/Bash
+# that rubocop lints. Its release-spec coverage already rides RSPEC_CHANGED into
+# RUN_RUBY_TESTS above; this adds the lint job without re-introducing the
+# generator/JS sensitivity that would force the full hosted matrix.
+if [ "$RELEASE_TOOLING_CHANGED" = true ]; then
   RUN_LINT=true
 fi
 

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -895,6 +895,65 @@ test_benchmark_comment_only_change_is_non_runtime_but_keeps_lint() {
   assert_contains "$out" '"run_ruby_tests": false' "benchmark comment output"
 }
 
+# Release tooling (rakelib/release.rake + script/release-* helpers) is covered
+# ONLY by the release rspec suite, never by generators or JS. It must request the
+# Ruby tests (so those specs run) while keeping run_generators / run_js_tests
+# false, so required-pr-gate (script/ci-required-hosted-gate) does not force the
+# full hosted matrix. Before this arm existed, rakelib/release.rake hit the
+# uncategorized catch-all and set run_generators=true.
+test_release_rake_change_runs_ruby_tests_without_generators() {
+  setup_repo
+  write_file_change "rakelib/release.rake" "task :release do; end"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": false' "release rake output"
+  assert_contains "$out" '"non_runtime_only": false' "release rake output"
+  assert_contains "$out" '"run_ruby_tests": true' "release rake output"
+  assert_contains "$out" '"run_generators": false' "release rake output"
+  assert_contains "$out" '"run_js_tests": false' "release rake output"
+  # Release tooling does not exercise the dummy app, E2E, or benchmarks.
+  assert_contains "$out" '"run_dummy_tests": false' "release rake output"
+  assert_contains "$out" '"run_e2e_tests": false' "release rake output"
+  assert_contains "$out" '"run_core_benchmarks": false' "release rake output"
+}
+
+# The release helper scripts under script/ must be caught by the release-tooling
+# arm, not the broad script/* CI-infrastructure arm (which would set
+# run_generators=true and force hosted CI). Same contract as release.rake.
+test_release_finish_script_change_runs_ruby_tests_without_generators() {
+  setup_repo
+  write_file_change "script/release-finish" "#!/usr/bin/env bash"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": false' "release-finish output"
+  assert_contains "$out" '"non_runtime_only": false' "release-finish output"
+  assert_contains "$out" '"run_ruby_tests": true' "release-finish output"
+  assert_contains "$out" '"run_generators": false' "release-finish output"
+  assert_contains "$out" '"run_js_tests": false' "release-finish output"
+  assert_contains "$out" '"run_dummy_tests": false' "release-finish output"
+}
+
+# Regression guard: a CHANGELOG.md-only change is documentation (matched by the
+# *.md docs arm) and must stay skippable — docs_only / non_runtime_only true,
+# every run_* false. Release stamping touches CHANGELOG.md, so this keeps that
+# path from ever forcing CI.
+test_changelog_only_change_is_non_runtime_only() {
+  setup_repo
+  write_file_change "CHANGELOG.md" "## [Unreleased]"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": true' "changelog output"
+  assert_contains "$out" '"non_runtime_only": true' "changelog output"
+  assert_contains "$out" '"run_lint": false' "changelog output"
+  assert_contains "$out" '"run_ruby_tests": false' "changelog output"
+  assert_contains "$out" '"run_js_tests": false' "changelog output"
+  assert_contains "$out" '"run_generators": false' "changelog output"
+  assert_contains "$out" '"benchmarks_changed": false' "changelog output"
+}
+
 test_empty_diff_skips_everything() {
   setup_repo
   git commit --allow-empty -m "no file changes" >/dev/null
@@ -908,6 +967,9 @@ test_empty_diff_skips_everything() {
 }
 
 run_test test_empty_diff_skips_everything
+run_test test_release_rake_change_runs_ruby_tests_without_generators
+run_test test_release_finish_script_change_runs_ruby_tests_without_generators
+run_test test_changelog_only_change_is_non_runtime_only
 run_test test_docs_changes_are_non_runtime_only
 run_test test_internal_non_markdown_docs_are_non_runtime_only
 run_test test_issue_template_changes_are_non_runtime_only

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -897,42 +897,73 @@ test_benchmark_comment_only_change_is_non_runtime_but_keeps_lint() {
 
 # Release tooling (rakelib/release.rake + script/release-* helpers) is covered
 # ONLY by the release rspec suite, never by generators or JS. It must request the
-# Ruby tests (so those specs run) while keeping run_generators / run_js_tests
-# false, so required-pr-gate (script/ci-required-hosted-gate) does not force the
-# full hosted matrix. Before this arm existed, rakelib/release.rake hit the
-# uncategorized catch-all and set run_generators=true.
-test_release_rake_change_runs_ruby_tests_without_generators() {
+# Ruby tests (so those specs run) AND lint (rubocop covers this Ruby/Bash) while
+# keeping run_generators / run_js_tests false, so required-pr-gate
+# (script/ci-required-hosted-gate) does not force the full hosted matrix. Before
+# this arm existed, rakelib/release.rake hit the uncategorized catch-all and set
+# run_generators=true.
+#
+# All five release-tooling paths share one contract, asserted identically via
+# this helper so a one-character typo in any pattern can't silently fall through
+# to the generator-sensitive script/* CI-infra arm.
+assert_release_tooling_contract() {
+  local out="$1"
+  local label="$2"
+  assert_contains "$out" '"docs_only": false' "$label"
+  assert_contains "$out" '"non_runtime_only": false' "$label"
+  # Rubocop must run so release tooling is linted (the lint job is hosted-gated
+  # on run_lint; without this it would never lint these paths).
+  assert_contains "$out" '"run_lint": true' "$label"
+  # Release specs run (release_rake_helpers_spec / release_forward_port_script_spec).
+  assert_contains "$out" '"run_ruby_tests": true' "$label"
+  # Primary goal: NOT generator-sensitive, so required-pr-gate won't force hosted CI.
+  assert_contains "$out" '"run_generators": false' "$label"
+  assert_contains "$out" '"run_js_tests": false' "$label"
+  # Release tooling does not exercise the dummy app, E2E, or benchmarks.
+  assert_contains "$out" '"run_dummy_tests": false' "$label"
+  assert_contains "$out" '"run_e2e_tests": false' "$label"
+  assert_contains "$out" '"run_core_benchmarks": false' "$label"
+}
+
+test_release_rake_change_runs_ruby_tests_and_lint_without_generators() {
   setup_repo
   write_file_change "rakelib/release.rake" "task :release do; end"
 
-  local out
-  out="$(detector_output)"
-  assert_contains "$out" '"docs_only": false' "release rake output"
-  assert_contains "$out" '"non_runtime_only": false' "release rake output"
-  assert_contains "$out" '"run_ruby_tests": true' "release rake output"
-  assert_contains "$out" '"run_generators": false' "release rake output"
-  assert_contains "$out" '"run_js_tests": false' "release rake output"
-  # Release tooling does not exercise the dummy app, E2E, or benchmarks.
-  assert_contains "$out" '"run_dummy_tests": false' "release rake output"
-  assert_contains "$out" '"run_e2e_tests": false' "release rake output"
-  assert_contains "$out" '"run_core_benchmarks": false' "release rake output"
+  assert_release_tooling_contract "$(detector_output)" "release rake output"
 }
 
 # The release helper scripts under script/ must be caught by the release-tooling
 # arm, not the broad script/* CI-infrastructure arm (which would set
 # run_generators=true and force hosted CI). Same contract as release.rake.
-test_release_finish_script_change_runs_ruby_tests_without_generators() {
+test_release_finish_script_change_runs_ruby_tests_and_lint_without_generators() {
   setup_repo
   write_file_change "script/release-finish" "#!/usr/bin/env bash"
 
-  local out
-  out="$(detector_output)"
-  assert_contains "$out" '"docs_only": false' "release-finish output"
-  assert_contains "$out" '"non_runtime_only": false' "release-finish output"
-  assert_contains "$out" '"run_ruby_tests": true' "release-finish output"
-  assert_contains "$out" '"run_generators": false' "release-finish output"
-  assert_contains "$out" '"run_js_tests": false' "release-finish output"
-  assert_contains "$out" '"run_dummy_tests": false' "release-finish output"
+  assert_release_tooling_contract "$(detector_output)" "release-finish output"
+}
+
+# Per-path coverage for the remaining three release-tooling globs. Without these,
+# a typo in any single pattern would route that path to the generator-sensitive
+# script/* CI-infra arm undetected.
+test_release_forward_port_script_change_runs_ruby_tests_and_lint_without_generators() {
+  setup_repo
+  write_file_change "script/release-forward-port" "#!/usr/bin/env bash"
+
+  assert_release_tooling_contract "$(detector_output)" "release-forward-port output"
+}
+
+test_release_forward_port_test_change_runs_ruby_tests_and_lint_without_generators() {
+  setup_repo
+  write_file_change "script/release-forward-port-test.bash" "#!/usr/bin/env bash"
+
+  assert_release_tooling_contract "$(detector_output)" "release-forward-port-test output"
+}
+
+test_release_finish_test_change_runs_ruby_tests_and_lint_without_generators() {
+  setup_repo
+  write_file_change "script/release-finish-test.bash" "#!/usr/bin/env bash"
+
+  assert_release_tooling_contract "$(detector_output)" "release-finish-test output"
 }
 
 # Regression guard: a CHANGELOG.md-only change is documentation (matched by the
@@ -967,8 +998,11 @@ test_empty_diff_skips_everything() {
 }
 
 run_test test_empty_diff_skips_everything
-run_test test_release_rake_change_runs_ruby_tests_without_generators
-run_test test_release_finish_script_change_runs_ruby_tests_without_generators
+run_test test_release_rake_change_runs_ruby_tests_and_lint_without_generators
+run_test test_release_finish_script_change_runs_ruby_tests_and_lint_without_generators
+run_test test_release_forward_port_script_change_runs_ruby_tests_and_lint_without_generators
+run_test test_release_forward_port_test_change_runs_ruby_tests_and_lint_without_generators
+run_test test_release_finish_test_change_runs_ruby_tests_and_lint_without_generators
 run_test test_changelog_only_change_is_non_runtime_only
 run_test test_docs_changes_are_non_runtime_only
 run_test test_internal_non_markdown_docs_are_non_runtime_only

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -919,10 +919,14 @@ assert_release_tooling_contract() {
   # Primary goal: NOT generator-sensitive, so required-pr-gate won't force hosted CI.
   assert_contains "$out" '"run_generators": false' "$label"
   assert_contains "$out" '"run_js_tests": false' "$label"
-  # Release tooling does not exercise the dummy app, E2E, or benchmarks.
+  # Release tooling does not exercise the dummy app, E2E, or benchmarks. Assert
+  # the FULL benchmark contract so a regression that flips any benchmark suite
+  # (e.g. a stray BENCH_PRO_CHANGED) cannot pass.
   assert_contains "$out" '"run_dummy_tests": false' "$label"
   assert_contains "$out" '"run_e2e_tests": false' "$label"
   assert_contains "$out" '"run_core_benchmarks": false' "$label"
+  assert_contains "$out" '"run_pro_benchmarks": false' "$label"
+  assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "$label"
 }
 
 test_release_rake_change_runs_ruby_tests_and_lint_without_generators() {
@@ -966,6 +970,31 @@ test_release_finish_test_change_runs_ruby_tests_and_lint_without_generators() {
   assert_release_tooling_contract "$(detector_output)" "release-finish-test output"
 }
 
+# Comment-only change to release tooling takes the SOURCE_COMMENT_ONLY_CHANGED
+# branch of the release arm (not RELEASE_TOOLING_CHANGED), so it stays
+# non-runtime — rubocop still runs (lint catches comment-affecting style) but the
+# release rspec suite does not. Mirrors
+# test_benchmark_comment_only_change_is_non_runtime_but_keeps_lint. The fixture
+# uses plain Ruby with no heredoc so source_file_has_multiline_string_construct
+# does not (correctly, conservatively) force a full run.
+test_release_tooling_comment_only_change_is_non_runtime_but_keeps_lint() {
+  setup_repo
+  mkdir -p rakelib
+  printf 'namespace :release do\n  task :stub do\n    puts "ok"\n  end\nend\n' > rakelib/release.rake
+  commit_change "add release rake stub"
+  perl -0pi -e 's/namespace :release do/# Describe the release tasks.\nnamespace :release do/' \
+    rakelib/release.rake
+  commit_change "release rake comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": false' "release comment output"
+  assert_contains "$out" '"non_runtime_only": true' "release comment output"
+  assert_contains "$out" '"run_lint": true' "release comment output"
+  assert_contains "$out" '"run_ruby_tests": false' "release comment output"
+  assert_contains "$out" '"run_generators": false' "release comment output"
+}
+
 # Regression guard: a CHANGELOG.md-only change is documentation (matched by the
 # *.md docs arm) and must stay skippable — docs_only / non_runtime_only true,
 # every run_* false. Release stamping touches CHANGELOG.md, so this keeps that
@@ -1003,6 +1032,7 @@ run_test test_release_finish_script_change_runs_ruby_tests_and_lint_without_gene
 run_test test_release_forward_port_script_change_runs_ruby_tests_and_lint_without_generators
 run_test test_release_forward_port_test_change_runs_ruby_tests_and_lint_without_generators
 run_test test_release_finish_test_change_runs_ruby_tests_and_lint_without_generators
+run_test test_release_tooling_comment_only_change_is_non_runtime_but_keeps_lint
 run_test test_changelog_only_change_is_non_runtime_only
 run_test test_docs_changes_are_non_runtime_only
 run_test test_internal_non_markdown_docs_are_non_runtime_only


### PR DESCRIPTION
## What & why

Follow-up to the release-train series (#4255–#4258). A change to release-tooling source (`rakelib/release.rake`, `script/release-forward-port`, `script/release-finish`) currently hits the **catch-all** in `script/ci-changes-detector` (`*) return 1`), treated as "unknown → run everything" (`run_generators=true`). That makes `required-pr-gate` demand the full hosted matrix (Generator/Playwright/Integration/JS) — none of which exercise release tooling. The only tests that cover this code are the release specs.

This classifies those paths to run **rubocop + the release rspec** and **not** be generator-sensitive, so `required-pr-gate` no longer forces hosted CI for release-tooling PRs.

## Changes

- `script/ci-changes-detector`: new case arm (before the `script/*` CI-infra arm, after the specific source/spec arms) for `rakelib/release.rake`, `script/release-forward-port`(+`-test.bash`), `script/release-finish`(+`-test.bash`). Sets `DOCS_ONLY=false`, routes to `RSPEC_CHANGED=true`, sets no `GENERATORS_CHANGED`/`JS_CHANGED`. The detector itself and other unclassified paths keep the full-CI catch-all.
- `script/ci-changes-detector-test.bash`: 3 cases (`release.rake`-only, `release-finish`-only → `run_generators=false`; `CHANGELOG.md`-only → `docs_only=true` regression guard).

## Validation

- `bash script/ci-changes-detector-test.bash` → `52 run, 0 failed`.
- Before/after on `origin/jg/release-start-rc-cut`: `run_generators` **true → false** (`run_ruby_tests=true` preserved).
- `shellcheck -x` clean; release rspec → `256 examples, 0 failures`.

## Notes

- Coverage intact: `run_ruby_tests=true` preserved, so the release specs + rubocop run wherever hosted CI is selected (push-to-main, merge queue, release-targeted PRs, `+ci-run-hosted`). Opt-in rather than gate-forced on ordinary release-tooling PRs — consistent with the repo's optimized-CI philosophy.
- No changelog entry: CI tooling (no-entry category).

Confidence note: high. Additive detector arm; 52 detector tests green incl. new cases + a changelog regression guard; before/after effect proven on a real branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI change detection so edits to release tooling are routed to the correct Ruby test and lint workflow.
  * Release-tooling-only changes no longer trigger benchmark runs or generator/JS-sensitive hosted-matrix behavior.
  * Documentation-only (including changelog-only and comment-only) updates are correctly treated as non-runtime, keeping runtime suites disabled.

* **Tests**
  * Added regression coverage for release tooling change detection across multiple release-related scripts and comment-only scenarios, and updated the test suite accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->