### PR TITLE
[codex] Wire release harnesses into CI

### DIFF
--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -68,7 +68,9 @@ jobs:
             script/release-finish-test.bash
 
       - name: Ruby syntax check release scripts
-        run: ruby -c script/release-forward-port && ruby -c script/release-finish
+        run: |
+          ruby -c script/release-forward-port
+          ruby -c script/release-finish
 
       - name: Run git-diff-base test harness
         run: bash script/lib/git-diff-base-test.bash

--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -69,8 +69,14 @@ jobs:
 
       - name: Ruby syntax check release scripts
         run: |
+          set +e
           ruby -c script/release-forward-port
+          forward_port_status=$?
           ruby -c script/release-finish
+          finish_status=$?
+          if [ "$forward_port_status" -ne 0 ] || [ "$finish_status" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Run git-diff-base test harness
         run: bash script/lib/git-diff-base-test.bash

--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Ruby for release harnesses
         uses: ./.github/actions/setup-ruby
         with:
-          ruby-version: ${{ steps.tool-versions.outputs.ruby-version }}
+          ruby-version: ${{ steps.tool-versions.outputs.ruby-minor-version }}
           install-libyaml: 'false'
 
       - name: Shellcheck detector scripts and test harnesses

--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Shellcheck detector scripts and test harnesses
         run: |
           shellcheck -x \
+            bin/read-tool-version \
             script/lib/git-diff-base \
             script/lib/git-diff-base-test.bash \
             script/ci-changes-detector \

--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -11,6 +11,10 @@ on:
       - 'script/lib/git-diff-base-test.bash'
       - 'script/ci-changes-detector'
       - 'script/ci-changes-detector-test.bash'
+      - 'script/release-forward-port'
+      - 'script/release-forward-port-test.bash'
+      - 'script/release-finish'
+      - 'script/release-finish-test.bash'
       - '.github/workflows/git-diff-base-tests.yml'
   pull_request:
     paths:
@@ -18,6 +22,10 @@ on:
       - 'script/lib/git-diff-base-test.bash'
       - 'script/ci-changes-detector'
       - 'script/ci-changes-detector-test.bash'
+      - 'script/release-forward-port'
+      - 'script/release-forward-port-test.bash'
+      - 'script/release-finish'
+      - 'script/release-finish-test.bash'
       - '.github/workflows/git-diff-base-tests.yml'
   workflow_dispatch:
 
@@ -30,10 +38,23 @@ jobs:
           persist-credentials: false
 
       - name: Shellcheck detector scripts and test harnesses
-        run: shellcheck -x script/lib/git-diff-base script/lib/git-diff-base-test.bash script/ci-changes-detector script/ci-changes-detector-test.bash
+        run: |
+          shellcheck -x \
+            script/lib/git-diff-base \
+            script/lib/git-diff-base-test.bash \
+            script/ci-changes-detector \
+            script/ci-changes-detector-test.bash \
+            script/release-forward-port-test.bash \
+            script/release-finish-test.bash
 
       - name: Run git-diff-base test harness
         run: bash script/lib/git-diff-base-test.bash
 
       - name: Run CI changes detector test harness
         run: bash script/ci-changes-detector-test.bash
+
+      - name: Run release forward-port test harness
+        run: bash script/release-forward-port-test.bash
+
+      - name: Run release finish test harness
+        run: bash script/release-finish-test.bash

--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -15,6 +15,11 @@ on:
       - 'script/release-forward-port-test.bash'
       - 'script/release-finish'
       - 'script/release-finish-test.bash'
+      - 'bin/read-tool-version'
+      - '.tool-versions'
+      - '.minimum.tool-versions'
+      - '.github/actions/read-tool-versions/**'
+      - '.github/actions/setup-ruby/**'
       - '.github/workflows/git-diff-base-tests.yml'
   pull_request:
     paths:
@@ -26,6 +31,11 @@ on:
       - 'script/release-forward-port-test.bash'
       - 'script/release-finish'
       - 'script/release-finish-test.bash'
+      - 'bin/read-tool-version'
+      - '.tool-versions'
+      - '.minimum.tool-versions'
+      - '.github/actions/read-tool-versions/**'
+      - '.github/actions/setup-ruby/**'
       - '.github/workflows/git-diff-base-tests.yml'
   workflow_dispatch:
 
@@ -37,6 +47,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Read runtime versions
+        id: tool-versions
+        uses: ./.github/actions/read-tool-versions
+
+      - name: Set up Ruby for release harnesses
+        uses: ./.github/actions/setup-ruby
+        with:
+          ruby-version: ${{ steps.tool-versions.outputs.ruby-version }}
+          install-libyaml: 'false'
+
       - name: Shellcheck detector scripts and test harnesses
         run: |
           shellcheck -x \
@@ -46,6 +66,9 @@ jobs:
             script/ci-changes-detector-test.bash \
             script/release-forward-port-test.bash \
             script/release-finish-test.bash
+
+      - name: Ruby syntax check release scripts
+        run: ruby -c script/release-forward-port && ruby -c script/release-finish
 
       - name: Run git-diff-base test harness
         run: bash script/lib/git-diff-base-test.bash


### PR DESCRIPTION
## Summary

Wire the release-train Bash harnesses into the hosted `git-diff-base-tests.yml` workflow.

- Trigger the workflow when the release scripts, release harnesses, runtime-version files, local Ruby setup actions, `bin/read-tool-version`, or this workflow changes.
- Read the repo runtime versions, set up Ruby through the repo-local `setup-ruby` action, and run the release harnesses on the current Ruby minor line.
- ShellCheck the detector scripts plus `bin/read-tool-version` and the two release Bash harnesses.
- Run explicit Ruby syntax checks for `script/release-forward-port` and `script/release-finish` before executing both release harnesses.

## Root Cause

The release automation added local Bash harnesses, but the hosted harness workflow only listed `git-diff-base` and `ci-changes-detector` files in its path filters and steps. Release script changes could be classified by `script/ci-changes-detector`, but no hosted workflow directly ran the release forward-port or release-finish harnesses for `script/release-*` changes.

## Verification

- `shellcheck -x script/lib/git-diff-base script/lib/git-diff-base-test.bash script/ci-changes-detector script/ci-changes-detector-test.bash script/release-forward-port-test.bash script/release-finish-test.bash`
- `bash script/ci-changes-detector-test.bash` (56 run, 0 failed)
- `bash script/release-forward-port-test.bash` (16 run, 0 failed)
- `bash script/release-finish-test.bash` (22 run, 0 failed)
- `actionlint`
- `ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].sort.each { |f| YAML.safe_load_file(f, permitted_classes: [], aliases: false) }"`
- `pnpm start format.listDifferent`
- `script/ci-changes-detector origin/main`
- `codex review --uncommitted`
- Current-head hosted CI requested with `+ci-run-hosted`; `required-pr-gate` is green for `9391acfdaf4f`.

Known local gaps:

- `yamllint .github/` is not available locally (`command not found`).
- `bundle exec rubocop` fails on pre-existing `react_on_rails/spike/3313_prism_gemfile_rewriter/*` offenses unrelated to this workflow-only diff.
- `bash script/lib/git-diff-base-test.bash` fails locally on Apple Git 2.50.1 in `test_resolve_logs_deepen_progress` with `fatal: could not parse HEAD`; this harness was already part of the hosted workflow before this change, so hosted Ubuntu CI is the source of truth for that harness.

## Workflow Change Audit

- Secret references: unchanged; no secrets added or referenced.
- `permissions:` unchanged: `contents: read`.
- Checkout remains `actions/checkout@v4` with `persist-credentials: false`.
- New local actions executed by this workflow: `./.github/actions/read-tool-versions` and `./.github/actions/setup-ruby`.
- New transitive third-party action: the repo-local setup wrapper invokes `ruby/setup-ruby@v1`; no version change to that wrapper was made in this PR.
- `on:` triggers now include release scripts/harnesses, `bin/read-tool-version`, `.tool-versions`, `.minimum.tool-versions`, `.github/actions/read-tool-versions/**`, `.github/actions/setup-ruby/**`, and `.github/workflows/git-diff-base-tests.yml` in both `push` and `pull_request` path filters.
- New hosted gates: ShellCheck now covers the new harness dependencies, Ruby syntax checks run for the release scripts, and both release harnesses run in the existing workflow.
- Post-merge exercise follow-up: https://github.com/shakacode/react_on_rails/issues/4292
