### PR TITLE
Harden docs-only safety guard against pagination regressions

### DIFF
--- a/.github/actions/ensure-main-docs-safety/action.yml
+++ b/.github/actions/ensure-main-docs-safety/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'String output from ci-changes-detector ("true" or "false")'
     required: true
   previous-sha:
-    description: 'SHA of the previous commit on main (github.event.before)'
+    description: 'SHA to inspect for prior main CI status (github.event.before or github.event.merge_group.base_sha)'
     required: true
   exclude-workflows:
     description: 'Comma-separated workflow names to exclude from failure checks (e.g., "Benchmark Workflow")'

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -87,7 +87,13 @@ async function listJobsForRun({ github, context, run }) {
     run_id: run.id,
     per_page: 100,
   })) {
-    jobs.push(...response.data.jobs);
+    const pageJobs = Array.isArray(response.data) ? response.data : response.data?.jobs;
+
+    if (!Array.isArray(pageJobs)) {
+      throw new TypeError(`Expected jobs array while listing workflow run ${run.id} (${run.name}).`);
+    }
+
+    jobs.push(...pageJobs);
   }
 
   return jobs;

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -218,7 +218,13 @@ async function checkPreviousMainCommitStatus({
     });
 
     if (result.status === 'no-runs') {
-      core.info(`No workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`);
+      core.info(
+        [
+          `No push-event workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
+          'For batched merge queues, github.event.merge_group.base_sha can be a synthetic queue commit',
+          'that was never pushed to main, so there may be no push-event runs to inspect.',
+        ].join(' '),
+      );
       return;
     }
 

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -1,6 +1,7 @@
 const FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'action_required']);
 const GUARD_JOB_NAME = 'detect-changes';
 const GUARD_STEP_NAME = 'Guard docs-only main pushes';
+const TRUSTED_RUN_EVENTS = new Set(['push', 'merge_group']);
 const MAX_GUARD_ONLY_HOPS = 10;
 const MAX_NO_RUNS_HOPS = 50;
 
@@ -68,7 +69,9 @@ async function listWorkflowRunsForSha({ github, context, sha, createdAfter }) {
     direction: 'desc',
   })) {
     const pageRuns = response.data;
-    const relevantInPage = pageRuns.filter((run) => run.head_sha === sha);
+    const relevantInPage = pageRuns.filter(
+      (run) => run.head_sha === sha && TRUSTED_RUN_EVENTS.has(run.event),
+    );
 
     if (relevantInPage.length > 0) {
       workflowRuns.push(...relevantInPage);
@@ -254,7 +257,7 @@ function formatNoRunsTrailDetails(noRunsTrail) {
 
   return [
     '',
-    'Skipped candidate commits with no workflow runs while looking for the underlying CI state:',
+    'Skipped candidate commits with no trusted workflow runs while looking for the underlying CI state:',
     ...noRunsTrail.map((sha) => `- ${sha}`),
   ].join('\n');
 }
@@ -332,7 +335,7 @@ async function checkPreviousMainCommitStatus({
       if (parentSha) {
         core.info(
           [
-            `No workflow runs found for ${shaToCheck} in the last 7 days.`,
+            `No trusted workflow runs found for ${shaToCheck} in the last 7 days.`,
             'For batched merge queues, github.event.merge_group.base_sha can be a synthetic queue commit',
             `that was never pushed to main. Checking first parent ${parentSha} for the underlying CI state.`,
           ].join(' '),
@@ -358,12 +361,14 @@ async function checkPreviousMainCommitStatus({
       if (context.eventName === 'merge_group') {
         core.info(
           [
-            `No workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
+            `No trusted workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
             'This SHA is already in the default branch history; no parent tracing needed.',
           ].join('\n'),
         );
       } else {
-        core.info(`No workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`);
+        core.info(
+          `No trusted workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
+        );
       }
       return;
     }

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -57,46 +57,112 @@ function isGuardOnlyFailure(jobs) {
   );
 }
 
-async function listWorkflowRunsForSha({ github, context, sha, createdAfter }) {
+function githubApiErrorStatus(error) {
+  return error?.status ?? error?.response?.status;
+}
+
+function isGithubApiFailure(error) {
+  return Boolean(error?.githubApiFailure);
+}
+
+function githubApiFailureDetails(error, status = githubApiErrorStatus(error)) {
+  if (error?.githubApiFailure) {
+    return error.message || '';
+  }
+
+  const details = [];
+
+  if (status !== undefined) {
+    details.push(`GitHub API status: ${status}.`);
+  }
+
+  if (error?.message) {
+    details.push(error.message);
+  }
+
+  return details.join(' ');
+}
+
+function wrapGithubApiFailure(error, message) {
+  const status = githubApiErrorStatus(error);
+  const wrappedError = new Error([message, githubApiFailureDetails(error, status)].filter(Boolean).join(' '));
+
+  wrappedError.githubApiFailure = true;
+
+  if (status !== undefined) {
+    wrappedError.status = status;
+  }
+
+  return wrappedError;
+}
+
+async function listWorkflowRunsForEvent({ github, context, sha, createdAfter, event }) {
   const workflowRuns = [];
 
-  for await (const response of github.paginate.iterator(github.rest.actions.listWorkflowRunsForRepo, {
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    per_page: 30,
-    created: `>${createdAfter}`,
-    sort: 'created',
-    direction: 'desc',
-  })) {
-    const pageRuns = response.data;
-    const relevantInPage = pageRuns.filter(
-      (run) => run.head_sha === sha && TRUSTED_RUN_EVENTS.has(run.event),
-    );
+  try {
+    for await (const response of github.paginate.iterator(github.rest.actions.listWorkflowRunsForRepo, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      event,
+      per_page: 30,
+      created: `>${createdAfter}`,
+      sort: 'created',
+      direction: 'desc',
+    })) {
+      const pageRuns = response.data;
+      const relevantInPage = pageRuns.filter((run) => run.head_sha === sha);
 
-    if (relevantInPage.length > 0) {
-      workflowRuns.push(...relevantInPage);
+      if (relevantInPage.length > 0) {
+        workflowRuns.push(...relevantInPage);
+      }
     }
+  } catch (error) {
+    throw wrapGithubApiFailure(
+      error,
+      `GitHub Actions API failed while listing ${event} workflow runs for ${sha}.`,
+    );
   }
 
   return workflowRuns;
 }
 
+async function listWorkflowRunsForSha({ github, context, sha, createdAfter }) {
+  const runsByEvent = await Promise.all(
+    Array.from(TRUSTED_RUN_EVENTS, (event) =>
+      listWorkflowRunsForEvent({ github, context, sha, createdAfter, event }),
+    ),
+  );
+
+  return runsByEvent.flat();
+}
+
 async function listJobsForRun({ github, context, run }) {
   const jobs = [];
 
-  for await (const response of github.paginate.iterator(github.rest.actions.listJobsForWorkflowRun, {
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    run_id: run.id,
-    per_page: 100,
-  })) {
-    const pageJobs = Array.isArray(response.data) ? response.data : response.data?.jobs;
+  try {
+    for await (const response of github.paginate.iterator(github.rest.actions.listJobsForWorkflowRun, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      run_id: run.id,
+      per_page: 100,
+    })) {
+      const pageJobs = Array.isArray(response.data) ? response.data : response.data?.jobs;
 
-    if (!Array.isArray(pageJobs)) {
-      throw new TypeError(`Expected jobs array while listing workflow run ${run.id} (${run.name}).`);
+      if (!Array.isArray(pageJobs)) {
+        throw new TypeError(`Expected jobs array while listing workflow run ${run.id} (${run.name}).`);
+      }
+
+      jobs.push(...pageJobs);
+    }
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw error;
     }
 
-    jobs.push(...pageJobs);
+    throw wrapGithubApiFailure(
+      error,
+      `GitHub Actions API failed while listing jobs for workflow run ${run.id} (${run.name}).`,
+    );
   }
 
   return jobs;
@@ -174,41 +240,6 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
     failingRuns,
     guardOnlyRuns,
   };
-}
-
-function githubApiErrorStatus(error) {
-  return error?.status ?? error?.response?.status;
-}
-
-function isGithubApiFailure(error) {
-  return Boolean(error?.githubApiFailure);
-}
-
-function githubApiFailureDetails(error, status = githubApiErrorStatus(error)) {
-  const details = [];
-
-  if (status !== undefined) {
-    details.push(`GitHub API status: ${status}.`);
-  }
-
-  if (error?.message) {
-    details.push(error.message);
-  }
-
-  return details.join(' ');
-}
-
-function wrapGithubApiFailure(error, message) {
-  const status = githubApiErrorStatus(error);
-  const wrappedError = new Error([message, githubApiFailureDetails(error, status)].filter(Boolean).join(' '));
-
-  wrappedError.githubApiFailure = true;
-
-  if (status !== undefined) {
-    wrappedError.status = status;
-  }
-
-  return wrappedError;
 }
 
 async function firstParentSha({ github, context, sha }) {

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -185,14 +185,18 @@ async function firstParentSha({ github, context, sha }) {
 }
 
 function githubApiErrorStatus(error) {
-  return error?.status || error?.response?.status;
+  return error?.status ?? error?.response?.status;
+}
+
+function isGithubApiFailure(error) {
+  return Boolean(error?.githubApiFailure) || githubApiErrorStatus(error) !== undefined;
 }
 
 function githubApiFailureDetails(error) {
   const status = githubApiErrorStatus(error);
   const details = [];
 
-  if (status) {
+  if (status !== undefined) {
     details.push(`GitHub API status: ${status}.`);
   }
 
@@ -221,15 +225,17 @@ async function isCommitReachableFromDefaultBranch({ github, context, sha }) {
       return false;
     }
 
-    if (status) {
-      const wrappedError = new Error(
-        `GitHub compare API failed while checking whether ${sha} is reachable from ${defaultBranch}. ${githubApiFailureDetails(error)}`,
-      );
+    const details = githubApiFailureDetails(error);
+    const wrappedError = new Error(
+      [`GitHub compare API failed while checking whether ${sha} is reachable from ${defaultBranch}.`, details]
+        .filter(Boolean)
+        .join(' '),
+    );
+    wrappedError.githubApiFailure = true;
+    if (status !== undefined) {
       wrappedError.status = status;
-      throw wrappedError;
     }
-
-    throw error;
+    throw wrappedError;
   }
 }
 
@@ -329,7 +335,6 @@ async function checkPreviousMainCommitStatus({
       }
 
       if (shouldTraceNoRunsParent) {
-        noRunsTrail.push(shaToCheck);
         core.setFailed(
           [
             `Cannot determine prior real CI status because merge queue SHA ${shaToCheck} is not in the default branch and has no parent commits to inspect.`,
@@ -418,7 +423,7 @@ async function checkPreviousMainCommitStatus({
   try {
     await checkSha(previousSha, maxGuardOnlyHops, maxNoRunsHops);
   } catch (error) {
-    if (!githubApiErrorStatus(error)) {
+    if (!isGithubApiFailure(error)) {
       throw error;
     }
 

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -183,6 +183,26 @@ async function firstParentSha({ github, context, sha }) {
   return response.data.parents?.[0]?.sha;
 }
 
+async function isCommitReachableFromDefaultBranch({ github, context, sha }) {
+  const defaultBranch = context.payload?.repository?.default_branch || 'main';
+
+  try {
+    const response = await github.request('GET /repos/{owner}/{repo}/compare/{basehead}', {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      basehead: `${sha}...${defaultBranch}`,
+    });
+
+    return response.data.status === 'ahead' || response.data.status === 'identical';
+  } catch (error) {
+    if (error.status === 404) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
 async function checkPreviousMainCommitStatus({
   github,
   context,
@@ -199,11 +219,12 @@ async function checkPreviousMainCommitStatus({
   }
 
   const guardOnlyTrail = [];
+  const noRunsTrail = [];
 
   async function checkSha(shaToCheck, remainingGuardOnlyHops) {
     if (remainingGuardOnlyHops <= 0) {
       core.setFailed(
-        `Cannot determine prior real CI status after ${maxGuardOnlyHops} docs-only guard-only commits. Push a non-docs change to trigger hosted CI.`,
+        `Cannot determine prior real CI status after ${maxGuardOnlyHops} docs-only guard-only or no-run candidate commits. Push a non-docs change to trigger hosted CI.`,
       );
       return;
     }
@@ -218,11 +239,32 @@ async function checkPreviousMainCommitStatus({
     });
 
     if (result.status === 'no-runs') {
+      const shouldTraceNoRunsParent =
+        context.eventName === 'merge_group' &&
+        !(await isCommitReachableFromDefaultBranch({ github, context, sha: shaToCheck }));
+      const parentSha = shouldTraceNoRunsParent
+        ? await firstParentSha({ github, context, sha: shaToCheck })
+        : null;
+
+      if (parentSha) {
+        core.info(
+          [
+            `No push-event workflow runs found for ${shaToCheck} in the last 7 days.`,
+            'For batched merge queues, github.event.merge_group.base_sha can be a synthetic queue commit',
+            `that was never pushed to main. Checking first parent ${parentSha} for the underlying CI state.`,
+          ].join(' '),
+        );
+        noRunsTrail.push(shaToCheck);
+        await checkSha(parentSha, remainingGuardOnlyHops - 1);
+        return;
+      }
+
       core.info(
         [
           `No push-event workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
-          'For batched merge queues, github.event.merge_group.base_sha can be a synthetic queue commit',
-          'that was never pushed to main, so there may be no push-event runs to inspect.',
+          shouldTraceNoRunsParent
+            ? 'No parent commit was found to inspect for an underlying CI state.'
+            : 'Only merge_group SHAs outside the default branch history are traced through their first parent.',
         ].join(' '),
       );
       return;
@@ -244,6 +286,14 @@ async function checkPreviousMainCommitStatus({
 
     if (result.failingRuns.length > 0) {
       const details = result.failingRuns.map(summarizeRun).join('\n');
+      const noRunsTrailDetails =
+        noRunsTrail.length > 0
+          ? [
+              '',
+              'Skipped candidate commits with no push-event runs while looking for the underlying CI state:',
+              ...noRunsTrail.map((sha) => `- ${sha}`),
+            ].join('\n')
+          : '';
       const guardTrailDetails =
         guardOnlyTrail.length > 0
           ? [
@@ -260,6 +310,7 @@ async function checkPreviousMainCommitStatus({
         [
           `Cannot skip CI for docs-only commit because main commit ${shaToCheck} still has failing workflows:`,
           details,
+          noRunsTrailDetails,
           guardTrailDetails,
           '',
           'Fix these failures before pushing docs-only changes, or push non-docs changes to trigger hosted CI.',

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -265,7 +265,7 @@ async function checkPreviousMainCommitStatus({
           shouldTraceNoRunsParent
             ? 'No parent commit was found to inspect for an underlying CI state.'
             : 'Only merge_group SHAs outside the default branch history are traced through their first parent.',
-        ].join(' '),
+        ].join('\n'),
       );
       return;
     }

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -21,7 +21,11 @@ function latestRunsByWorkflow(workflowRuns) {
 
   for (const run of workflowRuns) {
     const existing = latestByWorkflow.get(run.workflow_id);
-    if (!existing || run.run_number > existing.run_number) {
+    if (
+      !existing ||
+      (existing.event !== 'push' && run.event === 'push') ||
+      (existing.event === run.event && run.run_number > existing.run_number)
+    ) {
       latestByWorkflow.set(run.workflow_id, run);
     }
   }
@@ -104,6 +108,7 @@ async function listWorkflowRunsForEvent({ github, context, sha, createdAfter, ev
       owner: context.repo.owner,
       repo: context.repo.repo,
       event,
+      head_sha: sha,
       per_page: 30,
       created: `>${createdAfter}`,
       sort: 'created',
@@ -332,11 +337,15 @@ async function checkPreviousMainCommitStatus({
         remainingGuardOnlyHops <= 0
           ? `${maxGuardOnlyHops} docs-only guard-only commits`
           : `${maxNoRunsHops} no-run merge queue candidate commits`;
+      const noRunsTrailForFailure =
+        remainingNoRunsHops <= 0 && !noRunsTrail.includes(shaToCheck)
+          ? [...noRunsTrail, shaToCheck]
+          : noRunsTrail;
 
       core.setFailed(
         [
           `Cannot determine prior real CI status after ${exhaustedLimit}.`,
-          formatNoRunsTrailDetails(noRunsTrail),
+          formatNoRunsTrailDetails(noRunsTrailForFailure),
           formatGuardOnlyTrailDetails(guardOnlyTrail),
           'Push a non-docs change to trigger hosted CI.',
         ]

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -100,6 +100,16 @@ function wrapGithubApiFailure(error, message) {
   return wrappedError;
 }
 
+function unexpectedGithubApiResponse(message) {
+  const error = new TypeError(message);
+  error.unexpectedGithubApiResponse = true;
+  return error;
+}
+
+function isUnexpectedGithubApiResponse(error) {
+  return Boolean(error?.unexpectedGithubApiResponse);
+}
+
 async function listWorkflowRunsForEvent({ github, context, sha, createdAfter, event }) {
   const workflowRuns = [];
 
@@ -154,13 +164,15 @@ async function listJobsForRun({ github, context, run }) {
       const pageJobs = Array.isArray(response.data) ? response.data : response.data?.jobs;
 
       if (!Array.isArray(pageJobs)) {
-        throw new TypeError(`Expected jobs array while listing workflow run ${run.id} (${run.name}).`);
+        throw unexpectedGithubApiResponse(
+          `Expected jobs array while listing workflow run ${run.id} (${run.name}).`,
+        );
       }
 
       jobs.push(...pageJobs);
     }
   } catch (error) {
-    if (error instanceof TypeError) {
+    if (isUnexpectedGithubApiResponse(error) || error instanceof TypeError) {
       throw error;
     }
 
@@ -474,6 +486,21 @@ async function checkPreviousMainCommitStatus({
   try {
     await checkSha(previousSha, maxGuardOnlyHops, maxNoRunsHops);
   } catch (error) {
+    if (isUnexpectedGithubApiResponse(error)) {
+      core.setFailed(
+        [
+          'Cannot determine prior real CI status because the GitHub API returned an unexpected response.',
+          error.message,
+          formatNoRunsTrailDetails(noRunsTrail),
+          formatGuardOnlyTrailDetails(guardOnlyTrail),
+          'Retry after the GitHub API recovers, or push a non-docs change to trigger hosted CI.',
+        ]
+          .filter(Boolean)
+          .join('\n'),
+      );
+      return;
+    }
+
     if (!isGithubApiFailure(error)) {
       throw error;
     }

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -174,22 +174,12 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
   };
 }
 
-async function firstParentSha({ github, context, sha }) {
-  const response = await github.rest.repos.getCommit({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    ref: sha,
-  });
-
-  return response.data.parents?.[0]?.sha;
-}
-
 function githubApiErrorStatus(error) {
   return error?.status ?? error?.response?.status;
 }
 
 function isGithubApiFailure(error) {
-  return Boolean(error?.githubApiFailure) || githubApiErrorStatus(error) !== undefined;
+  return Boolean(error?.githubApiFailure);
 }
 
 function githubApiFailureDetails(error) {
@@ -205,6 +195,33 @@ function githubApiFailureDetails(error) {
   }
 
   return details.join(' ');
+}
+
+function wrapGithubApiFailure(error, message) {
+  const status = githubApiErrorStatus(error);
+  const wrappedError = new Error([message, githubApiFailureDetails(error)].filter(Boolean).join(' '));
+
+  wrappedError.githubApiFailure = true;
+
+  if (status !== undefined) {
+    wrappedError.status = status;
+  }
+
+  return wrappedError;
+}
+
+async function firstParentSha({ github, context, sha }) {
+  try {
+    const response = await github.rest.repos.getCommit({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: sha,
+    });
+
+    return response.data.parents?.[0]?.sha;
+  } catch (error) {
+    throw wrapGithubApiFailure(error, `GitHub commit API failed while reading first parent for ${sha}.`);
+  }
 }
 
 async function isCommitReachableFromDefaultBranch({ github, context, sha }) {
@@ -225,17 +242,10 @@ async function isCommitReachableFromDefaultBranch({ github, context, sha }) {
       return false;
     }
 
-    const details = githubApiFailureDetails(error);
-    const wrappedError = new Error(
-      [`GitHub compare API failed while checking whether ${sha} is reachable from ${defaultBranch}.`, details]
-        .filter(Boolean)
-        .join(' '),
+    throw wrapGithubApiFailure(
+      error,
+      `GitHub compare API failed while checking whether ${sha} is reachable from ${defaultBranch}.`,
     );
-    wrappedError.githubApiFailure = true;
-    if (status !== undefined) {
-      wrappedError.status = status;
-    }
-    throw wrappedError;
   }
 }
 

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -2,6 +2,7 @@ const FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'actio
 const GUARD_JOB_NAME = 'detect-changes';
 const GUARD_STEP_NAME = 'Guard docs-only main pushes';
 const MAX_GUARD_ONLY_HOPS = 10;
+const MAX_NO_RUNS_HOPS = 50;
 
 function parseExcludeWorkflows(excludeWorkflowsInput) {
   return (excludeWorkflowsInput || '')
@@ -203,6 +204,32 @@ async function isCommitReachableFromDefaultBranch({ github, context, sha }) {
   }
 }
 
+function formatNoRunsTrailDetails(noRunsTrail) {
+  if (noRunsTrail.length === 0) {
+    return '';
+  }
+
+  return [
+    '',
+    'Skipped candidate commits with no push-event runs while looking for the underlying CI state:',
+    ...noRunsTrail.map((sha) => `- ${sha}`),
+  ].join('\n');
+}
+
+function formatGuardOnlyTrailDetails(guardOnlyTrail) {
+  if (guardOnlyTrail.length === 0) {
+    return '';
+  }
+
+  return [
+    '',
+    'Ignored docs-only guard-only failures while looking for the underlying CI state:',
+    ...guardOnlyTrail.map(
+      ({ sha, runs }) => `- ${sha}: ${runs.map((run) => `${run.name} #${run.run_number}`).join(', ')}`,
+    ),
+  ].join('\n');
+}
+
 async function checkPreviousMainCommitStatus({
   github,
   context,
@@ -210,6 +237,7 @@ async function checkPreviousMainCommitStatus({
   previousSha,
   excludeWorkflowsInput,
   maxGuardOnlyHops = MAX_GUARD_ONLY_HOPS,
+  maxNoRunsHops = MAX_NO_RUNS_HOPS,
   createdAfter = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
 }) {
   const excludeWorkflows = parseExcludeWorkflows(excludeWorkflowsInput);
@@ -221,10 +249,22 @@ async function checkPreviousMainCommitStatus({
   const guardOnlyTrail = [];
   const noRunsTrail = [];
 
-  async function checkSha(shaToCheck, remainingGuardOnlyHops) {
-    if (remainingGuardOnlyHops <= 0) {
+  async function checkSha(shaToCheck, remainingGuardOnlyHops, remainingNoRunsHops) {
+    if (remainingGuardOnlyHops <= 0 || remainingNoRunsHops <= 0) {
+      const exhaustedLimit =
+        remainingGuardOnlyHops <= 0
+          ? `${maxGuardOnlyHops} docs-only guard-only commits`
+          : `${maxNoRunsHops} no-run merge queue candidate commits`;
+
       core.setFailed(
-        `Cannot determine prior real CI status after ${maxGuardOnlyHops} docs-only guard-only or no-run candidate commits. Push a non-docs change to trigger hosted CI.`,
+        [
+          `Cannot determine prior real CI status after ${exhaustedLimit}.`,
+          formatNoRunsTrailDetails(noRunsTrail),
+          formatGuardOnlyTrailDetails(guardOnlyTrail),
+          'Push a non-docs change to trigger hosted CI.',
+        ]
+          .filter(Boolean)
+          .join('\n'),
       );
       return;
     }
@@ -255,18 +295,24 @@ async function checkPreviousMainCommitStatus({
           ].join(' '),
         );
         noRunsTrail.push(shaToCheck);
-        await checkSha(parentSha, remainingGuardOnlyHops - 1);
+        await checkSha(parentSha, remainingGuardOnlyHops, remainingNoRunsHops - 1);
         return;
       }
 
-      core.info(
-        [
+      if (context.eventName === 'merge_group') {
+        core.info(
+          [
+            `No push-event workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
+            shouldTraceNoRunsParent
+              ? 'No parent commit was found to inspect for an underlying CI state.'
+              : 'This SHA is already in the default branch history; no parent tracing needed.',
+          ].join('\n'),
+        );
+      } else {
+        core.info(
           `No push-event workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
-          shouldTraceNoRunsParent
-            ? 'No parent commit was found to inspect for an underlying CI state.'
-            : 'Only merge_group SHAs outside the default branch history are traced through their first parent.',
-        ].join('\n'),
-      );
+        );
+      }
       return;
     }
 
@@ -286,32 +332,13 @@ async function checkPreviousMainCommitStatus({
 
     if (result.failingRuns.length > 0) {
       const details = result.failingRuns.map(summarizeRun).join('\n');
-      const noRunsTrailDetails =
-        noRunsTrail.length > 0
-          ? [
-              '',
-              'Skipped candidate commits with no push-event runs while looking for the underlying CI state:',
-              ...noRunsTrail.map((sha) => `- ${sha}`),
-            ].join('\n')
-          : '';
-      const guardTrailDetails =
-        guardOnlyTrail.length > 0
-          ? [
-              '',
-              'Ignored docs-only guard-only failures while looking for the underlying CI state:',
-              ...guardOnlyTrail.map(
-                ({ sha, runs }) =>
-                  `- ${sha}: ${runs.map((run) => `${run.name} #${run.run_number}`).join(', ')}`,
-              ),
-            ].join('\n')
-          : '';
 
       core.setFailed(
         [
           `Cannot skip CI for docs-only commit because main commit ${shaToCheck} still has failing workflows:`,
           details,
-          noRunsTrailDetails,
-          guardTrailDetails,
+          formatNoRunsTrailDetails(noRunsTrail),
+          formatGuardOnlyTrailDetails(guardOnlyTrail),
           '',
           'Fix these failures before pushing docs-only changes, or push non-docs changes to trigger hosted CI.',
         ]
@@ -344,10 +371,10 @@ async function checkPreviousMainCommitStatus({
       `Main commit ${shaToCheck} only has docs-only guard failures. Checking first parent ${parentSha} for the underlying CI state.`,
     );
     guardOnlyTrail.push({ sha: shaToCheck, runs: result.guardOnlyRuns });
-    await checkSha(parentSha, remainingGuardOnlyHops - 1);
+    await checkSha(parentSha, remainingGuardOnlyHops - 1, remainingNoRunsHops);
   }
 
-  await checkSha(previousSha, maxGuardOnlyHops);
+  await checkSha(previousSha, maxGuardOnlyHops, maxNoRunsHops);
 }
 
 module.exports = {

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -328,13 +328,25 @@ async function checkPreviousMainCommitStatus({
         return;
       }
 
+      if (shouldTraceNoRunsParent) {
+        noRunsTrail.push(shaToCheck);
+        core.setFailed(
+          [
+            `Cannot determine prior real CI status because merge queue SHA ${shaToCheck} is not in the default branch and has no parent commits to inspect.`,
+            formatNoRunsTrailDetails(noRunsTrail),
+            'Push a non-docs change to trigger hosted CI.',
+          ]
+            .filter(Boolean)
+            .join('\n'),
+        );
+        return;
+      }
+
       if (context.eventName === 'merge_group') {
         core.info(
           [
             `No push-event workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
-            shouldTraceNoRunsParent
-              ? 'No parent commit was found to inspect for an underlying CI state.'
-              : 'This SHA is already in the default branch history; no parent tracing needed.',
+            'This SHA is already in the default branch history; no parent tracing needed.',
           ].join('\n'),
         );
       } else {
@@ -414,6 +426,8 @@ async function checkPreviousMainCommitStatus({
       [
         'Cannot determine prior real CI status because a GitHub API request failed.',
         githubApiFailureDetails(error),
+        formatNoRunsTrailDetails(noRunsTrail),
+        formatGuardOnlyTrailDetails(guardOnlyTrail),
         'Retry after the GitHub API recovers, or push a non-docs change to trigger hosted CI.',
       ]
         .filter(Boolean)

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -62,7 +62,6 @@ async function listWorkflowRunsForSha({ github, context, sha, createdAfter }) {
   for await (const response of github.paginate.iterator(github.rest.actions.listWorkflowRunsForRepo, {
     owner: context.repo.owner,
     repo: context.repo.repo,
-    event: 'push',
     per_page: 30,
     created: `>${createdAfter}`,
     sort: 'created',
@@ -182,8 +181,7 @@ function isGithubApiFailure(error) {
   return Boolean(error?.githubApiFailure);
 }
 
-function githubApiFailureDetails(error) {
-  const status = githubApiErrorStatus(error);
+function githubApiFailureDetails(error, status = githubApiErrorStatus(error)) {
   const details = [];
 
   if (status !== undefined) {
@@ -199,7 +197,7 @@ function githubApiFailureDetails(error) {
 
 function wrapGithubApiFailure(error, message) {
   const status = githubApiErrorStatus(error);
-  const wrappedError = new Error([message, githubApiFailureDetails(error)].filter(Boolean).join(' '));
+  const wrappedError = new Error([message, githubApiFailureDetails(error, status)].filter(Boolean).join(' '));
 
   wrappedError.githubApiFailure = true;
 
@@ -256,7 +254,7 @@ function formatNoRunsTrailDetails(noRunsTrail) {
 
   return [
     '',
-    'Skipped candidate commits with no push-event runs while looking for the underlying CI state:',
+    'Skipped candidate commits with no workflow runs while looking for the underlying CI state:',
     ...noRunsTrail.map((sha) => `- ${sha}`),
   ].join('\n');
 }
@@ -334,7 +332,7 @@ async function checkPreviousMainCommitStatus({
       if (parentSha) {
         core.info(
           [
-            `No push-event workflow runs found for ${shaToCheck} in the last 7 days.`,
+            `No workflow runs found for ${shaToCheck} in the last 7 days.`,
             'For batched merge queues, github.event.merge_group.base_sha can be a synthetic queue commit',
             `that was never pushed to main. Checking first parent ${parentSha} for the underlying CI state.`,
           ].join(' '),
@@ -360,14 +358,12 @@ async function checkPreviousMainCommitStatus({
       if (context.eventName === 'merge_group') {
         core.info(
           [
-            `No push-event workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
+            `No workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
             'This SHA is already in the default branch history; no parent tracing needed.',
           ].join('\n'),
         );
       } else {
-        core.info(
-          `No push-event workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`,
-        );
+        core.info(`No workflow runs found for ${shaToCheck} in the last 7 days. Allowing docs-only skip.`);
       }
       return;
     }

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -184,6 +184,25 @@ async function firstParentSha({ github, context, sha }) {
   return response.data.parents?.[0]?.sha;
 }
 
+function githubApiErrorStatus(error) {
+  return error?.status || error?.response?.status;
+}
+
+function githubApiFailureDetails(error) {
+  const status = githubApiErrorStatus(error);
+  const details = [];
+
+  if (status) {
+    details.push(`GitHub API status: ${status}.`);
+  }
+
+  if (error?.message) {
+    details.push(error.message);
+  }
+
+  return details.join(' ');
+}
+
 async function isCommitReachableFromDefaultBranch({ github, context, sha }) {
   const defaultBranch = context.payload?.repository?.default_branch || 'main';
 
@@ -196,8 +215,18 @@ async function isCommitReachableFromDefaultBranch({ github, context, sha }) {
 
     return response.data.status === 'ahead' || response.data.status === 'identical';
   } catch (error) {
-    if (error.status === 404) {
+    const status = githubApiErrorStatus(error);
+
+    if (status === 404 || status === 422) {
       return false;
+    }
+
+    if (status) {
+      const wrappedError = new Error(
+        `GitHub compare API failed while checking whether ${sha} is reachable from ${defaultBranch}. ${githubApiFailureDetails(error)}`,
+      );
+      wrappedError.status = status;
+      throw wrappedError;
     }
 
     throw error;
@@ -374,7 +403,23 @@ async function checkPreviousMainCommitStatus({
     await checkSha(parentSha, remainingGuardOnlyHops - 1, remainingNoRunsHops);
   }
 
-  await checkSha(previousSha, maxGuardOnlyHops, maxNoRunsHops);
+  try {
+    await checkSha(previousSha, maxGuardOnlyHops, maxNoRunsHops);
+  } catch (error) {
+    if (!githubApiErrorStatus(error)) {
+      throw error;
+    }
+
+    core.setFailed(
+      [
+        'Cannot determine prior real CI status because a GitHub API request failed.',
+        githubApiFailureDetails(error),
+        'Retry after the GitHub API recovers, or push a non-docs change to trigger hosted CI.',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
 }
 
 module.exports = {

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -80,6 +80,9 @@ function makeGithub({
   defaultBranchContainsSha = {},
   compareErrorByBase = {},
   commitErrorByRef = {},
+  workflowRunListOptions = [],
+  workflowRunIteratorError,
+  jobIteratorErrorByRunId = {},
 }) {
   const listWorkflowRunsForRepo = async () => {};
   const listJobsForWorkflowRun = async ({ run_id: runId }) => ({
@@ -90,6 +93,10 @@ function makeGithub({
     paginate: {
       iterator: async function* iterator(endpoint, options = {}) {
         if (endpoint === listJobsForWorkflowRun) {
+          if (jobIteratorErrorByRunId[options.run_id]) {
+            throw jobIteratorErrorByRunId[options.run_id];
+          }
+
           if (jobIteratorDataByRunId?.[options.run_id]) {
             for (const data of jobIteratorDataByRunId[options.run_id]) {
               yield { data };
@@ -102,6 +109,11 @@ function makeGithub({
             yield { data: { jobs } };
           }
           return;
+        }
+
+        workflowRunListOptions.push(options);
+        if (workflowRunIteratorError) {
+          throw workflowRunIteratorError;
         }
 
         for (const page of pages) {
@@ -510,6 +522,85 @@ async function testWorkflowDispatchRunDoesNotHideFailingTrustedRun() {
   assert.match(core.failed[0], /main commit previous-main still has failing workflows/);
 }
 
+async function testWorkflowRunsQueryTrustedEventsOnly() {
+  const workflowRunListOptions = [];
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {},
+    workflowRunListOptions,
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: 'quiet-main',
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.deepEqual(
+    workflowRunListOptions.map((options) => options.event),
+    ['push', 'merge_group'],
+  );
+}
+
+async function testWorkflowRunListNetworkFailureSetsHelpfulFailure() {
+  const workflowRunError = new Error('read ECONNRESET');
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {},
+    workflowRunIteratorError: workflowRunError,
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: 'previous-main',
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Cannot determine prior real CI status because a GitHub API request failed/);
+  assert.match(core.failed[0], /workflow runs for previous-main/);
+  assert.match(core.failed[0], /read ECONNRESET/);
+}
+
+async function testJobListNetworkFailureSetsHelpfulFailure() {
+  const previous = 'previous-main';
+  const failingRun = run({ id: 26, sha: previous, name: 'Main CI', conclusion: 'failure' });
+  const jobError = new Error('read ECONNRESET');
+  const github = makeGithub({
+    pages: [[failingRun]],
+    jobsByRunId: {},
+    parentsBySha: {},
+    jobIteratorErrorByRunId: {
+      26: jobError,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: previous,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Cannot determine prior real CI status because a GitHub API request failed/);
+  assert.match(core.failed[0], /jobs for workflow run 26/);
+  assert.match(core.failed[0], /read ECONNRESET/);
+}
+
 async function testNoRunSyntheticChainLooksThroughToParentFailure() {
   const syntheticBase = 'synthetic-base';
   const priorSyntheticBase = 'prior-synthetic-base';
@@ -630,6 +721,7 @@ async function testCompareTransientFailureSetsHelpfulFailure() {
   assert.equal(core.failed.length, 1);
   assert.match(core.failed[0], /Cannot determine prior real CI status because a GitHub API request failed/);
   assert.match(core.failed[0], /502/);
+  assert.equal(core.failed[0].match(/GitHub API status: 502/g).length, 1);
   assert.match(core.failed[0], /Skipped candidate commits[\s\S]*- synthetic-base/);
   assert.match(core.failed[0], /prior-synthetic-base/);
   assert.match(core.failed[0], /GitHub is unavailable/);
@@ -766,6 +858,9 @@ async function main() {
   await testNoRunSyntheticBaseAllowsQuietParentSkip();
   await testReachableMergeQueueRunFailureIsChecked();
   await testWorkflowDispatchRunDoesNotHideFailingTrustedRun();
+  await testWorkflowRunsQueryTrustedEventsOnly();
+  await testWorkflowRunListNetworkFailureSetsHelpfulFailure();
+  await testJobListNetworkFailureSetsHelpfulFailure();
   await testNoRunSyntheticChainLooksThroughToParentFailure();
   await testNoRunHopLimitStopsAtConfiguredLimitWithTrail();
   await testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -8,7 +8,7 @@ const {
   parseExcludeWorkflows,
 } = require('./check-previous-main.cjs');
 
-const context = { repo: { owner: 'shakacode', repo: 'react_on_rails' } };
+const context = { eventName: 'push', repo: { owner: 'shakacode', repo: 'react_on_rails' } };
 
 function run({ id, workflowId = id, sha, name = `Workflow ${id}`, runNumber = id, conclusion = 'success' }) {
   return {
@@ -62,7 +62,14 @@ function successJob(name = 'build') {
   };
 }
 
-function makeGithub({ pages, jobsByRunId, jobPagesByRunId, jobIteratorDataByRunId, parentsBySha }) {
+function makeGithub({
+  pages,
+  jobsByRunId,
+  jobPagesByRunId,
+  jobIteratorDataByRunId,
+  parentsBySha,
+  defaultBranchContainsSha = {},
+}) {
   const listWorkflowRunsForRepo = async () => {};
   const listJobsForWorkflowRun = async ({ run_id: runId }) => ({
     data: { jobs: jobsByRunId[runId] || [] },
@@ -91,12 +98,19 @@ function makeGithub({ pages, jobsByRunId, jobPagesByRunId, jobIteratorDataByRunI
         }
       },
     },
+    request: async (_route, { basehead }) => {
+      const [base] = basehead.split('...');
+      return { data: { status: defaultBranchContainsSha[base] ? 'ahead' : 'diverged' } };
+    },
     rest: {
       actions: {
         listWorkflowRunsForRepo,
         listJobsForWorkflowRun,
       },
       repos: {
+        compareCommitsWithBasehead: async ({ base }) => ({
+          data: { status: defaultBranchContainsSha[base] ? 'ahead' : 'diverged' },
+        }),
         getCommit: async ({ ref }) => ({
           data: { parents: parentsBySha[ref] ? [{ sha: parentsBySha[ref] }] : [] },
         }),
@@ -262,7 +276,7 @@ async function testGuardOnlyHopLimitStopsAtConfiguredLimit() {
   });
 
   assert.equal(core.failed.length, 1);
-  assert.match(core.failed[0], /after 1 docs-only guard-only commits/);
+  assert.match(core.failed[0], /after 1 docs-only guard-only or no-run candidate commits/);
 }
 
 async function testGuardOnlyFailuresLookThroughToParentFailure() {
@@ -303,6 +317,125 @@ async function testGuardOnlyFailuresLookThroughToParentFailure() {
   assert.equal(core.failed.length, 1);
   assert.match(core.failed[0], /main commit real-failure still has failing workflows/);
   assert.match(core.failed[0], /Ignored docs-only guard-only failures/);
+}
+
+async function testNoRunSyntheticBaseLooksThroughToParentFailure() {
+  const syntheticBase = 'synthetic-base';
+  const realFailure = 'real-failure';
+  const realRun = run({ id: 16, sha: realFailure, name: 'Main push lint', conclusion: 'failure' });
+  const github = makeGithub({
+    pages: [[realRun]],
+    jobsByRunId: {
+      16: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [syntheticBase]: realFailure,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /main commit real-failure still has failing workflows/);
+}
+
+async function testNoRunPushBaseAllowsQuietMainSkip() {
+  const quietMain = 'quiet-main';
+  const olderFailure = 'older-failure';
+  const realRun = run({ id: 17, sha: olderFailure, name: 'Main push lint', conclusion: 'failure' });
+  const github = makeGithub({
+    pages: [[realRun]],
+    jobsByRunId: {
+      17: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [quietMain]: olderFailure,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: quietMain,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.deepEqual(core.failed, []);
+  assert.match(core.infoMessages.at(-1), /Allowing docs-only skip/);
+}
+
+async function testNoRunSyntheticBaseAllowsQuietParentSkip() {
+  const syntheticBase = 'synthetic-base';
+  const quietMain = 'quiet-main';
+  const olderFailure = 'older-failure';
+  const realRun = run({ id: 18, sha: olderFailure, name: 'Main push lint', conclusion: 'failure' });
+  const github = makeGithub({
+    pages: [[realRun]],
+    jobsByRunId: {
+      18: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [syntheticBase]: quietMain,
+      [quietMain]: olderFailure,
+    },
+    defaultBranchContainsSha: {
+      [quietMain]: true,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.deepEqual(core.failed, []);
+  assert.match(core.infoMessages.at(-1), /Allowing docs-only skip/);
+}
+
+async function testNoRunSyntheticChainLooksThroughToParentFailure() {
+  const syntheticBase = 'synthetic-base';
+  const priorSyntheticBase = 'prior-synthetic-base';
+  const realFailure = 'real-failure';
+  const realRun = run({ id: 19, sha: realFailure, name: 'Main push lint', conclusion: 'failure' });
+  const github = makeGithub({
+    pages: [[realRun]],
+    jobsByRunId: {
+      19: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [syntheticBase]: priorSyntheticBase,
+      [priorSyntheticBase]: realFailure,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /main commit real-failure still has failing workflows/);
 }
 
 async function testGuardOnlyFailuresLookThroughToParentSuccess() {
@@ -352,6 +485,10 @@ async function main() {
   );
 
   await testGuardOnlyFailuresLookThroughToParentFailure();
+  await testNoRunSyntheticBaseLooksThroughToParentFailure();
+  await testNoRunPushBaseAllowsQuietMainSkip();
+  await testNoRunSyntheticBaseAllowsQuietParentSkip();
+  await testNoRunSyntheticChainLooksThroughToParentFailure();
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();
   await testPaginatedJobsAreChecked();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -70,6 +70,7 @@ function makeGithub({
   parentsBySha,
   defaultBranchContainsSha = {},
   compareErrorByBase = {},
+  commitErrorByRef = {},
 }) {
   const listWorkflowRunsForRepo = async () => {};
   const listJobsForWorkflowRun = async ({ run_id: runId }) => ({
@@ -113,9 +114,15 @@ function makeGithub({
         listJobsForWorkflowRun,
       },
       repos: {
-        getCommit: async ({ ref }) => ({
-          data: { parents: parentsBySha[ref] ? [{ sha: parentsBySha[ref] }] : [] },
-        }),
+        getCommit: async ({ ref }) => {
+          if (commitErrorByRef[ref]) {
+            throw commitErrorByRef[ref];
+          }
+
+          return {
+            data: { parents: parentsBySha[ref] ? [{ sha: parentsBySha[ref] }] : [] },
+          };
+        },
       },
     },
   };
@@ -563,6 +570,34 @@ async function testCompareNetworkFailureSetsHelpfulFailure() {
   assert.match(core.failed[0], /read ECONNRESET/);
 }
 
+async function testFirstParentNetworkFailureSetsHelpfulFailure() {
+  const syntheticBase = 'synthetic-base';
+  const commitError = new Error('read ECONNRESET');
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {},
+    commitErrorByRef: {
+      [syntheticBase]: commitError,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Cannot determine prior real CI status because a GitHub API request failed/);
+  assert.match(core.failed[0], /synthetic-base/);
+  assert.match(core.failed[0], /read ECONNRESET/);
+}
+
 async function testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed() {
   const syntheticBase = 'synthetic-base';
   const github = makeGithub({
@@ -641,6 +676,7 @@ async function main() {
   await testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure();
   await testCompareTransientFailureSetsHelpfulFailure();
   await testCompareNetworkFailureSetsHelpfulFailure();
+  await testFirstParentNetworkFailureSetsHelpfulFailure();
   await testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed();
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -69,6 +69,7 @@ function makeGithub({
   jobIteratorDataByRunId,
   parentsBySha,
   defaultBranchContainsSha = {},
+  compareErrorByBase = {},
 }) {
   const listWorkflowRunsForRepo = async () => {};
   const listJobsForWorkflowRun = async ({ run_id: runId }) => ({
@@ -100,6 +101,10 @@ function makeGithub({
     },
     request: async (_route, { basehead }) => {
       const [base] = basehead.split('...');
+      if (compareErrorByBase[base]) {
+        throw compareErrorByBase[base];
+      }
+
       return { data: { status: defaultBranchContainsSha[base] ? 'ahead' : 'diverged' } };
     },
     rest: {
@@ -462,6 +467,69 @@ async function testNoRunHopLimitStopsAtConfiguredLimitWithTrail() {
   assert.match(core.failed[0], /synthetic-base/);
 }
 
+async function testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure() {
+  const syntheticBase = 'synthetic-base';
+  const realFailure = 'real-failure';
+  const failingRun = run({ id: 16, sha: realFailure, name: 'Ruby Tests', conclusion: 'failure' });
+  const compareError = new Error('No common ancestor');
+  compareError.status = 422;
+  const github = makeGithub({
+    pages: [[failingRun]],
+    jobsByRunId: {
+      16: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [syntheticBase]: realFailure,
+    },
+    compareErrorByBase: {
+      [syntheticBase]: compareError,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /main commit real-failure still has failing workflows/);
+  assert.match(core.failed[0], /synthetic-base/);
+}
+
+async function testCompareTransientFailureSetsHelpfulFailure() {
+  const syntheticBase = 'synthetic-base';
+  const compareError = new Error('GitHub is unavailable');
+  compareError.status = 502;
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {},
+    compareErrorByBase: {
+      [syntheticBase]: compareError,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Cannot determine prior real CI status because a GitHub API request failed/);
+  assert.match(core.failed[0], /502/);
+  assert.match(core.failed[0], /GitHub is unavailable/);
+}
+
 async function testGuardOnlyFailuresLookThroughToParentSuccess() {
   const previous = 'docs-1';
   const parent = 'green';
@@ -514,6 +582,8 @@ async function main() {
   await testNoRunSyntheticBaseAllowsQuietParentSkip();
   await testNoRunSyntheticChainLooksThroughToParentFailure();
   await testNoRunHopLimitStopsAtConfiguredLimitWithTrail();
+  await testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure();
+  await testCompareTransientFailureSetsHelpfulFailure();
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();
   await testPaginatedJobsAreChecked();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -117,7 +117,11 @@ function makeGithub({
         }
 
         for (const page of pages) {
-          yield { data: options.event ? page.filter((run) => run.event === options.event) : page };
+          yield {
+            data: page.filter(
+              (run) => (!options.event || run.event === options.event) && run.head_sha === options.head_sha,
+            ),
+          };
         }
       },
     },
@@ -522,7 +526,7 @@ async function testWorkflowDispatchRunDoesNotHideFailingTrustedRun() {
   assert.match(core.failed[0], /main commit previous-main still has failing workflows/);
 }
 
-async function testWorkflowRunsQueryTrustedEventsOnly() {
+async function testWorkflowRunsQueryTrustedEventsAndHeadShaOnly() {
   const workflowRunListOptions = [];
   const github = makeGithub({
     pages: [],
@@ -542,8 +546,11 @@ async function testWorkflowRunsQueryTrustedEventsOnly() {
   });
 
   assert.deepEqual(
-    workflowRunListOptions.map((options) => options.event),
-    ['push', 'merge_group'],
+    workflowRunListOptions.map((options) => ({ event: options.event, headSha: options.head_sha })),
+    [
+      { event: 'push', headSha: 'quiet-main' },
+      { event: 'merge_group', headSha: 'quiet-main' },
+    ],
   );
 }
 
@@ -656,6 +663,7 @@ async function testNoRunHopLimitStopsAtConfiguredLimitWithTrail() {
   assert.equal(core.failed.length, 1);
   assert.match(core.failed[0], /after 1 no-run merge queue candidate commits/);
   assert.match(core.failed[0], /synthetic-base/);
+  assert.match(core.failed[0], /prior-synthetic-base/);
 }
 
 async function testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure() {
@@ -851,6 +859,13 @@ async function main() {
     ]).get(10).id,
     7,
   );
+  assert.equal(
+    latestRunsByWorkflow([
+      run({ id: 8, workflowId: 11, sha: 'a', runNumber: 1, event: 'push' }),
+      run({ id: 9, workflowId: 11, sha: 'a', runNumber: 2, event: 'merge_group' }),
+    ]).get(11).id,
+    8,
+  );
 
   await testGuardOnlyFailuresLookThroughToParentFailure();
   await testNoRunSyntheticBaseLooksThroughToParentFailure();
@@ -858,7 +873,7 @@ async function main() {
   await testNoRunSyntheticBaseAllowsQuietParentSkip();
   await testReachableMergeQueueRunFailureIsChecked();
   await testWorkflowDispatchRunDoesNotHideFailingTrustedRun();
-  await testWorkflowRunsQueryTrustedEventsOnly();
+  await testWorkflowRunsQueryTrustedEventsAndHeadShaOnly();
   await testWorkflowRunListNetworkFailureSetsHelpfulFailure();
   await testJobListNetworkFailureSetsHelpfulFailure();
   await testNoRunSyntheticChainLooksThroughToParentFailure();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -10,11 +10,20 @@ const {
 
 const context = { eventName: 'push', repo: { owner: 'shakacode', repo: 'react_on_rails' } };
 
-function run({ id, workflowId = id, sha, name = `Workflow ${id}`, runNumber = id, conclusion = 'success' }) {
+function run({
+  id,
+  workflowId = id,
+  sha,
+  name = `Workflow ${id}`,
+  runNumber = id,
+  conclusion = 'success',
+  event = 'push',
+}) {
   return {
     id,
     workflow_id: workflowId,
     head_sha: sha,
+    event,
     name,
     run_number: runNumber,
     status: 'completed',
@@ -96,7 +105,7 @@ function makeGithub({
         }
 
         for (const page of pages) {
-          yield { data: page };
+          yield { data: options.event ? page.filter((run) => run.event === options.event) : page };
         }
       },
     },
@@ -106,7 +115,15 @@ function makeGithub({
         throw compareErrorByBase[base];
       }
 
-      return { data: { status: defaultBranchContainsSha[base] ? 'ahead' : 'diverged' } };
+      const configuredStatus = defaultBranchContainsSha[base];
+      let status = 'diverged';
+      if (typeof configuredStatus === 'string') {
+        status = configuredStatus;
+      } else if (configuredStatus) {
+        status = 'ahead';
+      }
+
+      return { data: { status } };
     },
     rest: {
       actions: {
@@ -399,7 +416,7 @@ async function testNoRunSyntheticBaseAllowsQuietParentSkip() {
       [quietMain]: olderFailure,
     },
     defaultBranchContainsSha: {
-      [quietMain]: true,
+      [quietMain]: 'identical',
     },
   });
   const core = makeCore();
@@ -415,6 +432,40 @@ async function testNoRunSyntheticBaseAllowsQuietParentSkip() {
 
   assert.deepEqual(core.failed, []);
   assert.match(core.infoMessages.at(-1), /Allowing docs-only skip/);
+}
+
+async function testReachableMergeQueueRunFailureIsChecked() {
+  const previous = 'merge-queue-main';
+  const failingRun = run({
+    id: 23,
+    sha: previous,
+    name: 'Main queue CI',
+    conclusion: 'failure',
+    event: 'merge_group',
+  });
+  const github = makeGithub({
+    pages: [[failingRun]],
+    jobsByRunId: {
+      23: [buildFailureJob()],
+    },
+    parentsBySha: {},
+    defaultBranchContainsSha: {
+      [previous]: true,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: previous,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /main commit merge-queue-main still has failing workflows/);
 }
 
 async function testNoRunSyntheticChainLooksThroughToParentFailure() {
@@ -671,6 +722,7 @@ async function main() {
   await testNoRunSyntheticBaseLooksThroughToParentFailure();
   await testNoRunPushBaseAllowsQuietMainSkip();
   await testNoRunSyntheticBaseAllowsQuietParentSkip();
+  await testReachableMergeQueueRunFailureIsChecked();
   await testNoRunSyntheticChainLooksThroughToParentFailure();
   await testNoRunHopLimitStopsAtConfiguredLimitWithTrail();
   await testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -468,6 +468,48 @@ async function testReachableMergeQueueRunFailureIsChecked() {
   assert.match(core.failed[0], /main commit merge-queue-main still has failing workflows/);
 }
 
+async function testWorkflowDispatchRunDoesNotHideFailingTrustedRun() {
+  const previous = 'previous-main';
+  const failingPushRun = run({
+    id: 24,
+    workflowId: 240,
+    sha: previous,
+    name: 'Main CI',
+    runNumber: 1,
+    conclusion: 'failure',
+    event: 'push',
+  });
+  const passingManualRun = run({
+    id: 25,
+    workflowId: 240,
+    sha: previous,
+    name: 'Main CI',
+    runNumber: 2,
+    event: 'workflow_dispatch',
+  });
+  const github = makeGithub({
+    pages: [[failingPushRun, passingManualRun]],
+    jobsByRunId: {
+      24: [buildFailureJob()],
+      25: [successJob()],
+    },
+    parentsBySha: {},
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: previous,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /main commit previous-main still has failing workflows/);
+}
+
 async function testNoRunSyntheticChainLooksThroughToParentFailure() {
   const syntheticBase = 'synthetic-base';
   const priorSyntheticBase = 'prior-synthetic-base';
@@ -723,6 +765,7 @@ async function main() {
   await testNoRunPushBaseAllowsQuietMainSkip();
   await testNoRunSyntheticBaseAllowsQuietParentSkip();
   await testReachableMergeQueueRunFailureIsChecked();
+  await testWorkflowDispatchRunDoesNotHideFailingTrustedRun();
   await testNoRunSyntheticChainLooksThroughToParentFailure();
   await testNoRunHopLimitStopsAtConfiguredLimitWithTrail();
   await testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -503,14 +503,17 @@ async function testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure(
 
 async function testCompareTransientFailureSetsHelpfulFailure() {
   const syntheticBase = 'synthetic-base';
+  const priorSyntheticBase = 'prior-synthetic-base';
   const compareError = new Error('GitHub is unavailable');
   compareError.status = 502;
   const github = makeGithub({
     pages: [],
     jobsByRunId: {},
-    parentsBySha: {},
+    parentsBySha: {
+      [syntheticBase]: priorSyntheticBase,
+    },
     compareErrorByBase: {
-      [syntheticBase]: compareError,
+      [priorSyntheticBase]: compareError,
     },
   });
   const core = makeCore();
@@ -527,7 +530,32 @@ async function testCompareTransientFailureSetsHelpfulFailure() {
   assert.equal(core.failed.length, 1);
   assert.match(core.failed[0], /Cannot determine prior real CI status because a GitHub API request failed/);
   assert.match(core.failed[0], /502/);
+  assert.match(core.failed[0], /Skipped candidate commits[\s\S]*- synthetic-base/);
+  assert.match(core.failed[0], /prior-synthetic-base/);
   assert.match(core.failed[0], /GitHub is unavailable/);
+}
+
+async function testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed() {
+  const syntheticBase = 'synthetic-base';
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {},
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /not in the default branch and has no parent commits to inspect/);
+  assert.match(core.failed[0], /synthetic-base/);
 }
 
 async function testGuardOnlyFailuresLookThroughToParentSuccess() {
@@ -584,6 +612,7 @@ async function main() {
   await testNoRunHopLimitStopsAtConfiguredLimitWithTrail();
   await testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure();
   await testCompareTransientFailureSetsHelpfulFailure();
+  await testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed();
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();
   await testPaginatedJobsAreChecked();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -209,6 +209,33 @@ async function testOctokitJobIteratorArrayPagesAreChecked() {
   assert.match(core.failed[0], /Main push lint/);
 }
 
+async function testUnexpectedJobIteratorShapeFailsClearly() {
+  const previous = 'previous';
+  const failingRun = run({ id: 15, sha: previous, name: 'Main push lint', conclusion: 'failure' });
+  const github = makeGithub({
+    pages: [[failingRun]],
+    jobsByRunId: {},
+    jobIteratorDataByRunId: {
+      15: [{}],
+    },
+    parentsBySha: {},
+  });
+  const core = makeCore();
+
+  await assert.rejects(
+    () =>
+      checkPreviousMainCommitStatus({
+        github,
+        context,
+        core,
+        previousSha: previous,
+        excludeWorkflowsInput: '',
+        createdAfter: '2026-01-01T00:00:00.000Z',
+      }),
+    /Expected jobs array while listing workflow run 15 \(Main push lint\)\./,
+  );
+}
+
 async function testGuardOnlyHopLimitStopsAtConfiguredLimit() {
   const previous = 'docs-2';
   const parent = 'docs-1';
@@ -329,6 +356,7 @@ async function main() {
   await testNonContiguousWorkflowRunPagesAreChecked();
   await testPaginatedJobsAreChecked();
   await testOctokitJobIteratorArrayPagesAreChecked();
+  await testUnexpectedJobIteratorShapeFailsClearly();
   await testGuardOnlyHopLimitStopsAtConfiguredLimit();
 }
 

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -535,6 +535,34 @@ async function testCompareTransientFailureSetsHelpfulFailure() {
   assert.match(core.failed[0], /GitHub is unavailable/);
 }
 
+async function testCompareNetworkFailureSetsHelpfulFailure() {
+  const syntheticBase = 'synthetic-base';
+  const compareError = new Error('read ECONNRESET');
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {},
+    compareErrorByBase: {
+      [syntheticBase]: compareError,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Cannot determine prior real CI status because a GitHub API request failed/);
+  assert.match(core.failed[0], /synthetic-base/);
+  assert.match(core.failed[0], /read ECONNRESET/);
+}
+
 async function testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed() {
   const syntheticBase = 'synthetic-base';
   const github = makeGithub({
@@ -612,6 +640,7 @@ async function main() {
   await testNoRunHopLimitStopsAtConfiguredLimitWithTrail();
   await testCompareUnprocessableSyntheticBaseLooksThroughToParentFailure();
   await testCompareTransientFailureSetsHelpfulFailure();
+  await testCompareNetworkFailureSetsHelpfulFailure();
   await testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed();
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -78,6 +78,7 @@ function makeGithub({
   jobIteratorDataByRunId,
   parentsBySha,
   defaultBranchContainsSha = {},
+  compareBaseheads = [],
   compareErrorByBase = {},
   commitErrorByRef = {},
   workflowRunListOptions = [],
@@ -126,6 +127,7 @@ function makeGithub({
       },
     },
     request: async (_route, { basehead }) => {
+      compareBaseheads.push(basehead);
       const [base] = basehead.split('...');
       if (compareErrorByBase[base]) {
         throw compareErrorByBase[base];
@@ -278,18 +280,18 @@ async function testUnexpectedJobIteratorShapeFailsClearly() {
   });
   const core = makeCore();
 
-  await assert.rejects(
-    () =>
-      checkPreviousMainCommitStatus({
-        github,
-        context,
-        core,
-        previousSha: previous,
-        excludeWorkflowsInput: '',
-        createdAfter: '2026-01-01T00:00:00.000Z',
-      }),
-    /Expected jobs array while listing workflow run 15 \(Main push lint\)\./,
-  );
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: previous,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /GitHub API returned an unexpected response/);
+  assert.match(core.failed[0], /Expected jobs array while listing workflow run 15 \(Main push lint\)\./);
 }
 
 async function testGuardOnlyHopLimitStopsAtConfiguredLimit() {
@@ -814,6 +816,34 @@ async function testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed() {
   assert.match(core.failed[0], /synthetic-base/);
 }
 
+async function testMergeGroupReachabilityUsesRepositoryDefaultBranch() {
+  const syntheticBase = 'synthetic-base';
+  const compareBaseheads = [];
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {},
+    compareBaseheads,
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: {
+      ...context,
+      eventName: 'merge_group',
+      payload: { repository: { default_branch: 'trunk' } },
+    },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.deepEqual(compareBaseheads, ['synthetic-base...trunk']);
+}
+
 async function testGuardOnlyFailuresLookThroughToParentSuccess() {
   const previous = 'docs-1';
   const parent = 'green';
@@ -883,6 +913,7 @@ async function main() {
   await testCompareNetworkFailureSetsHelpfulFailure();
   await testFirstParentNetworkFailureSetsHelpfulFailure();
   await testNoRunUnreachableSyntheticBaseWithoutParentFailsClosed();
+  await testMergeGroupReachabilityUsesRepositoryDefaultBranch();
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();
   await testPaginatedJobsAreChecked();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -108,9 +108,6 @@ function makeGithub({
         listJobsForWorkflowRun,
       },
       repos: {
-        compareCommitsWithBasehead: async ({ base }) => ({
-          data: { status: defaultBranchContainsSha[base] ? 'ahead' : 'diverged' },
-        }),
         getCommit: async ({ ref }) => ({
           data: { parents: parentsBySha[ref] ? [{ sha: parentsBySha[ref] }] : [] },
         }),
@@ -276,7 +273,7 @@ async function testGuardOnlyHopLimitStopsAtConfiguredLimit() {
   });
 
   assert.equal(core.failed.length, 1);
-  assert.match(core.failed[0], /after 1 docs-only guard-only or no-run candidate commits/);
+  assert.match(core.failed[0], /after 1 docs-only guard-only commits/);
 }
 
 async function testGuardOnlyFailuresLookThroughToParentFailure() {
@@ -438,6 +435,33 @@ async function testNoRunSyntheticChainLooksThroughToParentFailure() {
   assert.match(core.failed[0], /main commit real-failure still has failing workflows/);
 }
 
+async function testNoRunHopLimitStopsAtConfiguredLimitWithTrail() {
+  const syntheticBase = 'synthetic-base';
+  const priorSyntheticBase = 'prior-synthetic-base';
+  const github = makeGithub({
+    pages: [],
+    jobsByRunId: {},
+    parentsBySha: {
+      [syntheticBase]: priorSyntheticBase,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context: { ...context, eventName: 'merge_group' },
+    core,
+    previousSha: syntheticBase,
+    excludeWorkflowsInput: '',
+    maxNoRunsHops: 1,
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /after 1 no-run merge queue candidate commits/);
+  assert.match(core.failed[0], /synthetic-base/);
+}
+
 async function testGuardOnlyFailuresLookThroughToParentSuccess() {
   const previous = 'docs-1';
   const parent = 'green';
@@ -489,6 +513,7 @@ async function main() {
   await testNoRunPushBaseAllowsQuietMainSkip();
   await testNoRunSyntheticBaseAllowsQuietParentSkip();
   await testNoRunSyntheticChainLooksThroughToParentFailure();
+  await testNoRunHopLimitStopsAtConfiguredLimitWithTrail();
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();
   await testPaginatedJobsAreChecked();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -62,7 +62,7 @@ function successJob(name = 'build') {
   };
 }
 
-function makeGithub({ pages, jobsByRunId, jobPagesByRunId, parentsBySha }) {
+function makeGithub({ pages, jobsByRunId, jobPagesByRunId, jobIteratorDataByRunId, parentsBySha }) {
   const listWorkflowRunsForRepo = async () => {};
   const listJobsForWorkflowRun = async ({ run_id: runId }) => ({
     data: { jobs: jobsByRunId[runId] || [] },
@@ -72,6 +72,13 @@ function makeGithub({ pages, jobsByRunId, jobPagesByRunId, parentsBySha }) {
     paginate: {
       iterator: async function* iterator(endpoint, options = {}) {
         if (endpoint === listJobsForWorkflowRun) {
+          if (jobIteratorDataByRunId?.[options.run_id]) {
+            for (const data of jobIteratorDataByRunId[options.run_id]) {
+              yield { data };
+            }
+            return;
+          }
+
           const jobPages = jobPagesByRunId?.[options.run_id] || [jobsByRunId[options.run_id] || []];
           for (const jobs of jobPages) {
             yield { data: { jobs } };
@@ -174,6 +181,32 @@ async function testPaginatedJobsAreChecked() {
 
   assert.equal(core.failed.length, 1);
   assert.match(core.failed[0], /Large workflow/);
+}
+
+async function testOctokitJobIteratorArrayPagesAreChecked() {
+  const previous = 'previous';
+  const failingRun = run({ id: 14, sha: previous, name: 'Main push lint', conclusion: 'failure' });
+  const github = makeGithub({
+    pages: [[failingRun]],
+    jobsByRunId: {},
+    jobIteratorDataByRunId: {
+      14: [[successJob('setup')], [buildFailureJob()]],
+    },
+    parentsBySha: {},
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: previous,
+    excludeWorkflowsInput: '',
+    createdAfter: '2026-01-01T00:00:00.000Z',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Main push lint/);
 }
 
 async function testGuardOnlyHopLimitStopsAtConfiguredLimit() {
@@ -295,6 +328,7 @@ async function main() {
   await testGuardOnlyFailuresLookThroughToParentSuccess();
   await testNonContiguousWorkflowRunPagesAreChecked();
   await testPaginatedJobsAreChecked();
+  await testOctokitJobIteratorArrayPagesAreChecked();
   await testGuardOnlyHopLimitStopsAtConfiguredLimit();
 }
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -76,11 +76,13 @@ jobs:
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   setup-matrix:
     needs: detect-changes

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -123,7 +123,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -121,11 +121,13 @@ jobs:
           fi
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   rspec-package-tests:
     needs: detect-changes

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,11 +76,13 @@ jobs:
           fi
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   setup-integration-matrix:
     needs: detect-changes

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -71,11 +71,13 @@ jobs:
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   docs-format-check:
     needs: detect-changes

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -73,7 +73,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -73,11 +73,13 @@ jobs:
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   build:
     needs: detect-changes

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,11 +65,13 @@ jobs:
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   playwright:
     needs: detect-changes

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -63,11 +63,13 @@ jobs:
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   precompile-check:
     needs: detect-changes

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -65,7 +65,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -76,11 +76,13 @@ jobs:
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   # Build webpack test bundles for dummy app
   build-dummy-app-webpack-test-bundles:

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -74,11 +74,13 @@ jobs:
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'merge_group'
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+          previous-sha: ${{ github.event.before || github.event.merge_group.base_sha }}
 
   pro-lint:
     needs: detect-changes

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          github.event_name == 'merge_group'
+          (github.event_name == 'merge_group' &&
+           github.event.merge_group.base_ref == 'refs/heads/main')
         uses: ./.github/actions/ensure-main-docs-safety
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}


### PR DESCRIPTION
## Summary

- Normalize docs-only guard job pagination so it handles the live Octokit iterator array shape as well as the existing mocked `{ jobs }` shape.
- Add regression coverage for the live job-page shape that caused the post-merge `TypeError`.
- Run the docs-only safety guard in workflows that already participate in `merge_group`, using `github.event.merge_group.base_sha` as the prior main SHA.

## Root Cause

The guard iterated `github.paginate.iterator(github.rest.actions.listJobsForWorkflowRun)` and assumed each page was shaped like `response.data.jobs`. On the live GitHub Actions runner, paginated job pages arrived as arrays, so the guard itself threw before it could inspect the previous main commit. Because the guard only ran on push-to-main, this helper regression was not exercised by the merge queue.

## Validation

- `node .github/actions/ensure-main-docs-safety/check-previous-main.test.cjs`
- `actionlint .github/workflows/gem-tests.yml .github/workflows/examples.yml .github/workflows/playwright.yml .github/workflows/package-js-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/precompile-check.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-test-package-and-gem.yml .github/workflows/integration-tests.yml`
- `pnpm exec prettier --check .github/actions/ensure-main-docs-safety/action.yml .github/actions/ensure-main-docs-safety/check-previous-main.cjs .github/actions/ensure-main-docs-safety/check-previous-main.test.cjs .github/workflows/gem-tests.yml .github/workflows/examples.yml .github/workflows/playwright.yml .github/workflows/package-js-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/precompile-check.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-test-package-and-gem.yml .github/workflows/integration-tests.yml`
- `pnpm exec eslint .github/actions/ensure-main-docs-safety/check-previous-main.cjs .github/actions/ensure-main-docs-safety/check-previous-main.test.cjs`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `script/ci-changes-detector origin/main`
- `codex review --uncommitted`

`bundle exec rubocop` was attempted and failed on existing tracked files under `react_on_rails/spike/3313_prism_gemfile_rewriter/*`; this PR does not change Ruby files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the docs-only safety guard to run for `merge_group` (merge-queue) events targeting `main`, not just direct `push`es.
  * Updated the guard to select the correct prior SHA for both `push` and `merge_group` events.
* **Bug Fixes**
  * Improved reliability and clarity of “no-run” handling and final error messages when the guard can’t safely skip.
* **Tests**
  * Expanded test coverage for alternate job listing shapes and additional no-run/quiet scenarios.
* **Documentation**
  * Clarified where `previous-sha` may be sourced in the action metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->