### PR TITLE
Hide legacy Redux install generator path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Changed
 
+- **Redux is now hidden from the V17 install generator path**: The `react_on_rails:install --redux` option is no longer shown in install generator help or usage text, and recovery guidance no longer recommends `--redux` for new installs. The hidden legacy path and direct `react_on_rails:react_with_redux` generator now warn that Redux scaffolding is legacy while keeping runtime Redux APIs available. Closes [Issue 4272](https://github.com/shakacode/react_on_rails/issues/4272) and [Issue 4273](https://github.com/shakacode/react_on_rails/issues/4273). [PR 4277](https://github.com/shakacode/react_on_rails/pull/4277) by [justin808](https://github.com/justin808).
+
 - **`create-react-on-rails-app` now defaults to Pro for React 19.2 support**: Running
   `npx create-react-on-rails-app my-app` no longer asks setup questions and generates the recommended
   React on Rails Pro scaffold by default. Automation note: non-TTY environments, including CI and piped

--- a/react_on_rails/lib/generators/USAGE
+++ b/react_on_rails/lib/generators/USAGE
@@ -2,12 +2,6 @@ Description:
 
 The react_on_rails:install generator integrates a React frontend, including SSR, with Rails.
 
-* Redux (Optional)
-
-    Passing the --redux generator option causes the generated Hello World example
-    to integrate the Redux state container framework. The necessary node modules
-    will be automatically included for you.
-
 * Tailwind CSS v4 (Optional)
 
     Passing the --tailwind generator option installs Tailwind CSS v4, configures

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -17,12 +17,13 @@ module ReactOnRails
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
 
-      # --redux
+      # Internal hidden legacy Redux plumbing for install_generator.
       class_option :redux,
                    type: :boolean,
                    default: false,
-                   desc: "Install Redux package and Redux version of Hello World Example",
-                   aliases: "-R"
+                   desc: "Internal legacy Redux scaffolding flag",
+                   aliases: "-R",
+                   hide: true
 
       # --rspack / --no-rspack (Rspack is the default on fresh installs; --no-rspack selects Webpack)
       # IMPORTANT: do NOT add a `default:` here. The absence of a default is load-bearing — Thor

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -818,8 +818,8 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
-        add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
+        add_legacy_redux_install_warning
       end
 
       def recovery_install_command
@@ -1104,8 +1104,8 @@ module ReactOnRails
           #{recovery_working_tree_note}
           Then re-run: #{recovery_install_command}
         MSG
-        GeneratorMessages.add_error(error)
         add_legacy_redux_install_warning_once
+        GeneratorMessages.add_error(error)
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1129,8 +1129,8 @@ module ReactOnRails
 
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
-        GeneratorMessages.add_error(error)
         add_legacy_redux_install_warning_once
+        GeneratorMessages.add_error(error)
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -791,13 +791,13 @@ module ReactOnRails
           if use_tailwind?
             [
               "Existing apps that need Redux with Tailwind should keep using the hidden install path:",
-              "bundle exec rails generate react_on_rails:install --redux --tailwind"
+              "rails generate react_on_rails:install --redux --tailwind"
             ]
           else
             [
               "Existing apps that need the legacy Redux scaffold can use the hidden react_with_redux generator. " \
               "That generator is also legacy and emits its own warning:",
-              "bundle exec rails generate react_on_rails:react_with_redux"
+              "rails generate react_on_rails:react_with_redux"
             ]
           end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -816,6 +816,7 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
+        # Set the flag after enqueueing so a failed warning add can be retried.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
       end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -199,7 +199,7 @@ module ReactOnRails
 
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
-          add_legacy_redux_install_warning
+          add_legacy_redux_install_warning_once
           add_package_json_scripts
           add_ci_workflow
           add_bin_scripts
@@ -813,6 +813,13 @@ module ReactOnRails
         MSG
       end
 
+      def add_legacy_redux_install_warning_once
+        return if @legacy_redux_install_warning_added
+
+        add_legacy_redux_install_warning
+        @legacy_redux_install_warning_added = true if options.redux?
+      end
+
       def recovery_install_command
         flags = []
         flags << "--redux" if options.redux?
@@ -1096,6 +1103,7 @@ module ReactOnRails
           Then re-run: #{recovery_install_command}
         MSG
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1120,6 +1128,7 @@ module ReactOnRails
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -801,6 +801,8 @@ module ReactOnRails
             ]
           end
 
+        # Keep this install-specific warning aligned with
+        # ReactWithReduxGenerator::LEGACY_REDUX_GENERATOR_WARNING.
         GeneratorMessages.add_warning(<<~MSG.strip)
           The install --redux option is a hidden legacy Redux generator path and is not recommended
           for new React on Rails apps.
@@ -817,7 +819,7 @@ module ReactOnRails
         return if @legacy_redux_install_warning_added
 
         add_legacy_redux_install_warning
-        @legacy_redux_install_warning_added = true if options.redux?
+        @legacy_redux_install_warning_added = true
       end
 
       def recovery_install_command

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -197,9 +197,10 @@ module ReactOnRails
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
 
+        add_legacy_redux_install_warning_once
+
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
-          add_legacy_redux_install_warning_once
           add_package_json_scripts
           add_ci_workflow
           add_bin_scripts
@@ -801,8 +802,6 @@ module ReactOnRails
             ]
           end
 
-        # Keep this install-specific warning aligned with
-        # ReactWithReduxGenerator::LEGACY_REDUX_GENERATOR_WARNING.
         GeneratorMessages.add_warning(<<~MSG.strip)
           The install --redux option is a hidden legacy Redux generator path and is not recommended
           for new React on Rails apps.

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -221,7 +221,7 @@ module ReactOnRails
         # print_generator_messages raises an exception. This prevents ENV pollution
         # that could affect subsequent processes.
         ENV.delete("REACT_ON_RAILS_SKIP_VALIDATION")
-        add_legacy_redux_install_warning_once
+        add_legacy_redux_install_warning_once_safely
         print_generator_messages
       end
 
@@ -819,6 +819,13 @@ module ReactOnRails
         # Set the flag after enqueueing so a failed warning add can be retried.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
+      end
+
+      def add_legacy_redux_install_warning_once_safely
+        add_legacy_redux_install_warning_once
+      rescue StandardError
+        # Preserve the primary generator output; this legacy advisory is best-effort.
+        nil
       end
 
       def recovery_install_command

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -32,12 +32,13 @@ module ReactOnRails
       # fetch USAGE file for details generator description
       source_root(File.expand_path(__dir__))
 
-      # --redux
+      # Hidden legacy --redux escape hatch for existing scripted installs.
       class_option :redux,
                    type: :boolean,
                    default: false,
-                   desc: "Install Redux package and Redux version of Hello World Example. Default: false",
-                   aliases: "-R"
+                   desc: "Deprecated legacy Redux install path; use react_on_rails:react_with_redux directly.",
+                   aliases: "-R",
+                   hide: true
 
       # --typescript
       class_option :typescript,
@@ -195,6 +196,7 @@ module ReactOnRails
         # This is inherited by all invoked generators and persists through Rails initialization
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
+        add_legacy_redux_install_warning
 
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
@@ -252,9 +254,9 @@ module ReactOnRails
         end
 
         # Component generator logic:
-        # - --rsc without --redux: Skip HelloWorld, HelloServer will be generated in setup_rsc
-        # - --rsc with --redux: Generate HelloWorldApp (user explicitly wants Redux) + HelloServer
-        # - Without --rsc: Normal behavior (HelloWorld or HelloWorldApp based on --redux)
+        # - --rsc without hidden legacy Redux: Skip HelloWorld; setup_rsc generates HelloServer.
+        # - Hidden legacy --redux: Generate HelloWorldApp as a one-major escape hatch.
+        # - Without --rsc: Generate the default HelloWorld example unless the legacy flag is present.
         if options.redux?
           invoke "react_on_rails:react_with_redux", [], { typescript: options.typescript?,
                                                           tailwind: use_tailwind?,
@@ -779,6 +781,33 @@ module ReactOnRails
       def shakapacker_setup_incomplete?
         # Strict comparison keeps nil (unset) distinct from true.
         @shakapacker_setup_incomplete == true
+      end
+
+      def add_legacy_redux_install_warning
+        return unless options.redux?
+
+        legacy_guidance, legacy_command =
+          if use_tailwind?
+            [
+              "Existing apps that need Redux with Tailwind should keep using the hidden install path:",
+              "bundle exec rails generate react_on_rails:install --redux --tailwind"
+            ]
+          else
+            [
+              "Existing apps that need the legacy Redux scaffold can run:",
+              "bundle exec rails generate react_on_rails:react_with_redux"
+            ]
+          end
+
+        GeneratorMessages.add_warning(<<~MSG.strip)
+          The install --redux option is a hidden legacy Redux generator path and is not recommended
+          for new React on Rails apps.
+          Use the default install generator for new apps. #{legacy_guidance}
+
+              #{legacy_command}
+
+          Runtime Redux APIs such as redux_store remain supported.
+        MSG
       end
 
       def recovery_install_command

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -197,8 +197,6 @@ module ReactOnRails
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
 
-        add_legacy_redux_install_warning_once
-
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
           add_package_json_scripts
@@ -223,6 +221,7 @@ module ReactOnRails
         # print_generator_messages raises an exception. This prevents ENV pollution
         # that could affect subsequent processes.
         ENV.delete("REACT_ON_RAILS_SKIP_VALIDATION")
+        add_legacy_redux_install_warning_once
         print_generator_messages
       end
 
@@ -817,8 +816,8 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
-        @legacy_redux_install_warning_added = true
         add_legacy_redux_install_warning
+        @legacy_redux_install_warning_added = true
       end
 
       def recovery_install_command
@@ -1103,8 +1102,8 @@ module ReactOnRails
           #{recovery_working_tree_note}
           Then re-run: #{recovery_install_command}
         MSG
-        add_legacy_redux_install_warning_once
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1128,8 +1127,8 @@ module ReactOnRails
 
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
-        add_legacy_redux_install_warning_once
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -798,7 +798,7 @@ module ReactOnRails
             [
               "Existing apps that need the legacy Redux scaffold can use the hidden react_with_redux generator. " \
               "That generator is also legacy and emits its own warning:",
-              "rails generate react_on_rails:react_with_redux"
+              legacy_redux_generator_command
             ]
           end
 
@@ -839,6 +839,13 @@ module ReactOnRails
         flags << "--no-agent-files" unless options.agent_files?
 
         ["rails generate react_on_rails:install", *flags.compact].join(" ")
+      end
+
+      def legacy_redux_generator_command
+        flags = []
+        flags << "--typescript" if options.typescript?
+
+        ["rails generate react_on_rails:react_with_redux", *flags].join(" ")
       end
 
       def optional_install_flags

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -196,9 +196,9 @@ module ReactOnRails
         # This is inherited by all invoked generators and persists through Rails initialization
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
-        add_legacy_redux_install_warning
 
         if installation_prerequisites_met? || options.ignore_warnings?
+          add_legacy_redux_install_warning
           invoke_generators
           add_package_json_scripts
           add_ci_workflow
@@ -794,7 +794,8 @@ module ReactOnRails
             ]
           else
             [
-              "Existing apps that need the legacy Redux scaffold can run:",
+              "Existing apps that need the legacy Redux scaffold can use the hidden react_with_redux generator. " \
+              "That generator is also legacy and emits its own warning:",
               "bundle exec rails generate react_on_rails:react_with_redux"
             ]
           end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -792,7 +792,7 @@ module ReactOnRails
           if use_tailwind?
             [
               "Existing apps that need Redux with Tailwind should keep using the hidden install path:",
-              "rails generate react_on_rails:install --redux --tailwind"
+              recovery_install_command
             ]
           else
             [
@@ -817,6 +817,7 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
+        # Set only after enqueueing; safe callers may retry if the warning helper fails.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
       end
@@ -829,25 +830,39 @@ module ReactOnRails
       end
 
       def recovery_install_command
-        flags = []
-        flags << "--redux" if options.redux?
-        flags << "--typescript" if options.typescript?
-        # Echo the resolved bundler choice (normalized to --rspack/--no-rspack, so a --webpack
-        # alias re-runs as --no-rspack) only when the user passed one explicitly. An unset choice
-        # re-resolves to the fresh-install default on re-run, so we don't pin it here.
-        flags << (using_rspack? ? "--rspack" : "--no-rspack") if bundler_flag_given?
-
-        if options.rsc?
-          flags << "--rsc"
-        elsif options.pro?
-          flags << "--pro"
-        end
+        flags = optional_install_flags
+        flags << explicit_bundler_install_flag
+        flags << product_stack_install_flag
 
         # Preserve an explicit agent-files opt-out so the suggested re-run doesn't emit
         # AGENTS.md/editor files a user deliberately skipped (--agent-files defaults to on).
         flags << "--no-agent-files" unless options.agent_files?
 
-        ["rails generate react_on_rails:install", *flags].join(" ")
+        ["rails generate react_on_rails:install", *flags.compact].join(" ")
+      end
+
+      def optional_install_flags
+        [
+          ["--redux", options.redux?],
+          ["--typescript", options.typescript?],
+          ["--tailwind", use_tailwind?]
+        ].filter_map { |flag, enabled| flag if enabled }
+      end
+
+      def explicit_bundler_install_flag
+        # Echo the resolved bundler choice (normalized to --rspack/--no-rspack, so a --webpack
+        # alias re-runs as --no-rspack) only when the user passed one explicitly. An unset choice
+        # re-resolves to the fresh-install default on re-run, so we don't pin it here.
+        return unless bundler_flag_given?
+
+        using_rspack? ? "--rspack" : "--no-rspack"
+      end
+
+      def product_stack_install_flag
+        return "--rsc" if options.rsc?
+        return "--pro" if options.pro?
+
+        nil
       end
 
       def rsc_verification_message

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -198,8 +198,8 @@ module ReactOnRails
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
 
         if installation_prerequisites_met? || options.ignore_warnings?
-          add_legacy_redux_install_warning
           invoke_generators
+          add_legacy_redux_install_warning
           add_package_json_scripts
           add_ci_workflow
           add_bin_scripts
@@ -786,6 +786,7 @@ module ReactOnRails
       def add_legacy_redux_install_warning
         return unless options.redux?
 
+        legacy_docs_url = "https://reactonrails.com/docs/api-reference/generator-details/"
         legacy_guidance, legacy_command =
           if use_tailwind?
             [
@@ -807,6 +808,7 @@ module ReactOnRails
 
               #{legacy_command}
 
+          For legacy Redux recovery details, see #{legacy_docs_url}.
           Runtime Redux APIs such as redux_store remain supported.
         MSG
       end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -221,6 +221,7 @@ module ReactOnRails
         # print_generator_messages raises an exception. This prevents ENV pollution
         # that could affect subsequent processes.
         ENV.delete("REACT_ON_RAILS_SKIP_VALIDATION")
+        # Keep primary failure details first; the legacy Redux advisory is best-effort.
         add_legacy_redux_install_warning_once_safely
         print_generator_messages
       end
@@ -816,15 +817,14 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
-        # Set the flag after enqueueing so a failed warning add can be retried.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
       end
 
       def add_legacy_redux_install_warning_once_safely
         add_legacy_redux_install_warning_once
-      rescue StandardError
-        # Preserve the primary generator output; this legacy advisory is best-effort.
+      rescue StandardError => e
+        warn "[react_on_rails] Skipped legacy Redux warning: #{e.message}"
         nil
       end
 
@@ -1111,7 +1111,7 @@ module ReactOnRails
           Then re-run: #{recovery_install_command}
         MSG
         GeneratorMessages.add_error(error)
-        add_legacy_redux_install_warning_once
+        add_legacy_redux_install_warning_once_safely
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1136,7 +1136,7 @@ module ReactOnRails
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
         GeneratorMessages.add_error(error)
-        add_legacy_redux_install_warning_once
+        add_legacy_redux_install_warning_once_safely
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,6 +13,7 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
+      # Keep this standalone warning aligned with InstallGenerator#add_legacy_redux_install_warning.
       LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip.freeze
         The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
         recommended for new React on Rails apps.
@@ -27,6 +28,7 @@ module ReactOnRails
       class_option :tailwind, type: :boolean, default: false, hide: true
 
       def run_generator
+        add_legacy_redux_generator_warning
         validate_standalone_tailwind
         create_redux_directories
         copy_base_files
@@ -128,10 +130,15 @@ module ReactOnRails
         install_packages_with_fallback(regular_packages, dev: false, package_manager:)
       end
 
-      def add_redux_specific_messages
+      def add_legacy_redux_generator_warning
         return if options[:invoked_by_install]
 
         GeneratorMessages.add_warning(LEGACY_REDUX_GENERATOR_WARNING)
+      end
+
+      def add_redux_specific_messages
+        return if options[:invoked_by_install]
+
         GeneratorMessages.add_info(
           GeneratorMessages.helpful_message_after_installation(component_name: "HelloWorldApp", route: "hello_world",
                                                                pro: Gem.loaded_specs.key?("react_on_rails_pro"),
@@ -145,8 +152,6 @@ module ReactOnRails
         return false if options[:invoked_by_install]
 
         GeneratorMessages.add_error(<<~MSG.strip)
-          🚫 The standalone react_on_rails:react_with_redux generator does not support --tailwind.
-
           Tailwind setup requires the base React on Rails installer so it can create the
           react_on_rails_tailwind pack, stylesheet, dependencies, and webpack/Rspack config.
 

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,6 +13,12 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
+      LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip
+        The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
+        recommended for new React on Rails apps.
+        New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
+        redux_store remain supported.
+      MSG
 
       class_option :typescript,
                    type: :boolean,
@@ -131,13 +137,14 @@ module ReactOnRails
       def add_redux_specific_messages
         return if options.invoked_by_install?
 
-        # Append Redux-specific post-install instructions
+        GeneratorMessages.add_warning(LEGACY_REDUX_GENERATOR_WARNING)
         GeneratorMessages.add_info(
           GeneratorMessages.helpful_message_after_installation(component_name: "HelloWorldApp", route: "hello_world",
                                                                pro: Gem.loaded_specs.key?("react_on_rails_pro"),
                                                                tailwind: use_tailwind?,
                                                                app_root: destination_root)
         )
+        print_generator_messages
       end
 
       private
@@ -152,9 +159,13 @@ module ReactOnRails
           Tailwind setup requires the base React on Rails installer so it can create the
           react_on_rails_tailwind pack, stylesheet, dependencies, and webpack/Rspack config.
 
-          Use the install generator for Redux + Tailwind setup:
+          Use the hidden legacy installer path if you intentionally need the Redux scaffold with Tailwind:
 
-            rails generate react_on_rails:install --redux --tailwind
+            bundle exec rails generate react_on_rails:install --redux --tailwind
+
+          For new apps, run the default installer without Redux:
+
+            bundle exec rails generate react_on_rails:install --tailwind
         MSG
         true
       end

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -36,7 +36,7 @@ module ReactOnRails
         add_redux_npm_dependencies
         add_redux_specific_messages
       ensure
-        print_generator_messages unless options.invoked_by_install?
+        print_generator_messages unless options[:invoked_by_install]
       end
 
       private
@@ -130,7 +130,7 @@ module ReactOnRails
       end
 
       def add_redux_specific_messages
-        return if options.invoked_by_install?
+        return if options[:invoked_by_install]
 
         GeneratorMessages.add_warning(LEGACY_REDUX_GENERATOR_WARNING)
         GeneratorMessages.add_info(
@@ -143,7 +143,7 @@ module ReactOnRails
 
       def unsupported_standalone_tailwind?
         return false unless use_tailwind?
-        return false if options.invoked_by_install?
+        return false if options[:invoked_by_install]
 
         GeneratorMessages.add_error(<<~MSG.strip)
           🚫 The standalone react_on_rails:react_with_redux generator does not support --tailwind.

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -19,7 +19,6 @@ module ReactOnRails
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
         redux_store remain supported.
       MSG
-      private_constant :LEGACY_REDUX_GENERATOR_WARNING
 
       class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
       class_option :invoked_by_install, type: :boolean, default: false, hide: true

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -35,7 +35,7 @@ module ReactOnRails
         add_redux_npm_dependencies
         add_redux_specific_messages
       ensure
-        print_generator_messages unless options[:invoked_by_install]
+        print_generator_messages unless options.invoked_by_install?
       end
 
       private
@@ -142,7 +142,7 @@ module ReactOnRails
 
       def unsupported_standalone_tailwind?
         return false unless use_tailwind?
-        return false if options[:invoked_by_install]
+        return false if options.invoked_by_install?
 
         GeneratorMessages.add_error(<<~MSG.strip)
           🚫 The standalone react_on_rails:react_with_redux generator does not support --tailwind.

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -152,11 +152,11 @@ module ReactOnRails
 
           Use the hidden legacy installer path if you intentionally need the Redux scaffold with Tailwind:
 
-            bundle exec rails generate react_on_rails:install --redux --tailwind
+            rails generate react_on_rails:install --redux --tailwind
 
           For new apps, run the default installer without Redux:
 
-            bundle exec rails generate react_on_rails:install --tailwind
+            rails generate react_on_rails:install --tailwind
         MSG
         true
       end

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -20,6 +20,7 @@ module ReactOnRails
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
         redux_store remain supported.
       MSG
+      private_constant :LEGACY_REDUX_GENERATOR_WARNING
 
       class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
       class_option :invoked_by_install, type: :boolean, default: false, hide: true

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,7 +13,7 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
-      LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip
+      LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip.freeze
         The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
         recommended for new React on Rails apps.
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -20,31 +20,25 @@ module ReactOnRails
         redux_store remain supported.
       MSG
 
-      class_option :typescript,
-                   type: :boolean,
-                   default: false,
-                   desc: "Generate TypeScript files",
-                   aliases: "-T"
+      class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
+      class_option :invoked_by_install, type: :boolean, default: false, hide: true
+      class_option :new_app, type: :boolean, default: false, hide: true
+      class_option :rsc, type: :boolean, default: false, hide: true
+      class_option :tailwind, type: :boolean, default: false, hide: true
 
-      class_option :invoked_by_install,
-                   type: :boolean,
-                   default: false,
-                   hide: true
+      def run_generator
+        validate_standalone_tailwind
+        create_redux_directories
+        copy_base_files
+        copy_base_redux_files
+        create_appropriate_templates
+        add_redux_npm_dependencies
+        add_redux_specific_messages
+      ensure
+        print_generator_messages unless options[:invoked_by_install]
+      end
 
-      class_option :new_app,
-                   type: :boolean,
-                   default: false,
-                   hide: true
-
-      class_option :rsc,
-                   type: :boolean,
-                   default: false,
-                   hide: true
-
-      class_option :tailwind,
-                   type: :boolean,
-                   default: false,
-                   hide: true
+      private
 
       def validate_standalone_tailwind
         return unless unsupported_standalone_tailwind?
@@ -144,10 +138,7 @@ module ReactOnRails
                                                                tailwind: use_tailwind?,
                                                                app_root: destination_root)
         )
-        print_generator_messages
       end
-
-      private
 
       def unsupported_standalone_tailwind?
         return false unless use_tailwind?

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -19,6 +19,7 @@ module ReactOnRails
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
         redux_store remain supported.
       MSG
+      private_constant :LEGACY_REDUX_GENERATOR_WARNING
 
       class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
       class_option :invoked_by_install, type: :boolean, default: false, hide: true

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,7 +13,8 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
-      # Keep this standalone warning aligned with InstallGenerator#add_legacy_redux_install_warning.
+      # Keep the runtime API compatibility sentence aligned with InstallGenerator#add_legacy_redux_install_warning.
+      # The install path adds recovery docs and command guidance that this standalone warning intentionally omits.
       LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip.freeze
         The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
         recommended for new React on Rails apps.
@@ -28,6 +29,7 @@ module ReactOnRails
       class_option :rsc, type: :boolean, default: false, hide: true
       class_option :tailwind, type: :boolean, default: false, hide: true
 
+      # Only this public method is dispatched by Rails; helpers below stay private.
       def run_generator
         add_legacy_redux_generator_warning
         validate_standalone_tailwind

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4403,7 +4403,7 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text).to include("React on Rails generator prerequisites not met")
       expect(output_text.index("legacy Redux generator path"))
-        .to be < output_text.index("React on Rails generator prerequisites not met")
+        .to be > output_text.index("React on Rails generator prerequisites not met")
     end
 
     specify "shows incomplete-installation guidance when shakapacker setup fails" do
@@ -4767,6 +4767,15 @@ describe InstallGenerator, type: :generator do
       message_text = GeneratorMessages.messages.join("\n")
       expect(message_text).to include("legacy Redux generator path")
       expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+    end
+
+    it "does not warn from the standalone Redux generator when invoked by install" do
+      redux_generator = redux_generator_fixture(invoked_by_install: true)
+      GeneratorMessages.clear
+
+      redux_generator.send(:add_legacy_redux_generator_warning)
+
+      expect(GeneratorMessages.messages.join("\n")).not_to include("legacy Redux generator path")
     end
 
     it "queues the standalone Redux warning before fallible scaffold work" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -349,6 +349,25 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  describe "Redux generator policy" do
+    it "hides the install --redux option from public help and usage text" do
+      redux_option = described_class.class_options.fetch(:redux)
+
+      expect(redux_option.hide).to be(true)
+
+      usage_text = File.read(File.expand_path("../../../lib/generators/USAGE", __dir__))
+      expect(usage_text).not_to include("--redux")
+      expect(usage_text).not_to include("Redux (Optional)")
+    end
+
+    it "marks the base generator Redux option as internal legacy plumbing" do
+      redux_option = ReactOnRails::Generators::BaseGenerator.class_options.fetch(:redux)
+
+      expect(redux_option.hide).to be(true)
+      expect(redux_option.description).to include("legacy")
+    end
+  end
+
   describe "manual generator fixtures" do
     it "keep CI workflow generation inside the generator spec destination" do
       prepare_destination
@@ -4485,6 +4504,27 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
     end
 
+    specify "hidden install --redux emits a legacy warning" do
+      install_generator = install_generator_fixture(redux: true)
+
+      install_generator.send(:add_legacy_redux_install_warning)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("legacy Redux generator path")
+      expect(output_text).to include("bundle exec rails generate react_on_rails:react_with_redux")
+    end
+
+    specify "hidden install --redux --tailwind warning stays on the install path" do
+      install_generator = install_generator_fixture(redux: true, tailwind: true)
+
+      install_generator.send(:add_legacy_redux_install_warning)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("Redux with Tailwind")
+      expect(output_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
+      expect(output_text).not_to include("react_on_rails:react_with_redux")
+    end
+
     specify "shakapacker gemfile error preserves original install flags" do
       # ignore_warnings: true is required so handle_shakapacker_gemfile_error logs
       # the error instead of raising Thor::Error, which lets this example inspect output.
@@ -4643,7 +4683,8 @@ describe InstallGenerator, type: :generator do
       expect(error_text).to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
-      expect(error_text).to include("rails generate react_on_rails:install --redux --tailwind")
+      expect(error_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
+      expect(error_text).to include("bundle exec rails generate react_on_rails:install --tailwind")
     end
 
     it "allows Redux Tailwind setup when invoked by the install generator" do
@@ -4654,6 +4695,18 @@ describe InstallGenerator, type: :generator do
       expect(GeneratorMessages.messages.join("\n")).not_to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
+    end
+
+    it "warns that direct standalone Redux generation is legacy" do
+      redux_generator = redux_generator_fixture
+      allow(redux_generator).to receive(:print_generator_messages)
+
+      redux_generator.add_redux_specific_messages
+
+      message_text = GeneratorMessages.messages.join("\n")
+      expect(message_text).to include("legacy Redux generator path")
+      expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+      expect(redux_generator).to have_received(:print_generator_messages)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4533,6 +4533,15 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("rails generate react_on_rails:react_with_redux")
     end
 
+    specify "hidden install --redux --typescript legacy warning preserves the TypeScript flag" do
+      install_generator = install_generator_fixture(redux: true, typescript: true)
+
+      install_generator.send(:add_legacy_redux_install_warning)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("rails generate react_on_rails:react_with_redux --typescript")
+    end
+
     specify "hidden install --redux legacy warning is only added once" do
       install_generator = install_generator_fixture(redux: true)
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4392,6 +4392,20 @@ describe InstallGenerator, type: :generator do
       install_generator.run_generators
     end
 
+    specify "run_generators warns hidden redux users when prerequisites fail" do
+      install_generator = install_generator_fixture(redux: true)
+      allow(install_generator).to receive(:installation_prerequisites_met?).and_return(false)
+      allow(install_generator).to receive(:print_generator_messages)
+
+      install_generator.run_generators
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("legacy Redux generator path")
+      expect(output_text).to include("React on Rails generator prerequisites not met")
+      expect(output_text.index("legacy Redux generator path"))
+        .to be < output_text.index("React on Rails generator prerequisites not met")
+    end
+
     specify "shows incomplete-installation guidance when shakapacker setup fails" do
       install_generator = install_generator_fixture
       install_generator.instance_variable_set(:@shakapacker_setup_incomplete, true)

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4518,7 +4518,7 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text.index("legacy Redux generator path"))
-        .to be < output_text.index("Failed to install Shakapacker")
+        .to be > output_text.index("Failed to install Shakapacker")
     end
 
     specify "hidden install --redux emits a legacy warning" do
@@ -4539,6 +4539,31 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text.scan("legacy Redux generator path").size).to eq(1)
+    end
+
+    specify "hidden install --redux legacy warning is retried if adding it fails" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning).and_raise(StandardError, "warning failed")
+      expect do
+        install_generator.send(:add_legacy_redux_install_warning_once)
+      end.to raise_error(StandardError, "warning failed")
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning).and_call_original
+      install_generator.send(:add_legacy_redux_install_warning_once)
+
+      expect(GeneratorMessages.messages.join("\n")).to include("legacy Redux generator path")
+    end
+
+    specify "hidden install --redux legacy warning is printed when invoked generators fail" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:installation_prerequisites_met?).and_return(true)
+      allow(install_generator).to receive(:invoke_generators).and_raise(Thor::Error, "generator failed")
+      allow(install_generator).to receive(:print_generator_messages)
+
+      expect { install_generator.run_generators }.to raise_error(Thor::Error, "generator failed")
+      expect(GeneratorMessages.messages.join("\n")).to include("legacy Redux generator path")
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do
@@ -4572,7 +4597,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
       expect(output_text).to include("legacy Redux generator path")
-      expect(output_text.index("legacy Redux generator path")).to be < output_text.index("Failed to add Shakapacker")
+      expect(output_text.index("legacy Redux generator path")).to be > output_text.index("Failed to add Shakapacker")
     end
 
     specify "rsc installs include the Pro verification checklist message" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4743,9 +4743,8 @@ describe InstallGenerator, type: :generator do
         .to raise_error(Thor::Error, /react_with_redux generator does not support --tailwind/)
 
       error_text = GeneratorMessages.messages.join("\n")
-      expect(error_text).to include(
-        "standalone react_on_rails:react_with_redux generator does not support --tailwind"
-      )
+      expect(error_text).to include("Tailwind setup requires the base React on Rails installer")
+      expect(error_text).not_to include("standalone react_on_rails:react_with_redux generator does not support")
       expect(error_text).to include("rails generate react_on_rails:install --redux --tailwind")
       expect(error_text).to include("rails generate react_on_rails:install --tailwind")
     end
@@ -4763,11 +4762,23 @@ describe InstallGenerator, type: :generator do
     it "warns that direct standalone Redux generation is legacy" do
       redux_generator = redux_generator_fixture
 
-      redux_generator.send(:add_redux_specific_messages)
+      redux_generator.send(:add_legacy_redux_generator_warning)
 
       message_text = GeneratorMessages.messages.join("\n")
       expect(message_text).to include("legacy Redux generator path")
       expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+    end
+
+    it "queues the standalone Redux warning before fallible scaffold work" do
+      redux_generator = redux_generator_fixture
+      allow(redux_generator).to receive(:create_redux_directories).and_raise(Thor::Error, "copy failed")
+      allow(redux_generator).to receive(:print_generator_messages)
+
+      expect { redux_generator.run_generator }.to raise_error(Thor::Error, "copy failed")
+
+      message_text = GeneratorMessages.messages.join("\n")
+      expect(message_text).to include("legacy Redux generator path")
+      expect(redux_generator).to have_received(:print_generator_messages)
     end
 
     it "prints queued messages when standalone Redux Tailwind validation fails" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4473,6 +4473,7 @@ describe InstallGenerator, type: :generator do
       install_generator = install_generator_fixture(
         redux: true,
         typescript: true,
+        tailwind: true,
         rspack: true,
         rsc: true,
         pro: true,
@@ -4484,7 +4485,7 @@ describe InstallGenerator, type: :generator do
 
       command = install_generator.send(:recovery_install_command)
 
-      expect(command).to eq("rails generate react_on_rails:install --redux --typescript --rspack --rsc")
+      expect(command).to eq("rails generate react_on_rails:install --redux --typescript --tailwind --rspack --rsc")
       expect(command).not_to include("--ignore-warnings")
       expect(command).not_to include("--force")
       expect(command).not_to include("--skip")
@@ -4605,14 +4606,14 @@ describe InstallGenerator, type: :generator do
       end.to raise_error(Thor::Error, /Failed to install Shakapacker/)
     end
 
-    specify "hidden install --redux --tailwind warning stays on the install path" do
-      install_generator = install_generator_fixture(redux: true, tailwind: true)
+    specify "hidden install --redux --tailwind warning preserves meaningful install flags" do
+      install_generator = install_generator_fixture(redux: true, tailwind: true, typescript: true)
 
       install_generator.send(:add_legacy_redux_install_warning)
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text).to include("Redux with Tailwind")
-      expect(output_text).to include("rails generate react_on_rails:install --redux --tailwind")
+      expect(output_text).to include("rails generate react_on_rails:install --redux --typescript --tailwind")
       expect(output_text).not_to include("react_on_rails:react_with_redux")
     end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4566,6 +4566,19 @@ describe InstallGenerator, type: :generator do
       expect(GeneratorMessages.messages.join("\n")).to include("legacy Redux generator path")
     end
 
+    specify "warning failures do not suppress queued generator messages" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:installation_prerequisites_met?).and_return(true)
+      allow(install_generator).to receive(:invoke_generators).and_raise(Thor::Error, "generator failed")
+      allow(install_generator).to receive(:add_legacy_redux_install_warning)
+        .and_raise(StandardError, "warning failed")
+      allow(install_generator).to receive(:print_generator_messages)
+
+      expect { install_generator.run_generators }.to raise_error(Thor::Error, "generator failed")
+      expect(install_generator).to have_received(:print_generator_messages)
+    end
+
     specify "hidden install --redux --tailwind warning stays on the install path" do
       install_generator = install_generator_fixture(redux: true, tailwind: true)
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4676,7 +4676,7 @@ describe InstallGenerator, type: :generator do
       redux_generator = redux_generator_fixture(tailwind: true)
       GeneratorMessages.clear
 
-      expect { redux_generator.validate_standalone_tailwind }
+      expect { redux_generator.send(:validate_standalone_tailwind) }
         .to raise_error(Thor::Error, /react_with_redux generator does not support --tailwind/)
 
       error_text = GeneratorMessages.messages.join("\n")
@@ -4691,7 +4691,7 @@ describe InstallGenerator, type: :generator do
       redux_generator = redux_generator_fixture(tailwind: true, invoked_by_install: true)
       GeneratorMessages.clear
 
-      expect { redux_generator.validate_standalone_tailwind }.not_to raise_error
+      expect { redux_generator.send(:validate_standalone_tailwind) }.not_to raise_error
       expect(GeneratorMessages.messages.join("\n")).not_to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
@@ -4699,13 +4699,21 @@ describe InstallGenerator, type: :generator do
 
     it "warns that direct standalone Redux generation is legacy" do
       redux_generator = redux_generator_fixture
-      allow(redux_generator).to receive(:print_generator_messages)
 
-      redux_generator.add_redux_specific_messages
+      redux_generator.send(:add_redux_specific_messages)
 
       message_text = GeneratorMessages.messages.join("\n")
       expect(message_text).to include("legacy Redux generator path")
       expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+    end
+
+    it "prints queued messages when standalone Redux Tailwind validation fails" do
+      redux_generator = redux_generator_fixture(tailwind: true)
+      allow(redux_generator).to receive(:print_generator_messages)
+
+      expect { redux_generator.run_generator }
+        .to raise_error(Thor::Error, /react_with_redux generator does not support --tailwind/)
+
       expect(redux_generator).to have_received(:print_generator_messages)
     end
   end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4512,7 +4512,7 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text).to include("legacy Redux generator path")
-      expect(output_text).to include("bundle exec rails generate react_on_rails:react_with_redux")
+      expect(output_text).to include("rails generate react_on_rails:react_with_redux")
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do
@@ -4522,7 +4522,7 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text).to include("Redux with Tailwind")
-      expect(output_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
+      expect(output_text).to include("rails generate react_on_rails:install --redux --tailwind")
       expect(output_text).not_to include("react_on_rails:react_with_redux")
     end
 
@@ -4694,8 +4694,8 @@ describe InstallGenerator, type: :generator do
       expect(error_text).to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
-      expect(error_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
-      expect(error_text).to include("bundle exec rails generate react_on_rails:install --tailwind")
+      expect(error_text).to include("rails generate react_on_rails:install --redux --tailwind")
+      expect(error_text).to include("rails generate react_on_rails:install --tailwind")
     end
 
     it "allows Redux Tailwind setup when invoked by the install generator" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4575,9 +4575,34 @@ describe InstallGenerator, type: :generator do
       allow(install_generator).to receive(:add_legacy_redux_install_warning)
         .and_raise(StandardError, "warning failed")
       allow(install_generator).to receive(:print_generator_messages)
+      allow(install_generator).to receive(:warn)
 
       expect { install_generator.run_generators }.to raise_error(Thor::Error, "generator failed")
       expect(install_generator).to have_received(:print_generator_messages)
+    end
+
+    specify "warning failures do not mask shakapacker gemfile errors" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning)
+        .and_raise(StandardError, "warning failed")
+      allow(install_generator).to receive(:warn)
+
+      expect do
+        install_generator.send(:handle_shakapacker_gemfile_error)
+      end.to raise_error(Thor::Error, /Failed to add Shakapacker/)
+    end
+
+    specify "warning failures do not mask shakapacker install errors" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning)
+        .and_raise(StandardError, "warning failed")
+      allow(install_generator).to receive(:warn)
+
+      expect do
+        install_generator.send(:handle_shakapacker_install_error)
+      end.to raise_error(Thor::Error, /Failed to install Shakapacker/)
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4516,6 +4516,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
+      expect(output_text).to include("Failed to install Shakapacker")
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text.index("legacy Redux generator path"))
         .to be > output_text.index("Failed to install Shakapacker")
@@ -4609,6 +4610,7 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.output.join("\n")
 
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
+      expect(output_text).to include("Failed to add Shakapacker")
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text.index("legacy Redux generator path")).to be > output_text.index("Failed to add Shakapacker")
     end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4503,6 +4503,8 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
       expect(output_text).to include("legacy Redux generator path")
+      expect(output_text.index("legacy Redux generator path"))
+        .to be < output_text.index("Failed to install Shakapacker")
     end
 
     specify "hidden install --redux emits a legacy warning" do
@@ -4513,6 +4515,16 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text).to include("rails generate react_on_rails:react_with_redux")
+    end
+
+    specify "hidden install --redux legacy warning is only added once" do
+      install_generator = install_generator_fixture(redux: true)
+
+      install_generator.send(:add_legacy_redux_install_warning_once)
+      install_generator.send(:add_legacy_redux_install_warning_once)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text.scan("legacy Redux generator path").size).to eq(1)
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do
@@ -4546,6 +4558,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
       expect(output_text).to include("legacy Redux generator path")
+      expect(output_text.index("legacy Redux generator path")).to be < output_text.index("Failed to add Shakapacker")
     end
 
     specify "rsc installs include the Pro verification checklist message" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4502,6 +4502,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
+      expect(output_text).to include("legacy Redux generator path")
     end
 
     specify "hidden install --redux emits a legacy warning" do
@@ -4535,6 +4536,16 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --rspack --pro")
+    end
+
+    specify "shakapacker gemfile error warns for hidden redux recovery" do
+      install_generator = install_generator_fixture(redux: true, ignore_warnings: true)
+
+      install_generator.send(:handle_shakapacker_gemfile_error)
+      output_text = GeneratorMessages.output.join("\n")
+
+      expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
+      expect(output_text).to include("legacy Redux generator path")
     end
 
     specify "rsc installs include the Pro verification checklist message" do


### PR DESCRIPTION
## Why

React on Rails V17 should steer new applications toward the default component/RSC path instead of presenting Redux as normal new-app guidance. This keeps the legacy Redux scaffold available for existing scripted installs and direct generator use while making clear that runtime Redux APIs remain supported for compatibility.

Closes #4272.
Closes #4273.

## What changed

- Hide the `react_on_rails:install --redux` / `-R` option from public generator help and usage text.
- Add a hidden legacy Redux warning for the install path, including early-failure handling, error-first ordering, and best-effort warning cleanup that does not suppress primary generator output.
- Queue the direct legacy Redux generator warning before fallible scaffold work, while suppressing the duplicate warning when invoked by `install`.
- Keep `react_on_rails:react_with_redux` available, but warn that it is a hidden legacy generator path and not recommended for new apps.
- Remove `--redux` from recovery guidance so failed new-app installs do not recommend Redux.
- Add focused generator specs for the hidden/deprecated policy, direct generator messaging, warning ordering, suppression guard behavior, and warning-failure fallback behavior.
- Add a changelog entry for the user-visible generator policy change.

## Validation

- PASS: `.agents/bin/agent-workflow-seam-doctor`
- PASS: `.agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4272 4273`
- PASS: `bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb:4395 spec/react_on_rails/generators/install_generator_spec.rb:4544 spec/react_on_rails/generators/install_generator_spec.rb:4569 spec/react_on_rails/generators/install_generator_spec.rb:4751 spec/react_on_rails/generators/install_generator_spec.rb:4765 spec/react_on_rails/generators/install_generator_spec.rb:4785 spec/react_on_rails/generators/install_generator_spec.rb:4794 spec/react_on_rails/generators/install_generator_spec.rb:4806` from `react_on_rails/` (8 examples)
- PASS: `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/generators/react_on_rails/install_generator.rb lib/generators/react_on_rails/react_with_redux_generator.rb spec/react_on_rails/generators/install_generator_spec.rb` from `react_on_rails/`
- PASS: `git diff --check`
- PASS: pre-commit and pre-push hooks with repo-compatible `lychee 0.23.0` on `PATH`

## CI recommendation

Generator output and install behavior changed, so this PR should get force-full hosted CI rather than docs-only or no hosted CI.