### PR TITLE
Docs: frame Redux as legacy shared-store guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Changed
 
+- **Redux is now hidden from the V17 install generator path**: The `react_on_rails:install --redux` option is no longer shown in install generator help or usage text, and recovery guidance no longer recommends `--redux` for new installs. The hidden legacy path and direct `react_on_rails:react_with_redux` generator now warn that Redux scaffolding is legacy while keeping runtime Redux APIs available. Closes [Issue 4272](https://github.com/shakacode/react_on_rails/issues/4272) and [Issue 4273](https://github.com/shakacode/react_on_rails/issues/4273). [PR 4277](https://github.com/shakacode/react_on_rails/pull/4277) by [justin808](https://github.com/justin808).
+
 - **`create-react-on-rails-app` now defaults to Pro for React 19.2 support**: Running
   `npx create-react-on-rails-app my-app` no longer asks setup questions and generates the recommended
   React on Rails Pro scaffold by default. Automation note: non-TTY environments, including CI and piped

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -25,9 +25,10 @@ Runtime options:
 
 Description:
 
-The react_on_rails:install generator integrates webpack with rails with ease. You
-can pass the options below to customize the generated example and supporting
-configuration.
+The react_on_rails:install generator integrates a JavaScript bundler with Rails
+with ease. Fresh installs use Rspack by default; pass --no-rspack to use
+Webpack. You can pass the options below to customize the generated example and
+supporting configuration.
 ```
 
 > [!WARNING]

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -1,6 +1,6 @@
 # Generator Details
 
-The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off — for example, the default for `-R` is that `redux` is off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` (or its alias `--webpack`) if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
+The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` (or its alias `--webpack`) if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
 
 Run `rails generate react_on_rails:install --help` for descriptions of all available options:
 
@@ -9,7 +9,6 @@ Usage:
   rails generate react_on_rails:install [options]
 
 Options:
-  -R, [--redux], [--no-redux]                      # Install Redux package and Redux version of Hello World Example. Default: false
   -T, [--typescript], [--no-typescript]            # Generate TypeScript files and install TypeScript dependencies. Default: false
       [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
       [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack)
@@ -27,13 +26,17 @@ Runtime options:
 Description:
 
 The react_on_rails:install generator integrates webpack with rails with ease. You
-can pass the redux option if you'd like to have redux setup for you automatically.
+can pass the options below to customize the generated example and supporting
+configuration.
 
-* Redux
-
-    Passing the --redux generator option causes the generated Hello World example
-    to integrate the Redux state container framework. The necessary node modules
-    will be automatically included for you.
+> [!WARNING]
+> The Redux installer path (`--redux` / `-R`) is a hidden legacy escape hatch, not
+> a recommended starter architecture. New apps should start with plain
+> `react_component` entries, React local state or context for island-local UI
+> state, and Rails props or server-state tools such as TanStack Query for data
+> loaded from the server. Use Redux only for an existing Redux app or an advanced
+> multi-island page where separate React roots must coordinate through one shared
+> client store.
 
 * TypeScript
 
@@ -82,9 +85,9 @@ Another good option is to create a simple test app per the [Tutorial](../getting
 
 ## Understanding the Organization of the Generated Client Code
 
-The React on Rails generator creates different directory structures depending on whether you use the `--redux` option.
+The React on Rails generator normally creates the simple component structure below. A hidden legacy Redux path remains available for existing apps and recovery work, but it is not the structure recommended for new React on Rails apps.
 
-### Default Structure (Without Redux)
+### Default Structure (Recommended, Without Redux)
 
 The basic generator creates a simple, flat structure optimized for auto-bundling:
 
@@ -104,9 +107,9 @@ app/javascript/
 
 For components that need different client vs. server implementations, use `.client.jsx` and `.server.jsx` suffixes (e.g., `HelloWorld.client.jsx` and `HelloWorld.server.jsx`).
 
-### Redux Structure (With `--redux` Option)
+### Legacy Redux Structure (Hidden `--redux` Path)
 
-The Redux generator creates a more structured organization with familiar Redux patterns:
+The hidden legacy Redux generator creates a more structured organization with familiar Redux patterns:
 
 ```text
 app/javascript/
@@ -130,12 +133,20 @@ app/javascript/
             └── helloWorldStore.js
 ```
 
-This structure follows Redux best practices:
+This legacy structure is useful only when you intentionally maintain Redux:
 
 - **`components/`**: Presentational "dumb" components that receive data via props
 - **`containers/`**: Container "smart" components connected to Redux store
 - **`actions/`** and **`reducers/`**: Standard Redux patterns
 - **`ror_components/`**: Entry point files that initialize Redux and render the app
+
+If you already have a React on Rails app and intentionally need to recreate the legacy Redux example, use the direct hidden generator after the base installer has configured React on Rails:
+
+```bash
+rails generate react_on_rails:react_with_redux --typescript
+```
+
+For full install recovery of an older Redux-generated app, the hidden `react_on_rails:install --redux` option still exists, but do not use it for greenfield apps.
 
 ### TypeScript Support
 
@@ -206,11 +217,8 @@ For apps with custom webpack configurations, review the generated config templat
 # Rspack (default) with TypeScript
 rails generate react_on_rails:install --typescript
 
-# Webpack with Redux
-rails generate react_on_rails:install --no-rspack --redux
-
-# Explicit Rspack with TypeScript and Redux
-rails generate react_on_rails:install --rspack --typescript --redux
+# Webpack with TypeScript
+rails generate react_on_rails:install --no-rspack --typescript
 ```
 
 For more details on Rspack configuration, see the [Webpack Configuration](../core-concepts/webpack-configuration.md#rspack-vs-webpack) docs.
@@ -245,9 +253,6 @@ For production, configure your license token: `export REACT_ON_RAILS_PRO_LICENSE
 ```bash
 # Pro with TypeScript
 rails generate react_on_rails:install --pro --typescript
-
-# Pro with Redux
-rails generate react_on_rails:install --pro --redux
 
 # Pro with Rspack
 rails generate react_on_rails:install --pro --rspack
@@ -300,12 +305,11 @@ In addition to all Pro files:
 # RSC with TypeScript
 rails generate react_on_rails:install --rsc --typescript
 
-# RSC with Redux (generates both HelloWorldApp and HelloServer)
-rails generate react_on_rails:install --rsc --redux
-
 # RSC with Rspack
 rails generate react_on_rails:install --rsc --rspack
 ```
+
+Do not combine RSC with the hidden legacy Redux installer for new apps. Existing Redux Client Components can continue to work beside RSC when Redux access stays in Client Components; see [RSC context and state migration](../migrating/rsc-context-and-state.md#redux-toolkit).
 
 **Upgrading an existing Pro app to RSC:**
 

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -121,6 +121,10 @@ rails generate react_on_rails:react_with_redux
 
 For an app that is already configured for TypeScript, add `--typescript` to generate `.ts` and `.tsx` Redux example files.
 
+> **Note:** The standalone `react_on_rails:react_with_redux` generator does not support `--tailwind`.
+> If you intentionally need the legacy Redux scaffold with Tailwind, run the full installer path instead:
+> `rails generate react_on_rails:install --redux --tailwind`.
+
 For full install recovery of an older Redux-generated app, the hidden `react_on_rails:install --redux` option still exists, but do not use it for greenfield apps.
 
 ### TypeScript Support

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -40,49 +40,19 @@ supporting configuration.
 > multi-island page where separate React roots must coordinate through one shared
 > client store.
 
-```text
-* TypeScript
+Additional option details:
 
-    Passing the --typescript generator option generates TypeScript files (.tsx)
-    instead of JavaScript files (.jsx) and sets up TypeScript configuration.
+- **TypeScript**: Passing the `--typescript` generator option generates TypeScript files (`.tsx`) instead of JavaScript files (`.jsx`) and sets up TypeScript configuration.
 
-* Tailwind CSS v4
+- **Tailwind CSS v4**: Passing the `--tailwind` generator option installs Tailwind CSS v4, configures `@tailwindcss/postcss` for Webpack or Rspack, and styles the generated SSR HelloWorld page. See [Styling with Tailwind CSS v4](../building-features/styling-with-tailwind.md).
 
-    Passing the --tailwind generator option installs Tailwind CSS v4,
-    configures `@tailwindcss/postcss` for Webpack or Rspack, and styles the
-    generated SSR HelloWorld page. See
-    [Styling with Tailwind CSS v4](../building-features/styling-with-tailwind.md).
+- **Rspack (default)**: Rspack is the default bundler for fresh installs, providing significantly faster builds (~20x improvement with SWC). Pass `--no-rspack` (or its alias `--webpack`) to use Webpack instead. Either way you get a unified configuration that works with both bundlers and a `bin/switch-bundler` utility to switch between them post-installation.
 
-* Rspack (default)
+- **Pro**: Passing the `--pro` generator option sets up React on Rails Pro with Node server rendering, fragment caching, and code-splitting support. Requires the `react_on_rails_pro` gem (add it to your Gemfile first). Creates the Pro initializer, `renderer/node-renderer.js`, and adds the Node Renderer process to `Procfile.dev`.
 
-    Rspack is the default bundler for fresh installs, providing significantly
-    faster builds (~20x improvement with SWC). Pass --no-rspack (or its alias
-    --webpack) to use Webpack instead. Either way you get a unified
-    configuration that works with both bundlers and a bin/switch-bundler
-    utility to switch between them post-installation.
+- **RSC (React Server Components)**: Passing the `--rsc` generator option sets up React Server Components support. This automatically includes Pro setup (`--rsc` implies `--pro`). Creates RSC webpack configuration, a HelloServer example component, and RSC routes. Requires React 19 with a compatible `react-on-rails-rsc` version.
 
-* Pro
-
-    Passing the --pro generator option sets up React on Rails Pro with Node
-    server rendering, fragment caching, and code-splitting support.
-    Requires the react_on_rails_pro gem (add it to your Gemfile first).
-    Creates the Pro initializer, renderer/node-renderer.js, and adds the Node Renderer
-    process to Procfile.dev.
-
-* RSC (React Server Components)
-
-    Passing the --rsc generator option sets up React Server Components support.
-    This automatically includes Pro setup (--rsc implies --pro). Creates RSC
-    webpack configuration, a HelloServer example component, and RSC routes.
-    Requires React 19 with a compatible `react-on-rails-rsc` version.
-
-*******************************************************************************
-
-
-Then you may run
-
-    `rails s`
-```
+Then you may run `rails s`.
 
 Another good option is to create a simple test app per the [Tutorial](../getting-started/tutorial.md).
 

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -143,8 +143,10 @@ This legacy structure is useful only when you intentionally maintain Redux:
 If you already have a React on Rails app and intentionally need to recreate the legacy Redux example, use the direct hidden generator after the base installer has configured React on Rails:
 
 ```bash
-rails generate react_on_rails:react_with_redux --typescript
+rails generate react_on_rails:react_with_redux
 ```
+
+For an app that is already configured for TypeScript, add `--typescript` to generate `.ts` and `.tsx` Redux example files.
 
 For full install recovery of an older Redux-generated app, the hidden `react_on_rails:install --redux` option still exists, but do not use it for greenfield apps.
 

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -31,8 +31,8 @@ configuration.
 
 > [!WARNING]
 > The Redux installer path (`--redux` / `-R`) is a hidden legacy escape hatch, not
-> a recommended starter architecture. New apps should start with plain
-> `react_component` entries, React local state or context for island-local UI
+> a recommended starter architecture. New apps should start with the
+> `react_component` view helper, React local state or context for island-local UI
 > state, and Rails props or server-state tools such as TanStack Query for data
 > loaded from the server. Use Redux only for an existing Redux app or an advanced
 > multi-island page where separate React roots must coordinate through one shared

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -28,6 +28,7 @@ Description:
 The react_on_rails:install generator integrates webpack with rails with ease. You
 can pass the options below to customize the generated example and supporting
 configuration.
+```
 
 > [!WARNING]
 > The Redux installer path (`--redux` / `-R`) is a hidden legacy escape hatch, not
@@ -38,6 +39,7 @@ configuration.
 > multi-island page where separate React roots must coordinate through one shared
 > client store.
 
+```text
 * TypeScript
 
     Passing the --typescript generator option generates TypeScript files (.tsx)

--- a/docs/oss/api-reference/javascript-api.md
+++ b/docs/oss/api-reference/javascript-api.md
@@ -48,9 +48,10 @@ The best source of docs is the `interface ReactOnRails` in [types/index.ts](http
 register(components);
 
 /**
- * Allows registration of store generators to be used by multiple React components on one Rails
- * view. Store generators are functions that take one arg, props, and return a store. Note that
- * the setStore API is different in that it's the actual store hydrated with props.
+ * Allows registration of store generators for legacy or advanced pages where multiple React
+ * roots on one Rails view share a Redux store. Store generators receive props and railsContext,
+ * then return a store. Note that the setStore API is different in that it's the actual store
+ * hydrated with props.
  * @param stores (key is store name, value is the store generator)
  */
 registerStoreGenerators(storesGenerators);

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -6,7 +6,7 @@
 
 > [!IMPORTANT]
 >
-> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md#important-redux-shared-store-caveat) for details and alternatives.
+> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md) for details and alternatives.
 
 You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -2,7 +2,7 @@
 
 > [!WARNING]
 >
-> This runtime API remains supported for existing apps and advanced shared-store use cases, but it is not recommended as the default state model for new React on Rails apps. Prefer the standard `react_component` view helper with props or a render-function unless multiple React islands must coordinate through one client store.
+> This runtime API remains supported for existing apps and advanced shared-store use cases, but it is not recommended as the default state model for new React on Rails apps. Prefer the standard `react_component` view helper with props or a render-function unless multiple React islands must coordinate through one client store. Keeping one large shared store can also prevent dynamic code splitting for performance.
 
 > [!IMPORTANT]
 >
@@ -14,7 +14,7 @@ If you are rendering one React component on a page, pass props to that component
 
 Choose state ownership before reaching for `redux_store`:
 
-- **Local island state:** use React Hooks or React Context inside one `react_component` root.
+- **Island-local state:** use React Hooks or React Context inside one `react_component` root.
 - **Server state:** use Rails controller props for initial data, then Rails JSON endpoints, GraphQL, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md) for data that belongs on the server.
 - **Multi-island shared client state:** use `redux_store` when separate React roots on one Rails page must read and update the same client-side state.
 

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -1,25 +1,31 @@
-# Redux Store
+# Redux Store API
 
 > [!WARNING]
 >
-> This Redux API is no longer recommended as it prevents dynamic code splitting for performance. Instead, you should use the standard `react_component` view helper passing in a "Render-Function."
+> This runtime API remains supported for existing apps and advanced shared-store use cases, but it is not recommended as the default state model for new React on Rails apps. Prefer the standard `react_component` view helper with props or a render-function unless multiple React islands must coordinate through one client store.
 
 > [!IMPORTANT]
 >
 > **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md#important-redux-shared-store-caveat) for details and alternatives.
 
-You don't need to use the `redux_store` api to use Redux. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
+You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 
-If you are only rendering one React component on a page, as is typical to do a "Single Page App" in React, then you should _probably_ pass the props to your React component in a "Render-Function."
+If you are rendering one React component on a page, pass props to that component through `react_component` and keep local UI state inside that React tree. A render-function is also a better fit when you need `railsContext`, routing setup, or custom hydration behavior for one root.
 
-Consider using the `redux_store` helper for the two following use cases:
+Choose state ownership before reaching for `redux_store`:
+
+- **Local island state:** use React Hooks or React Context inside one `react_component` root.
+- **Server state:** use Rails controller props for initial data, then Rails JSON endpoints, GraphQL, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md) for data that belongs on the server.
+- **Multi-island shared client state:** use `redux_store` when separate React roots on one Rails page must read and update the same client-side state.
+
+Consider using the `redux_store` helper for the following advanced use cases:
 
 1. You want to have multiple React components accessing the same store at once.
-2. You want to place the props to hydrate the client side stores at the very end of your HTML, probably server rendered, so that the browser can render all earlier HTML first. This is particularly useful if your props will be large. However, you're probably better off using [React on Rails Pro](../../pro/react-on-rails-pro.md) if you're at all concerned about performance.
+2. Place the props that hydrate client-side stores at the very end of your HTML, probably server-rendered, so that the browser can render all earlier HTML first. This is particularly useful if your props will be large. However, you're probably better off using [React on Rails Pro](../../pro/react-on-rails-pro.md) if you're at all concerned about performance.
 
-## Multiple React Components on a Page with One Store
+## Multiple React Islands on a Page with One Store
 
-You may wish to have 2 React components share the same the Redux store. For example, if your navbar is a React component, you may want it to use the same store as your component in the main area of the page. You may even want multiple React components in the main area, which allows for greater modularity. Also, you may want this to work with Turbolinks to minimize reloading the JavaScript.
+You may wish to have two separate React roots share the same Redux store. For example, if your navbar is a React component, you may want it to use the same store as your component in the main area of the page. You may even want multiple React components in the main area, which allows for greater modularity. Also, you may want this to work with Turbo or Turbolinks to minimize reloading the JavaScript.
 
 A good example of this would be something like a notifications counter in a header. As each notification is read in the body of the page, you would like to update the header. If both the header and body share the same Redux store, then this is trivial. Otherwise, we have to rely on other solutions, such as the header polling the server to see how many unread notifications exist.
 

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -6,7 +6,7 @@
 
 > [!IMPORTANT]
 >
-> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md) for details and alternatives.
+> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Turbolinks async script loading guidance](../building-features/turbolinks.md#async-script-loading) and [auto-bundling layout integration](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#layout-integration-with-auto-loading) for related script-ordering patterns.
 
 You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -20,12 +20,12 @@ Choose state ownership before reaching for `redux_store`:
 
 Consider using the `redux_store` helper for the following advanced use cases:
 
-1. You want to have multiple React components accessing the same store at once.
-2. Place the props that hydrate client-side stores at the very end of your HTML, probably server-rendered, so that the browser can render all earlier HTML first. This is particularly useful if your props will be large. However, you're probably better off using [React on Rails Pro](../../pro/react-on-rails-pro.md) if you're at all concerned about performance.
+1. You want multiple React roots or islands to access the same store at once.
+2. You want to place the props that hydrate client-side stores at the very end of your HTML, probably server-rendered, so that the browser can render all earlier HTML first. This is particularly useful if your props will be large. However, you're probably better off using [React on Rails Pro](../../pro/react-on-rails-pro.md) if you're at all concerned about performance.
 
 ## Multiple React Islands on a Page with One Store
 
-You may wish to have two separate React roots share the same Redux store. For example, if your navbar is a React component, you may want it to use the same store as your component in the main area of the page. You may even want multiple React components in the main area, which allows for greater modularity. Also, you may want this to work with Turbo or Turbolinks to minimize reloading the JavaScript.
+You may wish to have two separate React roots share the same Redux store. For example, if your navbar is a React island, you may want it to use the same store as another island in the main area of the page. You may even want multiple React islands in the main area, which allows for greater modularity. Also, you may want this to work with Turbo or Turbolinks to minimize reloading the JavaScript.
 
 A good example of this would be something like a notifications counter in a header. As each notification is read in the body of the page, you would like to update the header. If both the header and body share the same Redux store, then this is trivial. Otherwise, we have to rely on other solutions, such as the header polling the server to see how many unread notifications exist.
 

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -6,7 +6,7 @@
 
 > [!IMPORTANT]
 >
-> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Turbolinks async script loading guidance](../building-features/turbolinks.md#async-script-loading) and [auto-bundling layout integration](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#layout-integration-with-auto-loading) for related script-ordering patterns.
+> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [auto-bundling layout integration](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#layout-integration-with-auto-loading) guidance for related script-ordering patterns.
 
 You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 

--- a/docs/oss/building-features/react-and-redux.md
+++ b/docs/oss/building-features/react-and-redux.md
@@ -11,6 +11,8 @@ See [Sharing State Between Components](https://react.dev/learn/sharing-state-bet
 The `helloWorld/reducers/helloWorldReducer.js` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
 
 ```javascript
+import { combineReducers } from 'redux';
+
 import usersReducer from './usersReducer';
 import blogPostsReducer from './blogPostsReducer';
 import commentsReducer from './commentsReducer';
@@ -21,12 +23,14 @@ import { $$initialState as $$blogPostsState } from './blogPostsReducer';
 import { $$initialState as $$commentsState } from './commentsReducer';
 // ...
 
-export default {
+const rootReducer = combineReducers({
   $$usersStore: usersReducer,
   $$blogPostsStore: blogPostsReducer,
   $$commentsStore: commentsReducer,
   // ...
-};
+});
+
+export default rootReducer;
 
 export const initialStates = {
   $$usersState,

--- a/docs/oss/building-features/react-and-redux.md
+++ b/docs/oss/building-features/react-and-redux.md
@@ -8,7 +8,7 @@ See [Sharing State Between Components](https://react.dev/learn/sharing-state-bet
 
 ## Redux Reducers
 
-The `helloWorld/reducers/index.jsx` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
+The `helloWorld/reducers/helloWorldReducer.js` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
 
 ```javascript
 import usersReducer from './usersReducer';

--- a/docs/oss/building-features/react-and-redux.md
+++ b/docs/oss/building-features/react-and-redux.md
@@ -1,4 +1,6 @@
-# Communication between React Components and Redux Reducers
+# Legacy Redux Reducer Guidance
+
+Redux remains supported for existing React on Rails apps and advanced pages that need one client store shared across multiple React roots. For new apps, prefer local component state for island-specific UI, Rails props plus server-state tools for server-owned data, and reach for Redux only when those smaller patterns do not fit.
 
 ## Communication Between Components
 
@@ -6,7 +8,7 @@ See [Sharing State Between Components](https://react.dev/learn/sharing-state-bet
 
 ## Redux Reducers
 
-The `helloWorld/reducers/index.jsx` example that results from running the generator with the Redux option may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
+The `helloWorld/reducers/index.jsx` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
 
 ```javascript
 import usersReducer from './usersReducer';

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -41,7 +41,7 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
 
-**File: `app/javascript/src/RouterApp/RouterApp.jsx`**
+**File: `app/javascript/src/RouterApp/RouterRoutes.jsx`**
 
 ```jsx
 import React from 'react';
@@ -60,7 +60,7 @@ const RouterRoutes = (props) => (
 export default RouterRoutes;
 ```
 
-`RouterApp.jsx` is a shared route tree that expects a router context from its parent. Keep it outside
+`RouterRoutes.jsx` is a shared route tree that expects a router context from its parent. Keep it outside
 `ror_components/` and do not register it directly with React on Rails. Only the files inside
 `ror_components/` are registered entry points.
 
@@ -70,7 +70,7 @@ export default RouterRoutes;
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import RouterRoutes from '../RouterApp';
+import RouterRoutes from '../RouterRoutes';
 
 const RouterApp = (props) => (
   <BrowserRouter>
@@ -139,7 +139,7 @@ The server entry returns a render function, not JSX directly; see
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import RouterRoutes from '../RouterApp';
+import RouterRoutes from '../RouterRoutes';
 
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
@@ -201,9 +201,10 @@ export default HelloWorldApp;
 - Use `<Routes>` and `<Route>` with `element` prop
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
-- Components rendered through `react_component_hash` still need the explicit object return shape,
-  such as `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`, rather than
-  the render-function thunk shown here.
+- Components rendered through `react_component_hash` still need the explicit object return shape
+  instead of the render-function thunk shown here. Return the object described in
+  [Render-Functions](../core-concepts/render-functions.md), for example
+  `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`.
 
 ## Rails Routes Configuration
 

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -147,7 +147,7 @@ const RouterApp = (props, railsContext) => {
   // React on Rails calls RouterApp(props, railsContext), then renders the returned
   // function component. Props are passed again by React, but this example uses the
   // props and location captured by closure.
-  return () => (
+  return (_props) => (
     <StaticRouter location={location}>
       <RouterRoutes {...props} />
     </StaticRouter>
@@ -179,7 +179,7 @@ const HelloWorldApp = (props, railsContext) => {
   const store = configureStore(props);
   const { location } = railsContext;
 
-  return () => (
+  return (_props) => (
     <Provider store={store}>
       <StaticRouter location={location}>
         <Routes>

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -52,8 +52,8 @@ const About = () => <div>About</div>;
 
 const RouterRoutes = (props) => (
   <Routes>
-    <Route path="/" element={<Home {...props} />} />
-    <Route path="/about" element={<About />} />
+    <Route path="/hello_world" element={<Home {...props} />} />
+    <Route path="/hello_world/about" element={<About />} />
   </Routes>
 );
 
@@ -144,8 +144,9 @@ import RouterRoutes from '../RouterRoutes';
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  // React on Rails calls RouterApp(props, railsContext), then mounts the returned
-  // zero-argument function. Props and location are captured by closure.
+  // React on Rails calls RouterApp(props, railsContext), then renders the returned
+  // function component. Props are passed again by React, but this example uses the
+  // props and location captured by closure.
   return () => (
     <StaticRouter location={location}>
       <RouterRoutes {...props} />
@@ -202,8 +203,8 @@ export default HelloWorldApp;
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
 - Components rendered through `react_component_hash` still need the explicit object return shape
-  instead of the render-function thunk shown here. Return the object described in
-  [Render-Functions](../core-concepts/render-functions.md), for example
+  instead of the render-function thunk shown here. Keep using `renderToString(...)` and return the
+  object described in [Render-Functions](../core-concepts/render-functions.md), for example
   `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`.
 
 ## Rails Routes Configuration

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -50,15 +50,19 @@ import { Routes, Route } from 'react-router-dom';
 const Home = ({ name }) => <div>Hello, {name}!</div>;
 const About = () => <div>About</div>;
 
-const RouterApp = (props) => (
+const RouterRoutes = (props) => (
   <Routes>
     <Route path="/" element={<Home {...props} />} />
     <Route path="/about" element={<About />} />
   </Routes>
 );
 
-export default RouterApp;
+export default RouterRoutes;
 ```
+
+`RouterApp.jsx` is a shared route tree that expects a router context from its parent. Keep it outside
+`ror_components/` and do not register it directly with React on Rails. Only the files inside
+`ror_components/` are registered entry points.
 
 **File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
 
@@ -66,15 +70,15 @@ export default RouterApp;
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import RouterApp from '../RouterApp';
+import RouterRoutes from '../RouterApp';
 
-const RouterAppClient = (props) => (
+const RouterApp = (props) => (
   <BrowserRouter>
-    <RouterApp {...props} />
+    <RouterRoutes {...props} />
   </BrowserRouter>
 );
 
-export default RouterAppClient;
+export default RouterApp;
 ```
 
 ## Legacy Client-Side Setup with Redux
@@ -135,20 +139,21 @@ The server entry returns a render function, not JSX directly; see
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import RouterApp from '../RouterApp';
+import RouterRoutes from '../RouterApp';
 
-const RouterAppServer = (props, railsContext) => {
+const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  // React on Rails render-function contract: return a function, not JSX directly.
+  // React on Rails calls RouterApp(props, railsContext), then mounts the returned
+  // zero-argument function. Props and location are captured by closure.
   return () => (
     <StaticRouter location={location}>
-      <RouterApp {...props} />
+      <RouterRoutes {...props} />
     </StaticRouter>
   );
 };
 
-export default RouterAppServer;
+export default RouterApp;
 ```
 
 ## Legacy Server-Side Setup with Redux
@@ -197,8 +202,8 @@ export default HelloWorldApp;
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
 - Components rendered through `react_component_hash` still need the explicit object return shape,
-  such as `{ componentHtml: renderToString(...), ...otherSlots }`, rather than the render-function
-  thunk shown here.
+  such as `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`, rather than
+  the render-function thunk shown here.
 
 ## Rails Routes Configuration
 

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -109,6 +109,9 @@ export default HelloWorldApp;
 ## Basic Server-Side Rendering with React Router
 
 For server rendering without Redux, use the same route tree with `StaticRouter` instead of `BrowserRouter`.
+This `.client.jsx` / `.server.jsx` split assumes
+[auto-bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)
+is configured so React on Rails registers the client and server files separately.
 
 **File: `app/javascript/src/RouterApp/ror_components/RouterApp.server.jsx`**
 

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -106,9 +106,42 @@ export default HelloWorldApp;
 - Use `element` prop to specify components (not `component` or `render` props from v5)
 - Routes are automatically matched by best fit, not render order
 
-## Server-Side Rendering with React Router
+## Basic Server-Side Rendering with React Router
 
-For server rendering, use `StaticRouter` instead of `BrowserRouter`.
+For server rendering without Redux, use the same route tree with `StaticRouter` instead of `BrowserRouter`.
+
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.server.jsx`**
+
+```jsx
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom/server';
+import { Routes, Route } from 'react-router-dom';
+
+const Home = ({ name }) => <div>Hello, {name}!</div>;
+const About = () => <div>About</div>;
+
+const RouterApp = (props, railsContext) => {
+  const { location } = railsContext;
+
+  const html = renderToString(
+    <StaticRouter location={location}>
+      <Routes>
+        <Route path="/" element={<Home {...props} />} />
+        <Route path="/about" element={<About />} />
+      </Routes>
+    </StaticRouter>,
+  );
+
+  return { renderedHtml: html };
+};
+
+export default RouterApp;
+```
+
+## Legacy Server-Side Setup with Redux
+
+If your app still uses the legacy shared Redux store, keep the provider around the `StaticRouter`.
 
 **File: `app/javascript/src/HelloWorldApp/ror_components/HelloWorldApp.server.jsx`**
 

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -114,7 +114,6 @@ For server rendering without Redux, use the same route tree with `StaticRouter` 
 
 ```jsx
 import React from 'react';
-import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 import { Routes, Route } from 'react-router-dom';
 
@@ -124,16 +123,14 @@ const About = () => <div>About</div>;
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  const html = renderToString(
+  return (
     <StaticRouter location={location}>
       <Routes>
         <Route path="/" element={<Home {...props} />} />
         <Route path="/about" element={<About />} />
       </Routes>
-    </StaticRouter>,
+    </StaticRouter>
   );
-
-  return { renderedHtml: html };
 };
 
 export default RouterApp;

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -37,9 +37,34 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 **Note on Data Mode:** React Router's Data Mode (with loaders/actions) is designed for SPAs where the client handles data fetching. Since React on Rails uses Rails controllers to load data and pass it as props to React components, Data Mode would create duplicate data loading. Stick with Declarative Mode to leverage React on Rails' server-side data loading pattern.
 
-## Basic Client-Side Setup with Redux
+## Basic Client-Side Setup
 
-If you're using Redux (created with `rails generate react_on_rails:install --redux`), you can add React Router by wrapping your app:
+Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
+
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
+
+```jsx
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+const Home = ({ name }) => <div>Hello, {name}!</div>;
+const About = () => <div>About</div>;
+
+const RouterApp = (props) => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<Home {...props} />} />
+      <Route path="/about" element={<About />} />
+    </Routes>
+  </BrowserRouter>
+);
+
+export default RouterApp;
+```
+
+## Legacy Client-Side Setup with Redux
+
+If you're maintaining an app that already uses Redux, including the hidden legacy Redux generator output, you can add React Router by wrapping your app:
 
 **File: `app/javascript/src/HelloWorldApp/ror_components/HelloWorldApp.client.jsx`**
 
@@ -76,7 +101,7 @@ export default HelloWorldApp;
 
 **Key points:**
 
-- `<Provider>` wraps `<BrowserRouter>` so all routes have Redux access
+- In Redux-backed legacy apps, `<Provider>` wraps `<BrowserRouter>` so all routes have Redux access
 - Use `<Routes>` and `<Route>` (not `<Switch>` from React Router v5)
 - Use `element` prop to specify components (not `component` or `render` props from v5)
 - Routes are automatically matched by best fit, not render order

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -123,7 +123,7 @@ const About = () => <div>About</div>;
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  return (
+  return () => (
     <StaticRouter location={location}>
       <Routes>
         <Route path="/" element={<Home {...props} />} />

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -41,7 +41,7 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
 
-**File: `app/javascript/src/RouterApp/ror_components/RouterApp.jsx`**
+**File: `app/javascript/src/RouterApp/RouterApp.jsx`**
 
 ```jsx
 import React from 'react';
@@ -66,7 +66,7 @@ export default RouterApp;
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import RouterApp from './RouterApp';
+import RouterApp from '../RouterApp';
 
 const RouterAppClient = (props) => (
   <BrowserRouter>
@@ -127,17 +127,20 @@ For server rendering without Redux, use the same route tree with `StaticRouter` 
 This `.client.jsx` / `.server.jsx` split assumes
 [auto-bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)
 is configured so React on Rails registers the client and server files separately.
+The server entry returns a render function, not JSX directly; see
+[Render-Functions and railsContext](../core-concepts/render-functions-and-railscontext.md).
 
 **File: `app/javascript/src/RouterApp/ror_components/RouterApp.server.jsx`**
 
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import RouterApp from './RouterApp';
+import RouterApp from '../RouterApp';
 
 const RouterAppServer = (props, railsContext) => {
   const { location } = railsContext;
 
+  // React on Rails render-function contract: return a function, not JSX directly.
   return () => (
     <StaticRouter location={location}>
       <RouterApp {...props} />
@@ -193,6 +196,9 @@ export default HelloWorldApp;
 - Use `<Routes>` and `<Route>` with `element` prop
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
+- Components rendered through `react_component_hash` still need the explicit object return shape,
+  such as `{ componentHtml: renderToString(...), ...otherSlots }`, rather than the render-function
+  thunk shown here.
 
 ## Rails Routes Configuration
 

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -41,25 +41,40 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
 
-**File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.jsx`**
 
 ```jsx
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 
 const Home = ({ name }) => <div>Hello, {name}!</div>;
 const About = () => <div>About</div>;
 
 const RouterApp = (props) => (
-  <BrowserRouter>
-    <Routes>
-      <Route path="/" element={<Home {...props} />} />
-      <Route path="/about" element={<About />} />
-    </Routes>
-  </BrowserRouter>
+  <Routes>
+    <Route path="/" element={<Home {...props} />} />
+    <Route path="/about" element={<About />} />
+  </Routes>
 );
 
 export default RouterApp;
+```
+
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
+
+```jsx
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+import RouterApp from './RouterApp';
+
+const RouterAppClient = (props) => (
+  <BrowserRouter>
+    <RouterApp {...props} />
+  </BrowserRouter>
+);
+
+export default RouterAppClient;
 ```
 
 ## Legacy Client-Side Setup with Redux
@@ -118,25 +133,19 @@ is configured so React on Rails registers the client and server files separately
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import { Routes, Route } from 'react-router-dom';
+import RouterApp from './RouterApp';
 
-const Home = ({ name }) => <div>Hello, {name}!</div>;
-const About = () => <div>About</div>;
-
-const RouterApp = (props, railsContext) => {
+const RouterAppServer = (props, railsContext) => {
   const { location } = railsContext;
 
   return () => (
     <StaticRouter location={location}>
-      <Routes>
-        <Route path="/" element={<Home {...props} />} />
-        <Route path="/about" element={<About />} />
-      </Routes>
+      <RouterApp {...props} />
     </StaticRouter>
   );
 };
 
-export default RouterApp;
+export default RouterAppServer;
 ```
 
 ## Legacy Server-Side Setup with Redux
@@ -147,7 +156,6 @@ If your app still uses the legacy shared Redux store, keep the provider around t
 
 ```jsx
 import React from 'react';
-import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 import { Provider } from 'react-redux';
 import { Routes, Route } from 'react-router-dom';
@@ -162,7 +170,7 @@ const HelloWorldApp = (props, railsContext) => {
   const store = configureStore(props);
   const { location } = railsContext;
 
-  const html = renderToString(
+  return () => (
     <Provider store={store}>
       <StaticRouter location={location}>
         <Routes>
@@ -172,10 +180,8 @@ const HelloWorldApp = (props, railsContext) => {
           {/* <Route path="/contact" element={<Contact />} /> */}
         </Routes>
       </StaticRouter>
-    </Provider>,
+    </Provider>
   );
-
-  return { renderedHtml: html };
 };
 
 export default HelloWorldApp;

--- a/docs/oss/building-features/react-router.md
+++ b/docs/oss/building-features/react-router.md
@@ -144,9 +144,9 @@ import RouterRoutes from '../RouterRoutes';
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  // React on Rails calls RouterApp(props, railsContext), then renders the returned
-  // function component. Props are passed again by React, but this example uses the
-  // props and location captured by closure.
+  // React on Rails calls RouterApp(props, railsContext) to get this function,
+  // then calls createElement(returnedFn, props). This example uses the props
+  // and location captured by closure.
   return (_props) => (
     <StaticRouter location={location}>
       <RouterRoutes {...props} />
@@ -156,6 +156,11 @@ const RouterApp = (props, railsContext) => {
 
 export default RouterApp;
 ```
+
+> **Note:** Components rendered through `react_component_hash` still need the explicit object return shape
+> instead of the render-function thunk shown here. Keep using `renderToString(...)` and return the object
+> described in [Render-Functions](../core-concepts/render-functions.md), for example
+> `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`.
 
 ## Legacy Server-Side Setup with Redux
 

--- a/docs/oss/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
+++ b/docs/oss/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
@@ -728,7 +728,7 @@ As of version 13.3.4, bundles inside directories that match `config.components_s
 ## Redux Store Auto-Registration
 
 > [!NOTE]
-> Most applications use React components without Redux. If you don't use Redux stores, you can skip this section entirely.
+> Most applications use React components without Redux. If you don't maintain a legacy Redux app or an advanced multi-island shared store, you can skip this section entirely.
 
 In addition to components, React on Rails can automatically register Redux stores based on file system conventions. This eliminates manual `ReactOnRails.registerStore()` calls and generates individual packs for each store. The feature works the same way as component auto-registration.
 

--- a/docs/oss/core-concepts/how-react-on-rails-works.md
+++ b/docs/oss/core-concepts/how-react-on-rails-works.md
@@ -8,7 +8,7 @@ Ensure these generated bundle files are in your `.gitignore`, as you never want 
 
 Inside your Rails views, you can now use the `react_component` helper method provided by React on Rails. You can pass props directly to the React component helper.
 
-Optionally, you can also initialize a Redux store with the view or controller helper `redux_store` so that the Redux store can be shared amongst multiple React components.
+For legacy or advanced shared-store pages, you can also initialize a Redux store with the view or controller helper `redux_store` so that separate React roots can coordinate through one client store.
 
 ## Client-Side Rendering vs. Server-Side Rendering
 

--- a/docs/oss/core-concepts/render-functions-and-railscontext.md
+++ b/docs/oss/core-concepts/render-functions-and-railscontext.md
@@ -3,7 +3,7 @@
 ## Render-Functions
 
 When you use a render-function to create React components (or `renderedHtml` on the server), or you
-use shared Redux stores, you get two params passed to your function that creates a React component:
+register legacy or advanced shared Redux stores, React on Rails passes two params to the function it calls:
 
 1. `props`: Props that you pass in the view helper of either `react_component` or `redux_store`
 2. `railsContext`: Rails contextual information, such as the current pathname. You can customize
@@ -78,7 +78,7 @@ reduxStore = MyReduxStore(props, railsContext);
 > You never make these calls. React on Rails makes these calls when it does either client or server rendering. You will define functions that take these 2 params and return a React component or a Redux Store. Naturally, you do not have to use second parameter, `railsContext`, if you do not need it. If you don't take a second parameter, then you're probably defining a React function component and you will simply return a React Element, often just JSX.
 
 > [!NOTE]
-> See [Redux Store](../api-reference/redux-store-api.md#multiple-react-components-on-a-page-with-one-store) on how to set up Redux stores that allow multiple components to talk to the same store.
+> See [Redux Store](../api-reference/redux-store-api.md#multiple-react-islands-on-a-page-with-one-store) on how to set up Redux stores that allow multiple React roots to talk to the same store.
 
 The `railsContext` has: (see the implementation in [ReactOnRails::Helper](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/lib/react_on_rails/helper.rb), method `rails_context` for the definitive list).
 

--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -190,7 +190,7 @@ Now that you have React on Rails working, here's what to explore next:
 
 ### Advanced Features
 
-1. **[Redux Integration](../building-features/react-and-redux.md)** - Manage application state
+1. **[Redux Integration](../building-features/react-and-redux.md)** - Maintain legacy or advanced shared-store integrations
 2. **[React Router](../building-features/react-router.md)** - Client-side routing
 
 ### Pro Features

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -313,7 +313,7 @@ When rendering an existing Redux-backed component, the Rails side still uses the
 
 The component is named `HelloWorldApp` when you are working with the legacy generated Redux example. Adjust the component name and props key to match your app's controller setup.
 
-For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [Redux integration guide](../building-features/react-and-redux.md).
+For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [legacy Redux reducer guidance](../building-features/react-and-redux.md).
 
 ## What's Next?
 

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -303,7 +303,7 @@ Use Redux when your app already has Redux conventions, needs a shared client sto
 - **Server state:** pass initial data through Rails controller props, then refresh data through your Rails JSON endpoints, GraphQL layer, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md).
 - **Multi-island shared client state:** use Redux only when separate React roots on the same page must coordinate through one client store, such as a header counter and body list that update each other without a full page refresh.
 
-The installer has a hidden legacy Redux path for maintaining or recreating older generated apps, but this tutorial does not use it and new apps should not start with `--redux`. The legacy Redux structure has actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
+The installer has a [hidden legacy Redux path](../api-reference/generator-details.md#legacy-redux-structure-hidden---redux-path) for maintaining or recreating older generated apps, but this tutorial does not use it and new apps should not start with `--redux`. The legacy Redux structure has actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
 
 When rendering an existing Redux-backed component, the Rails side still uses the same view helper style:
 

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -9,7 +9,7 @@ This tutorial starts from the [Quick Start](./quick-start.md) app and builds a s
 - `bin/dev` with HMR during development
 - Optional server rendering with `prerender: true`
 
-Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux Integration](#appendix-redux-integration) when you need a shared client store or you are maintaining an existing Redux setup.
+Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux and State Choices](#appendix-redux-and-state-choices) when you need a multi-island shared client store or you are maintaining an existing Redux setup.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ Redux is still supported, but it is no longer the main path for a first React on
 - [Optional: Turn On Server Rendering](#optional-turn-on-server-rendering)
 - [Production Build And Deployment](#production-build-and-deployment)
 - [Troubleshooting](#troubleshooting)
-- [Appendix: Redux Integration](#appendix-redux-integration)
+- [Appendix: Redux and State Choices](#appendix-redux-and-state-choices)
 - [What's Next?](#whats-next)
 
 ## Prerequisites
@@ -295,25 +295,23 @@ Temporarily set `prerender: false` to confirm the browser render works, then rem
 <%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true, trace: true) %>
 ```
 
-## Appendix: Redux Integration
+## Appendix: Redux and State Choices
 
-Use Redux when your app already has Redux conventions, needs a shared client store across many React islands, or benefits from Redux middleware and DevTools. For local UI state, React Hooks are usually simpler.
+Use Redux when your app already has Redux conventions, needs a shared client store across many React islands, or benefits from Redux middleware and DevTools. For most new React on Rails apps, choose the smallest state tool that matches the data:
 
-To generate the Redux example for a new app, run the installer with both TypeScript and Redux:
+- **Local island state:** use React Hooks such as `useState` and `useReducer`, or React Context when nearby components under one React root need the same UI state.
+- **Server state:** pass initial data through Rails controller props, then refresh data through your Rails JSON endpoints, GraphQL layer, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md).
+- **Multi-island shared client state:** use Redux only when separate React roots on the same page must coordinate through one client store, such as a header counter and body list that update each other without a full page refresh.
 
-```bash
-bin/rails generate react_on_rails:install --typescript --redux
-```
+The installer has a hidden legacy Redux path for maintaining or recreating older generated apps, but this tutorial does not use it and new apps should not start with `--redux`. The legacy Redux structure has actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
 
-The Redux installer creates a larger structure with actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
-
-When rendering a Redux-backed component, the Rails side still uses the same view helper style:
+When rendering an existing Redux-backed component, the Rails side still uses the same view helper style:
 
 ```erb
 <%= react_component("HelloWorldApp", props: @hello_world_props, auto_load_bundle: true) %>
 ```
 
-The component is named `HelloWorldApp` because that is what the Redux installer generates. Adjust the component name and props key to match your app's controller setup.
+The component is named `HelloWorldApp` when you are working with the legacy generated Redux example. Adjust the component name and props key to match your app's controller setup.
 
 For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [Redux integration guide](../building-features/react-and-redux.md).
 

--- a/docs/oss/getting-started/using-react-on-rails.md
+++ b/docs/oss/getting-started/using-react-on-rails.md
@@ -158,7 +158,7 @@ The generator creates `bin/dev` for starting both:
 Sometimes you need more than just a simple React component. **Render-Functions** let you:
 
 1. Access Rails context (current URL, locale, etc.)
-2. Initialize Redux stores with props
+2. Initialize legacy shared Redux stores with props
 3. Set up React Router or TanStack Router (TanStack SSR requires React on Rails Pro)
 4. Return different components based on props
 
@@ -180,7 +180,7 @@ export default MyApp;
 ### When to Use Render-Functions
 
 - **Need railsContext** - Access current URL, locale, or custom Rails data
-- **Redux integration** - Initialize store with server-side props
+- **Redux integration** - Initialize a legacy or advanced shared store with server-side props
 - **React Router** - Set up routing with initial URL from Rails
 - **Conditional rendering** - Return different components based on props
 
@@ -237,7 +237,7 @@ Now that you understand the core concepts, here are recommended paths forward:
 
 ### Build Features
 
-- **[Redux Integration](../building-features/react-and-redux.md)** - Add state management
+- **[Redux Integration](../building-features/react-and-redux.md)** - Maintain legacy or advanced shared-store state
 - **[React Router](../building-features/react-router.md)** - Client-side routing
 - **[TanStack Router](../building-features/tanstack-router.md)** - Pro-only first-class router integration with SSR dehydration/hydration
 - **[Server-Side Rendering](../core-concepts/react-server-rendering.md)** - Deep dive into SSR

--- a/docs/oss/introduction.md
+++ b/docs/oss/introduction.md
@@ -85,7 +85,7 @@ Find guidance for your specific scenario:
 | **Compare Rails + frontend options** | [Comparison Guide](./getting-started/comparing-react-on-rails-to-alternatives.md)     |
 | **Enable server-side rendering**     | [SSR Guide](./core-concepts/react-server-rendering.md)                                |
 | **Set up hot reloading**             | [HMR Setup](./building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) |
-| **Use legacy shared Redux stores**   | [Redux Integration](./building-features/react-and-redux.md)                           |
+| **Use legacy shared Redux stores**   | [Legacy Redux Guidance](./building-features/react-and-redux.md)                       |
 | **Use TanStack Router**              | [TanStack Router Guide](./building-features/tanstack-router.md)                       |
 | **Deploy to production**             | [Deployment Guide](./deployment/README.md)                                            |
 | **Troubleshoot issues**              | [Troubleshooting](./deployment/troubleshooting.md)                                    |

--- a/docs/oss/introduction.md
+++ b/docs/oss/introduction.md
@@ -15,7 +15,7 @@ React on Rails bridges the gap between Ruby on Rails and React, allowing you to:
 - Pass props from Rails to React without building a separate API
 - Enable server-side rendering for better SEO and initial page load performance
 - Use hot module replacement (HMR) for fast development iterations
-- Integrate with Redux, React Router, and the modern React ecosystem
+- Integrate with React Router, server-state tools, and advanced shared-store libraries such as Redux
 
 Unlike a separate SPA approach, React on Rails lets you leverage Rails conventions while progressively enhancing your UI with React components.
 
@@ -67,7 +67,7 @@ Detailed integration instructions for existing Rails applications with Shakapack
 
 **[Complete Tutorial →](./getting-started/tutorial.md)**
 
-Step-by-step walkthrough building a full app with Redux, routing, and deployment.
+Step-by-step walkthrough building a TypeScript component with hooks, server rendering, and deployment guidance.
 
 ### 👀 Learn by Example?
 
@@ -85,7 +85,7 @@ Find guidance for your specific scenario:
 | **Compare Rails + frontend options** | [Comparison Guide](./getting-started/comparing-react-on-rails-to-alternatives.md)     |
 | **Enable server-side rendering**     | [SSR Guide](./core-concepts/react-server-rendering.md)                                |
 | **Set up hot reloading**             | [HMR Setup](./building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) |
-| **Use Redux with Rails**             | [Redux Integration](./building-features/react-and-redux.md)                           |
+| **Use legacy shared Redux stores**   | [Redux Integration](./building-features/react-and-redux.md)                           |
 | **Use TanStack Router**              | [TanStack Router Guide](./building-features/tanstack-router.md)                       |
 | **Deploy to production**             | [Deployment Guide](./deployment/README.md)                                            |
 | **Troubleshoot issues**              | [Troubleshooting](./deployment/troubleshooting.md)                                    |

--- a/docs/oss/introduction.md
+++ b/docs/oss/introduction.md
@@ -15,7 +15,7 @@ React on Rails bridges the gap between Ruby on Rails and React, allowing you to:
 - Pass props from Rails to React without building a separate API
 - Enable server-side rendering for better SEO and initial page load performance
 - Use hot module replacement (HMR) for fast development iterations
-- Integrate with React Router, server-state tools, and advanced shared-store libraries such as Redux
+- Integrate with React Router, server-state tools, and, for existing apps or advanced multi-island pages, shared-store libraries such as Redux
 
 Unlike a separate SPA approach, React on Rails lets you leverage Rails conventions while progressively enhancing your UI with React components.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -216,7 +216,7 @@ React on Rails bridges the gap between Ruby on Rails and React, allowing you to:
 - Pass props from Rails to React without building a separate API
 - Enable server-side rendering for better SEO and initial page load performance
 - Use hot module replacement (HMR) for fast development iterations
-- Integrate with React Router, server-state tools, and advanced shared-store libraries such as Redux
+- Integrate with React Router, server-state tools, and, for existing apps or advanced multi-island pages, shared-store libraries such as Redux
 
 Unlike a separate SPA approach, React on Rails lets you leverage Rails conventions while progressively enhancing your UI with React components.
 
@@ -18853,7 +18853,7 @@ SOURCE: docs/oss/api-reference/redux-store-api.md
 
 > [!IMPORTANT]
 >
-> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md#important-redux-shared-store-caveat) for details and alternatives.
+> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md) for details and alternatives.
 
 You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 
@@ -19166,6 +19166,7 @@ Description:
 The react_on_rails:install generator integrates webpack with rails with ease. You
 can pass the options below to customize the generated example and supporting
 configuration.
+```
 
 > [!WARNING]
 > The Redux installer path (`--redux` / `-R`) is a hidden legacy escape hatch, not
@@ -19176,6 +19177,7 @@ configuration.
 > multi-island page where separate React roots must coordinate through one shared
 > client store.
 
+```text
 * TypeScript
 
     Passing the --typescript generator option generates TypeScript files (.tsx)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -216,7 +216,7 @@ React on Rails bridges the gap between Ruby on Rails and React, allowing you to:
 - Pass props from Rails to React without building a separate API
 - Enable server-side rendering for better SEO and initial page load performance
 - Use hot module replacement (HMR) for fast development iterations
-- Integrate with Redux, React Router, and the modern React ecosystem
+- Integrate with React Router, server-state tools, and advanced shared-store libraries such as Redux
 
 Unlike a separate SPA approach, React on Rails lets you leverage Rails conventions while progressively enhancing your UI with React components.
 
@@ -268,7 +268,7 @@ Detailed integration instructions for existing Rails applications with Shakapack
 
 **[Complete Tutorial →](./getting-started/tutorial.md)**
 
-Step-by-step walkthrough building a full app with Redux, routing, and deployment.
+Step-by-step walkthrough building a TypeScript component with hooks, server rendering, and deployment guidance.
 
 ### 👀 Learn by Example?
 
@@ -286,7 +286,7 @@ Find guidance for your specific scenario:
 | **Compare Rails + frontend options** | [Comparison Guide](./getting-started/comparing-react-on-rails-to-alternatives.md)     |
 | **Enable server-side rendering**     | [SSR Guide](./core-concepts/react-server-rendering.md)                                |
 | **Set up hot reloading**             | [HMR Setup](./building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) |
-| **Use Redux with Rails**             | [Redux Integration](./building-features/react-and-redux.md)                           |
+| **Use legacy shared Redux stores**   | [Redux Integration](./building-features/react-and-redux.md)                           |
 | **Use TanStack Router**              | [TanStack Router Guide](./building-features/tanstack-router.md)                       |
 | **Deploy to production**             | [Deployment Guide](./deployment/README.md)                                            |
 | **Troubleshoot issues**              | [Troubleshooting](./deployment/troubleshooting.md)                                    |
@@ -547,7 +547,7 @@ Now that you have React on Rails working, here's what to explore next:
 
 ### Advanced Features
 
-1. **[Redux Integration](../building-features/react-and-redux.md)** - Manage application state
+1. **[Redux Integration](../building-features/react-and-redux.md)** - Maintain legacy or advanced shared-store integrations
 2. **[React Router](../building-features/react-router.md)** - Client-side routing
 
 ### Pro Features
@@ -862,7 +862,7 @@ This tutorial starts from the [Quick Start](./quick-start.md) app and builds a s
 - `bin/dev` with HMR during development
 - Optional server rendering with `prerender: true`
 
-Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux Integration](#appendix-redux-integration) when you need a shared client store or you are maintaining an existing Redux setup.
+Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux and State Choices](#appendix-redux-and-state-choices) when you need a multi-island shared client store or you are maintaining an existing Redux setup.
 
 ## Table of Contents
 
@@ -876,7 +876,7 @@ Redux is still supported, but it is no longer the main path for a first React on
 - [Optional: Turn On Server Rendering](#optional-turn-on-server-rendering)
 - [Production Build And Deployment](#production-build-and-deployment)
 - [Troubleshooting](#troubleshooting)
-- [Appendix: Redux Integration](#appendix-redux-integration)
+- [Appendix: Redux and State Choices](#appendix-redux-and-state-choices)
 - [What's Next?](#whats-next)
 
 ## Prerequisites
@@ -1148,27 +1148,25 @@ Temporarily set `prerender: false` to confirm the browser render works, then rem
 <%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true, trace: true) %>
 ```
 
-## Appendix: Redux Integration
+## Appendix: Redux and State Choices
 
-Use Redux when your app already has Redux conventions, needs a shared client store across many React islands, or benefits from Redux middleware and DevTools. For local UI state, React Hooks are usually simpler.
+Use Redux when your app already has Redux conventions, needs a shared client store across many React islands, or benefits from Redux middleware and DevTools. For most new React on Rails apps, choose the smallest state tool that matches the data:
 
-To generate the Redux example for a new app, run the installer with both TypeScript and Redux:
+- **Local island state:** use React Hooks such as `useState` and `useReducer`, or React Context when nearby components under one React root need the same UI state.
+- **Server state:** pass initial data through Rails controller props, then refresh data through your Rails JSON endpoints, GraphQL layer, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md).
+- **Multi-island shared client state:** use Redux only when separate React roots on the same page must coordinate through one client store, such as a header counter and body list that update each other without a full page refresh.
 
-```bash
-bin/rails generate react_on_rails:install --typescript --redux
-```
+The installer has a hidden legacy Redux path for maintaining or recreating older generated apps, but this tutorial does not use it and new apps should not start with `--redux`. The legacy Redux structure has actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
 
-The Redux installer creates a larger structure with actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
-
-When rendering a Redux-backed component, the Rails side still uses the same view helper style:
+When rendering an existing Redux-backed component, the Rails side still uses the same view helper style:
 
 ```erb
 <%= react_component("HelloWorldApp", props: @hello_world_props, auto_load_bundle: true) %>
 ```
 
-The component is named `HelloWorldApp` because that is what the Redux installer generates. Adjust the component name and props key to match your app's controller setup.
+The component is named `HelloWorldApp` when you are working with the legacy generated Redux example. Adjust the component name and props key to match your app's controller setup.
 
-For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [Redux integration guide](../building-features/react-and-redux.md).
+For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [legacy Redux reducer guidance](../building-features/react-and-redux.md).
 
 ## What's Next?
 
@@ -1738,7 +1736,7 @@ The generator creates `bin/dev` for starting both:
 Sometimes you need more than just a simple React component. **Render-Functions** let you:
 
 1. Access Rails context (current URL, locale, etc.)
-2. Initialize Redux stores with props
+2. Initialize legacy shared Redux stores with props
 3. Set up React Router or TanStack Router (TanStack SSR requires React on Rails Pro)
 4. Return different components based on props
 
@@ -1760,7 +1758,7 @@ export default MyApp;
 ### When to Use Render-Functions
 
 - **Need railsContext** - Access current URL, locale, or custom Rails data
-- **Redux integration** - Initialize store with server-side props
+- **Redux integration** - Initialize a legacy or advanced shared store with server-side props
 - **React Router** - Set up routing with initial URL from Rails
 - **Conditional rendering** - Return different components based on props
 
@@ -1817,7 +1815,7 @@ Now that you understand the core concepts, here are recommended paths forward:
 
 ### Build Features
 
-- **[Redux Integration](../building-features/react-and-redux.md)** - Add state management
+- **[Redux Integration](../building-features/react-and-redux.md)** - Maintain legacy or advanced shared-store state
 - **[React Router](../building-features/react-router.md)** - Client-side routing
 - **[TanStack Router](../building-features/tanstack-router.md)** - Pro-only first-class router integration with SSR dehydration/hydration
 - **[Server-Side Rendering](../core-concepts/react-server-rendering.md)** - Deep dive into SSR
@@ -2428,7 +2426,7 @@ Ensure these generated bundle files are in your `.gitignore`, as you never want 
 
 Inside your Rails views, you can now use the `react_component` helper method provided by React on Rails. You can pass props directly to the React component helper.
 
-Optionally, you can also initialize a Redux store with the view or controller helper `redux_store` so that the Redux store can be shared amongst multiple React components.
+For legacy or advanced shared-store pages, you can also initialize a Redux store with the view or controller helper `redux_store` so that separate React roots can coordinate through one client store.
 
 ## Client-Side Rendering vs. Server-Side Rendering
 
@@ -2569,7 +2567,7 @@ SOURCE: docs/oss/core-concepts/render-functions-and-railscontext.md
 ## Render-Functions
 
 When you use a render-function to create React components (or `renderedHtml` on the server), or you
-use shared Redux stores, you get two params passed to your function that creates a React component:
+register legacy or advanced shared Redux stores, React on Rails passes two params to the function it calls:
 
 1. `props`: Props that you pass in the view helper of either `react_component` or `redux_store`
 2. `railsContext`: Rails contextual information, such as the current pathname. You can customize
@@ -2644,7 +2642,7 @@ reduxStore = MyReduxStore(props, railsContext);
 > You never make these calls. React on Rails makes these calls when it does either client or server rendering. You will define functions that take these 2 params and return a React component or a Redux Store. Naturally, you do not have to use second parameter, `railsContext`, if you do not need it. If you don't take a second parameter, then you're probably defining a React function component and you will simply return a React Element, often just JSX.
 
 > [!NOTE]
-> See [Redux Store](../api-reference/redux-store-api.md#multiple-react-components-on-a-page-with-one-store) on how to set up Redux stores that allow multiple components to talk to the same store.
+> See [Redux Store](../api-reference/redux-store-api.md#multiple-react-islands-on-a-page-with-one-store) on how to set up Redux stores that allow multiple React roots to talk to the same store.
 
 The `railsContext` has: (see the implementation in [ReactOnRails::Helper](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/lib/react_on_rails/helper.rb), method `rails_context` for the definitive list).
 
@@ -4012,7 +4010,7 @@ As of version 13.3.4, bundles inside directories that match `config.components_s
 ## Redux Store Auto-Registration
 
 > [!NOTE]
-> Most applications use React components without Redux. If you don't use Redux stores, you can skip this section entirely.
+> Most applications use React components without Redux. If you don't maintain a legacy Redux app or an advanced multi-island shared store, you can skip this section entirely.
 
 In addition to components, React on Rails can automatically register Redux stores based on file system conventions. This eliminates manual `ReactOnRails.registerStore()` calls and generates individual packs for each store. The feature works the same way as component auto-registration.
 
@@ -4984,9 +4982,34 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 **Note on Data Mode:** React Router's Data Mode (with loaders/actions) is designed for SPAs where the client handles data fetching. Since React on Rails uses Rails controllers to load data and pass it as props to React components, Data Mode would create duplicate data loading. Stick with Declarative Mode to leverage React on Rails' server-side data loading pattern.
 
-## Basic Client-Side Setup with Redux
+## Basic Client-Side Setup
 
-If you're using Redux (created with `rails generate react_on_rails:install --redux`), you can add React Router by wrapping your app:
+Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
+
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
+
+```jsx
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+const Home = ({ name }) => <div>Hello, {name}!</div>;
+const About = () => <div>About</div>;
+
+const RouterApp = (props) => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<Home {...props} />} />
+      <Route path="/about" element={<About />} />
+    </Routes>
+  </BrowserRouter>
+);
+
+export default RouterApp;
+```
+
+## Legacy Client-Side Setup with Redux
+
+If you're maintaining an app that already uses Redux, including the hidden legacy Redux generator output, you can add React Router by wrapping your app:
 
 **File: `app/javascript/src/HelloWorldApp/ror_components/HelloWorldApp.client.jsx`**
 
@@ -5023,14 +5046,47 @@ export default HelloWorldApp;
 
 **Key points:**
 
-- `<Provider>` wraps `<BrowserRouter>` so all routes have Redux access
+- In Redux-backed legacy apps, `<Provider>` wraps `<BrowserRouter>` so all routes have Redux access
 - Use `<Routes>` and `<Route>` (not `<Switch>` from React Router v5)
 - Use `element` prop to specify components (not `component` or `render` props from v5)
 - Routes are automatically matched by best fit, not render order
 
-## Server-Side Rendering with React Router
+## Basic Server-Side Rendering with React Router
 
-For server rendering, use `StaticRouter` instead of `BrowserRouter`.
+For server rendering without Redux, use the same route tree with `StaticRouter` instead of `BrowserRouter`.
+This `.client.jsx` / `.server.jsx` split assumes
+[auto-bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)
+is configured so React on Rails registers the client and server files separately.
+
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.server.jsx`**
+
+```jsx
+import React from 'react';
+import { StaticRouter } from 'react-router-dom/server';
+import { Routes, Route } from 'react-router-dom';
+
+const Home = ({ name }) => <div>Hello, {name}!</div>;
+const About = () => <div>About</div>;
+
+const RouterApp = (props, railsContext) => {
+  const { location } = railsContext;
+
+  return () => (
+    <StaticRouter location={location}>
+      <Routes>
+        <Route path="/" element={<Home {...props} />} />
+        <Route path="/about" element={<About />} />
+      </Routes>
+    </StaticRouter>
+  );
+};
+
+export default RouterApp;
+```
+
+## Legacy Server-Side Setup with Redux
+
+If your app still uses the legacy shared Redux store, keep the provider around the `StaticRouter`.
 
 **File: `app/javascript/src/HelloWorldApp/ror_components/HelloWorldApp.server.jsx`**
 
@@ -8701,7 +8757,9 @@ PAGE: https://reactonrails.com/docs/building-features/react-and-redux
 SOURCE: docs/oss/building-features/react-and-redux.md
 ================================================================================
 
-# Communication between React Components and Redux Reducers
+# Legacy Redux Reducer Guidance
+
+Redux remains supported for existing React on Rails apps and advanced pages that need one client store shared across multiple React roots. For new apps, prefer local component state for island-specific UI, Rails props plus server-state tools for server-owned data, and reach for Redux only when those smaller patterns do not fit.
 
 ## Communication Between Components
 
@@ -8709,7 +8767,7 @@ See [Sharing State Between Components](https://react.dev/learn/sharing-state-bet
 
 ## Redux Reducers
 
-The `helloWorld/reducers/index.jsx` example that results from running the generator with the Redux option may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
+The `helloWorld/reducers/index.jsx` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
 
 ```javascript
 import usersReducer from './usersReducer';
@@ -18695,9 +18753,10 @@ The best source of docs is the `interface ReactOnRails` in [types/index.ts](http
 register(components);
 
 /**
- * Allows registration of store generators to be used by multiple React components on one Rails
- * view. Store generators are functions that take one arg, props, and return a store. Note that
- * the setStore API is different in that it's the actual store hydrated with props.
+ * Allows registration of store generators for legacy or advanced pages where multiple React
+ * roots on one Rails view share a Redux store. Store generators receive props and railsContext,
+ * then return a store. Note that the setStore API is different in that it's the actual store
+ * hydrated with props.
  * @param stores (key is store name, value is the store generator)
  */
 registerStoreGenerators(storesGenerators);
@@ -18769,28 +18828,34 @@ PAGE: https://reactonrails.com/docs/api-reference/redux-store-api
 SOURCE: docs/oss/api-reference/redux-store-api.md
 ================================================================================
 
-# Redux Store
+# Redux Store API
 
 > [!WARNING]
 >
-> This Redux API is no longer recommended as it prevents dynamic code splitting for performance. Instead, you should use the standard `react_component` view helper passing in a "Render-Function."
+> This runtime API remains supported for existing apps and advanced shared-store use cases, but it is not recommended as the default state model for new React on Rails apps. Prefer the standard `react_component` view helper with props or a render-function unless multiple React islands must coordinate through one client store.
 
 > [!IMPORTANT]
 >
 > **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md#important-redux-shared-store-caveat) for details and alternatives.
 
-You don't need to use the `redux_store` api to use Redux. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
+You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 
-If you are only rendering one React component on a page, as is typical to do a "Single Page App" in React, then you should _probably_ pass the props to your React component in a "Render-Function."
+If you are rendering one React component on a page, pass props to that component through `react_component` and keep local UI state inside that React tree. A render-function is also a better fit when you need `railsContext`, routing setup, or custom hydration behavior for one root.
 
-Consider using the `redux_store` helper for the two following use cases:
+Choose state ownership before reaching for `redux_store`:
 
-1. You want to have multiple React components accessing the same store at once.
-2. You want to place the props to hydrate the client side stores at the very end of your HTML, probably server rendered, so that the browser can render all earlier HTML first. This is particularly useful if your props will be large. However, you're probably better off using [React on Rails Pro](../../pro/react-on-rails-pro.md) if you're at all concerned about performance.
+- **Local island state:** use React Hooks or React Context inside one `react_component` root.
+- **Server state:** use Rails controller props for initial data, then Rails JSON endpoints, GraphQL, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md) for data that belongs on the server.
+- **Multi-island shared client state:** use `redux_store` when separate React roots on one Rails page must read and update the same client-side state.
 
-## Multiple React Components on a Page with One Store
+Consider using the `redux_store` helper for the following advanced use cases:
 
-You may wish to have 2 React components share the same the Redux store. For example, if your navbar is a React component, you may want it to use the same store as your component in the main area of the page. You may even want multiple React components in the main area, which allows for greater modularity. Also, you may want this to work with Turbolinks to minimize reloading the JavaScript.
+1. You want multiple React roots or islands to access the same store at once.
+2. You want to place the props that hydrate client-side stores at the very end of your HTML, probably server-rendered, so that the browser can render all earlier HTML first. This is particularly useful if your props will be large. However, you're probably better off using [React on Rails Pro](../../pro/react-on-rails-pro.md) if you're at all concerned about performance.
+
+## Multiple React Islands on a Page with One Store
+
+You may wish to have two separate React roots share the same Redux store. For example, if your navbar is a React island, you may want it to use the same store as another island in the main area of the page. You may even want multiple React islands in the main area, which allows for greater modularity. Also, you may want this to work with Turbo or Turbolinks to minimize reloading the JavaScript.
 
 A good example of this would be something like a notifications counter in a header. As each notification is read in the body of the page, you would like to update the header. If both the header and body share the same Redux store, then this is trivial. Otherwise, we have to rely on other solutions, such as the header polling the server to see how many unread notifications exist.
 
@@ -19056,7 +19121,7 @@ SOURCE: docs/oss/api-reference/generator-details.md
 
 # Generator Details
 
-The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off — for example, the default for `-R` is that `redux` is off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` (or its alias `--webpack`) if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
+The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` (or its alias `--webpack`) if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
 
 Run `rails generate react_on_rails:install --help` for descriptions of all available options:
 
@@ -19065,7 +19130,6 @@ Usage:
   rails generate react_on_rails:install [options]
 
 Options:
-  -R, [--redux], [--no-redux]                      # Install Redux package and Redux version of Hello World Example. Default: false
   -T, [--typescript], [--no-typescript]            # Generate TypeScript files and install TypeScript dependencies. Default: false
       [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
       [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack)
@@ -19083,13 +19147,17 @@ Runtime options:
 Description:
 
 The react_on_rails:install generator integrates webpack with rails with ease. You
-can pass the redux option if you'd like to have redux setup for you automatically.
+can pass the options below to customize the generated example and supporting
+configuration.
 
-* Redux
-
-    Passing the --redux generator option causes the generated Hello World example
-    to integrate the Redux state container framework. The necessary node modules
-    will be automatically included for you.
+> [!WARNING]
+> The Redux installer path (`--redux` / `-R`) is a hidden legacy escape hatch, not
+> a recommended starter architecture. New apps should start with the
+> `react_component` view helper, React local state or context for island-local UI
+> state, and Rails props or server-state tools such as TanStack Query for data
+> loaded from the server. Use Redux only for an existing Redux app or an advanced
+> multi-island page where separate React roots must coordinate through one shared
+> client store.
 
 * TypeScript
 
@@ -19138,9 +19206,9 @@ Another good option is to create a simple test app per the [Tutorial](../getting
 
 ## Understanding the Organization of the Generated Client Code
 
-The React on Rails generator creates different directory structures depending on whether you use the `--redux` option.
+The React on Rails generator normally creates the simple component structure below. A hidden legacy Redux path remains available for existing apps and recovery work, but it is not the structure recommended for new React on Rails apps.
 
-### Default Structure (Without Redux)
+### Default Structure (Recommended, Without Redux)
 
 The basic generator creates a simple, flat structure optimized for auto-bundling:
 
@@ -19160,9 +19228,9 @@ app/javascript/
 
 For components that need different client vs. server implementations, use `.client.jsx` and `.server.jsx` suffixes (e.g., `HelloWorld.client.jsx` and `HelloWorld.server.jsx`).
 
-### Redux Structure (With `--redux` Option)
+### Legacy Redux Structure (Hidden `--redux` Path)
 
-The Redux generator creates a more structured organization with familiar Redux patterns:
+The hidden legacy Redux generator creates a more structured organization with familiar Redux patterns:
 
 ```text
 app/javascript/
@@ -19186,12 +19254,22 @@ app/javascript/
             └── helloWorldStore.js
 ```
 
-This structure follows Redux best practices:
+This legacy structure is useful only when you intentionally maintain Redux:
 
 - **`components/`**: Presentational "dumb" components that receive data via props
 - **`containers/`**: Container "smart" components connected to Redux store
 - **`actions/`** and **`reducers/`**: Standard Redux patterns
 - **`ror_components/`**: Entry point files that initialize Redux and render the app
+
+If you already have a React on Rails app and intentionally need to recreate the legacy Redux example, use the direct hidden generator after the base installer has configured React on Rails:
+
+```bash
+rails generate react_on_rails:react_with_redux
+```
+
+For an app that is already configured for TypeScript, add `--typescript` to generate `.ts` and `.tsx` Redux example files.
+
+For full install recovery of an older Redux-generated app, the hidden `react_on_rails:install --redux` option still exists, but do not use it for greenfield apps.
 
 ### TypeScript Support
 
@@ -19262,11 +19340,8 @@ For apps with custom webpack configurations, review the generated config templat
 # Rspack (default) with TypeScript
 rails generate react_on_rails:install --typescript
 
-# Webpack with Redux
-rails generate react_on_rails:install --no-rspack --redux
-
-# Explicit Rspack with TypeScript and Redux
-rails generate react_on_rails:install --rspack --typescript --redux
+# Webpack with TypeScript
+rails generate react_on_rails:install --no-rspack --typescript
 ```
 
 For more details on Rspack configuration, see the [Webpack Configuration](../core-concepts/webpack-configuration.md#rspack-vs-webpack) docs.
@@ -19301,9 +19376,6 @@ For production, configure your license token: `export REACT_ON_RAILS_PRO_LICENSE
 ```bash
 # Pro with TypeScript
 rails generate react_on_rails:install --pro --typescript
-
-# Pro with Redux
-rails generate react_on_rails:install --pro --redux
 
 # Pro with Rspack
 rails generate react_on_rails:install --pro --rspack
@@ -19356,12 +19428,11 @@ In addition to all Pro files:
 # RSC with TypeScript
 rails generate react_on_rails:install --rsc --typescript
 
-# RSC with Redux (generates both HelloWorldApp and HelloServer)
-rails generate react_on_rails:install --rsc --redux
-
 # RSC with Rspack
 rails generate react_on_rails:install --rsc --rspack
 ```
+
+Do not combine RSC with the hidden legacy Redux installer for new apps. Existing Redux Client Components can continue to work beside RSC when Redux access stays in Client Components; see [RSC context and state migration](../migrating/rsc-context-and-state.md#redux-toolkit).
 
 **Upgrading an existing Pro app to RSC:**
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4986,7 +4986,7 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
 
-**File: `app/javascript/src/RouterApp/RouterApp.jsx`**
+**File: `app/javascript/src/RouterApp/RouterRoutes.jsx`**
 
 ```jsx
 import React from 'react';
@@ -5005,7 +5005,7 @@ const RouterRoutes = (props) => (
 export default RouterRoutes;
 ```
 
-`RouterApp.jsx` is a shared route tree that expects a router context from its parent. Keep it outside
+`RouterRoutes.jsx` is a shared route tree that expects a router context from its parent. Keep it outside
 `ror_components/` and do not register it directly with React on Rails. Only the files inside
 `ror_components/` are registered entry points.
 
@@ -5015,7 +5015,7 @@ export default RouterRoutes;
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import RouterRoutes from '../RouterApp';
+import RouterRoutes from '../RouterRoutes';
 
 const RouterApp = (props) => (
   <BrowserRouter>
@@ -5084,7 +5084,7 @@ The server entry returns a render function, not JSX directly; see
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import RouterRoutes from '../RouterApp';
+import RouterRoutes from '../RouterRoutes';
 
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
@@ -5146,9 +5146,10 @@ export default HelloWorldApp;
 - Use `<Routes>` and `<Route>` with `element` prop
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
-- Components rendered through `react_component_hash` still need the explicit object return shape,
-  such as `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`, rather than
-  the render-function thunk shown here.
+- Components rendered through `react_component_hash` still need the explicit object return shape
+  instead of the render-function thunk shown here. Return the object described in
+  [Render-Functions](../core-concepts/render-functions.md), for example
+  `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`.
 
 ## Rails Routes Configuration
 
@@ -8784,7 +8785,7 @@ See [Sharing State Between Components](https://react.dev/learn/sharing-state-bet
 
 ## Redux Reducers
 
-The `helloWorld/reducers/index.jsx` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
+The `helloWorld/reducers/helloWorldReducer.js` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
 
 ```javascript
 import usersReducer from './usersReducer';
@@ -18849,7 +18850,7 @@ SOURCE: docs/oss/api-reference/redux-store-api.md
 
 > [!WARNING]
 >
-> This runtime API remains supported for existing apps and advanced shared-store use cases, but it is not recommended as the default state model for new React on Rails apps. Prefer the standard `react_component` view helper with props or a render-function unless multiple React islands must coordinate through one client store.
+> This runtime API remains supported for existing apps and advanced shared-store use cases, but it is not recommended as the default state model for new React on Rails apps. Prefer the standard `react_component` view helper with props or a render-function unless multiple React islands must coordinate through one client store. Keeping one large shared store can also prevent dynamic code splitting for performance.
 
 > [!IMPORTANT]
 >
@@ -18861,7 +18862,7 @@ If you are rendering one React component on a page, pass props to that component
 
 Choose state ownership before reaching for `redux_store`:
 
-- **Local island state:** use React Hooks or React Context inside one `react_component` root.
+- **Island-local state:** use React Hooks or React Context inside one `react_component` root.
 - **Server state:** use Rails controller props for initial data, then Rails JSON endpoints, GraphQL, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md) for data that belongs on the server.
 - **Multi-island shared client state:** use `redux_store` when separate React roots on one Rails page must read and update the same client-side state.
 
@@ -19163,9 +19164,10 @@ Runtime options:
 
 Description:
 
-The react_on_rails:install generator integrates webpack with rails with ease. You
-can pass the options below to customize the generated example and supporting
-configuration.
+The react_on_rails:install generator integrates a JavaScript bundler with Rails
+with ease. Fresh installs use Rspack by default; pass --no-rspack to use
+Webpack. You can pass the options below to customize the generated example and
+supporting configuration.
 ```
 
 > [!WARNING]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5092,7 +5092,7 @@ const RouterApp = (props, railsContext) => {
   // React on Rails calls RouterApp(props, railsContext), then renders the returned
   // function component. Props are passed again by React, but this example uses the
   // props and location captured by closure.
-  return () => (
+  return (_props) => (
     <StaticRouter location={location}>
       <RouterRoutes {...props} />
     </StaticRouter>
@@ -5124,7 +5124,7 @@ const HelloWorldApp = (props, railsContext) => {
   const store = configureStore(props);
   const { location } = railsContext;
 
-  return () => (
+  return (_props) => (
     <Provider store={store}>
       <StaticRouter location={location}>
         <Routes>
@@ -8789,6 +8789,8 @@ See [Sharing State Between Components](https://react.dev/learn/sharing-state-bet
 The `helloWorld/reducers/helloWorldReducer.js` example from the hidden legacy Redux generator may be slightly confusing because of its simplicity. For clarity, what follows is a more fleshed-out example of what a reducer might look like:
 
 ```javascript
+import { combineReducers } from 'redux';
+
 import usersReducer from './usersReducer';
 import blogPostsReducer from './blogPostsReducer';
 import commentsReducer from './commentsReducer';
@@ -8799,12 +8801,14 @@ import { $$initialState as $$blogPostsState } from './blogPostsReducer';
 import { $$initialState as $$commentsState } from './commentsReducer';
 // ...
 
-export default {
+const rootReducer = combineReducers({
   $$usersStore: usersReducer,
   $$blogPostsStore: blogPostsReducer,
   $$commentsStore: commentsReducer,
   // ...
-};
+});
+
+export default rootReducer;
 
 export const initialStates = {
   $$usersState,
@@ -19180,49 +19184,19 @@ supporting configuration.
 > multi-island page where separate React roots must coordinate through one shared
 > client store.
 
-```text
-* TypeScript
+Additional option details:
 
-    Passing the --typescript generator option generates TypeScript files (.tsx)
-    instead of JavaScript files (.jsx) and sets up TypeScript configuration.
+- **TypeScript**: Passing the `--typescript` generator option generates TypeScript files (`.tsx`) instead of JavaScript files (`.jsx`) and sets up TypeScript configuration.
 
-* Tailwind CSS v4
+- **Tailwind CSS v4**: Passing the `--tailwind` generator option installs Tailwind CSS v4, configures `@tailwindcss/postcss` for Webpack or Rspack, and styles the generated SSR HelloWorld page. See [Styling with Tailwind CSS v4](../building-features/styling-with-tailwind.md).
 
-    Passing the --tailwind generator option installs Tailwind CSS v4,
-    configures `@tailwindcss/postcss` for Webpack or Rspack, and styles the
-    generated SSR HelloWorld page. See
-    [Styling with Tailwind CSS v4](../building-features/styling-with-tailwind.md).
+- **Rspack (default)**: Rspack is the default bundler for fresh installs, providing significantly faster builds (~20x improvement with SWC). Pass `--no-rspack` (or its alias `--webpack`) to use Webpack instead. Either way you get a unified configuration that works with both bundlers and a `bin/switch-bundler` utility to switch between them post-installation.
 
-* Rspack (default)
+- **Pro**: Passing the `--pro` generator option sets up React on Rails Pro with Node server rendering, fragment caching, and code-splitting support. Requires the `react_on_rails_pro` gem (add it to your Gemfile first). Creates the Pro initializer, `renderer/node-renderer.js`, and adds the Node Renderer process to `Procfile.dev`.
 
-    Rspack is the default bundler for fresh installs, providing significantly
-    faster builds (~20x improvement with SWC). Pass --no-rspack (or its alias
-    --webpack) to use Webpack instead. Either way you get a unified
-    configuration that works with both bundlers and a bin/switch-bundler
-    utility to switch between them post-installation.
+- **RSC (React Server Components)**: Passing the `--rsc` generator option sets up React Server Components support. This automatically includes Pro setup (`--rsc` implies `--pro`). Creates RSC webpack configuration, a HelloServer example component, and RSC routes. Requires React 19 with a compatible `react-on-rails-rsc` version.
 
-* Pro
-
-    Passing the --pro generator option sets up React on Rails Pro with Node
-    server rendering, fragment caching, and code-splitting support.
-    Requires the react_on_rails_pro gem (add it to your Gemfile first).
-    Creates the Pro initializer, renderer/node-renderer.js, and adds the Node Renderer
-    process to Procfile.dev.
-
-* RSC (React Server Components)
-
-    Passing the --rsc generator option sets up React Server Components support.
-    This automatically includes Pro setup (--rsc implies --pro). Creates RSC
-    webpack configuration, a HelloServer example component, and RSC routes.
-    Requires React 19 with a compatible `react-on-rails-rsc` version.
-
-*******************************************************************************
-
-
-Then you may run
-
-    `rails s`
-```
+Then you may run `rails s`.
 
 Another good option is to create a simple test app per the [Tutorial](../getting-started/tutorial.md).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -286,7 +286,7 @@ Find guidance for your specific scenario:
 | **Compare Rails + frontend options** | [Comparison Guide](./getting-started/comparing-react-on-rails-to-alternatives.md)     |
 | **Enable server-side rendering**     | [SSR Guide](./core-concepts/react-server-rendering.md)                                |
 | **Set up hot reloading**             | [HMR Setup](./building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) |
-| **Use legacy shared Redux stores**   | [Redux Integration](./building-features/react-and-redux.md)                           |
+| **Use legacy shared Redux stores**   | [Legacy Redux Guidance](./building-features/react-and-redux.md)                       |
 | **Use TanStack Router**              | [TanStack Router Guide](./building-features/tanstack-router.md)                       |
 | **Deploy to production**             | [Deployment Guide](./deployment/README.md)                                            |
 | **Troubleshoot issues**              | [Troubleshooting](./deployment/troubleshooting.md)                                    |
@@ -1156,7 +1156,7 @@ Use Redux when your app already has Redux conventions, needs a shared client sto
 - **Server state:** pass initial data through Rails controller props, then refresh data through your Rails JSON endpoints, GraphQL layer, or a server-state cache such as [TanStack Query](../building-features/tanstack-query.md).
 - **Multi-island shared client state:** use Redux only when separate React roots on the same page must coordinate through one client store, such as a header counter and body list that update each other without a full page refresh.
 
-The installer has a hidden legacy Redux path for maintaining or recreating older generated apps, but this tutorial does not use it and new apps should not start with `--redux`. The legacy Redux structure has actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
+The installer has a [hidden legacy Redux path](../api-reference/generator-details.md#legacy-redux-structure-hidden---redux-path) for maintaining or recreating older generated apps, but this tutorial does not use it and new apps should not start with `--redux`. The legacy Redux structure has actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
 
 When rendering an existing Redux-backed component, the Rails side still uses the same view helper style:
 
@@ -4986,25 +4986,40 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
 
-**File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.jsx`**
 
 ```jsx
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 
 const Home = ({ name }) => <div>Hello, {name}!</div>;
 const About = () => <div>About</div>;
 
 const RouterApp = (props) => (
-  <BrowserRouter>
-    <Routes>
-      <Route path="/" element={<Home {...props} />} />
-      <Route path="/about" element={<About />} />
-    </Routes>
-  </BrowserRouter>
+  <Routes>
+    <Route path="/" element={<Home {...props} />} />
+    <Route path="/about" element={<About />} />
+  </Routes>
 );
 
 export default RouterApp;
+```
+
+**File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
+
+```jsx
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+import RouterApp from './RouterApp';
+
+const RouterAppClient = (props) => (
+  <BrowserRouter>
+    <RouterApp {...props} />
+  </BrowserRouter>
+);
+
+export default RouterAppClient;
 ```
 
 ## Legacy Client-Side Setup with Redux
@@ -5063,25 +5078,19 @@ is configured so React on Rails registers the client and server files separately
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import { Routes, Route } from 'react-router-dom';
+import RouterApp from './RouterApp';
 
-const Home = ({ name }) => <div>Hello, {name}!</div>;
-const About = () => <div>About</div>;
-
-const RouterApp = (props, railsContext) => {
+const RouterAppServer = (props, railsContext) => {
   const { location } = railsContext;
 
   return () => (
     <StaticRouter location={location}>
-      <Routes>
-        <Route path="/" element={<Home {...props} />} />
-        <Route path="/about" element={<About />} />
-      </Routes>
+      <RouterApp {...props} />
     </StaticRouter>
   );
 };
 
-export default RouterApp;
+export default RouterAppServer;
 ```
 
 ## Legacy Server-Side Setup with Redux
@@ -5092,7 +5101,6 @@ If your app still uses the legacy shared Redux store, keep the provider around t
 
 ```jsx
 import React from 'react';
-import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 import { Provider } from 'react-redux';
 import { Routes, Route } from 'react-router-dom';
@@ -5107,7 +5115,7 @@ const HelloWorldApp = (props, railsContext) => {
   const store = configureStore(props);
   const { location } = railsContext;
 
-  const html = renderToString(
+  return () => (
     <Provider store={store}>
       <StaticRouter location={location}>
         <Routes>
@@ -5117,10 +5125,8 @@ const HelloWorldApp = (props, railsContext) => {
           {/* <Route path="/contact" element={<Contact />} /> */}
         </Routes>
       </StaticRouter>
-    </Provider>,
+    </Provider>
   );
-
-  return { renderedHtml: html };
 };
 
 export default HelloWorldApp;

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4986,7 +4986,7 @@ React Router v6 offers multiple routing approaches. For React on Rails, we recom
 
 Most React Router integrations do not need Redux. Route ordinary components inside one React root, pass initial data from Rails as props, and use your normal server-state approach for follow-up data loading.
 
-**File: `app/javascript/src/RouterApp/ror_components/RouterApp.jsx`**
+**File: `app/javascript/src/RouterApp/RouterApp.jsx`**
 
 ```jsx
 import React from 'react';
@@ -5011,7 +5011,7 @@ export default RouterApp;
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import RouterApp from './RouterApp';
+import RouterApp from '../RouterApp';
 
 const RouterAppClient = (props) => (
   <BrowserRouter>
@@ -5072,17 +5072,20 @@ For server rendering without Redux, use the same route tree with `StaticRouter` 
 This `.client.jsx` / `.server.jsx` split assumes
 [auto-bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)
 is configured so React on Rails registers the client and server files separately.
+The server entry returns a render function, not JSX directly; see
+[Render-Functions and railsContext](../core-concepts/render-functions-and-railscontext.md).
 
 **File: `app/javascript/src/RouterApp/ror_components/RouterApp.server.jsx`**
 
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import RouterApp from './RouterApp';
+import RouterApp from '../RouterApp';
 
 const RouterAppServer = (props, railsContext) => {
   const { location } = railsContext;
 
+  // React on Rails render-function contract: return a function, not JSX directly.
   return () => (
     <StaticRouter location={location}>
       <RouterApp {...props} />
@@ -5138,6 +5141,9 @@ export default HelloWorldApp;
 - Use `<Routes>` and `<Route>` with `element` prop
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
+- Components rendered through `react_component_hash` still need the explicit object return shape,
+  such as `{ componentHtml: renderToString(...), ...otherSlots }`, rather than the render-function
+  thunk shown here.
 
 ## Rails Routes Configuration
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5089,9 +5089,9 @@ import RouterRoutes from '../RouterRoutes';
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  // React on Rails calls RouterApp(props, railsContext), then renders the returned
-  // function component. Props are passed again by React, but this example uses the
-  // props and location captured by closure.
+  // React on Rails calls RouterApp(props, railsContext) to get this function,
+  // then calls createElement(returnedFn, props). This example uses the props
+  // and location captured by closure.
   return (_props) => (
     <StaticRouter location={location}>
       <RouterRoutes {...props} />
@@ -5101,6 +5101,11 @@ const RouterApp = (props, railsContext) => {
 
 export default RouterApp;
 ```
+
+> **Note:** Components rendered through `react_component_hash` still need the explicit object return shape
+> instead of the render-function thunk shown here. Keep using `renderToString(...)` and return the object
+> described in [Render-Functions](../core-concepts/render-functions.md), for example
+> `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`.
 
 ## Legacy Server-Side Setup with Redux
 
@@ -18859,7 +18864,7 @@ SOURCE: docs/oss/api-reference/redux-store-api.md
 
 > [!IMPORTANT]
 >
-> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Turbolinks async script loading guidance](../building-features/turbolinks.md#async-script-loading) and [auto-bundling layout integration](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#layout-integration-with-auto-loading) for related script-ordering patterns.
+> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [auto-bundling layout integration](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#layout-integration-with-auto-loading) guidance for related script-ordering patterns.
 
 You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 
@@ -19264,6 +19269,10 @@ rails generate react_on_rails:react_with_redux
 ```
 
 For an app that is already configured for TypeScript, add `--typescript` to generate `.ts` and `.tsx` Redux example files.
+
+> **Note:** The standalone `react_on_rails:react_with_redux` generator does not support `--tailwind`.
+> If you intentionally need the legacy Redux scaffold with Tailwind, run the full installer path instead:
+> `rails generate react_on_rails:install --redux --tailwind`.
 
 For full install recovery of an older Redux-generated app, the hidden `react_on_rails:install --redux` option still exists, but do not use it for greenfield apps.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4997,8 +4997,8 @@ const About = () => <div>About</div>;
 
 const RouterRoutes = (props) => (
   <Routes>
-    <Route path="/" element={<Home {...props} />} />
-    <Route path="/about" element={<About />} />
+    <Route path="/hello_world" element={<Home {...props} />} />
+    <Route path="/hello_world/about" element={<About />} />
   </Routes>
 );
 
@@ -5089,8 +5089,9 @@ import RouterRoutes from '../RouterRoutes';
 const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  // React on Rails calls RouterApp(props, railsContext), then mounts the returned
-  // zero-argument function. Props and location are captured by closure.
+  // React on Rails calls RouterApp(props, railsContext), then renders the returned
+  // function component. Props are passed again by React, but this example uses the
+  // props and location captured by closure.
   return () => (
     <StaticRouter location={location}>
       <RouterRoutes {...props} />
@@ -5147,8 +5148,8 @@ export default HelloWorldApp;
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
 - Components rendered through `react_component_hash` still need the explicit object return shape
-  instead of the render-function thunk shown here. Return the object described in
-  [Render-Functions](../core-concepts/render-functions.md), for example
+  instead of the render-function thunk shown here. Keep using `renderToString(...)` and return the
+  object described in [Render-Functions](../core-concepts/render-functions.md), for example
   `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`.
 
 ## Rails Routes Configuration
@@ -18854,7 +18855,7 @@ SOURCE: docs/oss/api-reference/redux-store-api.md
 
 > [!IMPORTANT]
 >
-> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Streaming Server Rendering documentation](../building-features/streaming-server-rendering.md) for details and alternatives.
+> **Script Loading Requirement:** If you use Redux shared stores with inline component registration (registering components in view templates with `<script>ReactOnRails.register({ MyComponent })</script>`), you **must use `defer: true`** in your `javascript_pack_tag` instead of `async: true`. With async loading, the bundle may execute before inline scripts, causing component registration failures. See the [Turbolinks async script loading guidance](../building-features/turbolinks.md#async-script-loading) and [auto-bundling layout integration](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#layout-integration-with-auto-loading) for related script-ordering patterns.
 
 You don't need to use the `redux_store` API to use Redux inside a single React root. This API was set up to support multiple calls to `react_component` on one page that all talk to the same Redux store.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4995,15 +4995,19 @@ import { Routes, Route } from 'react-router-dom';
 const Home = ({ name }) => <div>Hello, {name}!</div>;
 const About = () => <div>About</div>;
 
-const RouterApp = (props) => (
+const RouterRoutes = (props) => (
   <Routes>
     <Route path="/" element={<Home {...props} />} />
     <Route path="/about" element={<About />} />
   </Routes>
 );
 
-export default RouterApp;
+export default RouterRoutes;
 ```
+
+`RouterApp.jsx` is a shared route tree that expects a router context from its parent. Keep it outside
+`ror_components/` and do not register it directly with React on Rails. Only the files inside
+`ror_components/` are registered entry points.
 
 **File: `app/javascript/src/RouterApp/ror_components/RouterApp.client.jsx`**
 
@@ -5011,15 +5015,15 @@ export default RouterApp;
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
-import RouterApp from '../RouterApp';
+import RouterRoutes from '../RouterApp';
 
-const RouterAppClient = (props) => (
+const RouterApp = (props) => (
   <BrowserRouter>
-    <RouterApp {...props} />
+    <RouterRoutes {...props} />
   </BrowserRouter>
 );
 
-export default RouterAppClient;
+export default RouterApp;
 ```
 
 ## Legacy Client-Side Setup with Redux
@@ -5080,20 +5084,21 @@ The server entry returns a render function, not JSX directly; see
 ```jsx
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
-import RouterApp from '../RouterApp';
+import RouterRoutes from '../RouterApp';
 
-const RouterAppServer = (props, railsContext) => {
+const RouterApp = (props, railsContext) => {
   const { location } = railsContext;
 
-  // React on Rails render-function contract: return a function, not JSX directly.
+  // React on Rails calls RouterApp(props, railsContext), then mounts the returned
+  // zero-argument function. Props and location are captured by closure.
   return () => (
     <StaticRouter location={location}>
-      <RouterApp {...props} />
+      <RouterRoutes {...props} />
     </StaticRouter>
   );
 };
 
-export default RouterAppServer;
+export default RouterApp;
 ```
 
 ## Legacy Server-Side Setup with Redux
@@ -5142,8 +5147,8 @@ export default HelloWorldApp;
 - `location` prop takes a string path from `railsContext`
 - No need for `match()` or `RouterContext` - simplified API
 - Components rendered through `react_component_hash` still need the explicit object return shape,
-  such as `{ componentHtml: renderToString(...), ...otherSlots }`, rather than the render-function
-  thunk shown here.
+  such as `{ renderedHtml: { componentHtml: renderToString(...), ...otherSlots } }`, rather than
+  the render-function thunk shown here.
 
 ## Rails Routes Configuration
 

--- a/packages/react-on-rails/src/types/index.ts
+++ b/packages/react-on-rails/src/types/index.ts
@@ -500,9 +500,10 @@ export interface ReactOnRails {
   /** @deprecated Use registerStoreGenerators instead */
   registerStore(stores: Record<string, StoreGenerator>): void;
   /**
-   * Allows registration of store generators to be used by multiple React components on one Rails
-   * view. Store generators receive props and railsContext, then return a store. Note that the
-   * `setStore` API is different in that it's the actual store hydrated with props.
+   * Allows registration of store generators for legacy or advanced pages where multiple React roots
+   * on one Rails view share a Redux store. Store generators receive props and railsContext, then
+   * return a store. Note that the `setStore` API is different in that it's the actual store hydrated
+   * with props.
    * @param storeGenerators keys are store names, values are the store generators
    */
   registerStoreGenerators(storeGenerators: Record<string, StoreGenerator>): void;

--- a/packages/react-on-rails/src/types/index.ts
+++ b/packages/react-on-rails/src/types/index.ts
@@ -501,8 +501,8 @@ export interface ReactOnRails {
   registerStore(stores: Record<string, StoreGenerator>): void;
   /**
    * Allows registration of store generators to be used by multiple React components on one Rails
-   * view. Store generators are functions that take one arg, props, and return a store. Note that
-   * the `setStore` API is different in that it's the actual store hydrated with props.
+   * view. Store generators receive props and railsContext, then return a store. Note that the
+   * `setStore` API is different in that it's the actual store hydrated with props.
    * @param storeGenerators keys are store names, values are the store generators
    */
   registerStoreGenerators(storeGenerators: Record<string, StoreGenerator>): void;

--- a/react_on_rails/lib/generators/USAGE
+++ b/react_on_rails/lib/generators/USAGE
@@ -2,12 +2,6 @@ Description:
 
 The react_on_rails:install generator integrates a React frontend, including SSR, with Rails.
 
-* Redux (Optional)
-
-    Passing the --redux generator option causes the generated Hello World example
-    to integrate the Redux state container framework. The necessary node modules
-    will be automatically included for you.
-
 * Tailwind CSS v4 (Optional)
 
     Passing the --tailwind generator option installs Tailwind CSS v4, configures

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -17,12 +17,13 @@ module ReactOnRails
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
 
-      # --redux
+      # Internal hidden legacy Redux plumbing for install_generator.
       class_option :redux,
                    type: :boolean,
                    default: false,
-                   desc: "Install Redux package and Redux version of Hello World Example",
-                   aliases: "-R"
+                   desc: "Internal legacy Redux scaffolding flag",
+                   aliases: "-R",
+                   hide: true
 
       # --rspack / --no-rspack (Rspack is the default on fresh installs; --no-rspack selects Webpack)
       # IMPORTANT: do NOT add a `default:` here. The absence of a default is load-bearing — Thor

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -818,8 +818,8 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
-        add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
+        add_legacy_redux_install_warning
       end
 
       def recovery_install_command
@@ -1104,8 +1104,8 @@ module ReactOnRails
           #{recovery_working_tree_note}
           Then re-run: #{recovery_install_command}
         MSG
-        GeneratorMessages.add_error(error)
         add_legacy_redux_install_warning_once
+        GeneratorMessages.add_error(error)
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1129,8 +1129,8 @@ module ReactOnRails
 
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
-        GeneratorMessages.add_error(error)
         add_legacy_redux_install_warning_once
+        GeneratorMessages.add_error(error)
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -791,13 +791,13 @@ module ReactOnRails
           if use_tailwind?
             [
               "Existing apps that need Redux with Tailwind should keep using the hidden install path:",
-              "bundle exec rails generate react_on_rails:install --redux --tailwind"
+              "rails generate react_on_rails:install --redux --tailwind"
             ]
           else
             [
               "Existing apps that need the legacy Redux scaffold can use the hidden react_with_redux generator. " \
               "That generator is also legacy and emits its own warning:",
-              "bundle exec rails generate react_on_rails:react_with_redux"
+              "rails generate react_on_rails:react_with_redux"
             ]
           end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -816,6 +816,7 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
+        # Set the flag after enqueueing so a failed warning add can be retried.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
       end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -199,7 +199,7 @@ module ReactOnRails
 
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
-          add_legacy_redux_install_warning
+          add_legacy_redux_install_warning_once
           add_package_json_scripts
           add_ci_workflow
           add_bin_scripts
@@ -813,6 +813,13 @@ module ReactOnRails
         MSG
       end
 
+      def add_legacy_redux_install_warning_once
+        return if @legacy_redux_install_warning_added
+
+        add_legacy_redux_install_warning
+        @legacy_redux_install_warning_added = true if options.redux?
+      end
+
       def recovery_install_command
         flags = []
         flags << "--redux" if options.redux?
@@ -1096,6 +1103,7 @@ module ReactOnRails
           Then re-run: #{recovery_install_command}
         MSG
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1120,6 +1128,7 @@ module ReactOnRails
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -801,6 +801,8 @@ module ReactOnRails
             ]
           end
 
+        # Keep this install-specific warning aligned with
+        # ReactWithReduxGenerator::LEGACY_REDUX_GENERATOR_WARNING.
         GeneratorMessages.add_warning(<<~MSG.strip)
           The install --redux option is a hidden legacy Redux generator path and is not recommended
           for new React on Rails apps.
@@ -817,7 +819,7 @@ module ReactOnRails
         return if @legacy_redux_install_warning_added
 
         add_legacy_redux_install_warning
-        @legacy_redux_install_warning_added = true if options.redux?
+        @legacy_redux_install_warning_added = true
       end
 
       def recovery_install_command

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -197,9 +197,10 @@ module ReactOnRails
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
 
+        add_legacy_redux_install_warning_once
+
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
-          add_legacy_redux_install_warning_once
           add_package_json_scripts
           add_ci_workflow
           add_bin_scripts
@@ -801,8 +802,6 @@ module ReactOnRails
             ]
           end
 
-        # Keep this install-specific warning aligned with
-        # ReactWithReduxGenerator::LEGACY_REDUX_GENERATOR_WARNING.
         GeneratorMessages.add_warning(<<~MSG.strip)
           The install --redux option is a hidden legacy Redux generator path and is not recommended
           for new React on Rails apps.

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -221,7 +221,7 @@ module ReactOnRails
         # print_generator_messages raises an exception. This prevents ENV pollution
         # that could affect subsequent processes.
         ENV.delete("REACT_ON_RAILS_SKIP_VALIDATION")
-        add_legacy_redux_install_warning_once
+        add_legacy_redux_install_warning_once_safely
         print_generator_messages
       end
 
@@ -819,6 +819,13 @@ module ReactOnRails
         # Set the flag after enqueueing so a failed warning add can be retried.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
+      end
+
+      def add_legacy_redux_install_warning_once_safely
+        add_legacy_redux_install_warning_once
+      rescue StandardError
+        # Preserve the primary generator output; this legacy advisory is best-effort.
+        nil
       end
 
       def recovery_install_command

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -32,12 +32,13 @@ module ReactOnRails
       # fetch USAGE file for details generator description
       source_root(File.expand_path(__dir__))
 
-      # --redux
+      # Hidden legacy --redux escape hatch for existing scripted installs.
       class_option :redux,
                    type: :boolean,
                    default: false,
-                   desc: "Install Redux package and Redux version of Hello World Example. Default: false",
-                   aliases: "-R"
+                   desc: "Deprecated legacy Redux install path; use react_on_rails:react_with_redux directly.",
+                   aliases: "-R",
+                   hide: true
 
       # --typescript
       class_option :typescript,
@@ -195,6 +196,7 @@ module ReactOnRails
         # This is inherited by all invoked generators and persists through Rails initialization
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
+        add_legacy_redux_install_warning
 
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
@@ -252,9 +254,9 @@ module ReactOnRails
         end
 
         # Component generator logic:
-        # - --rsc without --redux: Skip HelloWorld, HelloServer will be generated in setup_rsc
-        # - --rsc with --redux: Generate HelloWorldApp (user explicitly wants Redux) + HelloServer
-        # - Without --rsc: Normal behavior (HelloWorld or HelloWorldApp based on --redux)
+        # - --rsc without hidden legacy Redux: Skip HelloWorld; setup_rsc generates HelloServer.
+        # - Hidden legacy --redux: Generate HelloWorldApp as a one-major escape hatch.
+        # - Without --rsc: Generate the default HelloWorld example unless the legacy flag is present.
         if options.redux?
           invoke "react_on_rails:react_with_redux", [], { typescript: options.typescript?,
                                                           tailwind: use_tailwind?,
@@ -779,6 +781,33 @@ module ReactOnRails
       def shakapacker_setup_incomplete?
         # Strict comparison keeps nil (unset) distinct from true.
         @shakapacker_setup_incomplete == true
+      end
+
+      def add_legacy_redux_install_warning
+        return unless options.redux?
+
+        legacy_guidance, legacy_command =
+          if use_tailwind?
+            [
+              "Existing apps that need Redux with Tailwind should keep using the hidden install path:",
+              "bundle exec rails generate react_on_rails:install --redux --tailwind"
+            ]
+          else
+            [
+              "Existing apps that need the legacy Redux scaffold can run:",
+              "bundle exec rails generate react_on_rails:react_with_redux"
+            ]
+          end
+
+        GeneratorMessages.add_warning(<<~MSG.strip)
+          The install --redux option is a hidden legacy Redux generator path and is not recommended
+          for new React on Rails apps.
+          Use the default install generator for new apps. #{legacy_guidance}
+
+              #{legacy_command}
+
+          Runtime Redux APIs such as redux_store remain supported.
+        MSG
       end
 
       def recovery_install_command

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -197,8 +197,6 @@ module ReactOnRails
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
 
-        add_legacy_redux_install_warning_once
-
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
           add_package_json_scripts
@@ -223,6 +221,7 @@ module ReactOnRails
         # print_generator_messages raises an exception. This prevents ENV pollution
         # that could affect subsequent processes.
         ENV.delete("REACT_ON_RAILS_SKIP_VALIDATION")
+        add_legacy_redux_install_warning_once
         print_generator_messages
       end
 
@@ -817,8 +816,8 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
-        @legacy_redux_install_warning_added = true
         add_legacy_redux_install_warning
+        @legacy_redux_install_warning_added = true
       end
 
       def recovery_install_command
@@ -1103,8 +1102,8 @@ module ReactOnRails
           #{recovery_working_tree_note}
           Then re-run: #{recovery_install_command}
         MSG
-        add_legacy_redux_install_warning_once
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1128,8 +1127,8 @@ module ReactOnRails
 
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
-        add_legacy_redux_install_warning_once
         GeneratorMessages.add_error(error)
+        add_legacy_redux_install_warning_once
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -798,7 +798,7 @@ module ReactOnRails
             [
               "Existing apps that need the legacy Redux scaffold can use the hidden react_with_redux generator. " \
               "That generator is also legacy and emits its own warning:",
-              "rails generate react_on_rails:react_with_redux"
+              legacy_redux_generator_command
             ]
           end
 
@@ -839,6 +839,13 @@ module ReactOnRails
         flags << "--no-agent-files" unless options.agent_files?
 
         ["rails generate react_on_rails:install", *flags.compact].join(" ")
+      end
+
+      def legacy_redux_generator_command
+        flags = []
+        flags << "--typescript" if options.typescript?
+
+        ["rails generate react_on_rails:react_with_redux", *flags].join(" ")
       end
 
       def optional_install_flags

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -196,9 +196,9 @@ module ReactOnRails
         # This is inherited by all invoked generators and persists through Rails initialization
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
-        add_legacy_redux_install_warning
 
         if installation_prerequisites_met? || options.ignore_warnings?
+          add_legacy_redux_install_warning
           invoke_generators
           add_package_json_scripts
           add_ci_workflow
@@ -794,7 +794,8 @@ module ReactOnRails
             ]
           else
             [
-              "Existing apps that need the legacy Redux scaffold can run:",
+              "Existing apps that need the legacy Redux scaffold can use the hidden react_with_redux generator. " \
+              "That generator is also legacy and emits its own warning:",
               "bundle exec rails generate react_on_rails:react_with_redux"
             ]
           end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -792,7 +792,7 @@ module ReactOnRails
           if use_tailwind?
             [
               "Existing apps that need Redux with Tailwind should keep using the hidden install path:",
-              "rails generate react_on_rails:install --redux --tailwind"
+              recovery_install_command
             ]
           else
             [
@@ -817,6 +817,7 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
+        # Set only after enqueueing; safe callers may retry if the warning helper fails.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
       end
@@ -829,25 +830,39 @@ module ReactOnRails
       end
 
       def recovery_install_command
-        flags = []
-        flags << "--redux" if options.redux?
-        flags << "--typescript" if options.typescript?
-        # Echo the resolved bundler choice (normalized to --rspack/--no-rspack, so a --webpack
-        # alias re-runs as --no-rspack) only when the user passed one explicitly. An unset choice
-        # re-resolves to the fresh-install default on re-run, so we don't pin it here.
-        flags << (using_rspack? ? "--rspack" : "--no-rspack") if bundler_flag_given?
-
-        if options.rsc?
-          flags << "--rsc"
-        elsif options.pro?
-          flags << "--pro"
-        end
+        flags = optional_install_flags
+        flags << explicit_bundler_install_flag
+        flags << product_stack_install_flag
 
         # Preserve an explicit agent-files opt-out so the suggested re-run doesn't emit
         # AGENTS.md/editor files a user deliberately skipped (--agent-files defaults to on).
         flags << "--no-agent-files" unless options.agent_files?
 
-        ["rails generate react_on_rails:install", *flags].join(" ")
+        ["rails generate react_on_rails:install", *flags.compact].join(" ")
+      end
+
+      def optional_install_flags
+        [
+          ["--redux", options.redux?],
+          ["--typescript", options.typescript?],
+          ["--tailwind", use_tailwind?]
+        ].filter_map { |flag, enabled| flag if enabled }
+      end
+
+      def explicit_bundler_install_flag
+        # Echo the resolved bundler choice (normalized to --rspack/--no-rspack, so a --webpack
+        # alias re-runs as --no-rspack) only when the user passed one explicitly. An unset choice
+        # re-resolves to the fresh-install default on re-run, so we don't pin it here.
+        return unless bundler_flag_given?
+
+        using_rspack? ? "--rspack" : "--no-rspack"
+      end
+
+      def product_stack_install_flag
+        return "--rsc" if options.rsc?
+        return "--pro" if options.pro?
+
+        nil
       end
 
       def rsc_verification_message

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -198,8 +198,8 @@ module ReactOnRails
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
 
         if installation_prerequisites_met? || options.ignore_warnings?
-          add_legacy_redux_install_warning
           invoke_generators
+          add_legacy_redux_install_warning
           add_package_json_scripts
           add_ci_workflow
           add_bin_scripts
@@ -786,6 +786,7 @@ module ReactOnRails
       def add_legacy_redux_install_warning
         return unless options.redux?
 
+        legacy_docs_url = "https://reactonrails.com/docs/api-reference/generator-details/"
         legacy_guidance, legacy_command =
           if use_tailwind?
             [
@@ -807,6 +808,7 @@ module ReactOnRails
 
               #{legacy_command}
 
+          For legacy Redux recovery details, see #{legacy_docs_url}.
           Runtime Redux APIs such as redux_store remain supported.
         MSG
       end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -221,6 +221,7 @@ module ReactOnRails
         # print_generator_messages raises an exception. This prevents ENV pollution
         # that could affect subsequent processes.
         ENV.delete("REACT_ON_RAILS_SKIP_VALIDATION")
+        # Keep primary failure details first; the legacy Redux advisory is best-effort.
         add_legacy_redux_install_warning_once_safely
         print_generator_messages
       end
@@ -816,15 +817,14 @@ module ReactOnRails
       def add_legacy_redux_install_warning_once
         return if @legacy_redux_install_warning_added
 
-        # Set the flag after enqueueing so a failed warning add can be retried.
         add_legacy_redux_install_warning
         @legacy_redux_install_warning_added = true
       end
 
       def add_legacy_redux_install_warning_once_safely
         add_legacy_redux_install_warning_once
-      rescue StandardError
-        # Preserve the primary generator output; this legacy advisory is best-effort.
+      rescue StandardError => e
+        warn "[react_on_rails] Skipped legacy Redux warning: #{e.message}"
         nil
       end
 
@@ -1111,7 +1111,7 @@ module ReactOnRails
           Then re-run: #{recovery_install_command}
         MSG
         GeneratorMessages.add_error(error)
-        add_legacy_redux_install_warning_once
+        add_legacy_redux_install_warning_once_safely
         raise Thor::Error, error unless options.ignore_warnings?
       end
 
@@ -1136,7 +1136,7 @@ module ReactOnRails
           Need help? Visit: https://github.com/shakacode/shakapacker/blob/main/docs/installation.md
         MSG
         GeneratorMessages.add_error(error)
-        add_legacy_redux_install_warning_once
+        add_legacy_redux_install_warning_once_safely
         raise Thor::Error, error unless options.ignore_warnings?
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,6 +13,7 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
+      # Keep this standalone warning aligned with InstallGenerator#add_legacy_redux_install_warning.
       LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip.freeze
         The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
         recommended for new React on Rails apps.
@@ -27,6 +28,7 @@ module ReactOnRails
       class_option :tailwind, type: :boolean, default: false, hide: true
 
       def run_generator
+        add_legacy_redux_generator_warning
         validate_standalone_tailwind
         create_redux_directories
         copy_base_files
@@ -128,10 +130,15 @@ module ReactOnRails
         install_packages_with_fallback(regular_packages, dev: false, package_manager:)
       end
 
-      def add_redux_specific_messages
+      def add_legacy_redux_generator_warning
         return if options[:invoked_by_install]
 
         GeneratorMessages.add_warning(LEGACY_REDUX_GENERATOR_WARNING)
+      end
+
+      def add_redux_specific_messages
+        return if options[:invoked_by_install]
+
         GeneratorMessages.add_info(
           GeneratorMessages.helpful_message_after_installation(component_name: "HelloWorldApp", route: "hello_world",
                                                                pro: Gem.loaded_specs.key?("react_on_rails_pro"),
@@ -145,8 +152,6 @@ module ReactOnRails
         return false if options[:invoked_by_install]
 
         GeneratorMessages.add_error(<<~MSG.strip)
-          🚫 The standalone react_on_rails:react_with_redux generator does not support --tailwind.
-
           Tailwind setup requires the base React on Rails installer so it can create the
           react_on_rails_tailwind pack, stylesheet, dependencies, and webpack/Rspack config.
 

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,6 +13,12 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
+      LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip
+        The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
+        recommended for new React on Rails apps.
+        New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
+        redux_store remain supported.
+      MSG
 
       class_option :typescript,
                    type: :boolean,
@@ -131,13 +137,14 @@ module ReactOnRails
       def add_redux_specific_messages
         return if options.invoked_by_install?
 
-        # Append Redux-specific post-install instructions
+        GeneratorMessages.add_warning(LEGACY_REDUX_GENERATOR_WARNING)
         GeneratorMessages.add_info(
           GeneratorMessages.helpful_message_after_installation(component_name: "HelloWorldApp", route: "hello_world",
                                                                pro: Gem.loaded_specs.key?("react_on_rails_pro"),
                                                                tailwind: use_tailwind?,
                                                                app_root: destination_root)
         )
+        print_generator_messages
       end
 
       private
@@ -152,9 +159,13 @@ module ReactOnRails
           Tailwind setup requires the base React on Rails installer so it can create the
           react_on_rails_tailwind pack, stylesheet, dependencies, and webpack/Rspack config.
 
-          Use the install generator for Redux + Tailwind setup:
+          Use the hidden legacy installer path if you intentionally need the Redux scaffold with Tailwind:
 
-            rails generate react_on_rails:install --redux --tailwind
+            bundle exec rails generate react_on_rails:install --redux --tailwind
+
+          For new apps, run the default installer without Redux:
+
+            bundle exec rails generate react_on_rails:install --tailwind
         MSG
         true
       end

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -36,7 +36,7 @@ module ReactOnRails
         add_redux_npm_dependencies
         add_redux_specific_messages
       ensure
-        print_generator_messages unless options.invoked_by_install?
+        print_generator_messages unless options[:invoked_by_install]
       end
 
       private
@@ -130,7 +130,7 @@ module ReactOnRails
       end
 
       def add_redux_specific_messages
-        return if options.invoked_by_install?
+        return if options[:invoked_by_install]
 
         GeneratorMessages.add_warning(LEGACY_REDUX_GENERATOR_WARNING)
         GeneratorMessages.add_info(
@@ -143,7 +143,7 @@ module ReactOnRails
 
       def unsupported_standalone_tailwind?
         return false unless use_tailwind?
-        return false if options.invoked_by_install?
+        return false if options[:invoked_by_install]
 
         GeneratorMessages.add_error(<<~MSG.strip)
           🚫 The standalone react_on_rails:react_with_redux generator does not support --tailwind.

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -19,7 +19,6 @@ module ReactOnRails
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
         redux_store remain supported.
       MSG
-      private_constant :LEGACY_REDUX_GENERATOR_WARNING
 
       class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
       class_option :invoked_by_install, type: :boolean, default: false, hide: true

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -35,7 +35,7 @@ module ReactOnRails
         add_redux_npm_dependencies
         add_redux_specific_messages
       ensure
-        print_generator_messages unless options[:invoked_by_install]
+        print_generator_messages unless options.invoked_by_install?
       end
 
       private
@@ -142,7 +142,7 @@ module ReactOnRails
 
       def unsupported_standalone_tailwind?
         return false unless use_tailwind?
-        return false if options[:invoked_by_install]
+        return false if options.invoked_by_install?
 
         GeneratorMessages.add_error(<<~MSG.strip)
           🚫 The standalone react_on_rails:react_with_redux generator does not support --tailwind.

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -152,11 +152,11 @@ module ReactOnRails
 
           Use the hidden legacy installer path if you intentionally need the Redux scaffold with Tailwind:
 
-            bundle exec rails generate react_on_rails:install --redux --tailwind
+            rails generate react_on_rails:install --redux --tailwind
 
           For new apps, run the default installer without Redux:
 
-            bundle exec rails generate react_on_rails:install --tailwind
+            rails generate react_on_rails:install --tailwind
         MSG
         true
       end

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -20,6 +20,7 @@ module ReactOnRails
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
         redux_store remain supported.
       MSG
+      private_constant :LEGACY_REDUX_GENERATOR_WARNING
 
       class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
       class_option :invoked_by_install, type: :boolean, default: false, hide: true

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,7 +13,7 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
-      LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip
+      LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip.freeze
         The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
         recommended for new React on Rails apps.
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -20,31 +20,25 @@ module ReactOnRails
         redux_store remain supported.
       MSG
 
-      class_option :typescript,
-                   type: :boolean,
-                   default: false,
-                   desc: "Generate TypeScript files",
-                   aliases: "-T"
+      class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
+      class_option :invoked_by_install, type: :boolean, default: false, hide: true
+      class_option :new_app, type: :boolean, default: false, hide: true
+      class_option :rsc, type: :boolean, default: false, hide: true
+      class_option :tailwind, type: :boolean, default: false, hide: true
 
-      class_option :invoked_by_install,
-                   type: :boolean,
-                   default: false,
-                   hide: true
+      def run_generator
+        validate_standalone_tailwind
+        create_redux_directories
+        copy_base_files
+        copy_base_redux_files
+        create_appropriate_templates
+        add_redux_npm_dependencies
+        add_redux_specific_messages
+      ensure
+        print_generator_messages unless options[:invoked_by_install]
+      end
 
-      class_option :new_app,
-                   type: :boolean,
-                   default: false,
-                   hide: true
-
-      class_option :rsc,
-                   type: :boolean,
-                   default: false,
-                   hide: true
-
-      class_option :tailwind,
-                   type: :boolean,
-                   default: false,
-                   hide: true
+      private
 
       def validate_standalone_tailwind
         return unless unsupported_standalone_tailwind?
@@ -144,10 +138,7 @@ module ReactOnRails
                                                                tailwind: use_tailwind?,
                                                                app_root: destination_root)
         )
-        print_generator_messages
       end
-
-      private
 
       def unsupported_standalone_tailwind?
         return false unless use_tailwind?

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -19,6 +19,7 @@ module ReactOnRails
         New apps should use the default React on Rails installer without Redux. Runtime Redux APIs such as
         redux_store remain supported.
       MSG
+      private_constant :LEGACY_REDUX_GENERATOR_WARNING
 
       class_option :typescript, type: :boolean, default: false, desc: "Generate TypeScript files", aliases: "-T"
       class_option :invoked_by_install, type: :boolean, default: false, hide: true

--- a/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -13,7 +13,8 @@ module ReactOnRails
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
-      # Keep this standalone warning aligned with InstallGenerator#add_legacy_redux_install_warning.
+      # Keep the runtime API compatibility sentence aligned with InstallGenerator#add_legacy_redux_install_warning.
+      # The install path adds recovery docs and command guidance that this standalone warning intentionally omits.
       LEGACY_REDUX_GENERATOR_WARNING = <<~MSG.strip.freeze
         The react_on_rails:react_with_redux generator is a hidden legacy Redux generator path and is not
         recommended for new React on Rails apps.
@@ -28,6 +29,7 @@ module ReactOnRails
       class_option :rsc, type: :boolean, default: false, hide: true
       class_option :tailwind, type: :boolean, default: false, hide: true
 
+      # Only this public method is dispatched by Rails; helpers below stay private.
       def run_generator
         add_legacy_redux_generator_warning
         validate_standalone_tailwind

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4403,7 +4403,7 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text).to include("React on Rails generator prerequisites not met")
       expect(output_text.index("legacy Redux generator path"))
-        .to be < output_text.index("React on Rails generator prerequisites not met")
+        .to be > output_text.index("React on Rails generator prerequisites not met")
     end
 
     specify "shows incomplete-installation guidance when shakapacker setup fails" do
@@ -4767,6 +4767,15 @@ describe InstallGenerator, type: :generator do
       message_text = GeneratorMessages.messages.join("\n")
       expect(message_text).to include("legacy Redux generator path")
       expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+    end
+
+    it "does not warn from the standalone Redux generator when invoked by install" do
+      redux_generator = redux_generator_fixture(invoked_by_install: true)
+      GeneratorMessages.clear
+
+      redux_generator.send(:add_legacy_redux_generator_warning)
+
+      expect(GeneratorMessages.messages.join("\n")).not_to include("legacy Redux generator path")
     end
 
     it "queues the standalone Redux warning before fallible scaffold work" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -349,6 +349,25 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  describe "Redux generator policy" do
+    it "hides the install --redux option from public help and usage text" do
+      redux_option = described_class.class_options.fetch(:redux)
+
+      expect(redux_option.hide).to be(true)
+
+      usage_text = File.read(File.expand_path("../../../lib/generators/USAGE", __dir__))
+      expect(usage_text).not_to include("--redux")
+      expect(usage_text).not_to include("Redux (Optional)")
+    end
+
+    it "marks the base generator Redux option as internal legacy plumbing" do
+      redux_option = ReactOnRails::Generators::BaseGenerator.class_options.fetch(:redux)
+
+      expect(redux_option.hide).to be(true)
+      expect(redux_option.description).to include("legacy")
+    end
+  end
+
   describe "manual generator fixtures" do
     it "keep CI workflow generation inside the generator spec destination" do
       prepare_destination
@@ -4485,6 +4504,27 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
     end
 
+    specify "hidden install --redux emits a legacy warning" do
+      install_generator = install_generator_fixture(redux: true)
+
+      install_generator.send(:add_legacy_redux_install_warning)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("legacy Redux generator path")
+      expect(output_text).to include("bundle exec rails generate react_on_rails:react_with_redux")
+    end
+
+    specify "hidden install --redux --tailwind warning stays on the install path" do
+      install_generator = install_generator_fixture(redux: true, tailwind: true)
+
+      install_generator.send(:add_legacy_redux_install_warning)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("Redux with Tailwind")
+      expect(output_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
+      expect(output_text).not_to include("react_on_rails:react_with_redux")
+    end
+
     specify "shakapacker gemfile error preserves original install flags" do
       # ignore_warnings: true is required so handle_shakapacker_gemfile_error logs
       # the error instead of raising Thor::Error, which lets this example inspect output.
@@ -4643,7 +4683,8 @@ describe InstallGenerator, type: :generator do
       expect(error_text).to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
-      expect(error_text).to include("rails generate react_on_rails:install --redux --tailwind")
+      expect(error_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
+      expect(error_text).to include("bundle exec rails generate react_on_rails:install --tailwind")
     end
 
     it "allows Redux Tailwind setup when invoked by the install generator" do
@@ -4654,6 +4695,18 @@ describe InstallGenerator, type: :generator do
       expect(GeneratorMessages.messages.join("\n")).not_to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
+    end
+
+    it "warns that direct standalone Redux generation is legacy" do
+      redux_generator = redux_generator_fixture
+      allow(redux_generator).to receive(:print_generator_messages)
+
+      redux_generator.add_redux_specific_messages
+
+      message_text = GeneratorMessages.messages.join("\n")
+      expect(message_text).to include("legacy Redux generator path")
+      expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+      expect(redux_generator).to have_received(:print_generator_messages)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4533,6 +4533,15 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("rails generate react_on_rails:react_with_redux")
     end
 
+    specify "hidden install --redux --typescript legacy warning preserves the TypeScript flag" do
+      install_generator = install_generator_fixture(redux: true, typescript: true)
+
+      install_generator.send(:add_legacy_redux_install_warning)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("rails generate react_on_rails:react_with_redux --typescript")
+    end
+
     specify "hidden install --redux legacy warning is only added once" do
       install_generator = install_generator_fixture(redux: true)
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4392,6 +4392,20 @@ describe InstallGenerator, type: :generator do
       install_generator.run_generators
     end
 
+    specify "run_generators warns hidden redux users when prerequisites fail" do
+      install_generator = install_generator_fixture(redux: true)
+      allow(install_generator).to receive(:installation_prerequisites_met?).and_return(false)
+      allow(install_generator).to receive(:print_generator_messages)
+
+      install_generator.run_generators
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text).to include("legacy Redux generator path")
+      expect(output_text).to include("React on Rails generator prerequisites not met")
+      expect(output_text.index("legacy Redux generator path"))
+        .to be < output_text.index("React on Rails generator prerequisites not met")
+    end
+
     specify "shows incomplete-installation guidance when shakapacker setup fails" do
       install_generator = install_generator_fixture
       install_generator.instance_variable_set(:@shakapacker_setup_incomplete, true)

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4518,7 +4518,7 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text.index("legacy Redux generator path"))
-        .to be < output_text.index("Failed to install Shakapacker")
+        .to be > output_text.index("Failed to install Shakapacker")
     end
 
     specify "hidden install --redux emits a legacy warning" do
@@ -4539,6 +4539,31 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text.scan("legacy Redux generator path").size).to eq(1)
+    end
+
+    specify "hidden install --redux legacy warning is retried if adding it fails" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning).and_raise(StandardError, "warning failed")
+      expect do
+        install_generator.send(:add_legacy_redux_install_warning_once)
+      end.to raise_error(StandardError, "warning failed")
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning).and_call_original
+      install_generator.send(:add_legacy_redux_install_warning_once)
+
+      expect(GeneratorMessages.messages.join("\n")).to include("legacy Redux generator path")
+    end
+
+    specify "hidden install --redux legacy warning is printed when invoked generators fail" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:installation_prerequisites_met?).and_return(true)
+      allow(install_generator).to receive(:invoke_generators).and_raise(Thor::Error, "generator failed")
+      allow(install_generator).to receive(:print_generator_messages)
+
+      expect { install_generator.run_generators }.to raise_error(Thor::Error, "generator failed")
+      expect(GeneratorMessages.messages.join("\n")).to include("legacy Redux generator path")
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do
@@ -4572,7 +4597,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
       expect(output_text).to include("legacy Redux generator path")
-      expect(output_text.index("legacy Redux generator path")).to be < output_text.index("Failed to add Shakapacker")
+      expect(output_text.index("legacy Redux generator path")).to be > output_text.index("Failed to add Shakapacker")
     end
 
     specify "rsc installs include the Pro verification checklist message" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4743,9 +4743,8 @@ describe InstallGenerator, type: :generator do
         .to raise_error(Thor::Error, /react_with_redux generator does not support --tailwind/)
 
       error_text = GeneratorMessages.messages.join("\n")
-      expect(error_text).to include(
-        "standalone react_on_rails:react_with_redux generator does not support --tailwind"
-      )
+      expect(error_text).to include("Tailwind setup requires the base React on Rails installer")
+      expect(error_text).not_to include("standalone react_on_rails:react_with_redux generator does not support")
       expect(error_text).to include("rails generate react_on_rails:install --redux --tailwind")
       expect(error_text).to include("rails generate react_on_rails:install --tailwind")
     end
@@ -4763,11 +4762,23 @@ describe InstallGenerator, type: :generator do
     it "warns that direct standalone Redux generation is legacy" do
       redux_generator = redux_generator_fixture
 
-      redux_generator.send(:add_redux_specific_messages)
+      redux_generator.send(:add_legacy_redux_generator_warning)
 
       message_text = GeneratorMessages.messages.join("\n")
       expect(message_text).to include("legacy Redux generator path")
       expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+    end
+
+    it "queues the standalone Redux warning before fallible scaffold work" do
+      redux_generator = redux_generator_fixture
+      allow(redux_generator).to receive(:create_redux_directories).and_raise(Thor::Error, "copy failed")
+      allow(redux_generator).to receive(:print_generator_messages)
+
+      expect { redux_generator.run_generator }.to raise_error(Thor::Error, "copy failed")
+
+      message_text = GeneratorMessages.messages.join("\n")
+      expect(message_text).to include("legacy Redux generator path")
+      expect(redux_generator).to have_received(:print_generator_messages)
     end
 
     it "prints queued messages when standalone Redux Tailwind validation fails" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4473,6 +4473,7 @@ describe InstallGenerator, type: :generator do
       install_generator = install_generator_fixture(
         redux: true,
         typescript: true,
+        tailwind: true,
         rspack: true,
         rsc: true,
         pro: true,
@@ -4484,7 +4485,7 @@ describe InstallGenerator, type: :generator do
 
       command = install_generator.send(:recovery_install_command)
 
-      expect(command).to eq("rails generate react_on_rails:install --redux --typescript --rspack --rsc")
+      expect(command).to eq("rails generate react_on_rails:install --redux --typescript --tailwind --rspack --rsc")
       expect(command).not_to include("--ignore-warnings")
       expect(command).not_to include("--force")
       expect(command).not_to include("--skip")
@@ -4605,14 +4606,14 @@ describe InstallGenerator, type: :generator do
       end.to raise_error(Thor::Error, /Failed to install Shakapacker/)
     end
 
-    specify "hidden install --redux --tailwind warning stays on the install path" do
-      install_generator = install_generator_fixture(redux: true, tailwind: true)
+    specify "hidden install --redux --tailwind warning preserves meaningful install flags" do
+      install_generator = install_generator_fixture(redux: true, tailwind: true, typescript: true)
 
       install_generator.send(:add_legacy_redux_install_warning)
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text).to include("Redux with Tailwind")
-      expect(output_text).to include("rails generate react_on_rails:install --redux --tailwind")
+      expect(output_text).to include("rails generate react_on_rails:install --redux --typescript --tailwind")
       expect(output_text).not_to include("react_on_rails:react_with_redux")
     end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4566,6 +4566,19 @@ describe InstallGenerator, type: :generator do
       expect(GeneratorMessages.messages.join("\n")).to include("legacy Redux generator path")
     end
 
+    specify "warning failures do not suppress queued generator messages" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:installation_prerequisites_met?).and_return(true)
+      allow(install_generator).to receive(:invoke_generators).and_raise(Thor::Error, "generator failed")
+      allow(install_generator).to receive(:add_legacy_redux_install_warning)
+        .and_raise(StandardError, "warning failed")
+      allow(install_generator).to receive(:print_generator_messages)
+
+      expect { install_generator.run_generators }.to raise_error(Thor::Error, "generator failed")
+      expect(install_generator).to have_received(:print_generator_messages)
+    end
+
     specify "hidden install --redux --tailwind warning stays on the install path" do
       install_generator = install_generator_fixture(redux: true, tailwind: true)
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4676,7 +4676,7 @@ describe InstallGenerator, type: :generator do
       redux_generator = redux_generator_fixture(tailwind: true)
       GeneratorMessages.clear
 
-      expect { redux_generator.validate_standalone_tailwind }
+      expect { redux_generator.send(:validate_standalone_tailwind) }
         .to raise_error(Thor::Error, /react_with_redux generator does not support --tailwind/)
 
       error_text = GeneratorMessages.messages.join("\n")
@@ -4691,7 +4691,7 @@ describe InstallGenerator, type: :generator do
       redux_generator = redux_generator_fixture(tailwind: true, invoked_by_install: true)
       GeneratorMessages.clear
 
-      expect { redux_generator.validate_standalone_tailwind }.not_to raise_error
+      expect { redux_generator.send(:validate_standalone_tailwind) }.not_to raise_error
       expect(GeneratorMessages.messages.join("\n")).not_to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
@@ -4699,13 +4699,21 @@ describe InstallGenerator, type: :generator do
 
     it "warns that direct standalone Redux generation is legacy" do
       redux_generator = redux_generator_fixture
-      allow(redux_generator).to receive(:print_generator_messages)
 
-      redux_generator.add_redux_specific_messages
+      redux_generator.send(:add_redux_specific_messages)
 
       message_text = GeneratorMessages.messages.join("\n")
       expect(message_text).to include("legacy Redux generator path")
       expect(message_text).to match(/not\s+recommended for new React on Rails apps/)
+    end
+
+    it "prints queued messages when standalone Redux Tailwind validation fails" do
+      redux_generator = redux_generator_fixture(tailwind: true)
+      allow(redux_generator).to receive(:print_generator_messages)
+
+      expect { redux_generator.run_generator }
+        .to raise_error(Thor::Error, /react_with_redux generator does not support --tailwind/)
+
       expect(redux_generator).to have_received(:print_generator_messages)
     end
   end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4512,7 +4512,7 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text).to include("legacy Redux generator path")
-      expect(output_text).to include("bundle exec rails generate react_on_rails:react_with_redux")
+      expect(output_text).to include("rails generate react_on_rails:react_with_redux")
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do
@@ -4522,7 +4522,7 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.messages.join("\n")
 
       expect(output_text).to include("Redux with Tailwind")
-      expect(output_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
+      expect(output_text).to include("rails generate react_on_rails:install --redux --tailwind")
       expect(output_text).not_to include("react_on_rails:react_with_redux")
     end
 
@@ -4694,8 +4694,8 @@ describe InstallGenerator, type: :generator do
       expect(error_text).to include(
         "standalone react_on_rails:react_with_redux generator does not support --tailwind"
       )
-      expect(error_text).to include("bundle exec rails generate react_on_rails:install --redux --tailwind")
-      expect(error_text).to include("bundle exec rails generate react_on_rails:install --tailwind")
+      expect(error_text).to include("rails generate react_on_rails:install --redux --tailwind")
+      expect(error_text).to include("rails generate react_on_rails:install --tailwind")
     end
 
     it "allows Redux Tailwind setup when invoked by the install generator" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4575,9 +4575,34 @@ describe InstallGenerator, type: :generator do
       allow(install_generator).to receive(:add_legacy_redux_install_warning)
         .and_raise(StandardError, "warning failed")
       allow(install_generator).to receive(:print_generator_messages)
+      allow(install_generator).to receive(:warn)
 
       expect { install_generator.run_generators }.to raise_error(Thor::Error, "generator failed")
       expect(install_generator).to have_received(:print_generator_messages)
+    end
+
+    specify "warning failures do not mask shakapacker gemfile errors" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning)
+        .and_raise(StandardError, "warning failed")
+      allow(install_generator).to receive(:warn)
+
+      expect do
+        install_generator.send(:handle_shakapacker_gemfile_error)
+      end.to raise_error(Thor::Error, /Failed to add Shakapacker/)
+    end
+
+    specify "warning failures do not mask shakapacker install errors" do
+      install_generator = install_generator_fixture(redux: true)
+
+      allow(install_generator).to receive(:add_legacy_redux_install_warning)
+        .and_raise(StandardError, "warning failed")
+      allow(install_generator).to receive(:warn)
+
+      expect do
+        install_generator.send(:handle_shakapacker_install_error)
+      end.to raise_error(Thor::Error, /Failed to install Shakapacker/)
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4516,6 +4516,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
+      expect(output_text).to include("Failed to install Shakapacker")
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text.index("legacy Redux generator path"))
         .to be > output_text.index("Failed to install Shakapacker")
@@ -4609,6 +4610,7 @@ describe InstallGenerator, type: :generator do
       output_text = GeneratorMessages.output.join("\n")
 
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
+      expect(output_text).to include("Failed to add Shakapacker")
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text.index("legacy Redux generator path")).to be > output_text.index("Failed to add Shakapacker")
     end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4503,6 +4503,8 @@ describe InstallGenerator, type: :generator do
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
       expect(output_text).to include("legacy Redux generator path")
+      expect(output_text.index("legacy Redux generator path"))
+        .to be < output_text.index("Failed to install Shakapacker")
     end
 
     specify "hidden install --redux emits a legacy warning" do
@@ -4513,6 +4515,16 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("legacy Redux generator path")
       expect(output_text).to include("rails generate react_on_rails:react_with_redux")
+    end
+
+    specify "hidden install --redux legacy warning is only added once" do
+      install_generator = install_generator_fixture(redux: true)
+
+      install_generator.send(:add_legacy_redux_install_warning_once)
+      install_generator.send(:add_legacy_redux_install_warning_once)
+      output_text = GeneratorMessages.messages.join("\n")
+
+      expect(output_text.scan("legacy Redux generator path").size).to eq(1)
     end
 
     specify "hidden install --redux --tailwind warning stays on the install path" do
@@ -4546,6 +4558,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
       expect(output_text).to include("legacy Redux generator path")
+      expect(output_text.index("legacy Redux generator path")).to be < output_text.index("Failed to add Shakapacker")
     end
 
     specify "rsc installs include the Pro verification checklist message" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4502,6 +4502,7 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Re-run: rails generate react_on_rails:install --redux --typescript")
+      expect(output_text).to include("legacy Redux generator path")
     end
 
     specify "hidden install --redux emits a legacy warning" do
@@ -4535,6 +4536,16 @@ describe InstallGenerator, type: :generator do
 
       expect(output_text).to include("clean up your working tree before rerunning")
       expect(output_text).to include("Then re-run: rails generate react_on_rails:install --rspack --pro")
+    end
+
+    specify "shakapacker gemfile error warns for hidden redux recovery" do
+      install_generator = install_generator_fixture(redux: true, ignore_warnings: true)
+
+      install_generator.send(:handle_shakapacker_gemfile_error)
+      output_text = GeneratorMessages.output.join("\n")
+
+      expect(output_text).to include("Then re-run: rails generate react_on_rails:install --redux")
+      expect(output_text).to include("legacy Redux generator path")
     end
 
     specify "rsc installs include the Pro verification checklist message" do


### PR DESCRIPTION
## Why

The V17 new-app path should no longer teach Redux as the normal starter architecture. Redux runtime APIs remain supported, so the docs need to preserve the legitimate shared-store guidance while steering greenfield apps toward local React state, Rails/server state, and smaller patterns first.

Closes #4275.

## What changed

- Remove greenfield `react_on_rails:install --redux` recommendations from generator and tutorial docs.
- Reframe the hidden Redux generator path as legacy/recovery guidance.
- Keep Redux runtime API docs, but label `redux_store` and `registerStoreGenerators` as legacy or advanced multi-island shared-store APIs.
- Add explicit state-choice framing: local island state, server state, and multi-island shared client state.
- Update adjacent getting-started, router, intro, and API docs so Redux is not presented as the default new-app path.
- Fix the React Router docs examples so shared route trees are not auto-registered as conflicting `ror_components` definitions.

## Validation

- PASS: `.agents/bin/agent-workflow-seam-doctor`
- PASS: `.agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4275` (`SECURITY_PREFLIGHT_OK`)
- PASS: `node script/generate-llms-full.mjs --check`
- PASS: `script/check-docs-sidebar`
- PASS: `pnpm start format.listDifferent`
- PASS: `PATH="/tmp/codex-lychee-0.23.0:$PATH" bin/check-links`
- PASS: `git diff --check`
- PASS: pre-commit and pre-push hooks with repo-compatible `lychee 0.23.0` on `PATH`

## CI recommendation

Docs-only change. No hosted CI label recommended beyond normal markdown/docs checks.
