### PR TITLE
Fix Pro renderer asset filename validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Node renderer rejects unsafe asset filenames**: The Pro Node renderer now rejects path-like,
+  drive-relative, alternate-stream, and control-character asset filenames before uploaded assets are copied
+  or `/asset-exists` probes bundle directories, returning a 400 without reporting rejected names to the
+  error reporter. [PR 4285](https://github.com/shakacode/react_on_rails/pull/4285) by
+  [ihabadham](https://github.com/ihabadham).
+
 - **[Pro]** **Streaming component caches honor `cache_options` on reads**: `cached_stream_react_component`
   wrote cached chunks with the user-supplied `cache_options` but read them back without any options, so
   key-altering options such as `namespace:` meant the cache never hit and every request re-streamed from

--- a/packages/react-on-rails-pro-node-renderer/src/shared/utils.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/utils.ts
@@ -235,6 +235,11 @@ export const delay = (milliseconds: number) =>
 
 // Keep aligned with ReactOnRailsPro::RollingDeploy::SAFE_HASH_PATTERN.
 const BUNDLE_TIMESTAMP_PATH_COMPONENT_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._-]*$/;
+const hasAsciiControlCharacter = (value: string) =>
+  Array.from(value).some((character) => {
+    const characterCode = character.charCodeAt(0);
+    return characterCode <= 0x1f || characterCode === 0x7f;
+  });
 
 function bundleTimestampPathComponent(bundleTimestamp: string | number) {
   const pathComponent = String(bundleTimestamp);
@@ -258,6 +263,7 @@ export function assetFilenamePathComponent(filename: string) {
     path.isAbsolute(pathComponent) ||
     path.posix.isAbsolute(pathComponent) ||
     path.win32.isAbsolute(pathComponent) ||
+    hasAsciiControlCharacter(pathComponent) ||
     pathComponent.includes('/') ||
     pathComponent.includes('\\') ||
     path.basename(pathComponent) !== pathComponent ||
@@ -265,7 +271,7 @@ export function assetFilenamePathComponent(filename: string) {
     path.win32.basename(pathComponent) !== pathComponent
   ) {
     throw new Error(
-      `Invalid asset filename path component: ${pathComponent}. Expected a single filename, not a path.`,
+      `Invalid asset filename path component: ${JSON.stringify(pathComponent)}. Expected a single filename, not a path.`,
     );
   }
 

--- a/packages/react-on-rails-pro-node-renderer/src/shared/utils.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/utils.ts
@@ -120,6 +120,38 @@ ${stack}`;
 // https://github.com/fastify/fastify-multipart?tab=readme-ov-file#usage
 const pump = promisify(pipeline);
 
+const hasAsciiControlCharacter = (value: string) => {
+  for (let index = 0; index < value.length; index += 1) {
+    const characterCode = value.charCodeAt(index);
+    if (characterCode <= 0x1f || characterCode === 0x7f) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export function validateAssetFilename(filename: unknown) {
+  if (
+    typeof filename !== 'string' ||
+    !filename ||
+    filename === '.' ||
+    filename === '..' ||
+    filename.includes('/') ||
+    filename.includes('\\') ||
+    filename.includes(':') ||
+    hasAsciiControlCharacter(filename) ||
+    // Catches Windows drive-relative values such as "C:file" that have no separator.
+    path.win32.basename(filename) !== filename
+  ) {
+    throw new Error(
+      `Invalid asset filename: ${JSON.stringify(filename)}. Expected a single filename, not a path.`,
+    );
+  }
+
+  return filename;
+}
+
 export async function saveMultipartFile(
   multipartFile: MultipartFile,
   destinationPath: string,
@@ -152,7 +184,7 @@ export function copyUploadedAsset(
 
 export async function copyUploadedAssets(uploadedAssets: Asset[], targetDirectory: string): Promise<void> {
   const copyMultipleAssets = uploadedAssets.map((asset) => {
-    const destinationAssetFilePath = path.join(targetDirectory, asset.filename);
+    const destinationAssetFilePath = path.join(targetDirectory, validateAssetFilename(asset.filename));
     return copyUploadedAsset(asset, destinationAssetFilePath, { overwrite: true });
   });
   await Promise.all(copyMultipleAssets);
@@ -235,11 +267,6 @@ export const delay = (milliseconds: number) =>
 
 // Keep aligned with ReactOnRailsPro::RollingDeploy::SAFE_HASH_PATTERN.
 const BUNDLE_TIMESTAMP_PATH_COMPONENT_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._-]*$/;
-const hasAsciiControlCharacter = (value: string) =>
-  Array.from(value).some((character) => {
-    const characterCode = character.charCodeAt(0);
-    return characterCode <= 0x1f || characterCode === 0x7f;
-  });
 
 function bundleTimestampPathComponent(bundleTimestamp: string | number) {
   const pathComponent = String(bundleTimestamp);
@@ -247,31 +274,6 @@ function bundleTimestampPathComponent(bundleTimestamp: string | number) {
     throw new Error(
       `Invalid bundle timestamp path component: ${pathComponent}. ` +
         'Expected only letters, digits, dots, underscores, and hyphens.',
-    );
-  }
-
-  return pathComponent;
-}
-
-export function assetFilenamePathComponent(filename: string) {
-  const pathComponent = filename;
-
-  if (
-    !pathComponent ||
-    pathComponent === '.' ||
-    pathComponent === '..' ||
-    path.isAbsolute(pathComponent) ||
-    path.posix.isAbsolute(pathComponent) ||
-    path.win32.isAbsolute(pathComponent) ||
-    hasAsciiControlCharacter(pathComponent) ||
-    pathComponent.includes('/') ||
-    pathComponent.includes('\\') ||
-    path.basename(pathComponent) !== pathComponent ||
-    path.posix.basename(pathComponent) !== pathComponent ||
-    path.win32.basename(pathComponent) !== pathComponent
-  ) {
-    throw new Error(
-      `Invalid asset filename path component: ${JSON.stringify(pathComponent)}. Expected a single filename, not a path.`,
     );
   }
 
@@ -291,7 +293,7 @@ export function getRequestBundleFilePath(bundleTimestamp: string | number) {
 
 export function getAssetPath(bundleTimestamp: string | number, filename: string) {
   const bundleDirectory = getBundleDirectory(bundleTimestamp);
-  return path.join(bundleDirectory, assetFilenamePathComponent(filename));
+  return path.join(bundleDirectory, validateAssetFilename(filename));
 }
 
 export async function validateBundlesExist(

--- a/packages/react-on-rails-pro-node-renderer/src/shared/utils.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/utils.ts
@@ -248,6 +248,30 @@ function bundleTimestampPathComponent(bundleTimestamp: string | number) {
   return pathComponent;
 }
 
+export function assetFilenamePathComponent(filename: string) {
+  const pathComponent = filename;
+
+  if (
+    !pathComponent ||
+    pathComponent === '.' ||
+    pathComponent === '..' ||
+    path.isAbsolute(pathComponent) ||
+    path.posix.isAbsolute(pathComponent) ||
+    path.win32.isAbsolute(pathComponent) ||
+    pathComponent.includes('/') ||
+    pathComponent.includes('\\') ||
+    path.basename(pathComponent) !== pathComponent ||
+    path.posix.basename(pathComponent) !== pathComponent ||
+    path.win32.basename(pathComponent) !== pathComponent
+  ) {
+    throw new Error(
+      `Invalid asset filename path component: ${pathComponent}. Expected a single filename, not a path.`,
+    );
+  }
+
+  return pathComponent;
+}
+
 export function getBundleDirectory(bundleTimestamp: string | number) {
   const { serverBundleCachePath } = getConfig();
   return path.resolve(serverBundleCachePath, bundleTimestampPathComponent(bundleTimestamp));
@@ -261,7 +285,7 @@ export function getRequestBundleFilePath(bundleTimestamp: string | number) {
 
 export function getAssetPath(bundleTimestamp: string | number, filename: string) {
   const bundleDirectory = getBundleDirectory(bundleTimestamp);
-  return path.join(bundleDirectory, filename);
+  return path.join(bundleDirectory, assetFilenamePathComponent(filename));
 }
 
 export async function validateBundlesExist(

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -1173,7 +1173,7 @@ export default function run(config: Partial<Config>) {
       const message =
         err instanceof Error ? err.message : `Invalid asset filename path component: ${filename}`;
       log.info(message);
-      await setResponse(errorResponseResult(message), res);
+      await setResponse(badRequestResponseResult(message), res);
       return;
     }
 

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -25,7 +25,7 @@ import { rm } from 'fs/promises';
 import { Transform } from 'stream';
 import fastify from 'fastify';
 import fastifyFormbody from '@fastify/formbody';
-import fastifyMultipart from '@fastify/multipart';
+import fastifyMultipart, { type MultipartFile } from '@fastify/multipart';
 import log, { sharedLoggerOptions } from './shared/log.js';
 import packageJson from './shared/packageJson.js';
 import { buildConfig, Config, getConfig } from './shared/configBuilder.js';
@@ -58,7 +58,7 @@ import {
   ResponseResult,
   saveMultipartFile,
   Asset,
-  assetFilenamePathComponent,
+  validateAssetFilename,
   getAssetPath,
 } from './shared/utils.js';
 import { startSsrRequestOptions, subSpan, trace, type TracingContext } from './shared/tracing.js';
@@ -94,6 +94,7 @@ declare module '@fastify/multipart' {
 declare module 'fastify' {
   interface FastifyRequest {
     uploadDir: string;
+    uploadAssetValidationError: string | null;
   }
 }
 
@@ -458,6 +459,16 @@ const extractBodyArrayField = <Key extends string>(
   return undefined;
 };
 
+function discardMultipartFile(part: MultipartFile) {
+  part.file.resume();
+  // eslint-disable-next-line no-param-reassign
+  part.value = {
+    filename: part.filename,
+    savedFilePath: '',
+    type: 'asset',
+  };
+}
+
 export default function run(config: Partial<Config>) {
   runRscPeerCompatibilityCheck({ proVersion: packageJson.version });
 
@@ -509,6 +520,7 @@ export default function run(config: Partial<Config>) {
   // from overwriting each other's files (GitHub issue #2449).
   // The directory path is lazily assigned in onFile (only for requests with file uploads).
   app.decorateRequest('uploadDir', '');
+  app.decorateRequest('uploadAssetValidationError', null);
   // Clean up the per-request upload directory after the response is sent.
   // Safe from a rate-limiting perspective (CodeQL js/missing-rate-limiting):
   // this is an internal service not exposed to the internet, the path is
@@ -527,6 +539,7 @@ export default function run(config: Partial<Config>) {
   // Supports multipart/form-data
   void app.register(fastifyMultipart, {
     attachFieldsToBody: 'keyValues',
+    preservePath: true,
     limits: {
       fieldSize: FIELD_SIZE_LIMIT,
       // For bundles and assets
@@ -540,18 +553,26 @@ export default function run(config: Partial<Config>) {
       if (typeof this?.uploadDir !== 'string') {
         throw new Error('onFile: expected `this` to be bound to the Fastify request');
       }
-      // Lazily assign a per-request upload directory on first file upload
+
+      if (this.uploadAssetValidationError) {
+        discardMultipartFile(part);
+        return;
+      }
+
+      let safeFilename: string;
+      try {
+        safeFilename = validateAssetFilename(part.filename);
+      } catch (err) {
+        this.uploadAssetValidationError = (err as Error).message;
+        discardMultipartFile(part);
+        return;
+      }
+
+      // Lazily assign a per-request upload directory on first valid file upload.
       if (this.uploadDir === '') {
         this.uploadDir = path.join(serverBundleCachePath, 'uploads', randomUUID());
       }
-      // Use path.basename to strip any directory components from the filename,
-      // preventing path traversal attacks (e.g. filename "../../etc/shadow").
-      const safeFilename = path.basename(part.filename);
-      if (!safeFilename) {
-        throw new Error(
-          `onFile: received file with empty or invalid filename: ${JSON.stringify(part.filename)}`,
-        );
-      }
+
       const destinationPath = path.join(this.uploadDir, safeFilename);
       await saveMultipartFile(part, destinationPath);
       // eslint-disable-next-line no-param-reassign
@@ -610,6 +631,11 @@ export default function run(config: Partial<Config>) {
         badRequestResponseResult('Invalid "rscStreamObservability" field in render request.'),
         res,
       );
+      return;
+    }
+
+    if (req.uploadAssetValidationError) {
+      await setResponse(badRequestResponseResult(req.uploadAssetValidationError), res);
       return;
     }
 
@@ -1086,6 +1112,11 @@ export default function run(config: Partial<Config>) {
       return;
     }
 
+    if (req.uploadAssetValidationError) {
+      await setResponse(badRequestResponseResult(req.uploadAssetValidationError), res);
+      return;
+    }
+
     const { providedNewBundles, assetsToCopy } = extractBundlesAndAssets(req.body);
 
     if (providedNewBundles.length === 0) {
@@ -1168,10 +1199,9 @@ export default function run(config: Partial<Config>) {
 
     let assetFilename: string;
     try {
-      assetFilename = assetFilenamePathComponent(filename);
+      assetFilename = validateAssetFilename(filename);
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : `Invalid asset filename path component: ${filename}`;
+      const { message } = err as Error;
       log.info(message);
       await setResponse(badRequestResponseResult(message), res);
       return;

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -58,6 +58,7 @@ import {
   ResponseResult,
   saveMultipartFile,
   Asset,
+  assetFilenamePathComponent,
   getAssetPath,
 } from './shared/utils.js';
 import { startSsrRequestOptions, subSpan, trace, type TracingContext } from './shared/tracing.js';
@@ -1165,6 +1166,17 @@ export default function run(config: Partial<Config>) {
       return;
     }
 
+    let assetFilename: string;
+    try {
+      assetFilename = assetFilenamePathComponent(filename);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : `Invalid asset filename path component: ${filename}`;
+      log.info(message);
+      await setResponse(errorResponseResult(message), res);
+      return;
+    }
+
     // Handle targetBundles as either a string or an array
     const targetBundles = extractBodyArrayField(req.body, 'targetBundles');
     if (!targetBundles || targetBundles.length === 0) {
@@ -1177,7 +1189,7 @@ export default function run(config: Partial<Config>) {
     // Check if the asset exists in each of the target bundles
     const results = await Promise.all(
       targetBundles.map(async (bundleHash) => {
-        const assetPath = getAssetPath(bundleHash, filename);
+        const assetPath = getAssetPath(bundleHash, assetFilename);
         const exists = await fileExistsAsync(assetPath);
 
         if (exists) {

--- a/packages/react-on-rails-pro-node-renderer/tests/sharedUtils.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/sharedUtils.test.ts
@@ -13,8 +13,9 @@
  * https://github.com/shakacode/react_on_rails/blob/main/REACT-ON-RAILS-PRO-LICENSE.md
  */
 
+import fs from 'fs';
 import path from 'path';
-import { assetFilenamePathComponent, getRequestBundleFilePath } from '../src/shared/utils';
+import { copyUploadedAssets, validateAssetFilename, getRequestBundleFilePath } from '../src/shared/utils';
 import { resetForTest, serverBundleCachePath } from './helper';
 
 const testName = 'sharedUtils';
@@ -42,11 +43,11 @@ describe('shared utils', () => {
     });
   });
 
-  describe('assetFilenamePathComponent', () => {
+  describe('validateAssetFilename', () => {
     test.each(['loadable-stats.json', 'react-client-manifest.json', 'asset_name-123.json'])(
       'accepts asset filename "%s"',
       (filename) => {
-        expect(assetFilenamePathComponent(filename)).toBe(filename);
+        expect(validateAssetFilename(filename)).toBe(filename);
       },
     );
 
@@ -60,11 +61,41 @@ describe('shared utils', () => {
       'assets\\loadable-stats.json',
       '/tmp/loadable-stats.json',
       'C:\\tmp\\loadable-stats.json',
+      'C:loadable-stats.json',
+      'file.txt:stream',
+      'foo:bar',
       'foo\0bar',
       'foo\nbar',
       'foo\x7Fbar',
     ])('rejects asset filename path "%s"', (filename) => {
-      expect(() => assetFilenamePathComponent(filename)).toThrow('Invalid asset filename path component');
+      expect(() => validateAssetFilename(filename)).toThrow('Invalid asset filename');
+    });
+
+    test.each([[['loadable-stats.json']], [42], [null], [undefined]])(
+      'rejects non-string asset filename %#',
+      (filename) => {
+        expect(() => validateAssetFilename(filename)).toThrow('Invalid asset filename');
+      },
+    );
+  });
+
+  describe('copyUploadedAssets', () => {
+    test('rejects unsafe filenames before joining the copy destination path', async () => {
+      const cachePath = serverBundleCachePath(testName);
+      const sourcePath = path.join(cachePath, 'uploaded-source.json');
+      const targetDirectory = path.join(cachePath, 'bundle-hash');
+      const escapedDestinationPath = path.resolve(targetDirectory, '..', 'escaped.json');
+      fs.mkdirSync(cachePath, { recursive: true });
+      fs.writeFileSync(sourcePath, '{}');
+
+      await expect(
+        copyUploadedAssets(
+          [{ type: 'asset', savedFilePath: sourcePath, filename: '../escaped.json' }],
+          targetDirectory,
+        ),
+      ).rejects.toThrow('Invalid asset filename');
+
+      expect(fs.existsSync(escapedDestinationPath)).toBe(false);
     });
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/sharedUtils.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/sharedUtils.test.ts
@@ -14,7 +14,7 @@
  */
 
 import path from 'path';
-import { getRequestBundleFilePath } from '../src/shared/utils';
+import { assetFilenamePathComponent, getRequestBundleFilePath } from '../src/shared/utils';
 import { resetForTest, serverBundleCachePath } from './helper';
 
 const testName = 'sharedUtils';
@@ -39,6 +39,29 @@ describe('shared utils', () => {
 
     test.each(['.server.abc123', '-server.abc123'])('rejects Ruby-unsafe bundle hash "%s"', (bundleHash) => {
       expect(() => getRequestBundleFilePath(bundleHash)).toThrow('Invalid bundle timestamp path component');
+    });
+  });
+
+  describe('assetFilenamePathComponent', () => {
+    test.each(['loadable-stats.json', 'react-client-manifest.json', 'asset_name-123.json'])(
+      'accepts asset filename "%s"',
+      (filename) => {
+        expect(assetFilenamePathComponent(filename)).toBe(filename);
+      },
+    );
+
+    test.each([
+      '',
+      '.',
+      '..',
+      '../loadable-stats.json',
+      '..\\loadable-stats.json',
+      'assets/loadable-stats.json',
+      'assets\\loadable-stats.json',
+      '/tmp/loadable-stats.json',
+      'C:\\tmp\\loadable-stats.json',
+    ])('rejects asset filename path "%s"', (filename) => {
+      expect(() => assetFilenamePathComponent(filename)).toThrow('Invalid asset filename path component');
     });
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/sharedUtils.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/sharedUtils.test.ts
@@ -60,6 +60,9 @@ describe('shared utils', () => {
       'assets\\loadable-stats.json',
       '/tmp/loadable-stats.json',
       'C:\\tmp\\loadable-stats.json',
+      'foo\0bar',
+      'foo\nbar',
+      'foo\x7Fbar',
     ])('rejects asset filename path "%s"', (filename) => {
       expect(() => assetFilenamePathComponent(filename)).toThrow('Invalid asset filename path component');
     });

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -524,30 +524,35 @@ describe('worker', () => {
     });
   });
 
-  test('post /asset-exists rejects traversal filenames', async () => {
+  test('post /asset-exists rejects unsafe filenames without reporting them', async () => {
     const bundleHash = 'some-bundle-hash';
     await createAsset(testName, bundleHash);
     const sentinelPath = path.resolve(serverBundleCachePathForTest(), '..', 'asset-exists-sentinel.txt');
     fs.writeFileSync(sentinelPath, 'outside renderer cache');
+    const reportMessageSpy = jest.spyOn(errorReporter, 'message').mockImplementation(jest.fn());
 
     const app = createWorker({
       password: 'my_password',
     });
 
-    const query = querystring.stringify({ filename: '../../asset-exists-sentinel.txt' });
-
     try {
-      const res = await app
-        .inject()
-        .post(`/asset-exists?${query}`)
-        .payload({
-          password: 'my_password',
-          targetBundles: [bundleHash],
-        })
-        .end();
-      expect(res.statusCode).toBe(400);
-      expect(res.payload).toContain('Invalid asset filename');
+      for (const filename of ['../../asset-exists-sentinel.txt', 'foo\0bar', 'foo\nbar']) {
+        const query = querystring.stringify({ filename });
+
+        const res = await app
+          .inject()
+          .post(`/asset-exists?${query}`)
+          .payload({
+            password: 'my_password',
+            targetBundles: [bundleHash],
+          })
+          .end();
+        expect(res.statusCode).toBe(400);
+        expect(res.payload).toContain('Invalid asset filename');
+      }
+      expect(reportMessageSpy).not.toHaveBeenCalled();
     } finally {
+      reportMessageSpy.mockRestore();
       fs.rmSync(sentinelPath, { force: true });
     }
   });

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -524,6 +524,34 @@ describe('worker', () => {
     });
   });
 
+  test('post /asset-exists rejects traversal filenames', async () => {
+    const bundleHash = 'some-bundle-hash';
+    await createAsset(testName, bundleHash);
+    const sentinelPath = path.resolve(serverBundleCachePathForTest(), '..', 'asset-exists-sentinel.txt');
+    fs.writeFileSync(sentinelPath, 'outside renderer cache');
+
+    const app = createWorker({
+      password: 'my_password',
+    });
+
+    const query = querystring.stringify({ filename: '../../asset-exists-sentinel.txt' });
+
+    try {
+      const res = await app
+        .inject()
+        .post(`/asset-exists?${query}`)
+        .payload({
+          password: 'my_password',
+          targetBundles: [bundleHash],
+        })
+        .end();
+      expect(res.statusCode).toBe(400);
+      expect(res.payload).toContain('Invalid asset filename');
+    } finally {
+      fs.rmSync(sentinelPath, { force: true });
+    }
+  });
+
   test('post /asset-exists requires targetBundles (protocol version 2.0.0)', async () => {
     await createAsset(testName, String(BUNDLE_TIMESTAMP));
     const app = createWorker({

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -14,6 +14,7 @@
  */
 
 import fs from 'fs';
+import FormData from 'form-data';
 import path from 'path';
 import querystring from 'querystring';
 import { PassThrough, Readable } from 'stream';
@@ -129,6 +130,41 @@ describe('worker', () => {
     expect(fs.existsSync(vmBundlePath(testName))).toBe(true);
     expect(fs.existsSync(assetPath(testName, String(BUNDLE_TIMESTAMP)))).toBe(true);
     expect(fs.existsSync(assetPathOther(testName, String(BUNDLE_TIMESTAMP)))).toBe(true);
+  });
+
+  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest rejects unsafe uploaded asset filenames', async () => {
+    const app = createWorker();
+    const httpErrorLogSpy = jest.spyOn(app.log, 'error');
+
+    try {
+      const form = new FormData();
+      form.append('gemVersion', gemVersion);
+      form.append('protocolVersion', protocolVersion);
+      form.append('railsEnv', railsEnv);
+      form.append('renderingRequest', 'ReactOnRails.dummy');
+      form.append('bundle', fs.readFileSync(getFixtureBundle()), {
+        contentType: 'text/javascript',
+        filename: 'bundle.js',
+      });
+      form.append('asset1', Buffer.from('{}'), {
+        contentType: 'application/json',
+        filepath: '../../loadable-stats.json',
+      });
+
+      const res = await app
+        .inject()
+        .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+        .payload(form.getBuffer())
+        .headers(form.getHeaders())
+        .end();
+
+      expect(res.statusCode).toBe(400);
+      expect(res.payload).toContain('Invalid asset filename');
+      expect(httpErrorLogSpy).not.toHaveBeenCalled();
+      expect(fs.existsSync(vmBundlePath(testName))).toBe(false);
+    } finally {
+      httpErrorLogSpy.mockRestore();
+    }
   });
 
   test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest', async () => {
@@ -557,6 +593,33 @@ describe('worker', () => {
     }
   });
 
+  test('post /asset-exists rejects repeated filename query keys without reporting them', async () => {
+    const bundleHash = 'some-bundle-hash';
+    await createAsset(testName, bundleHash);
+    const reportMessageSpy = jest.spyOn(errorReporter, 'message').mockImplementation(jest.fn());
+
+    const app = createWorker({
+      password: 'my_password',
+    });
+
+    try {
+      const res = await app
+        .inject()
+        .post('/asset-exists?filename=loadable-stats.json&filename=other.json')
+        .payload({
+          password: 'my_password',
+          targetBundles: [bundleHash],
+        })
+        .end();
+
+      expect(res.statusCode).toBe(400);
+      expect(res.payload).toContain('Invalid asset filename');
+      expect(reportMessageSpy).not.toHaveBeenCalled();
+    } finally {
+      reportMessageSpy.mockRestore();
+    }
+  });
+
   test('post /asset-exists requires targetBundles (protocol version 2.0.0)', async () => {
     await createAsset(testName, String(BUNDLE_TIMESTAMP));
     const app = createWorker({
@@ -597,6 +660,45 @@ describe('worker', () => {
     expect(res.statusCode).toBe(200);
     expect(fs.existsSync(assetPath(testName, bundleHash))).toBe(true);
     expect(fs.existsSync(assetPathOther(testName, bundleHash))).toBe(true);
+  });
+
+  test('post /upload-assets rejects unsafe uploaded filenames before copying assets', async () => {
+    const bundleHash = 'unsafe-upload-filename-hash';
+
+    const app = createWorker({
+      password: 'my_password',
+    });
+    const httpErrorLogSpy = jest.spyOn(app.log, 'error');
+
+    try {
+      const form = new FormData();
+      form.append('gemVersion', gemVersion);
+      form.append('protocolVersion', protocolVersion);
+      form.append('railsEnv', railsEnv);
+      form.append('password', 'my_password');
+      form.append(`bundle_${bundleHash}`, Buffer.from('bundle'), {
+        contentType: 'text/javascript',
+        filename: `${bundleHash}.js`,
+      });
+      form.append('asset1', Buffer.from('{}'), {
+        contentType: 'application/json',
+        filepath: '../../loadable-stats.json',
+      });
+
+      const res = await app
+        .inject()
+        .post(`/upload-assets`)
+        .payload(form.getBuffer())
+        .headers(form.getHeaders())
+        .end();
+
+      expect(res.statusCode).toBe(400);
+      expect(res.payload).toContain('Invalid asset filename');
+      expect(httpErrorLogSpy).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(serverBundleCachePathForTest(), bundleHash))).toBe(false);
+    } finally {
+      httpErrorLogSpy.mockRestore();
+    }
   });
 
   test('post /upload-assets ignores targetBundles when bundle_<hash> fields are present (backward compat)', async () => {


### PR DESCRIPTION
## Summary

Fixes `/asset-exists` filename handling for the Pro Node renderer.

The endpoint should only check asset basenames inside renderer bundle cache directories. Previously, unsafe filenames could escape the intended bundle boundary, and follow-up review found malformed filenames still produced noisy/unclean handling in two cases:

- invalid filename rejects used `errorResponseResult`, notifying the error reporter for expected malformed client input;
- NUL/control characters were not rejected before filesystem access, so `foo%00bar` could return a 500 from Node's path validation.

## Implementation

- Add shared asset filename path-component validation.
- Reject absolute paths, path separators, `.` / `..`, basename mismatches, and ASCII control characters.
- Return a plain 400 for unsafe asset filenames without reporting to `errorReporter`.
- Escape unsafe characters in invalid filename messages via `JSON.stringify`.
- Add endpoint-level and helper tests for traversal, NUL, newline, and DEL cases.

## Validation

- Empirical repro before fix: `tmp/experiments/20260629T155528Z-asset-exists-review-claims/cmd.sh`
  - traversal triggered error-reporter notification
  - `foo%00bar` returned 500 `ERR_INVALID_ARG_VALUE`
- Empirical probe after fix: `tmp/experiments/20260629T155528Z-asset-exists-review-claims/cmd-after.sh`
  - traversal/NUL/newline return 400
  - normal `loadable-stats.json` still returns 200 `{ exists: true }`
  - no `ErrorReporter notification` log label for invalid filenames
- `(cd packages/react-on-rails-pro-node-renderer && pnpm exec jest tests/worker.test.ts --runInBand)`
- `(cd packages/react-on-rails-pro-node-renderer && pnpm exec jest tests/sharedUtils.test.ts --runInBand)`
- `(cd packages/react-on-rails-pro-node-renderer && pnpm run type-check)`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `git diff --check`
- `codex review --uncommitted` — no actionable regressions found
- Pre-commit hooks passed
- Pre-push hooks passed

## Risk

Low. Scope is limited to authenticated Pro Node renderer asset-existence checks and shared path construction. Normal basename assets continue working; unsafe filenames now fail earlier with 400.

## Changelog

No changelog entry. Internal Pro renderer hardening; no user-facing API change beyond rejecting malformed filenames.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened Pro Node renderer asset handling with strict filename validation, returning an early **400** for unsafe/path-like, drive/absolute-like, and control-character filenames.
  * Multipart uploads now validate filenames during upload handling and safely discard invalid parts to prevent further processing.
  * `/asset-exists` now rejects invalid query filenames before resolving any asset paths.
* **Tests**
  * Added security-focused tests covering `validateAssetFilename`, asset-copy rejection, and endpoint behavior (HTTP 400, no error-reporting noise, and no filesystem artifacts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->