### PR TITLE
Fail fast for RSC on Rspack v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **[Pro]** **Fail fast for RSC with Rspack v1**: When React Server Components are enabled and Shakapacker is
   configured for Rspack, app boot and `react_on_rails:doctor` now reject `@rspack/core` v1 or a missing
   `@rspack/core` package with explicit Rspack v2 upgrade instructions.
+  [PR 4289](https://github.com/shakacode/react_on_rails/pull/4289) by [justin808](https://github.com/justin808).
 - **`create-react-on-rails-app` now defaults to Pro for React 19.2 support**: Running
   `npx create-react-on-rails-app my-app` no longer asks setup questions and generates the recommended
   React on Rails Pro scaffold by default. Automation note: non-TTY environments, including CI and piped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Changed
 
+- **[Pro]** **Fail fast for RSC with Rspack v1**: When React Server Components are enabled and Shakapacker is
+  configured for Rspack, app boot and `react_on_rails:doctor` now reject `@rspack/core` v1 or a missing
+  `@rspack/core` package with explicit Rspack v2 upgrade instructions.
 - **`create-react-on-rails-app` now defaults to Pro for React 19.2 support**: Running
   `npx create-react-on-rails-app my-app` no longer asks setup questions and generates the recommended
   React on Rails Pro scaffold by default. Automation note: non-TTY environments, including CI and piped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **[Pro]** **Fail fast for RSC with Rspack v1**: When React Server Components are enabled and Shakapacker is
   configured for Rspack, app boot and `react_on_rails:doctor` now reject `@rspack/core` v1 or a missing
-  `@rspack/core` package with explicit Rspack v2 upgrade instructions.
+  `@rspack/core` package with explicit Rspack v2 upgrade instructions. This guard only runs when RSC is enabled,
+  so Rspack v1 remains allowed for non-RSC apps, and bundler detection now honors `SHAKAPACKER_ASSETS_BUNDLER`
+  before `config/shakapacker.yml`.
   [PR 4289](https://github.com/shakacode/react_on_rails/pull/4289) by [justin808](https://github.com/justin808).
 - **`create-react-on-rails-app` now defaults to Pro for React 19.2 support**: Running
   `npx create-react-on-rails-app my-app` no longer asks setup questions and generates the recommended

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -4392,7 +4392,7 @@ module ReactOnRails
       return nil unless package_json_path
 
       package_json = parsed_package_json(package_json_path)
-      rsc_package_dependency_spec(package_json, package_name, fields: DECLARED_PACKAGE_DEPENDENCY_FIELDS)
+      rsc_package_dependency_spec(package_json, package_name, fields: GENERIC_DECLARED_PACKAGE_DEPENDENCY_FIELDS)
     rescue StandardError
       nil
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3617,8 +3617,8 @@ module ReactOnRails
     end
 
     def check_rsc_rspack_version
-      # check_rsc_setup gates this on enable_rsc_support before calling here.
       return unless active_assets_bundler == "rspack"
+      return unless rsc_support_enabled_for_doctor?
 
       rspack_version = detected_rspack_version_for_rsc
       if rspack_version && rsc_package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
@@ -3629,6 +3629,14 @@ module ReactOnRails
       checker.add_error(rsc_rspack_version_error(rspack_version))
     rescue StandardError => e
       checker.add_warning("⚠️  Could not verify Rspack version for RSC: #{e.message}")
+    end
+
+    def rsc_support_enabled_for_doctor?
+      return false unless ReactOnRails::Utils.react_on_rails_pro?
+      return false unless defined?(ReactOnRailsPro) && ReactOnRailsPro.respond_to?(:configuration)
+
+      pro_config = ReactOnRailsPro.configuration
+      pro_config.respond_to?(:enable_rsc_support) && pro_config.enable_rsc_support
     end
 
     def detected_rspack_version_for_rsc

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -4378,7 +4378,7 @@ module ReactOnRails
       return nil unless package_json_path
 
       package_json = parsed_package_json(package_json_path)
-      rsc_package_dependency_spec(package_json, package_name)
+      rsc_package_dependency_spec(package_json, package_name, fields: DECLARED_PACKAGE_DEPENDENCY_FIELDS)
     rescue StandardError
       nil
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3494,6 +3494,10 @@ module ReactOnRails
       config/rspack/rscWebpackConfig.js
     ].freeze
     RSC_PACKAGE_NAME = "react-on-rails-rsc"
+    RSC_RSPACK_PACKAGE = "@rspack/core"
+    MINIMUM_RSC_RSPACK_MAJOR = 2
+    RSPACK_V2_INSTALL_COMMAND = "pnpm add -D @rspack/core@^2 @rspack/cli@^2 " \
+                                "@rspack/dev-server@^2 @rspack/plugin-react-refresh@^2"
     RSC_DIST_TAGS_TO_CHECK = %w[next rc].freeze
     NPM_VIEW_FETCH_TIMEOUT_MS = 5_000
     NPM_VIEW_FETCH_TIMEOUT_SECONDS = NPM_VIEW_FETCH_TIMEOUT_MS / 1000.0
@@ -3548,6 +3552,7 @@ module ReactOnRails
       check_rsc_renderer_mode(pro_config)
       check_rsc_payload_route
       check_rsc_bundler_config
+      check_rsc_rspack_version
       check_rsc_rspack_lazy_compilation
       check_rsc_react_version
       check_rsc_procfile_watcher
@@ -3619,6 +3624,47 @@ module ReactOnRails
             rails g react_on_rails:rsc
         MSG
       end
+    end
+
+    def check_rsc_rspack_version
+      return unless active_assets_bundler == "rspack"
+
+      rspack_version = detected_rspack_version_for_rsc
+      if rspack_version && package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
+        checker.add_success("✅ Rspack #{rspack_version} is compatible with RSC")
+        return
+      end
+
+      checker.add_error(rsc_rspack_version_error(rspack_version))
+    rescue StandardError => e
+      checker.add_warning("⚠️  Could not verify Rspack version for RSC: #{e.message}")
+    end
+
+    def detected_rspack_version_for_rsc
+      detect_package_version_from_deps(RSC_RSPACK_PACKAGE) || declared_package_spec(RSC_RSPACK_PACKAGE)
+    end
+
+    def package_major_version(version)
+      return 0 if version.to_s.include?("/") && !version.to_s.start_with?("npm:")
+
+      major = version.to_s.sub(/\Anpm:[^@]+@/, "").match(/\d+/)&.[](0)
+      major.to_i
+    end
+
+    def rsc_rspack_version_error(rspack_version)
+      detected_version = rspack_version || "not found"
+
+      <<~MSG.strip
+        🚫 RSC with Rspack requires Rspack v2 or newer.
+
+        Detected #{RSC_RSPACK_PACKAGE}: #{detected_version}
+
+        Rspack v1 is not supported for React Server Components in React on Rails Pro.
+        Upgrade to Rspack v2 so RSC setup fails fast instead of hitting bundler or runtime surprises.
+
+        Fix:
+          #{RSPACK_V2_INSTALL_COMMAND}
+      MSG
     end
 
     def check_rsc_rspack_lazy_compilation

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3632,11 +3632,7 @@ module ReactOnRails
     end
 
     def rsc_support_enabled_for_doctor?
-      return false unless ReactOnRails::Utils.react_on_rails_pro?
-      return false unless defined?(ReactOnRailsPro) && ReactOnRailsPro.respond_to?(:configuration)
-
-      pro_config = ReactOnRailsPro.configuration
-      pro_config.respond_to?(:enable_rsc_support) && pro_config.enable_rsc_support
+      rsc_support_enabled_config_value
     end
 
     def detected_rspack_version_for_rsc

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3617,6 +3617,7 @@ module ReactOnRails
     end
 
     def check_rsc_rspack_version
+      # check_rsc_setup gates this on enable_rsc_support before calling here.
       return unless active_assets_bundler == "rspack"
 
       rspack_version = detected_rspack_version_for_rsc

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3644,7 +3644,11 @@ module ReactOnRails
     end
 
     def rsc_rspack_version_error(rspack_version)
-      rsc_rspack_version_requirement_error(rspack_version, error_prefix: "🚫")
+      rsc_rspack_version_requirement_error(
+        rspack_version,
+        error_prefix: "🚫",
+        package_json_path: package_json_path_for("RSC Rspack version")
+      )
     end
 
     def check_rsc_rspack_lazy_compilation

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -10,6 +10,7 @@ require_relative "utils"
 require_relative "version"
 require_relative "config_path_resolver"
 require_relative "shakapacker_config_helpers"
+require_relative "rsc_rspack_support"
 require_relative "dev/server_mode"
 require_relative "version_syntax_converter"
 require_relative "version_synchronizer"
@@ -51,6 +52,7 @@ module ReactOnRails
   class Doctor
     include ConfigPathResolver
     include ShakapackerConfigHelpers
+    include RscRspackSupport
 
     MESSAGE_COLORS = {
       error: :red,
@@ -3494,10 +3496,6 @@ module ReactOnRails
       config/rspack/rscWebpackConfig.js
     ].freeze
     RSC_PACKAGE_NAME = "react-on-rails-rsc"
-    RSC_RSPACK_PACKAGE = "@rspack/core"
-    MINIMUM_RSC_RSPACK_MAJOR = 2
-    RSPACK_V2_INSTALL_COMMAND = "pnpm add -D @rspack/core@^2 @rspack/cli@^2 " \
-                                "@rspack/dev-server@^2 @rspack/plugin-react-refresh@^2"
     RSC_DIST_TAGS_TO_CHECK = %w[next rc].freeze
     NPM_VIEW_FETCH_TIMEOUT_MS = 5_000
     NPM_VIEW_FETCH_TIMEOUT_SECONDS = NPM_VIEW_FETCH_TIMEOUT_MS / 1000.0
@@ -3514,14 +3512,6 @@ module ReactOnRails
       generate_rsc_manifest_client_references_if_needed
       RSC_REFERENCE_DISCOVERY_BUILD
     ].freeze
-    # npm registry package names used here must be lowercase; keep this allowlist
-    # narrow so names remain safe when reused as Node resolver args and paths.
-    PACKAGE_NAME_PATTERN = %r{
-      \A
-      (?:@[a-z0-9][a-z0-9._-]*/)?
-      [a-z0-9][a-z0-9._-]*
-      \z
-    }x
     # Keep in sync with RSC_CLIENT_MANIFEST_GUIDANCE in
     # packages/react-on-rails-pro/src/handleErrorRSC.ts.
     RSC_CLIENT_MANIFEST_CLEANUP_PATHS = %w[public/packs public/packs-test ssr-generated .node-renderer-bundles].freeze
@@ -3630,7 +3620,7 @@ module ReactOnRails
       return unless active_assets_bundler == "rspack"
 
       rspack_version = detected_rspack_version_for_rsc
-      if rspack_version && package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
+      if rspack_version && rsc_package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
         checker.add_success("✅ Rspack #{rspack_version} is compatible with RSC")
         return
       end
@@ -3644,27 +3634,8 @@ module ReactOnRails
       detect_package_version_from_deps(RSC_RSPACK_PACKAGE) || declared_package_spec(RSC_RSPACK_PACKAGE)
     end
 
-    def package_major_version(version)
-      return 0 if version.to_s.include?("/") && !version.to_s.start_with?("npm:")
-
-      major = version.to_s.sub(/\Anpm:[^@]+@/, "").match(/\d+/)&.[](0)
-      major.to_i
-    end
-
     def rsc_rspack_version_error(rspack_version)
-      detected_version = rspack_version || "not found"
-
-      <<~MSG.strip
-        🚫 RSC with Rspack requires Rspack v2 or newer.
-
-        Detected #{RSC_RSPACK_PACKAGE}: #{detected_version}
-
-        Rspack v1 is not supported for React Server Components in React on Rails Pro.
-        Upgrade to Rspack v2 so RSC setup fails fast instead of hitting bundler or runtime surprises.
-
-        Fix:
-          #{RSPACK_V2_INSTALL_COMMAND}
-      MSG
+      rsc_rspack_version_requirement_error(rspack_version, error_prefix: "🚫")
     end
 
     def check_rsc_rspack_lazy_compilation
@@ -4343,44 +4314,15 @@ module ReactOnRails
     end
 
     def installed_package_version(package_root, package_name)
-      version = installed_package_json(package_root, package_name)&.fetch("version", nil)
-      version if version&.match?(/\A\d+\.\d+\.\d+/)
+      rsc_installed_package_version(package_root, package_name) do |failed_package_name|
+        report_node_package_resolution_failed(failed_package_name)
+      end
     end
 
     def installed_package_json(package_root, package_name)
-      # Use Node's own module resolution to find the actually installed package,
-      # which handles hoisted dependencies in monorepos and pnpm workspaces.
-      # Resolve from the configured package root so nested client/ layouts work.
-      return nil unless valid_package_name?(package_name)
-
-      script = "console.log(require.resolve(process.argv[1] + '/package.json'))"
-      resolved_path = resolved_node_package_json_path(package_root, package_name, script)
-      # package_name has passed PACKAGE_NAME_PATTERN, so this fallback cannot escape node_modules.
-      # It covers classic flat node_modules layouts; pnpm virtual-store layouts rely on Node resolution above.
-      # Limitation: a stale orphaned directory can still be read if Node resolution fails.
-      resolved_path = File.join(package_root, "node_modules", package_name, "package.json") if resolved_path.empty?
-      return nil if resolved_path.empty? || !File.exist?(resolved_path)
-
-      JSON.parse(File.read(resolved_path))
-    rescue StandardError
-      nil
-    end
-
-    def valid_package_name?(package_name)
-      package_name.to_s.match?(PACKAGE_NAME_PATTERN)
-    end
-
-    def resolved_node_package_json_path(package_root, package_name, script)
-      stdout, _stderr, status = Open3.capture3("node", "-e", script, package_name, chdir: package_root)
-      unless status.success?
-        report_node_package_resolution_failed(package_name)
-        return ""
+      rsc_installed_package_json(package_root, package_name) do |failed_package_name|
+        report_node_package_resolution_failed(failed_package_name)
       end
-
-      stdout.strip
-    rescue StandardError
-      report_node_package_resolution_failed(package_name)
-      ""
     end
 
     def report_node_package_resolution_failed(package_name)
@@ -4427,8 +4369,7 @@ module ReactOnRails
       return nil unless package_json_path
 
       package_json = parsed_package_json(package_json_path)
-      all_deps = (package_json["dependencies"] || {}).merge(package_json["devDependencies"] || {})
-      all_deps[package_name]
+      rsc_package_dependency_spec(package_json, package_name)
     rescue StandardError
       nil
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3640,7 +3640,21 @@ module ReactOnRails
     end
 
     def detected_rspack_version_for_rsc
-      detect_package_version_from_deps(RSC_RSPACK_PACKAGE) || declared_package_spec(RSC_RSPACK_PACKAGE)
+      package_root = resolved_package_root
+      installed_version = nil
+      unless package_root_missing?(package_root)
+        installed_version = installed_package_version(package_root, RSC_RSPACK_PACKAGE)
+      end
+      installed_version || declared_rspack_version_for_rsc
+    rescue StandardError
+      nil
+    end
+
+    def declared_rspack_version_for_rsc
+      package_json_path = package_json_path_for("declared Rspack version")
+      return nil unless package_json_path
+
+      rsc_declared_package_version(package_json_path, RSC_RSPACK_PACKAGE)
     end
 
     def rsc_rspack_version_error(rspack_version)

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -18,8 +18,6 @@ module ReactOnRails
       dependencies
       devDependencies
       optionalDependencies
-      peerDependencies
-      peerOptionalDependencies
     ].freeze
     PACKAGE_NAME_PATTERN = %r{
       \A
@@ -94,9 +92,11 @@ module ReactOnRails
     end
 
     def rsc_package_major_version(version)
-      return 0 if version.to_s.include?("/") && !version.to_s.start_with?("npm:")
+      version_string = version.to_s
+      return 0 if version_string.include?("/") && !version_string.start_with?("npm:")
 
-      major = version.to_s.sub(/\Anpm:[^@]+@/, "").match(/\d+/)&.[](0)
+      version_without_alias = version_string.sub(%r{\Anpm:(?:@[^/]+/)?[^@]+@}, "")
+      major = version_without_alias.match(/\d+/)&.[](0)
       major.to_i
     end
 

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -14,10 +14,13 @@ module ReactOnRails
       @rspack/plugin-react-refresh
     ].freeze
     MINIMUM_RSC_RSPACK_MAJOR = 2
-    PACKAGE_DEPENDENCY_FIELDS = %w[
+    DECLARED_PACKAGE_DEPENDENCY_FIELDS = %w[
       dependencies
       devDependencies
-      optionalDependencies
+    ].freeze
+    RSC_RSPACK_PACKAGE_DEPENDENCY_FIELDS = [
+      *DECLARED_PACKAGE_DEPENDENCY_FIELDS,
+      "optionalDependencies"
     ].freeze
     PACKAGE_NAME_PATTERN = %r{
       \A
@@ -129,8 +132,8 @@ module ReactOnRails
       package_name.to_s.match?(PACKAGE_NAME_PATTERN)
     end
 
-    def rsc_package_dependency_spec(package_json, package_name)
-      PACKAGE_DEPENDENCY_FIELDS.each do |field|
+    def rsc_package_dependency_spec(package_json, package_name, fields: RSC_RSPACK_PACKAGE_DEPENDENCY_FIELDS)
+      fields.each do |field|
         spec = package_json.fetch(field, nil)&.fetch(package_name, nil)
         return spec if spec
       end

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -22,6 +22,11 @@ module ReactOnRails
       *DECLARED_PACKAGE_DEPENDENCY_FIELDS,
       "optionalDependencies"
     ].freeze
+    RSC_RSPACK_UPGRADE_PACKAGE_DEPENDENCY_FIELDS = [
+      *RSC_RSPACK_PACKAGE_DEPENDENCY_FIELDS,
+      "peerDependencies"
+    ].freeze
+    PATH_PROTOCOL_PACKAGE_SPEC_PATTERN = /\A(?:file|link|portal):/
     PACKAGE_NAME_PATTERN = %r{
       \A
       (?:@[a-z0-9][a-z0-9._-]*/)?
@@ -31,8 +36,8 @@ module ReactOnRails
 
     private
 
-    def rsc_rspack_v2_install_command
-      packages = RSC_RSPACK_V2_PACKAGES.map do |package_name|
+    def rsc_rspack_v2_install_command(package_json_path: nil)
+      packages = rsc_rspack_upgrade_packages(package_json_path).map do |package_name|
         "#{package_name}@^#{MINIMUM_RSC_RSPACK_MAJOR}"
       end.join(" ")
 
@@ -48,7 +53,12 @@ module ReactOnRails
       end
     end
 
-    def rsc_rspack_version_requirement_error(rspack_version, error_prefix: nil, include_doctor_recommendation: false)
+    def rsc_rspack_version_requirement_error(
+      rspack_version,
+      error_prefix: nil,
+      include_doctor_recommendation: false,
+      package_json_path: nil
+    )
       detected_version = rspack_version || "not found"
       prefix = "#{error_prefix} " if error_prefix
       doctor_recommendation = "\n\n#{ReactOnRails::DOCTOR_RECOMMENDATION}" if include_doctor_recommendation
@@ -59,10 +69,10 @@ module ReactOnRails
         Detected #{RSC_RSPACK_PACKAGE}: #{detected_version}
 
         Rspack v1 is not supported for React Server Components in React on Rails Pro.
-        Upgrade to Rspack v2 so RSC setup fails fast instead of hitting bundler or runtime surprises.
+        Upgrade to Rspack v2 to ensure RSC works correctly instead of hitting bundler or runtime surprises.
 
         Fix:
-          #{rsc_rspack_v2_install_command}#{doctor_recommendation}
+          #{rsc_rspack_v2_install_command(package_json_path:)}#{doctor_recommendation}
       MSG
     end
 
@@ -74,7 +84,7 @@ module ReactOnRails
     def rsc_installed_package_json(package_root, package_name, &)
       return nil unless valid_rsc_package_name?(package_name)
 
-      script = "console.log(require.resolve(process.argv[1] + '/package.json'))"
+      script = "console.log(require.resolve(process.argv[2] + '/package.json'))"
       resolved_path = rsc_resolved_node_package_json_path(package_root, package_name, script, &)
       # package_name has passed PACKAGE_NAME_PATTERN, so this fallback cannot escape node_modules.
       # It covers classic flat node_modules layouts; pnpm virtual-store layouts rely on Node resolution above.
@@ -102,7 +112,9 @@ module ReactOnRails
     def rsc_package_major_version(version)
       version_string = version.to_s
       # Path-based protocol specs cannot be statically verified; reject them unless Node resolution found v2.
+      return 0 if version_string.match?(PATH_PROTOCOL_PACKAGE_SPEC_PATTERN)
       return 0 if version_string.include?("/") && !version_string.start_with?("npm:")
+      return 0 if version_string.start_with?("workspace:") && !version_string.match?(/\d/)
 
       version_without_alias = version_string.sub(%r{\Anpm:(?:@[^/]+/)?[^@]+@}, "")
       major = version_without_alias.match(/\d+/)&.[](0)
@@ -142,8 +154,30 @@ module ReactOnRails
     end
 
     def rsc_normalized_declared_package_version(package_spec)
+      return nil if package_spec.to_s.match?(PATH_PROTOCOL_PACKAGE_SPEC_PATTERN)
+
       clean_version = package_spec.to_s.gsub(/\A[^0-9]*/, "")
       clean_version if clean_version.match?(/\A\d+\.\d+\.\d+\z/)
+    end
+
+    def rsc_rspack_upgrade_packages(package_json_path)
+      declared_packages = rsc_declared_rspack_upgrade_packages(package_json_path)
+      declared_packages.empty? ? RSC_RSPACK_V2_PACKAGES : declared_packages
+    end
+
+    def rsc_declared_rspack_upgrade_packages(package_json_path)
+      return [] if package_json_path.to_s.empty?
+
+      package_json = JSON.parse(File.read(package_json_path))
+      RSC_RSPACK_V2_PACKAGES.select do |package_name|
+        rsc_package_dependency_spec(
+          package_json,
+          package_name,
+          fields: RSC_RSPACK_UPGRADE_PACKAGE_DEPENDENCY_FIELDS
+        )
+      end
+    rescue StandardError
+      []
     end
   end
 end

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -77,7 +77,7 @@ module ReactOnRails
       # It covers classic flat node_modules layouts; pnpm virtual-store layouts rely on Node resolution above.
       # Limitation: a stale orphaned directory can still be read if Node resolution fails.
       resolved_path = File.join(package_root, "node_modules", package_name, "package.json") if resolved_path.empty?
-      return nil if resolved_path.empty? || !File.exist?(resolved_path)
+      return nil unless File.exist?(resolved_path)
 
       JSON.parse(File.read(resolved_path))
     rescue StandardError
@@ -87,7 +87,7 @@ module ReactOnRails
     def rsc_declared_package_spec(package_json_path, package_name)
       package_json = JSON.parse(File.read(package_json_path))
       rsc_package_dependency_spec(package_json, package_name)
-    rescue JSON::ParserError, Errno::ENOENT
+    rescue StandardError
       nil
     end
 

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -74,6 +74,9 @@ module ReactOnRails
 
         Rspack v1 is not supported for React Server Components in React on Rails Pro.
         Upgrade to Rspack v2 to ensure RSC works correctly instead of hitting bundler or runtime surprises.
+        If #{RSC_RSPACK_PACKAGE} is declared with an npm range, dist-tag, workspace spec, or local path that
+        React on Rails cannot statically verify, install dependencies so Node can resolve the installed package
+        version or pin #{RSC_RSPACK_PACKAGE} to Rspack v2.
 
         Fix:
           #{rsc_rspack_v2_install_command(package_json_path:)}#{doctor_recommendation}
@@ -131,6 +134,8 @@ module ReactOnRails
       return 0 if version_string.include?("/") && !version_string.start_with?("npm:")
       return 0 if version_string.start_with?("workspace:")
 
+      # Accept installed semver versions and simple declared lower-bound specs. Other npm ranges or dist-tags
+      # fail closed unless Node resolution already proved that the installed package is Rspack v2.
       major = version_string.match(/\Av?(\d+)\.\d+\.\d+(?:[-+].*)?\z/)&.[](1)
       major.to_i
     end
@@ -180,6 +185,8 @@ module ReactOnRails
 
     def rsc_rspack_upgrade_packages(package_json_path)
       declared_packages = rsc_declared_rspack_upgrade_packages(package_json_path)
+      # If package.json cannot be read, suggest the full Rspack v2 suite so generated Rspack apps get all
+      # companion packages needed by the standard React on Rails development workflow.
       return RSC_RSPACK_V2_PACKAGES if declared_packages.empty?
       return declared_packages if declared_packages.include?(RSC_RSPACK_PACKAGE)
 

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -33,7 +33,7 @@ module ReactOnRails
         "#{package_name}@^#{MINIMUM_RSC_RSPACK_MAJOR}"
       end.join(" ")
 
-      case ReactOnRails::Utils.detect_package_manager
+      case rsc_detected_package_manager
       when :pnpm
         "pnpm add -D #{packages}"
       when :bun
@@ -91,8 +91,14 @@ module ReactOnRails
       nil
     end
 
+    def rsc_declared_package_version(package_json_path, package_name)
+      package_spec = rsc_declared_package_spec(package_json_path, package_name)
+      rsc_normalized_declared_package_version(package_spec) || package_spec
+    end
+
     def rsc_package_major_version(version)
       version_string = version.to_s
+      # Path-based protocol specs cannot be statically verified; reject them unless Node resolution found v2.
       return 0 if version_string.include?("/") && !version_string.start_with?("npm:")
 
       version_without_alias = version_string.sub(%r{\Anpm:(?:@[^/]+/)?[^@]+@}, "")
@@ -100,7 +106,7 @@ module ReactOnRails
       major.to_i
     end
 
-    def rsc_resolved_node_package_json_path(package_root, package_name, script)
+    def rsc_resolved_node_package_json_path(package_root, package_name, script, &)
       stdout, _stderr, status = Open3.capture3("node", "-e", script, package_name, chdir: package_root)
       unless status.success?
         yield(package_name) if block_given?
@@ -111,6 +117,12 @@ module ReactOnRails
     rescue StandardError
       yield(package_name) if block_given?
       ""
+    end
+
+    def rsc_detected_package_manager
+      ReactOnRails::Utils.detect_package_manager
+    rescue StandardError
+      :yarn
     end
 
     def valid_rsc_package_name?(package_name)
@@ -124,6 +136,11 @@ module ReactOnRails
       end
 
       nil
+    end
+
+    def rsc_normalized_declared_package_version(package_spec)
+      clean_version = package_spec.to_s.gsub(/\A[^0-9]*/, "")
+      clean_version if clean_version.match?(/\A\d+\.\d+\.\d+\z/)
     end
   end
 end

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require_relative "utils"
+
+module ReactOnRails
+  module RscRspackSupport
+    RSC_RSPACK_PACKAGE = "@rspack/core"
+    RSC_RSPACK_V2_PACKAGES = %w[
+      @rspack/core
+      @rspack/cli
+      @rspack/dev-server
+      @rspack/plugin-react-refresh
+    ].freeze
+    MINIMUM_RSC_RSPACK_MAJOR = 2
+    PACKAGE_DEPENDENCY_FIELDS = %w[
+      dependencies
+      devDependencies
+      optionalDependencies
+      peerDependencies
+      peerOptionalDependencies
+    ].freeze
+    PACKAGE_NAME_PATTERN = %r{
+      \A
+      (?:@[a-z0-9][a-z0-9._-]*/)?
+      [a-z0-9][a-z0-9._-]*
+      \z
+    }x
+
+    private
+
+    def rsc_rspack_v2_install_command
+      packages = RSC_RSPACK_V2_PACKAGES.map do |package_name|
+        "#{package_name}@^#{MINIMUM_RSC_RSPACK_MAJOR}"
+      end.join(" ")
+
+      case ReactOnRails::Utils.detect_package_manager
+      when :pnpm
+        "pnpm add -D #{packages}"
+      when :bun
+        "bun add --dev #{packages}"
+      when :npm
+        "npm install --save-dev #{packages}"
+      else
+        "yarn add --dev #{packages}"
+      end
+    end
+
+    def rsc_rspack_version_requirement_error(rspack_version, error_prefix: nil, include_doctor_recommendation: false)
+      detected_version = rspack_version || "not found"
+      prefix = "#{error_prefix} " if error_prefix
+      doctor_recommendation = "\n\n#{ReactOnRails::DOCTOR_RECOMMENDATION}" if include_doctor_recommendation
+
+      <<~MSG.strip
+        #{prefix}RSC with Rspack requires Rspack v2 or newer.
+
+        Detected #{RSC_RSPACK_PACKAGE}: #{detected_version}
+
+        Rspack v1 is not supported for React Server Components in React on Rails Pro.
+        Upgrade to Rspack v2 so RSC setup fails fast instead of hitting bundler or runtime surprises.
+
+        Fix:
+          #{rsc_rspack_v2_install_command}#{doctor_recommendation}
+      MSG
+    end
+
+    def rsc_installed_package_version(package_root, package_name, &)
+      version = rsc_installed_package_json(package_root, package_name, &)&.fetch("version", nil)
+      version if version&.match?(/\A\d+\.\d+\.\d+/)
+    end
+
+    def rsc_installed_package_json(package_root, package_name, &)
+      return nil unless valid_rsc_package_name?(package_name)
+
+      script = "console.log(require.resolve(process.argv[1] + '/package.json'))"
+      resolved_path = rsc_resolved_node_package_json_path(package_root, package_name, script, &)
+      # package_name has passed PACKAGE_NAME_PATTERN, so this fallback cannot escape node_modules.
+      # It covers classic flat node_modules layouts; pnpm virtual-store layouts rely on Node resolution above.
+      # Limitation: a stale orphaned directory can still be read if Node resolution fails.
+      resolved_path = File.join(package_root, "node_modules", package_name, "package.json") if resolved_path.empty?
+      return nil if resolved_path.empty? || !File.exist?(resolved_path)
+
+      JSON.parse(File.read(resolved_path))
+    rescue StandardError
+      nil
+    end
+
+    def rsc_declared_package_spec(package_json_path, package_name)
+      package_json = JSON.parse(File.read(package_json_path))
+      rsc_package_dependency_spec(package_json, package_name)
+    rescue JSON::ParserError, Errno::ENOENT
+      nil
+    end
+
+    def rsc_package_major_version(version)
+      return 0 if version.to_s.include?("/") && !version.to_s.start_with?("npm:")
+
+      major = version.to_s.sub(/\Anpm:[^@]+@/, "").match(/\d+/)&.[](0)
+      major.to_i
+    end
+
+    def rsc_resolved_node_package_json_path(package_root, package_name, script)
+      stdout, _stderr, status = Open3.capture3("node", "-e", script, package_name, chdir: package_root)
+      unless status.success?
+        yield(package_name) if block_given?
+        return ""
+      end
+
+      stdout.strip
+    rescue StandardError
+      yield(package_name) if block_given?
+      ""
+    end
+
+    def valid_rsc_package_name?(package_name)
+      package_name.to_s.match?(PACKAGE_NAME_PATTERN)
+    end
+
+    def rsc_package_dependency_spec(package_json, package_name)
+      PACKAGE_DEPENDENCY_FIELDS.each do |field|
+        spec = package_json.fetch(field, nil)&.fetch(package_name, nil)
+        return spec if spec
+      end
+
+      nil
+    end
+  end
+end

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -97,6 +97,14 @@ module ReactOnRails
       nil
     end
 
+    def rsc_support_enabled_config_value
+      return false unless ReactOnRails::Utils.react_on_rails_pro?
+      return false unless defined?(ReactOnRailsPro) && ReactOnRailsPro.respond_to?(:configuration)
+
+      pro_config = ReactOnRailsPro.configuration
+      pro_config.respond_to?(:enable_rsc_support) && pro_config.enable_rsc_support
+    end
+
     def rsc_declared_package_spec(package_json_path, package_name)
       package_json = JSON.parse(File.read(package_json_path))
       rsc_package_dependency_spec(package_json, package_name)
@@ -124,6 +132,7 @@ module ReactOnRails
     end
 
     def rsc_resolved_node_package_json_path(package_root, package_name, script, &)
+      # Boot/doctor validation only. This is intentionally outside the request path.
       stdout, _stderr, status = Open3.capture3("node", "-e", script, package_name, chdir: package_root)
       unless status.success?
         yield(package_name) if block_given?
@@ -147,6 +156,7 @@ module ReactOnRails
     end
 
     def rsc_package_dependency_spec(package_json, package_name, fields: RSC_RSPACK_PACKAGE_DEPENDENCY_FIELDS)
+      # The default is Rspack-specific; generic package checks pass stricter dependency fields.
       fields.each do |field|
         spec = package_json.fetch(field, nil)&.fetch(package_name, nil)
         return spec if spec

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -18,6 +18,10 @@ module ReactOnRails
       dependencies
       devDependencies
     ].freeze
+    GENERIC_DECLARED_PACKAGE_DEPENDENCY_FIELDS = %w[
+      devDependencies
+      dependencies
+    ].freeze
     RSC_RSPACK_PACKAGE_DEPENDENCY_FIELDS = [
       *DECLARED_PACKAGE_DEPENDENCY_FIELDS,
       "optionalDependencies"

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -161,7 +161,7 @@ module ReactOnRails
       return nil if spec.start_with?("workspace:")
 
       spec = spec.sub(%r{\Anpm:(?:@[^/]+/)?[^@]+@}, "")
-      spec.match(/\A(?:[~^]|>=?|=)?\s*v?(\d+\.\d+\.\d+)\z/)&.[](1)
+      spec.match(/\A(?:[~^]|>=?|=)?\s*v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\z/)&.[](1)
     end
 
     def rsc_rspack_upgrade_packages(package_json_path)

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -117,7 +117,7 @@ module ReactOnRails
       # Path-based protocol specs cannot be statically verified; reject them unless Node resolution found v2.
       return 0 if version_string.match?(PATH_PROTOCOL_PACKAGE_SPEC_PATTERN)
       return 0 if version_string.include?("/") && !version_string.start_with?("npm:")
-      return 0 if version_string.start_with?("workspace:") && !version_string.match?(/\d/)
+      return 0 if version_string.start_with?("workspace:")
 
       major = version_string.match(/\Av?(\d+)\.\d+\.\d+(?:[-+].*)?\z/)&.[](1)
       major.to_i
@@ -158,9 +158,9 @@ module ReactOnRails
     def rsc_normalized_declared_package_version(package_spec)
       spec = package_spec.to_s.strip
       return nil if spec.match?(PATH_PROTOCOL_PACKAGE_SPEC_PATTERN)
+      return nil if spec.start_with?("workspace:")
 
       spec = spec.sub(%r{\Anpm:(?:@[^/]+/)?[^@]+@}, "")
-                 .delete_prefix("workspace:")
       spec.match(/\A(?:[~^]|>=?|=)?\s*v?(\d+\.\d+\.\d+)\z/)&.[](1)
     end
 

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -84,7 +84,7 @@ module ReactOnRails
     def rsc_installed_package_json(package_root, package_name, &)
       return nil unless valid_rsc_package_name?(package_name)
 
-      script = "console.log(require.resolve(process.argv[2] + '/package.json'))"
+      script = "console.log(require.resolve(process.argv[1] + '/package.json'))"
       resolved_path = rsc_resolved_node_package_json_path(package_root, package_name, script, &)
       # package_name has passed PACKAGE_NAME_PATTERN, so this fallback cannot escape node_modules.
       # It covers classic flat node_modules layouts; pnpm virtual-store layouts rely on Node resolution above.

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -111,13 +111,15 @@ module ReactOnRails
 
     def rsc_package_major_version(version)
       version_string = version.to_s
+      normalized_version = rsc_normalized_declared_package_version(version_string)
+      return normalized_version.split(".").first.to_i if normalized_version
+
       # Path-based protocol specs cannot be statically verified; reject them unless Node resolution found v2.
       return 0 if version_string.match?(PATH_PROTOCOL_PACKAGE_SPEC_PATTERN)
       return 0 if version_string.include?("/") && !version_string.start_with?("npm:")
       return 0 if version_string.start_with?("workspace:") && !version_string.match?(/\d/)
 
-      version_without_alias = version_string.sub(%r{\Anpm:(?:@[^/]+/)?[^@]+@}, "")
-      major = version_without_alias.match(/\d+/)&.[](0)
+      major = version_string.match(/\Av?(\d+)\.\d+\.\d+(?:[-+].*)?\z/)&.[](1)
       major.to_i
     end
 
@@ -154,15 +156,20 @@ module ReactOnRails
     end
 
     def rsc_normalized_declared_package_version(package_spec)
-      return nil if package_spec.to_s.match?(PATH_PROTOCOL_PACKAGE_SPEC_PATTERN)
+      spec = package_spec.to_s.strip
+      return nil if spec.match?(PATH_PROTOCOL_PACKAGE_SPEC_PATTERN)
 
-      clean_version = package_spec.to_s.gsub(/\A[^0-9]*/, "")
-      clean_version if clean_version.match?(/\A\d+\.\d+\.\d+\z/)
+      spec = spec.sub(%r{\Anpm:(?:@[^/]+/)?[^@]+@}, "")
+                 .delete_prefix("workspace:")
+      spec.match(/\A(?:[~^]|>=?|=)?\s*v?(\d+\.\d+\.\d+)\z/)&.[](1)
     end
 
     def rsc_rspack_upgrade_packages(package_json_path)
       declared_packages = rsc_declared_rspack_upgrade_packages(package_json_path)
-      declared_packages.empty? ? RSC_RSPACK_V2_PACKAGES : declared_packages
+      return RSC_RSPACK_V2_PACKAGES if declared_packages.empty?
+      return declared_packages if declared_packages.include?(RSC_RSPACK_PACKAGE)
+
+      [RSC_RSPACK_PACKAGE, *declared_packages]
     end
 
     def rsc_declared_rspack_upgrade_packages(package_json_path)

--- a/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
+++ b/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
@@ -19,6 +19,7 @@ module ReactOnRails
   # identically whether included or extended.
   module ShakapackerConfigHelpers
     DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
+    SHAKAPACKER_ASSETS_BUNDLER_ENV = "SHAKAPACKER_ASSETS_BUNDLER"
     SUPPORTED_ASSETS_BUNDLERS = %w[webpack rspack].freeze
 
     private
@@ -82,8 +83,12 @@ module ReactOnRails
       SUPPORTED_ASSETS_BUNDLERS.include?(normalized) ? normalized : nil
     end
 
+    def env_assets_bundler
+      normalize_assets_bundler(ENV.fetch(SHAKAPACKER_ASSETS_BUNDLER_ENV, nil))
+    end
+
     def active_assets_bundler
-      configured_assets_bundler || "webpack"
+      env_assets_bundler || configured_assets_bundler || "webpack"
     end
 
     def assets_bundler_label

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -248,8 +248,8 @@ module ReactOnRails
     end
 
     def validate_rsc_rspack_version!
-      return unless rsc_support_enabled?
       return unless active_assets_bundler == "rspack"
+      return unless rsc_support_enabled?
 
       rspack_version = detected_rspack_version_for_rsc
       return if rspack_version && rsc_package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
@@ -268,8 +268,18 @@ module ReactOnRails
 
       pro_config = ReactOnRailsPro.configuration
       pro_config.respond_to?(:enable_rsc_support) && pro_config.enable_rsc_support
-    rescue StandardError
-      false
+    rescue StandardError => e
+      raise ReactOnRails::Error, <<~MSG.strip
+        **ERROR** ReactOnRails: could not determine whether React Server Components are enabled.
+
+        React on Rails Pro configuration raised while validating RSC/Rspack compatibility:
+          #{e.class}: #{e.message}
+
+        Fix:
+          Ensure ReactOnRailsPro.configuration loads and exposes enable_rsc_support.
+
+        #{ReactOnRails::DOCTOR_RECOMMENDATION}
+      MSG
     end
 
     def package_dependency_spec(package_name)

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -283,7 +283,7 @@ module ReactOnRails
     end
 
     def package_dependency_spec(package_name)
-      rsc_declared_package_spec(node_package_version.package_json, package_name)
+      rsc_declared_package_version(node_package_version.package_json, package_name)
     end
 
     def rsc_rspack_version_error(rspack_version)

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -290,7 +290,8 @@ module ReactOnRails
       rsc_rspack_version_requirement_error(
         rspack_version,
         error_prefix: "**ERROR** ReactOnRails:",
-        include_doctor_recommendation: true
+        include_doctor_recommendation: true,
+        package_json_path: node_package_version.package_json
       )
     end
 

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -3,22 +3,19 @@
 require "json"
 require_relative "version_syntax_converter"
 require_relative "shakapacker_config_helpers"
+require_relative "rsc_rspack_support"
 
 module ReactOnRails
   # Responsible for checking versions of rubygem versus yarn node package
   # against each other at runtime.
   class VersionChecker # rubocop:disable Metrics/ClassLength
     include ShakapackerConfigHelpers
+    include RscRspackSupport
 
     attr_reader :node_package_version
 
     # Semver uses - to separate pre-release, but RubyGems use .
     VERSION_PARTS_REGEX = /(\d+)\.(\d+)\.(\d+)(?:[-.]([0-9A-Za-z.-]+))?/
-    RSC_RSPACK_PACKAGE = "@rspack/core"
-    MINIMUM_RSC_RSPACK_MAJOR = 2
-    RSPACK_V2_INSTALL_COMMAND = "pnpm add -D @rspack/core@^2 @rspack/cli@^2 " \
-                                "@rspack/dev-server@^2 @rspack/plugin-react-refresh@^2"
-
     def self.build
       new(NodePackageVersion.build)
     end
@@ -254,10 +251,15 @@ module ReactOnRails
       return unless rsc_support_enabled?
       return unless active_assets_bundler == "rspack"
 
-      rspack_version = package_dependency_spec(RSC_RSPACK_PACKAGE)
-      return if rspack_version && package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
+      rspack_version = detected_rspack_version_for_rsc
+      return if rspack_version && rsc_package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
 
       raise ReactOnRails::Error, rsc_rspack_version_error(rspack_version)
+    end
+
+    def detected_rspack_version_for_rsc
+      package_root = File.dirname(node_package_version.package_json)
+      rsc_installed_package_version(package_root, RSC_RSPACK_PACKAGE) || package_dependency_spec(RSC_RSPACK_PACKAGE)
     end
 
     def rsc_support_enabled?
@@ -271,36 +273,15 @@ module ReactOnRails
     end
 
     def package_dependency_spec(package_name)
-      package_json = JSON.parse(File.read(node_package_version.package_json))
-      all_deps = (package_json["dependencies"] || {}).merge(package_json["devDependencies"] || {})
-      all_deps[package_name]
-    rescue JSON::ParserError, Errno::ENOENT
-      nil
-    end
-
-    def package_major_version(version)
-      return 0 if version.to_s.include?("/") && !version.to_s.start_with?("npm:")
-
-      major = version.to_s.sub(/\Anpm:[^@]+@/, "").match(/\d+/)&.[](0)
-      major.to_i
+      rsc_declared_package_spec(node_package_version.package_json, package_name)
     end
 
     def rsc_rspack_version_error(rspack_version)
-      detected_version = rspack_version || "not found"
-
-      <<~MSG.strip
-        **ERROR** ReactOnRails: RSC with Rspack requires Rspack v2 or newer.
-
-        Detected #{RSC_RSPACK_PACKAGE}: #{detected_version}
-
-        Rspack v1 is not supported for React Server Components in React on Rails Pro.
-        Upgrade to Rspack v2 so RSC setup fails fast instead of hitting bundler or runtime surprises.
-
-        Fix:
-          #{RSPACK_V2_INSTALL_COMMAND}
-
-        #{ReactOnRails::DOCTOR_RECOMMENDATION}
-      MSG
+      rsc_rspack_version_requirement_error(
+        rspack_version,
+        error_prefix: "**ERROR** ReactOnRails:",
+        include_doctor_recommendation: true
+      )
     end
 
     def gem_version

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -263,11 +263,7 @@ module ReactOnRails
     end
 
     def rsc_support_enabled?
-      return false unless ReactOnRails::Utils.react_on_rails_pro?
-      return false unless defined?(ReactOnRailsPro) && ReactOnRailsPro.respond_to?(:configuration)
-
-      pro_config = ReactOnRailsPro.configuration
-      pro_config.respond_to?(:enable_rsc_support) && pro_config.enable_rsc_support
+      rsc_support_enabled_config_value
     rescue StandardError => e
       raise ReactOnRails::Error, <<~MSG.strip
         **ERROR** ReactOnRails: could not determine whether React Server Components are enabled.

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
+require "json"
 require_relative "version_syntax_converter"
+require_relative "shakapacker_config_helpers"
 
 module ReactOnRails
   # Responsible for checking versions of rubygem versus yarn node package
   # against each other at runtime.
   class VersionChecker # rubocop:disable Metrics/ClassLength
+    include ShakapackerConfigHelpers
+
     attr_reader :node_package_version
 
     # Semver uses - to separate pre-release, but RubyGems use .
     VERSION_PARTS_REGEX = /(\d+)\.(\d+)\.(\d+)(?:[-.]([0-9A-Za-z.-]+))?/
+    RSC_RSPACK_PACKAGE = "@rspack/core"
+    MINIMUM_RSC_RSPACK_MAJOR = 2
+    RSPACK_V2_INSTALL_COMMAND = "pnpm add -D @rspack/core@^2 @rspack/cli@^2 " \
+                                "@rspack/dev-server@^2 @rspack/plugin-react-refresh@^2"
 
     def self.build
       new(NodePackageVersion.build)
@@ -32,6 +40,7 @@ module ReactOnRails
       validate_package_gem_compatibility!
       validate_exact_version!
       validate_version_match!
+      validate_rsc_rspack_version!
     end
 
     private
@@ -236,6 +245,59 @@ module ReactOnRails
           Or run: bundle exec rake react_on_rails:sync_versions WRITE=true
 
         #{package_json_location}
+
+        #{ReactOnRails::DOCTOR_RECOMMENDATION}
+      MSG
+    end
+
+    def validate_rsc_rspack_version!
+      return unless rsc_support_enabled?
+      return unless active_assets_bundler == "rspack"
+
+      rspack_version = package_dependency_spec(RSC_RSPACK_PACKAGE)
+      return if rspack_version && package_major_version(rspack_version) >= MINIMUM_RSC_RSPACK_MAJOR
+
+      raise ReactOnRails::Error, rsc_rspack_version_error(rspack_version)
+    end
+
+    def rsc_support_enabled?
+      return false unless ReactOnRails::Utils.react_on_rails_pro?
+      return false unless defined?(ReactOnRailsPro) && ReactOnRailsPro.respond_to?(:configuration)
+
+      pro_config = ReactOnRailsPro.configuration
+      pro_config.respond_to?(:enable_rsc_support) && pro_config.enable_rsc_support
+    rescue StandardError
+      false
+    end
+
+    def package_dependency_spec(package_name)
+      package_json = JSON.parse(File.read(node_package_version.package_json))
+      all_deps = (package_json["dependencies"] || {}).merge(package_json["devDependencies"] || {})
+      all_deps[package_name]
+    rescue JSON::ParserError, Errno::ENOENT
+      nil
+    end
+
+    def package_major_version(version)
+      return 0 if version.to_s.include?("/") && !version.to_s.start_with?("npm:")
+
+      major = version.to_s.sub(/\Anpm:[^@]+@/, "").match(/\d+/)&.[](0)
+      major.to_i
+    end
+
+    def rsc_rspack_version_error(rspack_version)
+      detected_version = rspack_version || "not found"
+
+      <<~MSG.strip
+        **ERROR** ReactOnRails: RSC with Rspack requires Rspack v2 or newer.
+
+        Detected #{RSC_RSPACK_PACKAGE}: #{detected_version}
+
+        Rspack v1 is not supported for React Server Components in React on Rails Pro.
+        Upgrade to Rspack v2 so RSC setup fails fast instead of hitting bundler or runtime surprises.
+
+        Fix:
+          #{RSPACK_V2_INSTALL_COMMAND}
 
         #{ReactOnRails::DOCTOR_RECOMMENDATION}
       MSG

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5760,6 +5760,33 @@ RSpec.describe ReactOnRails::Doctor do
         end
       end
 
+      it "does not treat optionalDependencies as a declared RSC package" do
+        Dir.mktmpdir do |tmpdir|
+          Dir.chdir(tmpdir) do
+            File.write(
+              "package.json",
+              JSON.generate(
+                "dependencies" => {
+                  "react" => "19.0.7",
+                  "react-dom" => "19.0.7"
+                },
+                "optionalDependencies" => {
+                  "react-on-rails-rsc" => "19.2.0-rc.4"
+                }
+              )
+            )
+            install_react("19.0.7")
+            install_package("react-dom", "version" => "19.0.7")
+            stub_package_root(Dir.pwd)
+
+            doctor.send(:check_rsc_react_version)
+
+            error_msgs = checker.messages.select { |m| m[:type] == :error }.map { |m| m[:content] }
+            expect(error_msgs.none? { |msg| msg.include?("react-on-rails-rsc is declared") }).to be true
+          end
+        end
+      end
+
       it "keeps the React 19.0.4 security floor warning when broad RSC peer ranges allow older React" do
         Dir.mktmpdir do |tmpdir|
           Dir.chdir(tmpdir) do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5322,6 +5322,10 @@ RSpec.describe ReactOnRails::Doctor do
     before do
       allow(Rails).to receive(:root).and_return(Pathname.new(Dir.pwd))
       allow(doctor).to receive(:resolved_package_root).and_return(Dir.pwd)
+      allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
+      pro_config = double("ProConfig", enable_rsc_support: true)
+      stub_const("ReactOnRailsPro", Module.new)
+      ReactOnRailsPro.define_singleton_method(:configuration) { pro_config }
     end
 
     context "when RSC uses Rspack v1" do
@@ -5353,6 +5357,20 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_rsc_rspack_version)
         success_msgs = checker.messages.select { |m| m[:type] == :success }
         expect(success_msgs.any? { |m| m[:content].include?("Rspack 2.0.0 is compatible with RSC") }).to be true
+      end
+    end
+
+    context "when RSC is disabled" do
+      before do
+        pro_config = double("ProConfig", enable_rsc_support: false)
+        ReactOnRailsPro.define_singleton_method(:configuration) { pro_config }
+        write_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0")
+      end
+
+      it "does not report an Rspack error" do
+        doctor.send(:check_rsc_rspack_version)
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+        expect(error_msgs).to be_empty
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5742,6 +5742,29 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when React is declared in dependencies and devDependencies" do
+      around do |example|
+        Dir.mktmpdir do |tmpdir|
+          Dir.chdir(tmpdir) do
+            File.write(
+              "package.json",
+              '{"dependencies":{"react":"18.2.0"},"devDependencies":{"react":"19.0.4"}}'
+            )
+            example.run
+          end
+        end
+      end
+
+      it "preserves devDependencies precedence for declared package fallback" do
+        doctor.send(:check_rsc_react_version)
+        success_msgs = checker.messages.select { |m| m[:type] == :success }
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+
+        expect(success_msgs.any? { |m| m[:content].include?("React 19.0.4") }).to be true
+        expect(error_msgs).to be_empty
+      end
+    end
+
     context "when react-on-rails-rsc declares a React peer range" do
       around do |example|
         Dir.mktmpdir do |tmpdir|

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -341,6 +341,33 @@ RSpec.describe ReactOnRails::Doctor do
     end
   end
 
+  describe "#active_assets_bundler" do
+    around do |example|
+      previous_bundler = ENV.fetch("SHAKAPACKER_ASSETS_BUNDLER", nil)
+      example.run
+    ensure
+      if previous_bundler.nil?
+        ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
+      else
+        ENV["SHAKAPACKER_ASSETS_BUNDLER"] = previous_bundler
+      end
+    end
+
+    it "honors the command-level Shakapacker assets bundler override" do
+      ENV["SHAKAPACKER_ASSETS_BUNDLER"] = "rspack"
+      allow(doctor).to receive(:configured_assets_bundler).and_return("webpack")
+
+      expect(doctor.send(:active_assets_bundler)).to eq("rspack")
+    end
+
+    it "ignores unsupported command-level Shakapacker assets bundler values" do
+      ENV["SHAKAPACKER_ASSETS_BUNDLER"] = "vite"
+      allow(doctor).to receive(:configured_assets_bundler).and_return("webpack")
+
+      expect(doctor.send(:active_assets_bundler)).to eq("webpack")
+    end
+  end
+
   describe "#parsed_shakapacker_config" do
     it "reads and parses config/shakapacker.yml at most once per Doctor instance" do
       # Exercises Doctor's memoizing super override: several checks consult the
@@ -5314,8 +5341,16 @@ RSpec.describe ReactOnRails::Doctor do
     end
 
     around do |example|
+      previous_bundler = ENV.fetch("SHAKAPACKER_ASSETS_BUNDLER", nil)
+      ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(tmpdir) { example.run }
+      end
+    ensure
+      if previous_bundler.nil?
+        ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
+      else
+        ENV["SHAKAPACKER_ASSETS_BUNDLER"] = previous_bundler
       end
     end
 
@@ -5336,6 +5371,19 @@ RSpec.describe ReactOnRails::Doctor do
         error_msgs = checker.messages.select { |m| m[:type] == :error }
         expect(error_msgs.any? { |m| m[:content].include?("Rspack v2 or newer") }).to be true
         expect(error_msgs.any? { |m| m[:content].include?("@rspack/core@^2") }).to be true
+      end
+    end
+
+    context "when Rspack is selected for the command through SHAKAPACKER_ASSETS_BUNDLER" do
+      before do
+        ENV["SHAKAPACKER_ASSETS_BUNDLER"] = "rspack"
+        write_rspack_project(assets_bundler: "webpack", rspack_core_version: "^1.6.0")
+      end
+
+      it "reports an error with Rspack v2 fix instructions" do
+        doctor.send(:check_rsc_rspack_version)
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+        expect(error_msgs.any? { |m| m[:content].include?("Rspack v2 or newer") }).to be true
       end
     end
 
@@ -6038,7 +6086,7 @@ RSpec.describe ReactOnRails::Doctor do
           .with(
             "node",
             "-e",
-            "console.log(require.resolve(process.argv[1] + '/package.json'))",
+            "console.log(require.resolve(process.argv[2] + '/package.json'))",
             "react",
             chdir: package_root
           )
@@ -6132,9 +6180,13 @@ RSpec.describe ReactOnRails::Doctor do
     end
 
     around do |example|
+      previous_bundler = ENV.fetch("SHAKAPACKER_ASSETS_BUNDLER", nil)
+      ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(tmpdir) do
           FileUtils.mkdir_p("config/webpack")
+          FileUtils.mkdir_p("config")
+          File.write("config/shakapacker.yml", "default:\n  assets_bundler: webpack\n")
           File.write("config/routes.rb", "Rails.application.routes.draw do\n  rsc_payload_route\nend")
           File.write("config/webpack/rscWebpackConfig.js", "{}")
           File.write("Procfile.dev", "rsc-bundle: RSC_BUNDLE_ONLY=true bin/shakapacker --watch")
@@ -6157,6 +6209,12 @@ RSpec.describe ReactOnRails::Doctor do
           )
           example.run
         end
+      end
+    ensure
+      if previous_bundler.nil?
+        ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
+      else
+        ENV["SHAKAPACKER_ASSETS_BUNDLER"] = previous_bundler
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5324,7 +5324,7 @@ RSpec.describe ReactOnRails::Doctor do
     let(:doctor) { described_class.new(verbose: false, fix: false) }
     let(:checker) { doctor.instance_variable_get(:@checker) }
 
-    def write_rspack_project(assets_bundler:, rspack_core_version:)
+    def write_rspack_project(assets_bundler:, rspack_core_version:, dependency_field: "devDependencies")
       FileUtils.mkdir_p("config")
       File.write("config/shakapacker.yml", <<~YAML)
         default:
@@ -5333,10 +5333,14 @@ RSpec.describe ReactOnRails::Doctor do
 
       dependencies = { "react" => "19.0.4" }
       dev_dependencies = {}
-      dev_dependencies["@rspack/core"] = rspack_core_version if rspack_core_version
+      package_json = { "dependencies" => dependencies, "devDependencies" => dev_dependencies }
+      if rspack_core_version
+        package_json[dependency_field] ||= {}
+        package_json[dependency_field]["@rspack/core"] = rspack_core_version
+      end
       File.write(
         "package.json",
-        JSON.generate("dependencies" => dependencies, "devDependencies" => dev_dependencies)
+        JSON.generate(package_json)
       )
     end
 
@@ -5400,6 +5404,22 @@ RSpec.describe ReactOnRails::Doctor do
 
     context "when RSC uses Rspack v2" do
       before { write_rspack_project(assets_bundler: "rspack", rspack_core_version: "^2.0.0") }
+
+      it "reports success" do
+        doctor.send(:check_rsc_rspack_version)
+        success_msgs = checker.messages.select { |m| m[:type] == :success }
+        expect(success_msgs.any? { |m| m[:content].include?("Rspack 2.0.0 is compatible with RSC") }).to be true
+      end
+    end
+
+    context "when RSC uses Rspack v2 from optional dependencies" do
+      before do
+        write_rspack_project(
+          assets_bundler: "rspack",
+          rspack_core_version: "^2.0.0",
+          dependency_field: "optionalDependencies"
+        )
+      end
 
       it "reports success" do
         doctor.send(:check_rsc_rspack_version)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5274,6 +5274,80 @@ RSpec.describe ReactOnRails::Doctor do
     end
   end
 
+  describe "check_rsc_rspack_version" do
+    let(:doctor) { described_class.new(verbose: false, fix: false) }
+    let(:checker) { doctor.instance_variable_get(:@checker) }
+
+    def write_rspack_project(assets_bundler:, rspack_core_version:)
+      FileUtils.mkdir_p("config")
+      File.write("config/shakapacker.yml", <<~YAML)
+        default:
+          assets_bundler: #{assets_bundler}
+      YAML
+
+      dependencies = { "react" => "19.0.4" }
+      dev_dependencies = {}
+      dev_dependencies["@rspack/core"] = rspack_core_version if rspack_core_version
+      File.write(
+        "package.json",
+        JSON.generate("dependencies" => dependencies, "devDependencies" => dev_dependencies)
+      )
+    end
+
+    around do |example|
+      Dir.mktmpdir do |tmpdir|
+        Dir.chdir(tmpdir) { example.run }
+      end
+    end
+
+    before do
+      allow(Rails).to receive(:root).and_return(Pathname.new(Dir.pwd))
+      allow(doctor).to receive(:resolved_package_root).and_return(Dir.pwd)
+    end
+
+    context "when RSC uses Rspack v1" do
+      before { write_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0") }
+
+      it "reports an error with Rspack v2 fix instructions" do
+        doctor.send(:check_rsc_rspack_version)
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+        expect(error_msgs.any? { |m| m[:content].include?("Rspack v2 or newer") }).to be true
+        expect(error_msgs.any? { |m| m[:content].include?("@rspack/core@^2") }).to be true
+      end
+    end
+
+    context "when RSC uses Rspack but @rspack/core is missing" do
+      before { write_rspack_project(assets_bundler: "rspack", rspack_core_version: nil) }
+
+      it "reports an error with Rspack v2 fix instructions" do
+        doctor.send(:check_rsc_rspack_version)
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+        expect(error_msgs.any? { |m| m[:content].include?("Detected @rspack/core: not found") }).to be true
+        expect(error_msgs.any? { |m| m[:content].include?("@rspack/core@^2") }).to be true
+      end
+    end
+
+    context "when RSC uses Rspack v2" do
+      before { write_rspack_project(assets_bundler: "rspack", rspack_core_version: "^2.0.0") }
+
+      it "reports success" do
+        doctor.send(:check_rsc_rspack_version)
+        success_msgs = checker.messages.select { |m| m[:type] == :success }
+        expect(success_msgs.any? { |m| m[:content].include?("Rspack 2.0.0 is compatible with RSC") }).to be true
+      end
+    end
+
+    context "when the app uses webpack" do
+      before { write_rspack_project(assets_bundler: "webpack", rspack_core_version: "^1.6.0") }
+
+      it "does not report an Rspack error" do
+        doctor.send(:check_rsc_rspack_version)
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+        expect(error_msgs).to be_empty
+      end
+    end
+  end
+
   describe "check_rsc_rspack_lazy_compilation" do
     let(:doctor) { described_class.new(verbose: false, fix: false) }
     let(:checker) { doctor.instance_variable_get(:@checker) }

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5050,6 +5050,25 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_rsc_setup)
         expect(checker.messages.length).to eq(initial_count)
       end
+
+      it "does not reject Rspack v1 when RSC is disabled" do
+        initial_count = checker.messages.length
+
+        Dir.mktmpdir do |tmpdir|
+          Dir.chdir(tmpdir) do
+            FileUtils.mkdir_p("config")
+            File.write("config/shakapacker.yml", "default:\n  assets_bundler: rspack\n")
+            File.write(
+              "package.json",
+              JSON.generate("dependencies" => {}, "devDependencies" => { "@rspack/core" => "^1.6.0" })
+            )
+
+            doctor.send(:check_rsc_setup)
+          end
+        end
+
+        expect(checker.messages.length).to eq(initial_count)
+      end
     end
 
     context "when RSC is enabled with valid setup" do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6106,7 +6106,7 @@ RSpec.describe ReactOnRails::Doctor do
           .with(
             "node",
             "-e",
-            "console.log(require.resolve(process.argv[2] + '/package.json'))",
+            "console.log(require.resolve(process.argv[1] + '/package.json'))",
             "react",
             chdir: package_root
           )

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -512,6 +512,17 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           end.to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: file:\.\./rspack-2\.0\.0})
         end
 
+        it "rejects workspace protocol specs even when they contain a v2-looking version" do
+          stub_failed_node_package_resolution
+
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "workspace:^2.0.0"
+            )
+          end.to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: workspace:\^2\.0\.0})
+        end
+
         it "does not treat peer dependencies as installed Rspack" do
           expect do
             validate_rsc_rspack_project(

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -503,6 +503,17 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           end.not_to raise_error
         end
 
+        it "allows generated Rspack v2 prerelease lower-bound specs" do
+          stub_failed_node_package_resolution
+
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^2.0.0-0"
+            )
+          end.not_to raise_error
+        end
+
         it "rejects path protocol specs even when the path contains a v2-looking version" do
           expect do
             validate_rsc_rspack_project(

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -243,6 +243,7 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           assets_bundler:,
           rspack_core_version:,
           dependency_field: "devDependencies",
+          rspack_package_versions: {},
           installed_rspack_core_version: nil,
           package_manager: nil
         )
@@ -260,6 +261,10 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           if rspack_core_version
             package_json[dependency_field] ||= {}
             package_json[dependency_field]["@rspack/core"] = rspack_core_version
+          end
+          rspack_package_versions.each do |package_name, package_version|
+            package_json[dependency_field] ||= {}
+            package_json[dependency_field][package_name] = package_version
           end
           File.write(
             File.join(root, "package.json"),
@@ -297,6 +302,7 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           rspack_core_version:,
           rsc_enabled: true,
           dependency_field: "devDependencies",
+          rspack_package_versions: {},
           installed_rspack_core_version: nil,
           package_manager: nil,
           configuration_error: nil,
@@ -316,6 +322,7 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
               assets_bundler:,
               rspack_core_version:,
               dependency_field:,
+              rspack_package_versions:,
               installed_rspack_core_version:,
               package_manager:
             )
@@ -337,6 +344,11 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           end
         end
 
+        def stub_failed_node_package_resolution
+          status = instance_double(Process::Status, success?: false)
+          allow(Open3).to receive(:capture3).and_return(["", "Cannot find module", status])
+        end
+
         it "raises before boot when active Rspack is v1" do
           expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0") }
             .to raise_error(ReactOnRails::Error, /RSC with Rspack requires Rspack v2 or newer/)
@@ -345,6 +357,13 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
         it "normalizes simple declared ranges in Rspack v2 errors" do
           expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0") }
             .to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: 1\.6\.0})
+        end
+
+        it "rejects upper-bound declared Rspack ranges" do
+          stub_failed_node_package_resolution
+
+          expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "<2.0.0") }
+            .to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: <2\.0\.0})
         end
 
         it "uses the detected package manager in Rspack v2 fix instructions" do
@@ -368,6 +387,25 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             aggregate_failures do
               expect(error.message).to include("npm install --save-dev @rspack/core@^2")
               expect(error.message).not_to include("@rspack/cli")
+            end
+          }
+        end
+
+        it "includes missing @rspack/core in fix instructions when only a companion package is declared" do
+          stub_failed_node_package_resolution
+
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: nil,
+              rspack_package_versions: { "@rspack/cli" => "^1.6.0" },
+              package_manager: "npm@10.0.0"
+            )
+          end.to raise_error(ReactOnRails::Error) { |error|
+            aggregate_failures do
+              expect(error.message)
+                .to include("npm install --save-dev @rspack/core@^2 @rspack/cli@^2")
+              expect(error.message).not_to include("@rspack/dev-server")
             end
           }
         end

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -299,7 +299,8 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           dependency_field: "devDependencies",
           installed_rspack_core_version: nil,
           package_manager: nil,
-          configuration_error: nil
+          configuration_error: nil,
+          package_json_read_error_after_version_cache: false
         )
           Dir.mktmpdir do |root|
             write_rsc_rspack_project_files(
@@ -313,6 +314,11 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             stub_rsc_rspack_project(root, rsc_enabled:, configuration_error:)
             package_json = File.join(root, "package.json")
             node_package_version = VersionChecker::NodePackageVersion.new(package_json)
+            if package_json_read_error_after_version_cache
+              node_package_version.raw
+              allow(File).to receive(:read).and_call_original
+              allow(File).to receive(:read).with(package_json).and_raise(Errno::EACCES)
+            end
             VersionChecker.new(node_package_version).validate_version_and_package_compatibility!
           end
         end
@@ -347,6 +353,16 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
         it "raises before boot when active Rspack is missing @rspack/core" do
           expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: nil) }
             .to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: not found})
+        end
+
+        it "fails clearly when package.json cannot be reread for the RSC Rspack version" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^1.6.0",
+              package_json_read_error_after_version_cache: true
+            )
+          end.to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: not found})
         end
 
         it "allows active Rspack v2" do

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -300,8 +300,16 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           installed_rspack_core_version: nil,
           package_manager: nil,
           configuration_error: nil,
+          env_assets_bundler: nil,
           package_json_read_error_after_version_cache: false
         )
+          previous_bundler = ENV.fetch("SHAKAPACKER_ASSETS_BUNDLER", nil)
+          if env_assets_bundler.nil?
+            ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
+          else
+            ENV["SHAKAPACKER_ASSETS_BUNDLER"] = env_assets_bundler
+          end
+
           Dir.mktmpdir do |root|
             write_rsc_rspack_project_files(
               root,
@@ -320,6 +328,12 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
               allow(File).to receive(:read).with(package_json).and_raise(Errno::EACCES)
             end
             VersionChecker.new(node_package_version).validate_version_and_package_compatibility!
+          end
+        ensure
+          if previous_bundler.nil?
+            ENV.delete("SHAKAPACKER_ASSETS_BUNDLER")
+          else
+            ENV["SHAKAPACKER_ASSETS_BUNDLER"] = previous_bundler
           end
         end
 
@@ -341,6 +355,21 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
               package_manager: "npm@10.0.0"
             )
           end.to raise_error(ReactOnRails::Error, %r{npm install --save-dev @rspack/core@\^2})
+        end
+
+        it "does not add undeclared Rspack companion packages to fix instructions" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^1.6.0",
+              package_manager: "npm@10.0.0"
+            )
+          end.to raise_error(ReactOnRails::Error) { |error|
+            aggregate_failures do
+              expect(error.message).to include("npm install --save-dev @rspack/core@^2")
+              expect(error.message).not_to include("@rspack/cli")
+            end
+          }
         end
 
         it "falls back to yarn instructions when package manager detection fails" do
@@ -399,6 +428,15 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           end.not_to raise_error
         end
 
+        it "rejects path protocol specs even when the path contains a v2-looking version" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "file:../rspack-2.0.0"
+            )
+          end.to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: file:\.\./rspack-2\.0\.0})
+        end
+
         it "does not treat peer dependencies as installed Rspack" do
           expect do
             validate_rsc_rspack_project(
@@ -419,6 +457,16 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
         it "allows Rspack v1 when webpack is active" do
           expect { validate_rsc_rspack_project(assets_bundler: "webpack", rspack_core_version: "^1.6.0") }
             .not_to raise_error
+        end
+
+        it "raises when Rspack is selected through SHAKAPACKER_ASSETS_BUNDLER" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "webpack",
+              rspack_core_version: "^1.6.0",
+              env_assets_bundler: "rspack"
+            )
+          end.to raise_error(ReactOnRails::Error, /RSC with Rspack requires Rspack v2 or newer/)
         end
 
         it "does not read RSC support when webpack is active" do

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -232,6 +232,77 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
         end
       end
 
+      context "when React Server Components are enabled with Rspack" do
+        def write_rsc_rspack_project(root, assets_bundler:, rspack_core_version:, rsc_enabled:)
+          write_rsc_rspack_project_files(root, assets_bundler:, rspack_core_version:)
+          stub_rsc_rspack_project(root, rsc_enabled:)
+        end
+
+        def write_rsc_rspack_project_files(root, assets_bundler:, rspack_core_version:)
+          FileUtils.mkdir_p(File.join(root, "config"))
+          File.write(File.join(root, "config/shakapacker.yml"), <<~YAML)
+            default:
+              assets_bundler: #{assets_bundler}
+          YAML
+
+          dependencies = { "react-on-rails-pro" => "17.0.0" }
+          dev_dependencies = {}
+          dev_dependencies["@rspack/core"] = rspack_core_version if rspack_core_version
+          File.write(
+            File.join(root, "package.json"),
+            JSON.generate("dependencies" => dependencies, "devDependencies" => dev_dependencies)
+          )
+        end
+
+        def stub_rsc_rspack_project(root, rsc_enabled:)
+          allow(Rails).to receive(:root).and_return(Pathname.new(root))
+          allow(ReactOnRails).to receive_message_chain(:configuration, :node_modules_location).and_return("")
+          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
+          stub_gem_version("17.0.0")
+
+          stub_const("ReactOnRailsPro", Module.new)
+          stub_const("ReactOnRailsPro::Configuration", Class.new)
+          pro_config = instance_double(ReactOnRailsPro::Configuration, enable_rsc_support: rsc_enabled)
+          ReactOnRailsPro.define_singleton_method(:configuration) { pro_config }
+        end
+
+        def validate_rsc_rspack_project(assets_bundler:, rspack_core_version:, rsc_enabled: true)
+          Dir.mktmpdir do |root|
+            write_rsc_rspack_project(root, assets_bundler:, rspack_core_version:, rsc_enabled:)
+            package_json = File.join(root, "package.json")
+            node_package_version = VersionChecker::NodePackageVersion.new(package_json)
+            VersionChecker.new(node_package_version).validate_version_and_package_compatibility!
+          end
+        end
+
+        it "raises before boot when active Rspack is v1" do
+          expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0") }
+            .to raise_error(ReactOnRails::Error, /RSC with Rspack requires Rspack v2 or newer/)
+        end
+
+        it "raises before boot when active Rspack is missing @rspack/core" do
+          expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: nil) }
+            .to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: not found})
+        end
+
+        it "allows active Rspack v2" do
+          expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^2.0.0") }
+            .not_to raise_error
+        end
+
+        it "allows Rspack v1 when RSC is disabled" do
+          expect do
+            validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0",
+                                        rsc_enabled: false)
+          end.not_to raise_error
+        end
+
+        it "allows Rspack v1 when webpack is active" do
+          expect { validate_rsc_rspack_project(assets_bundler: "webpack", rspack_core_version: "^1.6.0") }
+            .not_to raise_error
+        end
+      end
+
       context "when package.json file does not exist" do
         let(:node_package_version) do
           instance_double(VersionChecker::NodePackageVersion,

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -366,6 +366,21 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             .to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: <2\.0\.0})
         end
 
+        it "explains that unsupported npm ranges fail closed unless the installed package resolves to v2" do
+          stub_failed_node_package_resolution
+
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: ">=2.0.0 <3.0.0"
+            )
+          end.to raise_error(ReactOnRails::Error) { |error|
+            expect(error.message).to include(
+              "React on Rails cannot statically verify, install dependencies so Node can resolve"
+            )
+          }
+        end
+
         it "uses the detected package manager in Rspack v2 fix instructions" do
           expect do
             validate_rsc_rspack_project(

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -362,6 +362,25 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           end.not_to raise_error
         end
 
+        it "allows @rspack/core v2 from a scoped npm alias" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "npm:@rspack/core@^2.0.0"
+            )
+          end.not_to raise_error
+        end
+
+        it "does not treat peer dependencies as installed Rspack" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^2.0.0",
+              dependency_field: "peerDependencies"
+            )
+          end.to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: not found})
+        end
+
         it "allows Rspack v1 when RSC is disabled" do
           expect do
             validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0",

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -409,6 +409,43 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           end.not_to raise_error
         end
 
+        it "allows Node-resolved Rspack v2 when the flat node_modules fallback is absent" do
+          Dir.mktmpdir do |root|
+            write_rsc_rspack_project_files(root, assets_bundler: "rspack", rspack_core_version: nil)
+            resolved_package_json = File.join(root, "resolved-packages/@rspack/core/package.json")
+            FileUtils.mkdir_p(File.dirname(resolved_package_json))
+            File.write(
+              resolved_package_json,
+              JSON.generate("name" => "@rspack/core", "version" => "2.1.0")
+            )
+            stub_rsc_rspack_project(root, rsc_enabled: true)
+            node_package_version = VersionChecker::NodePackageVersion.new(File.join(root, "package.json"))
+            status = instance_double(Process::Status, success?: true)
+            allow(Open3).to receive(:capture3)
+              .and_return(["#{resolved_package_json}\n", "", status])
+
+            expect { described_class.new(node_package_version).validate_version_and_package_compatibility! }
+              .not_to raise_error
+            expect(Open3).to have_received(:capture3).with(
+              "node",
+              "-e",
+              "console.log(require.resolve(process.argv[1] + '/package.json'))",
+              "@rspack/core",
+              chdir: root
+            )
+          end
+        end
+
+        it "raises when installed Rspack is v1 even if package.json declares v2" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^2.0.0",
+              installed_rspack_core_version: "1.6.0"
+            )
+          end.to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: 1\.6\.0})
+        end
+
         it "allows @rspack/core v2 from optional dependencies" do
           expect do
             validate_rsc_rspack_project(

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -275,7 +275,7 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           )
         end
 
-        def stub_rsc_rspack_project(root, rsc_enabled:)
+        def stub_rsc_rspack_project(root, rsc_enabled:, configuration_error: nil)
           allow(Rails).to receive(:root).and_return(Pathname.new(root))
           allow(ReactOnRails).to receive_message_chain(:configuration, :node_modules_location).and_return("")
           allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
@@ -283,6 +283,11 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
 
           stub_const("ReactOnRailsPro", Module.new)
           stub_const("ReactOnRailsPro::Configuration", Class.new)
+          if configuration_error
+            ReactOnRailsPro.define_singleton_method(:configuration) { raise configuration_error }
+            return
+          end
+
           pro_config = instance_double(ReactOnRailsPro::Configuration, enable_rsc_support: rsc_enabled)
           ReactOnRailsPro.define_singleton_method(:configuration) { pro_config }
         end
@@ -293,7 +298,8 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           rsc_enabled: true,
           dependency_field: "devDependencies",
           installed_rspack_core_version: nil,
-          package_manager: nil
+          package_manager: nil,
+          configuration_error: nil
         )
           Dir.mktmpdir do |root|
             write_rsc_rspack_project_files(
@@ -304,7 +310,7 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
               installed_rspack_core_version:,
               package_manager:
             )
-            stub_rsc_rspack_project(root, rsc_enabled:)
+            stub_rsc_rspack_project(root, rsc_enabled:, configuration_error:)
             package_json = File.join(root, "package.json")
             node_package_version = VersionChecker::NodePackageVersion.new(package_json)
             VersionChecker.new(node_package_version).validate_version_and_package_compatibility!
@@ -366,6 +372,29 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
         it "allows Rspack v1 when webpack is active" do
           expect { validate_rsc_rspack_project(assets_bundler: "webpack", rspack_core_version: "^1.6.0") }
             .not_to raise_error
+        end
+
+        it "does not read RSC support when webpack is active" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "webpack",
+              rspack_core_version: "^1.6.0",
+              configuration_error: RuntimeError.new("Pro config unavailable")
+            )
+          end.not_to raise_error
+        end
+
+        it "fails clearly when active Rspack cannot read Pro RSC configuration" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^1.6.0",
+              configuration_error: RuntimeError.new("Pro config unavailable")
+            )
+          end.to raise_error(
+            ReactOnRails::Error,
+            /could not determine whether React Server Components are enabled/
+          )
         end
       end
 

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -238,19 +238,40 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           stub_rsc_rspack_project(root, rsc_enabled:)
         end
 
-        def write_rsc_rspack_project_files(root, assets_bundler:, rspack_core_version:)
+        def write_rsc_rspack_project_files(
+          root,
+          assets_bundler:,
+          rspack_core_version:,
+          dependency_field: "devDependencies",
+          installed_rspack_core_version: nil,
+          package_manager: nil
+        )
           FileUtils.mkdir_p(File.join(root, "config"))
           File.write(File.join(root, "config/shakapacker.yml"), <<~YAML)
             default:
               assets_bundler: #{assets_bundler}
           YAML
 
-          dependencies = { "react-on-rails-pro" => "17.0.0" }
-          dev_dependencies = {}
-          dev_dependencies["@rspack/core"] = rspack_core_version if rspack_core_version
+          package_json = {
+            "dependencies" => { "react-on-rails-pro" => "17.0.0" },
+            "devDependencies" => {}
+          }
+          package_json["packageManager"] = package_manager if package_manager
+          if rspack_core_version
+            package_json[dependency_field] ||= {}
+            package_json[dependency_field]["@rspack/core"] = rspack_core_version
+          end
           File.write(
             File.join(root, "package.json"),
-            JSON.generate("dependencies" => dependencies, "devDependencies" => dev_dependencies)
+            JSON.generate(package_json)
+          )
+
+          return unless installed_rspack_core_version
+
+          FileUtils.mkdir_p(File.join(root, "node_modules/@rspack/core"))
+          File.write(
+            File.join(root, "node_modules/@rspack/core/package.json"),
+            JSON.generate("name" => "@rspack/core", "version" => installed_rspack_core_version)
           )
         end
 
@@ -266,9 +287,24 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           ReactOnRailsPro.define_singleton_method(:configuration) { pro_config }
         end
 
-        def validate_rsc_rspack_project(assets_bundler:, rspack_core_version:, rsc_enabled: true)
+        def validate_rsc_rspack_project(
+          assets_bundler:,
+          rspack_core_version:,
+          rsc_enabled: true,
+          dependency_field: "devDependencies",
+          installed_rspack_core_version: nil,
+          package_manager: nil
+        )
           Dir.mktmpdir do |root|
-            write_rsc_rspack_project(root, assets_bundler:, rspack_core_version:, rsc_enabled:)
+            write_rsc_rspack_project_files(
+              root,
+              assets_bundler:,
+              rspack_core_version:,
+              dependency_field:,
+              installed_rspack_core_version:,
+              package_manager:
+            )
+            stub_rsc_rspack_project(root, rsc_enabled:)
             package_json = File.join(root, "package.json")
             node_package_version = VersionChecker::NodePackageVersion.new(package_json)
             VersionChecker.new(node_package_version).validate_version_and_package_compatibility!
@@ -280,6 +316,16 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             .to raise_error(ReactOnRails::Error, /RSC with Rspack requires Rspack v2 or newer/)
         end
 
+        it "uses the detected package manager in Rspack v2 fix instructions" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^1.6.0",
+              package_manager: "npm@10.0.0"
+            )
+          end.to raise_error(ReactOnRails::Error, %r{npm install --save-dev @rspack/core@\^2})
+        end
+
         it "raises before boot when active Rspack is missing @rspack/core" do
           expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: nil) }
             .to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: not found})
@@ -288,6 +334,26 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
         it "allows active Rspack v2" do
           expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^2.0.0") }
             .not_to raise_error
+        end
+
+        it "allows installed Rspack v2 when package.json does not declare @rspack/core" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: nil,
+              installed_rspack_core_version: "2.1.0"
+            )
+          end.not_to raise_error
+        end
+
+        it "allows @rspack/core v2 from optional dependencies" do
+          expect do
+            validate_rsc_rspack_project(
+              assets_bundler: "rspack",
+              rspack_core_version: "^2.0.0",
+              dependency_field: "optionalDependencies"
+            )
+          end.not_to raise_error
         end
 
         it "allows Rspack v1 when RSC is disabled" do

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -322,6 +322,11 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             .to raise_error(ReactOnRails::Error, /RSC with Rspack requires Rspack v2 or newer/)
         end
 
+        it "normalizes simple declared ranges in Rspack v2 errors" do
+          expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0") }
+            .to raise_error(ReactOnRails::Error, %r{Detected @rspack/core: 1\.6\.0})
+        end
+
         it "uses the detected package manager in Rspack v2 fix instructions" do
           expect do
             validate_rsc_rspack_project(
@@ -330,6 +335,13 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
               package_manager: "npm@10.0.0"
             )
           end.to raise_error(ReactOnRails::Error, %r{npm install --save-dev @rspack/core@\^2})
+        end
+
+        it "falls back to yarn instructions when package manager detection fails" do
+          allow(ReactOnRails::Utils).to receive(:detect_package_manager).and_raise(RuntimeError, "unavailable")
+
+          expect { validate_rsc_rspack_project(assets_bundler: "rspack", rspack_core_version: "^1.6.0") }
+            .to raise_error(ReactOnRails::Error, %r{yarn add --dev @rspack/core@\^2})
         end
 
         it "raises before boot when active Rspack is missing @rspack/core" do


### PR DESCRIPTION
## Summary
- Add a doctor check that fails Pro RSC setups using the active Rspack bundler when @rspack/core is missing or still on v1.
- Add startup validation through ReactOnRails::VersionChecker so apps with RSC enabled do not boot on Rspack v1.
- Share RSC/Rspack package lookup, version parsing, and package-manager-aware upgrade guidance between doctor and startup validation.
- Add RSpec coverage for doctor/startup validation and a changelog entry.

## Confirmed Scope
Rspack v1 remains allowed in React on Rails v17 when RSC is not enabled. The new hard error is limited to Pro RSC setups where enable_rsc_support is true and the active Shakapacker bundler is Rspack.

## Why
RSC should be an easy, low-gotcha adoption path. Since Rspack v1 is not a good target for React Server Components, this makes the v2 requirement explicit and fail-fast only for RSC users.

## Validation
- BUNDLE_GEMFILE=react_on_rails/Gemfile bundle exec rspec react_on_rails/spec/lib/react_on_rails/doctor_spec.rb react_on_rails/spec/react_on_rails/version_checker_spec.rb - 450 examples, 0 failures
- bundle exec rubocop react_on_rails/lib/react_on_rails/doctor.rb react_on_rails/lib/react_on_rails/version_checker.rb react_on_rails/lib/react_on_rails/rsc_rspack_support.rb react_on_rails/spec/lib/react_on_rails/doctor_spec.rb react_on_rails/spec/react_on_rails/version_checker_spec.rb - no offenses
- pnpm exec prettier --check CHANGELOG.md - clean
- git diff --check -- CHANGELOG.md react_on_rails/lib/react_on_rails/doctor.rb react_on_rails/lib/react_on_rails/version_checker.rb react_on_rails/lib/react_on_rails/rsc_rspack_support.rb react_on_rails/spec/lib/react_on_rails/doctor_spec.rb react_on_rails/spec/react_on_rails/version_checker_spec.rb - clean
- bundle exec lefthook run pre-push --command branch-lint - passed
- .agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4289 - SECURITY_PREFLIGHT_OK



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fail-fast validation for React Server Components when the Rspack bundler is active and Pro RSC support is enabled: startup and diagnostics now stop early if `@rspack/core` is missing or is Rspack v1, with explicit upgrade guidance to Rspack v2+.

* **Tests**
  * Added regression coverage for the RSC/Rspack compatibility checks, including missing dependencies, v1 vs v2 behavior, and ensuring no Rspack/RSC validation runs when it shouldn’t.

* **Documentation**
  * Updated the changelog with a new Pro entry describing the fail-fast behavior and the Rspack v2+ upgrade instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





