### PR TITLE
[codex] Add Vegeta load-generator sharding

### DIFF
--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -1,8 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Benchmark script for React on Rails Pro Node Renderer
-# Uses Vegeta with HTTP/2 Cleartext (h2c) support
+# Benchmark script for React on Rails Pro Node Renderer.
+#
+# Uses Vegeta with HTTP/2 Cleartext (h2c) support. Set
+# LOAD_GENERATOR_SHARDS=N to split each test across N Vegeta attack processes;
+# the script concatenates the binary result streams and runs one merged Vegeta
+# report so percentiles are recomputed over the combined sample distribution.
 
 require "English"
 require "open3"
@@ -36,6 +40,7 @@ end
 PASSWORD = read_password_from_config
 BASE_URL = env_or_default("BASE_URL", "localhost:3800")
 PROTOCOL_VERSION = read_protocol_version
+LOAD_GENERATOR_SHARDS = env_or_default("LOAD_GENERATOR_SHARDS", 1).to_i
 
 # Test cases: JavaScript expressions to evaluate
 # Format: { name: "test_name", request: "javascript_code", rsc: true/false }
@@ -152,12 +157,96 @@ def render_body(rendering_request)
   ].join("&")
 end
 
-# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+def validate_node_renderer_benchmark_config!
+  validate_benchmark_config!
+  validate_positive_integer(LOAD_GENERATOR_SHARDS, "LOAD_GENERATOR_SHARDS")
+
+  return if LOAD_GENERATOR_SHARDS == 1
+  return if LOAD_GENERATOR_SHARDS <= CONNECTIONS && LOAD_GENERATOR_SHARDS <= MAX_CONNECTIONS
+
+  raise "LOAD_GENERATOR_SHARDS must be no greater than CONNECTIONS and MAX_CONNECTIONS " \
+        "(got shards=#{LOAD_GENERATOR_SHARDS}, connections=#{CONNECTIONS}, max_connections=#{MAX_CONNECTIONS})"
+end
+
+def distribute_integer(total, shard_count)
+  base, remainder = total.divmod(shard_count)
+  Array.new(shard_count) { |index| base + (index < remainder ? 1 : 0) }
+end
+
+def format_vegeta_rate(rate)
+  formatted = format("%.6f", rate)
+  formatted.sub(/\.?0+\z/, "")
+end
+
+def vegeta_rates_for_shards(shard_count)
+  return Array.new(shard_count, "0") if RATE == "max"
+
+  Array.new(shard_count, format_vegeta_rate(RATE.to_f / shard_count))
+end
+
+def vegeta_result_file(name, shard_number, shard_count)
+  return "#{OUTDIR}/#{name}_vegeta.bin" if shard_count == 1
+
+  "#{OUTDIR}/#{name}_vegeta_shard_#{shard_number}_of_#{shard_count}.bin"
+end
+
+def run_vegeta_attack_shards(name, targets_file, shard_count)
+  worker_counts = distribute_integer(CONNECTIONS, shard_count)
+  max_worker_counts = distribute_integer(MAX_CONNECTIONS, shard_count)
+  rates = vegeta_rates_for_shards(shard_count)
+
+  Array.new(shard_count) do |index|
+    shard_number = index + 1
+    result_file = vegeta_result_file(name, shard_number, shard_count)
+    vegeta_args = [
+      "-rate=#{rates.fetch(index)}",
+      "-workers=#{worker_counts.fetch(index)}",
+      "-max-workers=#{max_worker_counts.fetch(index)}"
+    ]
+
+    puts "  Shard #{shard_number}/#{shard_count}: #{vegeta_args.join(' ')}" if shard_count > 1
+
+    vegeta_cmd = [
+      "vegeta", "attack",
+      "-targets=#{Shellwords.escape(targets_file)}",
+      *vegeta_args,
+      "-duration=#{DURATION}",
+      "-timeout=#{REQUEST_TIMEOUT}",
+      "-h2c", # HTTP/2 Cleartext (required for node renderer)
+      "-max-body=0",
+      "> #{Shellwords.escape(result_file)}"
+    ].join(" ")
+
+    raise "Vegeta attack failed for #{name} shard #{shard_number}/#{shard_count}" unless system(vegeta_cmd)
+
+    result_file
+  end
+end
+
+def run_vegeta_reports(result_files, vegeta_txt, vegeta_json)
+  escaped_results = result_files.map { |path| Shellwords.escape(path) }.join(" ")
+
+  # Vegeta's binary result stream is concatenable, so feeding all shard files to
+  # one report recomputes percentiles over the merged sample distribution.
+  unless system("bash", "-c",
+                "set -o pipefail; cat #{escaped_results} | vegeta report | " \
+                "tee #{Shellwords.escape(vegeta_txt)}")
+    raise "Vegeta text report failed"
+  end
+
+  unless system("bash", "-c",
+                "set -o pipefail; cat #{escaped_results} | vegeta report -type=json > " \
+                "#{Shellwords.escape(vegeta_json)}")
+    raise "Vegeta JSON report failed"
+  end
+end
+
+# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
 # Run Vegeta benchmark for a single test case. Returns [rps, p50, p90, status]
 # on success and RAISES on any Vegeta/parse failure so the suite can record the
 # failure and exit non-zero instead of shipping fabricated metrics to Bencher.
-def run_vegeta_benchmark(test_case, bundle_timestamp)
+def run_vegeta_benchmark(test_case, bundle_timestamp, shard_count: LOAD_GENERATOR_SHARDS)
   name = test_case[:name]
   request = test_case[:request]
 
@@ -169,7 +258,6 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
   # Create temp files for Vegeta
   targets_file = "#{OUTDIR}/#{name}_vegeta_targets.txt"
   body_file = "#{OUTDIR}/#{name}_vegeta_body.txt"
-  vegeta_bin = "#{OUTDIR}/#{name}_vegeta.bin"
   vegeta_json = "#{OUTDIR}/#{name}_vegeta.json"
   vegeta_txt = "#{OUTDIR}/#{name}_vegeta.txt"
 
@@ -183,48 +271,11 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
     @#{body_file}
   TARGETS
 
-  # Configure Vegeta arguments for max rate
-  is_max_rate = RATE == "max"
-  vegeta_args =
-    if is_max_rate
-      ["-rate=0", "-workers=#{CONNECTIONS}", "-max-workers=#{CONNECTIONS}"]
-    else
-      ["-rate=#{RATE}", "-workers=#{CONNECTIONS}", "-max-workers=#{MAX_CONNECTIONS}"]
-    end
-
-  # Run Vegeta attack with h2c
-  # All paths are Shellwords.escape'd for parity with the k6 command in bench.rb,
-  # so an OUTDIR (or test name) containing spaces/special chars can't break the
-  # shell command.
-  vegeta_cmd = [
-    "vegeta", "attack",
-    "-targets=#{Shellwords.escape(targets_file)}",
-    *vegeta_args,
-    "-duration=#{DURATION}",
-    "-timeout=#{REQUEST_TIMEOUT}",
-    "-h2c", # HTTP/2 Cleartext (required for node renderer)
-    "-max-body=0",
-    "> #{Shellwords.escape(vegeta_bin)}"
-  ].join(" ")
-
-  raise "Vegeta attack failed for #{name}" unless system(vegeta_cmd)
-
-  # Generate text report (display and save). Run through bash with pipefail so a
-  # non-zero `vegeta report` exit is not masked by tee's (always-zero) status;
-  # the default /bin/sh on Linux CI is dash, which has no `set -o pipefail`.
-  unless system("bash", "-c",
-                "set -o pipefail; vegeta report #{Shellwords.escape(vegeta_bin)} | " \
-                "tee #{Shellwords.escape(vegeta_txt)}")
-    raise "Vegeta text report failed"
-  end
-
-  # Generate JSON report
-  unless system("vegeta report -type=json #{Shellwords.escape(vegeta_bin)} > #{Shellwords.escape(vegeta_json)}")
-    raise "Vegeta JSON report failed"
-  end
+  result_files = run_vegeta_attack_shards(name, targets_file, shard_count)
+  run_vegeta_reports(result_files, vegeta_txt, vegeta_json)
 
   # Delete the large binary file to save disk space
-  FileUtils.rm_f(vegeta_bin)
+  FileUtils.rm_f(*result_files)
 
   # Parse results
   vegeta_data = parse_json_file(vegeta_json, "Vegeta")
@@ -236,7 +287,7 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
   [vegeta_rps, vegeta_p50, vegeta_p90, vegeta_status]
 end
 
-# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
 # Run a batch of test cases against a bundle, collecting per-test failures
 # instead of aborting on the first. A failed test is recorded as FAILED in the
@@ -279,10 +330,10 @@ end
 # Main execution
 
 if __FILE__ == $PROGRAM_NAME
-  validate_benchmark_config!
+  validate_node_renderer_benchmark_config!
 
   # Check required tools
-  check_required_tools(%w[vegeta curl column tee bash])
+  check_required_tools(%w[vegeta curl column tee bash cat])
 
   # Wait for node renderer to be ready
   # Note: Node renderer only speaks HTTP/2, but we can still check with a simple GET
@@ -345,6 +396,7 @@ if __FILE__ == $PROGRAM_NAME
     "REQUEST_TIMEOUT" => REQUEST_TIMEOUT,
     "CONNECTIONS" => CONNECTIONS,
     "MAX_CONNECTIONS" => MAX_CONNECTIONS,
+    "LOAD_GENERATOR_SHARDS" => LOAD_GENERATOR_SHARDS,
     "RSC_TESTS" => rsc_tests.map { |tc| tc[:name] }.join(", ").then { |s| s.empty? ? "none" : s },
     "NON_RSC_TESTS" => non_rsc_tests.map { |tc| tc[:name] }.join(", ").then { |s| s.empty? ? "none" : s }
   )

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -5,8 +5,8 @@
 #
 # Uses Vegeta with HTTP/2 Cleartext (h2c) support. Set
 # LOAD_GENERATOR_SHARDS=N to split each test across N Vegeta attack processes;
-# the script concatenates the binary result streams and runs one merged Vegeta
-# report so percentiles are recomputed over the combined sample distribution.
+# the script passes every shard result file to one merged Vegeta report so
+# percentiles are recomputed over the combined sample distribution.
 
 require "English"
 require "open3"
@@ -58,6 +58,8 @@ TEST_CASES = [
 # Script-specific configuration (common params from benchmark_config.rb)
 SUMMARY_TXT = "#{OUTDIR}/node_renderer_summary.txt".freeze
 BMF_PREFIX = "Pro Node Renderer: "
+VEGETA_RATE_PRECISION = 6
+VEGETA_RATE_SCALE = 10**VEGETA_RATE_PRECISION
 
 # Local wrapper for add_summary_line to use local constant
 def add_to_summary(*parts)
@@ -162,10 +164,13 @@ def validate_node_renderer_benchmark_config!
   validate_positive_integer(LOAD_GENERATOR_SHARDS, "LOAD_GENERATOR_SHARDS")
 
   return if LOAD_GENERATOR_SHARDS == 1
-  return if LOAD_GENERATOR_SHARDS <= CONNECTIONS && LOAD_GENERATOR_SHARDS <= MAX_CONNECTIONS
 
-  raise "LOAD_GENERATOR_SHARDS must be no greater than CONNECTIONS and MAX_CONNECTIONS " \
-        "(got shards=#{LOAD_GENERATOR_SHARDS}, connections=#{CONNECTIONS}, max_connections=#{MAX_CONNECTIONS})"
+  unless LOAD_GENERATOR_SHARDS <= CONNECTIONS && LOAD_GENERATOR_SHARDS <= MAX_CONNECTIONS
+    raise "LOAD_GENERATOR_SHARDS must be no greater than CONNECTIONS and MAX_CONNECTIONS " \
+          "(got shards=#{LOAD_GENERATOR_SHARDS}, connections=#{CONNECTIONS}, max_connections=#{MAX_CONNECTIONS})"
+  end
+
+  validate_fixed_rate_shards!(LOAD_GENERATOR_SHARDS)
 end
 
 def distribute_integer(total, shard_count)
@@ -173,15 +178,41 @@ def distribute_integer(total, shard_count)
   Array.new(shard_count) { |index| base + (index < remainder ? 1 : 0) }
 end
 
-def format_vegeta_rate(rate)
-  formatted = format("%.6f", rate)
-  formatted.sub(/\.?0+\z/, "")
+def scaled_vegeta_rate
+  whole, fractional = RATE.split(".", 2)
+  fractional_digits = (fractional || "").ljust(VEGETA_RATE_PRECISION + 1, "0")
+  scaled = (whole.to_i * VEGETA_RATE_SCALE) + fractional_digits[0, VEGETA_RATE_PRECISION].to_i
+  scaled += 1 if fractional_digits[VEGETA_RATE_PRECISION].to_i >= 5
+  scaled
+end
+
+def validate_fixed_rate_shards!(shard_count)
+  return if RATE == "max" || scaled_vegeta_rate >= shard_count
+
+  minimum_rate = format_scaled_vegeta_rate_for_message(shard_count)
+  raise "RATE must be at least #{minimum_rate} when LOAD_GENERATOR_SHARDS=#{shard_count}"
+end
+
+def format_scaled_vegeta_rate_for_message(scaled_rate)
+  whole, fractional = scaled_rate.divmod(VEGETA_RATE_SCALE)
+  return whole.to_s if fractional.zero?
+
+  "#{whole}.#{fractional.to_s.rjust(VEGETA_RATE_PRECISION, '0').sub(/0+\z/, '')}"
+end
+
+def format_vegeta_attack_rate(scaled_rate)
+  whole, fractional = scaled_rate.divmod(VEGETA_RATE_SCALE)
+  return whole.to_s if fractional.zero?
+
+  # Vegeta accepts integer rates or integer-frequency duration syntax, but not
+  # bare decimals like "0.333333".
+  "#{scaled_rate}/#{VEGETA_RATE_SCALE}s"
 end
 
 def vegeta_rates_for_shards(shard_count)
   return Array.new(shard_count, "0") if RATE == "max"
 
-  Array.new(shard_count, format_vegeta_rate(RATE.to_f / shard_count))
+  distribute_integer(scaled_vegeta_rate, shard_count).map { |rate| format_vegeta_attack_rate(rate) }
 end
 
 def vegeta_result_file(name, shard_number, shard_count)
@@ -190,14 +221,18 @@ def vegeta_result_file(name, shard_number, shard_count)
   "#{OUTDIR}/#{name}_vegeta_shard_#{shard_number}_of_#{shard_count}.bin"
 end
 
-def run_vegeta_attack_shards(name, targets_file, shard_count)
+def vegeta_result_files(name, shard_count)
+  Array.new(shard_count) { |index| vegeta_result_file(name, index + 1, shard_count) }
+end
+
+def vegeta_attack_shard_specs(targets_file, result_files)
+  shard_count = result_files.length
   worker_counts = distribute_integer(CONNECTIONS, shard_count)
   max_worker_counts = distribute_integer(MAX_CONNECTIONS, shard_count)
   rates = vegeta_rates_for_shards(shard_count)
 
-  Array.new(shard_count) do |index|
+  result_files.map.with_index do |result_file, index|
     shard_number = index + 1
-    result_file = vegeta_result_file(name, shard_number, shard_count)
     vegeta_args = [
       "-rate=#{rates.fetch(index)}",
       "-workers=#{worker_counts.fetch(index)}",
@@ -217,28 +252,80 @@ def run_vegeta_attack_shards(name, targets_file, shard_count)
       "> #{Shellwords.escape(result_file)}"
     ].join(" ")
 
-    raise "Vegeta attack failed for #{name} shard #{shard_number}/#{shard_count}" unless system(vegeta_cmd)
-
-    result_file
+    { command: vegeta_cmd, result_file:, shard_count:, shard_number: }
   end
 end
 
+def vegeta_shard_label(shard_spec)
+  "shard #{shard_spec.fetch(:shard_number)}/#{shard_spec.fetch(:shard_count)}"
+end
+
+def process_status_description(status)
+  return "exited with status #{status.exitstatus}" if status.exitstatus
+  return "terminated by signal #{status.termsig}" if status.termsig
+
+  "finished unsuccessfully"
+end
+
+def wait_for_vegeta_attack_shards(running_shards)
+  running_shards.filter_map do |shard_spec|
+    _pid, status = Process.wait2(shard_spec.fetch(:pid))
+    next if status.success?
+
+    "#{vegeta_shard_label(shard_spec)} #{process_status_description(status)}"
+  rescue Errno::ECHILD
+    "#{vegeta_shard_label(shard_spec)} could not be waited on"
+  end
+end
+
+def stop_vegeta_attack_shards(running_shards)
+  running_shards.each do |shard_spec|
+    Process.kill("TERM", shard_spec.fetch(:pid))
+  rescue Errno::ESRCH
+    nil
+  end
+end
+
+def run_vegeta_attack_shards(name, targets_file, result_files)
+  running_shards = []
+  current_spec = nil
+
+  vegeta_attack_shard_specs(targets_file, result_files).each do |shard_spec|
+    current_spec = shard_spec
+    running_shards << shard_spec.merge(pid: Process.spawn(shard_spec.fetch(:command)))
+  end
+
+  failures = wait_for_vegeta_attack_shards(running_shards)
+  raise "Vegeta attack failed for #{name}: #{failures.join(', ')}" if failures.any?
+
+  result_files
+rescue SystemCallError => e
+  stop_vegeta_attack_shards(running_shards)
+  wait_for_vegeta_attack_shards(running_shards)
+  raise "Vegeta attack failed for #{name} #{vegeta_shard_label(current_spec)}: #{e.message}"
+end
+
+def vegeta_report_command(result_files, *args)
+  ["vegeta", "report", *args, *result_files].map { |part| Shellwords.escape(part) }.join(" ")
+end
+
+def run_vegeta_report_command!(command, failure_message)
+  return if system("bash", "-c", "set -o pipefail; #{command}")
+
+  raise failure_message
+end
+
 def run_vegeta_reports(result_files, vegeta_txt, vegeta_json)
-  escaped_results = result_files.map { |path| Shellwords.escape(path) }.join(" ")
-
-  # Vegeta's binary result stream is concatenable, so feeding all shard files to
-  # one report recomputes percentiles over the merged sample distribution.
-  unless system("bash", "-c",
-                "set -o pipefail; cat #{escaped_results} | vegeta report | " \
-                "tee #{Shellwords.escape(vegeta_txt)}")
-    raise "Vegeta text report failed"
-  end
-
-  unless system("bash", "-c",
-                "set -o pipefail; cat #{escaped_results} | vegeta report -type=json > " \
-                "#{Shellwords.escape(vegeta_json)}")
-    raise "Vegeta JSON report failed"
-  end
+  # Pass multiple gob files to one report; naive `cat` concatenation fails with
+  # duplicate gob type declarations on Vegeta 12.13.
+  run_vegeta_report_command!(
+    "#{vegeta_report_command(result_files)} | tee #{Shellwords.escape(vegeta_txt)}",
+    "Vegeta text report failed"
+  )
+  run_vegeta_report_command!(
+    "#{vegeta_report_command(result_files, '-type=json')} > #{Shellwords.escape(vegeta_json)}",
+    "Vegeta JSON report failed"
+  )
 end
 
 # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -271,20 +358,23 @@ def run_vegeta_benchmark(test_case, bundle_timestamp, shard_count: LOAD_GENERATO
     @#{body_file}
   TARGETS
 
-  result_files = run_vegeta_attack_shards(name, targets_file, shard_count)
-  run_vegeta_reports(result_files, vegeta_txt, vegeta_json)
+  result_files = vegeta_result_files(name, shard_count)
+  begin
+    run_vegeta_attack_shards(name, targets_file, result_files)
+    run_vegeta_reports(result_files, vegeta_txt, vegeta_json)
 
-  # Delete the large binary file to save disk space
-  FileUtils.rm_f(*result_files)
+    # Parse results
+    vegeta_data = parse_json_file(vegeta_json, "Vegeta")
+    vegeta_rps = vegeta_data["throughput"]&.round(2) || "MISSING"
+    vegeta_p50 = vegeta_data.dig("latencies", "50th")&./(1_000_000.0)&.round(2) || "MISSING"
+    vegeta_p90 = vegeta_data.dig("latencies", "90th")&./(1_000_000.0)&.round(2) || "MISSING"
+    vegeta_status = vegeta_data["status_codes"]&.map { |k, v| "#{k}=#{v}" }&.join(",") || "MISSING"
 
-  # Parse results
-  vegeta_data = parse_json_file(vegeta_json, "Vegeta")
-  vegeta_rps = vegeta_data["throughput"]&.round(2) || "MISSING"
-  vegeta_p50 = vegeta_data.dig("latencies", "50th")&./(1_000_000.0)&.round(2) || "MISSING"
-  vegeta_p90 = vegeta_data.dig("latencies", "90th")&./(1_000_000.0)&.round(2) || "MISSING"
-  vegeta_status = vegeta_data["status_codes"]&.map { |k, v| "#{k}=#{v}" }&.join(",") || "MISSING"
-
-  [vegeta_rps, vegeta_p50, vegeta_p90, vegeta_status]
+    [vegeta_rps, vegeta_p50, vegeta_p90, vegeta_status]
+  ensure
+    # Delete the large binary files to save disk space, including failed partial runs.
+    FileUtils.rm_f(result_files)
+  end
 end
 
 # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -333,7 +423,7 @@ if __FILE__ == $PROGRAM_NAME
   validate_node_renderer_benchmark_config!
 
   # Check required tools
-  check_required_tools(%w[vegeta curl column tee bash cat])
+  check_required_tools(%w[vegeta curl column tee bash])
 
   # Wait for node renderer to be ready
   # Note: Node renderer only speaks HTTP/2, but we can still check with a simple GET

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -60,6 +60,11 @@ SUMMARY_TXT = "#{OUTDIR}/node_renderer_summary.txt".freeze
 BMF_PREFIX = "Pro Node Renderer: "
 VEGETA_RATE_PRECISION = 6
 VEGETA_RATE_SCALE = 10**VEGETA_RATE_PRECISION
+VEGETA_DURATION_UNITS_IN_SECONDS = {
+  "s" => 1,
+  "m" => 60,
+  "h" => 3600
+}.freeze
 
 # Local wrapper for add_summary_line to use local constant
 def add_to_summary(*parts)
@@ -163,8 +168,6 @@ def validate_node_renderer_benchmark_config!
   validate_benchmark_config!
   validate_positive_integer(LOAD_GENERATOR_SHARDS, "LOAD_GENERATOR_SHARDS")
 
-  return if LOAD_GENERATOR_SHARDS == 1
-
   unless LOAD_GENERATOR_SHARDS <= CONNECTIONS && LOAD_GENERATOR_SHARDS <= MAX_CONNECTIONS
     raise "LOAD_GENERATOR_SHARDS must be no greater than CONNECTIONS and MAX_CONNECTIONS " \
           "(got shards=#{LOAD_GENERATOR_SHARDS}, connections=#{CONNECTIONS}, max_connections=#{MAX_CONNECTIONS})"
@@ -178,6 +181,19 @@ def distribute_integer(total, shard_count)
   Array.new(shard_count) { |index| base + (index < remainder ? 1 : 0) }
 end
 
+def duration_seconds(duration)
+  duration.scan(/(\d+(?:\.\d+)?)([smh])/).sum(Rational(0)) do |number, unit|
+    Rational(number) * VEGETA_DURATION_UNITS_IN_SECONDS.fetch(unit)
+  end
+end
+
+def minimum_scaled_rate_for_duration(duration)
+  seconds = duration_seconds(duration)
+  raise "DURATION must be greater than 0 for fixed RATE" if seconds.zero?
+
+  (VEGETA_RATE_SCALE / seconds).ceil
+end
+
 def scaled_vegeta_rate
   whole, fractional = RATE.split(".", 2)
   fractional_digits = (fractional || "").ljust(VEGETA_RATE_PRECISION + 1, "0")
@@ -187,10 +203,20 @@ def scaled_vegeta_rate
 end
 
 def validate_fixed_rate_shards!(shard_count)
-  return if RATE == "max" || scaled_vegeta_rate >= shard_count
+  return if RATE == "max"
 
-  minimum_rate = format_scaled_vegeta_rate_for_message(shard_count)
-  raise "RATE must be at least #{minimum_rate} when LOAD_GENERATOR_SHARDS=#{shard_count}"
+  shard_rates = distribute_integer(scaled_vegeta_rate, shard_count)
+  minimum_rate_for_shards = shard_count
+  if shard_rates.min.zero?
+    minimum_rate = format_scaled_vegeta_rate_for_message(minimum_rate_for_shards)
+    raise "RATE must be at least #{minimum_rate} when LOAD_GENERATOR_SHARDS=#{shard_count}"
+  end
+
+  minimum_rate_per_shard = minimum_scaled_rate_for_duration(DURATION)
+  return if shard_rates.min >= minimum_rate_per_shard
+
+  minimum_rate = format_scaled_vegeta_rate_for_message(minimum_rate_per_shard * shard_count)
+  raise "RATE must be at least #{minimum_rate} when LOAD_GENERATOR_SHARDS=#{shard_count} and DURATION=#{DURATION}"
 end
 
 def format_scaled_vegeta_rate_for_message(scaled_rate)

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -10,6 +10,15 @@ require_relative "../bench-node-renderer"
 # collector), and must be surfaced so the suite can exit non-zero instead of
 # reporting a green run on fabricated data (#3459).
 RSpec.describe "bench-node-renderer" do
+  describe "#validate_node_renderer_benchmark_config!" do
+    it "rejects more load-generator shards than available Vegeta workers" do
+      stub_const("LOAD_GENERATOR_SHARDS", CONNECTIONS + 1)
+
+      expect { validate_node_renderer_benchmark_config! }
+        .to raise_error(/LOAD_GENERATOR_SHARDS must be no greater than CONNECTIONS and MAX_CONNECTIONS/)
+    end
+  end
+
   describe "#run_vegeta_suite" do
     # Minimal stand-in for BmfCollector that records exactly what would ship to
     # Bencher, so the specs can assert failed tests never reach the payload.
@@ -76,6 +85,65 @@ RSpec.describe "bench-node-renderer" do
 
       expect(failed).to eq(["simple_eval (non-RSC)", "react_ssr (non-RSC)"])
       expect(collector.added).to be_empty
+    end
+  end
+
+  describe "#run_vegeta_benchmark" do
+    it "merges multiple shard result streams into one Vegeta report" do
+      allow(File).to receive(:write)
+      allow(FileUtils).to receive(:rm_f)
+      allow(self).to receive_messages(system: true, parse_json_file: { "throughput" => 123.456,
+                                                                       "latencies" => { "50th" => 1_500_000,
+                                                                                        "90th" => 2_500_000 },
+                                                                       "status_codes" => { "200" => 30 } })
+
+      result = run_vegeta_benchmark({ name: "simple_eval", request: "2+2" }, "bundleX", shard_count: 3)
+
+      expect(result).to eq([123.46, 1.5, 2.5, "200=30"])
+      expect(self).to have_received(:system).with(
+        a_string_matching(/vegeta attack .* -workers=4 -max-workers=4 .*simple_eval_vegeta_shard_1_of_3\.bin/)
+      )
+      expect(self).to have_received(:system).with(
+        a_string_matching(/vegeta attack .* -workers=3 -max-workers=3 .*simple_eval_vegeta_shard_2_of_3\.bin/)
+      )
+      expect(self).to have_received(:system).with(
+        a_string_matching(/vegeta attack .* -workers=3 -max-workers=3 .*simple_eval_vegeta_shard_3_of_3\.bin/)
+      )
+      shard_result_files = [
+        "simple_eval_vegeta_shard_1_of_3.bin",
+        "simple_eval_vegeta_shard_2_of_3.bin",
+        "simple_eval_vegeta_shard_3_of_3.bin"
+      ]
+      expect(self).to have_received(:system).with(
+        "bash",
+        "-c",
+        a_string_including("set -o pipefail; cat", *shard_result_files, "| vegeta report | tee")
+      )
+      expect(self).to have_received(:system).with(
+        "bash",
+        "-c",
+        a_string_including("set -o pipefail; cat", *shard_result_files, "| vegeta report -type=json >")
+      )
+      expect(FileUtils).to have_received(:rm_f).with(
+        a_string_matching(/simple_eval_vegeta_shard_1_of_3\.bin/),
+        a_string_matching(/simple_eval_vegeta_shard_2_of_3\.bin/),
+        a_string_matching(/simple_eval_vegeta_shard_3_of_3\.bin/)
+      )
+    end
+
+    it "raises before reporting or parsing when a shard attack fails" do
+      allow(File).to receive(:write)
+      allow(self).to receive(:system) do |*args|
+        command = args.join(" ")
+        !command.include?("simple_eval_vegeta_shard_2_of_3.bin")
+      end
+      allow(self).to receive(:parse_json_file)
+
+      expect { run_vegeta_benchmark({ name: "simple_eval", request: "2+2" }, "bundleX", shard_count: 3) }
+        .to raise_error(%r{Vegeta attack failed for simple_eval shard 2/3})
+
+      expect(self).not_to have_received(:system).with("bash", "-c", /vegeta report/)
+      expect(self).not_to have_received(:parse_json_file)
     end
   end
 end

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -10,12 +10,30 @@ require_relative "../bench-node-renderer"
 # collector), and must be surfaced so the suite can exit non-zero instead of
 # reporting a green run on fabricated data (#3459).
 RSpec.describe "bench-node-renderer" do
+  def process_status(success:, exitstatus: nil, termsig: nil)
+    instance_double(Process::Status, success?: success, exitstatus:, termsig:)
+  end
+
   describe "#validate_node_renderer_benchmark_config!" do
     it "rejects more load-generator shards than available Vegeta workers" do
       stub_const("LOAD_GENERATOR_SHARDS", CONNECTIONS + 1)
 
       expect { validate_node_renderer_benchmark_config! }
         .to raise_error(/LOAD_GENERATOR_SHARDS must be no greater than CONNECTIONS and MAX_CONNECTIONS/)
+    end
+  end
+
+  describe "#vegeta_rates_for_shards" do
+    it "distributes fixed-rate remainder across shards using Vegeta-compatible syntax" do
+      stub_const("RATE", "1")
+
+      expect(vegeta_rates_for_shards(3)).to eq(%w[333334/1000000s 333333/1000000s 333333/1000000s])
+    end
+
+    it "keeps evenly divisible fixed rates as integer rates" do
+      stub_const("RATE", "9")
+
+      expect(vegeta_rates_for_shards(3)).to eq(%w[3 3 3])
     end
   end
 
@@ -89,9 +107,21 @@ RSpec.describe "bench-node-renderer" do
   end
 
   describe "#run_vegeta_benchmark" do
-    it "merges multiple shard result streams into one Vegeta report" do
+    it "runs all shards concurrently before merging their result streams into one Vegeta report" do
+      events = []
+      spawned_commands = []
+
       allow(File).to receive(:write)
       allow(FileUtils).to receive(:rm_f)
+      allow(Process).to receive(:spawn) do |command|
+        events << :spawn
+        spawned_commands << command
+        spawned_commands.length
+      end
+      allow(Process).to receive(:wait2) do |pid|
+        events << :wait
+        [pid, process_status(success: true)]
+      end
       allow(self).to receive_messages(system: true, parse_json_file: { "throughput" => 123.456,
                                                                        "latencies" => { "50th" => 1_500_000,
                                                                                         "90th" => 2_500_000 },
@@ -100,13 +130,10 @@ RSpec.describe "bench-node-renderer" do
       result = run_vegeta_benchmark({ name: "simple_eval", request: "2+2" }, "bundleX", shard_count: 3)
 
       expect(result).to eq([123.46, 1.5, 2.5, "200=30"])
-      expect(self).to have_received(:system).with(
-        a_string_matching(/vegeta attack .* -workers=4 -max-workers=4 .*simple_eval_vegeta_shard_1_of_3\.bin/)
-      )
-      expect(self).to have_received(:system).with(
-        a_string_matching(/vegeta attack .* -workers=3 -max-workers=3 .*simple_eval_vegeta_shard_2_of_3\.bin/)
-      )
-      expect(self).to have_received(:system).with(
+      expect(events).to eq(%i[spawn spawn spawn wait wait wait])
+      expect(spawned_commands).to contain_exactly(
+        a_string_matching(/vegeta attack .* -workers=4 -max-workers=4 .*simple_eval_vegeta_shard_1_of_3\.bin/),
+        a_string_matching(/vegeta attack .* -workers=3 -max-workers=3 .*simple_eval_vegeta_shard_2_of_3\.bin/),
         a_string_matching(/vegeta attack .* -workers=3 -max-workers=3 .*simple_eval_vegeta_shard_3_of_3\.bin/)
       )
       shard_result_files = [
@@ -117,33 +144,52 @@ RSpec.describe "bench-node-renderer" do
       expect(self).to have_received(:system).with(
         "bash",
         "-c",
-        a_string_including("set -o pipefail; cat", *shard_result_files, "| vegeta report | tee")
+        a_string_including("set -o pipefail; vegeta report", *shard_result_files, "| tee")
       )
       expect(self).to have_received(:system).with(
         "bash",
         "-c",
-        a_string_including("set -o pipefail; cat", *shard_result_files, "| vegeta report -type=json >")
+        a_string_including(
+          "set -o pipefail; vegeta report #{Shellwords.escape('-type=json')}",
+          *shard_result_files,
+          ">"
+        )
       )
       expect(FileUtils).to have_received(:rm_f).with(
-        a_string_matching(/simple_eval_vegeta_shard_1_of_3\.bin/),
-        a_string_matching(/simple_eval_vegeta_shard_2_of_3\.bin/),
-        a_string_matching(/simple_eval_vegeta_shard_3_of_3\.bin/)
+        contain_exactly(
+          a_string_matching(/simple_eval_vegeta_shard_1_of_3\.bin/),
+          a_string_matching(/simple_eval_vegeta_shard_2_of_3\.bin/),
+          a_string_matching(/simple_eval_vegeta_shard_3_of_3\.bin/)
+        )
       )
     end
 
     it "raises before reporting or parsing when a shard attack fails" do
       allow(File).to receive(:write)
-      allow(self).to receive(:system) do |*args|
-        command = args.join(" ")
-        !command.include?("simple_eval_vegeta_shard_2_of_3.bin")
+      allow(FileUtils).to receive(:rm_f)
+      next_pid = 0
+      allow(Process).to receive(:spawn) do |_command|
+        next_pid += 1
       end
+      allow(Process).to receive(:wait2) do |pid|
+        status = pid == 2 ? process_status(success: false, exitstatus: 1) : process_status(success: true)
+        [pid, status]
+      end
+      allow(self).to receive(:system)
       allow(self).to receive(:parse_json_file)
 
       expect { run_vegeta_benchmark({ name: "simple_eval", request: "2+2" }, "bundleX", shard_count: 3) }
-        .to raise_error(%r{Vegeta attack failed for simple_eval shard 2/3})
+        .to raise_error(%r{Vegeta attack failed for simple_eval: shard 2/3 exited with status 1})
 
       expect(self).not_to have_received(:system).with("bash", "-c", /vegeta report/)
       expect(self).not_to have_received(:parse_json_file)
+      expect(FileUtils).to have_received(:rm_f).with(
+        contain_exactly(
+          a_string_matching(/simple_eval_vegeta_shard_1_of_3\.bin/),
+          a_string_matching(/simple_eval_vegeta_shard_2_of_3\.bin/),
+          a_string_matching(/simple_eval_vegeta_shard_3_of_3\.bin/)
+        )
+      )
     end
   end
 end

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -21,6 +21,40 @@ RSpec.describe "bench-node-renderer" do
       expect { validate_node_renderer_benchmark_config! }
         .to raise_error(/LOAD_GENERATOR_SHARDS must be no greater than CONNECTIONS and MAX_CONNECTIONS/)
     end
+
+    it "rejects fixed rates that would round to unlimited Vegeta rate with one shard" do
+      stub_const("LOAD_GENERATOR_SHARDS", 1)
+      stub_const("RATE", "0.0000004")
+
+      expect { validate_node_renderer_benchmark_config! }
+        .to raise_error(/RATE must be at least 0\.000001 when LOAD_GENERATOR_SHARDS=1/)
+    end
+
+    it "rejects fixed rates whose per-shard request period exceeds the benchmark duration" do
+      stub_const("LOAD_GENERATOR_SHARDS", 1)
+      stub_const("RATE", "0.000001")
+      stub_const("DURATION", "30s")
+
+      expect { validate_node_renderer_benchmark_config! }
+        .to raise_error(/RATE must be at least 0\.033334 when LOAD_GENERATOR_SHARDS=1 and DURATION=30s/)
+    end
+
+    it "rejects zero duration for fixed-rate Vegeta benchmarks" do
+      stub_const("LOAD_GENERATOR_SHARDS", 1)
+      stub_const("RATE", "1")
+      stub_const("DURATION", "0s")
+
+      expect { validate_node_renderer_benchmark_config! }
+        .to raise_error(/DURATION must be greater than 0 for fixed RATE/)
+    end
+
+    it "accepts fixed rates that schedule at least one request per shard within the benchmark duration" do
+      stub_const("LOAD_GENERATOR_SHARDS", 1)
+      stub_const("RATE", "0.033334")
+      stub_const("DURATION", "30s")
+
+      expect { validate_node_renderer_benchmark_config! }.not_to raise_error
+    end
   end
 
   describe "#vegeta_rates_for_shards" do
@@ -108,6 +142,11 @@ RSpec.describe "bench-node-renderer" do
 
   describe "#run_vegeta_benchmark" do
     it "runs all shards concurrently before merging their result streams into one Vegeta report" do
+      stub_const("CONNECTIONS", 10)
+      stub_const("MAX_CONNECTIONS", 10)
+      stub_const("RATE", "max")
+      stub_const("DURATION", "30s")
+
       events = []
       spawned_commands = []
 


### PR DESCRIPTION
## Summary

Adds optional `LOAD_GENERATOR_SHARDS` support to the Pro Node Renderer Vegeta benchmark. Each benchmark test can split the configured total load across multiple concurrent Vegeta attack processes, then run one merged Vegeta report over all shard result files so p50/p90 are recomputed from the combined sample distribution.

This is the first, lowest-risk slice of the benchmark-methodology work inspired by the Evil Martians write-up: give the load generator headroom and verify the rig is not the bottleneck.

## Details

- Keeps default behavior unchanged with `LOAD_GENERATOR_SHARDS=1` for `RATE=max`, while fixing decimal fixed-rate handling to use Vegeta-compatible integer-frequency syntax.
- Validates shard count is positive and does not exceed `CONNECTIONS` or `MAX_CONNECTIONS`, so no shard gets zero workers.
- Splits fixed `RATE`, `CONNECTIONS`, and `MAX_CONNECTIONS` across shards; `RATE=max` keeps Vegeta `-rate=0` and distributes workers.
- Rejects fixed rates that would round any shard to Vegeta `-rate=0`, and rejects fixed rates whose per-shard request period exceeds `DURATION`.
- Starts every shard with `Process.spawn` before waiting on any shard, so shard runs are concurrent.
- Uses native multi-file `vegeta report <file...>` and `vegeta report -type=json <file...>` instead of concatenating gob streams.
- Cleans shard result files from an `ensure` block, including failed partial runs.
- Rebased on current `origin/main` at `ee0c19f12515ee2aea8896c0da4be44ce2599b64`.

## Review / Churn

- Fixed the prior concurrency, failed-shard cleanup, fixed-rate remainder, underflow, and duration-floor review findings.
- Current-head Codex review against `origin/main`: no actionable correctness issues.
- Claude `/code-review` and `/simplify` were unavailable locally because the Claude CLI weekly limit is exhausted until Jul 6 at 9pm Pacific/Honolulu.

## Validation

- `bundle exec rspec benchmarks/spec/bench_node_renderer_spec.rb` - 12 examples, 0 failures
- `CONNECTIONS=2 MAX_CONNECTIONS=2 bundle exec rspec benchmarks/spec/bench_node_renderer_spec.rb` - 12 examples, 0 failures
- `bundle exec rspec benchmarks/spec` - 325 examples, 0 failures
- `BUNDLE_GEMFILE=Gemfile bundle exec rubocop benchmarks/bench-node-renderer.rb benchmarks/spec/bench_node_renderer_spec.rb --force-exclusion` - 2 files inspected, no offenses
- `git diff --check` - clean
- `script/ci-changes-detector origin/main` - changed category: Benchmark scripts; recommended CI jobs: Lint (Ruby + JS)
- Direct validation probes: underflowing fixed rates now fail before Vegeta, the exact fixed-rate/duration boundary passes, native multi-file Vegeta JSON reports merge shard files, and Vegeta accepts the emitted integer-frequency rate syntax.
- `codex review --base origin/main` - no actionable correctness issues
- pre-push hook after final force-push: focused RuboCop clean, no Markdown files to check

## QA Evidence

No separate manual QA lane is required for this benchmark-harness-only change. Behavior is covered by focused specs plus direct Vegeta command smokes for the changed rate/report paths.

## Follow-up Plan

1. Add the same optional load-generator sharding pattern for Rails/k6, using raw samples and merged percentile calculation rather than averaging summaries.
2. In a separate CI rollout PR, add workflow input/default wiring and adjust CPU allocation so multiple load-generator processes are not all pinned to one CPU.
3. Add broader contributor docs once the local Lychee hook/config mismatch is handled; this PR keeps Markdown out of scope because the local hook currently cannot parse the existing `.lychee.toml` with lychee 0.24.2.

## Changelog

Not user-visible; internal benchmark harness only.

## Labels

Labels: `ready-for-hosted-ci`. Benchmark-harness-only change; no runtime behavior change and no CI workflow change in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark runs can now split load generation across multiple shards to run in parallel.
  * Rate settings are shard-aware, and results are merged into a single combined report.

* **Bug Fixes**
  * Added stricter validation for shard counts and fixed-rate scheduling to prevent invalid configurations.
  * Improved cleanup to remove partial shard outputs even when a run fails.
  * Metrics/status reporting now reflects merged results for consistency.

* **Tests**
  * Expanded coverage for shard validation, successful multi-shard execution, and failure handling/cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->