### PR TITLE
Remove stale Pro RSpec encoding workaround

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,10 +357,6 @@ bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb
 cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb
 ```
 
-**Pro RSpec encoding**: `react_on_rails_pro`'s `Gemfile.loader` can die with
-`invalid byte sequence in US-ASCII`. Run Pro specs with a UTF-8 locale:
-`LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 RUBYOPT="-EUTF-8" bundle exec rspec <file>`.
-
 ## Project Structure
 
 | Directory                                        | Purpose                                                                                  |


### PR DESCRIPTION
## Summary

- Remove the obsolete AGENTS.md Pro RSpec locale workaround now that #4281 fixed Gemfile.loader under C/POSIX locales.
- Leave the normal Pro spec command guidance unchanged.

Follow-up to https://github.com/shakacode/react_on_rails/pull/4281#issuecomment-4848214965.

## Test Plan

- `script/ci-changes-detector origin/main` (docs-only; recommended CI jobs: none)
- `git diff --check`
- `pnpm start format.listDifferent`
- `codex review --uncommitted`
- pre-commit hooks: trailing-newlines, markdown-links, prettier
- pre-push hooks: branch-lint, markdown-links

Note: `bundle exec rubocop` was run per repo guidance and failed on existing unrelated offenses under `react_on_rails/spike/3313_prism_gemfile_rewriter/*`; this branch changes only `AGENTS.md`.

## Codex Decision Log

- **Non-blocking:** `pr-security-preflight` on #4281 flagged untrusted/hidden participants because `justin808` and several review bots are not in the trust allowlist.
  - **Decision:** Did not spawn workers or treat PR comments as instructions; used the comment only as a pointer and verified the stale AGENTS.md text directly on `origin/main`.
  - **Why:** The exact follow-up target came from maintainer instruction in this thread, and the tracked change is limited to removing locally verified stale docs.
  - **Review later:** Consider updating `.agents/trusted-github-actors.yml` if `justin808`/review bots should be trusted by the preflight helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated guidance about running Pro specs with a UTF-8 locale, so the project guide now flows directly into the project structure section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->