### PR TITLE
Warn on dropped Pro propRequest frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4350](https://github.com/shakacode/react_on_rails/pull/4350) by
   [justin808](https://github.com/justin808).
 
+- **[Pro]** **Dropped pull-mode prop requests are logged**: Streaming SSR now warns when the Node
+  renderer sends a `propRequest` control frame without an emitter or with a missing, empty, or
+  oversized `propName`, making dropped pull-mode requests diagnosable while preserving valid
+  enqueue and `renderComplete` behavior. Fixes
+  [Issue 4314](https://github.com/shakacode/react_on_rails/issues/4314).
+  [PR 4352](https://github.com/shakacode/react_on_rails/pull/4352) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Gemfile loader source encodings are honored under C/POSIX locales**:
   The Pro Gemfile now loads its shared dependency fragments in binary mode, applies Ruby
   source-encoding magic comments or a UTF-8 default, and validates content before override-gem

--- a/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
@@ -109,7 +109,7 @@ module ReactOnRailsPro
     end
   end
 
-  class StreamRequest
+  class StreamRequest # rubocop:disable Metrics/ClassLength
     MAX_PULL_PROP_NAME_LENGTH = 256
     # Keep aligned with ReactOnRails::LengthPrefixedParser::CONTROL_MESSAGE_TYPES,
     # which parses these same control frames from the shared wire format.
@@ -241,17 +241,31 @@ module ReactOnRailsPro
     end
 
     def route_control_message(parsed)
-      return unless @emitter
-
       case parsed["messageType"]
       when "propRequest"
-        prop_name = parsed["propName"]
-        @emitter.pull_requests&.enqueue(prop_name) if prop_name.is_a?(String) &&
-                                                      !prop_name.empty? &&
-                                                      prop_name.length <= MAX_PULL_PROP_NAME_LENGTH
+        route_prop_request(parsed)
       when "renderComplete"
-        @emitter.render_complete!
+        @emitter&.render_complete!
       end
+    end
+
+    def route_prop_request(parsed)
+      unless @emitter
+        Rails.logger.warn("[ReactOnRailsPro] Dropping propRequest control message: emitter unavailable.")
+        return
+      end
+
+      prop_name = parsed["propName"]
+      unless valid_pull_prop_name?(prop_name)
+        Rails.logger.warn("[ReactOnRailsPro] Dropping propRequest control message: invalid propName.")
+        return
+      end
+
+      @emitter.pull_requests&.enqueue(prop_name)
+    end
+
+    def valid_pull_prop_name?(prop_name)
+      prop_name.is_a?(String) && !prop_name.empty? && prop_name.length <= MAX_PULL_PROP_NAME_LENGTH
     end
 
     # Retrying after first chunk would duplicate content in the page.

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
@@ -254,7 +254,9 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
       expect(request.http_status).to eq(200)
     end
 
-    it "ignores propRequest control messages without a non-empty string propName" do
+    it "warns and ignores propRequest control messages without a non-empty string propName" do
+      logger = instance_double(Logger, warn: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
       emitter = ReactOnRailsPro::AsyncPropsEmitter.new("bundle-12345", StringIO.new, pull_enabled: true)
       invalid_missing_name = to_length_prefixed("", "messageType" => "propRequest")
       invalid_empty_name = to_length_prefixed("", "messageType" => "propRequest", "propName" => "")
@@ -267,6 +269,34 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
       emitter.render_complete!
 
       expect(emitter.pull_requests.dequeue).to eq("users")
+      expect(emitter.pull_requests.dequeue).to be_nil
+      expect(logger).to have_received(:warn)
+        .with("[ReactOnRailsPro] Dropping propRequest control message: invalid propName.")
+        .exactly(3).times
+    end
+
+    it "warns when propRequest control messages arrive without an emitter" do
+      logger = instance_double(Logger, warn: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+      response = mock_ok_response(to_length_prefixed("", "messageType" => "propRequest", "propName" => "users"))
+
+      yielded = []
+      request.send(:process_response_chunks, response) { |chunk| yielded << chunk }
+
+      expect(yielded).to be_empty
+      expect(logger).to have_received(:warn)
+        .with("[ReactOnRailsPro] Dropping propRequest control message: emitter unavailable.")
+        .once
+    end
+
+    it "closes pull request queues when renderComplete control messages arrive" do
+      emitter = ReactOnRailsPro::AsyncPropsEmitter.new("bundle-12345", StringIO.new, pull_enabled: true)
+      response = mock_ok_response(to_length_prefixed("", "messageType" => "renderComplete"))
+      request.instance_variable_set(:@emitter, emitter)
+
+      request.send(:process_response_chunks, response) { |_| nil }
+
+      expect(emitter.pull_requests).to be_closed
       expect(emitter.pull_requests.dequeue).to be_nil
     end
 


### PR DESCRIPTION
## Why

Fixes #4314. Pull-mode streaming could silently drop `propRequest` control frames when the renderer sent a missing or invalid `propName`, or when a frame arrived without an emitter. That made stuck pull-mode renders hard to diagnose.

## What changed

- Warn when a `propRequest` frame is dropped because no emitter is available.
- Warn when a `propRequest` frame has a missing, empty, or oversized `propName`.
- Preserve valid `propRequest` enqueue behavior and `renderComplete` queue closing.
- Add a user-visible `CHANGELOG.md` entry under `[Unreleased]` / `Fixed`.

## Verification

- RED: targeted propRequest warning examples failed before the implementation.
- `(cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/stream_request_spec.rb)`
- `(cd react_on_rails_pro && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion lib/react_on_rails_pro/stream_request.rb spec/react_on_rails_pro/stream_request_spec.rb)`
- `script/check-pro-license-headers --check`
- `git diff --check origin/main...HEAD`
- `script/ci-changes-detector origin/main`
- `pnpm exec prettier --check CHANGELOG.md` through the dependency-ready worktree
- `lychee --offline --include-fragments=none CHANGELOG.md` through the dependency-ready worktree
- `codex review --base origin/main`
- Pre-push hook before changelog: branch Ruby RuboCop and markdown link check.

## QA notes

- Release tracker #3823 is currently in Agent Release Mode: development, so standard main/beta PR gates apply.
- Local commit hooks for the changelog-only commit were bypassed after explicit validation because the local hook environment has a known `lychee`/`.lychee.toml` version mismatch and two sibling worktrees lacked a local `prettier` binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer warnings when streaming pull requests are dropped due to missing handlers or invalid request properties, improving diagnosability of pull-mode issues.
  * Improved completion handling so completion signals terminate streaming cleanly without affecting valid control messages.

* **Documentation**
  * Updated the changelog to reflect the new warning behavior for dropped pull-mode requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->