### PR TITLE
Fix Pro RSC preload replay after eviction

### DIFF
--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -249,8 +249,9 @@ const createRSCStreamFromArray = (payloads: string[]) => {
       payloads.forEach(handleChunk);
       // eslint-disable-next-line no-param-reassign
       payloads.push = (...chunks) => {
+        Array.prototype.push.apply(payloads, chunks);
         chunks.forEach(handleChunk);
-        return chunks.length;
+        return payloads.length;
       };
       streamController = controller;
     },

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -31,6 +31,32 @@ const loadClientModule = async (createFromReadableStream = jest.fn()) => {
 };
 
 const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+const decoder = new TextDecoder();
+
+const readStreamText = async (stream: ReadableStream<Uint8Array>) => {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let done = false;
+
+  while (!done) {
+    // eslint-disable-next-line no-await-in-loop
+    const readResult = await reader.read();
+    done = readResult.done;
+    if (readResult.value) {
+      chunks.push(readResult.value);
+    }
+  }
+
+  const byteLength = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const combined = new Uint8Array(byteLength);
+  let offset = 0;
+  chunks.forEach((chunk) => {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  });
+
+  return decoder.decode(combined);
+};
 
 const setDocumentReadyState = (readyState: DocumentReadyState) => {
   Object.defineProperty(document, 'readyState', {
@@ -129,6 +155,53 @@ describe('fetchRSC HTTP responses', () => {
         props: JSON.stringify(componentProps),
       })}`,
     );
+  });
+});
+
+describe('getReactServerComponent preloaded payload replay', () => {
+  afterEach(() => {
+    delete window.REACT_ON_RAILS_RSC_PAYLOADS;
+    delete window.REACT_ON_RAILS_RSC_ERRORS;
+    fetchMock.mockReset();
+    jest.dontMock('react-on-rails-rsc/client.browser');
+    jest.resetModules();
+  });
+
+  it('retains late streamed chunks so the same preloaded payload can be replayed after cache eviction', async () => {
+    const createFromReadableStream = jest.fn((stream: ReadableStream<Uint8Array>) => readStreamText(stream));
+    const { default: getReactServerComponent } = await loadClientModule(createFromReadableStream);
+    const { createEmbeddedPayloadKey } = await import('../src/utils.ts');
+    const originalReadyState = document.readyState;
+    const domNodeId = 'rsc-root';
+    const componentName = 'ReplayablePanel';
+    const componentProps = { selectedId: 1 };
+    const rscPayloadKey = createEmbeddedPayloadKey(componentName, componentProps, domNodeId);
+    const payloads = ['first'];
+    window.REACT_ON_RAILS_RSC_PAYLOADS = {
+      [rscPayloadKey]: payloads,
+    };
+
+    setDocumentReadyState('loading');
+
+    try {
+      const getComponent = getReactServerComponent(domNodeId, {
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      } as RailsContext);
+      const firstRenderPromise = getComponent({ componentName, componentProps });
+      const pushResult = payloads.push('second', 'third');
+
+      setDocumentReadyState('complete');
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+
+      await expect(firstRenderPromise).resolves.toBe('firstsecondthird');
+      expect(pushResult).toBe(3);
+      expect([...payloads]).toEqual(['first', 'second', 'third']);
+      await expect(getComponent({ componentName, componentProps })).resolves.toBe('firstsecondthird');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(createFromReadableStream).toHaveBeenCalledTimes(2);
+    } finally {
+      setDocumentReadyState(originalReadyState);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #4326.

Preloaded RSC payload arrays were treated as replay buffers, but late chunks arriving after the initial stream creation were only enqueued to the active stream and were not retained in the backing array. After `RSCProvider` LRU eviction and remount/refetch, the cached payload could replay a truncated Flight response.

This updates the Pro client RSC preload stream helper so appended chunks keep normal `Array#push` behavior while still feeding the live stream.

## Release Mode

- Target verified from labels/tracker: `17.0.0` development/beta lane, not `16.4.0`.
- Changelog classification: user-visible Pro runtime reliability fix.
- Changelog entry is reserved for the serial `CHANGELOG.md` finalizer lane for this batch.

## Codex Decision Log

- **Non-blocking:** Claude noted a pre-existing shared-array controller lifecycle concern for concurrent/live stream reuse.
  - **Decision:** Deferred out of this RC-blocker PR and resolved in-thread with `[auto-deferred]` rationale.
  - **Why:** This PR fixes the #4326 LRU eviction replay regression by restoring backing-array retention; a multi-controller broadcast/closed-controller guard is a separate behavior change.
  - **Review later:** Maintainer may choose to track that broader lifecycle hardening separately.

## Test Plan

- RED: `pnpm --filter react-on-rails-pro exec jest tests/getReactServerComponent.client.test.ts --runInBand` failed before the fix with an incomplete replay assertion.
- GREEN: `pnpm --filter react-on-rails-pro exec jest tests/getReactServerComponent.client.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro run test`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `pnpm exec prettier --check packages/react-on-rails-pro/src/getReactServerComponent.client.ts packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts`
- `script/check-pro-license-headers`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- `git diff --check`
- Coordinator self-review: `codex review --base origin/main` found no actionable issues.

## Batch Coordination

- Batch: `runtime-rc-blockers-20260701`
- Lane: `pro-preload`
- QA owner: `qa-runtime-rc-blockers`
- Merge authority: auto-merge only when local validation, hosted CI, review, QA, changelog/release-mode evidence, and merge ledger gates pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming behavior so newly added content is preserved and replayed correctly.
  * Fixed the return value for stream payload appends to reflect the updated total count.
  * Ensured preloaded content is fully retained across initial and subsequent renders without triggering unnecessary network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->