### PR TITLE
Fix stale incremental stream timeouts

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -657,6 +657,7 @@ export default function run(config: Partial<Config>) {
     let incrementalExecutionContextReleased = false;
     let pullModeRequestCanIdle = false;
     let incrementalResponseFinishTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    let stopIncrementalRequestReader: (() => void) | undefined;
     let incrementalTracingContext: TracingContext | undefined;
 
     const clearIncrementalResponseFinishTimeout = () => {
@@ -666,6 +667,24 @@ export default function run(config: Partial<Config>) {
 
       clearTimeout(incrementalResponseFinishTimeoutId);
       incrementalResponseFinishTimeoutId = undefined;
+    };
+
+    const shouldStopReadingIncrementalRequest = () =>
+      pullModeRequestCanIdle && responseStarted && incrementalResponseFinished;
+
+    const wakeIncrementalRequestReader = () => {
+      stopIncrementalRequestReader?.();
+      stopIncrementalRequestReader = undefined;
+    };
+
+    const waitForIncrementalRequestReaderStop = () => {
+      if (shouldStopReadingIncrementalRequest()) {
+        return Promise.resolve();
+      }
+
+      return new Promise<void>((resolve) => {
+        stopIncrementalRequestReader = resolve;
+      });
     };
 
     const releaseIncrementalExecutionContextWhenDone = () => {
@@ -686,6 +705,7 @@ export default function run(config: Partial<Config>) {
     const markIncrementalResponseFinished = () => {
       clearIncrementalResponseFinishTimeout();
       incrementalResponseFinished = true;
+      wakeIncrementalRequestReader();
       releaseIncrementalExecutionContextWhenDone();
     };
 
@@ -920,6 +940,8 @@ export default function run(config: Partial<Config>) {
               await closeIncrementalRequest();
             },
             getChunkTimeoutMs: getIncrementalRequestChunkTimeoutMs,
+            shouldStopReading: shouldStopReadingIncrementalRequest,
+            waitForStopReading: waitForIncrementalRequestReaderStop,
           });
         },
         startSsrRequestOptions({ renderingRequest: 'ReactOnRails.incrementalRender' }),

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -655,6 +655,7 @@ export default function run(config: Partial<Config>) {
     let incrementalRequestClosed = false;
     let incrementalResponseFinished = false;
     let incrementalExecutionContextReleased = false;
+    let pullModeRequestCanIdle = false;
     let incrementalResponseFinishTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let incrementalTracingContext: TracingContext | undefined;
 
@@ -714,6 +715,62 @@ export default function run(config: Partial<Config>) {
         }
         markIncrementalResponseFinished();
       }, INCREMENTAL_RESPONSE_FINISH_TIMEOUT_MS);
+    };
+
+    const refreshIncrementalResponseFinishTimeout = () => {
+      if (
+        !incrementalRequestClosed ||
+        incrementalResponseFinished ||
+        incrementalExecutionContextReleased ||
+        !incrementalSink
+      ) {
+        return;
+      }
+
+      clearIncrementalResponseFinishTimeout();
+      scheduleIncrementalResponseFinishTimeout();
+    };
+
+    const trackIncrementalResponseProgress = (stream: NonNullable<ResponseResult['stream']>) => {
+      const progressStream = new Transform({
+        transform(chunk, encoding, callback) {
+          refreshIncrementalResponseFinishTimeout();
+          callback(null, chunk);
+        },
+      });
+      const forwardSourceError = (error: Error) => progressStream.destroy(error);
+      const endProgressStream = () => {
+        if (!progressStream.writableEnded && !progressStream.destroyed) {
+          progressStream.end();
+        }
+      };
+
+      stream.once('close', endProgressStream);
+      stream.once('error', forwardSourceError);
+      progressStream.once('close', () => {
+        stream.off('close', endProgressStream);
+        stream.off('error', forwardSourceError);
+        if (!progressStream.writableEnded && !stream.destroyed) {
+          stream.destroy();
+        }
+      });
+      stream.pipe(progressStream);
+
+      return progressStream;
+    };
+
+    const getIncrementalRequestChunkTimeoutMs = () => {
+      if (
+        pullModeRequestCanIdle &&
+        responseStarted &&
+        !incrementalResponseFinished &&
+        !res.raw.destroyed &&
+        !res.raw.writableEnded
+      ) {
+        return Number.POSITIVE_INFINITY;
+      }
+
+      return STREAM_CHUNK_TIMEOUT_MS;
     };
 
     const waitForIncrementalRequestClose = async (closeRequestPromise: Promise<void>, timeoutMs: number) => {
@@ -798,6 +855,7 @@ export default function run(config: Partial<Config>) {
               try {
                 const { response, sink } = await handleIncrementalRenderRequest(initial);
                 incrementalSink = sink;
+                pullModeRequestCanIdle = !!incrementalSink && tempReqBody.pullEnabled === true;
 
                 return {
                   response,
@@ -836,13 +894,14 @@ export default function run(config: Partial<Config>) {
             onResponseStart: async (response: ResponseResult) => {
               responseStarted = true;
               if (response.stream) {
+                const responseStream = trackIncrementalResponseProgress(response.stream);
                 const markFinished = runWhenStreamFinishes(
-                  response.stream,
+                  responseStream,
                   res,
                   markIncrementalResponseFinished,
                 );
                 try {
-                  await setResponse(response, res);
+                  await setResponse({ ...response, stream: responseStream }, res);
                 } catch (error) {
                   markFinished();
                   throw error;
@@ -860,6 +919,7 @@ export default function run(config: Partial<Config>) {
             onRequestEnded: async () => {
               await closeIncrementalRequest();
             },
+            getChunkTimeoutMs: getIncrementalRequestChunkTimeoutMs,
           });
         },
         startSsrRequestOptions({ renderingRequest: 'ReactOnRails.incrementalRender' }),

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -73,6 +73,9 @@ const INCREMENTAL_REQUEST_CLOSE_TIMEOUT_MS = 1_000;
 // retain VM source-map registrations for the same idle period.
 const STREAM_CONTEXT_RELEASE_TIMEOUT_MS = STREAM_CHUNK_TIMEOUT_MS;
 const INCREMENTAL_RESPONSE_FINISH_TIMEOUT_MS = STREAM_CONTEXT_RELEASE_TIMEOUT_MS;
+// Pull-mode clients can legitimately pause longer than the normal chunk window;
+// this coarse deadman only bounds abandoned request/response pairs.
+const INCREMENTAL_PULL_MODE_IDLE_TIMEOUT_MS = STREAM_CHUNK_TIMEOUT_MS * 15;
 // Uncomment the below for testing timeouts:
 // import { delay } from './shared/utils.js';
 //
@@ -656,7 +659,9 @@ export default function run(config: Partial<Config>) {
     let incrementalResponseFinished = false;
     let incrementalExecutionContextReleased = false;
     let pullModeRequestCanIdle = false;
+    let incrementalRequestClosePromise: Promise<void> | undefined;
     let incrementalResponseFinishTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    let incrementalPullModeIdleTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let stopIncrementalRequestReader: (() => void) | undefined;
     let incrementalTracingContext: TracingContext | undefined;
 
@@ -667,6 +672,15 @@ export default function run(config: Partial<Config>) {
 
       clearTimeout(incrementalResponseFinishTimeoutId);
       incrementalResponseFinishTimeoutId = undefined;
+    };
+
+    const clearIncrementalPullModeIdleTimeout = () => {
+      if (!incrementalPullModeIdleTimeoutId) {
+        return;
+      }
+
+      clearTimeout(incrementalPullModeIdleTimeoutId);
+      incrementalPullModeIdleTimeoutId = undefined;
     };
 
     const shouldStopReadingIncrementalRequest = () =>
@@ -704,6 +718,7 @@ export default function run(config: Partial<Config>) {
 
     const markIncrementalResponseFinished = () => {
       clearIncrementalResponseFinishTimeout();
+      clearIncrementalPullModeIdleTimeout();
       incrementalResponseFinished = true;
       wakeIncrementalRequestReader();
       releaseIncrementalExecutionContextWhenDone();
@@ -737,6 +752,109 @@ export default function run(config: Partial<Config>) {
       }, INCREMENTAL_RESPONSE_FINISH_TIMEOUT_MS);
     };
 
+    const waitForIncrementalRequestClose = async (closeRequestPromise: Promise<void>, timeoutMs: number) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<'timeout'>((resolve) => {
+        timeoutId = setTimeout(() => resolve('timeout'), timeoutMs);
+      });
+
+      const result = await Promise.race([closeRequestPromise.then(() => 'closed' as const), timeoutPromise]);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      if (result === 'timeout') {
+        log.warn({
+          msg: 'Timed out waiting for incremental render close hook after response started',
+          timeoutMs,
+        });
+      }
+    };
+
+    const closeIncrementalRequest = async ({
+      timeoutMs = INCREMENTAL_REQUEST_CLOSE_TIMEOUT_MS,
+    }: { timeoutMs?: number } = {}) => {
+      if (!incrementalSink || incrementalRequestClosed) {
+        return;
+      }
+      clearIncrementalPullModeIdleTimeout();
+      if (incrementalRequestClosePromise) {
+        await incrementalRequestClosePromise;
+        return;
+      }
+      const sink = incrementalSink;
+
+      incrementalRequestClosePromise = (async () => {
+        await waitForIncrementalRequestClose(
+          Promise.resolve()
+            .then(() => sink.handleRequestClosed())
+            .catch((closeError: unknown) => {
+              log.error({
+                msg: 'Error while closing incremental render request after response started',
+                error: closeError,
+              });
+            }),
+          timeoutMs,
+        );
+      })();
+
+      try {
+        await incrementalRequestClosePromise;
+      } finally {
+        incrementalRequestClosePromise = undefined;
+        incrementalRequestClosed = true;
+        clearIncrementalPullModeIdleTimeout();
+        scheduleIncrementalResponseFinishTimeout();
+        releaseIncrementalExecutionContextWhenDone();
+      }
+    };
+
+    const shouldWatchPullModeIdleProgress = () =>
+      pullModeRequestCanIdle &&
+      responseStarted &&
+      !incrementalRequestClosed &&
+      !incrementalResponseFinished &&
+      !incrementalExecutionContextReleased &&
+      !!incrementalSink &&
+      !res.raw.destroyed &&
+      !res.raw.writableEnded;
+
+    const scheduleIncrementalPullModeIdleTimeout = () => {
+      if (incrementalPullModeIdleTimeoutId || !shouldWatchPullModeIdleProgress()) {
+        return;
+      }
+
+      incrementalPullModeIdleTimeoutId = setTimeout(() => {
+        incrementalPullModeIdleTimeoutId = undefined;
+        if (!shouldWatchPullModeIdleProgress()) {
+          return;
+        }
+
+        log.warn({
+          msg: 'Timed out waiting for pull-mode incremental render progress after response started',
+          timeoutMs: INCREMENTAL_PULL_MODE_IDLE_TIMEOUT_MS,
+        });
+
+        if (!res.raw.destroyed) {
+          res.raw.destroy();
+        }
+        void closeIncrementalRequest({
+          timeoutMs: INCREMENTAL_REQUEST_CLOSE_TIMEOUT_MS,
+        });
+        markIncrementalResponseFinished();
+      }, INCREMENTAL_PULL_MODE_IDLE_TIMEOUT_MS);
+    };
+
+    const refreshIncrementalPullModeIdleTimeout = () => {
+      if (!shouldWatchPullModeIdleProgress()) {
+        clearIncrementalPullModeIdleTimeout();
+        return;
+      }
+
+      clearIncrementalPullModeIdleTimeout();
+      scheduleIncrementalPullModeIdleTimeout();
+    };
+
     const refreshIncrementalResponseFinishTimeout = () => {
       if (
         !incrementalRequestClosed ||
@@ -754,6 +872,7 @@ export default function run(config: Partial<Config>) {
     const trackIncrementalResponseProgress = (stream: NonNullable<ResponseResult['stream']>) => {
       const progressStream = new Transform({
         transform(chunk, encoding, callback) {
+          refreshIncrementalPullModeIdleTimeout();
           refreshIncrementalResponseFinishTimeout();
           callback(null, chunk);
         },
@@ -787,56 +906,12 @@ export default function run(config: Partial<Config>) {
         !res.raw.destroyed &&
         !res.raw.writableEnded
       ) {
+        scheduleIncrementalPullModeIdleTimeout();
         return Number.POSITIVE_INFINITY;
       }
 
+      clearIncrementalPullModeIdleTimeout();
       return STREAM_CHUNK_TIMEOUT_MS;
-    };
-
-    const waitForIncrementalRequestClose = async (closeRequestPromise: Promise<void>, timeoutMs: number) => {
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      const timeoutPromise = new Promise<'timeout'>((resolve) => {
-        timeoutId = setTimeout(() => resolve('timeout'), timeoutMs);
-      });
-
-      const result = await Promise.race([closeRequestPromise.then(() => 'closed' as const), timeoutPromise]);
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-
-      if (result === 'timeout') {
-        log.warn({
-          msg: 'Timed out waiting for incremental render close hook after response started',
-          timeoutMs,
-        });
-      }
-    };
-
-    const closeIncrementalRequest = async ({
-      timeoutMs = INCREMENTAL_REQUEST_CLOSE_TIMEOUT_MS,
-    }: { timeoutMs?: number } = {}) => {
-      if (!incrementalSink || incrementalRequestClosed) {
-        return;
-      }
-      const sink = incrementalSink;
-
-      try {
-        await waitForIncrementalRequestClose(
-          Promise.resolve()
-            .then(() => sink.handleRequestClosed())
-            .catch((closeError: unknown) => {
-              log.error({
-                msg: 'Error while closing incremental render request after response started',
-                error: closeError,
-              });
-            }),
-          timeoutMs,
-        );
-      } finally {
-        incrementalRequestClosed = true;
-        scheduleIncrementalResponseFinishTimeout();
-        releaseIncrementalExecutionContextWhenDone();
-      }
     };
 
     try {
@@ -903,6 +978,7 @@ export default function run(config: Partial<Config>) {
                 return;
               }
 
+              refreshIncrementalPullModeIdleTimeout();
               try {
                 await incrementalSink.add(obj);
               } catch (err) {

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderStream.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderStream.ts
@@ -42,11 +42,20 @@ async function* withChunkTimeout<T>(
   waitForStopReading?: () => Promise<void>,
 ): AsyncGenerator<T, void, undefined> {
   const asyncIterator = iterator[Symbol.asyncIterator]();
+  const stopIterator = () => {
+    try {
+      const returnPromise = asyncIterator.return?.();
+      if (returnPromise) {
+        void Promise.resolve(returnPromise).catch(() => undefined);
+      }
+    } catch {
+      // The caller has already decided to stop reading; cleanup failures should not keep the response open.
+    }
+  };
 
   while (true) {
     if (shouldStopReading()) {
-      // eslint-disable-next-line no-await-in-loop
-      await asyncIterator.return?.();
+      stopIterator();
       return;
     }
 
@@ -64,8 +73,7 @@ async function* withChunkTimeout<T>(
           : nextChunkPromise);
         if (result === 'stop-reading') {
           if (shouldStopReading()) {
-            // eslint-disable-next-line no-await-in-loop
-            await asyncIterator.return?.();
+            stopIterator();
             return;
           }
 

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderStream.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderStream.ts
@@ -38,17 +38,50 @@ export class StreamChunkTimeoutError extends Error {
 async function* withChunkTimeout<T>(
   iterator: AsyncIterable<T>,
   getTimeoutMs: () => number,
+  shouldStopReading: () => boolean,
+  waitForStopReading?: () => Promise<void>,
 ): AsyncGenerator<T, void, undefined> {
   const asyncIterator = iterator[Symbol.asyncIterator]();
 
   while (true) {
+    if (shouldStopReading()) {
+      // eslint-disable-next-line no-await-in-loop
+      await asyncIterator.return?.();
+      return;
+    }
+
     let timeoutId: NodeJS.Timeout | undefined;
     const timeoutMs = getTimeoutMs();
 
     try {
       if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        const nextChunkPromise = asyncIterator.next();
+        const stopReadingPromise = waitForStopReading?.().then(() => 'stop-reading' as const);
+
         // eslint-disable-next-line no-await-in-loop
-        const result = await asyncIterator.next();
+        const result = await (stopReadingPromise
+          ? Promise.race([nextChunkPromise, stopReadingPromise])
+          : nextChunkPromise);
+        if (result === 'stop-reading') {
+          if (shouldStopReading()) {
+            // eslint-disable-next-line no-await-in-loop
+            await asyncIterator.return?.();
+            return;
+          }
+
+          // The stop signal was stale. Keep waiting for the in-flight read to settle
+          // before starting another read on the same async iterator.
+          // eslint-disable-next-line no-await-in-loop
+          const nextResult = await nextChunkPromise;
+          if (nextResult.done) {
+            return;
+          }
+
+          yield nextResult.value;
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
         if (result.done) {
           return;
         }
@@ -106,6 +139,8 @@ export interface IncrementalRenderStreamHandlerOptions {
   onUpdateReceived: (updateData: unknown) => Promise<void> | void;
   onRequestEnded: () => Promise<void> | void;
   getChunkTimeoutMs?: () => number;
+  shouldStopReading?: () => boolean;
+  waitForStopReading?: () => Promise<void>;
 }
 
 /**
@@ -123,6 +158,8 @@ export async function handleIncrementalRenderStream(
       onUpdateReceived,
       onRequestEnded,
       getChunkTimeoutMs = () => STREAM_CHUNK_TIMEOUT_MS,
+      shouldStopReading = () => false,
+      waitForStopReading,
     } = options;
 
     let hasReceivedFirstObject = false;
@@ -132,7 +169,12 @@ export async function handleIncrementalRenderStream(
     let onResponseStartPromise: Promise<void> | null = null;
 
     try {
-      for await (const chunk of withChunkTimeout(request.raw as AsyncIterable<Buffer>, getChunkTimeoutMs)) {
+      for await (const chunk of withChunkTimeout(
+        request.raw as AsyncIterable<Buffer>,
+        getChunkTimeoutMs,
+        shouldStopReading,
+        waitForStopReading,
+      )) {
         const chunkBuffer = chunk instanceof Buffer ? chunk : Buffer.from(chunk);
         totalBytesReceived += chunkBuffer.length;
 

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderStream.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderStream.ts
@@ -37,14 +37,27 @@ export class StreamChunkTimeoutError extends Error {
  */
 async function* withChunkTimeout<T>(
   iterator: AsyncIterable<T>,
-  timeoutMs: number,
+  getTimeoutMs: () => number,
 ): AsyncGenerator<T, void, undefined> {
   const asyncIterator = iterator[Symbol.asyncIterator]();
 
   while (true) {
     let timeoutId: NodeJS.Timeout | undefined;
+    const timeoutMs = getTimeoutMs();
 
     try {
+      if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await asyncIterator.next();
+        if (result.done) {
+          return;
+        }
+
+        yield result.value;
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
       // eslint-disable-next-line no-await-in-loop
       const result = await Promise.race([
         asyncIterator.next(),
@@ -92,6 +105,7 @@ export interface IncrementalRenderStreamHandlerOptions {
   onResponseStart: (response: ResponseResult) => Promise<void> | void;
   onUpdateReceived: (updateData: unknown) => Promise<void> | void;
   onRequestEnded: () => Promise<void> | void;
+  getChunkTimeoutMs?: () => number;
 }
 
 /**
@@ -102,7 +116,14 @@ export async function handleIncrementalRenderStream(
   options: IncrementalRenderStreamHandlerOptions,
 ): Promise<void> {
   return subSpan({ name: 'ror.incremental.stream' }, async () => {
-    const { request, onRenderRequestReceived, onResponseStart, onUpdateReceived, onRequestEnded } = options;
+    const {
+      request,
+      onRenderRequestReceived,
+      onResponseStart,
+      onUpdateReceived,
+      onRequestEnded,
+      getChunkTimeoutMs = () => STREAM_CHUNK_TIMEOUT_MS,
+    } = options;
 
     let hasReceivedFirstObject = false;
     const decoder = new StringDecoder('utf8');
@@ -111,10 +132,7 @@ export async function handleIncrementalRenderStream(
     let onResponseStartPromise: Promise<void> | null = null;
 
     try {
-      for await (const chunk of withChunkTimeout(
-        request.raw as AsyncIterable<Buffer>,
-        STREAM_CHUNK_TIMEOUT_MS,
-      )) {
+      for await (const chunk of withChunkTimeout(request.raw as AsyncIterable<Buffer>, getChunkTimeoutMs)) {
         const chunkBuffer = chunk instanceof Buffer ? chunk : Buffer.from(chunk);
         totalBytesReceived += chunkBuffer.length;
 

--- a/packages/react-on-rails-pro-node-renderer/tests/handleIncrementalRenderStream.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/handleIncrementalRenderStream.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { handleIncrementalRenderStream } from '../src/worker/handleIncrementalRenderStream';
-import { FIELD_SIZE_LIMIT } from '../src/shared/constants';
+import { FIELD_SIZE_LIMIT, STREAM_CHUNK_TIMEOUT_MS } from '../src/shared/constants';
 import * as errorReporter from '../src/shared/errorReporter';
 import type { ResponseResult } from '../src/shared/utils';
 
@@ -33,6 +33,54 @@ function createMockStream(chunks: Buffer[]): { raw: AsyncIterable<Buffer> } {
     },
   };
 }
+
+function createControlledStream(): {
+  raw: AsyncIterable<Buffer>;
+  push: (chunk: Buffer) => void;
+  end: () => void;
+} {
+  const queuedResults: IteratorResult<Buffer>[] = [];
+  let resolveNext: ((result: IteratorResult<Buffer>) => void) | undefined;
+
+  const emit = (result: IteratorResult<Buffer>) => {
+    if (resolveNext) {
+      const resolve = resolveNext;
+      resolveNext = undefined;
+      resolve(result);
+      return;
+    }
+
+    queuedResults.push(result);
+  };
+
+  return {
+    raw: {
+      [Symbol.asyncIterator](): AsyncIterator<Buffer> {
+        return {
+          next() {
+            const queuedResult = queuedResults.shift();
+            if (queuedResult) {
+              return Promise.resolve(queuedResult);
+            }
+
+            return new Promise<IteratorResult<Buffer>>((resolve) => {
+              resolveNext = resolve;
+            });
+          },
+        };
+      },
+    },
+    push: (chunk: Buffer) => emit({ value: chunk, done: false }),
+    end: () => emit({ value: undefined, done: true }),
+  };
+}
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 5; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
 
 /**
  * Creates a mock response result
@@ -361,6 +409,54 @@ describe('handleIncrementalRenderStream', () => {
   });
 
   describe('stream timeout', () => {
+    it('allows callers to suspend chunk timeouts for healthy pull-mode idle gaps', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const controlledStream = createControlledStream();
+        const onRenderRequestReceived = jest.fn().mockResolvedValue({
+          response: createMockResponse(),
+          shouldContinue: true,
+        });
+        const onUpdateReceived = jest.fn().mockResolvedValue(undefined);
+        const onRequestEnded = jest.fn();
+
+        const renderPromise = handleIncrementalRenderStream({
+          request: { raw: controlledStream.raw },
+          onRenderRequestReceived,
+          onResponseStart: jest.fn(),
+          onUpdateReceived,
+          onRequestEnded,
+          getChunkTimeoutMs: () => Number.POSITIVE_INFINITY,
+        });
+        const renderOutcome = renderPromise.then(
+          () => 'resolved' as const,
+          (error: unknown) => error,
+        );
+
+        controlledStream.push(Buffer.from(`${JSON.stringify({ id: 1 })}\n`));
+        await flushMicrotasks();
+        expect(onRenderRequestReceived).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(STREAM_CHUNK_TIMEOUT_MS + 1);
+        expect(onRequestEnded).not.toHaveBeenCalled();
+
+        controlledStream.push(Buffer.from(`${JSON.stringify({ id: 2 })}\n`));
+        await jest.advanceTimersByTimeAsync(0);
+        await flushMicrotasks();
+        expect(onUpdateReceived).toHaveBeenCalledTimes(1);
+        expect(onUpdateReceived).toHaveBeenCalledWith({ id: 2 });
+
+        controlledStream.end();
+        await flushMicrotasks();
+
+        await expect(renderOutcome).resolves.toBe('resolved');
+        expect(onRequestEnded).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('throws StreamChunkTimeoutError when a chunk takes too long', async () => {
       const mockRequest = {
         raw: {

--- a/packages/react-on-rails-pro-node-renderer/tests/handleIncrementalRenderStream.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/handleIncrementalRenderStream.test.ts
@@ -516,6 +516,62 @@ describe('handleIncrementalRenderStream', () => {
       }
     });
 
+    it('does not wait for iterator return when stopping a suspended request read', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const controlledStream = createControlledStream();
+        controlledStream.cancel.mockImplementation(() => new Promise(() => {}));
+        let stopReading = false;
+        let resolveStopReading: (() => void) | undefined;
+        const stopReadingPromise = new Promise<void>((resolve) => {
+          resolveStopReading = resolve;
+        });
+        const onRenderRequestReceived = jest.fn().mockResolvedValue({
+          response: createMockResponse(),
+          shouldContinue: true,
+        });
+        const onUpdateReceived = jest.fn().mockResolvedValue(undefined);
+        const onRequestEnded = jest.fn();
+
+        const renderPromise = handleIncrementalRenderStream({
+          request: { raw: controlledStream.raw },
+          onRenderRequestReceived,
+          onResponseStart: jest.fn(),
+          onUpdateReceived,
+          onRequestEnded,
+          getChunkTimeoutMs: () => Number.POSITIVE_INFINITY,
+          shouldStopReading: () => stopReading,
+          waitForStopReading: () => stopReadingPromise,
+        });
+        const renderOutcome = renderPromise.then(
+          () => 'resolved' as const,
+          (error: unknown) => error,
+        );
+
+        controlledStream.push(Buffer.from(`${JSON.stringify({ id: 1 })}\n`));
+        await flushMicrotasks();
+        expect(onRenderRequestReceived).toHaveBeenCalledTimes(1);
+
+        stopReading = true;
+        resolveStopReading?.();
+        const boundedOutcome = Promise.race([
+          renderOutcome,
+          new Promise<'timed-out'>((resolve) => {
+            setTimeout(() => resolve('timed-out'), 1);
+          }),
+        ]);
+        await jest.advanceTimersByTimeAsync(1);
+
+        await expect(boundedOutcome).resolves.toBe('resolved');
+        expect(onUpdateReceived).not.toHaveBeenCalled();
+        expect(onRequestEnded).toHaveBeenCalledTimes(1);
+        expect(controlledStream.cancel).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('throws StreamChunkTimeoutError when a chunk takes too long', async () => {
       const mockRequest = {
         raw: {

--- a/packages/react-on-rails-pro-node-renderer/tests/handleIncrementalRenderStream.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/handleIncrementalRenderStream.test.ts
@@ -38,9 +38,14 @@ function createControlledStream(): {
   raw: AsyncIterable<Buffer>;
   push: (chunk: Buffer) => void;
   end: () => void;
+  cancel: jest.Mock<Promise<IteratorResult<Buffer>>, []>;
 } {
   const queuedResults: IteratorResult<Buffer>[] = [];
   let resolveNext: ((result: IteratorResult<Buffer>) => void) | undefined;
+  const cancel = jest.fn(() => {
+    emit({ value: undefined, done: true });
+    return Promise.resolve({ value: undefined, done: true });
+  });
 
   const emit = (result: IteratorResult<Buffer>) => {
     if (resolveNext) {
@@ -67,11 +72,13 @@ function createControlledStream(): {
               resolveNext = resolve;
             });
           },
+          return: cancel,
         };
       },
     },
     push: (chunk: Buffer) => emit({ value: chunk, done: false }),
     end: () => emit({ value: undefined, done: true }),
+    cancel,
   };
 }
 
@@ -452,6 +459,58 @@ describe('handleIncrementalRenderStream', () => {
 
         await expect(renderOutcome).resolves.toBe('resolved');
         expect(onRequestEnded).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('allows callers to stop a suspended request read when the response finishes first', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const controlledStream = createControlledStream();
+        let stopReading = false;
+        let resolveStopReading: (() => void) | undefined;
+        const stopReadingPromise = new Promise<void>((resolve) => {
+          resolveStopReading = resolve;
+        });
+        const onRenderRequestReceived = jest.fn().mockResolvedValue({
+          response: createMockResponse(),
+          shouldContinue: true,
+        });
+        const onUpdateReceived = jest.fn().mockResolvedValue(undefined);
+        const onRequestEnded = jest.fn();
+
+        const renderPromise = handleIncrementalRenderStream({
+          request: { raw: controlledStream.raw },
+          onRenderRequestReceived,
+          onResponseStart: jest.fn(),
+          onUpdateReceived,
+          onRequestEnded,
+          getChunkTimeoutMs: () => Number.POSITIVE_INFINITY,
+          shouldStopReading: () => stopReading,
+          waitForStopReading: () => stopReadingPromise,
+        });
+        const renderOutcome = renderPromise.then(
+          () => 'resolved' as const,
+          (error: unknown) => error,
+        );
+
+        controlledStream.push(Buffer.from(`${JSON.stringify({ id: 1 })}\n`));
+        await flushMicrotasks();
+        expect(onRenderRequestReceived).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(STREAM_CHUNK_TIMEOUT_MS + 1);
+        expect(onRequestEnded).not.toHaveBeenCalled();
+
+        stopReading = true;
+        resolveStopReading?.();
+        await flushMicrotasks();
+
+        await expect(renderOutcome).resolves.toBe('resolved');
+        expect(onUpdateReceived).not.toHaveBeenCalled();
+        expect(onRequestEnded).toHaveBeenCalledTimes(1);
+        expect(controlledStream.cancel).toHaveBeenCalledTimes(1);
       } finally {
         jest.useRealTimers();
       }

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -17,13 +17,17 @@ import formAutoContent from 'form-auto-content';
 import fs from 'fs';
 import path from 'path';
 import querystring from 'querystring';
+import { Readable } from 'stream';
 import { createReadStream } from 'fs-extra';
 // eslint-disable-next-line import/no-relative-packages
 import packageJson from '../package.json';
 import worker, { configureFastify, disableHttp2 } from '../src/worker';
 import * as vm from '../src/worker/vm';
+import type { ExecutionContext } from '../src/worker/vm';
 import * as errorReporter from '../src/shared/errorReporter';
+import { STREAM_CHUNK_TIMEOUT_MS } from '../src/shared/constants';
 import { __resetTracingForTest, setupTracing, type TracingContext } from '../src/shared/tracing';
+import * as incremental from '../src/worker/handleIncrementalRenderRequest';
 import {
   BUNDLE_TIMESTAMP,
   SECONDARY_BUNDLE_TIMESTAMP,
@@ -51,6 +55,28 @@ const { protocolVersion } = packageJson;
 const railsEnv = 'test';
 
 disableHttp2();
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 5; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
+
+const waitForMockCalls = async (mockFn: jest.Mock, expectedCalls: number) => {
+  for (let i = 0; i < 50; i += 1) {
+    if (mockFn.mock.calls.length >= expectedCalls) {
+      return;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await jest.advanceTimersByTimeAsync(1);
+    // eslint-disable-next-line no-await-in-loop
+    await flushMicrotasks();
+  }
+
+  expect(mockFn).toHaveBeenCalledTimes(expectedCalls);
+};
 
 // Helper to create worker with standard options
 const createWorker = (options: Parameters<typeof worker>[0] = {}) =>
@@ -1408,6 +1434,73 @@ describe('worker', () => {
       expect(res.statusCode).toBe(200);
       expect(res.headers['cache-control']).toBe('public, max-age=31536000');
       expect(res.payload).toBe('{"html":"Dummy Object"}');
+    });
+
+    test('keeps an incremental response alive when response chunks arrive after request EOF', async () => {
+      jest.useFakeTimers();
+
+      const responseStream = new Readable({
+        read() {
+          // Test pushes chunks manually.
+        },
+      });
+      const handleRequestClosed = jest.fn().mockResolvedValue(undefined);
+      const releaseExecutionContext = jest.fn();
+      const handleSpy = jest.spyOn(incremental, 'handleIncrementalRenderRequest').mockResolvedValue({
+        response: {
+          status: 200,
+          headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+          stream: responseStream,
+        },
+        sink: {
+          add: jest.fn(),
+          handleRequestClosed,
+          executionContext: { release: releaseExecutionContext } as unknown as ExecutionContext,
+        },
+      });
+
+      try {
+        const app = createWorkerApp();
+        const payload = {
+          gemVersion,
+          protocolVersion,
+          password: 'my_password',
+          renderingRequest: 'ReactOnRails.dummy',
+          dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
+        };
+
+        const responsePromise = app
+          .inject()
+          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+          .payload(createNDJSONPayload(payload))
+          .headers({
+            'Content-Type': 'application/x-ndjson',
+          })
+          .end();
+
+        await waitForMockCalls(handleSpy, 1);
+        await waitForMockCalls(handleRequestClosed, 1);
+
+        responseStream.push('first chunk');
+        await jest.advanceTimersByTimeAsync(STREAM_CHUNK_TIMEOUT_MS - 1);
+
+        responseStream.push('second chunk');
+        await jest.advanceTimersByTimeAsync(1);
+
+        responseStream.push('third chunk');
+        responseStream.push(null);
+        await jest.advanceTimersByTimeAsync(0);
+
+        const res = await responsePromise;
+
+        expect(res.statusCode).toBe(200);
+        expect(res.payload).toBe('first chunksecond chunkthird chunk');
+        expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+      } finally {
+        responseStream.destroy();
+        handleSpy.mockRestore();
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -17,7 +17,7 @@ import formAutoContent from 'form-auto-content';
 import fs from 'fs';
 import path from 'path';
 import querystring from 'querystring';
-import { Readable } from 'stream';
+import { PassThrough, Readable } from 'stream';
 import { createReadStream } from 'fs-extra';
 // eslint-disable-next-line import/no-relative-packages
 import packageJson from '../package.json';
@@ -1497,6 +1497,156 @@ describe('worker', () => {
         expect(res.payload).toBe('first chunksecond chunkthird chunk');
         expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
       } finally {
+        responseStream.destroy();
+        handleSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+
+    test('closes a stalled pull-mode incremental stream after the idle watchdog expires', async () => {
+      jest.useFakeTimers();
+
+      const requestStream = new PassThrough();
+      const responseStream = new Readable({
+        read() {
+          // Test leaves the response open to simulate a renderer that stopped producing chunks.
+        },
+      });
+      const handleRequestClosed = jest.fn().mockResolvedValue(undefined);
+      const releaseExecutionContext = jest.fn();
+      const handleSpy = jest.spyOn(incremental, 'handleIncrementalRenderRequest').mockResolvedValue({
+        response: {
+          status: 200,
+          headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+          stream: responseStream,
+        },
+        sink: {
+          add: jest.fn(),
+          handleRequestClosed,
+          executionContext: { release: releaseExecutionContext } as unknown as ExecutionContext,
+        },
+      });
+
+      try {
+        const app = createWorkerApp();
+        const payload = {
+          gemVersion,
+          protocolVersion,
+          password: 'my_password',
+          renderingRequest: 'ReactOnRails.dummy',
+          dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
+          pullEnabled: true,
+        };
+
+        const responsePromise = app
+          .inject()
+          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+          .payload(requestStream)
+          .headers({
+            'Content-Type': 'application/x-ndjson',
+          })
+          .end();
+        const responseResultPromise = responsePromise.catch((error: unknown) => error);
+
+        requestStream.write(createNDJSONPayload(payload));
+        await waitForMockCalls(handleSpy, 1);
+
+        await jest.advanceTimersByTimeAsync(STREAM_CHUNK_TIMEOUT_MS);
+        expect(handleRequestClosed).not.toHaveBeenCalled();
+        expect(releaseExecutionContext).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(STREAM_CHUNK_TIMEOUT_MS * 14);
+        await waitForMockCalls(handleRequestClosed, 1);
+
+        const responseResult = await responseResultPromise;
+
+        expect(responseResult).toBeInstanceOf(Error);
+        expect((responseResult as Error).message).toContain('response destroyed before completion');
+        expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+      } finally {
+        requestStream.destroy();
+        responseStream.destroy();
+        handleSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+
+    test('does not fire the pull-mode idle watchdog while the request close hook is running', async () => {
+      jest.useFakeTimers();
+
+      const requestStream = new PassThrough();
+      const responseStream = new Readable({
+        read() {
+          // Test pushes chunks manually after the request close hook completes.
+        },
+      });
+      let finishRequestClose: (() => void) | undefined;
+      const handleRequestClosed = jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRequestClose = resolve;
+          }),
+      );
+      const releaseExecutionContext = jest.fn();
+      const handleSpy = jest.spyOn(incremental, 'handleIncrementalRenderRequest').mockResolvedValue({
+        response: {
+          status: 200,
+          headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+          stream: responseStream,
+        },
+        sink: {
+          add: jest.fn(),
+          handleRequestClosed,
+          executionContext: { release: releaseExecutionContext } as unknown as ExecutionContext,
+        },
+      });
+
+      try {
+        const app = createWorkerApp();
+        const payload = {
+          gemVersion,
+          protocolVersion,
+          password: 'my_password',
+          renderingRequest: 'ReactOnRails.dummy',
+          dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
+          pullEnabled: true,
+        };
+
+        const responsePromise = app
+          .inject()
+          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+          .payload(requestStream)
+          .headers({
+            'Content-Type': 'application/x-ndjson',
+          })
+          .end();
+        const responseResultPromise = responsePromise.catch((error: unknown) => error);
+
+        requestStream.write(createNDJSONPayload(payload));
+        await waitForMockCalls(handleSpy, 1);
+
+        await jest.advanceTimersByTimeAsync(STREAM_CHUNK_TIMEOUT_MS * 15 - 500);
+        requestStream.end();
+        await waitForMockCalls(handleRequestClosed, 1);
+
+        await jest.advanceTimersByTimeAsync(500);
+        expect(responseStream.destroyed).toBe(false);
+        expect(releaseExecutionContext).not.toHaveBeenCalled();
+
+        finishRequestClose?.();
+        await jest.advanceTimersByTimeAsync(0);
+        responseStream.push('finished after close hook');
+        responseStream.push(null);
+        await jest.advanceTimersByTimeAsync(0);
+
+        const responseResult = await responseResultPromise;
+
+        expect(responseResult).not.toBeInstanceOf(Error);
+        expect(responseResult.statusCode).toBe(200);
+        expect(responseResult.payload).toBe('finished after close hook');
+        expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+      } finally {
+        requestStream.destroy();
         responseStream.destroy();
         handleSpy.mockRestore();
         jest.useRealTimers();


### PR DESCRIPTION
## Summary

Fixes #4310.
Fixes #4311.

This keeps healthy Pro node-renderer incremental streams from being destroyed by stale 20s request/finish timers while chunks are still flowing. It also wakes a suspended pull-mode request reader when the incremental response finishes first, so idle request reads can close cleanly instead of hanging forever.

Follow-up review fixes add a bounded pull-mode idle watchdog for genuinely stalled pull-mode request/response pairs and worker-level regression coverage for the real route wiring.

Release target evidence: the linked issues are labeled for the 17.0.0 release tracker; changelog text is deferred to the serial batch changelog finalizer.

## Test plan

- RED: added the suspended request-read regression and confirmed it timed out before the follow-up fix.
- GREEN: `pnpm --dir packages/react-on-rails-pro-node-renderer exec jest tests/handleIncrementalRenderStream.test.ts --runInBand`
- GREEN: `pnpm --dir packages/react-on-rails-pro-node-renderer exec jest tests/worker.test.ts --runInBand --silent`
- GREEN after review follow-up/current-main merge: `pnpm --dir packages/react-on-rails-pro-node-renderer exec jest tests/worker.test.ts tests/handleIncrementalRenderStream.test.ts --runInBand --silent`
- GREEN: `pnpm --dir packages/react-on-rails-pro-node-renderer run type-check`
- GREEN: `pnpm exec prettier --check packages/react-on-rails-pro-node-renderer/src/worker.ts packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderStream.ts packages/react-on-rails-pro-node-renderer/tests/handleIncrementalRenderStream.test.ts packages/react-on-rails-pro-node-renderer/tests/worker.test.ts`
- GREEN: `pnpm run lint`
- GREEN: `pnpm start format.listDifferent`
- GREEN: `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- GREEN: `script/check-pro-license-headers`
- GREEN: `script/ci-changes-detector origin/main` reports only React on Rails Pro Node Renderer package changes after the merge-base refresh.
- GREEN: `git diff --check`
- GREEN: coordinator self-review clean after the pull-mode idle watchdog follow-up.

Broad-suite note: `pnpm --dir packages/react-on-rails-pro-node-renderer run test` is blocked locally by missing generated Pro dummy RSC fixtures (`react_on_rails_pro/spec/dummy/ssr-generated/{rsc-bundle.js,server-bundle.js}`), not by this patch; hosted selected node-renderer package checks are passing/pending on the PR head.

## Review Follow-up

- Resolved Claude resource-exhaustion concern by bounding abandoned pull-mode streams with `INCREMENTAL_PULL_MODE_IDLE_TIMEOUT_MS` and clearing that watchdog before `handleRequestClosed` can race a healthy stream.
- Resolved Claude worker-level coverage concern with route-level pull-mode tests for the stalled-stream watchdog and pending-close-hook race.

## Changelog

Deferred to the serial batch changelog finalizer. Suggested entry:

- **[Pro]** **Incremental streaming reliability**: Prevent stale request and response-finish timers from closing healthy incremental streams while chunks continue, while bounding abandoned pull-mode streams.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced incremental (streaming) rendering behavior to better handle pull-based streaming responses, including more reliable idle detection.
  * Added more robust lifecycle controls so incremental streams can pause and resume based on connection activity.
* **Bug Fixes**
  * Prevented incremental render timeouts from triggering prematurely during expected streaming gaps.
  * Fixed stalled pull-mode renders by ensuring they close cleanly when the response finishes first or when the idle watchdog expires.
  * Improved cleanup to ensure execution and streaming resources are released consistently after completion or cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->