### PR TITLE
Document runtime RC blocker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4354](https://github.com/shakacode/react_on_rails/pull/4354) by
   [justin808](https://github.com/justin808).
 
-- **RSC Rspack boot validation warns on undetermined versions**: Boot now warns and continues when
+- **[Pro]** **RSC Rspack boot validation warns on undetermined versions**: Boot now warns and continues when
   the active Rspack version cannot be determined, while strict doctor checks and provable Rspack v1
   failures still fail closed. Fixes [Issue 4340](https://github.com/shakacode/react_on_rails/issues/4340).
   [PR 4355](https://github.com/shakacode/react_on_rails/pull/4355) by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,26 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4352](https://github.com/shakacode/react_on_rails/pull/4352) by
   [justin808](https://github.com/justin808).
 
+- **[Pro]** **RSC preload replay survives cache eviction**: Preloaded RSC payloads now remain
+  replayable after route cache eviction, preventing stale preload state from breaking refetches.
+  Fixes [Issue 4326](https://github.com/shakacode/react_on_rails/issues/4326).
+  [PR 4353](https://github.com/shakacode/react_on_rails/pull/4353) by
+  [justin808](https://github.com/justin808).
+
+- **[Pro]** **Incremental stream timers stay aligned with active chunks**: Healthy pull-mode
+  incremental streams are no longer closed by stale request or finish timers while chunks keep
+  progressing, while abandoned streams remain bounded by an idle watchdog. Fixes
+  [Issue 4310](https://github.com/shakacode/react_on_rails/issues/4310) and
+  [Issue 4311](https://github.com/shakacode/react_on_rails/issues/4311).
+  [PR 4354](https://github.com/shakacode/react_on_rails/pull/4354) by
+  [justin808](https://github.com/justin808).
+
+- **RSC Rspack boot validation warns on undetermined versions**: Boot now warns and continues when
+  the active Rspack version cannot be determined, while strict doctor checks and provable Rspack v1
+  failures still fail closed. Fixes [Issue 4340](https://github.com/shakacode/react_on_rails/issues/4340).
+  [PR 4355](https://github.com/shakacode/react_on_rails/pull/4355) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Gemfile loader source encodings are honored under C/POSIX locales**:
   The Pro Gemfile now loads its shared dependency fragments in binary mode, applies Ruby
   source-encoding magic comments or a UTF-8 default, and validates content before override-gem


### PR DESCRIPTION
## Summary

- Adds Unreleased changelog entries for runtime RC blocker PRs #4353, #4354, and #4355.
- Keeps CHANGELOG.md edits in the reserved serial finalizer lane instead of the implementation PRs.
- Confirms the release target as the 17.0.0 tracker/labeled issues, not 16.4.0.

## Test plan

- GREEN: `git diff --check`
- GREEN: `pnpm start format.listDifferent`
- GREEN: pre-commit `trailing-newlines`, `markdown-links`, `prettier`
- GREEN: pre-push `branch-lint` (no Ruby files) and online `markdown-links` (14 redirects, 0 errors)
- NOTE: `bundle exec rubocop` was run from the repo root as required, but fails on pre-existing main-branch spike offenses under `react_on_rails/spike/3313_prism_gemfile_rewriter/*`; this changelog PR touches no Ruby files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of streaming and preload behavior, reducing issues after cache eviction and keeping active updates in sync.
  * Added a clearer warning for uncertain startup conditions in one boot path while preserving safer failure handling for verified problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->