### PR TITLE
Fix visible hydration cleanup for detached roots

### DIFF
--- a/packages/react-on-rails/src/ClientRenderer.ts
+++ b/packages/react-on-rails/src/ClientRenderer.ts
@@ -174,6 +174,7 @@ function scheduleWhenVisible(domNode: Element, callback: () => void): () => void
       const target = entries[0]?.target;
       if (target && !target.isConnected) {
         observer.disconnect();
+        callback();
         return;
       }
       const isVisible = entries.some((entry) => entry.isIntersecting || entry.intersectionRatio > 0);

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -1135,6 +1135,63 @@ describe('ClientRenderer', () => {
       );
       expect(mockHydrateOrRender).toHaveBeenCalledTimes(1);
     });
+
+    it('drops a scheduled visible root when the observed target is detached', () => {
+      type ObserverCallback = ConstructorParameters<typeof IntersectionObserver>[0];
+      const observerInstances: Array<{
+        callback: ObserverCallback;
+        disconnect: jest.Mock;
+        observe: jest.Mock;
+      }> = [];
+
+      class MockIntersectionObserver {
+        callback: ObserverCallback;
+
+        disconnect = jest.fn();
+
+        observe = jest.fn();
+
+        constructor(callback: ObserverCallback) {
+          this.callback = callback;
+          observerInstances.push(this);
+        }
+      }
+
+      Object.defineProperty(globalThis, 'IntersectionObserver', {
+        configurable: true,
+        value: MockIntersectionObserver,
+      });
+
+      const targetNode = setupScheduledComponentDom('hydrate-visible-detached-drop', 'visible');
+      const mockHydrateOrRender = require('../src/reactHydrateOrRender.ts').default as jest.Mock;
+
+      renderComponent('hydrate-visible-detached-drop');
+      expect(observerInstances).toHaveLength(1);
+      expect(mockHydrateOrRender).not.toHaveBeenCalled();
+
+      targetNode.remove();
+      observerInstances[0].callback(
+        [
+          { isIntersecting: false, intersectionRatio: 0, target: targetNode },
+        ] as unknown as IntersectionObserverEntry[],
+        observerInstances[0] as unknown as IntersectionObserver,
+      );
+
+      expect(observerInstances[0].disconnect).toHaveBeenCalledTimes(1);
+      expect(mockHydrateOrRender).not.toHaveBeenCalled();
+
+      const replacementNode = document.createElement('div');
+      replacementNode.id = 'hydrate-visible-detached-drop';
+      replacementNode.innerHTML = '<div>Replacement server rendered</div>';
+      document.body.appendChild(replacementNode);
+
+      renderComponent('hydrate-visible-detached-drop');
+
+      expect(observerInstances).toHaveLength(2);
+      expect(observerInstances[0].disconnect).toHaveBeenCalledTimes(1);
+      expect(observerInstances[1].observe).toHaveBeenCalledWith(replacementNode);
+      expect(mockHydrateOrRender).not.toHaveBeenCalled();
+    });
   });
 
   describe('page unload cleanup (React-root cleanup)', () => {


### PR DESCRIPTION
## Why

`hydrate_on: visible` could leave a scheduled root entry behind when the observed target was detached before it became visible. That stale scheduled entry kept the detached DOM node reachable and could prevent a replacement node with the same DOM id from scheduling cleanly.

Fixes #4328.

## What changed

- When the visible-hydration observer sees that its target is detached, it now runs the scheduled callback after disconnecting.
- The scheduled callback already guards `domNode.isConnected`, so this deletes the stale scheduled entry without hydrating the removed node.
- Added a regression test that detaches the observed node, verifies no hydration occurs, and confirms a replacement node can be observed with a fresh schedule.

## Validation

Coordinator verified:

- `pnpm --filter react-on-rails exec jest tests/ClientRenderer.test.ts --runInBand`
- `pnpm --filter react-on-rails run type-check`
- `pnpm exec prettier --check packages/react-on-rails/src/ClientRenderer.ts packages/react-on-rails/tests/ClientRenderer.test.ts`
- `pnpm exec eslint packages/react-on-rails/src/ClientRenderer.ts --no-warn-ignored`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` (clean: no actionable regressions)

Worker also ran:

- RED/green focused ClientRenderer regression path
- `pnpm test ClientRenderer`

## Changelog

Not added: this is an internal client cleanup bug fix with no public API or documentation change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduled hydration behavior when a visible target is removed from the page before it becomes active.
  * Improved handling of replaced DOM content so new elements can be observed correctly without triggering unexpected hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->