### PR TITLE
Avoid caching async props prerender streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Async-props prerender stream cache isolation**: Pro prerender stream caching now
+  bypasses renders that use async props, so per-request async stream output cannot be replayed from
+  another request's cached stream. Fixes
+  [Issue 4359](https://github.com/shakacode/react_on_rails/issues/4359).
+  [PR 4376](https://github.com/shakacode/react_on_rails/pull/4376) by
+  [justin808](https://github.com/justin808).
+
 - **`hydrate_on: nil` falls back to immediate hydration**: Passing `hydrate_on: nil` now behaves
   like the default `:immediate` mode instead of raising, while invalid explicit values still fail
   fast. Fixes [Issue 4342](https://github.com/shakacode/react_on_rails/issues/4342).

--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb
@@ -67,7 +67,8 @@ module ReactOnRailsPro
 
         def cache_enabled_for?(render_options)
           ReactOnRailsPro.configuration.prerender_caching &&
-            render_options.internal_option(:skip_prerender_cache).nil?
+            render_options.internal_option(:skip_prerender_cache).nil? &&
+            render_options.internal_option(:async_props_block).nil?
         end
 
         def render_with_cache(js_code, render_options)

--- a/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
@@ -139,6 +139,19 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
         def each; end
       end
     end
+    let(:fake_stream_class) do
+      Class.new do
+        def initialize(chunks)
+          @chunks = chunks
+        end
+
+        def each_chunk(&block)
+          return enum_for(:each_chunk) unless block
+
+          @chunks.each(&block)
+        end
+      end
+    end
     let(:pool) { instance_double(pool_class) }
     let(:cache_store) do
       Class.new do
@@ -155,6 +168,14 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
 
           # Store the original object reference so the spec catches cache metadata mutation leaks.
           @store[key] = yield
+        end
+
+        def read(key)
+          @store[key]
+        end
+
+        def write(key, value, _options = {})
+          @store[key] = value
         end
 
         def value_for(key)
@@ -300,6 +321,27 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
                 upstream_stream,
                 cache_options:)
         expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
+      end
+
+      it "does not replay a cached stream when async props can emit per-request data" do
+        async_props_block = proc { |emit| emit.call("currentUser", "request-user") }
+        first_options = build_render_options(streaming: true, internal_options: { async_props_block: })
+        second_options = build_render_options(streaming: true, internal_options: { async_props_block: })
+
+        allow(pool).to receive(:exec_server_render_js)
+          .and_return(
+            fake_stream_class.new(%w[shell user-a]),
+            fake_stream_class.new(%w[shell user-b])
+          )
+
+        first_chunks = []
+        described_class.exec_server_render_js(js_code, first_options).each_chunk { |chunk| first_chunks << chunk }
+        second_chunks = []
+        described_class.exec_server_render_js(js_code, second_options).each_chunk { |chunk| second_chunks << chunk }
+
+        expect(first_chunks).to eq(%w[shell user-a])
+        expect(second_chunks).to eq(%w[shell user-b])
+        expect(pool).to have_received(:exec_server_render_js).twice
       end
     end
   end

--- a/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
@@ -170,14 +170,6 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
           @store[key] = yield
         end
 
-        def read(key)
-          @store[key]
-        end
-
-        def write(key, value, _options = {})
-          @store[key] = value
-        end
-
         def value_for(key)
           @store.fetch(key)
         end


### PR DESCRIPTION
## Summary
- bypass Pro prerender stream caching whenever a render uses an async props block
- add a regression spec proving per-request async stream output is not replayed from another request
- document the release/runtime fix in the changelog

## Rationale
Issue #4359 is a release-blocking security/cache-isolation bug: async props can emit user-specific data after the initial render path, so reusing a prerender stream cache entry can replay another request's async content. This PR keeps static prerender stream caching intact but excludes async-props renders from that cache path.

Fixes #4359.

## Tests
- `BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rspec react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb`
- `cd react_on_rails_pro && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion`
- `script/check-pro-license-headers`
- `pnpm exec prettier --check CHANGELOG.md`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` (no findings)

## Codex Decision Log
- **Non-blocking:** Whether to try to cache async-props prerender streams with a richer cache key.
  - **Decision:** Disable prerender stream caching when `async_props_block` is present.
  - **Why:** The async block can encode request/user state that is not part of the current stream cache key, and the release-blocking risk is cross-user replay.
  - **Review later:** A future design could add explicit async-props-safe cache keys.

## Batch A
- Workflow config: UNKNOWN repo-local `.agents/agent-workflow.yml` and `.agents/workflows/pr-processing.md` absent; used installed PR-processing workflow.
- QA lane: required, owner `qa/batch-a`, pending final batch QA.
- Changelog: included in `CHANGELOG.md`.
