### PR TITLE
Guard preload links for older Shakapacker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **Preload links stay compatible with older Shakapacker**: `react_on_rails_preload_links` now
+  skips SRI attributes when Shakapacker does not expose integrity settings, avoiding a
+  `NoMethodError` while still emitting preload hints. Fixes
+  [Issue 4369](https://github.com/shakacode/react_on_rails/issues/4369).
+  [PR 4377](https://github.com/shakacode/react_on_rails/pull/4377) by
+  [justin808](https://github.com/justin808).
+
 - **`hydrate_on: nil` falls back to immediate hydration**: Passing `hydrate_on: nil` now behaves
   like the default `:immediate` mode instead of raising, while invalid explicit values still fail
   fast. Fixes [Issue 4342](https://github.com/shakacode/react_on_rails/issues/4342).

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -77,6 +77,8 @@ This helper only emits HTML link tags. Keep the normal `stylesheet_pack_tag` and
 
 When using a CDN asset host, keep Shakapacker's Subresource Integrity and `crossorigin` settings consistent between preload tags and the final script/style tags so the browser can reuse the preloaded response.
 
+With Shakapacker versions before 8.4 that do not expose `config.integrity`, preload links are still emitted without `integrity` attributes. React on Rails only adds preload SRI attributes when Shakapacker exposes integrity settings and marks them enabled.
+
 ---
 
 ### react_component_hash

--- a/docs/oss/building-features/performance-tracks-and-profiling.md
+++ b/docs/oss/building-features/performance-tracks-and-profiling.md
@@ -124,7 +124,7 @@ Then:
    you above it.
 4. Report a **Wilcoxon signed-rank p-value**; treat **p < 0.05** as strong directional evidence of a real shift when the paired samples consistently move in the same direction.
 
-We use [ShakaPerf](https://github.com/shakacode/shakaperf) for this — it brings up the twin production-local servers and runs the paired comparison with `shaka-perf compare --categories perf`. The methodology is what matters, not the tool: any harness that runs two production builds side by side under identical mobile throttling with paired sampling and a significance test gives you the same signal.
+We use ShakaPerf for this — it brings up the twin production-local servers and runs the paired comparison with `shaka-perf compare --categories perf`. The methodology is what matters, not the tool: any harness that runs two production builds side by side under identical mobile throttling with paired sampling and a significance test gives you the same signal.
 
 ### Reading the result
 

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -594,7 +594,7 @@ module ReactOnRails
       integrity = preload_source_integrity(source)
       return attributes unless integrity.present?
 
-      cross_origin = current_shakapacker_instance.config.integrity[:cross_origin]
+      cross_origin = shakapacker_integrity_config[:cross_origin]
       attributes.merge(integrity:, crossorigin: cross_origin.nil? ? preload_crossorigin : cross_origin)
     end
 
@@ -610,14 +610,21 @@ module ReactOnRails
     end
 
     def preload_source_integrity(source)
-      return unless current_shakapacker_instance.config.integrity[:enabled]
+      return unless shakapacker_integrity_config[:enabled]
 
       preload_manifest_value(source, "integrity")
     end
 
     def preload_crossorigin
-      cross_origin = current_shakapacker_instance.config.integrity[:cross_origin]
+      cross_origin = shakapacker_integrity_config[:cross_origin]
       cross_origin.nil? ? "anonymous" : cross_origin
+    end
+
+    def shakapacker_integrity_config
+      config = current_shakapacker_instance.config
+      return {} unless config.respond_to?(:integrity)
+
+      config.integrity || {}
     end
 
     def modulepreload_source?(source)

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -220,6 +220,44 @@ describe ReactOnRailsHelper do
       expect(links.first["crossorigin"]).to eq("anonymous")
     end
 
+    context "when Shakapacker does not expose integrity settings" do
+      let(:shakapacker_config) do
+        Object.new.tap do |config|
+          def config.nested_entries?
+            true
+          end
+        end
+      end
+
+      it "emits preload links without integrity attributes" do
+        allow(manifest).to receive(:lookup_pack_with_chunks!)
+          .with("generated/ModernComponent", type: :javascript)
+          .and_return([
+                        {
+                          "src" => "/packs/generated/ModernComponent-123.mjs",
+                          "integrity" => "sha384-modern"
+                        }
+                      ])
+        allow(manifest).to receive(:lookup_pack_with_chunks)
+          .with("generated/ModernComponent", type: :stylesheet)
+          .and_return([
+                        {
+                          "src" => "/packs/generated/ModernComponent-456.css",
+                          "integrity" => "sha384-style"
+                        }
+                      ])
+
+        links = preload_link_nodes(helper.react_on_rails_preload_links("modern_component"))
+
+        expect(links.map { |link| link["href"] }).to eq(
+          ["/packs/generated/ModernComponent-123.mjs", "/packs/generated/ModernComponent-456.css"]
+        )
+        expect(links.first["rel"]).to eq("modulepreload")
+        expect(links.first["crossorigin"]).to eq("anonymous")
+        expect(links.map { |link| link["integrity"] }).to eq([nil, nil])
+      end
+    end
+
     it "preserves configured crossorigin values on modulepreload tags without integrity" do
       allow(manifest).to receive(:lookup_pack_with_chunks!)
         .with("generated/ModernComponent", type: :javascript)


### PR DESCRIPTION
## Summary
- guard React on Rails preload-link SRI helpers when Shakapacker does not expose `config.integrity`
- keep preload hints rendering for Shakapacker versions before integrity settings existed
- document the compatibility behavior in the view helpers API reference and changelog

## Rationale
Issue #4369 affects apps on Shakapacker versions before the integrity configuration API: preload helpers can raise instead of emitting preload links. This PR treats missing integrity configuration as SRI disabled, preserving preload output while keeping existing SRI behavior for newer Shakapacker versions.

Fixes #4369.

## Tests
- `cd react_on_rails/spec/dummy && bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb:139`
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop`
- `pnpm exec prettier --check docs/oss/api-reference/view-helpers-api.md`
- `pnpm exec prettier --check CHANGELOG.md`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` (no findings)

- `pnpm exec prettier --check CHANGELOG.md docs/oss/api-reference/view-helpers-api.md docs/oss/building-features/performance-tracks-and-profiling.md`
- `lychee --config .lychee.toml docs/oss/building-features/performance-tracks-and-profiling.md`
- pre-push branch lint: RuboCop on branch Ruby files and online Lychee on branch Markdown files

## Codex Decision Log
- **Non-blocking:** Whether the stale ShakaPerf markdown link cleanup belongs in this PR.
  - **Decision:** Keep the one-line de-linking in this PR.
  - **Why:** Hosted `markdown-link-check` failed on the branch because the linked public repository returned 404; fixing that stale link was necessary to recover current-head hosted checks after the #4369 docs change.
  - **Review later:** None.

- **Non-blocking:** Whether missing Shakapacker integrity configuration should suppress all crossorigin attributes.
  - **Decision:** Only suppress SRI-derived `integrity` and configured `crossorigin`; keep existing modulepreload/browser preload behavior where applicable.
  - **Why:** Older Shakapacker has no integrity API, but preload links still need to render compatibly.
  - **Review later:** None.

## Batch A
- Workflow config: UNKNOWN repo-local `.agents/agent-workflow.yml` and `.agents/workflows/pr-processing.md` absent; used installed PR-processing workflow.
- QA lane: required, owner `qa/batch-a`, pending final batch QA.
- Changelog: included in `CHANGELOG.md`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preload link handling so links remain compatible with older builds when integrity settings aren’t available, avoiding errors and omitting unsupported security attributes.
  * Preload links still include the expected loading and cross-origin behavior.

* **Documentation**
  * Clarified preload/SRI behavior in the API reference.
  * Updated setup guidance wording in the performance profiling docs.

* **Chores**
  * Updated the changelog with the compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->