### PR TITLE
Handle fire-and-forget RSCRoute retry failures

### DIFF
--- a/packages/react-on-rails-pro/src/RSCRoute.tsx
+++ b/packages/react-on-rails-pro/src/RSCRoute.tsx
@@ -232,7 +232,7 @@ const RSCRouteContent = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
       // visible while the new promise streams in.
       const refetchPromise = refetchComponent(n, p, recoverOnError);
       const sharedRefetchVersion = getRefetchVersion(n, p);
-      return rejectErrorPayload(refetchPromise).catch((error: unknown) => {
+      const handledRefetchPromise = rejectErrorPayload(refetchPromise).catch((error: unknown) => {
         const serverComponentFetchError = toServerComponentFetchError(error, n, p);
         if (
           recoverOnError &&
@@ -245,6 +245,10 @@ const RSCRouteContent = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
         }
         throw serverComponentFetchError;
       });
+      if (recoverOnError) {
+        void handledRefetchPromise.catch(() => undefined);
+      }
+      return handledRefetchPromise;
     }, [getRefetchVersion, refetchComponent]);
 
     const clearRefetchError = useCallback(() => {

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -242,6 +242,30 @@ class CapturingErrorBoundary extends React.Component<
     );
   };
 
+  const FireAndForgetRetryControls: React.FC = () => {
+    const { refetch, refetchError, retry } = useCurrentRSCRoute();
+
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid="inline-refetch"
+          onClick={() => void refetch().catch(() => undefined)}
+        >
+          inline-refetch
+        </button>
+        {refetchError ? (
+          <div data-testid="recoverable-error">
+            {refetchError.message}
+            <button type="button" data-testid="inline-retry" onClick={() => void retry()}>
+              retry
+            </button>
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
   beforeEach(() => {
     // Start each test with a sensible default; tests that need different
     // payloads call setupSequencedFetcher again.
@@ -596,6 +620,71 @@ class CapturingErrorBoundary extends React.Component<
     await waitFor(() => expect(screen.getByTestId('card')).toHaveTextContent('Card v2'));
     expect(screen.queryByTestId('recoverable-error')).not.toBeInTheDocument();
     expect(ref.current!.refetchError).toBeNull();
+  });
+
+  it('1d4. production fire-and-forget retry failures are handled after refetchError records them', async () => {
+    process.env.NODE_ENV = 'production';
+    setupSequencedFetcher([
+      <div data-testid="card">
+        Card v1
+        <FireAndForgetRetryControls />
+      </div>,
+      rejectWith(new Error('initial recoverable refetch failed')),
+      rejectWith(new Error('fire-and-forget retry failed')),
+    ]);
+    const onRefetchError = jest.fn();
+    const unhandledRejections: unknown[] = [];
+    const captureUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    const ref = React.createRef<RSCRouteHandle>();
+
+    process.on('unhandledRejection', captureUnhandledRejection);
+    try {
+      await renderInAct(
+        <TestHarness>
+          <CapturingErrorBoundary fallback={(error) => <div data-testid="route-error">{error.message}</div>}>
+            <RSCRoute
+              ref={ref}
+              componentName="UserCard"
+              componentProps={{ id: 1 }}
+              onRefetchError={onRefetchError}
+            />
+          </CapturingErrorBoundary>
+        </TestHarness>,
+      );
+
+      expect(screen.getByTestId('card')).toHaveTextContent('Card v1');
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('inline-refetch'));
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('recoverable-error')).toHaveTextContent(
+          'initial recoverable refetch failed',
+        ),
+      );
+      await waitFor(() => expect(onRefetchError).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('inline-retry'));
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('recoverable-error')).toHaveTextContent('fire-and-forget retry failed'),
+      );
+      await waitFor(() => expect(onRefetchError).toHaveBeenCalledTimes(2));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(unhandledRejections).toEqual([]);
+      expect(screen.getByTestId('card')).toHaveTextContent('Card v1');
+      expect(screen.queryByTestId('route-error')).not.toBeInTheDocument();
+    } finally {
+      process.off('unhandledRejection', captureUnhandledRejection);
+    }
   });
 
   it('1e. production ignores recoverable refetch errors from stale route props', async () => {


### PR DESCRIPTION
## Summary

Fixes #4330.

Production `RSCRoute` recover-on-error retries preserve the previous route content, but a fire-and-forget caller could still leave the returned retry promise unhandled after the route recorded the recoverable error. This keeps the caller-visible promise rejected while attaching an internal no-op rejection handler in production recover-on-error mode.

## Changes

- Preserve the existing `refetch`/`retry` rejected promise contract for callers that await or catch it.
- Add a production recover-on-error handler so fire-and-forget retry failures do not surface as unhandled rejections.
- Add a regression test that retries from inline controls without catching the retry promise and asserts no `unhandledRejection` is emitted.

## Validation

- `pnpm --filter react-on-rails-pro exec jest tests/imperativeRefetch.client.test.tsx --runInBand`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm exec prettier --check packages/react-on-rails-pro/src/RSCRoute.tsx packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx`
- `pnpm exec eslint packages/react-on-rails-pro/src/RSCRoute.tsx packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx --no-warn-ignored`
- `script/check-pro-license-headers`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main`

No changelog entry: internal Pro client robustness fix with no public API change.