### PR TITLE
Flush RSC payloads before incomplete HTML tails

### DIFF
--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -265,30 +265,915 @@ function stylesheetTagsForRSCClientChunks(
   return stylesheetTags;
 }
 
-const RAW_TEXT_TAG_NAMES = ['script', 'style', 'textarea', 'title'];
+// Retain containers where injected payload scripts would not execute until after the closing tag.
+const RAW_TEXT_TAG_NAMES = [
+  'iframe',
+  'noembed',
+  'noframes',
+  'noscript',
+  'script',
+  'style',
+  'template',
+  'textarea',
+  'title',
+  'xmp',
+];
 
-const RAW_TEXT_TAG_PATTERN = new RegExp(`<(\\/?)(${RAW_TEXT_TAG_NAMES.join('|')})\\b[^>]*>`, 'gi');
+const RAW_TEXT_CLOSING_TAG_PREFIX_PATTERNS = new Map(
+  RAW_TEXT_TAG_NAMES.map((tagName) => [tagName, new RegExp(`</${tagName}(?=[\\s>/])`, 'gi')]),
+);
+const RAW_TEXT_TAG_NAME_SET = new Set(RAW_TEXT_TAG_NAMES);
+const FOREIGN_CONTENT_TAG_NAME_SET = new Set(['math', 'svg']);
+const SCRIPT_DOUBLE_ESCAPE_OPEN_PATTERN = /<script(?=[\s>/])/gi;
+const SCRIPT_SCAN_OVERLAP_LENGTH = Math.max('<!--'.length, '-->'.length, '<script'.length, '</script'.length);
+const CDATA_OPEN = '<![CDATA[';
+const CDATA_CLOSE = ']]>';
 
-function findUnclosedRawTextElementStart(htmlString: string) {
-  let openRawTextElement: { start: number; tagName: string } | undefined;
-  let match = RAW_TEXT_TAG_PATTERN.exec(htmlString);
-  while (match) {
-    const isClosingTag = match[1] === '/';
-    const tagName = match[2].toLowerCase();
-    if (isClosingTag) {
-      if (openRawTextElement?.tagName === tagName) {
-        openRawTextElement = undefined;
-      }
-    } else {
-      openRawTextElement = { start: match.index, tagName };
+type TemplateIgnoredTailScanState =
+  | { kind: 'comment' }
+  | { kind: 'cdata' }
+  | {
+      kind: 'template';
+      depth: number;
+      ignoredTailScanState?: TemplateIgnoredTailScanState;
     }
-    match = RAW_TEXT_TAG_PATTERN.exec(htmlString);
+  | {
+      kind: 'foreignContent';
+      tagName: string;
+      depth: number;
+      ignoredTailScanState?: TemplateIgnoredTailScanState;
+    }
+  | {
+      kind: 'rawText';
+      tagName: string;
+      scriptDataState?: ScriptDataState;
+    };
+
+type RetainedIncompleteHtmlTailScanState =
+  | { kind: 'comment'; closingSearchStart: number }
+  | { kind: 'cdata'; closingSearchStart: number }
+  | {
+      kind: 'foreignContent';
+      tagName: string;
+      closingSearchStart: number;
+      depth: number;
+      ignoredTailScanState?: TemplateIgnoredTailScanState;
+    }
+  | {
+      kind: 'rawText';
+      tagName: string;
+      closingSearchStart: number;
+      scriptDataState?: ScriptDataState;
+    }
+  | {
+      kind: 'template';
+      closingSearchStart: number;
+      depth: number;
+      ignoredTailScanState?: TemplateIgnoredTailScanState;
+    };
+
+type SplitIncompleteHtmlTailResult = {
+  completeHtml: string;
+  incompleteHtmlTagTail: string;
+  incompleteHtmlTailScanState?: RetainedIncompleteHtmlTailScanState;
+};
+
+type ScriptDataState = 'normal' | 'escaped' | 'doubleEscaped';
+
+type RawTextClosingTagScanResult = {
+  closingTagEnd?: number;
+  closingSearchStart: number;
+  scriptDataState?: ScriptDataState;
+};
+
+type ContainerTailScanResult = {
+  closingTagEnd?: number;
+  closingSearchStart: number;
+  depth: number;
+  ignoredTailScanState?: TemplateIgnoredTailScanState;
+};
+
+function findHtmlTagEnd(htmlString: string, tagStart: number) {
+  let quote: string | undefined;
+
+  for (let index = tagStart + 1; index < htmlString.length; index += 1) {
+    const character = htmlString[index];
+    if (quote) {
+      if (character === quote) quote = undefined;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      return index + 1;
+    }
   }
 
-  return openRawTextElement?.start;
+  return undefined;
 }
 
-function splitIncompleteHtmlTagTail(htmlString: string) {
+function isHtmlWhitespace(character: string) {
+  return (
+    character === '\t' || character === '\n' || character === '\f' || character === '\r' || character === ' '
+  );
+}
+
+function isHtmlSelfClosingStartTag(tag: string, attributesStartIndex: number) {
+  let state:
+    | 'beforeAttribute'
+    | 'attributeName'
+    | 'afterAttributeName'
+    | 'beforeAttributeValue'
+    | 'attributeValueQuoted'
+    | 'afterAttributeValueQuoted'
+    | 'attributeValueUnquoted'
+    | 'selfClosingStartTag' = 'beforeAttribute';
+  let quote: '"' | "'" | undefined;
+
+  for (let index = attributesStartIndex; index < tag.length - 1; index += 1) {
+    const character = tag[index];
+
+    if (state === 'attributeValueQuoted') {
+      if (character === quote) {
+        quote = undefined;
+        state = 'afterAttributeValueQuoted';
+      }
+    } else if (isHtmlWhitespace(character)) {
+      if (state === 'attributeName') {
+        state = 'afterAttributeName';
+      } else if (state === 'attributeValueUnquoted' || state === 'afterAttributeValueQuoted') {
+        state = 'beforeAttribute';
+      } else if (state === 'selfClosingStartTag') {
+        state = 'beforeAttribute';
+      }
+    } else if (state === 'beforeAttribute') {
+      state = character === '/' ? 'selfClosingStartTag' : 'attributeName';
+    } else if (state === 'attributeName') {
+      if (character === '=') state = 'beforeAttributeValue';
+    } else if (state === 'afterAttributeName') {
+      if (character === '=') {
+        state = 'beforeAttributeValue';
+      } else {
+        state = character === '/' ? 'selfClosingStartTag' : 'attributeName';
+      }
+    } else if (state === 'beforeAttributeValue') {
+      if (character === '"' || character === "'") {
+        quote = character;
+        state = 'attributeValueQuoted';
+      } else {
+        state = 'attributeValueUnquoted';
+      }
+    } else if (state === 'afterAttributeValueQuoted') {
+      state = character === '/' ? 'selfClosingStartTag' : 'attributeName';
+    } else if (state === 'selfClosingStartTag') {
+      state = character === '/' ? 'selfClosingStartTag' : 'attributeName';
+    }
+  }
+
+  return state === 'selfClosingStartTag';
+}
+
+function parseHtmlTag(htmlString: string, tagStart: number, tagEnd: number) {
+  const tag = htmlString.slice(tagStart, tagEnd);
+  const tagMatch = tag.match(/^<\s*(\/)?\s*([a-z][\w:-]*)(?=[\s>/])/i);
+  if (!tagMatch) return undefined;
+
+  const isClosingTag = tagMatch[1] === '/';
+
+  return {
+    isClosingTag,
+    isSelfClosingStartTag: !isClosingTag && isHtmlSelfClosingStartTag(tag, tagMatch[0].length),
+    tagName: tagMatch[2].toLowerCase(),
+  };
+}
+
+function findScriptDoubleEscapeOpenIndex(htmlString: string, startIndex: number) {
+  SCRIPT_DOUBLE_ESCAPE_OPEN_PATTERN.lastIndex = startIndex;
+  const match = SCRIPT_DOUBLE_ESCAPE_OPEN_PATTERN.exec(htmlString);
+  return match ? match.index : -1;
+}
+
+function updateScriptDataState(segment: string, initialState: ScriptDataState): ScriptDataState {
+  let state = initialState;
+  let searchIndex = 0;
+
+  while (searchIndex < segment.length) {
+    if (state === 'normal') {
+      const escapedStart = segment.indexOf('<!--', searchIndex);
+      if (escapedStart === -1) break;
+
+      state = 'escaped';
+      searchIndex = escapedStart + 4;
+    } else if (state === 'escaped') {
+      const escapedEnd = segment.indexOf('-->', searchIndex);
+      const doubleEscapeStart = findScriptDoubleEscapeOpenIndex(segment, searchIndex);
+
+      if (escapedEnd !== -1 && (doubleEscapeStart === -1 || escapedEnd < doubleEscapeStart)) {
+        state = 'normal';
+        searchIndex = escapedEnd + 3;
+      } else if (doubleEscapeStart !== -1) {
+        state = 'doubleEscaped';
+        searchIndex = SCRIPT_DOUBLE_ESCAPE_OPEN_PATTERN.lastIndex;
+      } else {
+        break;
+      }
+    } else if (state === 'doubleEscaped') {
+      const escapedEnd = segment.indexOf('-->', searchIndex);
+      if (escapedEnd === -1) break;
+
+      state = 'normal';
+      searchIndex = escapedEnd + 3;
+    } else {
+      break;
+    }
+  }
+
+  return state;
+}
+
+function scanScriptClosingTag(
+  htmlString: string,
+  startIndex: number,
+  initialScriptDataState: ScriptDataState = 'normal',
+): RawTextClosingTagScanResult {
+  const closingTagPrefixPattern = RAW_TEXT_CLOSING_TAG_PREFIX_PATTERNS.get('script');
+  if (!closingTagPrefixPattern) {
+    return { closingSearchStart: startIndex, scriptDataState: initialScriptDataState };
+  }
+
+  let contentScanStart = startIndex;
+  let scriptDataState = initialScriptDataState;
+  closingTagPrefixPattern.lastIndex = startIndex;
+
+  for (
+    let closingTagMatch = closingTagPrefixPattern.exec(htmlString);
+    closingTagMatch;
+    closingTagMatch = closingTagPrefixPattern.exec(htmlString)
+  ) {
+    scriptDataState = updateScriptDataState(
+      htmlString.slice(contentScanStart, closingTagMatch.index),
+      scriptDataState,
+    );
+
+    const closingTagEnd = findHtmlTagEnd(htmlString, closingTagMatch.index);
+    if (closingTagEnd === undefined) {
+      return { closingSearchStart: closingTagMatch.index, scriptDataState };
+    }
+
+    if (scriptDataState === 'doubleEscaped') {
+      scriptDataState = 'escaped';
+      contentScanStart = closingTagEnd;
+      closingTagPrefixPattern.lastIndex = closingTagEnd;
+    } else {
+      return { closingTagEnd, closingSearchStart: closingTagEnd, scriptDataState };
+    }
+  }
+
+  const safeScanEnd = Math.max(contentScanStart, htmlString.length - SCRIPT_SCAN_OVERLAP_LENGTH);
+  scriptDataState = updateScriptDataState(htmlString.slice(contentScanStart, safeScanEnd), scriptDataState);
+
+  return { closingSearchStart: safeScanEnd, scriptDataState };
+}
+
+function findRawTextClosingTagSearchStart(htmlString: string, tagName: string, searchStart: number) {
+  if (tagName === 'script') return searchStart;
+
+  return Math.max(searchStart, htmlString.length - `</${tagName}`.length);
+}
+
+function scanRawTextClosingTag(
+  htmlString: string,
+  tagName: string,
+  startIndex: number,
+  initialScriptDataState?: ScriptDataState,
+): RawTextClosingTagScanResult {
+  if (tagName === 'script') return scanScriptClosingTag(htmlString, startIndex, initialScriptDataState);
+
+  const closingTagPrefixPattern = RAW_TEXT_CLOSING_TAG_PREFIX_PATTERNS.get(tagName);
+  if (!closingTagPrefixPattern) return { closingSearchStart: startIndex };
+
+  closingTagPrefixPattern.lastIndex = startIndex;
+  const closingTagMatch = closingTagPrefixPattern.exec(htmlString);
+  if (!closingTagMatch) {
+    return {
+      closingSearchStart: findRawTextClosingTagSearchStart(htmlString, tagName, startIndex),
+    };
+  }
+
+  const closingTagEnd = findHtmlTagEnd(htmlString, closingTagMatch.index);
+  if (closingTagEnd === undefined) return { closingSearchStart: closingTagMatch.index };
+
+  return { closingTagEnd, closingSearchStart: closingTagEnd };
+}
+
+function findRawTextClosingTagEnd(htmlString: string, tagName: string, startIndex: number) {
+  return scanRawTextClosingTag(htmlString, tagName, startIndex).closingTagEnd;
+}
+
+function findCommentClosingTagSearchStart(htmlString: string, searchStart: number) {
+  return Math.max(searchStart, htmlString.length - 2);
+}
+
+function findCdataClosingTagSearchStart(htmlString: string, searchStart: number) {
+  return Math.max(searchStart, htmlString.length - (CDATA_CLOSE.length - 1));
+}
+
+function scanForeignContentTail(
+  htmlString: string,
+  startIndex: number,
+  tagName: string,
+  initialDepth = 1,
+  initialIgnoredTailScanState?: TemplateIgnoredTailScanState,
+): ContainerTailScanResult {
+  let depth = initialDepth;
+  let searchIndex = startIndex;
+  let closingSearchStart = startIndex;
+  let ignoredTailScanState = initialIgnoredTailScanState;
+
+  while (searchIndex < htmlString.length) {
+    if (ignoredTailScanState?.kind === 'comment') {
+      const commentEnd = htmlString.indexOf('-->', searchIndex);
+      if (commentEnd === -1) {
+        return {
+          closingSearchStart: findCommentClosingTagSearchStart(htmlString, searchIndex),
+          depth,
+          ignoredTailScanState,
+        };
+      }
+
+      searchIndex = commentEnd + 3;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else if (ignoredTailScanState?.kind === 'cdata') {
+      const cdataEnd = htmlString.indexOf(CDATA_CLOSE, searchIndex);
+      if (cdataEnd === -1) {
+        return {
+          closingSearchStart: findCdataClosingTagSearchStart(htmlString, searchIndex),
+          depth,
+          ignoredTailScanState,
+        };
+      }
+
+      searchIndex = cdataEnd + CDATA_CLOSE.length;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else if (ignoredTailScanState?.kind === 'rawText') {
+      const closingTagScan = scanRawTextClosingTag(
+        htmlString,
+        ignoredTailScanState.tagName,
+        searchIndex,
+        ignoredTailScanState.scriptDataState,
+      );
+      if (closingTagScan.closingTagEnd === undefined) {
+        return {
+          closingSearchStart: closingTagScan.closingSearchStart,
+          depth,
+          ignoredTailScanState: {
+            ...ignoredTailScanState,
+            scriptDataState: closingTagScan.scriptDataState,
+          },
+        };
+      }
+
+      searchIndex = closingTagScan.closingTagEnd;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else if (ignoredTailScanState?.kind === 'template') {
+      // scanTemplateTail is hoisted; the recursive scanner state can nest templates inside foreign content.
+      // eslint-disable-next-line no-use-before-define
+      const templateScan = scanTemplateTail(
+        htmlString,
+        searchIndex,
+        ignoredTailScanState.depth,
+        ignoredTailScanState.ignoredTailScanState,
+      );
+      if (templateScan.closingTagEnd === undefined) {
+        return {
+          closingSearchStart: templateScan.closingSearchStart,
+          depth,
+          ignoredTailScanState: {
+            kind: 'template' as const,
+            depth: templateScan.depth,
+            ignoredTailScanState: templateScan.ignoredTailScanState,
+          },
+        };
+      }
+
+      searchIndex = templateScan.closingTagEnd;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else {
+      const tagStart = htmlString.indexOf('<', searchIndex);
+      if (tagStart === -1) break;
+
+      if (htmlString.startsWith('<!--', tagStart)) {
+        const commentEnd = htmlString.indexOf('-->', tagStart + 4);
+        if (commentEnd === -1) {
+          return {
+            closingSearchStart: findCommentClosingTagSearchStart(htmlString, tagStart + 4),
+            depth,
+            ignoredTailScanState: { kind: 'comment' as const },
+          };
+        }
+
+        searchIndex = commentEnd + 3;
+        closingSearchStart = searchIndex;
+      } else if (htmlString.startsWith(CDATA_OPEN, tagStart)) {
+        const cdataEnd = htmlString.indexOf(CDATA_CLOSE, tagStart + CDATA_OPEN.length);
+        if (cdataEnd === -1) {
+          return {
+            closingSearchStart: findCdataClosingTagSearchStart(htmlString, tagStart + CDATA_OPEN.length),
+            depth,
+            ignoredTailScanState: { kind: 'cdata' as const },
+          };
+        }
+
+        searchIndex = cdataEnd + CDATA_CLOSE.length;
+        closingSearchStart = searchIndex;
+      } else {
+        const tagEnd = findHtmlTagEnd(htmlString, tagStart);
+        if (tagEnd === undefined) return { closingSearchStart: tagStart, depth };
+
+        const parsedTag = parseHtmlTag(htmlString, tagStart, tagEnd);
+        if (!parsedTag) {
+          searchIndex = tagStart + 1;
+        } else if (!parsedTag.isClosingTag && parsedTag.isSelfClosingStartTag) {
+          searchIndex = tagEnd;
+          closingSearchStart = searchIndex;
+        } else if (parsedTag.tagName === tagName) {
+          searchIndex = tagEnd;
+          closingSearchStart = searchIndex;
+          depth += parsedTag.isClosingTag ? -1 : 1;
+          if (depth === 0) {
+            return { closingTagEnd: searchIndex, closingSearchStart, depth };
+          }
+        } else if (!parsedTag.isClosingTag && parsedTag.tagName === 'template') {
+          // scanTemplateTail is hoisted; foreign-content scanning must ignore nested template contents.
+          // eslint-disable-next-line no-use-before-define
+          const templateScan = scanTemplateTail(htmlString, tagEnd);
+          if (templateScan.closingTagEnd === undefined) {
+            return {
+              closingSearchStart: templateScan.closingSearchStart,
+              depth,
+              ignoredTailScanState: {
+                kind: 'template' as const,
+                depth: templateScan.depth,
+                ignoredTailScanState: templateScan.ignoredTailScanState,
+              },
+            };
+          }
+
+          searchIndex = templateScan.closingTagEnd;
+          closingSearchStart = searchIndex;
+        } else if (!parsedTag.isClosingTag && RAW_TEXT_TAG_NAME_SET.has(parsedTag.tagName)) {
+          const closingTagScan = scanRawTextClosingTag(htmlString, parsedTag.tagName, tagEnd);
+          if (closingTagScan.closingTagEnd === undefined) {
+            return {
+              closingSearchStart: closingTagScan.closingSearchStart,
+              depth,
+              ignoredTailScanState: {
+                kind: 'rawText' as const,
+                tagName: parsedTag.tagName,
+                scriptDataState: closingTagScan.scriptDataState,
+              },
+            };
+          }
+
+          searchIndex = closingTagScan.closingTagEnd;
+          closingSearchStart = searchIndex;
+        } else {
+          searchIndex = tagEnd;
+          closingSearchStart = searchIndex;
+        }
+      }
+    }
+  }
+
+  return { closingSearchStart, depth, ignoredTailScanState };
+}
+
+function scanTemplateTail(
+  htmlString: string,
+  startIndex: number,
+  initialDepth = 1,
+  initialIgnoredTailScanState?: TemplateIgnoredTailScanState,
+): ContainerTailScanResult {
+  let depth = initialDepth;
+  let searchIndex = startIndex;
+  let closingSearchStart = startIndex;
+  let ignoredTailScanState = initialIgnoredTailScanState;
+
+  while (searchIndex < htmlString.length) {
+    if (ignoredTailScanState?.kind === 'comment') {
+      const commentEnd = htmlString.indexOf('-->', searchIndex);
+      if (commentEnd === -1) {
+        return {
+          closingSearchStart: findCommentClosingTagSearchStart(htmlString, searchIndex),
+          depth,
+          ignoredTailScanState,
+        };
+      }
+
+      searchIndex = commentEnd + 3;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else if (ignoredTailScanState?.kind === 'cdata') {
+      const cdataEnd = htmlString.indexOf(CDATA_CLOSE, searchIndex);
+      if (cdataEnd === -1) {
+        return {
+          closingSearchStart: findCdataClosingTagSearchStart(htmlString, searchIndex),
+          depth,
+          ignoredTailScanState,
+        };
+      }
+
+      searchIndex = cdataEnd + CDATA_CLOSE.length;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else if (ignoredTailScanState?.kind === 'rawText') {
+      const closingTagScan = scanRawTextClosingTag(
+        htmlString,
+        ignoredTailScanState.tagName,
+        searchIndex,
+        ignoredTailScanState.scriptDataState,
+      );
+      if (closingTagScan.closingTagEnd === undefined) {
+        return {
+          closingSearchStart: closingTagScan.closingSearchStart,
+          depth,
+          ignoredTailScanState: {
+            ...ignoredTailScanState,
+            scriptDataState: closingTagScan.scriptDataState,
+          },
+        };
+      }
+
+      searchIndex = closingTagScan.closingTagEnd;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else if (ignoredTailScanState?.kind === 'template') {
+      const templateScan = scanTemplateTail(
+        htmlString,
+        searchIndex,
+        ignoredTailScanState.depth,
+        ignoredTailScanState.ignoredTailScanState,
+      );
+      if (templateScan.closingTagEnd === undefined) {
+        return {
+          closingSearchStart: templateScan.closingSearchStart,
+          depth,
+          ignoredTailScanState: {
+            kind: 'template' as const,
+            depth: templateScan.depth,
+            ignoredTailScanState: templateScan.ignoredTailScanState,
+          },
+        };
+      }
+
+      searchIndex = templateScan.closingTagEnd;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else if (ignoredTailScanState?.kind === 'foreignContent') {
+      const foreignContentScan = scanForeignContentTail(
+        htmlString,
+        searchIndex,
+        ignoredTailScanState.tagName,
+        ignoredTailScanState.depth,
+        ignoredTailScanState.ignoredTailScanState,
+      );
+      if (foreignContentScan.closingTagEnd === undefined) {
+        return {
+          closingSearchStart: foreignContentScan.closingSearchStart,
+          depth,
+          ignoredTailScanState: {
+            kind: 'foreignContent' as const,
+            tagName: ignoredTailScanState.tagName,
+            depth: foreignContentScan.depth,
+            ignoredTailScanState: foreignContentScan.ignoredTailScanState,
+          },
+        };
+      }
+
+      searchIndex = foreignContentScan.closingTagEnd;
+      closingSearchStart = searchIndex;
+      ignoredTailScanState = undefined;
+    } else {
+      const tagStart = htmlString.indexOf('<', searchIndex);
+      if (tagStart === -1) break;
+
+      if (htmlString.startsWith('<!--', tagStart)) {
+        const commentEnd = htmlString.indexOf('-->', tagStart + 4);
+        if (commentEnd === -1) {
+          return {
+            closingSearchStart: findCommentClosingTagSearchStart(htmlString, tagStart + 4),
+            depth,
+            ignoredTailScanState: { kind: 'comment' as const },
+          };
+        }
+
+        searchIndex = commentEnd + 3;
+        closingSearchStart = searchIndex;
+      } else {
+        const tagEnd = findHtmlTagEnd(htmlString, tagStart);
+        if (tagEnd === undefined) {
+          return { closingSearchStart: tagStart, depth };
+        }
+
+        const parsedTag = parseHtmlTag(htmlString, tagStart, tagEnd);
+        if (!parsedTag) {
+          searchIndex = tagStart + 1;
+        } else if (parsedTag.tagName === 'template') {
+          searchIndex = tagEnd;
+          closingSearchStart = searchIndex;
+          depth += parsedTag.isClosingTag ? -1 : 1;
+          if (depth === 0) {
+            return { closingTagEnd: searchIndex, closingSearchStart, depth };
+          }
+        } else if (
+          !parsedTag.isClosingTag &&
+          !parsedTag.isSelfClosingStartTag &&
+          FOREIGN_CONTENT_TAG_NAME_SET.has(parsedTag.tagName)
+        ) {
+          const foreignContentScan = scanForeignContentTail(htmlString, tagEnd, parsedTag.tagName);
+          if (foreignContentScan.closingTagEnd === undefined) {
+            return {
+              closingSearchStart: foreignContentScan.closingSearchStart,
+              depth,
+              ignoredTailScanState: {
+                kind: 'foreignContent' as const,
+                tagName: parsedTag.tagName,
+                depth: foreignContentScan.depth,
+                ignoredTailScanState: foreignContentScan.ignoredTailScanState,
+              },
+            };
+          }
+
+          searchIndex = foreignContentScan.closingTagEnd;
+          closingSearchStart = searchIndex;
+        } else if (!parsedTag.isClosingTag && RAW_TEXT_TAG_NAME_SET.has(parsedTag.tagName)) {
+          const closingTagScan = scanRawTextClosingTag(htmlString, parsedTag.tagName, tagEnd);
+          if (closingTagScan.closingTagEnd === undefined) {
+            return {
+              closingSearchStart: closingTagScan.closingSearchStart,
+              depth,
+              ignoredTailScanState: {
+                kind: 'rawText' as const,
+                tagName: parsedTag.tagName,
+                scriptDataState: closingTagScan.scriptDataState,
+              },
+            };
+          }
+
+          searchIndex = closingTagScan.closingTagEnd;
+          closingSearchStart = searchIndex;
+        } else {
+          searchIndex = tagEnd;
+          closingSearchStart = searchIndex;
+        }
+      }
+    }
+  }
+
+  return { closingSearchStart, depth, ignoredTailScanState };
+}
+
+function findUnclosedRawTextElementTail(htmlString: string) {
+  let searchIndex = 0;
+
+  while (searchIndex < htmlString.length) {
+    const tagStart = htmlString.indexOf('<', searchIndex);
+    if (tagStart === -1) return undefined;
+
+    if (htmlString.startsWith('<!--', tagStart)) {
+      const commentEnd = htmlString.indexOf('-->', tagStart + 4);
+      if (commentEnd === -1) {
+        return {
+          start: tagStart,
+          scanState: {
+            kind: 'comment' as const,
+            closingSearchStart: findCommentClosingTagSearchStart(htmlString, tagStart + 4) - tagStart,
+          },
+        };
+      }
+
+      searchIndex = commentEnd + 3;
+    } else {
+      const tagEnd = findHtmlTagEnd(htmlString, tagStart);
+      if (tagEnd === undefined) return undefined;
+
+      const parsedTag = parseHtmlTag(htmlString, tagStart, tagEnd);
+      if (!parsedTag) {
+        searchIndex = tagStart + 1;
+      } else if (
+        !parsedTag.isClosingTag &&
+        !parsedTag.isSelfClosingStartTag &&
+        FOREIGN_CONTENT_TAG_NAME_SET.has(parsedTag.tagName)
+      ) {
+        const foreignContentScan = scanForeignContentTail(htmlString, tagEnd, parsedTag.tagName);
+        if (foreignContentScan.closingTagEnd === undefined) {
+          return {
+            start: tagStart,
+            scanState: {
+              kind: 'foreignContent' as const,
+              tagName: parsedTag.tagName,
+              closingSearchStart: foreignContentScan.closingSearchStart - tagStart,
+              depth: foreignContentScan.depth,
+              ignoredTailScanState: foreignContentScan.ignoredTailScanState,
+            },
+          };
+        }
+
+        searchIndex = foreignContentScan.closingTagEnd;
+      } else if (parsedTag.isClosingTag || !RAW_TEXT_TAG_NAME_SET.has(parsedTag.tagName)) {
+        searchIndex = tagEnd;
+      } else if (parsedTag.tagName === 'template') {
+        const templateScan = scanTemplateTail(htmlString, tagEnd);
+        if (templateScan.closingTagEnd === undefined) {
+          return {
+            start: tagStart,
+            scanState: {
+              kind: 'template' as const,
+              closingSearchStart: templateScan.closingSearchStart - tagStart,
+              depth: templateScan.depth,
+              ignoredTailScanState: templateScan.ignoredTailScanState,
+            },
+          };
+        }
+
+        searchIndex = templateScan.closingTagEnd;
+      } else {
+        const closingTagScan = scanRawTextClosingTag(htmlString, parsedTag.tagName, tagEnd);
+        if (closingTagScan.closingTagEnd === undefined) {
+          return {
+            start: tagStart,
+            scanState: {
+              kind: 'rawText' as const,
+              tagName: parsedTag.tagName,
+              closingSearchStart: closingTagScan.closingSearchStart - tagStart,
+              scriptDataState: closingTagScan.scriptDataState,
+            },
+          };
+        }
+
+        searchIndex = closingTagScan.closingTagEnd;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function splitNewUnclosedRawTextElementTail(htmlString: string): SplitIncompleteHtmlTailResult | undefined {
+  const rawTextElementTail = findUnclosedRawTextElementTail(htmlString);
+  if (rawTextElementTail === undefined) return undefined;
+
+  return {
+    completeHtml: htmlString.slice(0, rawTextElementTail.start),
+    incompleteHtmlTagTail: htmlString.slice(rawTextElementTail.start),
+    incompleteHtmlTailScanState: rawTextElementTail.scanState,
+  };
+}
+
+function splitAfterClosedRetainedRawTextOrCommentTail(htmlString: string, closingEnd: number) {
+  const suffix = htmlString.slice(closingEnd);
+  const suffixTail = splitNewUnclosedRawTextElementTail(suffix);
+  if (!suffixTail) {
+    return {
+      completeHtml: htmlString,
+      incompleteHtmlTagTail: '',
+    };
+  }
+
+  return {
+    completeHtml: htmlString.slice(0, closingEnd) + suffixTail.completeHtml,
+    incompleteHtmlTagTail: suffixTail.incompleteHtmlTagTail,
+    incompleteHtmlTailScanState: suffixTail.incompleteHtmlTailScanState,
+  };
+}
+
+function splitRetainedUnclosedRawTextOrCommentTail(
+  htmlString: string,
+  retainedTailScanState: RetainedIncompleteHtmlTailScanState,
+): SplitIncompleteHtmlTailResult | undefined {
+  if (retainedTailScanState.kind === 'comment') {
+    const commentEnd = htmlString.indexOf('-->', retainedTailScanState.closingSearchStart);
+    if (commentEnd === -1) {
+      return {
+        completeHtml: '',
+        incompleteHtmlTagTail: htmlString,
+        incompleteHtmlTailScanState: {
+          kind: 'comment',
+          closingSearchStart: findCommentClosingTagSearchStart(
+            htmlString,
+            retainedTailScanState.closingSearchStart,
+          ),
+        },
+      };
+    }
+
+    return splitAfterClosedRetainedRawTextOrCommentTail(htmlString, commentEnd + 3);
+  }
+
+  if (retainedTailScanState.kind === 'cdata') {
+    const cdataEnd = htmlString.indexOf(CDATA_CLOSE, retainedTailScanState.closingSearchStart);
+    if (cdataEnd === -1) {
+      return {
+        completeHtml: '',
+        incompleteHtmlTagTail: htmlString,
+        incompleteHtmlTailScanState: {
+          kind: 'cdata',
+          closingSearchStart: findCdataClosingTagSearchStart(
+            htmlString,
+            retainedTailScanState.closingSearchStart,
+          ),
+        },
+      };
+    }
+
+    return splitAfterClosedRetainedRawTextOrCommentTail(htmlString, cdataEnd + CDATA_CLOSE.length);
+  }
+
+  if (retainedTailScanState.kind === 'foreignContent') {
+    const foreignContentScan = scanForeignContentTail(
+      htmlString,
+      retainedTailScanState.closingSearchStart,
+      retainedTailScanState.tagName,
+      retainedTailScanState.depth,
+      retainedTailScanState.ignoredTailScanState,
+    );
+    if (foreignContentScan.closingTagEnd === undefined) {
+      return {
+        completeHtml: '',
+        incompleteHtmlTagTail: htmlString,
+        incompleteHtmlTailScanState: {
+          kind: 'foreignContent',
+          tagName: retainedTailScanState.tagName,
+          closingSearchStart: foreignContentScan.closingSearchStart,
+          depth: foreignContentScan.depth,
+          ignoredTailScanState: foreignContentScan.ignoredTailScanState,
+        },
+      };
+    }
+
+    return splitAfterClosedRetainedRawTextOrCommentTail(htmlString, foreignContentScan.closingTagEnd);
+  }
+
+  if (retainedTailScanState.kind === 'template') {
+    const templateScan = scanTemplateTail(
+      htmlString,
+      retainedTailScanState.closingSearchStart,
+      retainedTailScanState.depth,
+      retainedTailScanState.ignoredTailScanState,
+    );
+    if (templateScan.closingTagEnd === undefined) {
+      return {
+        completeHtml: '',
+        incompleteHtmlTagTail: htmlString,
+        incompleteHtmlTailScanState: {
+          kind: 'template',
+          closingSearchStart: templateScan.closingSearchStart,
+          depth: templateScan.depth,
+          ignoredTailScanState: templateScan.ignoredTailScanState,
+        },
+      };
+    }
+
+    return splitAfterClosedRetainedRawTextOrCommentTail(htmlString, templateScan.closingTagEnd);
+  }
+
+  const closingTagScan = scanRawTextClosingTag(
+    htmlString,
+    retainedTailScanState.tagName,
+    retainedTailScanState.closingSearchStart,
+    retainedTailScanState.scriptDataState,
+  );
+  if (closingTagScan.closingTagEnd === undefined) {
+    return {
+      completeHtml: '',
+      incompleteHtmlTagTail: htmlString,
+      incompleteHtmlTailScanState: {
+        kind: 'rawText',
+        tagName: retainedTailScanState.tagName,
+        closingSearchStart: closingTagScan.closingSearchStart,
+        scriptDataState: closingTagScan.scriptDataState,
+      },
+    };
+  }
+
+  return splitAfterClosedRetainedRawTextOrCommentTail(htmlString, closingTagScan.closingTagEnd);
+}
+
+function splitUnclosedRawTextElementTail(
+  htmlString: string,
+  retainedTailScanState?: RetainedIncompleteHtmlTailScanState,
+): SplitIncompleteHtmlTailResult | undefined {
+  if (retainedTailScanState) {
+    const retainedTail = splitRetainedUnclosedRawTextOrCommentTail(htmlString, retainedTailScanState);
+    if (retainedTail) return retainedTail;
+  }
+
+  return splitNewUnclosedRawTextElementTail(htmlString);
+}
+
+function findTrailingIncompleteHtmlTagStart(htmlString: string) {
   // Streaming renderer output is expected to be well-formed HTML where bare "<"
   // characters are tag starts. Observability mode holds any trailing incomplete
   // tag so flush marks never split a tag boundary.
@@ -296,26 +1181,65 @@ function splitIncompleteHtmlTagTail(htmlString: string) {
   // incomplete tag; React SSR encodes text "<" as "&lt;", so renderer output is safe.
   // Application inline scripts that stream a bare "<" operator across chunks are
   // outside this guard's assumptions.
-  const lastCompleteTagEnd = htmlString.lastIndexOf('>');
-  const lastTagStart = htmlString.lastIndexOf('<');
-  const rawTextElementStart = findUnclosedRawTextElementStart(htmlString);
-  if (rawTextElementStart !== undefined) {
-    return {
-      completeHtml: htmlString.slice(0, rawTextElementStart),
-      incompleteHtmlTagTail: htmlString.slice(rawTextElementStart),
-    };
+  let searchIndex = 0;
+  while (searchIndex < htmlString.length) {
+    const tagStart = htmlString.indexOf('<', searchIndex);
+    if (tagStart === -1) return undefined;
+
+    if (htmlString.startsWith('<!--', tagStart)) {
+      const commentEnd = htmlString.indexOf('-->', tagStart + 4);
+      if (commentEnd === -1) return tagStart;
+
+      searchIndex = commentEnd + 3;
+    } else {
+      const tagEnd = findHtmlTagEnd(htmlString, tagStart);
+      if (tagEnd === undefined) return tagStart;
+
+      const parsedTag = parseHtmlTag(htmlString, tagStart, tagEnd);
+      if (parsedTag && !parsedTag.isClosingTag && RAW_TEXT_TAG_NAME_SET.has(parsedTag.tagName)) {
+        if (parsedTag.tagName === 'template') {
+          const templateScan = scanTemplateTail(htmlString, tagEnd);
+          if (templateScan.closingTagEnd === undefined) return tagStart;
+
+          searchIndex = templateScan.closingTagEnd;
+        } else {
+          const closingTagEnd = findRawTextClosingTagEnd(htmlString, parsedTag.tagName, tagEnd);
+          if (closingTagEnd === undefined) return tagStart;
+
+          searchIndex = closingTagEnd;
+        }
+      } else {
+        searchIndex = tagEnd;
+      }
+    }
   }
 
-  // The streamed payload is well-formed HTML, so a trailing "<" means a split tag rather than text content.
-  if (lastTagStart === -1 || lastTagStart < lastCompleteTagEnd) {
-    return { completeHtml: htmlString, incompleteHtmlTagTail: '' };
-  }
+  return undefined;
+}
 
-  const incompleteHtmlTagTail = htmlString.slice(lastTagStart);
+function splitTrailingIncompleteHtmlTagTail(htmlString: string): SplitIncompleteHtmlTailResult {
+  const incompleteTagStart = findTrailingIncompleteHtmlTagStart(htmlString);
+  if (incompleteTagStart === undefined) return { completeHtml: htmlString, incompleteHtmlTagTail: '' };
+
+  const incompleteHtmlTagTail = htmlString.slice(incompleteTagStart);
   return {
-    completeHtml: htmlString.slice(0, lastTagStart),
+    completeHtml: htmlString.slice(0, incompleteTagStart),
     incompleteHtmlTagTail,
   };
+}
+
+function splitIncompleteHtmlTagTail(
+  htmlString: string,
+  retainedTailScanState?: RetainedIncompleteHtmlTailScanState,
+) {
+  const rawTextTail = splitUnclosedRawTextElementTail(htmlString, retainedTailScanState);
+  if (rawTextTail) {
+    if (rawTextTail.incompleteHtmlTagTail) return rawTextTail;
+
+    return splitTrailingIncompleteHtmlTagTail(rawTextTail.completeHtml);
+  }
+
+  return splitTrailingIncompleteHtmlTagTail(htmlString);
 }
 
 const LINK_TAG_PREFIX = '<link';
@@ -328,15 +1252,14 @@ function isLinkTagTail(normalizedTail: string) {
   return LINK_TAG_BOUNDARIES.has(normalizedTail.charAt(LINK_TAG_PREFIX.length));
 }
 
-function splitIncompleteLinkTagTail(htmlString: string) {
-  const lastCompleteTagEnd = htmlString.lastIndexOf('>');
-  const lastTagStart = htmlString.lastIndexOf('<');
+function splitIncompleteLinkTagTail(htmlString: string): SplitIncompleteHtmlTailResult {
+  const incompleteTagStart = findTrailingIncompleteHtmlTagStart(htmlString);
 
-  if (lastTagStart === -1 || lastTagStart < lastCompleteTagEnd) {
+  if (incompleteTagStart === undefined) {
     return { completeHtml: htmlString, incompleteHtmlTagTail: '' };
   }
 
-  const incompleteHtmlTagTail = htmlString.slice(lastTagStart);
+  const incompleteHtmlTagTail = htmlString.slice(incompleteTagStart);
   const normalizedTail = incompleteHtmlTagTail.toLowerCase();
 
   if (!isLinkTagTail(normalizedTail)) {
@@ -344,9 +1267,23 @@ function splitIncompleteLinkTagTail(htmlString: string) {
   }
 
   return {
-    completeHtml: htmlString.slice(0, lastTagStart),
+    completeHtml: htmlString.slice(0, incompleteTagStart),
     incompleteHtmlTagTail,
   };
+}
+
+function splitIncompleteLinkOrRawTextTail(
+  htmlString: string,
+  retainedTailScanState?: RetainedIncompleteHtmlTailScanState,
+) {
+  const rawTextTail = splitUnclosedRawTextElementTail(htmlString, retainedTailScanState);
+  if (rawTextTail) {
+    if (rawTextTail.incompleteHtmlTagTail) return rawTextTail;
+
+    return splitIncompleteLinkTagTail(rawTextTail.completeHtml);
+  }
+
+  return splitIncompleteLinkTagTail(htmlString);
 }
 
 type IncompleteHtmlTailMode = 'none' | 'link' | 'tag';
@@ -439,7 +1376,11 @@ function findIncompleteUTF8TailStartIndex(buffer: Buffer) {
   return tailStart;
 }
 
-function applyStreamedStylesheetPreloadGating(html: Buffer, incompleteHtmlTailMode: IncompleteHtmlTailMode) {
+function applyStreamedStylesheetPreloadGating(
+  html: Buffer,
+  incompleteHtmlTailMode: IncompleteHtmlTailMode,
+  retainedTailScanState?: RetainedIncompleteHtmlTailScanState,
+) {
   let stringSafeHtmlBuffer = html;
   let incompleteUTF8TailBuffer: Buffer = Buffer.alloc(0);
   if (incompleteHtmlTailMode !== 'none') {
@@ -453,12 +1394,26 @@ function applyStreamedStylesheetPreloadGating(html: Buffer, incompleteHtmlTailMo
   const htmlString = stringSafeHtmlBuffer.toString();
   let completeHtml = htmlString;
   let nextIncompleteHtmlTagTail = '';
+  let nextIncompleteHtmlTailScanState: RetainedIncompleteHtmlTailScanState | undefined;
   if (incompleteHtmlTailMode === 'tag') {
-    ({ completeHtml, incompleteHtmlTagTail: nextIncompleteHtmlTagTail } =
-      splitIncompleteHtmlTagTail(htmlString));
+    ({
+      completeHtml,
+      incompleteHtmlTagTail: nextIncompleteHtmlTagTail,
+      incompleteHtmlTailScanState: nextIncompleteHtmlTailScanState,
+    } = splitIncompleteHtmlTagTail(htmlString, retainedTailScanState));
   } else if (incompleteHtmlTailMode === 'link') {
-    ({ completeHtml, incompleteHtmlTagTail: nextIncompleteHtmlTagTail } =
-      splitIncompleteLinkTagTail(htmlString));
+    ({
+      completeHtml,
+      incompleteHtmlTagTail: nextIncompleteHtmlTagTail,
+      incompleteHtmlTailScanState: nextIncompleteHtmlTailScanState,
+    } = splitIncompleteLinkOrRawTextTail(htmlString, retainedTailScanState));
+    if (!nextIncompleteHtmlTagTail && incompleteUTF8TailBuffer.length > 0) {
+      ({
+        completeHtml,
+        incompleteHtmlTagTail: nextIncompleteHtmlTagTail,
+        incompleteHtmlTailScanState: nextIncompleteHtmlTailScanState,
+      } = splitTrailingIncompleteHtmlTagTail(completeHtml));
+    }
   }
   const gatedHtml = completeHtml.replace(
     /<link\b(?=[^>]*\brel=(["'])(?:(?!\1).)*\bpreload\b(?:(?!\1).)*\1)(?=[^>]*\bas=(["'])style\2)(?=[^>]*\bhref=(["'])(?:(?!\3).)+\3)[^>]*\/?>/gi,
@@ -476,6 +1431,8 @@ function applyStreamedStylesheetPreloadGating(html: Buffer, incompleteHtmlTailMo
   return {
     gatedHtmlBuffer: gatedHtml === completeHtml ? completeHtmlBuffer : Buffer.from(gatedHtml),
     incompleteHtmlTailBuffer,
+    incompleteHtmlTailScanState:
+      incompleteHtmlTailBuffer.length > 0 ? nextIncompleteHtmlTailScanState : undefined,
   };
 }
 
@@ -548,9 +1505,12 @@ export default function injectRSCPayload(
    */
   const htmlBuffers: Buffer[] = [];
   // Observability mode holds any split tag so inline mark scripts never land in
-  // the middle of markup. Without observability, preserve the older link-only
-  // hold used by stylesheet preload promotion.
+  // the middle of markup. Without observability, hold link tails plus open
+  // raw-text elements so payload scripts never flush inside app script/style text.
+  // If the app leaves such a container open, streaming intentionally buffers the
+  // remaining HTML until final flush rather than injecting scripts into it.
   let incompleteHtmlTailMode: IncompleteHtmlTailMode = rscStreamObservability ? 'tag' : 'link';
+  let retainedHtmlTailScanState: RetainedIncompleteHtmlTailScanState | undefined;
 
   /**
    * Buffer for stylesheet links inferred from RSC client chunk references.
@@ -605,10 +1565,11 @@ export default function injectRSCPayload(
     // Calculate total buffer size for efficient memory allocation
     const rscInitializationSize = rscInitializationBuffers.reduce((sum, buf) => sum + buf.length, 0);
     const htmlBuffer = Buffer.concat(htmlBuffers);
-    const { gatedHtmlBuffer, incompleteHtmlTailBuffer } = applyStreamedStylesheetPreloadGating(
-      htmlBuffer,
-      incompleteHtmlTailMode,
-    );
+    const {
+      gatedHtmlBuffer,
+      incompleteHtmlTailBuffer,
+      incompleteHtmlTailScanState: nextRetainedHtmlTailScanState,
+    } = applyStreamedStylesheetPreloadGating(htmlBuffer, incompleteHtmlTailMode, retainedHtmlTailScanState);
     const shouldDeferRevealHtml =
       rscPromise &&
       shouldInferRSCClientStylesheets &&
@@ -635,6 +1596,7 @@ export default function injectRSCPayload(
         htmlBuffers.push(deferredRevealHtmlBuffer);
       }
       htmlBuffers.push(incompleteHtmlTailBuffer);
+      retainedHtmlTailScanState = deferredRevealHtmlBuffer ? undefined : nextRetainedHtmlTailScanState;
     };
 
     if (flushableHtmlBuffer.length === 0 && !hasFlushedOutputChunk) {
@@ -729,11 +1691,13 @@ export default function injectRSCPayload(
     rscInitializationBuffers.length = 0;
     rscClientStylesheetBuffers.length = 0;
     htmlBuffers.length = 0;
+    retainedHtmlTailScanState = undefined;
     if (deferredRevealHtmlBuffer) {
       htmlBuffers.push(deferredRevealHtmlBuffer);
     }
     if (incompleteHtmlTailBuffer.length > 0) {
       htmlBuffers.push(incompleteHtmlTailBuffer);
+      retainedHtmlTailScanState = deferredRevealHtmlBuffer ? undefined : nextRetainedHtmlTailScanState;
     }
     rscPayloadBuffers.length = 0;
     rscPayloadMarkBuffers.length = 0;
@@ -741,6 +1705,7 @@ export default function injectRSCPayload(
 
   const endResultStream = () => {
     incompleteHtmlTailMode = 'none';
+    retainedHtmlTailScanState = undefined;
     // Cancel any pending fallback timer unconditionally.
     // flush() only clears the timer when it actually flushes data (past the
     // early-return guards). If we're closing with empty buffers, the timer

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -265,6 +265,29 @@ function stylesheetTagsForRSCClientChunks(
   return stylesheetTags;
 }
 
+const RAW_TEXT_TAG_NAMES = ['script', 'style', 'textarea', 'title'];
+
+const RAW_TEXT_TAG_PATTERN = new RegExp(`<(\\/?)(${RAW_TEXT_TAG_NAMES.join('|')})\\b[^>]*>`, 'gi');
+
+function findUnclosedRawTextElementStart(htmlString: string) {
+  let openRawTextElement: { start: number; tagName: string } | undefined;
+  let match = RAW_TEXT_TAG_PATTERN.exec(htmlString);
+  while (match) {
+    const isClosingTag = match[1] === '/';
+    const tagName = match[2].toLowerCase();
+    if (isClosingTag) {
+      if (openRawTextElement?.tagName === tagName) {
+        openRawTextElement = undefined;
+      }
+    } else {
+      openRawTextElement = { start: match.index, tagName };
+    }
+    match = RAW_TEXT_TAG_PATTERN.exec(htmlString);
+  }
+
+  return openRawTextElement?.start;
+}
+
 function splitIncompleteHtmlTagTail(htmlString: string) {
   // Streaming renderer output is expected to be well-formed HTML where bare "<"
   // characters are tag starts. Observability mode holds any trailing incomplete
@@ -275,15 +298,23 @@ function splitIncompleteHtmlTagTail(htmlString: string) {
   // outside this guard's assumptions.
   const lastCompleteTagEnd = htmlString.lastIndexOf('>');
   const lastTagStart = htmlString.lastIndexOf('<');
+  const rawTextElementStart = findUnclosedRawTextElementStart(htmlString);
+  if (rawTextElementStart !== undefined) {
+    return {
+      completeHtml: htmlString.slice(0, rawTextElementStart),
+      incompleteHtmlTagTail: htmlString.slice(rawTextElementStart),
+    };
+  }
 
   // The streamed payload is well-formed HTML, so a trailing "<" means a split tag rather than text content.
   if (lastTagStart === -1 || lastTagStart < lastCompleteTagEnd) {
     return { completeHtml: htmlString, incompleteHtmlTagTail: '' };
   }
 
+  const incompleteHtmlTagTail = htmlString.slice(lastTagStart);
   return {
     completeHtml: htmlString.slice(0, lastTagStart),
-    incompleteHtmlTagTail: htmlString.slice(lastTagStart),
+    incompleteHtmlTagTail,
   };
 }
 
@@ -343,7 +374,41 @@ function promoteStylesheetPreloadTag(linkTag: string) {
   return promotedTag.replace(/\s*\/?>$/, ` data-precedence="rsc-css"${closing}`);
 }
 
-function hasIncompleteUTF8Tail(buffer: Buffer) {
+function utf8ContinuationByteCount(leadByte: number) {
+  if (leadByte >= 0xc2 && leadByte <= 0xdf) return 1;
+  if (leadByte >= 0xe0 && leadByte <= 0xef) return 2;
+  if (leadByte >= 0xf0 && leadByte <= 0xf4) return 3;
+
+  return undefined;
+}
+
+function findPreviousIncompleteUTF8TailStartIndex(buffer: Buffer, tailStart: number) {
+  let previousLeadByteIndex = tailStart - 1;
+  let continuationBytes = 0;
+
+  while (
+    previousLeadByteIndex >= 0 &&
+    buffer[previousLeadByteIndex] >= 0x80 &&
+    buffer[previousLeadByteIndex] <= 0xbf
+  ) {
+    continuationBytes += 1;
+    previousLeadByteIndex -= 1;
+  }
+
+  if (previousLeadByteIndex < 0) {
+    return continuationBytes > 0 ? 0 : undefined;
+  }
+
+  const leadByte = buffer[previousLeadByteIndex];
+  if (leadByte <= 0x7f) return undefined;
+
+  const expectedContinuationBytes = utf8ContinuationByteCount(leadByte);
+  if (expectedContinuationBytes === undefined) return undefined;
+
+  return continuationBytes < expectedContinuationBytes ? previousLeadByteIndex : undefined;
+}
+
+function findIncompleteUTF8TailStartIndex(buffer: Buffer) {
   let continuationBytes = 0;
   let leadByteIndex = buffer.length - 1;
 
@@ -353,32 +418,39 @@ function hasIncompleteUTF8Tail(buffer: Buffer) {
   }
 
   if (leadByteIndex < 0) {
-    return continuationBytes > 0;
+    return continuationBytes > 0 ? 0 : undefined;
   }
 
   const leadByte = buffer[leadByteIndex];
-  if (leadByte <= 0x7f) return false;
+  if (leadByte <= 0x7f) return undefined;
 
-  let expectedContinuationBytes = 0;
-  if (leadByte >= 0xc2 && leadByte <= 0xdf) {
-    expectedContinuationBytes = 1;
-  } else if (leadByte >= 0xe0 && leadByte <= 0xef) {
-    expectedContinuationBytes = 2;
-  } else if (leadByte >= 0xf0 && leadByte <= 0xf4) {
-    expectedContinuationBytes = 3;
-  } else {
-    return false;
+  const expectedContinuationBytes = utf8ContinuationByteCount(leadByte);
+  if (expectedContinuationBytes === undefined) return undefined;
+
+  if (continuationBytes >= expectedContinuationBytes) return undefined;
+
+  let tailStart = leadByteIndex;
+  let previousTailStart = findPreviousIncompleteUTF8TailStartIndex(buffer, tailStart);
+  while (previousTailStart !== undefined) {
+    tailStart = previousTailStart;
+    previousTailStart = findPreviousIncompleteUTF8TailStartIndex(buffer, tailStart);
   }
 
-  return continuationBytes < expectedContinuationBytes;
+  return tailStart;
 }
 
 function applyStreamedStylesheetPreloadGating(html: Buffer, incompleteHtmlTailMode: IncompleteHtmlTailMode) {
-  if (incompleteHtmlTailMode !== 'none' && hasIncompleteUTF8Tail(html)) {
-    return { gatedHtmlBuffer: html, hasIncompleteHtmlTail: true };
+  let stringSafeHtmlBuffer = html;
+  let incompleteUTF8TailBuffer: Buffer = Buffer.alloc(0);
+  if (incompleteHtmlTailMode !== 'none') {
+    const incompleteUTF8TailStartIndex = findIncompleteUTF8TailStartIndex(html);
+    if (incompleteUTF8TailStartIndex !== undefined) {
+      stringSafeHtmlBuffer = html.subarray(0, incompleteUTF8TailStartIndex);
+      incompleteUTF8TailBuffer = html.subarray(incompleteUTF8TailStartIndex);
+    }
   }
 
-  const htmlString = html.toString();
+  const htmlString = stringSafeHtmlBuffer.toString();
   let completeHtml = htmlString;
   let nextIncompleteHtmlTagTail = '';
   if (incompleteHtmlTailMode === 'tag') {
@@ -393,10 +465,17 @@ function applyStreamedStylesheetPreloadGating(html: Buffer, incompleteHtmlTailMo
     (linkTag) =>
       shouldPromoteStylesheetPreloadTag(linkTag) ? promoteStylesheetPreloadTag(linkTag) : linkTag,
   );
+  const completeHtmlByteLength = Buffer.byteLength(completeHtml, 'utf8');
+  const completeHtmlBuffer =
+    completeHtmlByteLength === html.length ? html : stringSafeHtmlBuffer.subarray(0, completeHtmlByteLength);
+  const incompleteHtmlTailBuffer = Buffer.concat([
+    nextIncompleteHtmlTagTail ? stringSafeHtmlBuffer.subarray(completeHtmlByteLength) : Buffer.alloc(0),
+    incompleteUTF8TailBuffer,
+  ]);
 
   return {
-    gatedHtmlBuffer: gatedHtml === htmlString && !nextIncompleteHtmlTagTail ? html : Buffer.from(gatedHtml),
-    hasIncompleteHtmlTail: Boolean(nextIncompleteHtmlTagTail),
+    gatedHtmlBuffer: gatedHtml === completeHtml ? completeHtmlBuffer : Buffer.from(gatedHtml),
+    incompleteHtmlTailBuffer,
   };
 }
 
@@ -526,7 +605,7 @@ export default function injectRSCPayload(
     // Calculate total buffer size for efficient memory allocation
     const rscInitializationSize = rscInitializationBuffers.reduce((sum, buf) => sum + buf.length, 0);
     const htmlBuffer = Buffer.concat(htmlBuffers);
-    const { gatedHtmlBuffer, hasIncompleteHtmlTail } = applyStreamedStylesheetPreloadGating(
+    const { gatedHtmlBuffer, incompleteHtmlTailBuffer } = applyStreamedStylesheetPreloadGating(
       htmlBuffer,
       incompleteHtmlTailMode,
     );
@@ -548,16 +627,24 @@ export default function injectRSCPayload(
       rscPayloadSize +
       payloadMarkScriptBytes;
 
-    if (hasIncompleteHtmlTail) {
-      return;
-    }
+    const retainDeferredHtmlAndIncompleteTail = () => {
+      if (incompleteHtmlTailBuffer.length === 0) return;
 
-    if (deferredRevealHtmlBuffer && flushableHtmlBuffer.length === 0 && !hasFlushedOutputChunk) {
+      htmlBuffers.length = 0;
+      if (deferredRevealHtmlBuffer) {
+        htmlBuffers.push(deferredRevealHtmlBuffer);
+      }
+      htmlBuffers.push(incompleteHtmlTailBuffer);
+    };
+
+    if (flushableHtmlBuffer.length === 0 && !hasFlushedOutputChunk) {
+      retainDeferredHtmlAndIncompleteTail();
       return;
     }
 
     // Skip flush if no data is buffered
     if (totalSizeWithoutFlushMark === 0) {
+      retainDeferredHtmlAndIncompleteTail();
       return;
     }
 
@@ -644,6 +731,9 @@ export default function injectRSCPayload(
     htmlBuffers.length = 0;
     if (deferredRevealHtmlBuffer) {
       htmlBuffers.push(deferredRevealHtmlBuffer);
+    }
+    if (incompleteHtmlTailBuffer.length > 0) {
+      htmlBuffers.push(incompleteHtmlTailBuffer);
     }
     rscPayloadBuffers.length = 0;
     rscPayloadMarkBuffers.length = 0;

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -604,9 +604,11 @@ describe('injectRSCPayload', () => {
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain(
-      'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">after',
+      '<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">after',
     );
+    expect(resultStr).toContain('before');
     expect(resultStr).not.toContain('rel="preload" as="style"');
+    expect(resultStr).not.toContain('client1-<script');
   });
 
   it('promotes streamed RSC stylesheet preloads split inside the link token', async () => {
@@ -621,9 +623,11 @@ describe('injectRSCPayload', () => {
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain(
-      'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">after',
+      '<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">after',
     );
+    expect(resultStr).toContain('before');
     expect(resultStr).not.toContain('rel="preload" as="style"');
+    expect(resultStr).not.toContain('<li<script');
   });
 
   it('does not hold non-link partial tags for stylesheet gating when observability is disabled', async () => {
@@ -684,9 +688,130 @@ describe('injectRSCPayload', () => {
     });
     const resultStr = await collectStreamData(result);
 
-    expect(resultStr).toContain('before<script>after</script>');
+    expect(resultStr).toContain('before');
+    expect(resultStr).toContain('<script>after</script>');
     expect(resultStr).toContain('perf.mark("react-on-rails:rsc:flush"');
     expect(resultStr).not.toContain('before<scr<script');
+  });
+
+  it('keeps opt-in observability scripts out of split raw-text closing tags', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: 'before<script>window.x = 1;</scr',
+      25: 'ipt>after',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('window.x = 1');
+
+    const resultStr = await allData;
+    const appScriptIndex = resultStr.indexOf('<script>window.x = 1;</script>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(appScriptIndex);
+    expect(resultStr).not.toContain('<script>window.x = 1;<script');
+  });
+
+  it('keeps opt-in observability scripts out of raw-text split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<script>window.msg = "caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('";</script>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('window.msg');
+
+    const resultStr = await allData;
+    const appScriptIndex = resultStr.indexOf('<script>window.msg = "café";</script>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(appScriptIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<script>window.msg = "caf<script');
+  });
+
+  it('keeps opt-in observability scripts out of ambiguous raw-text closing tag prefixes', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: 'before<style>body{color:red}</s',
+      25: 'tyle>after',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('body{color:red}');
+
+    const resultStr = await allData;
+    const styleIndex = resultStr.indexOf('<style>body{color:red}</style>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(styleIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(styleIndex);
+    expect(resultStr).not.toContain('<style>body{color:red}<script');
+  });
+
+  it('flushes complete HTML and RSC scripts while holding an observability split tag tail', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: 'before<div data-name="a',
+      25: 'pp">after</div>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<div data-name');
+    await expect(firstChunk).resolves.not.toContain('after</div>');
+
+    const resultStr = await allData;
+    expect(resultStr).toContain('<div data-name="app">after</div>');
+    expect(resultStr).not.toContain('<div data-name="a<script');
   });
 
   it('preserves split UTF-8 bytes when promoting streamed RSC stylesheet preloads', async () => {
@@ -707,9 +832,33 @@ describe('injectRSCPayload', () => {
     const resultStr = (await collectStreamBuffer(result)).toString('utf8');
 
     expect(resultStr).toContain(
-      'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">café after',
+      'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">caf',
     );
+    expect(resultStr).toContain('é after');
     expect(resultStr).not.toContain('\uFFFD');
+  });
+
+  it('keeps adjacent incomplete UTF-8 lead bytes out of decoded flushes', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([Buffer.from('before'), eAcuteBytes.subarray(0, 1)]);
+    const secondHtmlChunk = eAcuteBytes.subarray(0, 1);
+    const thirdHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from(' after')]);
+    const mockHTML = createMockHTMLByteStream({
+      0: firstHtmlChunk,
+      10: secondHtmlChunk,
+      20: thirdHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const resultBuffer = await collectStreamBuffer(result);
+
+    expect(resultBuffer.includes(Buffer.from([0xc3, 0xc3, 0xa9]))).toBe(true);
+    expect(resultBuffer.includes(Buffer.from('\uFFFD'))).toBe(false);
   });
 
   it('leaves app-authored style preloads as fetch hints', async () => {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -630,6 +630,29 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('<li<script');
   });
 
+  it('promotes split stylesheet links after a retained raw-text tail closes', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const mockHTML = createMockHTMLStream({
+      0: 'before<script>window.msg = 1;',
+      10: '</script><link rel="preload" as="style" href="/webpack/test/css/client1-',
+      20: '46072b81.css">after',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map([
+        ['client1', ['/webpack/test/css/client1-46072b81.css']],
+      ]),
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain(
+      '<script>window.msg = 1;</script><link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">after',
+    );
+    expect(resultStr).not.toContain('rel="preload" as="style"');
+    expect(resultStr).not.toContain('client1-<script');
+  });
+
   it('does not hold non-link partial tags for stylesheet gating when observability is disabled', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}']);
     const mockHTML = createMockHTMLStream({
@@ -673,7 +696,8 @@ describe('injectRSCPayload', () => {
   });
 
   it('keeps opt-in observability flush marks out of non-link split tags during stylesheet gating', async () => {
-    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream([flightData]);
     const mockHTML = createMockHTMLStream({
       0: 'before<scr',
       10: 'ipt>after</script>',
@@ -687,9 +711,13 @@ describe('injectRSCPayload', () => {
       rscStreamObservability: true,
     });
     const resultStr = await collectStreamData(result);
+    const prefixIndex = resultStr.indexOf('before');
+    const payloadIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    const originalScriptIndex = resultStr.lastIndexOf('<script>after</script>');
 
-    expect(resultStr).toContain('before');
-    expect(resultStr).toContain('<script>after</script>');
+    expect(prefixIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadIndex).toBeGreaterThan(prefixIndex);
+    expect(originalScriptIndex).toBeGreaterThan(payloadIndex);
     expect(resultStr).toContain('perf.mark("react-on-rails:rsc:flush"');
     expect(resultStr).not.toContain('before<scr<script');
   });
@@ -759,6 +787,396 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('<script>window.msg = "caf<script');
   });
 
+  it('keeps default RSC scripts out of raw-text split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<script>window.msg = "caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('";</script>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('window.msg');
+
+    const resultStr = await allData;
+    const appScriptIndex = resultStr.indexOf('<script>window.msg = "café";</script>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(appScriptIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<script>window.msg = "caf<script');
+  });
+
+  it('keeps default RSC scripts out of script double-escaped split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<script><!--<script>const marker = "</script>"; caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('";</script>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<script><!--<script>');
+
+    const resultStr = await allData;
+    const appScriptIndex = resultStr.indexOf(
+      '<script><!--<script>const marker = "</script>"; café";</script>after',
+    );
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(appScriptIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('const marker = "</script>"; caf<script');
+  });
+
+  it('does not keep scripts double-escaped after escaped script comments close', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<script><!--<script>-->window.msg = "caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('";</script>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+      250: Buffer.from('<p>later</p>'),
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, chunks, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('window.msg');
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 80);
+    });
+    expect(chunks.join('')).toContain('<script><!--<script>-->window.msg = "café";</script>after');
+    expect(chunks.join('')).not.toContain('<p>later</p>');
+
+    const resultStr = await allData;
+    const appScriptIndex = resultStr.indexOf('<script><!--<script>-->window.msg = "café";</script>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(appScriptIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('window.msg = "caf<script');
+  });
+
+  it('keeps default RSC scripts out of quoted raw-text closing tag candidates', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const firstHtmlChunk = 'before<style>body::before { content: "</style data=\\"not>closed\\";';
+    const secondHtmlChunk = ' color: red; }</style>after';
+    const mockHTML = createMockHTMLStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('body::before');
+
+    const resultStr = await allData;
+    const appStyleIndex = resultStr.indexOf(
+      '<style>body::before { content: "</style data=\\"not>closed\\"; color: red; }</style>after',
+    );
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appStyleIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(appStyleIndex);
+    expect(resultStr).not.toContain('body::before { content: "</style data=\\"not><script');
+  });
+
+  it('keeps default RSC scripts out of iframe split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([Buffer.from('before<iframe>caf'), eAcuteBytes.subarray(0, 1)]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</iframe>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<iframe>');
+
+    const resultStr = await allData;
+    const iframeIndex = resultStr.indexOf('<iframe>café</iframe>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(iframeIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(iframeIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<iframe>caf<script');
+  });
+
+  it('keeps default RSC scripts out of noscript split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([Buffer.from('before<noscript>caf'), eAcuteBytes.subarray(0, 1)]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</noscript>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<noscript>');
+
+    const resultStr = await allData;
+    const noscriptIndex = resultStr.indexOf('<noscript>café</noscript>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(noscriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(noscriptIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<noscript>caf<script');
+  });
+
+  it('keeps default RSC scripts out of template split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([Buffer.from('before<template>caf'), eAcuteBytes.subarray(0, 1)]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</template>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<template>');
+
+    const resultStr = await allData;
+    const templateIndex = resultStr.indexOf('<template>café</template>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(templateIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(templateIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<template>caf<script');
+  });
+
+  it('keeps default RSC scripts out of template quoted-attribute split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<template><span title="</template>">caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</span></template>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<template>');
+
+    const resultStr = await allData;
+    const templateIndex = resultStr.indexOf(
+      '<template><span title="</template>">café</span></template>after',
+    );
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(templateIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(templateIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<span title="</template>">caf<script');
+  });
+
+  it('keeps default RSC scripts out of nested template split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<template><template></template>caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</template>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<template>');
+
+    const resultStr = await allData;
+    const templateIndex = resultStr.indexOf('<template><template></template>café</template>after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(templateIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(templateIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<template><template></template>caf<script');
+  });
+
+  it('keeps default RSC scripts out of template raw-text split UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<template><script>const marker = "</template>"; caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([
+      eAcuteBytes.subarray(1),
+      Buffer.from('";</script></template>after'),
+    ]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<template>');
+
+    const resultStr = await allData;
+    const templateIndex = resultStr.indexOf(
+      '<template><script>const marker = "</template>"; café";</script></template>after',
+    );
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(templateIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(templateIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('const marker = "</template>"; caf<script');
+  });
+
+  it('keeps default RSC scripts out of template double-escaped script tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<template><script><!--<script>const marker = "</scr'),
+    ]);
+    const secondHtmlChunk = Buffer.concat([Buffer.from('ipt></template>"; caf'), eAcuteBytes.subarray(0, 1)]);
+    const thirdHtmlChunk = Buffer.concat([
+      eAcuteBytes.subarray(1),
+      Buffer.from('";</script></template>after'),
+    ]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+      45: thirdHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const templateContent =
+      '<template><script><!--<script>const marker = "</script></template>"; café";</script></template>after';
+    const templateIndex = resultStr.indexOf(templateContent);
+    const templateCloseIndex = templateIndex + templateContent.length;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(templateIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex < templateIndex || payloadScriptIndex > templateCloseIndex).toBe(true);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('const marker = "</script></template>"; caf<script');
+  });
+
   it('keeps opt-in observability scripts out of ambiguous raw-text closing tag prefixes', async () => {
     const flightData = '{"test": "data"}';
     const mockRSC = createMockRSCStream({ 0: flightData });
@@ -786,6 +1204,577 @@ describe('injectRSCPayload', () => {
     expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
     expect(payloadScriptIndex).toBeLessThan(styleIndex);
     expect(resultStr).not.toContain('<style>body{color:red}<script');
+  });
+
+  it('flushes raw-text tails when the closing tag name completes across chunks', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const appScript = '<script>window.msg = 1;</script>after';
+    const mockHTML = createMockHTMLStream({
+      5: 'before<script>window.msg = 1;</script',
+      25: '>after',
+      250: '<p>later</p>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, chunks, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedInitializationScript);
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('window.msg');
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 80);
+    });
+    expect(chunks.join('')).toContain(appScript);
+    expect(chunks.join('')).not.toContain('<p>later</p>');
+
+    const resultStr = await allData;
+    expect(resultStr).toContain(appScript);
+    expect(resultStr).toContain('<p>later</p>');
+  });
+
+  it('does not treat raw-text contents as nested raw-text tags', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const appScript = '<script>const msg = "Use <style> tags for CSS.";</script>after';
+    const mockHTML = createMockHTMLStream({
+      5: `before${appScript}`,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const resultStr = await collectStreamData(result);
+
+    const appScriptIndex = resultStr.indexOf(appScript);
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(appScriptIndex).toBeLessThan(payloadScriptIndex);
+    expect(resultStr).not.toContain('Use <style> tags for CSS."<script');
+  });
+
+  it('does not treat fake incomplete tags inside complete raw-text bodies as trailing tags', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const appScript = '<script>const html = "<span "; window.msg = 1;</script>after';
+    const mockHTML = createMockHTMLStream({
+      5: `before${appScript}`,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const resultStr = await collectStreamData(result);
+
+    const appScriptIndex = resultStr.indexOf(appScript);
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(appScriptIndex).toBeLessThan(payloadScriptIndex);
+    expect(resultStr).not.toContain('const html = "<span <script');
+  });
+
+  it('flushes raw-text tails closed by self-closing-style end tags', async () => {
+    const flightData = '{"test": "data"}';
+    const earlyHtml = 'before<script>window.msg = 1;</script/>after';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: earlyHtml,
+      250: '<p>later</p>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, chunks, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 80);
+    });
+    expect(chunks.join('')).toContain(earlyHtml);
+    expect(chunks.join('')).not.toContain('<p>later</p>');
+
+    const resultStr = await allData;
+    expect(resultStr).toContain(earlyHtml);
+    expect(resultStr).toContain('<p>later</p>');
+  });
+
+  it('keeps opt-in observability scripts out of split tag tails after retained raw-text closes', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: 'before<script>window.msg = 1;',
+      25: '</script><div class="he',
+      50: 'llo">after</div>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const resultStr = await collectStreamData(result);
+
+    const appScriptIndex = resultStr.indexOf('<script>window.msg = 1;</script>');
+    const appDivIndex = resultStr.indexOf('<div class="hello">after</div>');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(appDivIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(resultStr).not.toContain('<div class="he<script');
+  });
+
+  it('does not treat raw-text markers inside comments as raw-text tags', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const appComment = '<!-- <script> --><!-- rendered by app -->after';
+    const mockHTML = createMockHTMLStream({
+      5: `before${appComment}`,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const resultStr = await collectStreamData(result);
+
+    const appCommentIndex = resultStr.indexOf(appComment);
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appCommentIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(appCommentIndex).toBeLessThan(payloadScriptIndex);
+    expect(resultStr).not.toContain('<!-- <script><script');
+  });
+
+  it('does not treat raw-text markers inside complete SVG CDATA as raw-text tags', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 25: flightData });
+    const appSvg = '<svg><![CDATA[<script>]]></svg>after';
+    const mockHTML = createMockHTMLStream({
+      5: `before${appSvg}`,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const appSvgIndex = resultStr.indexOf(appSvg);
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appSvgIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(appSvgIndex).toBeLessThan(payloadScriptIndex);
+    expect(resultStr).not.toContain('<![CDATA[<script><script');
+  });
+
+  it('keeps default RSC scripts out of split SVG CDATA tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: 'before<svg><![CDATA[<script>',
+      25: ']]></svg>after',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const svgIndex = resultStr.indexOf('<svg>');
+    const cdataIndex = resultStr.indexOf('<![CDATA[<script>]]>');
+    const cdataCloseIndex = cdataIndex + '<![CDATA[<script>]]>'.length;
+    const svgCloseIndex = resultStr.indexOf('</svg>') + '</svg>'.length;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(svgIndex).toBeGreaterThanOrEqual(0);
+    expect(cdataIndex).toBeGreaterThanOrEqual(0);
+    expect(svgCloseIndex).toBeGreaterThanOrEqual('</svg>'.length);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex < cdataIndex || payloadScriptIndex > cdataCloseIndex).toBe(true);
+    expect(payloadScriptIndex < svgIndex || payloadScriptIndex > svgCloseIndex).toBe(true);
+    expect(resultStr).not.toContain('<![CDATA[<script><script');
+  });
+
+  it('keeps default RSC scripts out of split MathML CDATA tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<math><![CDATA[caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from(']]></math>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const mathContent = '<math><![CDATA[café]]></math>';
+    const mathIndex = resultStr.indexOf(mathContent);
+    const mathCloseIndex = mathIndex + mathContent.length;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(mathIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex < mathIndex || payloadScriptIndex > mathCloseIndex).toBe(true);
+    expect(resultStr).not.toContain('caf<script');
+    expect(resultStr).not.toContain('\uFFFD');
+  });
+
+  it('keeps default RSC scripts out of SVG CDATA after slash-valued attributes', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<svg data-icon=/><![CDATA[caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from(']]></svg>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const svgContent = '<svg data-icon=/><![CDATA[café]]></svg>';
+    const svgIndex = resultStr.indexOf(svgContent);
+    const svgCloseIndex = svgIndex + svgContent.length;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(svgIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex < svgIndex || payloadScriptIndex > svgCloseIndex).toBe(true);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<svg data-icon=/><script');
+  });
+
+  it('does not treat HTML CDATA markers outside foreign content as retained CDATA tails', async () => {
+    const flightData = '{"test": "data"}';
+    const earlyHtml = 'before<![CDATA[plain >after';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: earlyHtml,
+      250: '<p>later</p>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, chunks, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 80);
+    });
+    expect(chunks.join('')).toContain(earlyHtml);
+    expect(chunks.join('')).not.toContain('<p>later</p>');
+
+    const resultStr = await allData;
+    expect(resultStr).toContain(earlyHtml);
+    expect(resultStr).toContain('<p>later</p>');
+  });
+
+  it('keeps default RSC scripts out of foreign content tags with a spaced slash', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const firstHtmlChunk = 'before<svg / >still svg';
+    const secondHtmlChunk = '</svg>after';
+    const mockHTML = createMockHTMLStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const svgContent = '<svg / >still svg</svg>';
+    const svgIndex = resultStr.indexOf(svgContent);
+    const svgCloseIndex = svgIndex + svgContent.length;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(svgIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex < svgIndex || payloadScriptIndex > svgCloseIndex).toBe(true);
+    expect(resultStr).not.toContain('<svg / >still svg<script');
+  });
+
+  it('flushes self-closing foreign-content tags without retaining later HTML', async () => {
+    const flightData = '{"test": "data"}';
+    const earlyHtml = 'before<svg/>middle<math/><svg><svg/></svg><math><math/></math>after';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: earlyHtml,
+      250: '<p>later</p>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, chunks, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 80);
+    });
+    expect(chunks.join('')).toContain(earlyHtml);
+    expect(chunks.join('')).not.toContain('<p>later</p>');
+
+    const resultStr = await allData;
+    expect(resultStr).toContain(earlyHtml);
+    expect(resultStr).toContain('<p>later</p>');
+    expect(resultStr.indexOf(earlyHtml)).toBeLessThan(resultStr.indexOf('<p>later</p>'));
+  });
+
+  it('flushes self-closing raw-text-named foreign-content children without retaining later HTML', async () => {
+    const flightData = '{"test": "data"}';
+    const earlyHtml = 'before<svg><title/><script/></svg>after';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const mockHTML = createMockHTMLStream({
+      5: earlyHtml,
+      250: '<p>later</p>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, chunks, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 80);
+    });
+    expect(chunks.join('')).toContain(earlyHtml);
+    expect(chunks.join('')).not.toContain('<p>later</p>');
+
+    const resultStr = await allData;
+    expect(resultStr).toContain(earlyHtml);
+    expect(resultStr).toContain('<p>later</p>');
+    expect(resultStr.indexOf(earlyHtml)).toBeLessThan(resultStr.indexOf('<p>later</p>'));
+  });
+
+  it('tracks nested templates inside foreign content before flushing RSC scripts', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const firstHtmlChunk = 'before<svg><template><template></template></svg>still template';
+    const secondHtmlChunk = '</template></svg>after';
+    const mockHTML = createMockHTMLStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const svgContent = '<svg><template><template></template></svg>still template</template></svg>';
+    const svgIndex = resultStr.indexOf(svgContent);
+    const svgCloseIndex = svgIndex + svgContent.length;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(svgIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex < svgIndex || payloadScriptIndex > svgCloseIndex).toBe(true);
+    expect(resultStr).not.toContain('</svg>still template<script');
+  });
+
+  it('tracks nested foreign content inside templates before flushing RSC scripts', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const firstHtmlChunk = 'before<template><svg><foreignObject></template>still foreign';
+    const secondHtmlChunk = '</foreignObject></svg>real template</template>after';
+    const mockHTML = createMockHTMLStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const resultStr = await collectStreamData(result);
+
+    const templateContent =
+      '<template><svg><foreignObject></template>still foreign</foreignObject></svg>real template</template>';
+    const templateIndex = resultStr.indexOf(templateContent);
+    const templateCloseIndex = templateIndex + templateContent.length;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(templateIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex < templateIndex || payloadScriptIndex > templateCloseIndex).toBe(true);
+    expect(resultStr).not.toContain('</template>still foreign<script');
+  });
+
+  it('does not treat raw-text markers inside quoted attributes as raw-text tags', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const appHtml = '<div data-copy="<script>">after</div>';
+    const mockHTML = createMockHTMLStream({
+      5: `before${appHtml}`,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const resultStr = await collectStreamData(result);
+
+    const appHtmlIndex = resultStr.indexOf(appHtml);
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appHtmlIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(appHtmlIndex).toBeLessThan(payloadScriptIndex);
+    expect(resultStr).not.toContain('data-copy="<script><script');
+  });
+
+  it('keeps default RSC scripts out of split comments after complete comments', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<!--done-->x<!--caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('-->after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain('before<!--done-->x');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<!--caf');
+
+    const resultStr = await allData;
+    const splitCommentIndex = resultStr.indexOf('<!--café-->after');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(splitCommentIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(splitCommentIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<!--caf<script');
+  });
+
+  it('keeps default RSC scripts out of non-link split tag UTF-8 tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([Buffer.from('before<span title="caf'), eAcuteBytes.subarray(0, 1)]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('">after</span>')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<span');
+
+    const resultStr = await allData;
+    const splitSpanIndex = resultStr.indexOf('<span title="café">after</span>');
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(splitSpanIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeLessThan(splitSpanIndex);
+    expect(resultStr).not.toContain('\uFFFD');
+    expect(resultStr).not.toContain('<span title="caf<script');
+  });
+
+  it('does not treat custom elements with raw-text tag prefixes as raw-text tags', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const customElement = '<script-loader>ready</script-loader>after';
+    const mockHTML = createMockHTMLStream({
+      5: `before${customElement}`,
+      25: '<p>done</p>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(customElement);
+
+    const resultStr = await allData;
+    const customElementIndex = resultStr.indexOf(customElement);
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(customElementIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(customElementIndex).toBeLessThan(payloadScriptIndex);
+  });
+
+  it('keeps raw-text closing tag indices stable when content lowercases to more code points', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const appScript = '<script>window.city = "İstanbul";</script>after';
+    const mockHTML = createMockHTMLStream({
+      5: `before${appScript}`,
+      25: '<p>done</p>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain(appScript);
+
+    const resultStr = await allData;
+    const appScriptIndex = resultStr.indexOf(appScript);
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(appScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(appScriptIndex).toBeLessThan(payloadScriptIndex);
   });
 
   it('flushes complete HTML and RSC scripts while holding an observability split tag tail', async () => {
@@ -835,6 +1824,88 @@ describe('injectRSCPayload', () => {
       'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">caf',
     );
     expect(resultStr).toContain('é after');
+    expect(resultStr).not.toContain('\uFFFD');
+  });
+
+  it('flushes default-mode HTML prefixes before split UTF-8 text tails complete', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([Buffer.from('before<p>caf'), eAcuteBytes.subarray(0, 1)]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</p>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain('before<p>caf');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+
+    const resultStr = await allData;
+    expect(resultStr).toContain('é</p>after');
+    expect(resultStr).not.toContain('\uFFFD');
+  });
+
+  it('flushes observability-mode HTML prefixes before split UTF-8 text tails complete', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([Buffer.from('before<p>caf'), eAcuteBytes.subarray(0, 1)]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</p>after')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      rscStreamObservability: true,
+    });
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain('before<p>caf');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.toContain('perf.mark("react-on-rails:rsc:flush"');
+
+    const resultStr = await allData;
+    const payloadScriptIndex = resultStr.indexOf(expectedPayloadPushScript(flightData));
+    expect(payloadScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(resultStr).toContain('é</p>after');
+    expect(resultStr).not.toContain('\uFFFD');
+  });
+
+  it('keeps default RSC scripts out of quoted-attribute split UTF-8 tag tails', async () => {
+    const flightData = '{"test": "data"}';
+    const mockRSC = createMockRSCStream({ 0: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<span title=">caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('">after</span>')]);
+    const mockHTML = createMockHTMLByteStream({
+      5: firstHtmlChunk,
+      25: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain('before');
+    await expect(firstChunk).resolves.toContain(expectedPayloadPushScript(flightData));
+    await expect(firstChunk).resolves.not.toContain('<span title');
+
+    const resultStr = await allData;
+    expect(resultStr).toContain('<span title=">café">after</span>');
+    expect(resultStr).not.toContain('title=">caf<script');
     expect(resultStr).not.toContain('\uFFFD');
   });
 


### PR DESCRIPTION
## Summary

Fixes #4327.

`injectRSCPayload` used to skip an entire flush whenever streamed HTML ended with an incomplete HTML or UTF-8 tail. That let complete HTML prefixes, RSC initialization, payload scripts, stylesheet buffers, and observability marks accumulate behind a small incomplete tail. This keeps only the incomplete tail buffered while flushing the complete prefix and ready RSC data.

## Changes

- Track the exact incomplete UTF-8 or HTML tag tail as a retained buffer.
- Flush complete HTML prefixes, RSC initialization, stylesheet buffers, payload scripts, and observability marks while preserving the tail for the next chunk.
- Preserve deferred Suspense reveal HTML ordering and append retained tails after each successful flush.
- Add regression coverage for an observability split-tag tail where the first output chunk now flushes safe HTML and RSC scripts.

## Validation

- `pnpm --dir packages/react-on-rails-pro exec jest tests/injectRSCPayload.test.ts --runInBand`
- `pnpm --dir packages/react-on-rails-pro run test:streaming`
- `pnpm --dir packages/react-on-rails-pro run type-check`
- `pnpm exec prettier --check packages/react-on-rails-pro/src/injectRSCPayload.ts packages/react-on-rails-pro/tests/injectRSCPayload.test.ts`
- `pnpm exec eslint packages/react-on-rails-pro/src/injectRSCPayload.ts packages/react-on-rails-pro/tests/injectRSCPayload.test.ts --no-warn-ignored`
- `script/check-pro-license-headers`
- `git diff --check origin/main...HEAD`
- Read-only second review subagent: no actionable issues; reran focused Jest and diff-check.

No changelog entry: internal Pro streaming robustness fix with no public API change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened streamed rendering so incomplete HTML and UTF-8 byte fragments are preserved between flush cycles, avoiding dropped or corrupted markup.
  * Improved stylesheet preload handling during streaming, including safer promotion when preload/link markup is split across chunks.
  * Corrected boundary handling for raw-text elements (e.g., script/style/textarea/title) and refined opt-in observability injection to prevent malformed output at split points.
* **Tests**
  * Expanded and tightened streamed boundary, stylesheet gating, and UTF-8 safety coverage, including edge cases around chunked tag/byte splits and flush ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Streaming Behavior Note

This fix deliberately buffers open raw-text, template, and foreign-content containers until their browser-visible closing boundary is known, so RSC scripts are not emitted inside those containers. Plain text split on incomplete UTF-8 bytes keeps only the incomplete byte tail buffered while the UTF-8-safe prefix can flush.



## Merge Readiness Note

- Release mode: development from release tracker #3823; target branch `main` is beta phase. Accelerated-RC `Agent Merge Confidence` block is not required.
- Review coverage for current head `3ad31b1695924de6836ac72a1e9c993464fc96cd`: Claude review check passed and CodeRabbit check passed. Codex review hit usage limits after stale review artifacts; Greptile has only stale review/comment artifacts for earlier heads. Coverage floor still has two working systems; degraded systems are recorded here per AGENTS.md.
- Current-head gates before merge: `pr-ci-readiness 4379` reported READY, GraphQL unresolved review threads count was 0, and strict `script/pr-merge-ledger 4379 --strict --changelog-classification not_user_visible --finding-dispositions /tmp/ror-batch-e-dispositions-4379.json` is the final ledger gate.
