### PR TITLE
Fail fast when local benchmark server exits

### DIFF
--- a/benchmarks/lib/local_benchmark_runner/process_wait.rb
+++ b/benchmarks/lib/local_benchmark_runner/process_wait.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "socket"
+
+module LocalBenchmarkRunner
+  module ProcessWait
+    ALREADY_REAPED = :already_reaped
+
+    module_function
+
+    def wait_for_port(pid, port, label, timeout:, sleep_interval: 1)
+      attempt = 0
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        if (status = reap_if_exited(pid))
+          raise "#{label} (pid #{pid}) exited during startup#{exit_detail(status)}"
+        end
+        return if port_open?(port)
+
+        remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        raise "#{label} failed to start within #{timeout}s" if remaining <= 0
+
+        attempt += 1
+        puts "  attempt #{attempt}: #{label} (port #{port}) not ready yet (timeout #{timeout}s)..."
+        sleep [sleep_interval, remaining].min
+      end
+    end
+
+    def port_open?(port)
+      TCPSocket.new("localhost", port).close
+      true
+    rescue StandardError
+      false
+    end
+
+    def reap_if_exited(pid)
+      _, status = Process.waitpid2(pid, Process::WNOHANG)
+      status
+    rescue Errno::ECHILD
+      ALREADY_REAPED
+    end
+
+    def exit_detail(status)
+      case status
+      when Process::Status
+        " (#{status})"
+      when ALREADY_REAPED
+        " (already reaped)"
+      else
+        ""
+      end
+    end
+  end
+end

--- a/benchmarks/lib/local_benchmark_runner/process_wait.rb
+++ b/benchmarks/lib/local_benchmark_runner/process_wait.rb
@@ -12,10 +12,11 @@ module LocalBenchmarkRunner
       attempt = 0
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
       loop do
+        return if port_open?(port)
+
         if (status = reap_if_exited(pid))
           raise "#{label} (pid #{pid}) exited during startup#{exit_detail(status)}"
         end
-        return if port_open?(port)
 
         remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
         raise "#{label} failed to start within #{timeout}s" if remaining <= 0

--- a/benchmarks/run-local-benchmark.rb
+++ b/benchmarks/run-local-benchmark.rb
@@ -23,10 +23,10 @@ require "English"
 require "fileutils"
 require "optparse"
 require "shellwords"
-require "socket"
 
 require_relative "generate_matrix"
 require_relative "lib/bencher_runner"
+require_relative "lib/local_benchmark_runner/process_wait"
 
 REPO_ROOT = File.expand_path("..", __dir__)
 SERVER_PORT = 3001
@@ -36,9 +36,9 @@ SERVER_PORT = 3001
 RENDERER_PORT = 3800
 # How long to wait for the production server (and, for pro, the renderer) to bind. A cold
 # production Puma boot eager-loads the whole app before listening, which is slow on the first
-# run after a fresh build — observed ~83s on a 2021 M1 Max, vs ~2s warm. wait_for_port still
-# checks the process is alive each second, so a real crash fails fast; this generous ceiling
-# only affects a slow-but-alive boot. Override with BENCHMARK_SERVER_BOOT_TIMEOUT if needed.
+# run after a fresh build — observed ~83s on a 2021 M1 Max, vs ~2s warm. wait_for_port reaps
+# an exited direct child each second, so a real crash fails fast; this generous ceiling only
+# affects a slow-but-alive boot. Override with BENCHMARK_SERVER_BOOT_TIMEOUT if needed.
 SERVER_BOOT_TIMEOUT = ENV.fetch("BENCHMARK_SERVER_BOOT_TIMEOUT", "240").then do |raw|
   seconds = Integer(raw, exception: false)
   next seconds if seconds&.positive?
@@ -150,32 +150,11 @@ def run!(command, chdir: REPO_ROOT, env: {})
 end
 
 def wait_for_port(pid, port, label)
-  attempt = 0
-  while attempt < SERVER_BOOT_TIMEOUT
-    raise "#{label} (pid #{pid}) exited during startup" unless process_alive?(pid)
-    return if port_open?(port)
-
-    attempt += 1
-    puts "  attempt #{attempt}/#{SERVER_BOOT_TIMEOUT}: #{label} (port #{port}) not ready yet..."
-    sleep 1
-  end
-  raise "#{label} failed to start within #{SERVER_BOOT_TIMEOUT}s"
+  LocalBenchmarkRunner::ProcessWait.wait_for_port(pid, port, label, timeout: SERVER_BOOT_TIMEOUT)
 end
 
 def port_open?(port)
-  TCPSocket.new("localhost", port).close
-  true
-rescue StandardError
-  false
-end
-
-def process_alive?(pid)
-  Process.kill(0, pid)
-  true
-rescue Errno::ESRCH
-  false
-rescue Errno::EPERM
-  true # Process exists but is owned by another user — still alive, just unsignalable.
+  LocalBenchmarkRunner::ProcessWait.port_open?(port)
 end
 
 web_concurrency = [cpu_count - 1, 1].max

--- a/benchmarks/spec/local_benchmark_runner/process_wait_spec.rb
+++ b/benchmarks/spec/local_benchmark_runner/process_wait_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/local_benchmark_runner/process_wait"
+
+RSpec.describe LocalBenchmarkRunner::ProcessWait do
+  describe ".wait_for_port" do
+    it "fails fast when a direct child exits before opening the port" do
+      pid = Process.spawn("sh", "-c", "exit 42")
+      sleep 0.05
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      expect do
+        described_class.wait_for_port(pid, 65_530, "Rails server", timeout: 2, sleep_interval: 0.01)
+      end.to raise_error(RuntimeError, /Rails server \(pid #{pid}\) exited during startup .*exit 42/)
+      expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).to be < 0.5
+    ensure
+      begin
+        Process.wait(pid, Process::WNOHANG) if pid
+      rescue Errno::ECHILD
+        nil
+      end
+    end
+
+    it "treats timeout as elapsed seconds when polling faster than once per second" do
+      pid = Process.spawn("sh", "-c", "sleep 1")
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      expect do
+        described_class.wait_for_port(pid, 65_531, "Rails server", timeout: 0.05, sleep_interval: 0.01)
+      end.to raise_error(RuntimeError, "Rails server failed to start within 0.05s")
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      expect(elapsed).to be >= 0.05
+      expect(elapsed).to be < 0.5
+    ensure
+      if pid
+        begin
+          Process.kill("TERM", pid)
+        rescue Errno::ESRCH
+          nil
+        end
+        begin
+          Process.wait(pid)
+        rescue Errno::ECHILD
+          nil
+        end
+      end
+    end
+  end
+end

--- a/benchmarks/spec/local_benchmark_runner/process_wait_spec.rb
+++ b/benchmarks/spec/local_benchmark_runner/process_wait_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe LocalBenchmarkRunner::ProcessWait do
       end
     end
 
+    it "accepts an open port when the wrapper process has already exited" do
+      server = TCPServer.new("localhost", 0)
+      pid = Process.spawn("sh", "-c", "exit 0")
+      sleep 0.05
+
+      expect do
+        described_class.wait_for_port(pid, server.addr[1], "Rails server", timeout: 2, sleep_interval: 0.01)
+      end.not_to raise_error
+    ensure
+      server&.close
+      begin
+        Process.wait(pid, Process::WNOHANG) if pid
+      rescue Errno::ECHILD
+        nil
+      end
+    end
+
     it "treats timeout as elapsed seconds when polling faster than once per second" do
       pid = Process.spawn("sh", "-c", "sleep 1")
 


### PR DESCRIPTION
## Why

Local benchmark runs waited for the full server boot timeout when the spawned production server exited before binding its port. That made a crashed benchmark server look like a slow boot and delayed diagnosis.

Closes #4318.

## What changed

- Extracted the benchmark server wait logic into `LocalBenchmarkRunner::ProcessWait`.
- Replaced signal-0 liveness checks with `Process.waitpid2(..., WNOHANG)` for the direct child process so exited/zombie servers are detected immediately.
- Kept `BENCHMARK_SERVER_BOOT_TIMEOUT` as elapsed seconds, including faster polling intervals.
- Added specs for fast child-exit detection and timeout-second semantics.

## Validation

- `bundle exec rspec benchmarks/spec`
- `BUNDLE_GEMFILE=Gemfile bundle exec rubocop benchmarks/run-local-benchmark.rb benchmarks/lib/local_benchmark_runner/process_wait.rb benchmarks/spec/local_benchmark_runner/process_wait_spec.rb`
- `ruby -c benchmarks/lib/local_benchmark_runner/process_wait.rb`
- `ruby -c benchmarks/run-local-benchmark.rb`
- `git diff --check origin/main...HEAD`
- Pre-push hook passed branch Ruby lint and markdown-link checks.
- Codex autoreview: one timeout-semantics finding fixed, rerun clean.
- Claude second review: `NO_FINDINGS`.

## Batch D notes

This PR handles the claimed benchmark lane for #4318. Issue #4321 was not included because the private coordination claim repeatedly returned write-contention state, so it remains a separate blocked/UNKNOWN lane rather than being mixed into this branch.
