### PR TITLE
Preserve agent-coord-bounded output on bounded exits

### DIFF
--- a/.agents/skills/pr-batch/bin/agent-coord-bounded
+++ b/.agents/skills/pr-batch/bin/agent-coord-bounded
@@ -55,6 +55,13 @@ def exit_code_for_status(status)
   status.exitstatus || 1
 end
 
+def flush_captured_output(stdout_file, stderr_file)
+  stdout_file.rewind
+  stderr_file.rewind
+  print stdout_file.read
+  $stderr.print(stderr_file.read)
+end
+
 options = {}
 
 parser = OptionParser.new do |opts|
@@ -114,6 +121,7 @@ begin
   loop do
     if interrupted_signal
       terminate_process_group(pid, signal: interrupted_signal)
+      flush_captured_output(stdout_file, stderr_file)
       exit(128 + Signal.list.fetch(interrupted_signal))
     end
 
@@ -133,20 +141,19 @@ begin
 
   if interrupted_signal
     terminate_process_group(pid, signal: interrupted_signal)
+    flush_captured_output(stdout_file, stderr_file)
     exit(128 + Signal.list.fetch(interrupted_signal))
   end
 
   terminate_process_group(pid) if timed_out
 
   if timed_out
+    flush_captured_output(stdout_file, stderr_file)
     warn "agent-coord-bounded: timed out after #{timeout}s: #{Shellwords.join(command)}"
     exit 124
   end
 
-  stdout_file.rewind
-  stderr_file.rewind
-  print stdout_file.read
-  $stderr.print(stderr_file.read)
+  flush_captured_output(stdout_file, stderr_file)
 
   exit(exit_code_for_status(status))
 ensure

--- a/.agents/skills/pr-batch/bin/agent-coord-bounded
+++ b/.agents/skills/pr-batch/bin/agent-coord-bounded
@@ -37,13 +37,36 @@ rescue Errno::ESRCH
   nil
 end
 
+def process_group_alive?(pid)
+  Process.kill(0, -pid)
+  true
+rescue Errno::ESRCH
+  false
+rescue Errno::EPERM
+  true
+end
+
+def wait_for_process_group_exit(pid, deadline)
+  while Time.now < deadline
+    return true unless process_group_alive?(pid)
+
+    sleep 0.05
+  end
+
+  !process_group_alive?(pid)
+end
+
 def terminate_process_group(pid, signal: "TERM", grace_seconds: 1, kill_grace_seconds: 1)
+  term_deadline = Time.now + grace_seconds
   signal_process_group(pid, signal)
-  status = wait_for_child(pid, Time.now + grace_seconds)
+  status = wait_for_child(pid, term_deadline)
+  return status if wait_for_process_group_exit(pid, term_deadline)
 
   # The direct child may exit before helper processes in its process group.
   signal_process_group(pid, "KILL")
-  status ||= wait_for_child(pid, Time.now + kill_grace_seconds)
+  kill_deadline = Time.now + kill_grace_seconds
+  status ||= wait_for_child(pid, kill_deadline)
+  wait_for_process_group_exit(pid, kill_deadline)
 
   status
 end

--- a/.agents/skills/pr-batch/bin/agent-coord-bounded-test.rb
+++ b/.agents/skills/pr-batch/bin/agent-coord-bounded-test.rb
@@ -27,14 +27,17 @@ class AgentCoordBoundedTest < Minitest::Test
   def test_times_out_and_reports_unknown_friendly_status
     with_fake_agent_coord(<<~RUBY) do |env|
       puts "partial json output"
+      $stderr.puts "partial stderr output"
       $stdout.flush
+      $stderr.flush
       sleep 5
     RUBY
-      stdout, stderr, status = run_script(env, "--timeout", "0.2", "doctor", "--json")
+      stdout, stderr, status = run_script(env, "--timeout", "1", "doctor", "--json")
 
       assert_equal 124, status.exitstatus
-      assert_empty stdout
-      assert_includes stderr, "agent-coord-bounded: timed out after 0.2s"
+      assert_equal "partial json output\n", stdout
+      assert_includes stderr, "partial stderr output"
+      assert_includes stderr, "agent-coord-bounded: timed out after 1.0s"
       assert_includes stderr, "agent-coord doctor --json"
     end
   end
@@ -116,15 +119,21 @@ class AgentCoordBoundedTest < Minitest::Test
   def test_terminates_agent_coord_process_group_when_interrupted
     Dir.mktmpdir("agent-coord-bounded-test") do |dir|
       child_pid_file = File.join(dir, "child.pid")
+      wrapper_stdout_file = File.join(dir, "wrapper.stdout")
+      wrapper_stderr_file = File.join(dir, "wrapper.stderr")
       wrapper_pid = nil
       child_pid = nil
 
       with_fake_agent_coord(<<~RUBY, "AGENT_COORD_CHILD_PID" => child_pid_file) do |env|
+        puts "interrupted stdout output"
+        $stderr.puts "interrupted stderr output"
+        $stdout.flush
+        $stderr.flush
         File.write(ENV.fetch("AGENT_COORD_CHILD_PID"), Process.pid.to_s)
         sleep 10
       RUBY
         wrapper_pid = Process.spawn(env, RbConfig.ruby, SCRIPT, "--timeout", "20", "status",
-                                    out: File::NULL, err: File::NULL)
+                                    out: wrapper_stdout_file, err: wrapper_stderr_file)
 
         assert wait_until(timeout: 5) { File.size?(child_pid_file) }, "fake agent-coord did not start"
 
@@ -133,6 +142,8 @@ class AgentCoordBoundedTest < Minitest::Test
         _, status = Process.waitpid2(wrapper_pid)
 
         assert_equal 143, status.exitstatus
+        assert_equal "interrupted stdout output\n", File.read(wrapper_stdout_file)
+        assert_includes File.read(wrapper_stderr_file), "interrupted stderr output"
         assert wait_until(timeout: 5) { !process_alive?(child_pid) }, "fake agent-coord survived wrapper termination"
       ensure
         Process.kill("KILL", wrapper_pid) if wrapper_pid && process_alive?(wrapper_pid)

--- a/.agents/skills/pr-batch/bin/agent-coord-bounded-test.rb
+++ b/.agents/skills/pr-batch/bin/agent-coord-bounded-test.rb
@@ -181,6 +181,47 @@ class AgentCoordBoundedTest < Minitest::Test
     end
   end
 
+  def test_timeout_replays_helper_output_before_killing_process_group
+    Dir.mktmpdir("agent-coord-bounded-test") do |dir|
+      helper_pid_file = File.join(dir, "helper.pid")
+      helper_pid = nil
+
+      with_fake_agent_coord(<<~RUBY, "AGENT_COORD_HELPER_PID" => helper_pid_file) do |env|
+        helper_code = <<~'HELPER'
+          trap("TERM") do
+            sleep 0.2
+            puts "helper stdout after TERM"
+            $stderr.puts "helper stderr after TERM"
+            $stdout.flush
+            $stderr.flush
+            exit! 0
+          end
+          File.write(ENV.fetch("AGENT_COORD_HELPER_PID"), Process.pid.to_s)
+          sleep 10
+        HELPER
+        helper_pid = Process.spawn({ "AGENT_COORD_HELPER_PID" => ENV.fetch("AGENT_COORD_HELPER_PID") },
+                                   #{RbConfig.ruby.dump}, "-e", helper_code)
+        Process.detach(helper_pid)
+        deadline = Time.now + 5
+        sleep 0.05 until File.size?(ENV.fetch("AGENT_COORD_HELPER_PID")) || Time.now >= deadline
+        sleep 10
+      RUBY
+        stdout, stderr, status = run_script(env, "--timeout", "1", "status")
+
+        assert_equal 124, status.exitstatus
+        assert_includes stdout, "helper stdout after TERM"
+        assert_includes stderr, "helper stderr after TERM"
+        assert_includes stderr, "agent-coord-bounded: timed out after 1.0s"
+        assert wait_until(timeout: 5) { File.size?(helper_pid_file) }, "fake helper did not start"
+
+        helper_pid = File.read(helper_pid_file).to_i
+        assert wait_until(timeout: 5) { !process_alive?(helper_pid) }, "helper survived process-group cleanup"
+      ensure
+        Process.kill("KILL", helper_pid) if helper_pid && process_alive?(helper_pid)
+      end
+    end
+  end
+
   def test_process_alive_treats_eperm_as_alive
     original_kill = Process.method(:kill)
     # This patches Process globally for the duration of the assertion; the


### PR DESCRIPTION
## Why

`agent-coord-bounded` captured child stdout/stderr into temporary files, but timeout and interrupt exits could return without replaying those captured streams. That made degraded coordination reads harder to diagnose because the underlying command output was lost.

Closes #4320.

## What changed

- Added one `flush_captured_output` helper for the bounded wrapper.
- Reused it in normal completion, timeout, and SIGINT/SIGTERM interrupt paths.
- Added regression coverage for partial stdout/stderr preservation on timeout and interrupted exits.

## Validation

- `ruby .agents/skills/pr-batch/bin/agent-coord-bounded-test.rb` — 13 runs, 72 assertions, 0 failures.
- `BUNDLE_GEMFILE=Gemfile bundle exec rubocop .agents/skills/pr-batch/bin/agent-coord-bounded .agents/skills/pr-batch/bin/agent-coord-bounded-test.rb`
- `.agents/bin/agent-workflow-seam-doctor`
- `.agents/bin/validate --changed`
- `git diff --check origin/main...HEAD`
- Pre-push hook passed branch Ruby lint and markdown-link checks.
- Codex autoreview: clean.
- Claude second review: `NO_FINDINGS`.

## Batch D notes

This PR only handles the claimed #4320 lane. Issue #4322 could not be claimed because private coordination repeatedly returned write-contention state, and #4323 depends on the unresolved #4322/#4320 follow-up surface, so those lanes remain separate blocked/UNKNOWN dispositions.
