### PR TITLE
Release incremental render context on setup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4350](https://github.com/shakacode/react_on_rails/pull/4350) by
   [justin808](https://github.com/justin808).
 
+- **[Pro]** **Incremental render setup failures release renderer context**:
+  The Pro node renderer now releases the execution context and destroys started streams when
+  pull-mode incremental render setup fails, preventing orphaned renderer work after response-start
+  errors. Fixes [Issue 4312](https://github.com/shakacode/react_on_rails/issues/4312).
+  [PR 4383](https://github.com/shakacode/react_on_rails/pull/4383) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Dropped pull-mode prop requests are logged**: Streaming SSR now warns when the Node
   renderer sends a `propRequest` control frame without an emitter or with a missing, empty, or
   oversized `propName`, making dropped pull-mode requests diagnosable while preserving valid

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
@@ -226,125 +226,144 @@ export async function handleIncrementalRenderRequest(
       return { response };
     }
 
-    // Set up pull mode if enabled: inject propRequest emitter into sharedExecutionContext
-    // so AsyncPropsManager (inside VM) can emit propRequests to the response stream.
     let finalResponse = response;
-    const { pullEnabled, pushProps } = firstRequestChunk;
-    if (pullEnabled && response.stream) {
-      const sourceStream = response.stream;
-      const { sharedExecutionContext } = executionContext;
-      sharedExecutionContext.set(PULL_ENABLED_KEY, true);
-      sharedExecutionContext.set(PUSH_PROPS_KEY, new Set(pushProps || []));
 
-      // Create injectable PassThrough — sits after the length-prefixed transform.
-      // Both HTML chunks (from React) and propRequest chunks (from us) flow through it.
-      const injectableStream = new PassThrough();
-      const writeRenderCompleteAndEnd = () => {
-        if (injectableStream.destroyed || injectableStream.writableEnded) return;
-        try {
-          injectableStream.write(formatRenderCompleteChunk());
-        } catch (err) {
-          log.warn({ msg: 'Failed to write renderComplete chunk', err });
-        }
-        injectableStream.end();
-      };
+    try {
+      // Set up pull mode if enabled: inject propRequest emitter into sharedExecutionContext
+      // so AsyncPropsManager (inside VM) can emit propRequests to the response stream.
+      const { pullEnabled, pushProps } = firstRequestChunk;
+      if (pullEnabled && response.stream) {
+        const sourceStream = response.stream;
+        const { sharedExecutionContext } = executionContext;
+        sharedExecutionContext.set(PULL_ENABLED_KEY, true);
+        sharedExecutionContext.set(PUSH_PROPS_KEY, new Set(pushProps || []));
 
-      // Register event handlers BEFORE pipe() to guarantee we catch 'end'
-      // even if the source stream has already buffered all its data.
-      sourceStream.on('end', () => {
-        if (injectableStream.writableNeedDrain) {
-          injectableStream.once('drain', writeRenderCompleteAndEnd);
-          return;
-        }
-        writeRenderCompleteAndEnd();
-      });
-      sourceStream.on('error', (err) => {
-        injectableStream.destroy(err);
-      });
-      // Fastify destroys the returned stream when the browser/Rails client disconnects.
-      // Propagate that premature teardown back through the pull wrapper so upstream
-      // React/RSC work and async prop fetches abort just like the non-pull path.
-      injectableStream.once('close', () => {
-        if (!injectableStream.writableEnded && !sourceStream.destroyed) {
-          sourceStream.destroy();
-        }
-      });
-
-      // { end: false } prevents pipe from auto-closing injectableStream when
-      // the source ends — we write renderComplete in the 'end' handler above.
-      sourceStream.pipe(injectableStream, { end: false });
-
-      // Set the emitter callback — AsyncPropsManager calls this from inside the VM
-      sharedExecutionContext.set(PROP_REQUEST_EMITTER_KEY, (propName: string) => {
-        if (injectableStream.destroyed || injectableStream.writableEnded) {
-          log.warn({ msg: 'Skipping propRequest after stream closed', propName });
-          return;
-        }
-        if (propName.length > MAX_PULL_PROP_NAME_LENGTH) {
-          log.warn({
-            msg: 'Skipping oversized propRequest',
-            propNameLength: propName.length,
-            maxPropNameLength: MAX_PULL_PROP_NAME_LENGTH,
-          });
-          return;
-        }
-        try {
-          injectableStream.write(formatPropRequestChunk(propName));
-        } catch (err) {
-          log.error({ msg: 'Failed to write propRequest chunk', propName, err });
-        }
-      });
-
-      const manager = sharedExecutionContext.get(ASYNC_PROPS_MANAGER_KEY);
-      catchUpAsyncPropsManagerPullBridge(manager);
-
-      finalResponse = { ...response, stream: injectableStream };
-    }
-
-    // Return the result with a sink that uses the execution context
-    return {
-      response: finalResponse,
-      sink: {
-        executionContext,
-        add: async (chunk: unknown) => {
+        // Create injectable PassThrough — sits after the length-prefixed transform.
+        // Both HTML chunks (from React) and propRequest chunks (from us) flow through it.
+        const injectableStream = new PassThrough();
+        const writeRenderCompleteAndEnd = () => {
+          if (injectableStream.destroyed || injectableStream.writableEnded) return;
           try {
-            assertIsUpdateChunk(chunk);
-            await subSpan({ name: 'ror.incremental.process_chunk' }, async () => {
-              const bundlePath = getRequestBundleFilePath(chunk.bundleTimestamp);
-              const result = await executionContext.runInVM(chunk.updateChunk, bundlePath);
+            injectableStream.write(formatRenderCompleteChunk());
+          } catch (err) {
+            log.warn({ msg: 'Failed to write renderComplete chunk', err });
+          }
+          injectableStream.end();
+        };
+
+        // Register event handlers BEFORE pipe() to guarantee we catch 'end'
+        // even if the source stream has already buffered all its data.
+        sourceStream.on('end', () => {
+          if (injectableStream.writableNeedDrain) {
+            injectableStream.once('drain', writeRenderCompleteAndEnd);
+            return;
+          }
+          writeRenderCompleteAndEnd();
+        });
+        sourceStream.on('error', (err) => {
+          injectableStream.destroy(err);
+        });
+        // Fastify destroys the returned stream when the browser/Rails client disconnects.
+        // Propagate that premature teardown back through the pull wrapper so upstream
+        // React/RSC work and async prop fetches abort just like the non-pull path.
+        injectableStream.once('close', () => {
+          if (!injectableStream.writableEnded && !sourceStream.destroyed) {
+            sourceStream.destroy();
+          }
+        });
+
+        // { end: false } prevents pipe from auto-closing injectableStream when
+        // the source ends — we write renderComplete in the 'end' handler above.
+        sourceStream.pipe(injectableStream, { end: false });
+
+        // Set the emitter callback — AsyncPropsManager calls this from inside the VM
+        sharedExecutionContext.set(PROP_REQUEST_EMITTER_KEY, (propName: string) => {
+          if (injectableStream.destroyed || injectableStream.writableEnded) {
+            log.warn({ msg: 'Skipping propRequest after stream closed', propName });
+            return;
+          }
+          if (propName.length > MAX_PULL_PROP_NAME_LENGTH) {
+            log.warn({
+              msg: 'Skipping oversized propRequest',
+              propNameLength: propName.length,
+              maxPropNameLength: MAX_PULL_PROP_NAME_LENGTH,
+            });
+            return;
+          }
+          try {
+            injectableStream.write(formatPropRequestChunk(propName));
+          } catch (err) {
+            log.error({ msg: 'Failed to write propRequest chunk', propName, err });
+          }
+        });
+
+        const manager = sharedExecutionContext.get(ASYNC_PROPS_MANAGER_KEY);
+        catchUpAsyncPropsManagerPullBridge(manager);
+
+        finalResponse = { ...response, stream: injectableStream };
+      }
+
+      // Return the result with a sink that uses the execution context
+      return {
+        response: finalResponse,
+        sink: {
+          executionContext,
+          add: async (chunk: unknown) => {
+            try {
+              assertIsUpdateChunk(chunk);
+              await subSpan({ name: 'ror.incremental.process_chunk' }, async () => {
+                const bundlePath = getRequestBundleFilePath(chunk.bundleTimestamp);
+                const result = await executionContext.runInVM(chunk.updateChunk, bundlePath);
+                if (isErrorRenderResult(result)) {
+                  throw new Error(result.exceptionMessage);
+                }
+              });
+            } catch (err) {
+              if (err instanceof InvalidIncrementalRenderChunkError) {
+                log.error({ msg: 'Invalid incremental render chunk', err, chunk });
+              } else {
+                log.error({ msg: 'Error running incremental render chunk', err, chunk });
+              }
+            }
+          },
+          handleRequestClosed: async () => {
+            if (!onRequestClosedUpdateChunk) {
+              return;
+            }
+
+            const bundlePath = getRequestBundleFilePath(onRequestClosedUpdateChunk.bundleTimestamp);
+            try {
+              const result = await executionContext.runInVM(
+                onRequestClosedUpdateChunk.updateChunk,
+                bundlePath,
+              );
               if (isErrorRenderResult(result)) {
                 throw new Error(result.exceptionMessage);
               }
-            });
-          } catch (err) {
-            if (err instanceof InvalidIncrementalRenderChunkError) {
-              log.error({ msg: 'Invalid incremental render chunk', err, chunk });
-            } else {
-              log.error({ msg: 'Error running incremental render chunk', err, chunk });
+            } catch (err: unknown) {
+              log.error({
+                msg: 'Error running onRequestClosedUpdateChunk',
+                err,
+                onRequestClosedUpdateChunk,
+              });
             }
-          }
+          },
         },
-        handleRequestClosed: async () => {
-          if (!onRequestClosedUpdateChunk) {
-            return;
-          }
+      };
+    } catch (error) {
+      try {
+        if (finalResponse.stream && !finalResponse.stream.destroyed) {
+          finalResponse.stream.destroy();
+        }
+        if (response.stream && response.stream !== finalResponse.stream && !response.stream.destroyed) {
+          response.stream.destroy();
+        }
+      } finally {
+        executionContext.release();
+      }
 
-          const bundlePath = getRequestBundleFilePath(onRequestClosedUpdateChunk.bundleTimestamp);
-          try {
-            const result = await executionContext.runInVM(onRequestClosedUpdateChunk.updateChunk, bundlePath);
-            if (isErrorRenderResult(result)) {
-              throw new Error(result.exceptionMessage);
-            }
-          } catch (err: unknown) {
-            log.error({
-              msg: 'Error running onRequestClosedUpdateChunk',
-              err,
-              onRequestClosedUpdateChunk,
-            });
-          }
-        },
-      },
-    };
+      throw error;
+    }
   } catch (error) {
     // Handle any unexpected errors
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
@@ -227,6 +227,7 @@ export async function handleIncrementalRenderRequest(
     }
 
     let finalResponse = response;
+    let pullModeStream: PassThrough | undefined;
 
     try {
       // Set up pull mode if enabled: inject propRequest emitter into sharedExecutionContext
@@ -241,6 +242,7 @@ export async function handleIncrementalRenderRequest(
         // Create injectable PassThrough — sits after the length-prefixed transform.
         // Both HTML chunks (from React) and propRequest chunks (from us) flow through it.
         const injectableStream = new PassThrough();
+        pullModeStream = injectableStream;
         const writeRenderCompleteAndEnd = () => {
           if (injectableStream.destroyed || injectableStream.writableEnded) return;
           try {
@@ -352,10 +354,22 @@ export async function handleIncrementalRenderRequest(
       };
     } catch (error) {
       try {
-        if (finalResponse.stream && !finalResponse.stream.destroyed) {
+        if (pullModeStream && !pullModeStream.destroyed) {
+          pullModeStream.destroy();
+        }
+        if (
+          finalResponse.stream &&
+          finalResponse.stream !== pullModeStream &&
+          !finalResponse.stream.destroyed
+        ) {
           finalResponse.stream.destroy();
         }
-        if (response.stream && response.stream !== finalResponse.stream && !response.stream.destroyed) {
+        if (
+          response.stream &&
+          response.stream !== finalResponse.stream &&
+          response.stream !== pullModeStream &&
+          !response.stream.destroyed
+        ) {
           response.stream.destroy();
         }
       } finally {

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
@@ -227,6 +227,7 @@ export async function handleIncrementalRenderRequest(
     }
 
     let finalResponse = response;
+    let pullModeSharedExecutionContext: Map<string, unknown> | undefined;
     let pullModeStream: PassThrough | undefined;
 
     try {
@@ -236,6 +237,7 @@ export async function handleIncrementalRenderRequest(
       if (pullEnabled && response.stream) {
         const sourceStream = response.stream;
         const { sharedExecutionContext } = executionContext;
+        pullModeSharedExecutionContext = sharedExecutionContext;
         sharedExecutionContext.set(PULL_ENABLED_KEY, true);
         sharedExecutionContext.set(PUSH_PROPS_KEY, new Set(pushProps || []));
 
@@ -353,6 +355,12 @@ export async function handleIncrementalRenderRequest(
         },
       };
     } catch (error) {
+      if (pullModeSharedExecutionContext) {
+        pullModeSharedExecutionContext.delete(PULL_ENABLED_KEY);
+        pullModeSharedExecutionContext.delete(PUSH_PROPS_KEY);
+        pullModeSharedExecutionContext.delete(PROP_REQUEST_EMITTER_KEY);
+      }
+
       try {
         if (pullModeStream && !pullModeStream.destroyed) {
           pullModeStream.destroy();

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
@@ -357,23 +357,17 @@ export async function handleIncrementalRenderRequest(
         if (pullModeStream && !pullModeStream.destroyed) {
           pullModeStream.destroy();
         }
-        if (
-          finalResponse.stream &&
-          finalResponse.stream !== pullModeStream &&
-          !finalResponse.stream.destroyed
-        ) {
-          finalResponse.stream.destroy();
-        }
-        if (
-          response.stream &&
-          response.stream !== finalResponse.stream &&
-          response.stream !== pullModeStream &&
-          !response.stream.destroyed
-        ) {
+        if (response.stream && response.stream !== pullModeStream && !response.stream.destroyed) {
           response.stream.destroy();
         }
-      } finally {
+      } catch (err) {
+        log.error({ msg: 'Error cleaning up incremental render setup failure', err });
+      }
+
+      try {
         executionContext.release();
+      } catch (err) {
+        log.error({ msg: 'Error releasing execution context after incremental render setup failure', err });
       }
 
       throw error;

--- a/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
@@ -139,6 +139,12 @@ describe('async props protocol constants', () => {
 
   it('releases the execution context and destroys the started stream when pull catch-up throws', async () => {
     const sourceStream = new PassThrough();
+    let injectableStream: PassThrough | undefined;
+    const originalPipe = sourceStream.pipe.bind(sourceStream);
+    jest.spyOn(sourceStream, 'pipe').mockImplementation((destination, options) => {
+      injectableStream = destination as PassThrough;
+      return originalPipe(destination, options);
+    });
     const releaseExecutionContext = jest.fn();
     const sharedExecutionContext = new Map<string, unknown>([
       [
@@ -179,6 +185,8 @@ describe('async props protocol constants', () => {
     });
     expect(sink).toBeUndefined();
     expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+    expect(injectableStream).toBeDefined();
+    expect(injectableStream?.destroyed).toBe(true);
     expect(sourceStream.destroyed).toBe(true);
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
@@ -189,4 +189,49 @@ describe('async props protocol constants', () => {
     expect(injectableStream?.destroyed).toBe(true);
     expect(sourceStream.destroyed).toBe(true);
   });
+
+  it('preserves the original setup error when cleanup release throws', async () => {
+    const sourceStream = new PassThrough();
+    const sharedExecutionContext = new Map<string, unknown>([
+      [
+        ASYNC_PROPS_MANAGER_KEY,
+        {
+          catchUpPropRequests: () => {
+            throw new Error('pull catch-up exploded');
+          },
+        },
+      ],
+    ]);
+
+    jest.spyOn(handleRenderRequestModule, 'handleRenderRequest').mockResolvedValue({
+      response: {
+        headers: { 'Cache-Control': 'public, max-age=31536000' },
+        status: 200,
+        stream: sourceStream,
+      },
+      executionContext: {
+        sharedExecutionContext,
+        runInVM: jest.fn(),
+        release: jest.fn(() => {
+          throw new Error('release exploded');
+        }),
+      } as unknown as ExecutionContext,
+    });
+
+    const { response, sink } = await handleIncrementalRenderRequest({
+      firstRequestChunk: {
+        renderingRequest: 'ReactOnRails.dummy',
+        pullEnabled: true,
+      },
+      bundleTimestamp: 'pull-cleanup-error-regression',
+    });
+
+    expect(response).toEqual({
+      status: 500,
+      headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+      data: 'pull catch-up exploded',
+    });
+    expect(sink).toBeUndefined();
+    expect(sourceStream.destroyed).toBe(true);
+  });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
@@ -188,6 +188,9 @@ describe('async props protocol constants', () => {
     expect(injectableStream).toBeDefined();
     expect(injectableStream?.destroyed).toBe(true);
     expect(sourceStream.destroyed).toBe(true);
+    expect(sharedExecutionContext.has(PULL_ENABLED_KEY)).toBe(false);
+    expect(sharedExecutionContext.has(PUSH_PROPS_KEY)).toBe(false);
+    expect(sharedExecutionContext.has(PROP_REQUEST_EMITTER_KEY)).toBe(false);
   });
 
   it('preserves the original setup error when cleanup release throws', async () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/asyncPropsProtocol.test.ts
@@ -136,4 +136,49 @@ describe('async props protocol constants', () => {
 
     expect(sourceStream.destroyed).toBe(true);
   });
+
+  it('releases the execution context and destroys the started stream when pull catch-up throws', async () => {
+    const sourceStream = new PassThrough();
+    const releaseExecutionContext = jest.fn();
+    const sharedExecutionContext = new Map<string, unknown>([
+      [
+        ASYNC_PROPS_MANAGER_KEY,
+        {
+          catchUpPropRequests: () => {
+            throw new Error('pull catch-up exploded');
+          },
+        },
+      ],
+    ]);
+
+    jest.spyOn(handleRenderRequestModule, 'handleRenderRequest').mockResolvedValue({
+      response: {
+        headers: { 'Cache-Control': 'public, max-age=31536000' },
+        status: 200,
+        stream: sourceStream,
+      },
+      executionContext: {
+        sharedExecutionContext,
+        runInVM: jest.fn(),
+        release: releaseExecutionContext,
+      } as unknown as ExecutionContext,
+    });
+
+    const { response, sink } = await handleIncrementalRenderRequest({
+      firstRequestChunk: {
+        renderingRequest: 'ReactOnRails.dummy',
+        pullEnabled: true,
+      },
+      bundleTimestamp: 'pull-catch-up-regression',
+    });
+
+    expect(response).toEqual({
+      status: 500,
+      headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+      data: 'pull catch-up exploded',
+    });
+    expect(sink).toBeUndefined();
+    expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+    expect(sourceStream.destroyed).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #4312.

This releases the Pro node renderer execution context and destroys started streams when pull-mode incremental render setup fails after the initial render request has already returned a context. The rejection is still surfaced through the existing error-response path, but the renderer no longer leaves orphaned incremental work behind.

## Why

A setup failure between `handleRenderRequest` and pull-stream handoff could keep the renderer context alive after the request had already failed. That made failure paths retain worker resources longer than the request lifecycle.

## Tests

- `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/asyncPropsProtocol.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/incrementalRender.test.ts --runInBand`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `pnpm --filter react-on-rails-pro-node-renderer exec prettier --check src/worker/handleIncrementalRenderRequest.ts tests/asyncPropsProtocol.test.ts`
- `pnpm run type-check`
- `pnpm exec prettier --check CHANGELOG.md`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main`
- Pre-push hook branch lint and Markdown link checks

## Codex Decision Log

- **Non-blocking:** Whether to broaden the cleanup into the outer error handler or keep it scoped around post-render pull setup.
  - **Decision:** Added scoped cleanup around the setup segment that owns the returned execution context and started stream.
  - **Why:** The outer handler does not always know which post-render resources were created; keeping cleanup next to setup prevents double-release while covering the leak path.
  - **Review later:** None.

## Batch Notes

- Batch: Batch A release/runtime no-PR issues.
- Workflow config: `UNKNOWN` (`.agents/agent-workflow.yml` and repo-local `.agents/workflows/pr-processing.md` absent in this checkout; using installed workflow).
- Coordination: target-scope status read degraded/stale; direct heartbeat succeeded at changelog push phase.
- QA lane: pending `qa/batch-a` final evidence.
- Changelog: included in this PR.
