### PR TITLE
Preserve streaming LoadError during dependency failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Streaming dependency load errors stay visible**: Pro streaming cleanup now tolerates dependency
+  load failures that happen before stream observability state is captured, so the original `LoadError`
+  remains visible instead of being masked by cleanup. Fixes
+  [Issue 4324](https://github.com/shakacode/react_on_rails/issues/4324).
+  [PR 4388](https://github.com/shakacode/react_on_rails/pull/4388) by
+  [justin808](https://github.com/justin808).
+
 - **`hydrate_on: nil` falls back to immediate hydration**: Passing `hydrate_on: nil` now behaves
   like the default `:immediate` mode instead of raising, while invalid explicit values still fail
   fast. Fixes [Issue 4342](https://github.com/shakacode/react_on_rails/issues/4342).

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -127,6 +127,8 @@ module ReactOnRailsPro
     end
 
     def restore_rsc_stream_observability_state(state)
+      return if state.nil?
+
       @react_on_rails_rsc_stream_observability = state[:enabled]
       @react_on_rails_rsc_stream_started_at = state[:started_at]
       @react_on_rails_rsc_stream_initial_chunk_bytes = state[:initial_chunk_bytes]

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -54,8 +54,8 @@ module ReactOnRailsPro
     def stream_view_containing_react_components(
       template:, close_stream_at_end: true, content_type: nil, rsc_stream_observability: false, **render_options
     )
-      require_streaming_dependencies
       previous_rsc_stream_observability_state = current_rsc_stream_observability_state
+      require_streaming_dependencies
       warn_on_non_html_formats_without_content_type(render_options[:formats], content_type)
       initialize_rsc_stream_observability_state(rsc_stream_observability)
 
@@ -127,8 +127,6 @@ module ReactOnRailsPro
     end
 
     def restore_rsc_stream_observability_state(state)
-      return if state.nil?
-
       @react_on_rails_rsc_stream_observability = state[:enabled]
       @react_on_rails_rsc_stream_started_at = state[:started_at]
       @react_on_rails_rsc_stream_initial_chunk_bytes = state[:initial_chunk_bytes]

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
@@ -583,6 +583,17 @@ RSpec.describe ReactOnRailsPro::Stream do
     end
 
     describe "exception handling" do
+      it "preserves dependency load errors raised before stream observability state is captured" do
+        _queues, controller, _stream = setup_stream_test(component_count: 0)
+        allow(controller).to receive(:require_streaming_dependencies).and_raise(
+          LoadError, "cannot load such file -- async/limited_queue"
+        )
+
+        expect do
+          controller.stream_view_containing_react_components(template: "ignored")
+        end.to raise_error(LoadError, %r{async/limited_queue})
+      end
+
       it "does not commit the response when render_to_string raises" do
         _queues, controller, stream = setup_stream_test(component_count: 0)
 


### PR DESCRIPTION
## Summary

Fixes #4324. This Pro streaming path can fail while loading its async streaming dependencies before stream observability state has been captured. The cleanup path now captures the previous stream-observability state before loading dependencies so the original dependency `LoadError` remains visible instead of being replaced by cleanup work.

## Tests

- `cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/stream_spec.rb` — 30 examples, 0 failures
- `BUNDLE_GEMFILE=Gemfile bundle exec rubocop react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb` — 2 files, no offenses
- `pnpm exec prettier --check CHANGELOG.md` — passed
- `git diff --check origin/main...HEAD` and `git diff --check` — passed
- `codex review --base origin/main` — clean; no introduced correctness issues
- pre-commit hook — trailing-newlines, offline markdown-links, Prettier on `CHANGELOG.md` passed
- pre-push hook — branch Ruby RuboCop passed; online markdown-links passed with redirects only

## Batch QA Evidence

- QA lane: required for Batch C; coordinator closeout in progress.
- Scope checked so far: #4324 Pro stream failure path on current head `e208b4ca3cca3541b6246ae96942f867251acc44` after merging `origin/main`.
- Automated checks: focused Pro stream spec, touched-file RuboCop, changelog Prettier, whitespace checks, local Codex review, pre-commit, and pre-push.
- Release-blocking status: in_progress until PR checks, current-head review threads, and batch QA final-state buckets are complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved streaming dependency `LoadError`s so they remain visible instead of being masked by later cleanup.
* **Tests**
  * Added a spec to verify `LoadError`s from streaming dependency loading are re-raised unchanged.
* **Documentation**
  * Updated the changelog entry in the Unreleased “Fixed” section (Pro).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
