### PR TITLE
Handle sync RSC route failures as fetch errors

### DIFF
--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -68,6 +68,9 @@ const dropVersionStateKey = (prev: Record<string, number>, key: string) => {
   return next;
 };
 
+const rejectWithError = <T,>(error: unknown): Promise<T> =>
+  Promise.reject(error instanceof Error ? error : new Error(String(error)));
+
 /**
  * Creates a provider context for React Server Components.
  *
@@ -288,7 +291,12 @@ export const createRSCProvider = ({
 
     const getComponent = useCallback(
       (componentName: string, componentProps: unknown) => {
-        const key = createRSCPayloadKey(componentName, componentProps);
+        let key: string;
+        try {
+          key = createRSCPayloadKey(componentName, componentProps);
+        } catch (error) {
+          return rejectWithError<ReactNode>(error);
+        }
         const cached = fetchRSCPromises.get(key);
         if (cached !== undefined) {
           return cached;
@@ -377,12 +385,7 @@ export const createRSCProvider = ({
         try {
           serverComponentPromise = getServerComponent({ componentName, componentProps });
         } catch (error) {
-          // The in-flight latch is incremented only after `setPinned` succeeds
-          // below, so a synchronous producer throw only restores the marker.
-          if (notifyRoutesOnSuccess) {
-            evictedSuccessfulPayloadKeys.set(key, true);
-          }
-          throw error;
+          serverComponentPromise = rejectWithError(error);
         }
 
         promise = serverComponentPromise.then(markPayloadIfSuccessful, evictPromiseIfRejected).finally(() => {
@@ -419,7 +422,12 @@ export const createRSCProvider = ({
 
     const refetchComponent = useCallback(
       (componentName: string, componentProps: unknown, recoverOnError?: boolean) => {
-        const key = createRSCPayloadKey(componentName, componentProps);
+        let key: string;
+        try {
+          key = createRSCPayloadKey(componentName, componentProps);
+        } catch (error) {
+          return rejectWithError<ReactNode>(error);
+        }
         refetchVersionsRef.current[key] = (refetchVersionsRef.current[key] ?? 0) + 1;
         let promise!: Promise<ReactNode>;
         const restoreLastSuccessfulPromise = () => {

--- a/packages/react-on-rails-pro/src/RSCRoute.tsx
+++ b/packages/react-on-rails-pro/src/RSCRoute.tsx
@@ -232,7 +232,7 @@ const RSCRouteContent = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
       // visible while the new promise streams in.
       const refetchPromise = refetchComponent(n, p, recoverOnError);
       const sharedRefetchVersion = getRefetchVersion(n, p);
-      return rejectErrorPayload(refetchPromise).catch((error: unknown) => {
+      const handledRefetchPromise = rejectErrorPayload(refetchPromise).catch((error: unknown) => {
         const serverComponentFetchError = toServerComponentFetchError(error, n, p);
         if (
           recoverOnError &&
@@ -245,6 +245,10 @@ const RSCRouteContent = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
         }
         throw serverComponentFetchError;
       });
+      if (recoverOnError) {
+        void handledRefetchPromise.catch(() => undefined);
+      }
+      return handledRefetchPromise;
     }, [getRefetchVersion, refetchComponent]);
 
     const clearRefetchError = useCallback(() => {

--- a/packages/react-on-rails-pro/src/RSCRoute.tsx
+++ b/packages/react-on-rails-pro/src/RSCRoute.tsx
@@ -60,6 +60,9 @@ class RSCRouteErrorBoundary extends Component<
     const { error } = this.state;
     const { componentName, componentProps, children } = this.props;
     if (error) {
+      if (isServerComponentFetchError(error)) {
+        throw error;
+      }
       throw new ServerComponentFetchError(error.message, componentName, componentProps, error);
     }
 
@@ -172,11 +175,13 @@ const toServerComponentFetchError = (
 };
 
 type RefetchErrorState = [string, ServerComponentFetchError];
+type RSCContextValue = ReturnType<typeof useRSC>;
+type RSCRouteContentProps = Omit<RSCRouteProps, 'ssr'> & { rscContext: RSCContextValue };
 
-const RSCRouteContent = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
-  ({ componentName, componentProps, onRefetchError }, ref) => {
+const RSCRouteContent = forwardRef<RSCRouteHandle, RSCRouteContentProps>(
+  ({ componentName, componentProps, onRefetchError, rscContext }, ref) => {
     const { getComponent, refetchComponent, getRefetchVersion, retainComponent, successfulVersions } =
-      useRSC();
+      rscContext;
     const currentRouteKey = useMemo(
       () => createRSCPayloadKey(componentName, componentProps),
       [componentName, componentProps],
@@ -271,15 +276,32 @@ const RSCRouteContent = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
     const componentPromise = getComponent(componentName, componentProps);
     return (
       <CurrentRSCRouteContext.Provider value={handle}>
-        <RSCRouteErrorBoundary componentName={componentName} componentProps={componentProps}>
-          <PromiseWrapper promise={componentPromise} />
-        </RSCRouteErrorBoundary>
+        <PromiseWrapper promise={componentPromise} />
       </CurrentRSCRouteContext.Provider>
     );
   },
 );
 
 RSCRouteContent.displayName = 'RSCRouteContent';
+
+const RSCRouteContentWithErrorBoundary = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
+  ({ componentName, componentProps, onRefetchError }, ref) => {
+    const rscContext = useRSC();
+    return (
+      <RSCRouteErrorBoundary componentName={componentName} componentProps={componentProps}>
+        <RSCRouteContent
+          ref={ref}
+          componentName={componentName}
+          componentProps={componentProps}
+          onRefetchError={onRefetchError}
+          rscContext={rscContext}
+        />
+      </RSCRouteErrorBoundary>
+    );
+  },
+);
+
+RSCRouteContentWithErrorBoundary.displayName = 'RSCRouteContentWithErrorBoundary';
 
 /**
  * Renders a React Server Component inside a React Client Component.
@@ -314,7 +336,7 @@ const RSCRoute = forwardRef<RSCRouteHandle, RSCRouteProps>(
     }
 
     return (
-      <RSCRouteContent
+      <RSCRouteContentWithErrorBoundary
         ref={ref}
         componentName={componentName}
         componentProps={componentProps}

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -195,7 +195,7 @@ export const fetchRSC = ({
   replayConsoleScripts,
 }: FetchRSCOptions) => {
   if (!rscPayloadGenerationUrlPath) {
-    throw createMissingRSCPayloadPathError(componentName);
+    return Promise.reject(createMissingRSCPayloadPathError(componentName));
   }
 
   try {
@@ -230,7 +230,7 @@ export const fetchRSC = ({
       `Failed to prepare RSC request for component "${componentName}": ${extractErrorMessage(error)}`,
     );
     wrapper.cause = error;
-    throw wrapper;
+    return Promise.reject(wrapper);
   }
 };
 
@@ -357,7 +357,6 @@ const getReactServerComponent =
       }
     }
     if (!railsContext.rscPayloadGenerationUrlPath) {
-      // fetchRSC throws synchronously for a missing path; keep this API on the Promise rejection path.
       return Promise.reject(createMissingRSCPayloadPathError(componentName));
     }
 

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1459,7 +1459,10 @@ describe('RSCRoute successful-version error reset', () => {
     }
 
     syncThrowIds.add(0);
-    expect(() => rscApi.getComponent('Card', { id: 0 })).toThrow('sync boom 0');
+    await act(async () => {
+      await expect(rscApi.getComponent('Card', { id: 0 })).rejects.toThrow('sync boom 0');
+      await flushMacrotasks();
+    });
 
     const replacement = await startLoad(0);
     await resolveLoad(replacement, <span>replacement 0</span>);

--- a/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
+++ b/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
@@ -293,6 +293,120 @@ describe('RSCRoute deferred SSR behavior', () => {
     }
   });
 
+  it('wraps synchronous payload key failures in ServerComponentFetchError during the client Suspense retry', async () => {
+    const circularProps: Record<string, unknown> = {};
+    circularProps.self = circularProps;
+    const getServerComponent = jest.fn(() => Promise.resolve(<div>Should not load</div>));
+    const RSCProvider = createRSCProvider({ getServerComponent });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | undefined;
+    let capturedError: Error | undefined;
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      root = createRoot(container);
+
+      await act(async () => {
+        root?.render(
+          <RSCProvider>
+            <TestErrorBoundary
+              onError={(error) => {
+                capturedError = error;
+              }}
+            >
+              <React.Suspense fallback={<div>Loading deferred route...</div>}>
+                <RSCRoute componentName="CircularRoute" componentProps={circularProps} ssr={false} />
+              </React.Suspense>
+            </TestErrorBoundary>
+          </RSCProvider>,
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(isServerComponentFetchError(capturedError)).toBe(true);
+      if (!isServerComponentFetchError(capturedError)) {
+        throw new Error('Expected a ServerComponentFetchError');
+      }
+      expect(capturedError.serverComponentName).toBe('CircularRoute');
+      expect(capturedError.serverComponentProps).toBe(circularProps);
+      expect(capturedError.originalError).toBeInstanceOf(TypeError);
+      expect(getServerComponent).not.toHaveBeenCalled();
+    } finally {
+      const mountedRoot = root;
+      try {
+        if (mountedRoot) {
+          await act(async () => {
+            mountedRoot.unmount();
+            await Promise.resolve();
+          });
+        }
+        container.remove();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    }
+  });
+
+  it('wraps synchronous provider load failures in ServerComponentFetchError during the client Suspense retry', async () => {
+    const syncError = new Error('sync provider failed');
+    const getServerComponent = jest.fn((): Promise<React.ReactNode> => {
+      throw syncError;
+    });
+    const RSCProvider = createRSCProvider({ getServerComponent });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | undefined;
+    let capturedError: Error | undefined;
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      root = createRoot(container);
+
+      await act(async () => {
+        root?.render(
+          <RSCProvider>
+            <TestErrorBoundary
+              onError={(error) => {
+                capturedError = error;
+              }}
+            >
+              <React.Suspense fallback={<div>Loading deferred route...</div>}>
+                <RSCRoute componentName="SyncRoute" componentProps={{ id: 1 }} ssr={false} />
+              </React.Suspense>
+            </TestErrorBoundary>
+          </RSCProvider>,
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(isServerComponentFetchError(capturedError)).toBe(true);
+      if (!isServerComponentFetchError(capturedError)) {
+        throw new Error('Expected a ServerComponentFetchError');
+      }
+      expect(capturedError.message).toBe('sync provider failed');
+      expect(capturedError.serverComponentName).toBe('SyncRoute');
+      expect(capturedError.serverComponentProps).toEqual({ id: 1 });
+      expect(capturedError.originalError).toBe(syncError);
+      expect(getServerComponent).toHaveBeenCalledTimes(1);
+    } finally {
+      const mountedRoot = root;
+      try {
+        if (mountedRoot) {
+          await act(async () => {
+            mountedRoot.unmount();
+            await Promise.resolve();
+          });
+        }
+        container.remove();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    }
+  });
+
   it('allows an error boundary fallback to refetch and render recovered content', async () => {
     let rejectPayload: ((error: Error) => void) | undefined;
     const payloadPromise = new Promise<React.ReactNode>((_resolve, reject) => {

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -156,6 +156,21 @@ describe('fetchRSC HTTP responses', () => {
       })}`,
     );
   });
+
+  it('returns a rejected promise for synchronous request preparation failures', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const circularProps: Record<string, unknown> = {};
+    circularProps.self = circularProps;
+
+    await expect(
+      fetchRSC({
+        componentName: 'BrokenPropsPanel',
+        componentProps: circularProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      }),
+    ).rejects.toThrow('Failed to prepare RSC request for component "BrokenPropsPanel"');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('getReactServerComponent preloaded payload replay', () => {

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -242,6 +242,30 @@ class CapturingErrorBoundary extends React.Component<
     );
   };
 
+  const FireAndForgetRetryControls: React.FC = () => {
+    const { refetch, refetchError, retry } = useCurrentRSCRoute();
+
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid="inline-refetch"
+          onClick={() => void refetch().catch(() => undefined)}
+        >
+          inline-refetch
+        </button>
+        {refetchError ? (
+          <div data-testid="recoverable-error">
+            {refetchError.message}
+            <button type="button" data-testid="inline-retry" onClick={() => void retry()}>
+              retry
+            </button>
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
   beforeEach(() => {
     // Start each test with a sensible default; tests that need different
     // payloads call setupSequencedFetcher again.
@@ -596,6 +620,71 @@ class CapturingErrorBoundary extends React.Component<
     await waitFor(() => expect(screen.getByTestId('card')).toHaveTextContent('Card v2'));
     expect(screen.queryByTestId('recoverable-error')).not.toBeInTheDocument();
     expect(ref.current!.refetchError).toBeNull();
+  });
+
+  it('1d4. production fire-and-forget retry failures are handled after refetchError records them', async () => {
+    process.env.NODE_ENV = 'production';
+    setupSequencedFetcher([
+      <div data-testid="card">
+        Card v1
+        <FireAndForgetRetryControls />
+      </div>,
+      rejectWith(new Error('initial recoverable refetch failed')),
+      rejectWith(new Error('fire-and-forget retry failed')),
+    ]);
+    const onRefetchError = jest.fn();
+    const unhandledRejections: unknown[] = [];
+    const captureUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    const ref = React.createRef<RSCRouteHandle>();
+
+    process.on('unhandledRejection', captureUnhandledRejection);
+    try {
+      await renderInAct(
+        <TestHarness>
+          <CapturingErrorBoundary fallback={(error) => <div data-testid="route-error">{error.message}</div>}>
+            <RSCRoute
+              ref={ref}
+              componentName="UserCard"
+              componentProps={{ id: 1 }}
+              onRefetchError={onRefetchError}
+            />
+          </CapturingErrorBoundary>
+        </TestHarness>,
+      );
+
+      expect(screen.getByTestId('card')).toHaveTextContent('Card v1');
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('inline-refetch'));
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('recoverable-error')).toHaveTextContent(
+          'initial recoverable refetch failed',
+        ),
+      );
+      await waitFor(() => expect(onRefetchError).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('inline-retry'));
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('recoverable-error')).toHaveTextContent('fire-and-forget retry failed'),
+      );
+      await waitFor(() => expect(onRefetchError).toHaveBeenCalledTimes(2));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(unhandledRejections).toEqual([]);
+      expect(screen.getByTestId('card')).toHaveTextContent('Card v1');
+      expect(screen.queryByTestId('route-error')).not.toBeInTheDocument();
+    } finally {
+      process.off('unhandledRejection', captureUnhandledRejection);
+    }
   });
 
   it('1e. production ignores recoverable refetch errors from stale route props', async () => {


### PR DESCRIPTION
## Why

Fixes #4372 as a stacked Batch E follow-up on #4378. Sync throws from RSC route fetch/render setup should flow through the same RSCRoute error recovery path as async fetch failures instead of bypassing the route error boundary behavior.

## What changed

- Normalizes synchronous provider/fetch failures into rejected fetch promises for RSCRoute handling.
- Keeps retry/refetch bookkeeping consistent when route fetches fail synchronously.
- Adds server/client route regression coverage for sync failure handling.

## Validation

- `pnpm --filter react-on-rails-pro exec jest tests/deferredRouteSsr.test.tsx tests/getReactServerComponent.client.test.ts tests/boundedCacheProvider.client.test.tsx --runInBand`
- `pnpm --filter react-on-rails-pro exec jest tests/imperativeRefetch.client.test.tsx --runInBand`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm exec prettier --check packages/react-on-rails-pro/src/RSCProvider.tsx packages/react-on-rails-pro/src/RSCRoute.tsx packages/react-on-rails-pro/src/getReactServerComponent.client.ts packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts`
- `pnpm exec eslint packages/react-on-rails-pro/src/RSCProvider.tsx packages/react-on-rails-pro/src/RSCRoute.tsx packages/react-on-rails-pro/src/getReactServerComponent.client.ts packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts --no-warn-ignored`
- `script/check-pro-license-headers`
- `git diff --check origin/codex/batch-e-pro-route...HEAD && git diff --check origin/main...HEAD`
- `codex review --base origin/codex/batch-e-pro-route`
