### PR TITLE
Skip generated stylesheet metadata for OSS renders

### DIFF
--- a/react_on_rails/lib/react_on_rails/pro_helper.rb
+++ b/react_on_rails/lib/react_on_rails/pro_helper.rb
@@ -48,6 +48,7 @@ module ReactOnRails
     end
 
     def generated_stylesheet_hrefs_json(render_options)
+      return unless ReactOnRails::Utils.react_on_rails_pro?
       return unless render_options.auto_load_bundle
 
       pack_name = "generated/#{render_options.react_component_name}"

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -1555,6 +1555,22 @@ describe ReactOnRailsHelper do
           .to eq(["/webpack/test/css/shared-generated-pack-deadbeef.css"].to_json)
       end
     end
+
+    context "when auto-loaded generated stylesheet hrefs run without Pro" do
+      before do
+        allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
+        allow(render_options).to receive(:auto_load_bundle).and_return(true)
+        allow(helper).to receive(:preload_sources_for_stylesheet_pack)
+      end
+
+      it "does not compute or emit Pro-only generated stylesheet metadata" do
+        result = helper.send(:generate_component_script, render_options)
+        script = Nokogiri::HTML.fragment(result).css("script.js-react-on-rails-component").first
+
+        expect(script["data-generated-stylesheet-hrefs"]).to be_nil
+        expect(helper).not_to have_received(:preload_sources_for_stylesheet_pack)
+      end
+    end
   end
 
   describe "#generate_store_script" do

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -1538,6 +1538,7 @@ describe ReactOnRailsHelper do
       end
 
       before do
+        allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
         allow(render_options).to receive(:auto_load_bundle).and_return(true)
         allow(helper).to receive(:preload_sources_for_stylesheet_pack)
           .with("generated/HelloWorld")


### PR DESCRIPTION
## Rationale

Fixes #4341. OSS component renders do not need Pro-only generated stylesheet href metadata, so the helper should avoid doing that discovery work unless React on Rails Pro is active.

## Changes

- Return early from `generated_stylesheet_hrefs_json` when Pro is not installed.
- Add helper coverage proving OSS renders neither compute nor emit the generated stylesheet metadata.

## Validation

- `PR_BATCH_SKILL_DIR=.agents/skills/pr-batch .agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4341`
- `.agents/bin/agent-workflow-seam-doctor`
- `(cd react_on_rails/spec/dummy && bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb:1512 spec/helpers/react_on_rails_helper_spec.rb:1528)`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/pro_helper.rb spec/dummy/spec/helpers/react_on_rails_helper_spec.rb)`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` returned no actionable findings.
- `git push -u origin codex/g1-4341-stylesheets` pre-push hook passed branch RuboCop and markdown-links.

## Codex Decision Log

- **Non-blocking:** Changelog classification for merge-ledger closeout.
  - **Decision:** `not_user_visible`.
  - **Why:** This is an internal OSS fast path that avoids Pro-only stylesheet metadata discovery without changing rendered output or public API.
  - **Review later:** None.
