### PR TITLE
Avoid mutating render option inputs

### DIFF
--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -491,6 +491,7 @@ module ReactOnRails
     end
 
     def create_render_options(react_component_name, options)
+      options = options.dup
       # If no store dependencies are passed, default to all registered stores up till now
       unless options.key?(:store_dependencies)
         store_dependencies = registered_stores_including_deferred.map { |store| store[:store_name] }

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -844,6 +844,51 @@ describe ReactOnRailsHelper do
     end
   end
 
+  describe "#create_render_options" do
+    let(:component_name) { "App" }
+
+    before do
+      helper.instance_variable_set(:@react_on_rails_rsc_stream_observability, true)
+    end
+
+    after do
+      helper.instance_variable_set(:@react_on_rails_rsc_stream_observability, false)
+    end
+
+    it "does not mutate a frozen options hash when store dependencies are supplied" do
+      options = {
+        store_dependencies: ["appStore"],
+        render_mode: :html_streaming
+      }.freeze
+
+      render_options = nil
+      expect do
+        render_options = helper.send(:create_render_options, component_name, options)
+      end.not_to raise_error
+
+      expect(render_options.internal_option(:rsc_stream_observability)).to be true
+      expect(options).not_to have_key(:rsc_stream_observability)
+    end
+
+    it "does not leak stream observability into a reused options hash" do
+      options = {
+        store_dependencies: ["appStore"],
+        render_mode: :html_streaming
+      }
+
+      render_options = helper.send(:create_render_options, component_name, options)
+
+      expect(render_options.internal_option(:rsc_stream_observability)).to be true
+      expect(options).not_to have_key(:rsc_stream_observability)
+
+      helper.instance_variable_set(:@react_on_rails_rsc_stream_observability, false)
+      render_options = helper.send(:create_render_options, component_name, options)
+
+      expect(render_options.internal_option(:rsc_stream_observability)).to be_nil
+      expect(options).not_to have_key(:rsc_stream_observability)
+    end
+  end
+
   describe "#server_render_js error serialization" do
     let(:runtime_available) do
       ExecJS.runtime&.available?


### PR DESCRIPTION
## Rationale

Fixes #4343. The stream-observability option was being added to the same options hash supplied by callers, which let one render mutate a reused or frozen `RenderOptions` input hash.

## Changes

- Duplicate the helper options before adding default store dependencies and internal observability state.
- Add regression coverage for frozen options and reused options hashes with `store_dependencies` already present.

## Validation

- `PR_BATCH_SKILL_DIR=.agents/skills/pr-batch .agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4343`
- `.agents/bin/agent-workflow-seam-doctor`
- `(cd react_on_rails/spec/dummy && bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb:820 spec/helpers/react_on_rails_helper_spec.rb:835)`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/helper.rb spec/dummy/spec/helpers/react_on_rails_helper_spec.rb)`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` returned no actionable findings. Its broad helper-spec probe hit a local Capybara `bind(2)` permission failure outside this branch delta; the focused examples passed.
- `git push -u origin codex/g2-4343-render-options` pre-push hook passed branch RuboCop and markdown-links.

## Codex Decision Log

- **Non-blocking:** Changelog classification for merge-ledger closeout.
  - **Decision:** `not_user_visible`.
  - **Why:** The change preserves the existing render API and output while preventing an internal helper from mutating caller-owned option hashes.
  - **Review later:** None.
