### PR TITLE
Optimize response type emitter snapshots

### DIFF
--- a/react_on_rails/lib/react_on_rails/typescript_response_types.rb
+++ b/react_on_rails/lib/react_on_rails/typescript_response_types.rb
@@ -378,24 +378,23 @@ module ReactOnRails
       include TypeSpecHelpers
 
       def initialize(registry)
-        @registry = registry
+        types = registry.types
+        @responses = registry.responses
+        @definitions = (types + responses).freeze
+        @definition_names = definitions.to_h { |definition| [definition.name, true] }.freeze
       end
 
       def to_d_ts
         lines = [GENERATED_HEADER, "", JSON_VALUE_DEFINITION]
         definitions.each { |definition| lines.push("", interface_definition(definition)) }
         lines.push("", response_map_definition)
-        lines.push("", response_helpers) unless registry.responses.empty?
+        lines.push("", response_helpers) unless responses.empty?
         "#{lines.join("\n")}\n"
       end
 
       private
 
-      attr_reader :registry
-
-      def definitions
-        registry.types + registry.responses
-      end
+      attr_reader :definitions, :definition_names, :responses
 
       def interface_definition(definition)
         body = fields_to_lines(definition.fields, indentation: "  ")
@@ -405,9 +404,9 @@ module ReactOnRails
       end
 
       def response_map_definition
-        return "export interface RailsResponseTypes {}" if registry.responses.empty?
+        return "export interface RailsResponseTypes {}" if responses.empty?
 
-        body = registry.responses.map do |response|
+        body = responses.map do |response|
           "  #{quote_property(response.response_key)}: #{response.name};"
         end
         "export interface RailsResponseTypes {\n#{body.join("\n")}\n}"
@@ -498,7 +497,7 @@ module ReactOnRails
           raise ReactOnRails::Error, "TypeScript type reference must be a valid identifier: #{name.inspect}"
         end
 
-        return type_name if definitions.any? { |definition| definition.name == type_name }
+        return type_name if definition_names.key?(type_name)
 
         raise ReactOnRails::Error, "Unknown TypeScript type reference: #{name.inspect}"
       end

--- a/react_on_rails/lib/react_on_rails/typescript_response_types.rb
+++ b/react_on_rails/lib/react_on_rails/typescript_response_types.rb
@@ -380,8 +380,8 @@ module ReactOnRails
       def initialize(registry)
         types = registry.types
         @responses = registry.responses
-        @definitions = (types + responses).freeze
-        @definition_names = definitions.to_h { |definition| [definition.name, true] }.freeze
+        @definitions = (types + @responses).freeze
+        @definition_names = @definitions.to_h { |definition| [definition.name, true] }.freeze
       end
 
       def to_d_ts

--- a/react_on_rails/spec/react_on_rails/typescript_response_types_emitter_spec.rb
+++ b/react_on_rails/spec/react_on_rails/typescript_response_types_emitter_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+module ReactOnRails
+  RSpec.describe TypeScriptResponseTypes, "emitter snapshots" do
+    before { described_class.reset! }
+
+    after { described_class.reset! }
+
+    it "snapshots registry definitions once per emission regardless of custom type references" do
+      described_class.define_type("Project", fields: { id: :number })
+      described_class.define_type("Owner", fields: { id: :number, project: "Project" })
+      described_class.define_response(
+        "projects.index",
+        type_name: "ProjectsIndexResponse",
+        fields: {
+          projects: { array: "Project" },
+          owner: "Owner",
+          featured: {
+            fields: {
+              project: "Project",
+              owner: "Owner"
+            }
+          }
+        }
+      )
+
+      registry = described_class.registry
+      expect(registry).to receive(:types).once.and_call_original
+      expect(registry).to receive(:responses).once.and_call_original
+
+      declaration = described_class.to_d_ts
+
+      expect(declaration).to include("projects: Project[];")
+      expect(declaration).to include("owner: Owner;")
+    end
+  end
+end


### PR DESCRIPTION
## Rationale

Fixes #4344. Emitting TypeScript response declarations repeatedly read the registry while resolving custom type references, so larger registries paid avoidable snapshot cost during one emission.

## Changes

- Snapshot registry types and responses once when constructing the emitter.
- Cache definition names for O(1) custom type reference checks.
- Add regression coverage that verifies `types` and `responses` are each read once while still resolving nested custom references.

## Validation

- `PR_BATCH_SKILL_DIR=.agents/skills/pr-batch .agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4344`
- `.agents/bin/agent-workflow-seam-doctor`
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/typescript_response_types*_spec.rb)` (60 examples)
- `(cd react_on_rails && RUBYOPT=-W0 BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/typescript_response_types.rb spec/react_on_rails/typescript_response_types_emitter_spec.rb)`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` returned no actionable findings.
- `git push -u origin codex/g3-4344-types` pre-push hook passed branch RuboCop and markdown-links.

## Codex Decision Log

- **Non-blocking:** Changelog classification for merge-ledger closeout.
  - **Decision:** `not_user_visible`.
  - **Why:** This is an internal declaration-emitter optimization that preserves generated TypeScript output while reducing registry snapshot work.
  - **Review later:** None.
