### PR TITLE
Extract shared redux_store kwargs validator (#4402)

### DIFF
--- a/react_on_rails/lib/react_on_rails/controller.rb
+++ b/react_on_rails/lib/react_on_rails/controller.rb
@@ -13,15 +13,7 @@ module ReactOnRails
     # Be sure to include view helper `redux_store_hydration_data` at the end of your layout or view
     # or else there will be no client side hydration of your stores.
     def redux_store(store_name, props: {}, **rest)
-      immediate_hydration_present = rest.key?(:immediate_hydration)
-      unknown_keys = rest.keys - [:immediate_hydration]
-      if unknown_keys.any?
-        plural = unknown_keys.one? ? "" : "s"
-        unknown_options = unknown_keys.map { |key| ":#{key}" }.join(", ")
-        raise ArgumentError, "unknown keyword#{plural}: #{unknown_options}"
-      end
-
-      ReactOnRails::Helper.warn_removed_immediate_hydration_option("redux_store") if immediate_hydration_present
+      ReactOnRails::Helper.validate_redux_store_options!(rest)
 
       redux_store_data = { store_name:,
                            props: }

--- a/react_on_rails/lib/react_on_rails/controller.rb
+++ b/react_on_rails/lib/react_on_rails/controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "react_on_rails/helper"
+
 module ReactOnRails
   module Controller
     # Separate initialization of store from react_component allows multiple react_component calls to

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -46,6 +46,20 @@ module ReactOnRails
           @removed_immediate_hydration_warnings = {}
         end
       end
+
+      # Validates the **rest kwargs accepted by both redux_store implementations
+      # (controller concern and view helper). Raises ArgumentError for unknown
+      # keywords and warns once if the removed :immediate_hydration option is passed.
+      def validate_redux_store_options!(rest)
+        unknown_keys = rest.keys - [:immediate_hydration]
+        if unknown_keys.any?
+          plural = unknown_keys.one? ? "" : "s"
+          unknown_options = unknown_keys.map { |key| ":#{key}" }.join(", ")
+          raise ArgumentError, "unknown keyword#{plural}: #{unknown_options}"
+        end
+
+        warn_removed_immediate_hydration_option("redux_store") if rest.key?(:immediate_hydration)
+      end
     end
 
     # react_component_name: can be a React function or class component or a "Render-Function".
@@ -200,15 +214,7 @@ module ReactOnRails
     #                        app/javascript/bundles/ror_stores/commentsStore.js
     #                      The store file must export default a store generator function.
     def redux_store(store_name, props: {}, defer: false, auto_load_bundle: nil, **rest)
-      immediate_hydration_present = rest.key?(:immediate_hydration)
-      unknown_keys = rest.keys - [:immediate_hydration]
-      if unknown_keys.any?
-        plural = unknown_keys.one? ? "" : "s"
-        unknown_options = unknown_keys.map { |key| ":#{key}" }.join(", ")
-        raise ArgumentError, "unknown keyword#{plural}: #{unknown_options}"
-      end
-
-      ReactOnRails::Helper.warn_removed_immediate_hydration_option("redux_store") if immediate_hydration_present
+      ReactOnRails::Helper.validate_redux_store_options!(rest)
 
       # Auto-load store pack if configured
       should_auto_load = auto_load_bundle.nil? ? ReactOnRails.configuration.auto_load_bundle : auto_load_bundle


### PR DESCRIPTION
## Summary

`ReactOnRails::Controller#redux_store` and `ReactOnRails::Helper#redux_store` carried a byte-for-byte identical 9-line block that validated `**rest` kwargs (unknown-keyword `ArgumentError` with a pluralized message) and emitted the removed-`immediate_hydration` deprecation warning. Verified identical before extracting:

```
diff <(sed -n '16,24p' controller.rb) <(sed -n '203,211p' helper.rb)  # no output → identical
```

This PR extracts that logic into a single class method, `ReactOnRails::Helper.validate_redux_store_options!`, placed in the existing `class << self` block next to `warn_removed_immediate_hydration_option`, and delegates from both call sites.

## Rationale

- Removes identical duplication; establishes a single source of truth for `redux_store` kwargs validation.
- Any future change to the accepted option set or the warning is now made in one place, eliminating the silent-divergence failure mode (same class of bug as #4316).
- `ReactOnRails::Helper` is the right home: `controller.rb` (a plain mixin) already reaches into `ReactOnRails::Helper` for `warn_removed_immediate_hydration_option`, so no new coupling is introduced.

## Impact

- Internal refactor only. No user-visible behavior change: error class, exact message text (including singular/plural form), and warn-once semantics are all unchanged. `redux_store` remains a supported (if discouraged) API.
- No changelog entry (pure internal refactor, no behavior change).

## Validation

RuboCop (changed files) — clean:
```
(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/controller.rb lib/react_on_rails/helper.rb)
# 2 files inspected, no offenses detected
```

Controller spec — 2 examples, 0 failures (covers unknown-keyword `ArgumentError` and `immediate_hydration` warn-once):
```
(cd react_on_rails && bundle exec rspec spec/react_on_rails/controller_spec.rb)
# 2 examples, 0 failures
```

Helper `#redux_store` specs — 11 examples, 0 failures (covers `typo_option` `ArgumentError` and `immediate_hydration` warn):
```
(cd react_on_rails/spec/dummy && bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb -e "redux_store")
# 11 examples, 0 failures
```

All specs pass with no assertion changes.

## Codex Decision Log

- **Method name / location:** Used the issue's proposed name and home — `ReactOnRails::Helper.validate_redux_store_options!(rest)` inside the existing `class << self` block. A standalone `module_function` module was considered and rejected (adds a file for one method).
- **Behavioral equivalence of the inlined `immediate_hydration` check:** The original block computed `immediate_hydration_present = rest.key?(:immediate_hydration)` at the top and referenced it after the unknown-key check. The extracted method inlines `rest.key?(:immediate_hydration)` into the final `warn_removed_immediate_hydration_option` call. This is equivalent: `rest` is not mutated between those points, and when an unknown key raises, control never reaches the warning in either version.

Fixes #4402

Confidence note: high — pure refactor pinned by existing specs; the extracted block has no dependence on instance state (`rest` passed in; warning already routed through the shared class method), the removed and added code are semantically identical, and both spec files pass without assertion changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Redux store options, so invalid settings are rejected more reliably.
  * Continued support for the deprecated `immediate_hydration` option with a clearer one-time warning.
  * Reduced differences between controller and view helper behavior when registering store hydration and render data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->