### PR TITLE
[Pro] Remove unused addressable and rainbow runtime deps from gemspec (#4416)

### DIFF
--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -21,13 +21,11 @@ PATH
   remote: .
   specs:
     react_on_rails_pro (17.0.0.rc.6)
-      addressable
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
-      rainbow
       react_on_rails (= 17.0.0.rc.6)
 
 GEM

--- a/react_on_rails_pro/react_on_rails_pro.gemspec
+++ b/react_on_rails_pro/react_on_rails_pro.gemspec
@@ -49,7 +49,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.3.0"
 
-  s.add_runtime_dependency "addressable"
   s.add_runtime_dependency "async", ">= 2.29"
   s.add_runtime_dependency "async-http", "~> 0.95"
   s.add_runtime_dependency "execjs", "~> 2.9"
@@ -57,7 +56,6 @@ Gem::Specification.new do |s|
   # Pro's only JWT call site (LicenseValidator) pins algorithm: "RS256" with
   # public-key verification, which is safe on jwt 2.x as well as 3.x.
   s.add_runtime_dependency "jwt", ">= 2.5", "< 4"
-  s.add_runtime_dependency "rainbow"
   s.add_runtime_dependency "react_on_rails", ReactOnRails::VERSION
   s.add_development_dependency "bundler"
   s.add_development_dependency "commonmarker"

--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -21,13 +21,11 @@ PATH
   remote: ../..
   specs:
     react_on_rails_pro (17.0.0.rc.6)
-      addressable
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
-      rainbow
       react_on_rails (= 17.0.0.rc.6)
 
 GEM

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -13,13 +13,11 @@ PATH
   remote: ../..
   specs:
     react_on_rails_pro (17.0.0.rc.6)
-      addressable
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
-      rainbow
       react_on_rails (= 17.0.0.rc.6)
 
 GEM


### PR DESCRIPTION
## Summary

Removes the unused direct runtime dependencies `addressable` and `rainbow` from `react_on_rails_pro.gemspec` and regenerates the three lockfiles that embed the Pro gemspec.

`Fixes #4416`

## Rationale

`react_on_rails_pro.gemspec` declared `addressable` and `rainbow` as direct runtime dependencies, but **no Pro Ruby code references either gem**. Verified: `git grep -inE "addressable|rainbow" -- lib app exe rakelib scripts bin` from `react_on_rails_pro/` returns **zero hits** (exit 1).

Both gems arrive **transitively** via `react_on_rails`, which both declares and actively uses them:
- OSS `react_on_rails.gemspec` declares `addressable` (L38) and `rainbow, "~> 3.0"` (L42).
- Pro's gemspec depends on `react_on_rails` (unchanged).

So both gems remain in every Pro app's bundle regardless. The two direct declarations were pure dependency-tree noise.

## Impact

Dependency hygiene only. **No runtime behavior change** — both gems still resolve at the same versions (`addressable 2.8.x`, `rainbow 3.1.1`) through the `react_on_rails` edge. Pro's declarations were unversioned; OSS pins `rainbow ~> 3.0`, so resolution cannot loosen.

## Lockfile evidence

### Changed dependencies
- Removed `addressable` and `rainbow` as **direct** runtime deps of `react_on_rails_pro`. No additions, no version changes.

### Sibling-lock comparison (all three regenerated consistently)
All three locks were regenerated with `bundle lock` (Bundler 4.0.10, matching the committed generator). Each diff is identical in nature — only the two direct-dependency edges under the `react_on_rails_pro` PATH spec disappear:

```
    react_on_rails_pro (17.0.0.rc.6)
-      addressable
       async (>= 2.29)
       ...
       jwt (>= 2.5, < 4)
-      rainbow
       react_on_rails (= 17.0.0.rc.6)
```

- `react_on_rails_pro/Gemfile.lock` — regenerated via `BUNDLE_GEMFILE=Gemfile bundle lock`
- `react_on_rails_pro/spec/dummy/Gemfile.lock` — regenerated via `bundle lock`
- `react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock` — regenerated via `bundle lock`

### Both gems remain transitively (grep evidence)
In every one of the three locks, `addressable` and `rainbow` still appear:
- Under the `react_on_rails` PATH spec (`addressable`, `rainbow (~> 3.0)`).
- Resolved in the GEM section: `addressable (2.8.8)` in the Pro lock / `addressable (2.8.7)` in the dummies, and `rainbow (3.1.1)` in all three.
- Pulled by additional transitive deps (e.g. `addressable (~> 2.8)`, `addressable (>= 2.8.0)`).

### Platform / source-build / build-time dependency change
**None.** No platform-precompiled gems, no source-build gems, no build-time dependencies changed. `BUNDLED WITH` and platform lists are unchanged.

### Lockfile content-diff note
Each of the three lock diffs is **only** the intended graph change (two removed direct edges). **No incidental version bumps** and no other churn were introduced by the regeneration.

### Dependabot compatibility
No lockfile was added, moved, renamed, or newly committed — the three locks already exist and are covered by the existing `.github/dependabot.yml` `bundler` ecosystem entries for these directories. No `package-ecosystem`/`directory` changes are needed. `eval_gemfile` usage in the Pro/dummy Gemfiles is unchanged.

## Validation

```
# All three regenerated cleanly (exit 0):
(cd react_on_rails_pro && BUNDLE_GEMFILE=Gemfile bundle lock)                     # -> Writing lockfile
(cd react_on_rails_pro/spec/dummy && bundle lock)                                # -> Writing lockfile
(cd react_on_rails_pro/spec/execjs-compatible-dummy && bundle lock)              # -> Writing lockfile

# bundle check passes in each (exit 0):
react_on_rails_pro                  -> The Gemfile's dependencies are satisfied
spec/dummy                          -> The Gemfile's dependencies are satisfied
spec/execjs-compatible-dummy        -> The Gemfile's dependencies are satisfied

# No direct usage remains / no new usage snuck in (exit 1, no hits):
git grep -inE "addressable|rainbow" -- react_on_rails_pro ':!*.lock' ':!react_on_rails_pro/CHANGELOG*'

# Gemspec rubocop: the only 4 offenses reported (Gemspec/DevelopmentDependencies
# on add_development_dependency lines) are pre-existing on origin/main and
# untouched by this PR. This change introduces zero new offenses.
```

## Codex Decision Log

- Verified `addressable`/`rainbow` were direct runtime deps (gemspec L52/L60) and unused in Pro code (grep exit 1) before editing.
- Confirmed transitive coverage via OSS `react_on_rails` gemspec + Pro's `react_on_rails` dep before removal.
- Chose `bundle lock` (not `bundle install`) to minimize lock churn; verified each diff is limited to the two removed edges with no version bumps.
- Confirmed both gems remain in all three locks (PATH-spec edges + resolved GEM versions) after regeneration.
- Did **not** touch `react_on_rails_pro/CHANGELOG.md` (out of file scope for this worker); flagged for the coordinator.

## Confidence note:

High. The change is a pure dependency-hygiene edit with mechanically verified transitive coverage. All three locks regenerate cleanly, `bundle check` passes in each, both gems remain resolved at identical versions, and every lock diff is limited to the intended two-edge removal with no incidental bumps. Only residual risk is the hosted-CI generator/lockfile gate, which is a process step, not a correctness concern.
