### PR TITLE
Extract install_dependency_group helper in JsDependencyManager (#4403)

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -281,42 +281,51 @@ module ReactOnRails
         MSG
       end
 
-      def add_css_dependencies
-        say "Installing CSS handling dependencies..."
-        return if add_packages(CSS_DEPENDENCIES)
+      # Installs a named group of packages, degrading gracefully per the module's
+      # error-handling philosophy (warn + manual-install instructions, never raise).
+      #
+      # @param installing_label [String] noun phrase for the "Installing ..." status line
+      # @param failure_label [String] noun phrase for the "Failed to add ..." / "Error adding ..." warnings
+      # @param packages [Array<String>] package specifiers to add
+      # @param dev [Boolean] whether to add as dev dependencies
+      # @param plural [Boolean] whether the manual-install sentence says "them" (true) or "it" (false)
+      # @param failure_note [String, nil] extra sentence emitted only in the non-exception failure path
+      # @return [Boolean] true when all packages were added, false otherwise
+      def install_dependency_group(installing_label, failure_label, packages, dev: false, plural: true,
+                                   failure_note: nil)
+        say "Installing #{installing_label}..."
+        return true if add_packages(packages, dev:)
 
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to add CSS dependencies.
-
-          You can install them manually by running:
-            #{manual_add_packages_command(CSS_DEPENDENCIES)}
-        MSG
+        GeneratorMessages.add_warning(
+          dependency_group_failure_message("Failed to add #{failure_label}.", packages, dev:, plural:,
+                                                                                        note: failure_note)
+        )
+        false
       rescue StandardError => e
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Error adding CSS dependencies: #{e.message}
+        GeneratorMessages.add_warning(
+          dependency_group_failure_message("Error adding #{failure_label}: #{e.message}", packages, dev:,
+                                                                                                    plural:)
+        )
+        false
+      end
 
-          You can install them manually by running:
-            #{manual_add_packages_command(CSS_DEPENDENCIES)}
-        MSG
+      def dependency_group_failure_message(headline, packages, dev:, plural: true, note: nil)
+        pronoun = plural ? "them" : "it"
+        [
+          "⚠️  #{headline}",
+          "",
+          note,
+          "You can install #{pronoun} manually by running:",
+          "  #{manual_add_packages_command(packages, dev:)}"
+        ].compact.join("\n")
+      end
+
+      def add_css_dependencies
+        install_dependency_group("CSS handling dependencies", "CSS dependencies", CSS_DEPENDENCIES)
       end
 
       def add_tailwind_dependencies
-        say "Installing Tailwind CSS v4 dependencies..."
-        return if add_packages(TAILWIND_DEPENDENCIES)
-
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to add Tailwind CSS dependencies.
-
-          You can install them manually by running:
-            #{manual_add_packages_command(TAILWIND_DEPENDENCIES)}
-        MSG
-      rescue StandardError => e
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Error adding Tailwind CSS dependencies: #{e.message}
-
-          You can install them manually by running:
-            #{manual_add_packages_command(TAILWIND_DEPENDENCIES)}
-        MSG
+        install_dependency_group("Tailwind CSS v4 dependencies", "Tailwind CSS dependencies", TAILWIND_DEPENDENCIES)
       end
 
       def add_tailwind_dependencies_if_requested
@@ -327,82 +336,29 @@ module ReactOnRails
       end
 
       def add_rspack_dependencies
-        say "Installing Rspack core dependencies..."
-        return if add_packages(RSPACK_DEPENDENCIES)
-
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to add Rspack dependencies.
-
-          You can install them manually by running:
-            #{manual_add_packages_command(RSPACK_DEPENDENCIES)}
-        MSG
-      rescue StandardError => e
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Error adding Rspack dependencies: #{e.message}
-
-          You can install them manually by running:
-            #{manual_add_packages_command(RSPACK_DEPENDENCIES)}
-        MSG
+        install_dependency_group("Rspack core dependencies", "Rspack dependencies", RSPACK_DEPENDENCIES)
       end
 
       def add_swc_dependencies
-        say "Installing SWC transpiler dependencies (20x faster than Babel)..."
-        return if add_packages(SWC_DEPENDENCIES, dev: true)
-
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to add SWC dependencies.
-
-          SWC is the default JavaScript transpiler for Shakapacker 9.3.0+.
-          You can install them manually by running:
-            #{manual_add_packages_command(SWC_DEPENDENCIES, dev: true)}
-        MSG
-      rescue StandardError => e
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Error adding SWC dependencies: #{e.message}
-
-          You can install them manually by running:
-            #{manual_add_packages_command(SWC_DEPENDENCIES, dev: true)}
-        MSG
+        install_dependency_group(
+          "SWC transpiler dependencies (20x faster than Babel)", "SWC dependencies", SWC_DEPENDENCIES,
+          dev: true, failure_note: "SWC is the default JavaScript transpiler for Shakapacker 9.3.0+."
+        )
       end
 
+      # Returns true/false so the caller (install_generator) can decide whether to warn about
+      # incomplete Babel compatibility after switching from SWC. Do not change to the `return if`
+      # pattern the other groups use.
       def add_babel_react_dependencies
-        say "Installing Babel React preset dependency..."
-        return true if add_packages(BABEL_REACT_DEPENDENCIES, dev: true)
-
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to add Babel React preset dependency.
-
-          You can install it manually by running:
-            #{manual_add_packages_command(BABEL_REACT_DEPENDENCIES, dev: true)}
-        MSG
-        false
-      rescue StandardError => e
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Error adding Babel React preset dependency: #{e.message}
-
-          You can install it manually by running:
-            #{manual_add_packages_command(BABEL_REACT_DEPENDENCIES, dev: true)}
-        MSG
-        false
+        install_dependency_group(
+          "Babel React preset dependency", "Babel React preset dependency", BABEL_REACT_DEPENDENCIES,
+          dev: true, plural: false
+        )
       end
 
       def add_typescript_dependencies
-        say "Installing TypeScript dependencies..."
-        return if add_packages(TYPESCRIPT_DEPENDENCIES, dev: true)
-
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to add TypeScript dependencies.
-
-          You can install them manually by running:
-            #{manual_add_packages_command(TYPESCRIPT_DEPENDENCIES, dev: true)}
-        MSG
-      rescue StandardError => e
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Error adding TypeScript dependencies: #{e.message}
-
-          You can install them manually by running:
-            #{manual_add_packages_command(TYPESCRIPT_DEPENDENCIES, dev: true)}
-        MSG
+        install_dependency_group("TypeScript dependencies", "TypeScript dependencies", TYPESCRIPT_DEPENDENCIES,
+                                 dev: true)
       end
 
       def add_pro_dependencies

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -699,6 +699,107 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
     end
   end
 
+  describe "#install_dependency_group" do
+    let(:packages) { %w[foo@^1.0.0 bar@^2.0.0] }
+
+    it "returns true and adds no warning when the packages install successfully" do
+      result = instance.send(:install_dependency_group, "Foo dependencies", "Foo dependencies", packages)
+
+      expect(result).to be(true)
+      expect(warnings.size).to eq(0)
+    end
+
+    it "passes the dev flag through to add_npm_dependencies" do
+      instance.send(:install_dependency_group, "Foo dependencies", "Foo dependencies", packages, dev: true)
+
+      expect(instance.add_npm_dependencies_calls).to include(
+        a_hash_including(packages:, dev: true)
+      )
+    end
+
+    it "returns false and warns with manual instructions when the add fails" do
+      instance.add_npm_dependencies_result = false
+      instance.system_result = false
+      allow(instance).to receive(:existing_package_names).and_return([])
+
+      result = instance.send(:install_dependency_group, "Foo dependencies", "Foo dependencies", packages)
+
+      expect(result).to be(false)
+      expect(warnings.first.to_s).to include("Failed to add Foo dependencies")
+      expect(warnings.first.to_s).to include("You can install them manually by running:")
+    end
+
+    it "returns false and warns with the exception message when the add raises" do
+      allow(instance).to receive(:add_packages).and_raise(StandardError, "network error")
+
+      result = instance.send(:install_dependency_group, "Foo dependencies", "Foo dependencies", packages)
+
+      expect(result).to be(false)
+      expect(warnings.first.to_s).to include("Error adding Foo dependencies: network error")
+    end
+
+    it "uses singular wording when plural: false" do
+      instance.add_npm_dependencies_result = false
+      instance.system_result = false
+      allow(instance).to receive(:existing_package_names).and_return([])
+
+      instance.send(:install_dependency_group, "Foo dependency", "Foo dependency", packages, plural: false)
+
+      expect(warnings.first.to_s).to include("You can install it manually by running:")
+    end
+
+    it "emits the failure_note only in the non-exception failure path, above the manual instructions" do
+      instance.add_npm_dependencies_result = false
+      instance.system_result = false
+      allow(instance).to receive(:existing_package_names).and_return([])
+
+      instance.send(
+        :install_dependency_group, "Foo dependencies", "Foo dependencies", packages,
+        failure_note: "A helpful note."
+      )
+
+      expect(warnings.first.to_s).to include(
+        "Failed to add Foo dependencies.\n\nA helpful note.\nYou can install them manually by running:"
+      )
+    end
+
+    it "omits the failure_note from the exception path" do
+      allow(instance).to receive(:add_packages).and_raise(StandardError, "boom")
+
+      instance.send(
+        :install_dependency_group, "Foo dependencies", "Foo dependencies", packages,
+        failure_note: "A helpful note."
+      )
+
+      expect(warnings.first.to_s).not_to include("A helpful note.")
+    end
+  end
+
+  describe "#add_swc_dependencies" do
+    it "keeps the SWC failure note above the manual-install instructions when the add fails" do
+      instance.add_npm_dependencies_result = false
+      instance.system_result = false
+      allow(instance).to receive(:existing_package_names).and_return([])
+
+      instance.send(:add_swc_dependencies)
+
+      expect(warnings.first.to_s).to include(
+        "Failed to add SWC dependencies.\n\n" \
+        "SWC is the default JavaScript transpiler for Shakapacker 9.3.0+.\n" \
+        "You can install them manually by running:"
+      )
+    end
+
+    it "omits the SWC failure note when the add raises" do
+      allow(instance).to receive(:add_packages).and_raise(StandardError, "network error")
+
+      instance.send(:add_swc_dependencies)
+
+      expect(warnings.first.to_s).to include("Error adding SWC dependencies: network error")
+      expect(warnings.first.to_s).not_to include("SWC is the default JavaScript transpiler")
+    end
+  end
+
   describe "#rsc_packages_with_version" do
     it "defines an explicit RSC package version pin independent from the React semver range prefix" do
       expect(ReactOnRails::Generators::JsDependencyManager::RSC_REACT_VERSION_RANGE).to eq("~19.0.4")


### PR DESCRIPTION
## Summary

Pure refactor of `ReactOnRails::Generators::JsDependencyManager`: collapses the
five near-identical `add_*_dependencies` methods (`css`, `tailwind`, `rspack`,
`swc`, `typescript`) plus the babel-react variant into a single parameterized
`install_dependency_group` helper (with a `dependency_group_failure_message`
formatter) and thin one-line wrappers.

Each method previously repeated the same four-step shape — `say` a label →
`add_packages(CONST[, dev:])` → `GeneratorMessages.add_warning` on failure →
`rescue StandardError` with a second warning — differing only in the package
constant, the labels, the `dev:` flag, an optional failure note (SWC), and the
singular/plural pronoun (babel). Roughly 90 lines of copy-paste collapse into
one helper; future dependency groups become one-line additions.

Fixes #4403

## Rationale

Removes the duplication cluster flagged by the 2026-07-02 maintainability audit
(flay masses 105 + 88) without changing any generator behavior.

## Impact (internal only — no behavior or API change)

- **Wrapper method names preserved.** `add_css_dependencies`,
  `add_tailwind_dependencies`, `add_rspack_dependencies`, `add_swc_dependencies`,
  `add_typescript_dependencies`, and `add_babel_react_dependencies` still exist
  and are called from `setup_js_dependencies`, from
  `install_generator.rb` (`add_typescript_dependencies` L1253,
  `add_babel_react_dependencies` L483), and from specs via `send`.
- **Warning/status text is byte-identical**, including:
  - the SWC-only failure note (`SWC is the default JavaScript transpiler for
    Shakapacker 9.3.0+.`) that appears **only** in the non-exception failure
    path, above the manual-install instructions — asymmetry preserved via the
    `failure_note:` knob;
  - babel's singular wording ("You can install **it** manually") — preserved via
    a `plural: false` knob.
- **`add_babel_react_dependencies` keeps its explicit `true`/`false` return**,
  consumed by `install_generator`'s babel-compatibility check. The helper returns
  `true` on success / `false` on failure, matching the original contract.
- **Minor, non-observable normalization:** the five non-babel wrappers now return
  `true`/`false` (helper return) instead of the previous bare-`return` `nil`-ish
  value. No caller or spec consumes these return values, so this is not an
  observable change. Called out here per the issue's acceptance criteria.
- Net **-44 lines** in the source file (97 deletions / 53 insertions incl. the
  new helper + docs); **no new RuboCop metrics disables**.

## Validation evidence

```
# Unit spec (authoritative — directly asserts message text, dev flags, packages,
# and return values for every touched method; +9 new examples for the helper)
$ cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/js_dependency_manager_spec.rb
95 examples, 0 failures

# RuboCop (CI-equivalent single-file)
$ cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop \
    lib/generators/react_on_rails/js_dependency_manager.rb \
    spec/react_on_rails/generators/js_dependency_manager_spec.rb
2 files inspected, no offenses detected
```

New specs added: a `#install_dependency_group` group (success/false/raise paths,
`dev:` pass-through, singular wording, and failure-note placement/omission) plus
an `#add_swc_dependencies` group pinning the SWC note ordering byte-exactly.

**Note on `install_generator_spec.rb`:** this heavy end-to-end suite (generates
real Rails apps) fails locally in this environment on **clean `main`** as well —
verified by stashing this branch's changes and re-running the same examples
(e.g. `install_generator_spec.rb:652`, `:3228`), which reproduce identical
generator-infrastructure failures (`Expected file …HelloWorld.client.tsx to
exist`, route-generation errors) unrelated to this diff. These pre-existing local
failures are not introduced by this change; the CI environment runs the full
suite.

## Codex Decision Log

- **Parameterization surface:** verified all five methods (+ babel) are
  structurally identical apart from constant/labels/`dev:`; captured every
  difference as helper parameters: `installing_label`, `failure_label`,
  `packages`, `dev:`, `plural:`, `failure_note:`. The `say` label and the
  "Failed to add …"/"Error adding …" label are distinct strings (e.g. CSS says
  "CSS handling dependencies" but warns "CSS dependencies"), so they are two
  separate parameters.
- **Message-order fidelity:** reconstructed the emitted warning as an array join
  (`headline, "", note, "You can install … running:", "  <cmd>"`) with `.compact`
  so the no-note groups render `headline / blank / instructions` and SWC renders
  `headline / blank / note / instructions` — matching the original heredocs
  exactly. Caught and fixed an initial note/blank-line ordering bug via a
  byte-exact spec assertion.
- **`add_babel_react_dependencies`:** deliberately routed through the helper's
  boolean return rather than the `return if` pattern the other five use, because
  its return value is consumed by a caller. Documented this with a code comment.
- **Scope discipline:** did not fold in `add_react_dependencies` (dynamic package
  list) or `add_rsc_dependencies`/`add_pro_dependencies` (bespoke messaging),
  which the issue lists as optional and which have materially different shapes.

Confidence note: **High.** The change is a mechanical extraction pinned by the
unit spec, which asserts on the exact warning text, `dev:` flags, package lists,
and return contracts for every affected method. RuboCop is clean and the diff is
a net line reduction with no new disables. The only residual is that the
end-to-end `install_generator_spec.rb` could not be run green locally due to a
pre-existing environment issue reproduced on clean `main`; CI will exercise it.
