### PR TITLE
Prune stale knip ignores and enforce binaries in CI (#4408)

### DIFF
--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -200,8 +200,8 @@ jobs:
         run: cd react_on_rails/spec/dummy && RAILS_ENV="test" bundle exec rake react_on_rails:generate_packs
       - name: Detect dead code
         run: |
-          pnpm exec knip --exclude binaries
-          pnpm exec knip --production --exclude binaries
+          pnpm exec knip
+          pnpm exec knip --production
 
       - name: Lint JS
         run: pnpm run eslint --report-unused-disable-directives

--- a/knip.ts
+++ b/knip.ts
@@ -14,11 +14,17 @@ const config: KnipConfig = {
       ],
       project: ['*.{js,mjs,ts}', 'test/shakaperf/**/*.ts'],
       ignoreBinaries: [
-        // Has to be installed globally
-        'yalc',
         // Pro package binaries used in Pro workflows
         'playwright',
         'e2e-test',
+        // pnpm script inside react_on_rails_pro/spec/dummy (that tree is excluded from
+        // knip via the react_on_rails_pro/** ignore below); invoked by pro-integration-tests.yml.
+        'e2e-test:rsc',
+        // GitHub CLI, preinstalled on GitHub Actions runners; invoked by update-llms-full.yml.
+        'gh',
+        // Task runner invoked by the `start`/`lint` package.json scripts. `knip --production`
+        // strips this devDependency and would otherwise report `nps` as an unlisted binary.
+        'nps',
         // Local binaries
         'bin/.*',
       ],
@@ -50,11 +56,6 @@ const config: KnipConfig = {
         // SWC transpiler dependencies used by Shakapacker in dummy apps
         '@swc/core',
         'swc-loader',
-        // Used via nps (package-scripts.yml) which knip doesn't fully analyze
-        'nps',
-        // Used for package validation but not directly imported
-        '@arethetypeswrong/cli',
-        'publint',
         // Used by the release gate workflow via `pnpm exec shaka-perf`; Knip does
         // not detect that CLI usage from the GitHub Actions shell command.
         'shaka-perf',
@@ -64,7 +65,7 @@ const config: KnipConfig = {
     // Create React on Rails app package workspace
     'packages/create-react-on-rails-app': {
       entry: ['bin/create-react-on-rails-app.js!', 'src/index.ts!'],
-      project: ['src/**/*.ts', 'tests/**/*.ts', 'jest.config.js'],
+      project: ['src/**/*.ts', 'tests/**/*.ts'],
       ignore: ['lib/**', 'node_modules/**'],
     },
 
@@ -162,19 +163,16 @@ const config: KnipConfig = {
         'tests/fixtures/**',
         // Build output directories that should be ignored
         'lib/**',
-        // Pro features exported for external consumption
-        'src/streamServerRenderedReactComponent.ts:transformRenderStreamChunksToResultObject',
-        'src/streamServerRenderedReactComponent.ts:streamServerRenderedComponent',
-        'src/ServerComponentFetchError.ts:isServerComponentFetchError',
-        'src/RSCRoute.tsx:RSCRouteProps',
-        'src/streamServerRenderedReactComponent.ts:StreamingTrackers',
       ],
     },
     'react_on_rails/spec/dummy': {
       entry: [
         'app/assets/config/manifest.js!',
         'client/app/packs/**/*.{js,jsx,ts,tsx}!',
-        // Not sure why this isn't detected as a dependency of client/app/packs/server-bundle.ts
+        // Not sure why this isn't detected as a dependency of client/app/packs/server-bundle.ts.
+        // The file is produced by `rake react_on_rails:generate_packs` (run in CI before knip),
+        // so knip only reports this entry as an unmatched pattern on a fresh checkout without
+        // generated packs. Keep it: the entry does real work in CI where the file exists.
         'client/app/generated/server-bundle-generated.js!',
         'config/webpack/{production,development,test}.js',
         // Declaring this as webpack.config instead doesn't work correctly
@@ -213,8 +211,6 @@ const config: KnipConfig = {
         'Assets/*': ['client/app/assets/*'],
       },
       ignoreBinaries: [
-        // Has to be installed globally
-        'yalc',
         // Local binaries
         'bin/.*',
       ],
@@ -223,12 +219,11 @@ const config: KnipConfig = {
         '@rescript/react',
         // The Babel plugin fails to detect it
         'babel-plugin-transform-react-remove-prop-types',
-        // Loaded only when REACT_COMPILER=1 in babel.config.js (which Knip ignores above), so
-        // it is never seen as used by static analysis. See docs/oss/building-features/react-compiler.md.
-        'babel-plugin-react-compiler',
-        // Required by @babel/plugin-transform-runtime for polyfills (used by webpack)
+        // Required by @babel/plugin-transform-runtime for polyfills (used by webpack).
+        // Only flagged as unused by `knip --production`, which strips the dev-only usage.
         '@babel/runtime',
-        // Used in webpack server config for CSS extraction
+        // Used in webpack server config for CSS extraction.
+        // Only flagged as unused by `knip --production`, which strips the dev-only usage.
         'mini-css-extract-plugin',
         // Webpack config merge helper is used in the dummy app config, but not detected reliably by Knip.
         'webpack-merge',
@@ -256,6 +251,8 @@ const config: KnipConfig = {
       ],
     },
   },
+  // These test-only reset helpers are used across files (imported by test setup), but
+  // `knip --production` strips test files and would report them as unused exports.
   ignoreIssues: {
     'packages/react-on-rails-pro-node-renderer/src/shared/tracing.ts': ['exports'],
     'packages/react-on-rails-pro-node-renderer/src/worker/fastifyConfig.ts': ['exports'],


### PR DESCRIPTION
## Why

`knip.ts` had accumulated ignore entries that knip's own configuration hints flag as unnecessary, and the CI invocation hid the entire unlisted-binaries issue class with a blanket `--exclude binaries`. That flag permanently masked the repo's two real external binaries (`e2e-test:rsc`, `gh`) and would silently accept any future unlisted binary. Stale suppression lists are how future dead code becomes invisible, so this prunes the dead entries, allowlists the real binaries with rationale, and lets CI enforce the binaries class again.

Fixes #4408

## What changed

### `knip.ts`
**Removed** (genuinely stale in every invocation mode):
- `'nps'` from root `ignoreDependencies` — it is a script binary, not an imported dependency, so it belongs in `ignoreBinaries`, not `ignoreDependencies`.
- `'@arethetypeswrong/cli'`, `'publint'` from root `ignoreDependencies`.
- `'babel-plugin-react-compiler'` from spec/dummy `ignoreDependencies`.
- both `'yalc'` `ignoreBinaries` entries (root + spec/dummy).
- the redundant `'jest.config.js'` project glob in `packages/create-react-on-rails-app`.
- the 5 per-export ignores in the `react-on-rails-pro` workspace.

**Added** a scoped `ignoreBinaries` allowlist with inline rationale:
- `'e2e-test:rsc'` — a pnpm script in `react_on_rails_pro/spec/dummy/package.json:109`; that tree is excluded from knip via the `react_on_rails_pro/**` ignore, and the script is invoked by `pro-integration-tests.yml:790`.
- `'gh'` — GitHub CLI, preinstalled on GitHub Actions runners, invoked by `update-llms-full.yml:89`.
- `'nps'` — the task runner behind the `start`/`lint` package.json scripts. `knip --production` strips this devDependency and reports it as an unlisted binary once `--exclude binaries` is dropped, so it must be allowlisted.

**Documented** the environment-dependent `client/app/generated/server-bundle-generated.js!` entry: the file is produced by `rake react_on_rails:generate_packs` (run in CI before knip), so knip only reports it as an unmatched pattern on a fresh checkout without generated packs. Kept, per issue step 2 — it does real work in CI.

### `.github/workflows/lint-js-and-ruby.yml`
- Dropped `--exclude binaries` from both knip invocations in the "Detect dead code" step so CI enforces the unlisted-binaries class.

## Deviation from the issue's plan (important)

The issue described the `ignoreIssues` block and the `@babel/runtime` / `mini-css-extract-plugin` / four dummy-component (`@dr.pogodin/react-helmet`, `create-react-class`, `react-redux`, `react-router-dom`) ignores as **proven no-ops** to delete. That evidence came from a **single `knip` invocation without generated packs**. CI runs knip in **four** effective states (default/`--production` × packs-present/absent), and I verified empirically that these entries are load-bearing in states the issue did not test:

- `knip --production` (both pack states) reports the `__reset*ForTest` exports as unused if the `ignoreIssues` block is removed, and reports `@babel/runtime` + `mini-css-extract-plugin` as unused dependencies if their ignores are removed. Production mode strips test/dev usage.
- A fresh checkout **without** generated packs reports the four dummy-component deps as unused if their ignores are removed (they resolve only once packs are generated).

Removing any of these would turn CI or local dev red, so they are **kept**. This is consistent with the repo policy of never removing entries still doing real work.

**Consequence for the acceptance criterion:** "0 configuration hints" is not simultaneously satisfiable with a green CI, because knip computes hints per-invocation and an entry that is redundant in `default + packs` mode is load-bearing in `--production` or `no-packs` mode. The practical, security-relevant goal — CI passing with `--exclude binaries` removed — **is** met. The `server.js` hint in `react_on_rails_pro/spec/dummy/package.json` is out of scope (not a `knip.ts` entry) and left as-is. `treatConfigHintsAsErrors` (issue step 7, optional) is intentionally **not** enabled, since the residual hints are unavoidable.

## Validation (real results, CI state = generated packs present)

| Command | Result |
| --- | --- |
| `pnpm install --prefer-offline` | ok |
| `cd react_on_rails/spec/dummy && rake react_on_rails:generate_packs` | exit 0 (matches CI step before knip) |
| `pnpm exec knip` (no `--exclude`) | **exit 0** |
| `pnpm exec knip --production` (no `--exclude`) | **exit 0** |
| `pnpm run lint` | exit 0 |
| `pnpm start format.listDifferent` | exit 0 ("All matched files use Prettier code style!") |
| `pnpm run type-check` | exit 0 |
| `pnpm run build` | exit 0 |
| `actionlint .github/workflows/lint-js-and-ruby.yml` | exit 0 |

`yamllint` not installed locally (skipped). Fresh-checkout-only note: `knip --production` **without** generated packs exits 1 on a pre-existing `prop-types` unused-dependency (present in the stock config too); CI always generates packs first, so this never affects CI.

## Codex Decision Log

- **Self-review:** `codex review --base origin/main` was **unavailable** (hit OpenAI usage limit mid-run). Performed a careful manual, empirical self-review instead: every removed entry was confirmed stale across all four knip invocation states, and every kept entry was confirmed load-bearing by re-running knip with it deleted. Both added binaries were confirmed to be legitimately external/unlisted (script in a knip-excluded tree; runner-preinstalled CLI).
- **Behavior-preserving:** config-only + CI-enforcement change; no runtime/library code touched.

## Stale-base / new-gate race control

This broadens a lint gate (CI now enforces the knip binaries class). Sweep result: the only other open PR touching `.github/workflows/lint-js-and-ruby.yml` is **#4390** (hosted-CI safeguards); it edits only the top-of-file `on:`/`if:` trigger block (~line 23), not the "Detect dead code" step (~line 201) — **no overlap**, clean auto-merge expected. No open PR touches `knip.ts` or adds new binary invocations. Coordinator: if a new PR adds a binary invocation before this lands, it must add the binary to `ignoreBinaries` (or list it) or CI will now fail.

Labels: ready-for-hosted-ci, hosted-ci-no-benchmarks

Rationale: CI/tooling-only change that must be exercised by hosted CI (the knip step runs there with generated packs); `hosted-ci-no-benchmarks` because a knip config change cannot affect runtime performance.
