### PR TITLE
Add mechanical parity guards for Ruby↔TS protocol constants (#4412)

### DIFF
--- a/.github/workflows/check-mirrored-blocks.yml
+++ b/.github/workflows/check-mirrored-blocks.yml
@@ -7,16 +7,25 @@ permissions:
 "on":
   push:
     branches: [main]
+    # Keep these paths in one-to-one sync with MIRROR_ROOTS in bin/lint-mirrored-blocks
+    # (each root maps to `<root>/**`). If MIRROR_ROOTS changes, update both lists below.
     paths:
       - 'bin/lint-mirrored-blocks'
       - 'packages/react-on-rails/**'
       - 'packages/react-on-rails-pro/**'
+      - 'packages/react-on-rails-pro-node-renderer/src/**'
+      - 'react_on_rails/lib/**'
+      - 'react_on_rails_pro/lib/**'
       - '.github/workflows/check-mirrored-blocks.yml'
   pull_request:
+    # Keep in sync with MIRROR_ROOTS in bin/lint-mirrored-blocks (see note above).
     paths:
       - 'bin/lint-mirrored-blocks'
       - 'packages/react-on-rails/**'
       - 'packages/react-on-rails-pro/**'
+      - 'packages/react-on-rails-pro-node-renderer/src/**'
+      - 'react_on_rails/lib/**'
+      - 'react_on_rails_pro/lib/**'
       - '.github/workflows/check-mirrored-blocks.yml'
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -15,6 +15,8 @@ on:
       - 'script/release-forward-port-test.bash'
       - 'script/release-finish'
       - 'script/release-finish-test.bash'
+      - 'bin/lint-mirrored-blocks'
+      - 'script/lint-mirrored-blocks-test.bash'
       - 'bin/read-tool-version'
       - '.tool-versions'
       - '.minimum.tool-versions'
@@ -31,6 +33,8 @@ on:
       - 'script/release-forward-port-test.bash'
       - 'script/release-finish'
       - 'script/release-finish-test.bash'
+      - 'bin/lint-mirrored-blocks'
+      - 'script/lint-mirrored-blocks-test.bash'
       - 'bin/read-tool-version'
       - '.tool-versions'
       - '.minimum.tool-versions'
@@ -66,7 +70,8 @@ jobs:
             script/ci-changes-detector \
             script/ci-changes-detector-test.bash \
             script/release-forward-port-test.bash \
-            script/release-finish-test.bash
+            script/release-finish-test.bash \
+            script/lint-mirrored-blocks-test.bash
 
       - name: Ruby syntax check release scripts
         run: |
@@ -90,3 +95,6 @@ jobs:
 
       - name: Run release finish test harness
         run: bash script/release-finish-test.bash
+
+      - name: Run mirrored-blocks lint test harness
+        run: bash script/lint-mirrored-blocks-test.bash

--- a/bin/lint-mirrored-blocks
+++ b/bin/lint-mirrored-blocks
@@ -693,9 +693,41 @@ def values_target_path_from(line)
   clean_repo_path(match[1].sub(/[.,;:)\]]+\z/, ""))
 end
 
+QUOTE_CHARS = ["'", '"', "`"].freeze
+
+# True when index begins a Ruby (`#`), JS/TS line (`//`) or single-line block (`/* ... */`)
+# comment (outside any string — callers gate on that).
+def comment_start_at?(line, index)
+  char = line[index]
+  char == "#" || (char == "/" && ["/", "*"].include?(line[index + 1]))
+end
+
+# Return the code portion of a line with any trailing comment removed. Comment openers inside
+# a quoted string (e.g. a URL like 'http://x') are ignored. Only single-line comments are
+# handled — a value region spanning a multi-line /* ... */ is not supported and would leak its
+# tail; regions are single-line constant declarations, so this is sufficient.
+def strip_line_comment(line)
+  quote = nil
+  index = 0
+  while index < line.length
+    char = line[index]
+    if quote
+      quote = nil if char == quote
+    elsif QUOTE_CHARS.include?(char)
+      quote = char
+    elsif comment_start_at?(line, index)
+      return line[0...index]
+    end
+    index += 1
+  end
+  line
+end
+
 # Collect quoted-string and integer literals from one line of a value region.
 # %w[...]/%i[...] words are unquoted, so expand them to individual string values.
-def literals_on_line(line)
+# Trailing comments are stripped first so prose tokens never enter the contract.
+def literals_on_line(raw_line)
+  line = strip_line_comment(raw_line)
   literals = []
   line.scan(PERCENT_WORD_ARRAY_PATTERN) { |_open, body| literals.concat(body.split(/\s+/).reject(&:empty?)) }
   # Remove the %w/%i bodies before scanning quoted strings so their contents are not double counted.

--- a/bin/lint-mirrored-blocks
+++ b/bin/lint-mirrored-blocks
@@ -705,6 +705,19 @@ def literals_on_line(line)
   literals
 end
 
+# Collect literals from a value region [start_index, end_index). Stacked MIRROR VALUES OF:
+# markers (a region can be pinned to several targets) and any nested END marker are skipped
+# so tokens inside those comment lines (e.g. a target path) never leak into the guarded set.
+def collect_region_literals(lines, start_index, end_index)
+  values = []
+  (start_index...end_index).each do |i|
+    next if lines[i].match?(VALUES_MARKER_PATTERN) || lines[i].match?(VALUES_END_PATTERN)
+
+    values.concat(literals_on_line(lines[i]))
+  end
+  values
+end
+
 def parse_values_marker(path, lines, marker_index, errors)
   target_path = values_target_path_from(lines[marker_index])
   unless target_path
@@ -720,8 +733,7 @@ def parse_values_marker(path, lines, marker_index, errors)
     return nil
   end
 
-  values = []
-  ((marker_index + 1)...end_index).each { |i| values.concat(literals_on_line(lines[i])) }
+  values = collect_region_literals(lines, marker_index + 1, end_index)
   if values.empty?
     errors << "#{path}:#{marker_index + 1}: no string or integer literals found in " \
               "'#{VALUES_MARKER}' region (lines #{marker_index + 2}-#{end_index})"

--- a/bin/lint-mirrored-blocks
+++ b/bin/lint-mirrored-blocks
@@ -5,9 +5,20 @@ require "open3"
 require "pathname"
 
 MARKER = "MIRROR OF:"
+# Value-set mirror mode (language-agnostic). Unlike MIRROR OF:, which brace-matches a
+# JS `{...}` block and compares its text byte-for-byte, MIRROR VALUES OF: guards an
+# explicitly delimited region and compares only the *set* of quoted-string and integer
+# literals it contains. This lets Ruby (`%w[...].freeze`, `= 256`) and TS
+# (`[...] as const`, scattered `'literal'` args) definitions of the same wire-protocol
+# contract be pinned to each other without requiring identical syntax or a shared block.
+VALUES_MARKER = "MIRROR VALUES OF:"
+VALUES_END_MARKER = "MIRROR VALUES END"
 MIRROR_ROOTS = %w[
   packages/react-on-rails
   packages/react-on-rails-pro
+  packages/react-on-rails-pro-node-renderer/src
+  react_on_rails/lib
+  react_on_rails_pro/lib
 ].freeze
 WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
 REGEX_LITERAL_PRECEDING_PUNCTUATION_BYTES = "([{}=,:;!&|?+-*~%^<>".bytes.freeze
@@ -34,6 +45,25 @@ TARGET_PATH_PATTERN = %r{
   ([A-Za-z0-9_@./+\-]+)
   `?
 }ix
+
+# Value-mode markers accept Ruby (`#`) as well as JS (`//`, `*`, `/*`) comment prefixes so
+# the same guard can pin a Ruby constant to a TS constant. The prefix is text-matched (not
+# lexer-classified) because value regions live in Ruby files the JS lexer does not model.
+COMMENT_PREFIX = %r{(?:(?://|\#|\*)\s*|/\*+\s*)}
+VALUES_MARKER_PATTERN = /\A\s*#{COMMENT_PREFIX}#{Regexp.escape(VALUES_MARKER)}/o
+VALUES_END_PATTERN = /\A\s*#{COMMENT_PREFIX}#{Regexp.escape(VALUES_END_MARKER)}\b/o
+VALUES_TARGET_PATH_PATTERN = %r{
+  #{Regexp.escape(VALUES_MARKER)}
+  \s+
+  `?
+  ([A-Za-z0-9_@./+\-]+)
+  `?
+}iox
+# String literals: '...' , "..." (single line, with escapes) plus Ruby %w[...]/%i[...] words.
+# Integer literals: standalone decimal numbers (e.g. MAX_PULL_PROP_NAME_LENGTH = 256).
+STRING_LITERAL_PATTERN = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/
+PERCENT_WORD_ARRAY_PATTERN = /%[wi]([\[({<])([^\])}>]*)[\])}>]/
+INTEGER_LITERAL_PATTERN = /(?<![\w.])\d+(?![\w.])/
 GUARD_HEADER_PATTERN = /
   \A
   (?:
@@ -50,6 +80,15 @@ MarkerRecord = Struct.new(
   :normalized_block,
   :block_start_line,
   :block_end_line,
+  keyword_init: true
+)
+ValuesRecord = Struct.new(
+  :path,
+  :line_number,
+  :target_path,
+  :literal_values,
+  :region_start_line,
+  :region_end_line,
   keyword_init: true
 )
 BlockStart = Struct.new(:line_index, :open_index, keyword_init: true)
@@ -647,6 +686,73 @@ def parse_markers(path, content)
   [records, errors]
 end
 
+def values_target_path_from(line)
+  match = line.match(VALUES_TARGET_PATH_PATTERN)
+  return nil unless match
+
+  clean_repo_path(match[1].sub(/[.,;:)\]]+\z/, ""))
+end
+
+# Collect quoted-string and integer literals from one line of a value region.
+# %w[...]/%i[...] words are unquoted, so expand them to individual string values.
+def literals_on_line(line)
+  literals = []
+  line.scan(PERCENT_WORD_ARRAY_PATTERN) { |_open, body| literals.concat(body.split(/\s+/).reject(&:empty?)) }
+  # Remove the %w/%i bodies before scanning quoted strings so their contents are not double counted.
+  remainder = line.gsub(PERCENT_WORD_ARRAY_PATTERN, "")
+  remainder.scan(STRING_LITERAL_PATTERN) { |match| literals << match[1...-1] }
+  remainder.scan(INTEGER_LITERAL_PATTERN) { |match| literals << match }
+  literals
+end
+
+def parse_values_marker(path, lines, marker_index, errors)
+  target_path = values_target_path_from(lines[marker_index])
+  unless target_path
+    errors << "#{path}:#{marker_index + 1}: unable to parse mirror target path; " \
+              "expected '#{VALUES_MARKER} <path>'"
+    return nil
+  end
+
+  end_index = (marker_index + 1...lines.length).find { |i| lines[i].match?(VALUES_END_PATTERN) }
+  unless end_index
+    errors << "#{path}:#{marker_index + 1}: missing closing '#{VALUES_END_MARKER}' comment for " \
+              "'#{VALUES_MARKER}' region"
+    return nil
+  end
+
+  values = []
+  ((marker_index + 1)...end_index).each { |i| values.concat(literals_on_line(lines[i])) }
+  if values.empty?
+    errors << "#{path}:#{marker_index + 1}: no string or integer literals found in " \
+              "'#{VALUES_MARKER}' region (lines #{marker_index + 2}-#{end_index})"
+    return nil
+  end
+
+  ValuesRecord.new(
+    path:,
+    line_number: marker_index + 1,
+    target_path:,
+    literal_values: values.uniq.sort,
+    region_start_line: marker_index + 2,
+    region_end_line: end_index
+  )
+end
+
+def parse_values_markers(path, content)
+  lines = content.lines
+  records = []
+  errors = []
+
+  lines.each_with_index do |line, index|
+    next unless line.match?(VALUES_MARKER_PATTERN)
+
+    record = parse_values_marker(path, lines, index, errors)
+    records << record if record
+  end
+
+  [records, errors]
+end
+
 def first_difference(left, right)
   left_lines = left.lines
   right_lines = right.lines
@@ -681,33 +787,103 @@ def drift_message(record, candidate)
     "block #{candidate.block_start_line}-#{candidate.block_end_line}#{detail}"
 end
 
+def values_drift_message(record, candidate)
+  only_here = record.literal_values - candidate.literal_values
+  only_there = candidate.literal_values - record.literal_values
+  detail = ""
+  detail += "\n  only in #{record.path}: #{only_here.join(', ')}" unless only_here.empty?
+  detail += "\n  only in #{candidate.path}: #{only_there.join(', ')}" unless only_there.empty?
+
+  "#{record.path}:#{record.line_number} values region " \
+    "#{record.region_start_line}-#{record.region_end_line} " \
+    "does not match #{candidate.path}:#{candidate.line_number} values region " \
+    "#{candidate.region_start_line}-#{candidate.region_end_line}#{detail}"
+end
+
+def values_target_error(record)
+  return "target #{record.target_path} is outside mirror marker scope" unless mirror_scope_path?(record.target_path)
+  return "target #{record.target_path} cannot be the same file" if record.target_path == record.path
+  return "target #{record.target_path} does not exist" unless File.file?(record.target_path)
+
+  nil
+end
+
+def values_pair_error(record, by_path, seen_pairs)
+  candidates = by_path.fetch(record.target_path, []).select { |candidate| candidate.target_path == record.path }
+  return "target #{record.target_path} has no reciprocal #{VALUES_MARKER} marker" if candidates.empty?
+  return nil if candidates.any? { |candidate| candidate.literal_values == record.literal_values }
+
+  candidate = candidates.first
+  pair_key = [[record.path, record.line_number], [candidate.path, candidate.line_number]].sort
+  return nil if seen_pairs[pair_key]
+
+  seen_pairs[pair_key] = true
+  values_drift_message(record, candidate)
+end
+
+def check_values_records(values_records, errors)
+  by_path = values_records.group_by(&:path)
+  seen_pairs = {}
+
+  values_records.each do |record|
+    target_error = values_target_error(record)
+    if target_error
+      errors << "#{record.path}:#{record.line_number}: #{target_error}"
+      next
+    end
+
+    pair_error = values_pair_error(record, by_path, seen_pairs)
+    errors << pair_error if pair_error
+  end
+end
+
+def collect_block_records(path, content, records, errors)
+  file_records, file_errors = parse_markers(path, content)
+  records.concat(file_records)
+  errors.concat(file_errors)
+rescue StandardError => e
+  errors << "#{path}: unexpected error during parsing (#{e.class}: #{e.message})"
+end
+
+def collect_values_records(path, content, values_records, errors)
+  file_values, file_values_errors = parse_values_markers(path, content)
+  values_records.concat(file_values)
+  errors.concat(file_values_errors)
+rescue StandardError => e
+  errors << "#{path}: unexpected error during values parsing (#{e.class}: #{e.message})"
+end
+
+def process_file(path, records, values_records, errors)
+  content = File.binread(path)
+  has_block_marker = content.include?(MARKER)
+  has_values_marker = content.include?(VALUES_MARKER)
+  return unless has_block_marker || has_values_marker
+
+  content.force_encoding(Encoding::UTF_8)
+  unless content.valid_encoding?
+    errors << "#{path}: contains a MIRROR marker but is not valid UTF-8"
+    return
+  end
+
+  collect_block_records(path, content, records, errors) if has_block_marker
+  collect_values_records(path, content, values_records, errors) if has_values_marker
+end
+
 ROOT = repo_root
 Dir.chdir(ROOT)
 
 records = []
+values_records = []
 errors = []
 
 git_files.sort.each do |path|
   next unless File.file?(path)
   next unless mirror_scope_path?(path)
 
-  content = File.binread(path)
-  next unless content.include?(MARKER)
-
-  content.force_encoding(Encoding::UTF_8)
-  unless content.valid_encoding?
-    errors << "#{path}: contains #{MARKER.inspect} but is not valid UTF-8"
-    next
-  end
-
-  begin
-    file_records, file_errors = parse_markers(path, content)
-    records.concat(file_records)
-    errors.concat(file_errors)
-  rescue StandardError => e
-    errors << "#{path}: unexpected error during parsing (#{e.class}: #{e.message})"
-  end
+  process_file(path, records, values_records, errors)
 end
+
+check_values_records(values_records, errors)
 
 records_by_path = records.group_by(&:path)
 drift_pair_keys = {}
@@ -750,4 +926,6 @@ if errors.any?
 end
 
 pair_count = records.map { |record| [record.path, record.target_path].sort }.uniq.length
+values_pair_count = values_records.map { |record| [record.path, record.target_path].sort }.uniq.length
 puts "Checked #{records.length} #{MARKER} markers across #{pair_count} mirrored pairs."
+puts "Checked #{values_records.length} #{VALUES_MARKER} markers across #{values_pair_count} value-mirrored pairs."

--- a/packages/react-on-rails-pro-node-renderer/src/shared/licenseValidator.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/licenseValidator.ts
@@ -20,7 +20,9 @@ import { PUBLIC_KEY } from './licensePublicKey.js';
  * Valid license plan types.
  * Must match VALID_PLANS in react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb
  */
+// MIRROR VALUES OF: react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb
 const VALID_PLANS = ['paid', 'startup', 'nonprofit', 'education', 'oss', 'partner'] as const;
+// MIRROR VALUES END
 export type ValidPlan = (typeof VALID_PLANS)[number];
 
 interface LicenseData {

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
@@ -24,11 +24,13 @@ import type { ExecutionContext } from './vm';
 import { formatPropRequestChunk, formatRenderCompleteChunk } from './streamingUtils';
 
 // These keys must match the constants in AsyncPropsManager.ts (react-on-rails-pro package)
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/AsyncPropsManager.ts
 export const PULL_ENABLED_KEY = 'pullEnabled';
 export const PUSH_PROPS_KEY = 'pushProps';
 export const PROP_REQUEST_EMITTER_KEY = 'propRequestEmitter';
 export const ASYNC_PROPS_MANAGER_KEY = 'asyncPropsManager';
 export const MAX_PULL_PROP_NAME_LENGTH = 256;
+// MIRROR VALUES END
 
 export type IncrementalRenderSink = {
   /** Called for every subsequent NDJSON object after the first one */

--- a/packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts
@@ -20,6 +20,9 @@ function formatControlMessageChunk(metadata: Record<string, string>): Buffer {
   return Buffer.from(header);
 }
 
+// The control-message type strings below are the TS end of the streaming wire protocol.
+// MIRROR VALUES OF: react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
+// MIRROR VALUES OF: react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
 export function formatPropRequestChunk(propName: string): Buffer {
   return formatControlMessageChunk({ messageType: 'propRequest', propName });
 }
@@ -27,3 +30,4 @@ export function formatPropRequestChunk(propName: string): Buffer {
 export function formatRenderCompleteChunk(): Buffer {
   return formatControlMessageChunk({ messageType: 'renderComplete' });
 }
+// MIRROR VALUES END

--- a/packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts
@@ -20,14 +20,18 @@ function formatControlMessageChunk(metadata: Record<string, string>): Buffer {
   return Buffer.from(header);
 }
 
-// The control-message type strings below are the TS end of the streaming wire protocol.
+// Control-message type strings: the TS end of the streaming wire protocol. The guarded
+// region below wraps only this single-line declaration (mirroring the Ruby single-line
+// CONTROL_MESSAGE_TYPES arrays) so unrelated literals in the functions cannot leak in.
 // MIRROR VALUES OF: react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
 // MIRROR VALUES OF: react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
+const CONTROL_MESSAGE_TYPES = { propRequest: 'propRequest', renderComplete: 'renderComplete' } as const;
+// MIRROR VALUES END
+
 export function formatPropRequestChunk(propName: string): Buffer {
-  return formatControlMessageChunk({ messageType: 'propRequest', propName });
+  return formatControlMessageChunk({ messageType: CONTROL_MESSAGE_TYPES.propRequest, propName });
 }
 
 export function formatRenderCompleteChunk(): Buffer {
-  return formatControlMessageChunk({ messageType: 'renderComplete' });
+  return formatControlMessageChunk({ messageType: CONTROL_MESSAGE_TYPES.renderComplete });
 }
-// MIRROR VALUES END

--- a/packages/react-on-rails-pro/src/AsyncPropsManager.ts
+++ b/packages/react-on-rails-pro/src/AsyncPropsManager.ts
@@ -60,11 +60,15 @@ type PromiseController = {
  */
 type PropRequestEmitter = (propName: string) => void;
 
+// Shared-execution-context keys + max pull-prop name length: the node renderer reads these
+// same keys off the execution context, so both definitions must list the identical values.
+// MIRROR VALUES OF: packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts
 const ASYNC_PROPS_MANAGER_KEY = 'asyncPropsManager';
 const PULL_ENABLED_KEY = 'pullEnabled';
 const PUSH_PROPS_KEY = 'pushProps';
 const PROP_REQUEST_EMITTER_KEY = 'propRequestEmitter';
 const MAX_PULL_PROP_NAME_LENGTH = 256;
+// MIRROR VALUES END
 
 class AsyncPropsManager {
   private static readonly MAX_BUFFERED_REQUESTS = 500;

--- a/packages/react-on-rails/src/ClientRenderer.ts
+++ b/packages/react-on-rails/src/ClientRenderer.ts
@@ -368,7 +368,9 @@ function trackRendererMount(domNodeId: string, domNode: Element, result: Rendere
  * delegates to a renderer registered by the user.
  */
 function renderElement(el: Element, railsContext: RailsContext): void {
-  // This must match lib/react_on_rails/helper.rb
+  // This must match the data-* attributes emitted by lib/react_on_rails/pro_helper.rb.
+  // Covered end-to-end by every spec/dummy client-rendering test (renaming either side fails
+  // loudly), so no MIRROR VALUES guard is added here.
   const name = el.getAttribute('data-component-name') || '';
   const domNodeId = domNodeIdForEl(el);
   const props = el.textContent !== null ? (JSON.parse(el.textContent) as Record<string, unknown>) : {};

--- a/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
+++ b/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
@@ -13,7 +13,10 @@ module ReactOnRails
   class LengthPrefixedParser
     # Keep aligned with ReactOnRailsPro::StreamRequest::CONTROL_MESSAGE_TYPES,
     # which routes these same control frames during bidirectional streaming.
+    # MIRROR VALUES OF: react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
+    # MIRROR VALUES OF: packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts
     CONTROL_MESSAGE_TYPES = %w[propRequest renderComplete].freeze
+    # MIRROR VALUES END
     private_constant :CONTROL_MESSAGE_TYPES
 
     # Parses a complete length-prefixed result string that must contain exactly one chunk.

--- a/react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb
@@ -29,7 +29,9 @@ module ReactOnRailsPro
     # - education: For educational institutions
     # - oss: For open source projects
     # - partner: Strategic partners
+    # MIRROR VALUES OF: packages/react-on-rails-pro-node-renderer/src/shared/licenseValidator.ts
     VALID_PLANS = %w[paid startup nonprofit education oss partner].freeze
+    # MIRROR VALUES END
 
     # Plans that require attribution by default (complimentary licenses)
     #

--- a/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
@@ -113,7 +113,10 @@ module ReactOnRailsPro
     MAX_PULL_PROP_NAME_LENGTH = 256
     # Keep aligned with ReactOnRails::LengthPrefixedParser::CONTROL_MESSAGE_TYPES,
     # which parses these same control frames from the shared wire format.
+    # MIRROR VALUES OF: react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
+    # MIRROR VALUES OF: packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts
     CONTROL_MESSAGE_TYPES = %w[propRequest renderComplete].freeze
+    # MIRROR VALUES END
     private_constant :CONTROL_MESSAGE_TYPES
 
     def http_status = @status

--- a/script/lint-mirrored-blocks-test.bash
+++ b/script/lint-mirrored-blocks-test.bash
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Regression test harness for bin/lint-mirrored-blocks. Requires bash, git, and
+# ruby. Run with `bash script/lint-mirrored-blocks-test.bash`.
+#
+# Focus: the MIRROR VALUES OF: value-set mode, and specifically that stacked
+# MIRROR VALUES OF: markers over one region (as used by the CONTROL_MESSAGE_TYPES
+# triangle) do not leak tokens from a marker's own comment line into the guarded
+# value set. See the leak/masking scenarios below.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/bin/lint-mirrored-blocks"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+FAILURES=()
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$CURRENT_TEST: $message")
+  if [ -n "${SUBSHELL_FAILURES_FILE:-}" ]; then
+    printf '%s\n' "$CURRENT_TEST: $message" >> "$SUBSHELL_FAILURES_FILE"
+  fi
+  echo "  FAIL: $message" >&2
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      fail "$label: expected to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*)
+      fail "$label: expected NOT to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+    *) ;;
+  esac
+}
+
+run_test() {
+  local test_fn="$1"
+  CURRENT_TEST="$test_fn"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $test_fn"
+
+  local tmpdir before_failed had_errexit=false subshell_failures
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/lint-mirrored-blocks-test.XXXXXX")"
+  subshell_failures="$tmpdir/failures.log"
+  : > "$subshell_failures"
+  before_failed="$TESTS_FAILED"
+
+  case "$-" in
+    *e*) had_errexit=true ;;
+  esac
+
+  set +e
+  (
+    set -uo pipefail
+    SUBSHELL_FAILURES_FILE="$subshell_failures"
+    export SUBSHELL_FAILURES_FILE
+    cd "$tmpdir" || exit 1
+    "$test_fn"
+  )
+  local rc=$?
+  if [ "$had_errexit" = true ]; then
+    set -e
+  fi
+
+  if [ -s "$subshell_failures" ]; then
+    while IFS= read -r failure_line; do
+      [ -n "$failure_line" ] || continue
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      FAILURES+=("$failure_line")
+    done < "$subshell_failures"
+  fi
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
+    echo "  FAIL: subshell exited $rc" >&2
+  fi
+}
+
+# Create a temp git repo whose MIRROR_ROOTS include the two package roots the
+# linter already scans, then copy in the real linter. The linter reads
+# `git ls-files`, so fixtures must be tracked.
+setup_repo() {
+  git init -b main >/dev/null 2>&1
+  git config user.email test@example.com
+  git config user.name "Mirror Lint Test"
+  mkdir -p bin packages/react-on-rails/src packages/react-on-rails-pro/src
+  cp "$LINTER" bin/lint-mirrored-blocks
+  chmod +x bin/lint-mirrored-blocks
+}
+
+commit_all() {
+  git add -A >/dev/null 2>&1
+  git commit -qm fixtures >/dev/null 2>&1
+}
+
+# Happy path: stacked markers over one region, all three sides agree.
+test_stacked_markers_agree_pass() {
+  setup_repo
+  cat > packages/react-on-rails/src/a.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/b.ts
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/c.ts
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/b.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/c.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  commit_all
+  local output
+  output="$(ruby bin/lint-mirrored-blocks 2>&1)"
+  local rc=$?
+  [ "$rc" -eq 0 ] || fail "expected exit 0 for agreeing stacked markers, got $rc: $output"
+  # a.ts carries two stacked markers (-> b.ts, -> c.ts); b.ts and c.ts each carry
+  # one reciprocal marker. That is 4 markers across the two pairs a<->b and a<->c.
+  assert_contains "$output" "4 MIRROR VALUES OF: markers across 2 value-mirrored pairs" "summary"
+}
+
+# Regression: a quoted token on the SECOND stacked marker's own comment line must
+# NOT leak into the first marker's value set (it would create false drift).
+test_stacked_marker_line_token_does_not_leak() {
+  setup_repo
+  cat > packages/react-on-rails/src/a.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/b.ts
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/c.ts 'LEAK'
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/b.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/c.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  commit_all
+  local output
+  output="$(ruby bin/lint-mirrored-blocks 2>&1)"
+  local rc=$?
+  [ "$rc" -eq 0 ] || fail "LEAK token on a stacked marker line was extracted (false drift), exit $rc: $output"
+  assert_not_contains "$output" "LEAK" "output"
+}
+
+# Regression: a marker-line token equal to a real value must NOT mask a genuine
+# one-sided deletion. a.ts drops 'beta' from its array but carries 'beta' in a
+# marker-line path token; the drift against b.ts/c.ts must still be reported.
+test_marker_line_token_does_not_mask_real_drift() {
+  setup_repo
+  cat > packages/react-on-rails/src/a.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/b.ts
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/c.ts 'beta'
+const X = ['alpha'] as const;
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/b.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/c.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'] as const;
+// MIRROR VALUES END
+EOF
+  commit_all
+  local output
+  output="$(ruby bin/lint-mirrored-blocks 2>&1)"
+  local rc=$?
+  [ "$rc" -ne 0 ] || fail "real drift (a.ts missing beta) was masked by a marker-line token: $output"
+  assert_contains "$output" "beta" "drift output"
+}
+
+setup_repo >/dev/null 2>&1 || true
+
+run_test test_stacked_markers_agree_pass
+run_test test_stacked_marker_line_token_does_not_leak
+run_test test_marker_line_token_does_not_mask_real_drift
+
+echo
+echo "lint-mirrored-blocks tests: $TESTS_RUN run, $TESTS_FAILED failed"
+
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  printf '\nFailures:\n' >&2
+  printf '  - %s\n' "${FAILURES[@]}" >&2
+  exit 1
+fi

--- a/script/lint-mirrored-blocks-test.bash
+++ b/script/lint-mirrored-blocks-test.bash
@@ -9,8 +9,8 @@
 
 set -uo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 LINTER="$REPO_ROOT/bin/lint-mirrored-blocks"
 
 TESTS_RUN=0
@@ -102,10 +102,25 @@ run_test() {
 # Create a temp git repo whose MIRROR_ROOTS include the two package roots the
 # linter already scans, then copy in the real linter. The linter reads
 # `git ls-files`, so fixtures must be tracked.
+#
+# Safety: run_test always invokes the test functions (and therefore setup_repo)
+# from inside a fresh mktemp sandbox. As defence in depth, refuse to run if the
+# current directory is at or under the real checkout — this guarantees
+# `git init` / `git config` can never reinitialize or rewrite the real repo's
+# .git or git identity even if setup_repo is ever called from the wrong place.
 setup_repo() {
+  local cwd
+  cwd="$(pwd -P)"
+  case "$cwd/" in
+    "$REPO_ROOT"/*)
+      echo "setup_repo refused: cwd '$cwd' is inside the real checkout '$REPO_ROOT'" >&2
+      return 1
+      ;;
+  esac
   git init -b main >/dev/null 2>&1
-  git config user.email test@example.com
-  git config user.name "Mirror Lint Test"
+  # --local scopes the identity to this sandbox's .git; global config is untouched.
+  git config --local user.email test@example.com
+  git config --local user.name "Mirror Lint Test"
   mkdir -p bin packages/react-on-rails/src packages/react-on-rails-pro/src
   cp "$LINTER" bin/lint-mirrored-blocks
   chmod +x bin/lint-mirrored-blocks
@@ -201,8 +216,6 @@ EOF
   [ "$rc" -ne 0 ] || fail "real drift (a.ts missing beta) was masked by a marker-line token: $output"
   assert_contains "$output" "beta" "drift output"
 }
-
-setup_repo >/dev/null 2>&1 || true
 
 run_test test_stacked_markers_agree_pass
 run_test test_stacked_marker_line_token_does_not_leak

--- a/script/lint-mirrored-blocks-test.bash
+++ b/script/lint-mirrored-blocks-test.bash
@@ -217,9 +217,59 @@ EOF
   assert_contains "$output" "beta" "drift output"
 }
 
+# Regression: an ordinary (non-marker) comment inside a value region carrying a fake
+# quoted token / number must NOT become part of the contract (no false drift). Covers
+# Ruby `#`, JS `//`, and single-line `/* */`.
+test_prose_comment_token_does_not_leak() {
+  setup_repo
+  cat > packages/react-on-rails/src/a.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/b.ts
+const X = ['alpha', 'beta']; // local note about 'notAValue' and 123
+/* another 'ghost' 456 */
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/b.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'];
+// MIRROR VALUES END
+EOF
+  commit_all
+  local output
+  output="$(ruby bin/lint-mirrored-blocks 2>&1)"
+  local rc=$?
+  [ "$rc" -eq 0 ] || fail "prose-comment token caused false drift, exit $rc: $output"
+  assert_not_contains "$output" "notAValue" "output"
+  assert_not_contains "$output" "ghost" "output"
+}
+
+# Regression: a comment that mentions the value missing from the array must NOT mask
+# real drift. a.ts dropped 'beta' from its array but names it in a comment; the drift
+# against b.ts must still be reported.
+test_prose_comment_does_not_mask_real_drift() {
+  setup_repo
+  cat > packages/react-on-rails/src/a.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/b.ts
+const X = ['alpha']; // dropped 'beta' here on purpose
+// MIRROR VALUES END
+EOF
+  cat > packages/react-on-rails-pro/src/b.ts <<'EOF'
+// MIRROR VALUES OF: packages/react-on-rails/src/a.ts
+const X = ['alpha', 'beta'];
+// MIRROR VALUES END
+EOF
+  commit_all
+  local output
+  output="$(ruby bin/lint-mirrored-blocks 2>&1)"
+  local rc=$?
+  [ "$rc" -ne 0 ] || fail "real drift (a.ts missing beta) was masked by a comment mentioning beta: $output"
+  assert_contains "$output" "beta" "drift output"
+}
+
 run_test test_stacked_markers_agree_pass
 run_test test_stacked_marker_line_token_does_not_leak
 run_test test_marker_line_token_does_not_mask_real_drift
+run_test test_prose_comment_token_does_not_leak
+run_test test_prose_comment_does_not_mask_real_drift
 
 echo
 echo "lint-mirrored-blocks tests: $TESTS_RUN run, $TESTS_FAILED failed"


### PR DESCRIPTION
Fixes #4412

## Why

The Rails ⇄ node-renderer cross-process contracts — the streaming wire-protocol control-message types, the license plan list, and the shared-execution-context keys — are each defined two or three times, once per language/package, and were kept in sync by "keep in sync" comments alone. Silent drift (e.g. renaming a control-message type on one side) ships as a version-skew bug that breaks stream routing with **no CI signal**, because the repo's only mechanical guard, `bin/lint-mirrored-blocks`, could not reach these pairs.

## Root constraint discovered

`bin/lint-mirrored-blocks` guards only two TS↔TS pairs today. Its `MIRROR OF:` mode is built on a **JS lexer**: markers must be JS comments (`//`, `*`, `/*`), and the guarded region must be a **brace-matched `{...}` block** whose normalized text is compared **byte-for-byte**. I verified empirically that:

- A bare `const X = [...]` (no `{...}` block) → `unable to extract mirrored block`.
- A Ruby `#` marker → **silently ignored** (marker count unchanged); a one-sided TS→`.rb` marker → `no reciprocal MIRROR OF: marker`.
- The tool reads `git ls-files`, so new/edited files must be tracked to be seen.

So **no Ruby↔TS pair and no bare-value-list constant** can be guarded by the existing mode without either a runtime-shape change (wrapping constants in `{...}` — forbidden by the issue: "no runtime/packaging changes") or a new lexer mode. This matches the issue's own risk note.

## What changed

A new, **additive, language-agnostic** `MIRROR VALUES OF:` mode in `bin/lint-mirrored-blocks` (the existing brace-based `MIRROR OF:` mode is untouched):

- Accepts Ruby (`#`) as well as JS (`//`, `*`, `/*`) comment prefixes.
- Guards an **explicitly delimited region** (`MIRROR VALUES OF: <path>` … `MIRROR VALUES END`) and compares the **set** of quoted-string and integer literals it contains — so `%w[...].freeze` (Ruby), `[...] as const` (TS), and scattered `'literal'` args all mirror each other **without requiring identical syntax or a shared block**. Order-independent; `256` (int) and `'256'` (string) normalize equal.
- `MIRROR_ROOTS` extended with `react_on_rails/lib`, `react_on_rails_pro/lib`, and `packages/react-on-rails-pro-node-renderer/src` so the new markers are in scope. Reciprocal-marker + drift semantics reuse the existing model.

Plus: fixed the stale comment pointer at `ClientRenderer.ts` (the `data-*` attributes are emitted by `pro_helper.rb`, not `helper.rb`) and documented that pair as e2e-covered (pair (h), intentionally not machine-guarded).

**No runtime or packaging changes** — only comment markers and lint tooling.

## Discovered mirror map (what is now guarded)

| Contract | Canonical / side A | Mirror(s) | Mode |
|---|---|---|---|
| `CONTROL_MESSAGE_TYPES` = `{propRequest, renderComplete}` | `react_on_rails/lib/react_on_rails/length_prefixed_parser.rb:16` | `react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb:116` **and** `packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts:23-29` | `MIRROR VALUES OF:` (3 pairs, full triangle) |
| `VALID_PLANS` = `{paid, startup, nonprofit, education, oss, partner}` | `react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb:32` | `packages/react-on-rails-pro-node-renderer/src/shared/licenseValidator.ts:23` | `MIRROR VALUES OF:` (1 pair) |
| sharedExecutionContext keys + `MAX_PULL_PROP_NAME_LENGTH` = `{asyncPropsManager, pullEnabled, pushProps, propRequestEmitter, 256}` | `packages/react-on-rails-pro/src/AsyncPropsManager.ts:63-67` | `packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts:27-31` | `MIRROR VALUES OF:` (1 pair, TS↔TS) |

Total: **10 `MIRROR VALUES OF:` markers across 5 value-mirrored pairs** (existing 4 `MIRROR OF:` / 2 pairs preserved).

## Files changed

- `bin/lint-mirrored-blocks` — new value-set mode (+markers/roots).
- `react_on_rails/lib/react_on_rails/length_prefixed_parser.rb`, `react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb`, `packages/react-on-rails-pro-node-renderer/src/worker/streamingUtils.ts` — CONTROL_MESSAGE_TYPES markers.
- `react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb`, `packages/react-on-rails-pro-node-renderer/src/shared/licenseValidator.ts` — VALID_PLANS markers.
- `packages/react-on-rails-pro/src/AsyncPropsManager.ts`, `packages/react-on-rails-pro-node-renderer/src/worker/handleIncrementalRenderRequest.ts` — sharedExecutionContext-keys markers.
- `packages/react-on-rails/src/ClientRenderer.ts` — stale-pointer fix + e2e-coverage note (pair h).

## Validation (real results)

- `ruby bin/lint-mirrored-blocks` → `Checked 4 MIRROR OF: markers across 2 mirrored pairs.` / `Checked 10 MIRROR VALUES OF: markers across 5 value-mirrored pairs.` (exit 0).
- **Guard-fails-on-drift proof** (temporarily edit one side, re-run, revert):
  - Rename `renderComplete`→`renderDone` in only `streamingUtils.ts` → lint **fails** with `only in ...streamingUtils.ts: renderDone` / `only in ...length_prefixed_parser.rb: renderComplete` (and the pro pair). Revert → green.
  - Drop `partner` from `VALID_PLANS` on the Ruby side only → lint **fails** with `only in ...licenseValidator.ts: partner`. Revert → green.
- `pnpm run build` → exit 0. `pnpm run type-check` → all packages Done, exit 0. `pnpm run lint` → exit 0. `pnpm start format.listDifferent` → "All matched files use Prettier code style!".
- `bundle exec rubocop bin/lint-mirrored-blocks` → **no offenses**. Rubocop on all three touched Ruby files → no offenses.

## QA Evidence (stream boot / round-trip)

Both ends of the guarded wire protocol were exercised locally (no full live node↔Rails HTTP stream was booted; closest streaming unit/integration tests were run and are stated explicitly):

- `react_on_rails/spec/lib/react_on_rails/length_prefixed_parser_spec.rb` — **13 examples, 0 failures** (Ruby parser round-trips the length-prefixed framing incl. control messages + multibyte byte-length).
- `packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts` + `AsyncPropManager.test.ts` — **47 passed** (TS framing round-trip + shared-context keys + control-message formatters).
- `packages/react-on-rails-pro-node-renderer/tests/streamErrorHang.test.ts` — **6 passed** (boots a node-renderer worker + ExecutionContext and streams via `streamingUtils`).
- `packages/react-on-rails/tests/serverRenderUtils.test.ts` — **9 passed** (wire-framing builder).
- `react_on_rails_pro/spec/react_on_rails_pro/license_validator_spec.rb` — **62 examples, 0 failures** (VALID_PLANS).

## Codex Decision Log

- Codex self-review (`codex review --base origin/main`) was **unavailable** (usage limit hit mid-run). Performed a careful manual review instead: verified `"MIRROR VALUES OF:"` does not contain the `"MIRROR OF:"` substring (no cross-triggering of the two modes); verified the integer literal pattern ignores `es2020`, `0.33.5`, `abc123` and captures only standalone decimals; confirmed `%w[...]` bodies are removed before quoted-string scanning to avoid double counting; confirmed the existing brace-mode code path is unchanged and its 2 pairs still pass.
- Chose a **value-set** mode over a golden-file/JSON-contract (issue's step 2/3) because it is fully within this lane's scope (`bin/lint-mirrored-blocks`), requires **zero runtime/packaging change**, and is symmetric across languages. Parity-spec / golden-file approaches for the wire framing (pair b) and RailsContext (pair e) remain open for follow-up.

## DISCOVERED-OUT-OF-LANE

- `.github/workflows/check-mirrored-blocks.yml` path filters still list only the two original roots. The issue's acceptance criteria want them to cover every `MIRROR_ROOTS` entry (add `react_on_rails/**`, `react_on_rails_pro/**`, node-renderer `src/**`). This file is a HARD-BOUNDARY workflow file for this lane — **left to the coordinator/workflow lane.** Until updated, a PR touching *only* the new roots won't trigger the check on PR (it still runs on `push` to main and via `merge_group`).
- Ruby-side `MAX_PULL_PROP_NAME_LENGTH = 256` in `stream_request.rb:113` is not machine-linked to the TS `256` (the TS `256` is grouped with the sharedExecutionContext keys, so a clean Ruby↔TS `256`-only region isn't available without splitting the TS block). Left as comment-only.

## DISCOVERED-DRIFT

- None. All three `CONTROL_MESSAGE_TYPES` definitions and both `VALID_PLANS` lists already agree; the guards passed on first run. (The `ClientRenderer.ts` comment *pointer* was stale — `helper.rb` vs `pro_helper.rb` — and is fixed here; the guarded *values* were not drifted.)

## Stale-base race control (NEW-GATE evidence)

This PR adds a new lint gate via `MIRROR_ROOTS`. Two open PRs currently touch newly-guarded files; the coordinator should re-check/sweep before landing:
- **#4383** (Release incremental render context on setup failure) — touches `handleIncrementalRenderRequest.ts`, but only the function body (~L226+), **not** the L27-31 constant block my marker wraps. Low collision.
- **#4374** (Fix visible hydration cleanup for detached roots) — touches `ClientRenderer.ts`, but not the `renderElement`/`data-component-name` region. Low collision.

Note: **#4413** (base/ shims) lands **after** this PR and will extend the same `bin/lint-mirrored-blocks`.

Labels: ready-for-hosted-ci, hosted-ci-no-benchmarks

_Rationale: pure internal CI-tooling + comment-marker change with no runtime path, so full hosted CI validates the guard without benchmark cost._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “mirror values” support to the mirrored-blocks linter, with set-based literal collection and clearer value drift detection.
  * Expanded mirrored-blocks CI triggers and added dedicated mirrored-blocks lint test execution.

* **Bug Fixes**
  * Improved validation for reciprocal value markers, including reporting when literal sets differ.

* **Tests**
  * Added a bash regression harness covering stacked markers, leakage/masking prevention, and prose-comment edge cases.

* **Documentation**
  * Added “must mirror” documentation comments to align shared constants and wire-protocol type values across implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->