### PR TITLE
Remove obsolete Ruby<2.6 YAML-aliases capability shim (#4417)

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -383,14 +383,7 @@ module ReactOnRails
         require "yaml"
 
         rendered_content = render_shakapacker_yml_erb(content)
-        if yaml_safe_load_supports_aliases?
-          return YAML.safe_load(rendered_content, permitted_classes: [Symbol], aliases: true)
-        end
-        return {} if yaml_content_uses_aliases?(rendered_content)
-
-        YAML.safe_load(rendered_content, permitted_classes: [Symbol])
-      rescue ArgumentError => e
-        parse_shakapacker_yml_after_alias_keyword_error(e, rendered_content)
+        YAML.safe_load(rendered_content, permitted_classes: [Symbol], aliases: true)
       rescue ShakapackerYmlErbError
         raise
       rescue ScriptError, StandardError
@@ -419,42 +412,6 @@ module ReactOnRails
         say_status :warning,
                    "Skipping generated precompile_hook updates so custom Shakapacker config is not overwritten.",
                    :yellow
-      end
-
-      def parse_shakapacker_yml_after_alias_keyword_error(error, content)
-        return {} unless yaml_alias_keyword_error?(error)
-        return {} if yaml_content_uses_aliases?(content)
-
-        YAML.safe_load(content, permitted_classes: [Symbol])
-      end
-
-      def yaml_safe_load_supports_aliases?
-        YAML.method(:safe_load).parameters.any? do |type, name|
-          type == :keyrest || (type == :key && name == :aliases)
-        end
-      rescue StandardError
-        false
-      end
-
-      def yaml_alias_keyword_error?(error)
-        error.message.include?("aliases")
-      end
-
-      def yaml_content_uses_aliases?(content)
-        require "psych"
-
-        yaml_node_uses_aliases?(Psych.parse_stream(content))
-      rescue StandardError
-        true
-      end
-
-      def yaml_node_uses_aliases?(node)
-        return false unless node
-        return true if node.respond_to?(:anchor) && node.anchor
-        return true if defined?(Psych::Nodes::Alias) && node.is_a?(Psych::Nodes::Alias)
-        return false unless node.respond_to?(:children)
-
-        node.children.any? { |child| yaml_node_uses_aliases?(child) }
       end
 
       def shakapacker_supports_precompile_hook?

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -386,6 +386,14 @@ module ReactOnRails
         YAML.safe_load(rendered_content, permitted_classes: [Symbol], aliases: true)
       rescue ShakapackerYmlErbError
         raise
+      rescue ArgumentError => e
+        # The gemspec floor is Ruby >= 3.3.0, which bundles Psych >= 5.x, where the
+        # `aliases:` keyword is always supported. An ArgumentError here means an
+        # unusually old, explicitly pinned Psych (< 3.1) lacks that keyword. Surface
+        # this loudly rather than swallowing it into {}, which would silently discard
+        # the entire shakapacker.yml and fall back to defaults.
+        raise ArgumentError, "Could not parse #{SHAKAPACKER_YML_PATH}: #{e.message}. " \
+                             "psych >= 3.1 (bundled with Ruby >= 2.6) is required for YAML alias support."
       rescue ScriptError, StandardError
         {}
       end

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -228,6 +228,17 @@ RSpec.describe GeneratorHelper, type: :generator do
       )
     end
 
+    it "surfaces a clear error instead of silently discarding config when psych lacks alias support" do
+      # Simulates an unusually old, explicitly pinned psych (< 3.1) where the
+      # aliases: keyword is unknown. This must fail loudly, not swallow the whole
+      # shakapacker.yml into {} and fall back to defaults.
+      allow(YAML).to receive(:safe_load).and_raise(ArgumentError, "unknown keyword: :aliases")
+
+      expect do
+        parse_shakapacker_yml_content(aliased_config)
+      end.to raise_error(ArgumentError, /psych >= 3\.1 .* is required for YAML alias support/)
+    end
+
     it "warns and raises when shakapacker.yml ERB cannot be evaluated" do
       expect do
         parse_shakapacker_yml_content(<<~YAML)

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -221,18 +221,11 @@ RSpec.describe GeneratorHelper, type: :generator do
       YAML
     end
 
-    it "fails closed instead of parsing aliased configs without alias support" do
-      allow(self).to receive(:yaml_safe_load_supports_aliases?).and_return(true)
-      allow(YAML).to receive(:safe_load) do |_content, aliases: false, **_kwargs|
-        raise ArgumentError, "unknown keyword: :aliases" if aliases
-
-        {
-          "default" => { "precompile_hook" => "bin/shakapacker-precompile-hook" },
-          "test" => { "precompile_hook" => "bin/shakapacker-precompile-hook" }
-        }
-      end
-
-      expect(parse_shakapacker_yml_content(aliased_config)).to eq({})
+    it "parses aliased configs, resolving merge keys" do
+      expect(parse_shakapacker_yml_content(aliased_config)).to eq(
+        "default" => { "precompile_hook" => "bin/shakapacker-precompile-hook" },
+        "test" => { "precompile_hook" => "bin/shakapacker-precompile-hook" }
+      )
     end
 
     it "warns and raises when shakapacker.yml ERB cannot be evaluated" do


### PR DESCRIPTION
## Summary

Removes the obsolete Ruby<2.6 `YAML.safe_load(aliases:)` capability shim from `shakapacker_precompile_hook_helper.rb`.

## Rationale

- Both gemspecs pin `required_ruby_version = ">= 3.3.0"` (`react_on_rails/react_on_rails.gemspec:36`, `react_on_rails_pro/react_on_rails_pro.gemspec:50`).
- The `aliases:` keyword for `YAML.safe_load` has been supported since Psych 3.1, bundled with Ruby 2.6. Ruby 3.3 bundles Psych 5.x.
- Therefore the runtime capability probe (`yaml_safe_load_supports_aliases?`) is **always** true on any supported Ruby, and the `ArgumentError` fallback branch is **unreachable dead code**.

## Changes

- `parse_shakapacker_yml_content` now calls `YAML.safe_load(rendered_content, permitted_classes: [Symbol], aliases: true)` **unconditionally**.
- Deleted the five now-dead private helpers:
  - `parse_shakapacker_yml_after_alias_keyword_error`
  - `yaml_safe_load_supports_aliases?`
  - `yaml_alias_keyword_error?`
  - `yaml_content_uses_aliases?`
  - `yaml_node_uses_aliases?`
- The fail-closed rescues (`ShakapackerYmlErbError`, `ScriptError`/`StandardError`) are preserved unchanged — they guard real failure modes (bad ERB, malformed YAML), not the aliases capability.
- Replaced the spec example that stubbed the probe and faked an `ArgumentError` ("fails closed instead of parsing aliased configs without alias support") with a positive example asserting an anchored/aliased `shakapacker.yml` parses with merge keys resolved.

`git grep` for all five removed method names returns zero hits.

## Impact

Internal only, no user-visible behavior change. On any supported Ruby (>= 3.3.0) the `aliases: true` path was already the one taken, so the reachable behavior is byte-for-byte identical. No CHANGELOG entry needed. No RBS changes (no sig file exists for this generator helper). No docs changes (generator-internal behavior).

## Validation

Ran from `react_on_rails/` with its own bundle:

```
$ BUNDLE_GEMFILE=Gemfile bundle exec rspec spec/react_on_rails/generators/generator_helper_spec.rb
92 examples, 0 failures

$ BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb spec/react_on_rails/generators/generator_helper_spec.rb
2 files inspected, no offenses detected
```

The new positive example — `#parse_shakapacker_yml_content parses aliased configs, resolving merge keys` — passes, confirming the aliased-config fixture is parsed with its merge key (`<<: *default`) resolved.

Note: the full `spec/react_on_rails/generators/` directory sweep triggers an `npm install` for the dummy-for-generators integration app, which fails in the sandbox with unrelated npm tarball/registry errors. The changed method is exercised directly by the targeted `generator_helper_spec.rb` above (green), and hosted CI runs the full generator suite.

Fixes #4417

## Review disposition (Psych < 3.1 silent-discard concern)

Codex (P2) and the Claude review both raised the same concern: the gemspec constrains Ruby (>= 3.3) but not Psych, so an app that explicitly pins `psych < 3.1` would hit `ArgumentError: unknown keyword: :aliases` from `YAML.safe_load(..., aliases: true)`. That `ArgumentError` is a `StandardError`, so the broad `rescue ScriptError, StandardError => {}` would swallow it and silently discard the entire `shakapacker.yml`, falling back to defaults — even for alias-free configs.

**Decision: targeted fix (not a waiver), commit `6d8180f`.** Added a dedicated `rescue ArgumentError` above the broad rescue that re-raises with an actionable message naming the `psych >= 3.1` requirement. This fails loud/fast instead of failing silently.

- Does **not** reintroduce the removed runtime capability probe or add a `psych` gemspec dependency — it is pure error classification.
- On every supported runtime (Ruby >= 3.3 bundles Psych 5.x), `safe_load(..., aliases: true)` never raises `ArgumentError`, so behavior is byte-for-byte unchanged there; the new rescue only fires in the unsupported Psych-pin edge case.
- `Psych::SyntaxError` (malformed YAML) and `Psych::DisallowedClass` descend from `RuntimeError`, **not** `ArgumentError` (verified on Psych 5.4), so the intentional fail-closed-to-`{}` behavior for genuine parse failures is preserved.
- Added spec `#parse_shakapacker_yml_content surfaces a clear error instead of silently discarding config when psych lacks alias support`.

Both review threads were replied to with this rationale and resolved.

## Codex Decision Log

- Confirmed Ruby floor `>= 3.3.0` in both gemspecs before editing — the shim's precondition (Ruby < 2.6) can never be met on a supported install, so no supported environment loses capability.
- Verified via `git grep` that all five removed helpers had callers only inside this file's dead branches plus the single spec at `generator_helper_spec.rb:225` — no cross-file consumers, no RBS signatures.
- Preserved the actual YAML-load behavior (`aliases: true` still enabled) and the surrounding fail-closed rescues; only the capability detection + fallback were removed.
- Replaced (rather than merely deleted) the fail-closed spec with a positive aliased-parse assertion so the aliased-config path retains coverage.
- Review follow-up: rather than reintroduce the removed probe, reclassified the old-Psych `ArgumentError` to fail loud (commit `6d8180f`) — strictly better than the prior silent `{}`, with zero behavior change on supported runtimes.

## Confidence note

High. The change is a dead-code removal proven by the Ruby floor and a zero-hit caller audit; the one reachable behavior (parse with `aliases: true`) is unchanged and now covered by a positive spec, plus a targeted fix so the unsupported old-Psych edge case fails loud instead of silently discarding config. Targeted spec is green (93/0) and rubocop is clean. Only residual uncertainty is the sandbox-only inability to run the full npm-backed generator integration sweep, which hosted CI covers and which is unrelated to this Ruby-level change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML configuration handling during precompile by consistently supporting alias-based configs on compatible environments.
  * If the runtime does not support YAML aliases, the process now fails with a clear error instead of silently falling back to unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
