### PR TITLE
Move Node tsconfigs from @tsconfig/node14 to @tsconfig/node18 (#4410)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
-    "@tsconfig/node14": "^14.1.2",
+    "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.14",
     "@types/k6": "^2.0.0",
     "@types/node": "^20.17.16",

--- a/packages/react-on-rails-pro-node-renderer/src/tsconfig.json
+++ b/packages/react-on-rails-pro-node-renderer/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     // This copies JS files to the output directory. Make false once all code is converted.
     "allowJs": true,

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -335,7 +335,7 @@ function applyFastifyConfigWithHealthEndpointMigrationHint(
         'to the built-in health endpoints. See docs/oss/building-features/node-renderer/health-checks.md.';
 
       log.error({ err: error, route: conflictingPath }, message);
-      const migrationError = new Error(message) as Error & { cause?: unknown };
+      const migrationError = new Error(message);
       migrationError.cause = error;
       throw migrationError;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.0.7(react@19.0.7))(react@19.0.7)
-      '@tsconfig/node14':
-        specifier: ^14.1.2
-        version: 14.1.8
+      '@tsconfig/node18':
+        specifier: ^18.2.4
+        version: 18.2.6
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -3533,8 +3533,8 @@ packages:
   '@tsconfig/create-react-app@2.0.11':
     resolution: {integrity: sha512-vvIx+rDshVTVyA0l8OAjt8LCFUX0xhp6I5me1ggoQCg4Lny0xLG2Y1aXC7b76TCAq5hbUwTRhKF1RR33Yl7mkA==}
 
-  '@tsconfig/node14@14.1.8':
-    resolution: {integrity: sha512-SjGT+qPvh8Uhc849yNMD0ZIPr69AyB7Z46nMqhrI3gCVocd6mhI0jP4YE4onO/ufpmengRfTxNMpdpKEp2xRIg==}
+  '@tsconfig/node18@18.2.6':
+    resolution: {integrity: sha512-eAWQzAjPj18tKnDzmWstz4OyWewLUNBm9tdoN9LayzoboRktYx3Enk1ZXPmThj55L7c4VWYq/Bzq0A51znZfhw==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -14023,7 +14023,7 @@ snapshots:
 
   '@tsconfig/create-react-app@2.0.11': {}
 
-  '@tsconfig/node14@14.1.8': {}
+  '@tsconfig/node18@18.2.6': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14",
+  "extends": "@tsconfig/node18",
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": false,
@@ -7,6 +7,11 @@
     "declarationMap": true,
     // needed for Jest tests even though we don't use .tsx
     "jsx": "react-jsx",
+    // target/lib are pinned to es2020 (NOT the @tsconfig/node18 base's es2022/es2023) on purpose:
+    // this config is inherited by the browser-facing packages react-on-rails and react-on-rails-pro,
+    // whose `tsc` build emits the published lib/*.js consumed by END-USER BROWSERS. Keeping es2020
+    // here avoids raising their browser baseline. The node-renderer uses its own src/tsconfig.json
+    // (no target/lib override) so it genuinely inherits es2022/es2023 for Node >=18.19. See #4410.
     "lib": ["dom", "es2020"],
     "noImplicitAny": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Why

The repo's engine floors are **Node >=18.19.0** (`react-on-rails-pro-node-renderer`) and **>=18.0.0** (`create-react-on-rails-app`), and the toolchain pins Node **22.12.0** (`.tool-versions` / `.nvmrc`). Yet two tsconfigs still extended the deprecated `@tsconfig/node14`. Nothing in the repo supports Node 14. This moves both off node14 onto `@tsconfig/node18`.

`Fixes #4410`

## Browser baseline is deliberately preserved (no user-visible change)

The root `tsconfig.json` is inherited by the **browser-facing** packages `react-on-rails` and `react-on-rails-pro`, whose `tsc` build emits the published `lib/*.js` consumed by **end-user browsers** (e.g. `ReactOnRails.client.js`). To avoid raising the browser baseline, the root **keeps its explicit `target: es2020` / `lib: ["dom","es2020"]`** and only swaps `extends` to `@tsconfig/node18`. Because the root overrides target/lib, the node18 base's es2022/es2023 do **not** reach the browser packages — their emitted output is byte-compatible with before.

The node18 preset genuinely takes effect only in the node-renderer's own `src/tsconfig.json`, which has no target/lib override → it inherits es2022/es2023 (correct for its Node >=18.19 floor, and not browser-facing).

## What changed (5 files — pure config + 1 required node-renderer line)

- **`tsconfig.json`** (root): `extends` → `@tsconfig/node18`; `target`/`lib` kept at **es2020 / ["dom","es2020"]** with an explanatory comment (deliberate browser pin).
- **`packages/react-on-rails-pro-node-renderer/src/tsconfig.json`**: `extends` → `@tsconfig/node18/tsconfig.json` (inherits es2022/es2023 for the emitted Node `lib/`; `module: "nodenext"` preserved).
- **`packages/react-on-rails-pro-node-renderer/src/worker.ts`**: drop the now-redundant `& { cause?: unknown }` cast. At the node-renderer's es2022 target `Error.cause` is natively typed, so `@typescript-eslint/no-redundant-type-constituents` flags the intersection (verified: reverting this line fails eslint). This is the **only** source edit genuinely required by the bump.
- **`package.json`**: swap `@tsconfig/node14@^14.1.2` devDep → `@tsconfig/node18@^18.2.4`.
- **`pnpm-lock.yaml`**: regenerated (pure type-preset swap).

The browser packages (`react-on-rails`, `react-on-rails-pro`) stay at es2020, so **no browser-source changes are needed** — their `Error.cause` handling already compiled and typed correctly at es2020 on `main` and is left untouched.

## `tsc --showConfig` (after)

| project | target | lib | module / moduleResolution |
|---|---|---|---|
| root → react-on-rails / react-on-rails-pro (browser) | **es2020** (unchanged) | **["dom","es2020"]** (unchanged) | node16 / node16 |
| node-renderer `src/` | **es2022** | **["es2023"]** | nodenext / node16 |

## Validation (real results)

| Command | Result |
|---|---|
| `pnpm run build` (4 packages) | ✅ pass |
| `pnpm run type-check` (9 projects) | ✅ pass |
| `pnpm run lint` | ✅ pass (0 errors) |
| `pnpm start format.listDifferent` | ✅ clean |
| `pnpm --filter react-on-rails test` | ✅ 26 suites / 359 tests |
| `pnpm --filter react-on-rails-pro test` | ✅ 41 suites / 485 tests |
| `pnpm --filter create-react-on-rails-app test` | ✅ 6 suites / 104 tests |
| node-renderer test (non-streaming) | ✅ 32 suites / 443 tests |
| `pnpm run knip` | ⚠️ fails **identically on clean `origin/main`** (pre-existing; no `@tsconfig` mention) |
| `pnpm run attw` | ⚠️ fails **identically on clean `origin/main`** (`--pack` config; pre-existing) |

**Pre-existing environment-only failures (verified identical on clean `origin/main`):** 4 node-renderer streaming suites fail with `ENOENT … spec/dummy/ssr-generated/server-bundle.js` (require a pre-built dummy server bundle absent here).

## Lockfile evidence (Dependabot / npm ecosystem, root directory)

`pnpm-lock.yaml` content diff is exactly the one dep swap: `'@tsconfig/node14'` `^14.1.2` (v `14.1.8`) → `'@tsconfig/node18'` `^18.2.4` (v `18.2.6`). **No transitive dependency changes** (both presets have zero deps). **No platform-precompiled / source-build / build-time dependency changed** — `@tsconfig/node18` is a pure JSON TSConfig preset (no install scripts, no native binaries).

## Codex Decision Log

- **Browser-target decision — Option 2 (keep browser at es2020):** chosen over raising the browser baseline; the node-renderer (genuine Node code) is where node18/es2022 applies. Zero browser-bundle impact.
- **Minimal diff:** the browser-source edits from an earlier revision were no-ops at es2020 (their code already compiled/typed `cause` correctly), so they were reverted to `origin/main`. Only `worker.ts` (node-renderer, es2022) is kept — the redundant cast is a real lint error there.
- **Changelog:** `not_user_visible` — published browser bundles byte-compatible (es2020); only the node-renderer's internal `lib/` moves to es2022 (runs on the Node >=18.19 already required). `script/pr-merge-ledger 4429 --strict --changelog-classification not_user_visible` → `violations: []`, `complete_allowed: true`.
- **Review threads:** all resolved (railsAction Codex/Greptile P2 + two claude[bot] threads on tsconfig/comment rationale).

Labels: `ready-for-hosted-ci` — build-config + dependency + lockfile change; all local gates green, ready for the hosted CI matrix.
