### PR TITLE
Extract generator scan/tracking helpers (#4405)

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/pro_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/pro_generator.rb
@@ -441,8 +441,8 @@ module ReactOnRails
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength
-      # rubocop:disable Metrics/PerceivedComplexity, Style/ExplicitBlockArgument
-      def rewrite_non_comment_lines(content)
+      # rubocop:disable Metrics/PerceivedComplexity
+      def rewrite_non_comment_lines(content, &block)
         in_block_comment = false
         in_multiline_template_literal = false
         pending_multiline_module_call_depth = 0
@@ -464,8 +464,8 @@ module ReactOnRails
                 rewrite_line_after_template_literal_close(
                   line,
                   pending_multiline_module_call_depth,
-                  pending_multiline_static_import_specifier
-                ) { |line_fragment| yield line_fragment }
+                  pending_multiline_static_import_specifier, &block
+                )
               in_multiline_template_literal = updated_template_literal_state
               in_block_comment = unclosed_block_comment_starts?(rewritten_line)
               rewritten_line
@@ -475,8 +475,8 @@ module ReactOnRails
                   line,
                   pending_multiline_module_call_depth,
                   pending_multiline_static_import_specifier,
-                  in_block_comment:
-                ) { |line_fragment| yield line_fragment }
+                  in_block_comment:, &block
+                )
               in_multiline_template_literal = updated_template_literal_state
               in_block_comment = unclosed_block_comment_starts?(rewritten_line)
               rewritten_line
@@ -491,8 +491,8 @@ module ReactOnRails
                 rewrite_line_after_block_comment_close(
                   line,
                   pending_multiline_module_call_depth,
-                  pending_multiline_static_import_specifier
-                ) { |line_fragment| yield line_fragment }
+                  pending_multiline_static_import_specifier, &block
+                )
               in_block_comment = true if unclosed_block_comment_starts?(rewritten_line)
               rewritten_line
             else
@@ -500,14 +500,12 @@ module ReactOnRails
             end
           elsif stripped.start_with?("/*")
             if stripped.include?("*/")
-              rewritten_line = yield line
-              rewritten_line, pending_multiline_static_import_specifier =
-                update_pending_multiline_static_import_tracking(
-                  rewritten_line,
-                  pending_multiline_static_import_specifier
+              rewritten_line, pending_multiline_module_call_depth, pending_multiline_static_import_specifier =
+                rewrite_and_track_line(
+                  line,
+                  pending_multiline_module_call_depth,
+                  pending_multiline_static_import_specifier, &block
                 )
-              rewritten_line, pending_multiline_module_call_depth =
-                update_pending_multiline_module_call_tracking(rewritten_line, pending_multiline_module_call_depth)
               in_block_comment = true if unclosed_block_comment_starts?(rewritten_line)
               rewritten_line
             else
@@ -517,20 +515,18 @@ module ReactOnRails
           elsif stripped.start_with?("//") || stripped.match?(/\A\*\s/)
             line
           else
-            rewritten_line = yield line
-            rewritten_line, pending_multiline_static_import_specifier =
-              update_pending_multiline_static_import_tracking(
-                rewritten_line,
-                pending_multiline_static_import_specifier
+            rewritten_line, pending_multiline_module_call_depth, pending_multiline_static_import_specifier =
+              rewrite_and_track_line(
+                line,
+                pending_multiline_module_call_depth,
+                pending_multiline_static_import_specifier, &block
               )
-            rewritten_line, pending_multiline_module_call_depth =
-              update_pending_multiline_module_call_tracking(rewritten_line, pending_multiline_module_call_depth)
             in_block_comment = true if unclosed_block_comment_starts?(rewritten_line)
             rewritten_line
           end
         end.join
       end
-      # rubocop:enable Metrics/PerceivedComplexity, Style/ExplicitBlockArgument
+      # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def unclosed_block_comment_starts?(line)
@@ -615,6 +611,19 @@ module ReactOnRails
         suffix_code = suffix[separator_match.end(0)..].to_s
         rewritten_suffix_code = rewrite_base_package_patterns(suffix_code)
         "#{line[0..closing_quote_index]}#{separator_match[:separator]}#{rewritten_suffix_code}"
+      end
+
+      # Rewrites one non-comment line (fragment) via the given block, then threads the
+      # multiline-static-import and multiline-module-call tracking state through it.
+      # Returns [rewritten_line, module_call_depth, static_import_specifier] so callers
+      # keep the loop-local state assignment explicit rather than mutating shared state.
+      def rewrite_and_track_line(line, pending_depth, pending_multiline_static_import_specifier)
+        rewritten_line = yield line
+        rewritten_line, pending_multiline_static_import_specifier =
+          update_pending_multiline_static_import_tracking(rewritten_line, pending_multiline_static_import_specifier)
+        rewritten_line, pending_depth =
+          update_pending_multiline_module_call_tracking(rewritten_line, pending_depth)
+        [rewritten_line, pending_depth, pending_multiline_static_import_specifier]
       end
 
       def update_pending_multiline_module_call_tracking(line, pending_depth)
@@ -754,33 +763,28 @@ module ReactOnRails
         backslash_count.odd?
       end
 
-      def rewrite_line_after_block_comment_close(line, pending_depth, pending_multiline_static_import_specifier)
+      def rewrite_line_after_block_comment_close(line, pending_depth, pending_multiline_static_import_specifier, &)
         closing_index = line.index("*/")
         return [line, pending_depth, pending_multiline_static_import_specifier] unless closing_index
         return [line, pending_depth, pending_multiline_static_import_specifier] if closing_index >= line.length - 2
 
         comment_prefix = line[0, closing_index + 2]
         line_fragment = line[(closing_index + 2)..]
-        rewritten_fragment = yield line_fragment
-        rewritten_fragment, pending_multiline_static_import_specifier =
-          update_pending_multiline_static_import_tracking(rewritten_fragment, pending_multiline_static_import_specifier)
-        rewritten_fragment, pending_depth =
-          update_pending_multiline_module_call_tracking(rewritten_fragment, pending_depth)
+        rewritten_fragment, pending_depth, pending_multiline_static_import_specifier =
+          rewrite_and_track_line(line_fragment, pending_depth, pending_multiline_static_import_specifier, &)
         ["#{comment_prefix}#{rewritten_fragment}", pending_depth, pending_multiline_static_import_specifier]
       end
 
-      def rewrite_line_after_template_literal_close(line, pending_depth, pending_multiline_static_import_specifier)
+      def rewrite_line_after_template_literal_close(line, pending_depth, pending_multiline_static_import_specifier,
+                                                    &)
         closing_index = first_unescaped_backtick_index(line)
         return [line, pending_depth, pending_multiline_static_import_specifier] unless closing_index
         return [line, pending_depth, pending_multiline_static_import_specifier] if closing_index >= line.length - 1
 
         template_literal_prefix = line[0, closing_index + 1]
         line_fragment = line[(closing_index + 1)..]
-        rewritten_fragment = yield line_fragment
-        rewritten_fragment, pending_multiline_static_import_specifier =
-          update_pending_multiline_static_import_tracking(rewritten_fragment, pending_multiline_static_import_specifier)
-        rewritten_fragment, pending_depth =
-          update_pending_multiline_module_call_tracking(rewritten_fragment, pending_depth)
+        rewritten_fragment, pending_depth, pending_multiline_static_import_specifier =
+          rewrite_and_track_line(line_fragment, pending_depth, pending_multiline_static_import_specifier, &)
         ["#{template_literal_prefix}#{rewritten_fragment}", pending_depth, pending_multiline_static_import_specifier]
       end
 
@@ -788,18 +792,16 @@ module ReactOnRails
         line,
         pending_depth,
         pending_multiline_static_import_specifier,
-        in_block_comment: false
+        in_block_comment: false,
+        &
       )
         opening_index = opening_backtick_index_for_multiline_start(line, in_block_comment:)
         return [line, pending_depth, pending_multiline_static_import_specifier] unless opening_index&.positive?
 
         line_prefix = line[0, opening_index]
         template_literal_suffix = line[opening_index..]
-        rewritten_prefix = yield line_prefix
-        rewritten_prefix, pending_multiline_static_import_specifier =
-          update_pending_multiline_static_import_tracking(rewritten_prefix, pending_multiline_static_import_specifier)
-        rewritten_prefix, pending_depth =
-          update_pending_multiline_module_call_tracking(rewritten_prefix, pending_depth)
+        rewritten_prefix, pending_depth, pending_multiline_static_import_specifier =
+          rewrite_and_track_line(line_prefix, pending_depth, pending_multiline_static_import_specifier, &)
         ["#{rewritten_prefix}#{template_literal_suffix}", pending_depth, pending_multiline_static_import_specifier]
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
@@ -978,7 +978,16 @@ module ReactOnRails
           [nil, escaped, index]
         end
 
-        def js_code_position?(content, target_index)
+        # Sentinel returned by scan_js_code_chars when a regex literal spans target_index,
+        # so callers can reproduce the original `return false` guard.
+        REGEX_SPANS_TARGET = :regex_spans_target
+
+        # Scans content up to target_index, skipping regex literals and threading JS
+        # string/comment state via advance_js_scan_state. Yields each code (non-string,
+        # non-comment) character so callers can fold over it (e.g. brace-depth tracking).
+        # Returns the final scan state (nil means the target is at a code position), or
+        # REGEX_SPANS_TARGET when a regex literal starts before but ends at/after target_index.
+        def scan_js_code_chars(content, target_index)
           state = nil
           escaped = false
           index = 0
@@ -988,46 +997,27 @@ module ReactOnRails
             next_char = content[index + 1]
             if state.nil? && js_regex_literal_start?(content, index)
               regex_end = js_regex_literal_end(content, index)
-              return false if regex_end >= target_index
+              return REGEX_SPANS_TARGET if regex_end >= target_index
 
               index = regex_end + 1
               next
             end
 
             state, escaped, index = advance_js_scan_state(state, escaped, char, next_char, index)
+            yield char if state.nil? && block_given?
             index += 1
           end
 
-          state.nil?
+          state
+        end
+
+        def js_code_position?(content, target_index)
+          scan_js_code_chars(content, target_index).nil?
         end
 
         def js_top_level_position?(content, target_index)
-          state = nil
-          escaped = false
           depth = 0
-          index = 0
-
-          while index < target_index
-            char = content[index]
-            next_char = content[index + 1]
-            if state.nil? && js_regex_literal_start?(content, index)
-              regex_end = js_regex_literal_end(content, index)
-              return false if regex_end >= target_index
-
-              index = regex_end + 1
-              next
-            end
-
-            state, escaped, index = advance_js_scan_state(state, escaped, char, next_char, index)
-            if state
-              index += 1
-              next
-            end
-
-            depth += js_depth_delta(char, depth)
-            index += 1
-          end
-
+          state = scan_js_code_chars(content, target_index) { |char| depth += js_depth_delta(char, depth) }
           state.nil? && depth.zero?
         end
 
@@ -1765,9 +1755,15 @@ module ReactOnRails
           content_without_comments = rsc_plugin_options_without_comments(content)
           pattern = /^[ \t]*(?:const|let|var)\s+\{([^}]*)\}\s*=\s*require\(['"]#{Regexp.escape(package_name)}['"]\);?/
 
+          any_top_level_destructuring_match?(content_without_comments, pattern, binding_name)
+        end
+
+        # Scans already-comment-stripped content for `pattern` (whose first capture group is the
+        # destructuring body) and returns true when any match sits at module scope and declares
+        # binding_name. The module-scope check guards against false positives when the same
+        # destructuring appears inside a function body (which does not produce a module-scope binding).
+        def any_top_level_destructuring_match?(content_without_comments, pattern, binding_name)
           content_without_comments.to_enum(:scan, pattern).any? do |captures|
-            # Module-scope check guards against false positives when the same destructuring
-            # appears inside a function body (which does not produce a module-scope binding).
             next false unless js_top_level_position?(content_without_comments, Regexp.last_match.begin(0))
 
             destructuring_declares_binding?(captures.first, binding_name)
@@ -1824,11 +1820,7 @@ module ReactOnRails
           content_without_comments = rsc_plugin_options_without_comments(content)
           pattern = /^[ \t]*(?:const|let|var)\s+\{([^}]*)\}/
 
-          content_without_comments.to_enum(:scan, pattern).any? do |captures|
-            next false unless js_top_level_position?(content_without_comments, Regexp.last_match.begin(0))
-
-            destructuring_declares_binding?(captures.first, binding_name)
-          end
+          any_top_level_destructuring_match?(content_without_comments, pattern, binding_name)
         end
 
         def destructuring_declares_binding?(bindings, binding_name)


### PR DESCRIPTION
## Summary

Pure maintainability refactor of the two largest generator files. Extracts the repeated JS scan/tracking blocks into named private helpers so each duplicated block appears exactly once. Behavior is pinned by the existing generator specs and is unchanged.

**Rationale:** these hand-rolled JS line-rewriter/lexer scan loops carry sibling branches that repeat identical multi-line blocks (flay mass 104 / 92 / 84 in the 2026-07-02 audit). Extraction keeps the interim code maintainable without expanding it, ahead of the eventual Prism migration (#3313).

## Changes

`pro_generator.rb`
- New `rewrite_and_track_line` helper captures the shared three-step sequence: rewrite fragment via block -> `update_pending_multiline_static_import_tracking` -> `update_pending_multiline_module_call_tracking`, returning `[rewritten_line, module_call_depth, static_import_specifier]`. It now backs the inline `/* ... */` branch, the default branch, and the three fragment helpers (`rewrite_line_after_block_comment_close`, `rewrite_line_after_template_literal_close`, `rewrite_line_before_template_literal_open`).
- The `in_block_comment = ... unclosed_block_comment_starts?(rewritten_line)` re-check stays at the call sites (it mutates loop-local state).
- Dropped the `Style/ExplicitBlockArgument` disable from `rewrite_non_comment_lines` (block-forwarding cleanup). The five `Metrics/*` disables remain (still required per rubocop).

`client_references.rb`
- New `scan_js_code_chars(content, target_index)` captures the shared lexer loop (regex-literal skip + `advance_js_scan_state`) and yields each code (non-string, non-comment) character. `js_code_position?` is now "scan and check `state.nil?`"; `js_top_level_position?` folds brace depth over the yielded code chars. A `REGEX_SPANS_TARGET` sentinel preserves the original early `return false` when a regex literal spans `target_index`.
- New `any_top_level_destructuring_match?(content_without_comments, pattern, binding_name)` captures the scan/guard/destructure block shared by `commonjs_named_imported?` and `top_level_destructured_binding?`.

## Impact

Internal only. No public API changes; all touched methods are private generator helpers. No behavior change. No spec assertions changed (specs that reach into `commonjs_named_imported?`, `js_top_level_position?`, `js_code_position?` by name still resolve — those method names are preserved).

## Validation

```
# react_on_rails package dir
bundle exec rspec spec/react_on_rails/generators/pro_generator_spec.rb \
  spec/react_on_rails/generators/rsc_generator_spec.rb
#   -> 348 examples, 0 failures  (identical to pre-change baseline: 348, 0)

bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb
#   -> 593 examples, 0 failures

BUNDLE_GEMFILE=../Gemfile bundle exec rubocop \
  lib/generators/react_on_rails/pro_generator.rb \
  lib/generators/react_on_rails/rsc_setup/client_references.rb
#   -> 2 files inspected, no offenses detected

ruby -c on both files -> Syntax OK
```

## Codex Decision Log

- **Block forwarding + Ruby floor:** the gem targets Ruby >= 3.3 (`TargetRubyVersion: 3.3`). rubocop's `Naming/BlockForwarding` / `Style/ArgumentsForwarding` autocorrect the fragment helpers to anonymous `&` forwarding; verified this is valid at 3.3 (anonymous block param + forwarding is a 3.1+ feature) and that `Lint/Syntax` passes. Kept rubocop's canonical form rather than fighting it.
- **`rewrite_and_track_line` returns, not mutates:** state is threaded through the return tuple so the loop-local assignment stays explicit (matches the existing fragment-helper contract order `[line, depth, static_import]`).
- **`REGEX_SPANS_TARGET` sentinel:** chosen over `throw/catch` so the shared scanner can signal the regex-spans-target case while both `js_code_position?` (`state.nil?`) and `js_top_level_position?` (`state.nil? && depth.zero?`) naturally reduce the sentinel to `false`, exactly reproducing the original early `return false`.
- **Depth-fold equivalence:** in the original `js_top_level_position?`, `depth` was updated only when `state` was falsy after advancing; the new scanner yields `char` under the same `state.nil?` condition, so depth accounting is byte-for-byte equivalent.
- **Out-of-scope guard:** the generator spec suite's `pnpm install` dirtied `pnpm-lock.yaml`; reverted it so only the two owned source files are in the diff.

Confidence note: High. Behavior-preserving extraction with no assertion changes; the pro+rsc generator suite is identical to the pre-change baseline (348/0), the install end-to-end safety net is green (593/0), rubocop is clean, and both files parse. The scan loops were moved verbatim (no lexing-logic changes), and each equivalence point above was reasoned through against the original control flow.

Fixes #4405
