### PR TITLE
Remove dead methods; prune always-false Rails<5.0 spec branches (#4418)

### DIFF
--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -1044,10 +1044,6 @@ module ReactOnRails
       result
     end
 
-    def replay_console_option(val)
-      val.nil? ? ReactOnRails.configuration.replay_console : val
-    end
-
     def in_mailer?
       return false unless defined?(controller)
       return false unless defined?(ActionMailer::Base)

--- a/react_on_rails/lib/react_on_rails/utils.rb
+++ b/react_on_rails/lib/react_on_rails/utils.rb
@@ -162,16 +162,6 @@ module ReactOnRails
       !!system(which_command, command, out: File::NULL, err: File::NULL)
     end
 
-    def self.rails_version_less_than(version)
-      @rails_version_less_than ||= {}
-
-      return @rails_version_less_than[version] if @rails_version_less_than.key?(version)
-
-      @rails_version_less_than[version] = begin
-        Gem::Version.new(Rails.version) < Gem::Version.new(version)
-      end
-    end
-
     module Required
       def required(arg_name)
         raise ReactOnRails::Error, "#{arg_name} is required"

--- a/react_on_rails/lib/react_on_rails/utils.rb
+++ b/react_on_rails/lib/react_on_rails/utils.rb
@@ -41,10 +41,6 @@ module ReactOnRails
       [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
     end
 
-    def self.server_rendering_is_enabled?
-      ReactOnRails.configuration.server_bundle_js_file.present?
-    end
-
     # Invokes command, exiting with a detailed message if there's a failure.
     def self.invoke_and_exit_if_failed(cmd, failure_message)
       stdout, stderr, status = Open3.capture3(cmd)

--- a/react_on_rails/rakelib/example_type.rb
+++ b/react_on_rails/rakelib/example_type.rb
@@ -77,7 +77,7 @@ module ReactOnRails
       attr_writer :rails_options
 
       def rails_options
-        @rails_options ||= if ReactOnRails::Utils.rails_version_less_than("7.0")
+        @rails_options ||= if rails_version_less_than("7.0")
                              "--skip-bundle --skip-spring --skip-git --skip-test-unit --skip-active-record -J"
                            else
                              "--skip-bundle --skip-spring --skip-git --skip-test-unit --skip-active-record -j webpack"
@@ -108,6 +108,12 @@ module ReactOnRails
       end
 
       private
+
+      # Compares the running Rails version against the given version string.
+      # Rake-only helper for example generation (previously ReactOnRails::Utils.rails_version_less_than).
+      def rails_version_less_than(version)
+        Gem::Version.new(Rails.version) < Gem::Version.new(version)
+      end
 
       # Defines globs that scoop up all files (including dotfiles) in given directory
       def all_files_in_dir(p_dir)

--- a/react_on_rails/sig/react_on_rails/utils.rbs
+++ b/react_on_rails/sig/react_on_rails/utils.rbs
@@ -5,7 +5,6 @@ module ReactOnRails
     def self.truthy_presence: (untyped obj) -> untyped
     def self.wrap_message: (String msg, ?Symbol color) -> String
     def self.object_to_boolean: (untyped value) -> bool
-    def self.server_rendering_is_enabled?: () -> bool
     def self.invoke_and_exit_if_failed: (String cmd, String failure_message) -> Array[String]
     def self.server_bundle_path_is_http?: () -> bool
     def self.bundle_js_file_path: (String bundle_name) -> String
@@ -21,7 +20,6 @@ module ReactOnRails
     def self.server_bundle_js_file_path: () -> String
     def self.running_on_windows?: () -> bool
     def self.rails_version_less_than: (String version) -> bool
-    def self.rails_version_less_than_4_1_1?: () -> bool
     def self.source_path: () -> String
     def self.public_bundles_full_path: () -> String
     def self.generated_assets_full_path: () -> String

--- a/react_on_rails/sig/react_on_rails/utils.rbs
+++ b/react_on_rails/sig/react_on_rails/utils.rbs
@@ -19,7 +19,6 @@ module ReactOnRails
     def self.default_troubleshooting_section: () -> String
     def self.server_bundle_js_file_path: () -> String
     def self.running_on_windows?: () -> bool
-    def self.rails_version_less_than: (String version) -> bool
     def self.source_path: () -> String
     def self.public_bundles_full_path: () -> String
     def self.generated_assets_full_path: () -> String

--- a/react_on_rails/spec/dummy/spec/requests/server_render_check_spec.rb
+++ b/react_on_rails/spec/dummy/spec/requests/server_render_check_spec.rb
@@ -130,15 +130,9 @@ describe "Server Rendering", :server_rendering do
     end
 
     def do_request(path)
-      if ReactOnRails::Utils.rails_version_less_than("5.0")
-        get(path,
-            { ab: :cd },
-            "HTTP_ACCEPT_LANGUAGE" => http_accept_language)
-      else
-        get(path,
-            params: { ab: :cd },
-            headers: { "HTTP_ACCEPT_LANGUAGE" => http_accept_language })
-      end
+      get(path,
+          params: { ab: :cd },
+          headers: { "HTTP_ACCEPT_LANGUAGE" => http_accept_language })
     end
 
     context "with shared redux store" do

--- a/react_on_rails/spec/react_on_rails/utils_spec.rb
+++ b/react_on_rails/spec/react_on_rails/utils_spec.rb
@@ -541,56 +541,6 @@ module ReactOnRails
         end
       end
 
-      describe ".rails_version_less_than" do
-        subject { described_class.rails_version_less_than("4") }
-
-        describe ".rails_version_less_than" do
-          before { described_class.instance_variable_set :@rails_version_less_than, nil }
-
-          context "with Rails 3" do
-            before { allow(Rails).to receive(:version).and_return("3") }
-
-            it { is_expected.to be(true) }
-          end
-
-          context "with Rails 3.2" do
-            before { allow(Rails).to receive(:version).and_return("3.2") }
-
-            it { is_expected.to be(true) }
-          end
-
-          context "with Rails 4" do
-            before { allow(Rails).to receive(:version).and_return("4") }
-
-            it { is_expected.to be(false) }
-          end
-
-          context "with Rails 4.2" do
-            before { allow(Rails).to receive(:version).and_return("4.2") }
-
-            it { is_expected.to be(false) }
-          end
-
-          context "with Rails 10.0" do
-            before { allow(Rails).to receive(:version).and_return("10.0") }
-
-            it { is_expected.to be(false) }
-          end
-
-          context "when called twice" do
-            before do
-              allow(Rails).to receive(:version).and_return("4.2")
-            end
-
-            it "memoizes the result" do
-              2.times { described_class.rails_version_less_than("4") }
-
-              expect(Rails).to have_received(:version).once
-            end
-          end
-        end
-      end
-
       describe ".smart_trim" do
         let(:long_string) { "1234567890" }
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
@@ -60,10 +60,6 @@ module ReactOnRailsPro
       @pull_requests = PullRequestQueue.new(@pushed_props) if pull_enabled
     end
 
-    def pull_enabled?
-      @pull_enabled
-    end
-
     # Sends an async prop to the Node renderer.
     # The prop value is JSON-serialized and sent as an NDJSON line.
     # On the Node side, this triggers asyncPropsManager.setProp(propName, value).

--- a/react_on_rails_pro/spec/dummy/spec/requests/server_render_check_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/server_render_check_spec.rb
@@ -133,15 +133,9 @@ describe "Server Rendering", :server_rendering do
     end
 
     def do_request(path)
-      if ReactOnRails::Utils.rails_version_less_than("5.0")
-        get(path,
-            { ab: :cd },
-            "HTTP_ACCEPT_LANGUAGE" => http_accept_language)
-      else
-        get(path,
-            params: { ab: :cd },
-            headers: { "HTTP_ACCEPT_LANGUAGE" => http_accept_language })
-      end
+      get(path,
+          params: { ab: :cd },
+          headers: { "HTTP_ACCEPT_LANGUAGE" => http_accept_language })
     end
 
     context "with shared redux store" do

--- a/react_on_rails_pro/spec/react_on_rails_pro/async_props_emitter_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/async_props_emitter_spec.rb
@@ -156,17 +156,6 @@ RSpec.describe ReactOnRailsPro::AsyncPropsEmitter do
     end
   end
 
-  describe "#pull_enabled?" do
-    it "returns false by default" do
-      expect(emitter.pull_enabled?).to be false
-    end
-
-    it "returns true when initialized with pull_enabled: true" do
-      pull_emitter = described_class.new(bundle_timestamp, request_stream, pull_enabled: true)
-      expect(pull_emitter.pull_enabled?).to be true
-    end
-  end
-
   describe "#pull_requests" do
     it "is nil when pull mode is disabled" do
       expect(emitter.pull_requests).to be_nil

--- a/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
@@ -383,11 +383,10 @@ describe ReactOnRailsPro::Request do
       bidi_response = mock_response(status: 200, chunks: [to_length_prefixed("chunk")])
       allow(mock_connection).to receive(:post_bidi).and_return([mock_output, bidi_response])
 
-      allow(ReactOnRailsPro::AsyncPropsEmitter).to receive(:new) do |bundle_timestamp, _output, pull_enabled: false|
+      allow(ReactOnRailsPro::AsyncPropsEmitter).to receive(:new) do |bundle_timestamp, _output, **_kwargs|
         instance_double(
           ReactOnRailsPro::AsyncPropsEmitter,
           end_stream_chunk: { bundleTimestamp: bundle_timestamp, updateChunk: "mocked_js" },
-          pull_enabled?: pull_enabled,
           render_complete!: nil
         )
       end


### PR DESCRIPTION
## Summary

Dead-code cleanup from the 17.0.0 pre-release maintainability audit (#4346). **Pure refactor: no runtime behavior change** — removes unused methods, an unreachable spec branch, and relocates a rake-only helper out of the public `Utils` surface. Every removal is proven dead by repo-wide grep.

Fixes #4418

All five items from the issue are complete.

## What changed

**1. Removed `ReactOnRailsHelper#replay_console_option`** (`react_on_rails/lib/react_on_rails/helper.rb`) — unused wrapper. `config.replay_console` itself is untouched and still read elsewhere; only this dead wrapper is gone.

**2. Removed `Utils.server_rendering_is_enabled?`** (`react_on_rails/lib/react_on_rails/utils.rb`) + its RBS signature (`sig/react_on_rails/utils.rbs`). Also removed the stale `rails_version_less_than_4_1_1?` RBS signature — the method was removed from `utils.rb` long ago (see `CHANGELOG.md:1170`), leaving only a dangling signature.

**3. Removed Pro `AsyncPropsEmitter#pull_enabled?`** (`react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb`) — no production callers. The `pull_enabled` keyword arg, `@pull_enabled` ivar, and the `PullRequestQueue` gating logic all stay; only the unused reader is removed. Its two spec callers were updated: the `describe "#pull_enabled?"` block was deleted from `async_props_emitter_spec.rb`, and the `pull_enabled?:` stub was dropped from the verifying `instance_double` in `request_spec.rb` (a verifying double raises once the real method is gone; the stubbed `.new` block now uses `**_kwargs` since `pull_enabled` is no longer read there).

**4. Pruned always-false `rails_version_less_than("5.0")` branch** in both dummy apps' `spec/dummy/spec/requests/server_render_check_spec.rb`. The gemspec Rails floor is `>= 5.2` (`react_on_rails.gemspec:41`), so that branch is unreachable; simplified `do_request` to the modern `get(path, params: { ab: :cd }, headers: { ... })` form only.

**5. Relocated `Utils.rails_version_less_than` to `rakelib/example_type.rb`.** After item 4, its only non-spec caller was the rake example generator (`example_type.rb:80`). Moved it there as a private helper (dropping the memo cache — `rails_options` is already memoized, so it is called at most once per instance), removed it from `utils.rb` + its RBS sig, and removed the `.rails_version_less_than` describe block from `utils_spec.rb`. It is no longer part of the public `Utils` surface.

## Per-removal dead-code evidence

Final `git grep` on the head commit:

| Symbol | Result |
|--------|--------|
| `replay_console_option` | **0 hits** (was 1: def only; no `:sym`/`"str"` dynamic-dispatch forms) |
| `server_rendering_is_enabled` | **0 hits** (was 2: def + RBS) |
| `pull_enabled?` (predicate) | **0 hits** (was 3: def + spec block + verifying double) |
| `rails_version_less_than_4_1_1` | CHANGELOG line only (stale RBS sig removed) |
| `rails_version_less_than` | only `rakelib/example_type.rb` (def + call) + historical CHANGELOG; **0 in `lib/`, 0 in specs** |

`replay_console_option` and `server_rendering_is_enabled?` also had zero spec references. `pull_enabled?` had no production caller — only the two spec references, both updated in this PR.

## Validation

Run from the worktree on latest `origin/main` (includes #4402), after building dummy webpack bundles (`pnpm install --prefer-offline` + `pnpm run build:test`):

- **RuboCop (OSS)** — `bundle exec rubocop` on `helper.rb`, `utils.rb`, `rakelib/example_type.rb`, core dummy spec, `utils_spec.rb` → **no offenses**
- **RuboCop (Pro)** — `bundle exec rubocop --ignore-parent-exclusion` on `async_props_emitter.rb`, `async_props_emitter_spec.rb`, `request_spec.rb`, Pro dummy spec → **no offenses**
- **RBS** — `bundle exec rake rbs:validate` → **✓ RBS validation passed**
- **`utils_spec.rb`** — `82 examples, 0 failures` (was 88; the 6 removed `rails_version_less_than` contexts account for the drop)
- **Pro `async_props_emitter_spec.rb` + `request_spec.rb`** — `54 examples, 0 failures, 1 pending` (the 1 pending is the pre-existing known-issue #3300, explicitly marked PENDING — unrelated to this PR)
- **Core dummy `server_render_check_spec.rb`** — **`10 examples, 0 failures`** (fully green; positive proof the `do_request` simplification works)
- **Pro dummy `server_render_check_spec.rb`** — `9 examples, 7 failures`, isolated as **pre-existing / not caused by this change**: stashing this PR's edit reproduces the identical `9 examples, 7 failures` on the unmodified baseline. The failing examples show `got: ""` (empty SSR content in this environment), not any `get`-plumbing error, and the two `railsContext` examples that use the touched `do_request` fail identically with and without the change.

## Codex Decision Log

- **`rails_version_less_than` relocation (item 5).** Implemented as a private instance method on `ReactOnRails::TaskHelpers::ExampleType` rather than inlining `Gem::Version.new(Rails.version) < Gem::Version.new("7.0")`, keeping the readable named predicate at the call site. The `Rails` constant is available because the caller `rakelib/shakapacker_examples.rake` does `require "rails/version"`. The memo cache from the original `Utils` version was dropped: `rails_options` is itself memoized (`@rails_options ||=`), so the helper runs at most once per instance and the cache was dead weight. The `require_relative ...utils` line in `example_type.rb` was intentionally left in place — removing it is an unrelated, slightly load-order-risky change with no dead-code payoff.
- **`pull_enabled?` verifying double (item 3).** `request_spec.rb` uses a *verifying* `instance_double`, which validates that stubbed methods exist on the real class. Simply deleting the method without touching the double would make the double raise. The `pull_enabled?:` stub was removed and the block signature changed to `**_kwargs` (the `.new` interception still needs to accept the `pull_enabled:` keyword that production code passes, but no longer reads it). The separate `have_received(:new).with(..., pull_enabled: true)` assertion is unaffected — it inspects the argument passed to `.new`, not the double's methods.

## Impact

Internal only. `replay_console_option`, `pull_enabled?`, and the pruned spec branch are internal. `server_rendering_is_enabled?` and `rails_version_less_than` were public but undocumented `Utils` methods (zero `docs/` hits) — removing/relocating them in the 17.0.0 RC window is intentional and free. No public JS/renderer surface is touched.

## Confidence note

**High.** Every removal is grep-proven dead; RuboCop + RBS are green; `utils_spec` and the Pro unit specs are green; the core dummy request spec is fully green (10/10) after building bundles. The only non-passing suite (Pro dummy `server_render_check_spec`) is proven pre-existing via an identical baseline failure count with the change stashed. No item was deferred — all five are complete, plus the bonus stale-RBS-sig removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
