### PR TITLE
Wire eslint-rules RuleTester suite into a runner, CI, and knip (#4409)

### DIFF
--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -207,6 +207,8 @@ jobs:
         run: pnpm run eslint --report-unused-disable-directives
       - name: Test GitHub Action helpers
         run: node .github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+      - name: Test custom ESLint rules
+        run: pnpm run test:eslint-rules
       - name: Check formatting
         run: pnpm start format.listDifferent
       - name: Lint SCSS with stylelint

--- a/knip.ts
+++ b/knip.ts
@@ -11,8 +11,11 @@ const config: KnipConfig = {
         'benchmarks/k6.ts',
         '.github/workflows/shakaperf-release-gates.yml',
         'test/shakaperf/**/*.ts',
+        // Custom ESLint rule tests are run standalone via `pnpm run test:eslint-rules`
+        // (plain `node`, no importer), so knip needs them declared as entry points.
+        'eslint-rules/**/*.test.cjs',
       ],
-      project: ['*.{js,mjs,ts}', 'test/shakaperf/**/*.ts'],
+      project: ['*.{js,mjs,ts}', 'test/shakaperf/**/*.ts', 'eslint-rules/**/*.cjs'],
       ignoreBinaries: [
         // Pro package binaries used in Pro workflows
         'playwright',

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "scripts": {
     "test": "pnpm --filter \"./packages/*\" -r run test",
+    "test:eslint-rules": "node eslint-rules/no-use-client-in-server-files.test.cjs",
     "clean": "pnpm -r run clean",
     "start": "nps",
     "nps": "nps",
@@ -93,7 +94,7 @@
     "build-watch": "pnpm -r run build-watch",
     "lint": "nps eslint",
     "lint:scss": "stylelint \"react_on_rails/spec/dummy/app/assets/stylesheets/**/*.scss\" \"react_on_rails/spec/dummy/client/**/*.scss\"",
-    "check": "pnpm run lint && pnpm -r run check",
+    "check": "pnpm run lint && pnpm run test:eslint-rules && pnpm -r run check",
     "type-check": "pnpm -r run type-check",
     "publish": "pnpm -r run publish",
     "knip": "knip",


### PR DESCRIPTION
## Why

The custom ESLint rule `eslint-rules/no-use-client-in-server-files.cjs` guards a real hazard — a `'use client'` directive landing in a server-only (`.server.tsx`/`.server.ts`) file, which forces webpack to bundle it as a client component and breaks React's `react-server` conditional exports. A `RuleTester` suite ships right next to it in `eslint-rules/no-use-client-in-server-files.test.cjs`, but **nothing executed that suite**: no package script, no workflow, no lefthook entry referenced it (`grep -rn "no-use-client-in-server-files.test"` → zero hits). The rule could regress silently while its "tests" rotted — a coverage illusion. knip couldn't flag the orphan either, because the root workspace's `project` globs only scanned top-level files (no `eslint-rules/`, no `.cjs`).

`Fixes #4409`

## What changed

Smallest-footprint wiring, matching the **existing precedent** in this same workflow — the `Test GitHub Action helpers` step runs a standalone `.cjs` test via plain `node`. ESLint's `RuleTester` runs standalone and throws (exits non-zero) on failure, so no test framework is needed.

- **`package.json`**: add `"test:eslint-rules": "node eslint-rules/no-use-client-in-server-files.test.cjs"` and chain it into the aggregate `"check"` script (`pnpm run lint && pnpm run test:eslint-rules && pnpm -r run check`).
- **`.github/workflows/lint-js-and-ruby.yml`**: add a `Test custom ESLint rules` step immediately after `Test GitHub Action helpers` in the `build` job, so the suite runs on every PR.
- **`knip.ts`** (root workspace): add `eslint-rules/**/*.cjs` to `project` (so the directory is analyzed) and `eslint-rules/**/*.test.cjs` to `entry` (the test file has no importer, so knip needs it declared as an entry point). The rule `.cjs` is seen as used via its `import` in `eslint.config.ts`.

No new dependencies. The test file itself needed **no** changes to be runnable.

## Validation (real results, local; Node 22.12.0 pinned in `.tool-versions` = CI Node)

**Core proof — the test runs and passes via the new script:**
```
$ pnpm run test:eslint-rules
> node eslint-rules/no-use-client-in-server-files.test.cjs
(exit 0 — RuleTester is silent on success)
```

**Fail-when-broken proof — the test genuinely exercises the rule (not a no-op):** temporarily changed a `valid` fixture's filename from `Component.tsx` to `Component.server.tsx` (so a `'use client'` server file was asserted valid). The run **failed with exit code 1**:
```
AssertionError [ERR_ASSERTION]:
  actual: 1, expected: 0, operator: 'strictEqual'
 ELIFECYCLE  Command failed with exit code 1.
```
The rule correctly flagged 1 error where the (broken) test asserted 0. Reverted; `git diff` on the test file is empty and it passes again.

**Other gates (all green):**
| Check | Result |
| --- | --- |
| `pnpm exec knip` | exit 0 — no new findings; no `eslint-rules/` unused/unlisted lines |
| `pnpm exec knip --production` | exit 1 **on this branch AND on clean `origin/main`** — pre-existing `prop-types` finding in `react_on_rails/spec/dummy` (generated-packs artifact), byte-identical behavior with/without my change. My globs add zero new findings. |
| `pnpm run lint` (eslint) | exit 0 |
| `pnpm start format.listDifferent` (prettier) | "All matched files use Prettier code style!" |
| `pnpm run type-check` | all 9 workspaces pass |
| `pnpm run test` (main suite) | unchanged script (byte-identical to `main`); orthogonal to `test:eslint-rules`. Sanity-ran `create-react-on-rails-app`: 104/104 pass |
| `actionlint .github/workflows/lint-js-and-ruby.yml` | **NO ISSUES (exit 0)** |
| `yamllint` | repo has no yamllint config and uses actionlint as the workflow linter; my 2 added lines produce zero yamllint findings (only pre-existing default-config line-length noise on other lines) |
| pre-commit hooks | trailing-newlines, prettier, eslint all pass |

## QA Evidence

- The exact command CI will run (`pnpm run test:eslint-rules`) was executed locally on the pinned CI Node (22.12.0) and **passes** (exit 0).
- Proved the test is **real, not a no-op**: deliberately broke a fixture → the command **failed (exit 1, `ERR_ASSERTION actual:1 expected:0`)** → reverted → passes again (empty `git diff` on the test file). This is the "deliberately break an assertion, confirm the step fails, restore" evidence the issue's acceptance criteria requires.
- After the PR opens I will confirm the new `Test custom ESLint rules` CI step goes green.

## Codex Decision Log

`codex review --base origin/main` ran and returned: *"No actionable correctness, CI wiring, or maintainability issues were found in the diff. The new ESLint rule test script is wired into both the lint workflow and the root check script, and the Knip entries account for the standalone test files."* No findings to address.

## New-gate stale-base race control

Swept open PRs (`gh pr list --state open`, 24 open). Only **#4390** (`Tighten hosted CI workflow safeguards`) also touches `lint-js-and-ruby.yml`, but it edits the `detect-changes` job's `if:` condition (~line 26); my change adds a step in the `build` job (~line 210) — **no line-level collision**, merges cleanly in either order. No PR touches `eslint-rules/`, `knip.ts`, or `package.json` scripts. Coordinator should re-sweep before landing.

Labels: ready-for-hosted-ci, hosted-ci-no-benchmarks — CI/tooling-only change (test wiring, knip globs, one CI step); cannot affect runtime performance, so benchmarks add no signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks for custom lint rules to the validation workflow and main project check command.
  * Included standalone rule tests in workspace coverage so they run consistently.

* **Chores**
  * Updated repository configuration so the new lint-rule tests are recognized by maintenance tools and CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->