### PR TITLE
Delegate deprecated base/ shims to capabilities/ instead of cloning (#4413)

### DIFF
--- a/packages/react-on-rails/src/base/client.ts
+++ b/packages/react-on-rails/src/base/client.ts
@@ -3,35 +3,20 @@
  * with older versions of react-on-rails-pro that import from `react-on-rails/@internal/base/client`.
  */
 
-import type { ReactElement } from 'react';
+// This is a thin compatibility shim: the implementation lives in `capabilities/core.ts`
+// (`createCoreCapability`). This file adds only the shim-specific concerns that old Pro
+// consumers rely on — singleton caching/validation and the client-side lifecycle stubs
+// that `createReactOnRails` overrides — and re-shapes the object to the historical
+// `BaseClientObjectType` surface (no Pro methods).
+
 import type {
   RegisteredComponent,
-  RenderReturnType,
   RegisteredComponentValue,
-  AuthenticityHeaders,
   Store,
   StoreGenerator,
-  ReactOnRailsOptions,
   ReactOnRailsInternal,
 } from '../types/index.ts';
-import * as Authenticity from '../Authenticity.ts';
-import buildConsoleReplay, { consoleReplay } from '../buildConsoleReplay.ts';
-import reactHydrateOrRender from '../reactHydrateOrRender.ts';
-import createReactOutput from '../createReactOutput.ts';
-import componentRegistrationMetric from '../componentRegistrationMetric.ts';
-import {
-  buildRootErrorCallbackOptions,
-  getRootErrorHandlers,
-  resetRootErrorHandlers,
-  setRootErrorHandlers,
-} from '../rootErrorHandlers.ts';
-
-const DEFAULT_OPTIONS = {
-  traceTurbolinks: false,
-  turbo: false,
-  debugMode: false,
-  logComponentRegistration: false,
-};
+import { createCoreCapability } from '../capabilities/core.ts';
 
 type RegisteredComponentEntry = RegisteredComponent<RegisteredComponentValue>;
 
@@ -78,8 +63,6 @@ export function createBaseClientObject(
   registries: Registries,
   currentObject: BaseClientObjectType | null = null,
 ): BaseClientObjectType {
-  const { ComponentRegistry, StoreRegistry } = registries;
-
   // Error detection: currentObject is null but we have a cached object
   // This indicates webpack misconfiguration (multiple runtime chunks)
   if (currentObject === null && cachedObject !== null) {
@@ -127,244 +110,41 @@ Fix: Use only react-on-rails OR react-on-rails-pro, not both.`);
     return cachedObject;
   }
 
-  // Create and return new object
-  const obj = {
-    options: {} as Partial<ReactOnRailsOptions>,
-    isRSCBundle: false,
+  // Delegate the core method implementations to `createCoreCapability` (the canonical source),
+  // then re-shape to the historical base surface: strip the Pro-only stubs and add the
+  // client-side lifecycle stubs that `createReactOnRails` overrides at initialization. The
+  // stripped names are kept in sync with the `Omit<...>` in BaseClientObjectType so the shim
+  // object's enumerable keys match what old Pro consumers received.
+  const proOnlyMethods = new Set<string>([
+    'getOrWaitForComponent',
+    'getOrWaitForStore',
+    'getOrWaitForStoreGenerator',
+    'reactOnRailsStoreLoaded',
+    'streamServerRenderedReactComponent',
+    'serverRenderRSCReactComponent',
+    'addAsyncPropsCapabilityToComponentProps',
+    'getOrCreateAsyncPropsManager',
+  ]);
+  const core = createCoreCapability(registries);
+  const obj = Object.fromEntries(
+    Object.entries(core).filter(([key]) => !proOnlyMethods.has(key)),
+  ) as unknown as BaseClientObjectType;
 
-    // ===================================================================
-    // STABLE METHOD IMPLEMENTATIONS - Core package implementations
-    // ===================================================================
+  // ===================================================================
+  // CLIENT-SIDE RENDERING STUBS - To be overridden by createReactOnRails
+  // ===================================================================
 
-    authenticityToken(): string | null {
-      return Authenticity.authenticityToken();
-    },
+  obj.reactOnRailsPageLoaded = (): Promise<void> => {
+    throw new Error(
+      'ReactOnRails.reactOnRailsPageLoaded is not initialized. This is a bug in react-on-rails.',
+    );
+  };
 
-    authenticityHeaders(otherHeaders: Record<string, string> = {}): AuthenticityHeaders {
-      return Authenticity.authenticityHeaders(otherHeaders);
-    },
-
-    reactHydrateOrRender(domNode: Element, reactElement: ReactElement, hydrate: boolean): RenderReturnType {
-      // The component name is unknown on this low-level path; the dom id still ties errors to a mount.
-      const rootErrorCallbackOptions = buildRootErrorCallbackOptions(
-        { domNodeId: domNode.id || undefined },
-        hydrate,
-      );
-      return reactHydrateOrRender(domNode, reactElement, hydrate, rootErrorCallbackOptions);
-    },
-
-    setOptions(newOptions: Partial<ReactOnRailsOptions>): void {
-      const { traceTurbolinks, turbo, debugMode, logComponentRegistration, rootErrorHandlers, ...rest } =
-        newOptions;
-
-      if (typeof traceTurbolinks !== 'undefined') {
-        this.options.traceTurbolinks = traceTurbolinks;
-      }
-
-      if (typeof turbo !== 'undefined') {
-        this.options.turbo = turbo;
-      }
-
-      if (typeof debugMode !== 'undefined') {
-        this.options.debugMode = debugMode;
-        if (debugMode) {
-          console.log('[ReactOnRails] Debug mode enabled');
-        }
-      }
-
-      if (typeof logComponentRegistration !== 'undefined') {
-        this.options.logComponentRegistration = logComponentRegistration;
-        if (logComponentRegistration) {
-          console.log('[ReactOnRails] Component registration logging enabled');
-        }
-      }
-
-      if (Object.prototype.hasOwnProperty.call(newOptions, 'rootErrorHandlers')) {
-        // MIRROR OF: packages/react-on-rails/src/capabilities/core.ts
-        // Validates and merges the handlers per key (partial updates keep previously registered
-        // callbacks); warns when the React runtime cannot support them. Store the merged result so
-        // `option('rootErrorHandlers')` reflects the effective registration.
-        if (typeof rootErrorHandlers === 'undefined') {
-          resetRootErrorHandlers();
-          this.options.rootErrorHandlers = undefined;
-        } else {
-          setRootErrorHandlers(rootErrorHandlers);
-          this.options.rootErrorHandlers = getRootErrorHandlers();
-        }
-      }
-
-      if (Object.keys(rest).length > 0) {
-        throw new Error(`Invalid options passed to ReactOnRails.options: ${JSON.stringify(rest)}`);
-      }
-    },
-
-    option<K extends keyof ReactOnRailsOptions>(key: K): ReactOnRailsOptions[K] {
-      return this.options[key];
-    },
-
-    buildConsoleReplay(): string {
-      return buildConsoleReplay();
-    },
-
-    getConsoleReplayScript(): string {
-      return consoleReplay();
-    },
-
-    resetOptions(): void {
-      this.options = { ...DEFAULT_OPTIONS };
-      resetRootErrorHandlers();
-    },
-
-    // ===================================================================
-    // REGISTRY METHOD IMPLEMENTATIONS - Using provided registries
-    // ===================================================================
-
-    register(components: Record<string, RegisteredComponentValue>): void {
-      if (this.options.debugMode || this.options.logComponentRegistration) {
-        // Use performance.now() if available, otherwise fallback to Date.now()
-        const perf = typeof performance !== 'undefined' ? performance : { now: () => Date.now() };
-        const startTime = perf.now();
-        const componentNames = Object.keys(components);
-        console.log(
-          `[ReactOnRails] Registering ${componentNames.length} component(s): ${componentNames.join(', ')}`,
-        );
-
-        ComponentRegistry.register(components);
-
-        const endTime = perf.now();
-        console.log(
-          `[ReactOnRails] Component registration completed in ${(endTime - startTime).toFixed(2)}ms`,
-        );
-
-        // Log individual component details if in full debug mode
-        if (this.options.debugMode) {
-          componentNames.forEach((name) => {
-            const component = components[name];
-            const registrationMetric = componentRegistrationMetric(component);
-            console.log(
-              `[ReactOnRails] ✅ Registered: ${name} (${registrationMetric.value} ${registrationMetric.label})`,
-            );
-          });
-        }
-      } else {
-        ComponentRegistry.register(components);
-      }
-    },
-
-    registerStore(stores: Record<string, StoreGenerator>): void {
-      this.registerStoreGenerators(stores);
-    },
-
-    registerStoreGenerators(storeGenerators: Record<string, StoreGenerator>): void {
-      if (!storeGenerators) {
-        throw new Error(
-          'Called ReactOnRails.registerStoreGenerators with a null or undefined, rather than ' +
-            'an Object with keys being the store names and the values are the store generators.',
-        );
-      }
-      StoreRegistry.register(storeGenerators);
-    },
-
-    getStore(name: string, throwIfMissing = true): Store | undefined {
-      return StoreRegistry.getStore(name, throwIfMissing);
-    },
-
-    getStoreGenerator(name: string): StoreGenerator {
-      return StoreRegistry.getStoreGenerator(name);
-    },
-
-    setStore(name: string, store: Store): void {
-      StoreRegistry.setStore(name, store);
-    },
-
-    clearHydratedStores(): void {
-      StoreRegistry.clearHydratedStores();
-    },
-
-    clearStoreGenerators(): void {
-      StoreRegistry.clearStoreGenerators();
-    },
-
-    getComponent(name: string): RegisteredComponentEntry {
-      return ComponentRegistry.get(name);
-    },
-
-    registeredComponents(): Map<string, RegisteredComponentEntry> {
-      return ComponentRegistry.components();
-    },
-
-    storeGenerators(): Map<string, StoreGenerator> {
-      return StoreRegistry.storeGenerators();
-    },
-
-    stores(): Map<string, Store> {
-      return StoreRegistry.stores();
-    },
-
-    render(
-      name: string,
-      props: Record<string, unknown>,
-      domNodeId: string,
-      hydrate: boolean,
-    ): RenderReturnType {
-      const componentObj = ComponentRegistry.get(name);
-      const reactElement = createReactOutput({ componentObj, props, domNodeId });
-
-      return reactHydrateOrRender(
-        document.getElementById(domNodeId) as Element,
-        reactElement as ReactElement,
-        hydrate,
-        buildRootErrorCallbackOptions(
-          { componentName: name || undefined, domNodeId: domNodeId || undefined },
-          hydrate,
-        ),
-      );
-    },
-
-    // ===================================================================
-    // CLIENT-SIDE RENDERING STUBS - To be overridden by createReactOnRails
-    // ===================================================================
-
-    reactOnRailsPageLoaded(): Promise<void> {
-      throw new Error(
-        'ReactOnRails.reactOnRailsPageLoaded is not initialized. This is a bug in react-on-rails.',
-      );
-    },
-
-    reactOnRailsComponentLoaded(domId: string): Promise<void> {
-      void domId; // Mark as used
-      throw new Error(
-        'ReactOnRails.reactOnRailsComponentLoaded is not initialized. This is a bug in react-on-rails.',
-      );
-    },
-
-    // ===================================================================
-    // SSR STUBS - Will throw errors in client bundle, overridden in full
-    // ===================================================================
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    serverRenderReactComponent(...args: any[]): any {
-      void args; // Mark as used
-      throw new Error(
-        'serverRenderReactComponent is not available in "react-on-rails/client". Import "react-on-rails" server-side.',
-      );
-    },
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handleError(...args: any[]): any {
-      void args; // Mark as used
-      throw new Error(
-        'handleError is not available in "react-on-rails/client". Import "react-on-rails" server-side.',
-      );
-    },
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    prepareRenderResult(...args: any[]): any {
-      void args; // Mark as used
-      throw new Error(
-        'prepareRenderResult is not available in "react-on-rails/client". Import "react-on-rails" server-side.',
-      );
-    },
+  obj.reactOnRailsComponentLoaded = (domId: string): Promise<void> => {
+    void domId; // Mark as used
+    throw new Error(
+      'ReactOnRails.reactOnRailsComponentLoaded is not initialized. This is a bug in react-on-rails.',
+    );
   };
 
   // Cache the object and registries

--- a/packages/react-on-rails/src/base/client.ts
+++ b/packages/react-on-rails/src/base/client.ts
@@ -38,6 +38,27 @@ interface Registries {
   };
 }
 
+// Pro-only methods that `createCoreCapability` includes as stubs but the historical base
+// surface omits. This list drives the runtime key-stripping in `createBaseClientObject`.
+// `satisfies readonly (keyof ReactOnRailsInternal)[]` makes a typo or a stale name a compile
+// error, and the `assertProOnlyMethodsMatchOmit` guard inside `createBaseClientObject` pins this
+// list to the `Omit<...>` in `BaseClientObjectType` so the runtime list and the exported type can
+// never drift.
+const PRO_ONLY_METHODS = [
+  'getOrWaitForComponent',
+  'getOrWaitForStore',
+  'getOrWaitForStoreGenerator',
+  'reactOnRailsStoreLoaded',
+  'streamServerRenderedReactComponent',
+  'serverRenderRSCReactComponent',
+  'addAsyncPropsCapabilityToComponentProps',
+  'getOrCreateAsyncPropsManager',
+] as const satisfies readonly (keyof ReactOnRailsInternal)[];
+
+// The omitted set below is kept in lockstep with the runtime `PRO_ONLY_METHODS` list by a
+// compile-time guard inside `createBaseClientObject` (see `assertProOnlyMethodsMatchOmit`), so the
+// exported type and the runtime key-stripping can never drift. This is a plain `//` comment (not
+// JSDoc) so it stays out of the published `.d.ts`, keeping the declared surface byte-identical.
 /**
  * Base client object type that includes all core ReactOnRails methods except Pro-specific ones.
  * Derived from ReactOnRailsInternal by omitting Pro-only methods.
@@ -110,21 +131,29 @@ Fix: Use only react-on-rails OR react-on-rails-pro, not both.`);
     return cachedObject;
   }
 
+  // Compile-time drift guard (function-local so it emits nothing to the published `.d.ts`).
+  // Proves the runtime `PRO_ONLY_METHODS` list covers EXACTLY the keys that `BaseClientObjectType`
+  // omits from `ReactOnRailsInternal` — no more, no less. If a new Pro-only stub is added to
+  // `createCoreCapability` and only one side is updated (the runtime list OR the `Omit<...>`
+  // union), the two unions stop being mutually assignable, `AssertMatch` resolves to `never`, and
+  // `satisfies AssertMatch` fails to compile. `Exclude<keyof I, keyof BaseClientObjectType>`
+  // recovers the omitted-key set because `Omit` drops exactly those keys.
+  type OmittedBaseKeys = Exclude<keyof ReactOnRailsInternal, keyof BaseClientObjectType>;
+  type ProOnlyMethodName = (typeof PRO_ONLY_METHODS)[number];
+  type AssertMatch = [OmittedBaseKeys] extends [ProOnlyMethodName]
+    ? [ProOnlyMethodName] extends [OmittedBaseKeys]
+      ? true
+      : never
+    : never;
+  const assertProOnlyMethodsMatchOmit = true satisfies AssertMatch;
+  void assertProOnlyMethodsMatchOmit;
+
   // Delegate the core method implementations to `createCoreCapability` (the canonical source),
-  // then re-shape to the historical base surface: strip the Pro-only stubs and add the
-  // client-side lifecycle stubs that `createReactOnRails` overrides at initialization. The
-  // stripped names are kept in sync with the `Omit<...>` in BaseClientObjectType so the shim
-  // object's enumerable keys match what old Pro consumers received.
-  const proOnlyMethods = new Set<string>([
-    'getOrWaitForComponent',
-    'getOrWaitForStore',
-    'getOrWaitForStoreGenerator',
-    'reactOnRailsStoreLoaded',
-    'streamServerRenderedReactComponent',
-    'serverRenderRSCReactComponent',
-    'addAsyncPropsCapabilityToComponentProps',
-    'getOrCreateAsyncPropsManager',
-  ]);
+  // then re-shape to the historical base surface: strip the Pro-only stubs (using the shared
+  // `PRO_ONLY_METHODS` list that the drift guard above pins to `BaseClientObjectType`, so runtime
+  // and type can never drift) and add the client-side lifecycle stubs that `createReactOnRails`
+  // overrides at initialization.
+  const proOnlyMethods = new Set<string>(PRO_ONLY_METHODS);
   const core = createCoreCapability(registries);
   const obj = Object.fromEntries(
     Object.entries(core).filter(([key]) => !proOnlyMethods.has(key)),

--- a/packages/react-on-rails/src/base/full.rsc.ts
+++ b/packages/react-on-rails/src/base/full.rsc.ts
@@ -3,8 +3,13 @@
  * with older versions of react-on-rails-pro that import from `react-on-rails/@internal/base/full`.
  */
 
+// This is a thin compatibility shim: the RSC SSR stubs live in `capabilities/ssr.rsc.ts`
+// (`createSSRCapability`). This file composes them onto the base client object, preserving
+// the historical `createBaseFullObject` surface old Pro consumers rely on.
+
 import { createBaseClientObject, type BaseClientObjectType } from './client.ts';
 import type { BaseFullObjectType, ReactOnRailsFullSpecificFunctions } from './full.ts';
+import { createSSRCapability } from '../capabilities/ssr.rsc.ts';
 
 export type * from './full.ts';
 
@@ -15,21 +20,9 @@ export function createBaseFullObject(
   // Get or create client object (with caching logic)
   const clientObject = createBaseClientObject(registries, currentObject);
 
-  // Define SSR-specific functions with proper types
-  // This object acts as a type-safe specification of what we're adding to the base object
-  const reactOnRailsFullSpecificFunctions: ReactOnRailsFullSpecificFunctions = {
-    handleError() {
-      throw new Error('"handleError" function is not supported in RSC bundle');
-    },
-
-    serverRenderReactComponent() {
-      throw new Error('"serverRenderReactComponent" function is not supported in RSC bundle');
-    },
-
-    prepareRenderResult() {
-      throw new Error('"prepareRenderResult" function is not supported in RSC bundle');
-    },
-  };
+  // Delegate the RSC SSR stubs to `createSSRCapability` (the canonical source).
+  // Typed to ReactOnRailsFullSpecificFunctions so we add exactly the SSR surface, nothing more.
+  const reactOnRailsFullSpecificFunctions: ReactOnRailsFullSpecificFunctions = createSSRCapability();
 
   // Type assertion is safe here because:
   // 1. We start with BaseClientObjectType (from createBaseClientObject)

--- a/packages/react-on-rails/src/base/full.ts
+++ b/packages/react-on-rails/src/base/full.ts
@@ -3,20 +3,13 @@
  * with older versions of react-on-rails-pro that import from `react-on-rails/@internal/base/full`.
  */
 
-import { createBaseClientObject, type BaseClientObjectType } from './client.ts';
-import type { ReactOnRailsInternal, RenderParams, ErrorOptions, RenderingError } from '../types/index.ts';
-import handleError from '../handleError.ts';
-import serverRenderReactComponent from '../serverRenderReactComponent.ts';
-import { buildLengthPrefixedResult } from '../serverRenderUtils.ts';
+// This is a thin compatibility shim: the SSR implementations live in `capabilities/ssr.ts`
+// (`createSSRCapability`). This file composes them onto the base client object, preserving
+// the historical `createBaseFullObject` surface old Pro consumers rely on.
 
-// Warn about bundle size when included in browser bundles
-if (typeof window !== 'undefined') {
-  console.warn(
-    'Optimization opportunity: "react-on-rails" includes ~14KB of server-rendering code. ' +
-      'Browsers may not need it. See https://forum.shakacode.com/t/how-to-use-different-versions-of-a-file-for-client-and-server-rendering/1352 ' +
-      '(Requires creating a free account). Click this for the stack trace.',
-  );
-}
+import { createBaseClientObject, type BaseClientObjectType } from './client.ts';
+import type { ReactOnRailsInternal } from '../types/index.ts';
+import { createSSRCapability } from '../capabilities/ssr.ts';
 
 /**
  * SSR-specific functions that extend the base client object to create a full object.
@@ -43,29 +36,9 @@ export function createBaseFullObject(
   // Get or create client object (with caching logic)
   const clientObject = createBaseClientObject(registries, currentObject);
 
-  // Define SSR-specific functions with proper types
-  // This object acts as a type-safe specification of what we're adding to the base object
-  const reactOnRailsFullSpecificFunctions: ReactOnRailsFullSpecificFunctions = {
-    handleError(options: ErrorOptions): string | undefined {
-      return handleError(options);
-    },
-
-    serverRenderReactComponent(options: RenderParams): null | string | Promise<string> {
-      return serverRenderReactComponent(options);
-    },
-
-    prepareRenderResult(
-      html: string,
-      consoleReplayScript: string,
-      hasErrors: boolean,
-      renderingError: RenderingError | null,
-    ): string {
-      return buildLengthPrefixedResult(html, consoleReplayScript, {
-        hasErrors,
-        error: renderingError ?? undefined,
-      });
-    },
-  };
+  // Delegate the SSR-specific functions to `createSSRCapability` (the canonical source).
+  // Typed to ReactOnRailsFullSpecificFunctions so we add exactly the SSR surface, nothing more.
+  const reactOnRailsFullSpecificFunctions: ReactOnRailsFullSpecificFunctions = createSSRCapability();
 
   // Type assertion is safe here because:
   // 1. We start with BaseClientObjectType (from createBaseClientObject)

--- a/packages/react-on-rails/src/capabilities/core.ts
+++ b/packages/react-on-rails/src/capabilities/core.ts
@@ -106,7 +106,6 @@ export function createCoreCapability(registries: Registries) {
       }
 
       if (Object.prototype.hasOwnProperty.call(newOptions, 'rootErrorHandlers')) {
-        // MIRROR OF: packages/react-on-rails/src/base/client.ts
         // Validates and merges the handlers per key (partial updates keep previously registered
         // callbacks); warns when the React runtime cannot support them. Store the merged result so
         // `option('rootErrorHandlers')` reflects the effective registration.


### PR DESCRIPTION
## Why

The `@deprecated` back-compat shims `base/client.ts`, `base/full.ts`, and `base/full.rsc.ts` are kept only so older *published* `react-on-rails-pro` versions can keep importing `react-on-rails/@internal/base/client` and `@internal/base/full`. Instead of delegating to their replacements, they **cloned ~220 lines** of `capabilities/core.ts` / `capabilities/ssr.ts` / `capabilities/ssr.rsc.ts`. Only the 13-line `rootErrorHandlers` block was guarded by `bin/lint-mirrored-blocks` (the `MIRROR OF:` marker pair); the surrounding ~200 duplicated lines could drift silently.

The compatibility contract is the **exported surface**, not the duplicated bodies. So the shims now delegate. (In-repo Pro packages import nothing from `@internal/base` — verified with `git grep` — so surface parity is judged against the emitted `.d.ts` baseline + the runtime object shape, exactly as the issue prescribes.)

Fixes #4413

## What changed

- **`base/client.ts`** (375 -> 155 lines): builds its object from `createCoreCapability(registries)`, strips the 8 Pro-only stubs (the same names the `Omit<...>` in `BaseClientObjectType` removes), and re-adds the two client-side lifecycle **throwing stubs** (`reactOnRailsPageLoaded` / `reactOnRailsComponentLoaded`) that `createReactOnRails` overrides at init. Its own singleton caching/validation is preserved verbatim.
- **`base/full.ts`** (83 -> 56 lines): delegates the SSR functions to `createSSRCapability()` from `capabilities/ssr.ts`; same `Object.assign` composition and explicit `ReactOnRailsFullSpecificFunctions` typing as before.
- **`base/full.rsc.ts`** (47 -> 40 lines): delegates to `createSSRCapability()` from `capabilities/ssr.rsc.ts` (the RSC throwing stubs).
- **`capabilities/core.ts`**: removes only its now-orphaned `// MIRROR OF:` comment line (one line; no surface change — its `.d.ts` is byte-identical, verified). This is required because the mirror guard is reciprocal: once `base/client.ts` no longer clones the block, the core-side marker has no counterpart. `capabilities/ssr.ts` / `capabilities/ssr.rsc.ts` (delegation targets) are **untouched**.

Net **-255 lines** (58 insertions / 313 deletions).

## Compatibility proof — exported surface unchanged

The emitted `.d.ts` for all three shims is **byte-identical** to `origin/main` (baseline captured before the change, re-diffed after):

```
base/client.d.ts:   IDENTICAL
base/full.d.ts:     IDENTICAL
base/full.rsc.d.ts: IDENTICAL
```

And the **runtime object key sets** are identical before vs after (built the object both ways and diffed `Object.keys(...).sort()`):

```
createBaseClientObject: 28 keys, IDENTICAL to origin/main
createBaseFullObject:   28 keys, IDENTICAL to origin/main
```

Runtime smoke test confirms: **zero Pro-method leakage** into the base object, both lifecycle stubs present and throwing the historical `"is not initialized. This is a bug in react-on-rails."` error, and `capabilities/core.ts`'s own `.d.ts` is unchanged (target surface preserved).

## Validation (real results)

| Check | Command | Result |
|---|---|---|
| Type-check (all 3 pkgs) | `pnpm --filter react-on-rails{,-pro,-pro-node-renderer} run type-check` | pass |
| Build | `pnpm run build` (react-on-rails) | pass |
| `.d.ts` surface diff | `diff` baseline vs new | byte-identical (all 3) |
| Unit tests | `pnpm run test` (react-on-rails) | 359 passed / 26 suites (incl. the `deprecated base client` test importing `createBaseClientObject` directly) |
| ESLint | `pnpm run lint` | pass |
| Prettier | `prettier --check` (changed files) | pass |
| Knip | `pnpm run knip` | pass (only pre-existing spec/dummy config hints) |
| Mirror guard | `ruby bin/lint-mirrored-blocks` | pass — now `2 MIRROR OF: markers across 1 pair` (was 4/2); obsolete base<->core pair removed, unrelated ClientRenderer pair intact |
| Runtime shape | node smoke test | key sets identical, stubs throw, no Pro leakage |

## bin/lint-mirrored-blocks

**Not modified.** The guard is generic and reciprocal; deleting the `MIRROR OF:` marker from `base/client.ts` (the delegated file) and its orphaned counterpart in `capabilities/core.ts` is sufficient. The tool then reports the pair is gone and stays green. No change to the tool itself was needed.

## Codex Decision Log

- **Codex review** (`codex review --base origin/main`, exit 0) verdict: *"The changes consistently delegate the deprecated base shims to the existing capability implementations without introducing an observable behavioral regression in the reviewed diff."* — **no findings**.
- Manual adversarial self-review corroborated: the three behavioral risks were (1) Pro-stub leakage from delegating to `createCoreCapability` — mitigated by stripping the 8 Pro keys and proven by the runtime key-set diff; (2) losing the lifecycle throwing stubs — re-added explicitly and proven by the smoke test; (3) breaking the reciprocal mirror guard — resolved by removing the orphaned marker and confirmed by `bin/lint-mirrored-blocks` exit 0. Singleton caching/validation in `base/client.ts` is preserved verbatim.

## Labels

`Labels: ready-for-hosted-ci` — `script/ci-changes-detector origin/main` sets `run_generators=true` for JS/TS changes, so `required-pr-gate` needs hosted CI confirmation for this npm-package change even though generators aren't touched.

Generated with [Claude Code](https://claude.com/claude-code)
