### PR TITLE
Improve release-finish dry-run fetch handling

### DIFF
--- a/script/release-finish
+++ b/script/release-finish
@@ -116,7 +116,7 @@ class ReleaseFinish
       parser.on("--remote NAME", "Remote for fetch and branch deletion (default: origin)") do |remote|
         @options[:remote] = remote
       end
-      parser.on("--dry-run", "Print the exact commands without executing any of them") do
+      parser.on("--dry-run", "Preview the plan; still fetches remote refs needed for current-state checks") do
         @options[:dry_run] = true
       end
       parser.on("--yes", "Skip interactive confirmations (still honors --dry-run)") do
@@ -155,10 +155,10 @@ class ReleaseFinish
     release_branch = "release/#{version}"
 
     section "Promote #{version} (runbook step 4)"
-    fetch_remote!(@options.fetch(:remote))
     ensure_on_release_branch!(release_branch)
     ensure_clean_worktree!
 
+    fetch_remote!(@options.fetch(:remote))
     rc_tag = resolve_rc_tag!(version)
     ensure_tip_matches_rc_tag!(rc_tag)
 
@@ -269,10 +269,11 @@ class ReleaseFinish
     source = "#{remote}/#{release_branch}"
 
     section "Close out #{version} (runbook step 5)"
-    fetch_remote!(remote)
     ensure_on_main!
-    ensure_local_main_matches_remote!(remote)
     ensure_clean_worktree!
+
+    fetch_remote!(remote)
+    ensure_local_main_matches_remote!(remote)
 
     forward_port_to_main!(source)
     delete_release_branch!(release_branch, remote)
@@ -442,16 +443,16 @@ class ReleaseFinish
     answer.strip.casecmp?("y") || answer.strip.casecmp?("yes")
   end
 
-  # Run a command, or print it under --dry-run. Read-only setup (git fetch, the
-  # forward-port dry-run) flows through here so dry-run prints the full recipe.
-  def run_or_print(*command)
-    if @options[:dry_run]
+  # Run a command, or print it under --dry-run. Use force for read-only probes
+  # that must execute even while dry-run previews outward release actions.
+  def run_or_print(*command, env: {}, force: false)
+    if @options[:dry_run] && !force
       puts "DRY RUN: would run: #{command.join(' ')}"
       return
     end
 
     puts "+ #{command.join(' ')}"
-    return if system(*command)
+    return if system(env, *command)
 
     raise GitError, "command failed: #{command.join(' ')}"
   end
@@ -467,10 +468,7 @@ class ReleaseFinish
     # Fetch is read-only for the worktree and release branches, and the dry-run
     # plan must resolve tags and remote-tracking refs from the same state as a
     # real run.
-    puts "+ git fetch -- #{remote}"
-    return if system("git", "fetch", "--", remote)
-
-    raise GitError, "command failed: git fetch -- #{remote}"
+    run_or_print("git", "fetch", "--", remote, env: { "GIT_TERMINAL_PROMPT" => "0" }, force: true)
   end
 
   # ---------------------------------------------------------------------------

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -242,6 +242,7 @@ test_promote_aborts_when_not_on_release_branch() {
 
   assert_status 1 "$RF_STATUS" "promote wrong-branch status"
   assert_contains "$RF_OUT" "not on release/1.0.0" "promote wrong-branch"
+  assert_not_contains "$RF_OUT" "+ git fetch -- origin" "promote wrong-branch should stop before fetch"
   assert_not_contains "$RF_OUT" "rake release[1.0.0]" "promote wrong-branch should stop before release"
 }
 
@@ -287,6 +288,7 @@ test_promote_aborts_on_dirty_worktree() {
 
   assert_status 1 "$RF_STATUS" "promote dirty status"
   assert_contains "$RF_OUT" "working tree is not clean" "promote dirty"
+  assert_not_contains "$RF_OUT" "+ git fetch -- origin" "promote dirty should stop before fetch"
 }
 
 # --- promote: guard — missing rc tag ---------------------------------------
@@ -528,6 +530,7 @@ test_close_out_aborts_when_not_on_main() {
 
   assert_status 1 "$RF_STATUS" "close-out wrong-branch status"
   assert_contains "$RF_OUT" "not on main" "close-out wrong-branch"
+  assert_not_contains "$RF_OUT" "+ git fetch -- origin" "close-out wrong-branch should stop before fetch"
 }
 
 # --- close-out: guard — dirty tree -----------------------------------------
@@ -540,6 +543,7 @@ test_close_out_aborts_on_dirty_worktree() {
 
   assert_status 1 "$RF_STATUS" "close-out dirty status"
   assert_contains "$RF_OUT" "working tree is not clean" "close-out dirty"
+  assert_not_contains "$RF_OUT" "+ git fetch -- origin" "close-out dirty should stop before fetch"
 }
 
 # --- shared: argument validation -------------------------------------------
@@ -574,6 +578,7 @@ test_help_exits_zero() {
 
   assert_status 0 "$RF_STATUS" "help status"
   assert_contains "$RF_OUT" "Orchestrates the release-train runbook steps 4" "help"
+  assert_contains "$RF_OUT" "still fetches remote refs needed for current-state checks" "help dry-run fetch disclosure"
 }
 
 run_test test_promote_dry_run_prints_commands_and_runs_nothing


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #4382 review closeout.
- Document that `--dry-run` still performs the read-only fetch needed for current remote refs.
- Run cheap local branch/worktree guards before the fetch for `promote` and `close-out`.
- Reuse `run_or_print` for forced read-only fetches and set `GIT_TERMINAL_PROMPT=0` for non-prompting behavior.

## Review Thread Closeout
- Addresses https://github.com/shakacode/react_on_rails/pull/4382#discussion_r3511443107
- Addresses https://github.com/shakacode/react_on_rails/pull/4382#discussion_r3511443396

## Tests
- `ruby -c script/release-finish`
- `bash script/release-finish-test.bash`
- `BUNDLE_GEMFILE="$(pwd)/Gemfile" bundle exec rubocop script/release-finish`
- `git diff --check`
- `codex review --uncommitted` (no discrete correctness issues)

## Changelog
- Not user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow checks so branch and clean-working-tree validation happen before any remote fetches in failure cases.
  * Updated dry-run help and behavior: it still performs remote-reference fetching for state checks, while keeping command output accurate.
  * Remote fetch steps now run consistently with the intended dry-run/execute semantics.
* **Tests**
  * Strengthened release workflow tests to verify guard/abort output ordering and dry-run fetch messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->