### PR TITLE
[Pro] Reduce tag-index cache work during streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Changed
 
+- **[Pro]** **Reduced tag-index cache work for streamed cache writes**: Multi-tag cache registration now
+  batch-reads existing tag indexes when supported, and streamed cache misses defer cache writes and tag
+  registration until queued response chunks have drained. Streamed and async cache misses also register tags
+  with the same completion-time cache options used for the cache write, keeping TTL snapshots aligned. Fixes
+  [Issue 4319](https://github.com/shakacode/react_on_rails/issues/4319).
+  [PR 4443](https://github.com/shakacode/react_on_rails/pull/4443) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Fail fast for RSC with Rspack v1**: When React Server Components are enabled and Shakapacker is
   configured for Rspack, app boot and `react_on_rails:doctor` now reject `@rspack/core` v1 or a missing
   `@rspack/core` package with explicit Rspack v2 upgrade instructions. This guard only runs when RSC is enabled,

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1044,18 +1044,14 @@ module ReactOnRailsProHelper
   def handle_stream_cache_miss(component_name, raw_options, auto_load_bundle, view_cache_key, &)
     normalized_cache_tags = ReactOnRailsPro::Cache.normalize_tags(raw_options[:cache_tags])
     raw_cache_options = raw_options[:cache_options] || {}
-    tag_index_cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
     cache_aware_options = raw_options.merge(
       on_complete: lambda { |chunks|
-        next if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
-
-        cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
-        Rails.cache.write(view_cache_key, chunks, cache_options)
-        ReactOnRailsPro::Cache.register_normalized_tags(
-          normalized_cache_tags,
-          view_cache_key,
-          tag_index_cache_options
-        )
+        (@react_on_rails_pending_stream_cache_writes ||= []) << {
+          cache_key: view_cache_key,
+          chunks:,
+          normalized_cache_tags:,
+          raw_cache_options:
+        }
       }
     )
 
@@ -1122,7 +1118,7 @@ module ReactOnRailsProHelper
     end
 
     Rails.logger.debug { "React on Rails Pro async cache MISS for #{cache_key.inspect}" }
-    render_async_react_component_with_cache(component_name, raw_options, cache_key, raw_cache_options, cache_options, &)
+    render_async_react_component_with_cache(component_name, raw_options, cache_key, raw_cache_options, &)
   end
 
   # Renders async without caching (when :if/:unless conditions disable cache)
@@ -1142,7 +1138,6 @@ module ReactOnRailsProHelper
     raw_options,
     cache_key,
     raw_cache_options,
-    cache_options_at_miss,
     &
   )
     normalized_cache_tags = ReactOnRailsPro::Cache.normalize_tags(raw_options[:cache_tags])
@@ -1153,7 +1148,7 @@ module ReactOnRailsProHelper
       unless ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
         cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
         Rails.cache.write(cache_key, result, cache_options)
-        ReactOnRailsPro::Cache.register_normalized_tags(normalized_cache_tags, cache_key, cache_options_at_miss)
+        ReactOnRailsPro::Cache.register_normalized_tags(normalized_cache_tags, cache_key, cache_options)
       end
       result
     end

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1046,12 +1046,19 @@ module ReactOnRailsProHelper
     raw_cache_options = raw_options[:cache_options] || {}
     cache_aware_options = raw_options.merge(
       on_complete: lambda { |chunks|
-        (@react_on_rails_pending_stream_cache_writes ||= []) << {
+        cache_write = {
           cache_key: view_cache_key,
           chunks:,
           normalized_cache_tags:,
           raw_cache_options:
         }
+
+        pending_stream_cache_writes = @react_on_rails_pending_stream_cache_writes
+        if pending_stream_cache_writes
+          pending_stream_cache_writes << cache_write
+        else
+          ReactOnRailsPro::StreamCacheWrites.flush([cache_write])
+        end
       }
     )
 

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1046,12 +1046,13 @@ module ReactOnRailsProHelper
     raw_cache_options = raw_options[:cache_options] || {}
     cache_aware_options = raw_options.merge(
       on_complete: lambda { |chunks|
-        cache_write = {
+        cache_write = ReactOnRailsPro::StreamCacheWrites.build(
           cache_key: view_cache_key,
           chunks:,
           normalized_cache_tags:,
           raw_cache_options:
-        }
+        )
+        next unless cache_write
 
         pending_stream_cache_writes = @react_on_rails_pending_stream_cache_writes
         if pending_stream_cache_writes

--- a/react_on_rails_pro/lib/react_on_rails_pro/cache/tag_index.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/cache/tag_index.rb
@@ -29,12 +29,13 @@ module ReactOnRailsPro
     #   limits. The payload holds the expanded entry keys written under that
     #   tag plus the index entry's own absolute expiry so concurrent writers can
     #   merge to the max TTL.
-    # - Appends are a plain read-modify-write. ActiveSupport::Cache has no
-    #   atomic set-append, so concurrent appends under the same tag can lose an
-    #   index entry (lossy-OK). A lost entry is lost only from the *index* —
-    #   the cached data is intact; it just survives revalidate_tag and expires
-    #   via its own :expires_in. Tag revalidation is therefore best-effort,
-    #   with correctness bounded by :expires_in.
+    # - Appends batch-read existing index entries, then write each updated
+    #   entry with its own TTL. ActiveSupport::Cache has no atomic set-append,
+    #   so concurrent appends under the same tag can lose an index entry
+    #   (lossy-OK). A lost entry is lost only from the *index* — the cached data
+    #   is intact; it just survives revalidate_tag and expires via its own
+    #   :expires_in. Tag revalidation is therefore best-effort, with
+    #   correctness bounded by :expires_in.
     # - A missing or evicted index entry means "nothing to revalidate" — never
     #   an error. This also covers :null_store and per-process :memory_store.
     # rubocop:disable Metrics/ClassLength
@@ -82,7 +83,7 @@ module ReactOnRailsPro
           entry_options = merged_cache_options(cache_options)
           entry_key = normalized_entry_key(cache_key, cache_options)
           warn_if_expires_in_missing(entry_options, entry_key)
-          normalized_tags.uniq.each { |tag| append_entry_key(tag, entry_key, entry_options) }
+          append_entry_keys(normalized_tags.uniq, entry_key, entry_options)
         end
 
         # Deletes every cache entry recorded under the given tags, then the
@@ -172,21 +173,37 @@ module ReactOnRailsPro
                 "Save the record before using it as a cache tag, or use an explicit String tag."
         end
 
-        def append_entry_key(tag, entry_key, cache_options)
-          key = index_key(tag)
-          keys, existing_expires_at = read_index(key)
-          # De-dup while keeping the entry key in last (most recent) position.
-          keys.delete(entry_key)
-          keys << entry_key
-          enforce_max_keys(tag, keys)
-
+        def append_entry_keys(tags, entry_key, cache_options)
+          keys_by_tag = tags.to_h { |tag| [tag, index_key(tag)] }
+          existing_indexes = read_indexes(keys_by_tag.values)
           now = Time.now.to_f
-          expires_at = [existing_expires_at, now + index_ttl(cache_options)].compact.max
-          write_index(key, keys, expires_at)
+          entry_expires_at = now + index_ttl(cache_options)
+
+          tags.each do |tag|
+            key = keys_by_tag[tag]
+            keys, existing_expires_at = existing_indexes.fetch(key)
+            # De-dup while keeping the entry key in last (most recent) position.
+            keys.delete(entry_key)
+            keys << entry_key
+            enforce_max_keys(tag, keys)
+
+            expires_at = [existing_expires_at, entry_expires_at].compact.max
+            write_index(key, keys, expires_at)
+          end
         end
 
         def read_index(key)
-          payload = Rails.cache.read(key)
+          parse_index_payload(Rails.cache.read(key))
+        end
+
+        def read_indexes(keys)
+          return keys.to_h { |key| [key, read_index(key)] } if keys.one? || !Rails.cache.respond_to?(:read_multi)
+
+          payloads = Rails.cache.read_multi(*keys)
+          keys.to_h { |key| [key, parse_index_payload(payloads[key])] }
+        end
+
+        def parse_index_payload(payload)
           case payload
           when Hash
             [Array(payload["keys"]), payload["expires_at"]&.to_f]

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -27,7 +27,7 @@ module ReactOnRailsPro
         cache_key:,
         chunks:,
         normalized_cache_tags:,
-        cache_options: cache_write_options(raw_cache_options)
+        cache_options: ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
       }
     end
 
@@ -56,21 +56,6 @@ module ReactOnRailsPro
       )
     rescue StandardError
       # Cache write failure logging must not keep a fully drained response open.
-    end
-
-    def cache_write_options(raw_cache_options)
-      unless snapshot_expires_at?(raw_cache_options)
-        return ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
-      end
-
-      expires_in = raw_cache_options[:expires_at].to_time.to_f - Time.now.to_f
-      raw_cache_options.merge(
-        expires_in: [expires_in, ReactOnRailsPro::Cache::EXPIRED_CACHE_WRITE_TTL].max
-      ).except(:expires_at)
-    end
-
-    def snapshot_expires_at?(raw_cache_options)
-      raw_cache_options && raw_cache_options[:expires_at] && ReactOnRailsPro::Cache.cache_supports_expires_at?
     end
   end
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -27,7 +27,7 @@ module ReactOnRailsPro
         cache_key:,
         chunks:,
         normalized_cache_tags:,
-        cache_options: ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
+        raw_cache_options: raw_cache_options&.dup || {}
       }
     end
 
@@ -40,7 +40,10 @@ module ReactOnRailsPro
     end
 
     def write(cache_write)
-      cache_options = cache_write[:cache_options]
+      raw_cache_options = cache_write[:raw_cache_options]
+      return if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
+
+      cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
       Rails.cache.write(cache_write[:cache_key], cache_write[:chunks], cache_options)
       ReactOnRailsPro::Cache.register_normalized_tags(
         cache_write[:normalized_cache_tags],

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -22,24 +22,28 @@ module ReactOnRailsPro
 
     def flush(pending_writes)
       Array(pending_writes).each do |cache_write|
-        raw_cache_options = cache_write[:raw_cache_options]
-        next if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
-
-        cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
-        Rails.cache.write(cache_write[:cache_key], cache_write[:chunks], cache_options)
-        ReactOnRailsPro::Cache.register_normalized_tags(
-          cache_write[:normalized_cache_tags],
-          cache_write[:cache_key],
-          cache_options
-        )
+        write(cache_write)
+      rescue StandardError => e
+        log_failure(e)
       end
-    rescue StandardError => e
-      log_failure(e)
+    end
+
+    def write(cache_write)
+      raw_cache_options = cache_write[:raw_cache_options]
+      return if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
+
+      cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
+      Rails.cache.write(cache_write[:cache_key], cache_write[:chunks], cache_options)
+      ReactOnRailsPro::Cache.register_normalized_tags(
+        cache_write[:normalized_cache_tags],
+        cache_write[:cache_key],
+        cache_options
+      )
     end
 
     def log_failure(exception)
       Rails.logger.warn(
-        "[React on Rails Pro] Failed to write streamed cache entries after response drain: " \
+        "[React on Rails Pro] Failed to write streamed cache entry after response drain: " \
         "#{exception.class}: #{exception.message}"
       )
     rescue StandardError
@@ -127,7 +131,7 @@ module ReactOnRailsPro
         # the barrier may still have pending tasks that must be cancelled.
         # For post-commit errors (from drain_streams_concurrently), the barrier
         # is already stopped inside that method — stopping again is a no-op.
-        @async_barrier&.stop
+        stop_streaming_and_flush_cache_writes
         raise
       end
     ensure
@@ -280,6 +284,8 @@ module ReactOnRailsPro
     ensure
       @react_on_rails_pending_stream_cache_writes&.clear
     end
+
+    def stop_streaming_and_flush_cache_writes = @async_barrier&.stop.then { flush_pending_stream_cache_writes }
 
     # Drains all streaming tasks concurrently using a producer-consumer pattern.
     #

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -17,6 +17,25 @@ require "English"
 require "erb/util"
 
 module ReactOnRailsPro
+  module StreamCacheWrites
+    module_function
+
+    def flush(pending_writes)
+      Array(pending_writes).each do |cache_write|
+        raw_cache_options = cache_write[:raw_cache_options]
+        next if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
+
+        cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
+        Rails.cache.write(cache_write[:cache_key], cache_write[:chunks], cache_options)
+        ReactOnRailsPro::Cache.register_normalized_tags(
+          cache_write[:normalized_cache_tags],
+          cache_write[:cache_key],
+          cache_options
+        )
+      end
+    end
+  end
+
   module Stream
     extend ActiveSupport::Concern
 
@@ -64,6 +83,7 @@ module ReactOnRailsPro
         @async_barrier = Async::Barrier.new
         buffer_size = ReactOnRailsPro.configuration.concurrent_component_streaming_buffer_size
         @main_output_queue = Async::LimitedQueue.new(buffer_size)
+        @react_on_rails_pending_stream_cache_writes = []
 
         # Render template - components will start streaming immediately.
         # If a shell error occurs, consumer_stream_async raises PrerenderError here
@@ -85,6 +105,7 @@ module ReactOnRailsPro
 
         drain_streams_concurrently(parent_task)
         write_rsc_stream_observability_mark
+        flush_pending_stream_cache_writes
         # Do not close the response stream in an ensure block.
         # If an error occurs we may need the stream open to send diagnostic/error details
         # (for example, ApplicationController#rescue_from in the dummy app).
@@ -99,6 +120,7 @@ module ReactOnRailsPro
         raise
       end
     ensure
+      @react_on_rails_pending_stream_cache_writes = nil
       restore_rsc_stream_observability_state(previous_rsc_stream_observability_state)
     end
 
@@ -240,6 +262,12 @@ module ReactOnRailsPro
 
       nonce = content_security_policy_nonce
       nonce.present? ? %( nonce="#{ERB::Util.html_escape(nonce)}") : ""
+    end
+
+    def flush_pending_stream_cache_writes
+      ReactOnRailsPro::StreamCacheWrites.flush(@react_on_rails_pending_stream_cache_writes)
+    ensure
+      @react_on_rails_pending_stream_cache_writes&.clear
     end
 
     # Drains all streaming tasks concurrently using a producer-consumer pattern.

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -20,6 +20,17 @@ module ReactOnRailsPro
   module StreamCacheWrites
     module_function
 
+    def build(cache_key:, chunks:, normalized_cache_tags:, raw_cache_options:)
+      return if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
+
+      {
+        cache_key:,
+        chunks:,
+        normalized_cache_tags:,
+        cache_options: cache_write_options(raw_cache_options)
+      }
+    end
+
     def flush(pending_writes)
       Array(pending_writes).each do |cache_write|
         write(cache_write)
@@ -29,10 +40,7 @@ module ReactOnRailsPro
     end
 
     def write(cache_write)
-      raw_cache_options = cache_write[:raw_cache_options]
-      return if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
-
-      cache_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
+      cache_options = cache_write[:cache_options]
       Rails.cache.write(cache_write[:cache_key], cache_write[:chunks], cache_options)
       ReactOnRailsPro::Cache.register_normalized_tags(
         cache_write[:normalized_cache_tags],
@@ -49,9 +57,24 @@ module ReactOnRailsPro
     rescue StandardError
       # Cache write failure logging must not keep a fully drained response open.
     end
+
+    def cache_write_options(raw_cache_options)
+      unless snapshot_expires_at?(raw_cache_options)
+        return ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
+      end
+
+      expires_in = raw_cache_options[:expires_at].to_time.to_f - Time.now.to_f
+      raw_cache_options.merge(
+        expires_in: [expires_in, ReactOnRailsPro::Cache::EXPIRED_CACHE_WRITE_TTL].max
+      ).except(:expires_at)
+    end
+
+    def snapshot_expires_at?(raw_cache_options)
+      raw_cache_options && raw_cache_options[:expires_at] && ReactOnRailsPro::Cache.cache_supports_expires_at?
+    end
   end
 
-  module Stream
+  module Stream # rubocop:disable Metrics/ModuleLength
     extend ActiveSupport::Concern
 
     included do
@@ -285,7 +308,10 @@ module ReactOnRailsPro
       @react_on_rails_pending_stream_cache_writes&.clear
     end
 
-    def stop_streaming_and_flush_cache_writes = @async_barrier&.stop.then { flush_pending_stream_cache_writes }
+    def stop_streaming_and_flush_cache_writes
+      @async_barrier&.stop
+      flush_pending_stream_cache_writes
+    end
 
     # Drains all streaming tasks concurrently using a producer-consumer pattern.
     #

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -33,6 +33,17 @@ module ReactOnRailsPro
           cache_options
         )
       end
+    rescue StandardError => e
+      log_failure(e)
+    end
+
+    def log_failure(exception)
+      Rails.logger.warn(
+        "[React on Rails Pro] Failed to write streamed cache entries after response drain: " \
+        "#{exception.class}: #{exception.message}"
+      )
+    rescue StandardError
+      # Cache write failure logging must not keep a fully drained response open.
     end
   end
 

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1043,17 +1043,16 @@ describe ReactOnRailsProHelper do
           cache_key: "first-stream-cache-key",
           chunks: ["first chunk"],
           normalized_cache_tags: ["first-tag"],
-          raw_cache_options: { expires_in: 60 }
+          cache_options: { expires_in: 60 }
         }
         second_write = {
           cache_key: "second-stream-cache-key",
           chunks: ["second chunk"],
           normalized_cache_tags: ["second-tag"],
-          raw_cache_options: { expires_in: 60 }
+          cache_options: { expires_in: 60 }
         }
-        write_options = { expires_in: 45 }
+        write_options = { expires_in: 60 }
 
-        allow(ReactOnRailsPro::Cache).to receive(:cache_write_options).and_return(write_options)
         allow(Rails.cache).to receive(:write) do |cache_key, *_args|
           raise StandardError, "cache unavailable" if cache_key == "first-stream-cache-key"
         end
@@ -1080,9 +1079,9 @@ describe ReactOnRailsProHelper do
           cache_key: "completed-stream-cache-key",
           chunks: ["completed chunk"],
           normalized_cache_tags: ["completed-tag"],
-          raw_cache_options: { expires_in: 60 }
+          cache_options: { expires_in: 60 }
         }
-        write_options = { expires_in: 45 }
+        write_options = { expires_in: 60 }
 
         allow(self).to receive(:render_stream_template_chunk).and_return("initial chunk")
         allow(self).to receive(:emit_rsc_stream_server_timing_header)
@@ -1090,7 +1089,6 @@ describe ReactOnRailsProHelper do
           @react_on_rails_pending_stream_cache_writes << pending_write
           raise StandardError, "later stream failure"
         end
-        allow(ReactOnRailsPro::Cache).to receive(:cache_write_options).and_return(write_options)
         allow(Rails.cache).to receive(:write)
         allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
 
@@ -1103,8 +1101,8 @@ describe ReactOnRailsProHelper do
           .with(["completed-tag"], "completed-stream-cache-key", write_options)
       end
 
-      it "defers stream cache writes and registers tags with the write options from flush time" do
-        raw_cache_options = { expires_at: Time.now + 60 }
+      it "defers stream cache writes and registers tags with the write options captured at completion time" do
+        raw_cache_options = { expires_in: 60 }
         write_cache_options = { expires_in: 45 }
         captured_on_complete = nil
 
@@ -1132,7 +1130,7 @@ describe ReactOnRailsProHelper do
 
         captured_on_complete.call(["chunk"])
 
-        expect(ReactOnRailsPro::Cache).not_to have_received(:cache_write_options)
+        expect(ReactOnRailsPro::Cache).to have_received(:cache_write_options).once
         expect(Rails.cache).not_to have_received(:write)
         expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
 
@@ -1145,7 +1143,7 @@ describe ReactOnRailsProHelper do
       end
 
       it "writes stream cache immediately when no managed stream view flush is active" do
-        raw_cache_options = { expires_at: Time.now + 60 }
+        raw_cache_options = { expires_in: 60 }
         write_cache_options = { expires_in: 45 }
         captured_on_complete = nil
 
@@ -1178,11 +1176,46 @@ describe ReactOnRailsProHelper do
         expect(@react_on_rails_pending_stream_cache_writes).to be_nil
       end
 
-      it "does not flush stream cache entries whose expires_at passed before flush" do
-        raw_cache_options = { expires_at: Time.now - 60 }
+      it "writes stream cache entries with the expires_at TTL captured before deferred flush" do
+        completion_time = Time.now
+        raw_cache_options = { expires_at: completion_time + 5 }
         captured_on_complete = nil
 
-        allow(ReactOnRailsPro::Cache).to receive(:cache_write_options)
+        allow(Time).to receive(:now).and_return(completion_time)
+        allow(Rails.cache).to receive(:write)
+        allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
+        allow(self).to receive(:render_stream_component_with_props) do |_component_name, options, _auto_load_bundle, &|
+          captured_on_complete = options[:on_complete]
+          "initial chunk"
+        end
+        @react_on_rails_pending_stream_cache_writes = []
+
+        result = send(
+          :handle_stream_cache_miss,
+          component_name,
+          { cache_tags: ["stream-tag"], cache_options: raw_cache_options },
+          true,
+          "stream-cache-key"
+        ) { props }
+
+        expect(result).to eq("initial chunk")
+
+        captured_on_complete.call(["chunk"])
+        allow(Time).to receive(:now).and_return(completion_time + 10)
+        send(:flush_pending_stream_cache_writes)
+
+        expect(Rails.cache).to have_received(:write)
+          .with("stream-cache-key", ["chunk"], hash_including(expires_in: be_within(0.1).of(5)))
+        expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
+          .with(["stream-tag"], "stream-cache-key", hash_including(expires_in: be_within(0.1).of(5)))
+      end
+
+      it "does not queue stream cache entries whose expires_at passed before completion" do
+        completion_time = Time.now
+        raw_cache_options = { expires_at: completion_time - 60 }
+        captured_on_complete = nil
+
+        allow(Time).to receive(:now).and_return(completion_time)
         allow(Rails.cache).to receive(:write)
         allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
         allow(self).to receive(:render_stream_component_with_props) do |_component_name, options, _auto_load_bundle, &|
@@ -1204,7 +1237,7 @@ describe ReactOnRailsProHelper do
         captured_on_complete.call(["chunk"])
         send(:flush_pending_stream_cache_writes)
 
-        expect(ReactOnRailsPro::Cache).not_to have_received(:cache_write_options)
+        expect(@react_on_rails_pending_stream_cache_writes).to be_empty
         expect(Rails.cache).not_to have_received(:write)
         expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
       end

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -978,14 +978,18 @@ describe ReactOnRailsProHelper do
       it "serves MISS then HIT with identical chunks and no second Node call" do
         mock_request_and_response
         render_with_cached_stream
+        cache_write_chunk_counts = []
 
-        expect(Rails.cache)
-          .to receive(:write).with(anything, kind_of(Array), hash_including(expires_in: 60)).and_call_original
+        allow(Rails.cache).to receive(:write).and_wrap_original do |original_method, *args, **kwargs|
+          cache_write_chunk_counts << written_chunks.length
+          original_method.call(*args, **kwargs)
+        end
 
         # First render (MISS → write-through)
         first_run_chunks = run_stream
         expect(chunks_read.count).to eq(chunks.count)
         expect(first_run_chunks.first).to include("<h1>Header Rendered In View</h1>")
+        expect(cache_write_chunk_counts).to eq([first_run_chunks.length])
 
         # Second render (HIT → served from cache, no Node call; no new HTTPX chunks)
         reset_stream_buffers
@@ -1019,15 +1023,14 @@ describe ReactOnRailsProHelper do
         expect(chunks_read.count).to eq(chunks.count)
       end
 
-      it "keeps stream tag-index options from shrinking while converting write options at completion" do
+      it "defers stream cache writes and registers tags with the write options from flush time" do
         raw_cache_options = { expires_at: Time.now + 60 }
-        tag_index_cache_options = { expires_in: 60 }
         write_cache_options = { expires_in: 45 }
         captured_on_complete = nil
 
         allow(ReactOnRailsPro::Cache).to receive(:cache_write_options)
           .with(raw_cache_options)
-          .and_return(tag_index_cache_options, write_cache_options)
+          .and_return(write_cache_options)
         allow(Rails.cache).to receive(:write)
         allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
         allow(self).to receive(:render_stream_component_with_props) do |_component_name, options, _auto_load_bundle, &|
@@ -1044,20 +1047,27 @@ describe ReactOnRailsProHelper do
         ) { props }
 
         expect(result).to eq("initial chunk")
-        expect(ReactOnRailsPro::Cache).to have_received(:cache_write_options).once
+        expect(ReactOnRailsPro::Cache).not_to have_received(:cache_write_options)
 
         captured_on_complete.call(["chunk"])
 
-        expect(ReactOnRailsPro::Cache).to have_received(:cache_write_options).twice
+        expect(ReactOnRailsPro::Cache).not_to have_received(:cache_write_options)
+        expect(Rails.cache).not_to have_received(:write)
+        expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
+
+        send(:flush_pending_stream_cache_writes)
+
+        expect(ReactOnRailsPro::Cache).to have_received(:cache_write_options).once
         expect(Rails.cache).to have_received(:write).with("stream-cache-key", ["chunk"], write_cache_options)
         expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
-          .with(["stream-tag"], "stream-cache-key", tag_index_cache_options)
+          .with(["stream-tag"], "stream-cache-key", write_cache_options)
       end
 
-      it "does not write or register stream cache entries whose expires_at passed before completion" do
+      it "does not flush stream cache entries whose expires_at passed before flush" do
         raw_cache_options = { expires_at: Time.now - 60 }
         captured_on_complete = nil
 
+        allow(ReactOnRailsPro::Cache).to receive(:cache_write_options)
         allow(Rails.cache).to receive(:write)
         allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
         allow(self).to receive(:render_stream_component_with_props) do |_component_name, options, _auto_load_bundle, &|
@@ -1076,7 +1086,9 @@ describe ReactOnRailsProHelper do
         expect(result).to eq("initial chunk")
 
         captured_on_complete.call(["chunk"])
+        send(:flush_pending_stream_cache_writes)
 
+        expect(ReactOnRailsPro::Cache).not_to have_received(:cache_write_options)
         expect(Rails.cache).not_to have_received(:write)
         expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
       end
@@ -2238,7 +2250,7 @@ describe ReactOnRailsProHelper do
         expect(Rails.cache.read(component_cache_key)).to be_nil
       end
 
-      it "recomputes async write options at completion while keeping tag-index options from miss time" do
+      it "registers async tags with the write options from completion time" do
         raw_cache_options = { expires_at: Time.now + 60 }
         tag_index_cache_options = { expires_in: 60 }
         write_cache_options = { expires_in: 45 }
@@ -2263,7 +2275,7 @@ describe ReactOnRailsProHelper do
         expect(ReactOnRailsPro::Cache).to have_received(:cache_write_options).twice
         expect(Rails.cache).to have_received(:write).with(component_cache_key, "<div>async</div>", write_cache_options)
         expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
-          .with(["async-tag"], component_cache_key, tag_index_cache_options)
+          .with(["async-tag"], component_cache_key, write_cache_options)
       end
 
       it "respects :if option for conditional caching" do

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1043,13 +1043,13 @@ describe ReactOnRailsProHelper do
           cache_key: "first-stream-cache-key",
           chunks: ["first chunk"],
           normalized_cache_tags: ["first-tag"],
-          cache_options: { expires_in: 60 }
+          raw_cache_options: { expires_in: 60 }
         }
         second_write = {
           cache_key: "second-stream-cache-key",
           chunks: ["second chunk"],
           normalized_cache_tags: ["second-tag"],
-          cache_options: { expires_in: 60 }
+          raw_cache_options: { expires_in: 60 }
         }
         write_options = { expires_in: 60 }
 
@@ -1079,7 +1079,7 @@ describe ReactOnRailsProHelper do
           cache_key: "completed-stream-cache-key",
           chunks: ["completed chunk"],
           normalized_cache_tags: ["completed-tag"],
-          cache_options: { expires_in: 60 }
+          raw_cache_options: { expires_in: 60 }
         }
         write_options = { expires_in: 60 }
 
@@ -1101,7 +1101,7 @@ describe ReactOnRailsProHelper do
           .with(["completed-tag"], "completed-stream-cache-key", write_options)
       end
 
-      it "defers stream cache writes and registers tags with the write options captured at completion time" do
+      it "defers stream cache writes and registers tags with the write options captured at flush time" do
         raw_cache_options = { expires_in: 60 }
         write_cache_options = { expires_in: 45 }
         captured_on_complete = nil
@@ -1130,7 +1130,7 @@ describe ReactOnRailsProHelper do
 
         captured_on_complete.call(["chunk"])
 
-        expect(ReactOnRailsPro::Cache).to have_received(:cache_write_options).once
+        expect(ReactOnRailsPro::Cache).not_to have_received(:cache_write_options)
         expect(Rails.cache).not_to have_received(:write)
         expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
 
@@ -1178,7 +1178,7 @@ describe ReactOnRailsProHelper do
 
       it "keeps stream cache expires_at absolute when deferred flush is delayed" do
         completion_time = Time.now
-        expires_at = completion_time + 5
+        expires_at = completion_time + 15
         raw_cache_options = { expires_at: }
         captured_on_complete = nil
 
@@ -1210,6 +1210,75 @@ describe ReactOnRailsProHelper do
           .with("stream-cache-key", ["chunk"], { expires_at: })
         expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
           .with(["stream-tag"], "stream-cache-key", { expires_at: })
+      end
+
+      it "converts stream cache expires_at at deferred flush time when the cache store lacks expires_at support" do
+        completion_time = Time.now
+        expires_at = completion_time + 15
+        raw_cache_options = { expires_at: }
+        captured_on_complete = nil
+
+        allow(ReactOnRailsPro::Cache).to receive(:cache_supports_expires_at?).and_return(false)
+        allow(Time).to receive(:now).and_return(completion_time)
+        allow(Rails.cache).to receive(:write)
+        allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
+        allow(self).to receive(:render_stream_component_with_props) do |_component_name, options, _auto_load_bundle, &|
+          captured_on_complete = options[:on_complete]
+          "initial chunk"
+        end
+        @react_on_rails_pending_stream_cache_writes = []
+
+        result = send(
+          :handle_stream_cache_miss,
+          component_name,
+          { cache_tags: ["stream-tag"], cache_options: raw_cache_options },
+          true,
+          "stream-cache-key"
+        ) { props }
+
+        expect(result).to eq("initial chunk")
+
+        captured_on_complete.call(["chunk"])
+        allow(Time).to receive(:now).and_return(completion_time + 10)
+        send(:flush_pending_stream_cache_writes)
+
+        expect(Rails.cache).to have_received(:write)
+          .with("stream-cache-key", ["chunk"], hash_including(expires_in: be_within(0.1).of(5)))
+        expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
+          .with(["stream-tag"], "stream-cache-key", hash_including(expires_in: be_within(0.1).of(5)))
+      end
+
+      it "does not write stream cache entries whose expires_at passed before deferred flush" do
+        completion_time = Time.now
+        raw_cache_options = { expires_at: completion_time + 5 }
+        captured_on_complete = nil
+
+        allow(Time).to receive(:now).and_return(completion_time)
+        allow(Rails.cache).to receive(:write)
+        allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
+        allow(self).to receive(:render_stream_component_with_props) do |_component_name, options, _auto_load_bundle, &|
+          captured_on_complete = options[:on_complete]
+          "initial chunk"
+        end
+        @react_on_rails_pending_stream_cache_writes = []
+
+        result = send(
+          :handle_stream_cache_miss,
+          component_name,
+          { cache_tags: ["stream-tag"], cache_options: raw_cache_options },
+          true,
+          "stream-cache-key"
+        ) { props }
+
+        expect(result).to eq("initial chunk")
+
+        captured_on_complete.call(["chunk"])
+        allow(Time).to receive(:now).and_return(completion_time + 10)
+        send(:flush_pending_stream_cache_writes)
+
+        expect(@react_on_rails_pending_stream_cache_writes).to be_empty
+        expect(Rails.cache).not_to have_received(:write)
+        expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
       end
 
       it "does not queue stream cache entries whose expires_at passed before completion" do

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1023,6 +1023,21 @@ describe ReactOnRailsProHelper do
         expect(chunks_read.count).to eq(chunks.count)
       end
 
+      it "closes the stream when a deferred stream cache write fails after drain" do
+        mock_request_and_response
+        render_with_cached_stream
+
+        allow(Rails.cache).to receive(:write).and_raise(StandardError, "cache unavailable")
+        allow(Rails.logger).to receive(:warn)
+
+        expect { run_stream }.not_to raise_error
+
+        expect(mocked_stream).to have_received(:close)
+        expect(Rails.logger).to have_received(:warn)
+          .with("[React on Rails Pro] Failed to write streamed cache entries after response drain: " \
+                "StandardError: cache unavailable")
+      end
+
       it "defers stream cache writes and registers tags with the write options from flush time" do
         raw_cache_options = { expires_at: Time.now + 60 }
         write_cache_options = { expires_in: 45 }
@@ -2252,7 +2267,7 @@ describe ReactOnRailsProHelper do
 
       it "registers async tags with the write options from completion time" do
         raw_cache_options = { expires_at: Time.now + 60 }
-        tag_index_cache_options = { expires_in: 60 }
+        read_cache_options = { expires_in: 60 }
         write_cache_options = { expires_in: 45 }
         raw_options = {
           cache_key: "async-expiry-recompute",
@@ -2263,8 +2278,8 @@ describe ReactOnRailsProHelper do
 
         allow(ReactOnRailsPro::Cache).to receive(:cache_write_options)
           .with(raw_cache_options)
-          .and_return(tag_index_cache_options, write_cache_options)
-        allow(Rails.cache).to receive(:read).with(component_cache_key, tag_index_cache_options).and_return(nil)
+          .and_return(read_cache_options, write_cache_options)
+        allow(Rails.cache).to receive(:read).with(component_cache_key, read_cache_options).and_return(nil)
         allow(Rails.cache).to receive(:write)
         allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
         allow(self).to receive(:react_component).and_return("<div>async</div>")

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1176,11 +1176,13 @@ describe ReactOnRailsProHelper do
         expect(@react_on_rails_pending_stream_cache_writes).to be_nil
       end
 
-      it "writes stream cache entries with the expires_at TTL captured before deferred flush" do
+      it "keeps stream cache expires_at absolute when deferred flush is delayed" do
         completion_time = Time.now
-        raw_cache_options = { expires_at: completion_time + 5 }
+        expires_at = completion_time + 5
+        raw_cache_options = { expires_at: }
         captured_on_complete = nil
 
+        allow(ReactOnRailsPro::Cache).to receive(:cache_supports_expires_at?).and_return(true)
         allow(Time).to receive(:now).and_return(completion_time)
         allow(Rails.cache).to receive(:write)
         allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
@@ -1205,9 +1207,9 @@ describe ReactOnRailsProHelper do
         send(:flush_pending_stream_cache_writes)
 
         expect(Rails.cache).to have_received(:write)
-          .with("stream-cache-key", ["chunk"], hash_including(expires_in: be_within(0.1).of(5)))
+          .with("stream-cache-key", ["chunk"], { expires_at: })
         expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
-          .with(["stream-tag"], "stream-cache-key", hash_including(expires_in: be_within(0.1).of(5)))
+          .with(["stream-tag"], "stream-cache-key", { expires_at: })
       end
 
       it "does not queue stream cache entries whose expires_at passed before completion" do

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1034,8 +1034,73 @@ describe ReactOnRailsProHelper do
 
         expect(mocked_stream).to have_received(:close)
         expect(Rails.logger).to have_received(:warn)
-          .with("[React on Rails Pro] Failed to write streamed cache entries after response drain: " \
+          .with("[React on Rails Pro] Failed to write streamed cache entry after response drain: " \
                 "StandardError: cache unavailable")
+      end
+
+      it "continues flushing pending stream cache writes after one entry fails" do
+        first_write = {
+          cache_key: "first-stream-cache-key",
+          chunks: ["first chunk"],
+          normalized_cache_tags: ["first-tag"],
+          raw_cache_options: { expires_in: 60 }
+        }
+        second_write = {
+          cache_key: "second-stream-cache-key",
+          chunks: ["second chunk"],
+          normalized_cache_tags: ["second-tag"],
+          raw_cache_options: { expires_in: 60 }
+        }
+        write_options = { expires_in: 45 }
+
+        allow(ReactOnRailsPro::Cache).to receive(:cache_write_options).and_return(write_options)
+        allow(Rails.cache).to receive(:write) do |cache_key, *_args|
+          raise StandardError, "cache unavailable" if cache_key == "first-stream-cache-key"
+        end
+        allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
+        allow(Rails.logger).to receive(:warn)
+
+        ReactOnRailsPro::StreamCacheWrites.flush([first_write, second_write])
+
+        expect(Rails.cache).to have_received(:write)
+          .with("first-stream-cache-key", ["first chunk"], write_options)
+        expect(Rails.cache).to have_received(:write)
+          .with("second-stream-cache-key", ["second chunk"], write_options)
+        expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
+          .with(["second-tag"], "second-stream-cache-key", write_options)
+        expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
+          .with(["first-tag"], "first-stream-cache-key", write_options)
+        expect(Rails.logger).to have_received(:warn)
+          .with("[React on Rails Pro] Failed to write streamed cache entry after response drain: " \
+                "StandardError: cache unavailable")
+      end
+
+      it "flushes completed pending stream cache writes before re-raising stream failures" do
+        pending_write = {
+          cache_key: "completed-stream-cache-key",
+          chunks: ["completed chunk"],
+          normalized_cache_tags: ["completed-tag"],
+          raw_cache_options: { expires_in: 60 }
+        }
+        write_options = { expires_in: 45 }
+
+        allow(self).to receive(:render_stream_template_chunk).and_return("initial chunk")
+        allow(self).to receive(:emit_rsc_stream_server_timing_header)
+        allow(self).to receive(:drain_streams_concurrently) do
+          @react_on_rails_pending_stream_cache_writes << pending_write
+          raise StandardError, "later stream failure"
+        end
+        allow(ReactOnRailsPro::Cache).to receive(:cache_write_options).and_return(write_options)
+        allow(Rails.cache).to receive(:write)
+        allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
+
+        expect { stream_view_containing_react_components(template: template_path) }
+          .to raise_error(StandardError, "later stream failure")
+
+        expect(Rails.cache).to have_received(:write)
+          .with("completed-stream-cache-key", ["completed chunk"], write_options)
+        expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
+          .with(["completed-tag"], "completed-stream-cache-key", write_options)
       end
 
       it "defers stream cache writes and registers tags with the write options from flush time" do
@@ -1052,6 +1117,7 @@ describe ReactOnRailsProHelper do
           captured_on_complete = options[:on_complete]
           "initial chunk"
         end
+        @react_on_rails_pending_stream_cache_writes = []
 
         result = send(
           :handle_stream_cache_miss,
@@ -1078,6 +1144,40 @@ describe ReactOnRailsProHelper do
           .with(["stream-tag"], "stream-cache-key", write_cache_options)
       end
 
+      it "writes stream cache immediately when no managed stream view flush is active" do
+        raw_cache_options = { expires_at: Time.now + 60 }
+        write_cache_options = { expires_in: 45 }
+        captured_on_complete = nil
+
+        allow(ReactOnRailsPro::Cache).to receive(:cache_write_options)
+          .with(raw_cache_options)
+          .and_return(write_cache_options)
+        allow(Rails.cache).to receive(:write)
+        allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
+        allow(self).to receive(:render_stream_component_with_props) do |_component_name, options, _auto_load_bundle, &|
+          captured_on_complete = options[:on_complete]
+          "initial chunk"
+        end
+
+        result = send(
+          :handle_stream_cache_miss,
+          component_name,
+          { cache_tags: ["stream-tag"], cache_options: raw_cache_options },
+          true,
+          "stream-cache-key"
+        ) { props }
+
+        expect(result).to eq("initial chunk")
+
+        captured_on_complete.call(["chunk"])
+
+        expect(ReactOnRailsPro::Cache).to have_received(:cache_write_options).once
+        expect(Rails.cache).to have_received(:write).with("stream-cache-key", ["chunk"], write_cache_options)
+        expect(ReactOnRailsPro::Cache).to have_received(:register_normalized_tags)
+          .with(["stream-tag"], "stream-cache-key", write_cache_options)
+        expect(@react_on_rails_pending_stream_cache_writes).to be_nil
+      end
+
       it "does not flush stream cache entries whose expires_at passed before flush" do
         raw_cache_options = { expires_at: Time.now - 60 }
         captured_on_complete = nil
@@ -1089,6 +1189,7 @@ describe ReactOnRailsProHelper do
           captured_on_complete = options[:on_complete]
           "initial chunk"
         end
+        @react_on_rails_pending_stream_cache_writes = []
 
         result = send(
           :handle_stream_cache_miss,

--- a/react_on_rails_pro/spec/react_on_rails_pro/cache/tag_index_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/cache/tag_index_spec.rb
@@ -249,6 +249,16 @@ describe ReactOnRailsPro::Cache::TagIndex, :caching do
       expect(index_payload("tenant:7")["keys"]).to eq(["entry/one"])
     end
 
+    it "batch-reads existing index payloads when registering multiple tags" do
+      allow(Rails.cache).to receive(:read_multi).and_call_original
+
+      described_class.register(["post:42", "tenant:7"], "entry/one", { expires_in: 3600 })
+
+      expect(Rails.cache).to have_received(:read_multi)
+        .with(described_class.index_key("post:42"), described_class.index_key("tenant:7"))
+        .once
+    end
+
     it "revalidates entries under tags that would be invalid raw Memcached keys" do
       tag = "#{"tag with whitespace\nand controls " * 10}#{'x' * 300}"
       Rails.cache.write("entry/one", "one")


### PR DESCRIPTION
Summary:
- batch tag-index reads for multi-tag registration with read_multi when available
- defer streamed cache writes until after queued stream chunks drain
- use the same completion-time cache options for writes and tag registration

Tests:
- bundle exec rspec spec/react_on_rails_pro/cache/tag_index_spec.rb spec/react_on_rails_pro/cache_spec.rb
- cd react_on_rails_pro/spec/dummy && bundle exec rspec spec/helpers/react_on_rails_pro_helper_spec.rb:907 spec/helpers/react_on_rails_pro_helper_spec.rb:2253
- bundle exec rubocop
- git diff --check

Fixes #4319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamed/async React caching now defers cache writes and normalized cache tag registration until queued response chunks finish draining, using completion-time TTL/options.
  * Misses that are already expired are skipped, and deferred cache write failures after draining are handled safely with a warning (no crash).
* **Performance**
  * Tag-index updates are more efficient by batching existing index reads when registering multiple tags.
* **Tests**
  * Expanded tests for streamed/async cache write timing, batching behavior, TTL handling, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->