### PR TITLE
Fix Pro RSC loadable stats retry visibility

### DIFF
--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -107,6 +107,7 @@ const REACT_SUSPENSE_REVEAL_SCRIPT = /\$RC\(/;
 const LOADABLE_STATS_FILE_NAME = 'loadable-stats.json';
 const LOADABLE_STATS_INITIAL_READ_RETRY_DELAY_MS = 100;
 const LOADABLE_STATS_MAX_READ_RETRY_DELAY_MS = 30_000;
+const LOADABLE_STATS_UNEXPECTED_WARNING_INTERVAL_MS = LOADABLE_STATS_MAX_READ_RETRY_DELAY_MS;
 const RSC_CLIENT_STYLESHEET_INFERENCE_TIMEOUT_MS = 100;
 const STACK_FILE_LOCATION = /\(?((?:file:\/\/\/.+)|(?:\/.+)|(?:[A-Za-z]:[\\/].+)):\d+:\d+\)?\s*$/;
 
@@ -131,7 +132,12 @@ const EMPTY_RSC_CLIENT_CHUNK_STYLESHEET_HREFS_BY_CHUNK_NAME: RSCClientChunkStyle
   new Map();
 
 let rscClientChunkStylesheetHrefsLoadState: RSCClientChunkStylesheetHrefsLoadState | undefined;
-let lastUnexpectedLoadableStatsWarningKey: string | undefined;
+let lastUnexpectedLoadableStatsWarning:
+  | {
+      key: string;
+      warnedAtMs: number;
+    }
+  | undefined;
 let resolvedLoadableStatsPath: string | undefined;
 
 function rscClientChunkStylesheetHrefsRetryClockMs() {
@@ -146,8 +152,14 @@ function warnIfUnexpectedLoadableStatsFailure(error: unknown, loadableStatsPath:
   if (isFileNotFoundError(error)) return;
 
   const warningKey = `${loadableStatsPath}\n${error instanceof Error ? `${error.name}:${error.message}` : String(error)}`;
-  if (warningKey === lastUnexpectedLoadableStatsWarningKey) return;
-  lastUnexpectedLoadableStatsWarningKey = warningKey;
+  const nowMs = rscClientChunkStylesheetHrefsRetryClockMs();
+  if (
+    warningKey === lastUnexpectedLoadableStatsWarning?.key &&
+    nowMs - lastUnexpectedLoadableStatsWarning.warnedAtMs < LOADABLE_STATS_UNEXPECTED_WARNING_INTERVAL_MS
+  ) {
+    return;
+  }
+  lastUnexpectedLoadableStatsWarning = { key: warningKey, warnedAtMs: nowMs };
 
   // Missing stats are an expected fallback. Existing but malformed or unreadable
   // stats should stay visible while the retry window still allows recovery.
@@ -157,6 +169,12 @@ function warnIfUnexpectedLoadableStatsFailure(error: unknown, loadableStatsPath:
   );
 }
 
+function normalizeStackModuleDirectory(moduleDirectory: string) {
+  return /(?:^|[\\/])src$/.test(moduleDirectory)
+    ? resolvePath(moduleDirectory, '..', 'lib')
+    : moduleDirectory;
+}
+
 function moduleDirectoryFromStack(stack: unknown) {
   if (typeof stack !== 'string') return undefined;
 
@@ -164,7 +182,9 @@ function moduleDirectoryFromStack(stack: unknown) {
     const match = line.match(STACK_FILE_LOCATION);
     if (match) {
       const stackFilePath = match[1];
-      return dirname(stackFilePath.startsWith('file://') ? fileURLToPath(stackFilePath) : stackFilePath);
+      return normalizeStackModuleDirectory(
+        dirname(stackFilePath.startsWith('file://') ? fileURLToPath(stackFilePath) : stackFilePath),
+      );
     }
   }
 
@@ -283,7 +303,7 @@ function loadRSCClientChunkStylesheetHrefsByChunkName(): RSCClientChunkStyleshee
     return EMPTY_RSC_CLIENT_CHUNK_STYLESHEET_HREFS_BY_CHUNK_NAME;
   }
 
-  lastUnexpectedLoadableStatsWarningKey = undefined;
+  lastUnexpectedLoadableStatsWarning = undefined;
   rscClientChunkStylesheetHrefsLoadState = {
     status: 'success',
     stylesheetHrefsByChunkName,

--- a/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
+++ b/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
@@ -75,8 +75,6 @@ const missingLoadableStatsError = () =>
 describe('loadRSCClientChunkStylesheetHrefsByChunkName', () => {
   afterEach(() => {
     jest.dontMock('fs');
-    jest.dontMock('path');
-    jest.dontMock('url');
     jest.resetModules();
     jest.restoreAllMocks();
   });
@@ -185,6 +183,33 @@ describe('loadRSCClientChunkStylesheetHrefsByChunkName', () => {
     expect(consoleWarn).toHaveBeenCalledTimes(1);
   });
 
+  it('repeats identical unexpected loadable-stats warnings after the retry window stays failing', async () => {
+    let now = 1_000;
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const readFileSync = jest.fn().mockReturnValue('{');
+
+    jest.doMock('fs', () => ({
+      ...jest.requireActual<typeof import('fs')>('fs'),
+      readFileSync,
+    }));
+    const { default: injectRSCPayload } = await import('../src/injectRSCPayload.ts');
+    const flightData = '["client1","js/client1-12345678.chunk.js"]';
+
+    await expect(renderWithDefaultStylesheetInference(injectRSCPayload, flightData)).resolves.not.toContain(
+      '/webpack/test/css/client1-12345678.css',
+    );
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+
+    now += 30_000;
+    await expect(renderWithDefaultStylesheetInference(injectRSCPayload, flightData)).resolves.not.toContain(
+      '/webpack/test/css/client1-12345678.css',
+    );
+    expect(readFileSync).toHaveBeenCalledTimes(2);
+    expect(consoleWarn).toHaveBeenCalledTimes(2);
+  });
+
   it('resolves loadable-stats from a module-local path', async () => {
     const readFileSync = jest.fn().mockReturnValue(
       JSON.stringify({
@@ -235,6 +260,20 @@ describe('loadRSCClientChunkStylesheetHrefsByChunkName', () => {
         ].join('\n'),
       ),
     ).toBe('/srv/app (blue)/node_modules/react-on-rails-pro/lib');
+  });
+
+  it('normalizes source-map-rewritten stack frames back to the compiled module directory', async () => {
+    const { resolveLoadableStatsModuleDirectory } = await import('../src/injectRSCPayload.ts');
+
+    expect(
+      resolveLoadableStatsModuleDirectory(
+        undefined,
+        [
+          'Error',
+          '    at resolveLoadableStatsModuleDirectory (file:///opt/react-on-rails-pro/src/injectRSCPayload.ts:42:11)',
+        ].join('\n'),
+      ),
+    ).toBe('/opt/react-on-rails-pro/lib');
   });
 
   it('uses a monotonic Node clock when global performance is unavailable', async () => {


### PR DESCRIPTION
## Why

Follow-up to #4401 review feedback. The Pro RSC stylesheet stats loader could permanently suppress repeated malformed/unreadable stats warnings, and native ESM stack resolution could choose `src/` when source maps rewrote stack frames away from the compiled `lib/` runtime directory.

## What changed

- Time-bound duplicate malformed-stats warning suppression using the existing max retry delay.
- Normalize source-map-rewritten `src/` stack-derived module directories back to sibling `lib/`.
- Remove dead `jest.dontMock` cleanup calls from the focused test.
- Add regression coverage for both review findings.

## Test plan

- `pnpm --dir packages/react-on-rails-pro exec jest tests/loadClientChunkStylesheetHrefs.test.ts --runInBand`
- `pnpm exec prettier --check packages/react-on-rails-pro/src/injectRSCPayload.ts packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts`
- `pnpm --dir packages/react-on-rails-pro run type-check`
- `script/check-pro-license-headers`
- `git diff --check`
- `.agents/bin/validate --changed` reached green for Docs Sidebar, RuboCop, ESLint, Prettier, TypeScript, Pro RuboCop, Pro RBS, and Pro TypeScript, then failed at the existing local Pro JS job because `bin/ci-local` runs `cd react_on_rails_pro && pnpm run nps test`, but current `react_on_rails_pro/package-scripts.yml` has no `test` script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repeated warning spam when stylesheet metadata can’t be read, so the same warning won’t appear too frequently.
  * Improved how server stack traces are interpreted, helping path lookups work correctly for different path formats.
  * Better handling of source paths in stack traces so module directories resolve more reliably.

* **Tests**
  * Expanded coverage for warning retry timing and stack-path normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->