### PR TITLE
[Pro] Extract async props settled chunk writer

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
@@ -64,33 +64,14 @@ module ReactOnRailsPro
     # The prop value is JSON-serialized and sent as an NDJSON line.
     # On the Node side, this triggers asyncPropsManager.setProp(propName, value).
     def call(prop_name, prop_value)
-      update_chunk = generate_update_chunk(prop_name, prop_value)
-      @request_stream << "#{update_chunk.to_json}\n"
-      @pushed_props.add(prop_name)
-    rescue StandardError => e
-      # Continue streaming: one failed async prop write should not abort the
-      # entire render. The prop is not marked as pushed unless the write
-      # succeeds, so pull mode can request it again instead of silently hanging.
-      Rails.logger.error do
-        backtrace = e.backtrace&.first(5)&.join("\n")
-        "[ReactOnRailsPro::AsyncProps] Failed to send async prop '#{prop_name}': " \
-          "#{e.class} - #{e.message}\n#{backtrace}"
-      end
+      write_settled_chunk(prop_name, action: "send") { generate_update_chunk(prop_name, prop_value) }
     end
 
     # Rejects an async prop on the Node side so React can show an error boundary.
     def reject(prop_name, reason)
-      update_chunk = generate_reject_chunk(prop_name, reason)
-      @request_stream << "#{update_chunk.to_json}\n"
       # Once the reject chunk is written, Ruby treats the prop as settled too.
       # That keeps duplicate pull requests filtered even if the JS manager is recreated.
-      @pushed_props.add(prop_name)
-    rescue StandardError => e
-      Rails.logger.error do
-        backtrace = e.backtrace&.first(5)&.join("\n")
-        "[ReactOnRailsPro::AsyncProps] Failed to reject async prop '#{prop_name}': " \
-          "#{e.class} - #{e.message}\n#{backtrace}"
-      end
+      write_settled_chunk(prop_name, action: "reject") { generate_reject_chunk(prop_name, reason) }
     end
 
     # Generates the chunk that should be executed when the request stream closes.
@@ -109,6 +90,23 @@ module ReactOnRailsPro
     end
 
     private
+
+    def write_settled_chunk(prop_name, action:)
+      chunk = yield
+      @request_stream << "#{chunk.to_json}\n"
+      # Once the chunk is written, Ruby treats the prop as settled too.
+      # That keeps duplicate pull requests filtered even if the JS manager is recreated.
+      @pushed_props.add(prop_name)
+    rescue StandardError => e
+      # Continue streaming: one failed async prop write should not abort the
+      # entire render. The prop is not marked as pushed unless the write
+      # succeeds, so pull mode can request it again instead of silently hanging.
+      Rails.logger.error do
+        backtrace = e.backtrace&.first(5)&.join("\n")
+        "[ReactOnRailsPro::AsyncProps] Failed to #{action} async prop '#{prop_name}': " \
+          "#{e.class} - #{e.message}\n#{backtrace}"
+      end
+    end
 
     def generate_update_chunk(prop_name, value)
       {


### PR DESCRIPTION
## Summary

- Extract the duplicated async-prop build/write/settle/rescue flow from `AsyncPropsEmitter#call` and `#reject` into one private `write_settled_chunk` helper.
- Keep chunk generation inside the helper block so generation, stream write, pushed-prop settlement, and error logging remain under the same rescue policy as before.
- Preserve the rejected-prop settlement note and leave #4325's parked closed-stream log-level change out of this PR.

Closes #4404.
Refs #4325.

## Why

`#call` and `#reject` shared the same stream-write, pushed-prop settlement, and error logging policy. Keeping that policy in one helper reduces duplication without changing the NDJSON wire format, settlement timing, or current log behavior.

## Codex Decision Log

- **Non-blocking:** Should #4325's closed-stream log-level change be folded into this PR?
  - **Decision:** No; this PR keeps #4404 behavior-preserving and creates the single helper where #4325 can be implemented later if it is revived.
  - **Why:** #4325 currently has a trusted maintainer comment parking it as P3/no-PR absent customer or production evidence, while #4404 is independently useful as a scoped refactor.
  - **Review later:** Revisit #4325 when customer/production evidence or a maintainer priority bump exists.

## Changelog

- Not added: refactor only, no user-visible behavior change.

## Test Plan

- `PR_BATCH_SKILL_DIR=/Users/justin/.codex/skills/pr-batch /Users/justin/.codex/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4404 4325` -> `SECURITY_PREFLIGHT_OK`
- `cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/async_props_emitter_spec.rb`
- `bundle exec rubocop react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb`
- `bundle exec rubocop`
- `pnpm install`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `codex review --uncommitted` -> no correctness regressions found

Note: the issue's Pro-local `cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion` command could not run because that bundle does not include the `rubocop` executable; the root bundle RuboCop checks and git hooks passed for the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending asynchronous data updates, reducing the chance of duplicate or partially delivered responses.
  * Added more consistent handling of send and rejection errors, with clearer logging for failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->