### PR TITLE
[Pro] Avoid leaking RSC props through client fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   resolving stats.
   [PR 4447](https://github.com/shakacode/react_on_rails/pull/4447) by
   [justin808](https://github.com/justin808).
-- **[Pro]** **RSC client fetch failures no longer include serialized props in thrown error messages or causes**: Browser RSC requests still send the real `?props=...` payload to the Rails endpoint, but pre-response fetch failures now report the query-free component source path with a stable generic message so console logs, error boundaries, and error reporters do not capture accidental sensitive values from props. Fixes [Issue 4449](https://github.com/shakacode/react_on_rails/issues/4449). [PR 4450](https://github.com/shakacode/react_on_rails/pull/4450) by [ihabadham](https://github.com/ihabadham).
+- **[Pro]** **RSC client fetch failures no longer include serialized props in thrown error messages or causes**: Browser RSC requests still send the real `?props=...` payload to the Rails endpoint, but pre-response fetch failures now report the query-free component source path with a stable generic message so console logs, error boundaries, and error reporters do not capture accidental sensitive values from props. Retry props remain directly readable for refetches but are no longer enumerable error fields. Fixes [Issue 4449](https://github.com/shakacode/react_on_rails/issues/4449). [PR 4450](https://github.com/shakacode/react_on_rails/pull/4450) by [ihabadham](https://github.com/ihabadham).
 
 
 - **[Pro]** **Node renderer graceful shutdown and scheduled restarts**: Worker shutdown now counts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,8 +163,15 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   resolving stats.
   [PR 4447](https://github.com/shakacode/react_on_rails/pull/4447) by
   [justin808](https://github.com/justin808).
-- **[Pro]** **RSC client fetch failures no longer include serialized props in thrown error messages or causes**: Browser RSC requests still send the real `?props=...` payload to the Rails endpoint, but pre-response fetch failures now report the query-free component source path with a stable generic message so console logs, error boundaries, and error reporters do not capture accidental sensitive values from props. Retry props remain directly readable for refetches but are no longer enumerable error fields. Fixes [Issue 4449](https://github.com/shakacode/react_on_rails/issues/4449). [PR 4450](https://github.com/shakacode/react_on_rails/pull/4450) by [@ihabadham](https://github.com/ihabadham).
 
+- **[Pro]** **RSC client fetch failures no longer include serialized props in thrown error messages or causes**:
+  Browser RSC requests still send the real `?props=...` payload to the Rails endpoint, but pre-response fetch
+  failures now report the query-free component source path with a stable generic message so console logs, error
+  boundaries, and error reporters do not capture accidental sensitive values from props. Retry props remain
+  directly readable for refetches but are no longer enumerable error fields. Fixes
+  [Issue 4449](https://github.com/shakacode/react_on_rails/issues/4449).
+  [PR 4450](https://github.com/shakacode/react_on_rails/pull/4450) by
+  [ihabadham](https://github.com/ihabadham).
 
 - **[Pro]** **Node renderer graceful shutdown and scheduled restarts**: Worker shutdown now counts
   each active request once across response, abort, and timeout hooks; scheduled restart timeouts use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   resolving stats.
   [PR 4447](https://github.com/shakacode/react_on_rails/pull/4447) by
   [justin808](https://github.com/justin808).
+- **[Pro]** **RSC client fetch failures no longer include serialized props in thrown error messages or causes**: Browser RSC requests still send the real `?props=...` payload to the Rails endpoint, but pre-response fetch failures now report the query-free component source path with a stable generic message so console logs, error boundaries, and error reporters do not capture accidental sensitive values from props. Fixes [Issue 4449](https://github.com/shakacode/react_on_rails/issues/4449). [PR 4450](https://github.com/shakacode/react_on_rails/pull/4450) by [ihabadham](https://github.com/ihabadham).
+
 
 - **[Pro]** **Node renderer graceful shutdown and scheduled restarts**: Worker shutdown now counts
   each active request once across response, abort, and timeout hooks; scheduled restart timeouts use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   resolving stats.
   [PR 4447](https://github.com/shakacode/react_on_rails/pull/4447) by
   [justin808](https://github.com/justin808).
-- **[Pro]** **RSC client fetch failures no longer include serialized props in thrown error messages or causes**: Browser RSC requests still send the real `?props=...` payload to the Rails endpoint, but pre-response fetch failures now report the query-free component source path with a stable generic message so console logs, error boundaries, and error reporters do not capture accidental sensitive values from props. Retry props remain directly readable for refetches but are no longer enumerable error fields. Fixes [Issue 4449](https://github.com/shakacode/react_on_rails/issues/4449). [PR 4450](https://github.com/shakacode/react_on_rails/pull/4450) by [ihabadham](https://github.com/ihabadham).
+- **[Pro]** **RSC client fetch failures no longer include serialized props in thrown error messages or causes**: Browser RSC requests still send the real `?props=...` payload to the Rails endpoint, but pre-response fetch failures now report the query-free component source path with a stable generic message so console logs, error boundaries, and error reporters do not capture accidental sensitive values from props. Retry props remain directly readable for refetches but are no longer enumerable error fields. Fixes [Issue 4449](https://github.com/shakacode/react_on_rails/issues/4449). [PR 4450](https://github.com/shakacode/react_on_rails/pull/4450) by [@ihabadham](https://github.com/ihabadham).
 
 
 - **[Pro]** **Node renderer graceful shutdown and scheduled restarts**: Worker shutdown now counts

--- a/packages/react-on-rails-pro/src/ServerComponentFetchError.ts
+++ b/packages/react-on-rails-pro/src/ServerComponentFetchError.ts
@@ -30,6 +30,7 @@ export class ServerComponentFetchError extends Error {
     this.serverComponentName = componentName;
     Object.defineProperty(this, 'serverComponentProps', {
       configurable: true,
+      enumerable: false,
       value: componentProps,
       writable: true,
     });

--- a/packages/react-on-rails-pro/src/ServerComponentFetchError.ts
+++ b/packages/react-on-rails-pro/src/ServerComponentFetchError.ts
@@ -28,7 +28,11 @@ export class ServerComponentFetchError extends Error {
     super(message);
     this.name = 'ServerComponentFetchError';
     this.serverComponentName = componentName;
-    this.serverComponentProps = componentProps;
+    Object.defineProperty(this, 'serverComponentProps', {
+      configurable: true,
+      value: componentProps,
+      writable: true,
+    });
     this.originalError = originalError;
   }
 }

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -213,7 +213,7 @@ export const fetchRSC = ({
       cspNonce,
       replayConsoleScripts,
       // Keep `source` query-string free so serialized props aren't echoed into error messages
-      // or attached error-monitoring events. The outer wrapper below retains `fetchUrl` for reproducibility.
+      // or attached error-monitoring events.
       source: sourcePath,
     }).catch((error: unknown) => {
       // RSC stream diagnostic errors already carry component/source context — preserve them
@@ -221,7 +221,7 @@ export const fetchRSC = ({
       if (error instanceof Error && error.name === RSC_STREAM_DIAGNOSTIC_ERROR_NAME) throw error;
       if (isAbortError(error)) throw error;
       const wrapper: Error & { cause?: unknown } = new Error(
-        `Failed to fetch RSC payload for component "${componentName}" from "${fetchUrl}": ${extractErrorMessage(error)}`,
+        `Failed to fetch RSC payload for component "${componentName}" from "${sourcePath}": ${extractErrorMessage(error)}`,
       );
       wrapper.cause = error;
       throw wrapper;

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -166,6 +166,26 @@ const isAbortError = (error: unknown): boolean =>
   'name' in error &&
   (error as { name?: unknown }).name === 'AbortError';
 
+const RSC_PAYLOAD_FETCH_FAILURE_MESSAGE = 'request failed before receiving an RSC payload response.';
+
+const errorIncludesSerializedRSCProps = (
+  error: unknown,
+  {
+    encodedParams,
+    fetchUrl,
+    propsString,
+  }: {
+    encodedParams: string;
+    fetchUrl: string;
+    propsString: string;
+  },
+): boolean => {
+  const errorText = `${extractErrorMessage(error)}\n${error instanceof Error ? (error.stack ?? '') : ''}`;
+  return [fetchUrl, encodedParams, propsString, encodeURIComponent(propsString)].some(
+    (serializedValue) => serializedValue !== '' && errorText.includes(serializedValue),
+  );
+};
+
 /**
  * Fetches an RSC payload via HTTP request.
  *
@@ -220,10 +240,19 @@ export const fetchRSC = ({
       // (including .cause and the merged stack) instead of flattening to a plain Error.
       if (error instanceof Error && error.name === RSC_STREAM_DIAGNOSTIC_ERROR_NAME) throw error;
       if (isAbortError(error)) throw error;
+      const errorMessage = extractErrorMessage(error);
+      const serializedPropsInError = errorIncludesSerializedRSCProps(error, {
+        encodedParams,
+        fetchUrl,
+        propsString,
+      });
+      const safeErrorMessage = serializedPropsInError ? RSC_PAYLOAD_FETCH_FAILURE_MESSAGE : errorMessage;
       const wrapper: Error & { cause?: unknown } = new Error(
-        `Failed to fetch RSC payload for component "${componentName}" from "${sourcePath}": ${extractErrorMessage(error)}`,
+        `Failed to fetch RSC payload for component "${componentName}" from "${sourcePath}": ${safeErrorMessage}`,
       );
-      wrapper.cause = error;
+      if (!serializedPropsInError) {
+        wrapper.cause = error;
+      }
       throw wrapper;
     });
   } catch (error: unknown) {

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -326,7 +326,18 @@ export const fetchRSC = ({
     const encodedParams = new URLSearchParams({ props: propsString }).toString();
     const sourcePath = `/${strippedUrlPath}/${encodeURIComponent(componentName)}`;
     const fetchUrl = `${sourcePath}?${encodedParams}`;
-    const fetchPromise = fetchOptions ? fetch(fetchUrl, fetchOptions) : fetch(fetchUrl);
+    const fetchPromise = (() => {
+      try {
+        return fetchOptions ? fetch(fetchUrl, fetchOptions) : fetch(fetchUrl);
+      } catch (error) {
+        if (error instanceof Error) {
+          return Promise.reject(error);
+        }
+        const wrappedError: Error & { cause?: unknown } = new Error(String(error));
+        defineErrorCause(wrappedError, error);
+        return Promise.reject(wrappedError);
+      }
+    })();
 
     return createFromFetch(fetchPromise, {
       componentName,

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -169,9 +169,30 @@ const isAbortError = (error: unknown): boolean =>
 const RSC_PAYLOAD_FETCH_FAILURE_MESSAGE = 'request failed before receiving an RSC payload response.';
 const SERIALIZED_RSC_PROPS_SCAN_MAX_DEPTH = 8;
 const SERIALIZED_RSC_PROPS_SCAN_MAX_NODES = 64;
+const DISTINCTIVE_SERIALIZED_RSC_PROPS_MIN_LENGTH = 8;
+
+type SerializedRSCPropsValues = {
+  encodedParams: string;
+  fetchUrl: string;
+  propsString: string;
+  propsStringCameFromJSON: boolean;
+};
 
 const valueIncludesAnySerializedRSCProps = (value: string, serializedValues: string[]): boolean =>
   serializedValues.some((serializedValue) => serializedValue !== '' && value.includes(serializedValue));
+
+const buildSerializedRSCPropsValues = ({
+  encodedParams,
+  fetchUrl,
+  propsString,
+  propsStringCameFromJSON,
+}: SerializedRSCPropsValues): string[] => {
+  const serializedValues = [fetchUrl, encodedParams];
+  if (propsStringCameFromJSON && propsString.length >= DISTINCTIVE_SERIALIZED_RSC_PROPS_MIN_LENGTH) {
+    serializedValues.push(propsString, encodeURIComponent(propsString));
+  }
+  return serializedValues;
+};
 
 const defineErrorCause = (error: Error & { cause?: unknown }, cause: unknown) => {
   Object.defineProperty(error, 'cause', {
@@ -204,45 +225,60 @@ const valueGraphIncludesSerializedRSCProps = (
   }
   seen.add(value);
 
-  if (value instanceof Error) {
+  try {
     if (
-      valueIncludesAnySerializedRSCProps(value.message, serializedValues) ||
-      valueIncludesAnySerializedRSCProps(value.stack ?? '', serializedValues)
+      typeof URL !== 'undefined' &&
+      value instanceof URL &&
+      valueIncludesAnySerializedRSCProps(value.href, serializedValues)
     ) {
       return true;
     }
-  }
+    if (
+      typeof Request !== 'undefined' &&
+      value instanceof Request &&
+      valueIncludesAnySerializedRSCProps(value.url, serializedValues)
+    ) {
+      return true;
+    }
+    if (
+      typeof Response !== 'undefined' &&
+      value instanceof Response &&
+      valueIncludesAnySerializedRSCProps(value.url, serializedValues)
+    ) {
+      return true;
+    }
 
-  let descriptors: PropertyDescriptorMap;
-  try {
+    if (value instanceof Error) {
+      if (
+        valueIncludesAnySerializedRSCProps(value.message, serializedValues) ||
+        valueIncludesAnySerializedRSCProps(value.stack ?? '', serializedValues)
+      ) {
+        return true;
+      }
+    }
+
     // Inspect own data properties so non-enumerable Error.cause and fetch-library URL metadata are
-    // covered without invoking arbitrary getters on custom error objects.
-    descriptors = Object.getOwnPropertyDescriptors(value);
+    // covered without invoking arbitrary getters on custom error objects. Standard URL-bearing Web
+    // API objects expose URLs via prototype accessors and are handled explicitly above.
+    const descriptors = Object.getOwnPropertyDescriptors(value) as Record<PropertyKey, PropertyDescriptor>;
+    return Reflect.ownKeys(descriptors).some((key) => {
+      const descriptor = descriptors[key];
+      return (
+        'value' in descriptor &&
+        valueGraphIncludesSerializedRSCProps(descriptor.value, serializedValues, seen, depth + 1)
+      );
+    });
   } catch {
     return true;
   }
-
-  return Object.values(descriptors).some(
-    (descriptor) =>
-      'value' in descriptor &&
-      valueGraphIncludesSerializedRSCProps(descriptor.value, serializedValues, seen, depth + 1),
-  );
 };
 
 const errorIncludesSerializedRSCProps = (
   error: unknown,
-  {
-    encodedParams,
-    fetchUrl,
-    propsString,
-  }: {
-    encodedParams: string;
-    fetchUrl: string;
-    propsString: string;
-  },
+  serializedPropsValues: SerializedRSCPropsValues,
   errorMessage: string,
 ): boolean => {
-  const serializedValues = [fetchUrl, encodedParams, propsString, encodeURIComponent(propsString)];
+  const serializedValues = buildSerializedRSCPropsValues(serializedPropsValues);
   return (
     valueIncludesAnySerializedRSCProps(errorMessage, serializedValues) ||
     valueGraphIncludesSerializedRSCProps(error, serializedValues)
@@ -284,7 +320,8 @@ export const fetchRSC = ({
   }
 
   try {
-    const propsString = JSON.stringify(componentProps);
+    const stringifiedProps = JSON.stringify(componentProps);
+    const propsString = stringifiedProps ?? 'undefined';
     const strippedUrlPath = rscPayloadGenerationUrlPath.replace(/^\/|\/$/g, '');
     const encodedParams = new URLSearchParams({ props: propsString }).toString();
     const sourcePath = `/${strippedUrlPath}/${encodeURIComponent(componentName)}`;
@@ -310,6 +347,7 @@ export const fetchRSC = ({
           encodedParams,
           fetchUrl,
           propsString,
+          propsStringCameFromJSON: stringifiedProps !== undefined,
         },
         errorMessage,
       );

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -160,129 +160,35 @@ const createFromFetch = async (
 
 // Duck type instead of `instanceof DOMException`: cross-realm AbortErrors
 // have the correct name but fail instanceof checks across realm boundaries.
-const isAbortError = (error: unknown): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'name' in error &&
-  (error as { name?: unknown }).name === 'AbortError';
+const isAbortError = (error: unknown): boolean => {
+  try {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error as { name?: unknown }).name === 'AbortError'
+    );
+  } catch {
+    return false;
+  }
+};
 
 const RSC_PAYLOAD_FETCH_FAILURE_MESSAGE = 'request failed before receiving an RSC payload response.';
-const SERIALIZED_RSC_PROPS_SCAN_MAX_DEPTH = 8;
-const SERIALIZED_RSC_PROPS_SCAN_MAX_NODES = 64;
-const DISTINCTIVE_SERIALIZED_RSC_PROPS_MIN_LENGTH = 8;
 
-type SerializedRSCPropsValues = {
-  encodedParams: string;
-  fetchUrl: string;
-  propsString: string;
-  propsStringCameFromJSON: boolean;
-};
-
-const valueIncludesAnySerializedRSCProps = (value: string, serializedValues: string[]): boolean =>
-  serializedValues.some((serializedValue) => serializedValue !== '' && value.includes(serializedValue));
-
-const buildSerializedRSCPropsValues = ({
-  encodedParams,
-  fetchUrl,
-  propsString,
-  propsStringCameFromJSON,
-}: SerializedRSCPropsValues): string[] => {
-  const serializedValues = [fetchUrl, encodedParams];
-  if (propsStringCameFromJSON && propsString.length >= DISTINCTIVE_SERIALIZED_RSC_PROPS_MIN_LENGTH) {
-    serializedValues.push(propsString, encodeURIComponent(propsString));
+class RSCPreResponseFetchError extends Error {
+  constructor() {
+    super(RSC_PAYLOAD_FETCH_FAILURE_MESSAGE);
+    this.name = 'RSCPreResponseFetchError';
   }
-  return serializedValues;
-};
+}
 
 const defineErrorCause = (error: Error & { cause?: unknown }, cause: unknown) => {
   Object.defineProperty(error, 'cause', {
     configurable: true,
+    enumerable: false,
     value: cause,
     writable: true,
   });
-};
-
-const valueGraphIncludesSerializedRSCProps = (
-  value: unknown,
-  serializedValues: string[],
-  seen = new Set<unknown>(),
-  depth = 0,
-): boolean => {
-  if (typeof value === 'string') {
-    return valueIncludesAnySerializedRSCProps(value, serializedValues);
-  }
-
-  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
-    return false;
-  }
-
-  if (seen.has(value)) {
-    return false;
-  }
-
-  if (depth > SERIALIZED_RSC_PROPS_SCAN_MAX_DEPTH || seen.size >= SERIALIZED_RSC_PROPS_SCAN_MAX_NODES) {
-    return true;
-  }
-  seen.add(value);
-
-  try {
-    if (
-      typeof URL !== 'undefined' &&
-      value instanceof URL &&
-      valueIncludesAnySerializedRSCProps(value.href, serializedValues)
-    ) {
-      return true;
-    }
-    if (
-      typeof Request !== 'undefined' &&
-      value instanceof Request &&
-      valueIncludesAnySerializedRSCProps(value.url, serializedValues)
-    ) {
-      return true;
-    }
-    if (
-      typeof Response !== 'undefined' &&
-      value instanceof Response &&
-      valueIncludesAnySerializedRSCProps(value.url, serializedValues)
-    ) {
-      return true;
-    }
-
-    if (value instanceof Error) {
-      if (
-        valueIncludesAnySerializedRSCProps(value.message, serializedValues) ||
-        valueIncludesAnySerializedRSCProps(value.stack ?? '', serializedValues)
-      ) {
-        return true;
-      }
-    }
-
-    // Inspect own data properties so non-enumerable Error.cause and fetch-library URL metadata are
-    // covered without invoking arbitrary getters on custom error objects. Standard URL-bearing Web
-    // API objects expose URLs via prototype accessors and are handled explicitly above.
-    const descriptors = Object.getOwnPropertyDescriptors(value) as Record<PropertyKey, PropertyDescriptor>;
-    return Reflect.ownKeys(descriptors).some((key) => {
-      const descriptor = descriptors[key];
-      return (
-        'value' in descriptor &&
-        valueGraphIncludesSerializedRSCProps(descriptor.value, serializedValues, seen, depth + 1)
-      );
-    });
-  } catch {
-    return true;
-  }
-};
-
-const errorIncludesSerializedRSCProps = (
-  error: unknown,
-  serializedPropsValues: SerializedRSCPropsValues,
-  errorMessage: string,
-): boolean => {
-  const serializedValues = buildSerializedRSCPropsValues(serializedPropsValues);
-  return (
-    valueIncludesAnySerializedRSCProps(errorMessage, serializedValues) ||
-    valueGraphIncludesSerializedRSCProps(error, serializedValues)
-  );
 };
 
 /**
@@ -320,22 +226,22 @@ export const fetchRSC = ({
   }
 
   try {
-    const stringifiedProps = JSON.stringify(componentProps);
-    const propsString = stringifiedProps ?? 'undefined';
+    const propsString = JSON.stringify(componentProps) ?? 'undefined';
     const strippedUrlPath = rscPayloadGenerationUrlPath.replace(/^\/|\/$/g, '');
     const encodedParams = new URLSearchParams({ props: propsString }).toString();
     const sourcePath = `/${strippedUrlPath}/${encodeURIComponent(componentName)}`;
     const fetchUrl = `${sourcePath}?${encodedParams}`;
     const fetchPromise = (() => {
       try {
-        return fetchOptions ? fetch(fetchUrl, fetchOptions) : fetch(fetchUrl);
+        return Promise.resolve(fetchOptions ? fetch(fetchUrl, fetchOptions) : fetch(fetchUrl)).catch(
+          (error: unknown) => {
+            if (isAbortError(error)) throw error as Error;
+            throw new RSCPreResponseFetchError();
+          },
+        );
       } catch (error) {
-        if (error instanceof Error) {
-          return Promise.reject(error);
-        }
-        const wrappedError: Error & { cause?: unknown } = new Error(String(error));
-        defineErrorCause(wrappedError, error);
-        return Promise.reject(wrappedError);
+        if (isAbortError(error)) return Promise.reject(error as Error);
+        return Promise.reject(new RSCPreResponseFetchError());
       }
     })();
 
@@ -351,22 +257,14 @@ export const fetchRSC = ({
       // (including .cause and the merged stack) instead of flattening to a plain Error.
       if (error instanceof Error && error.name === RSC_STREAM_DIAGNOSTIC_ERROR_NAME) throw error;
       if (isAbortError(error)) throw error;
-      const errorMessage = extractErrorMessage(error);
-      const serializedPropsInError = errorIncludesSerializedRSCProps(
-        error,
-        {
-          encodedParams,
-          fetchUrl,
-          propsString,
-          propsStringCameFromJSON: stringifiedProps !== undefined,
-        },
-        errorMessage,
-      );
-      const safeErrorMessage = serializedPropsInError ? RSC_PAYLOAD_FETCH_FAILURE_MESSAGE : errorMessage;
+      const safeErrorMessage =
+        error instanceof RSCPreResponseFetchError
+          ? RSC_PAYLOAD_FETCH_FAILURE_MESSAGE
+          : extractErrorMessage(error);
       const wrapper: Error & { cause?: unknown } = new Error(
         `Failed to fetch RSC payload for component "${componentName}" from "${sourcePath}": ${safeErrorMessage}`,
       );
-      if (!serializedPropsInError) {
+      if (!(error instanceof RSCPreResponseFetchError)) {
         defineErrorCause(wrapper, error);
       }
       throw wrapper;

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -167,6 +167,67 @@ const isAbortError = (error: unknown): boolean =>
   (error as { name?: unknown }).name === 'AbortError';
 
 const RSC_PAYLOAD_FETCH_FAILURE_MESSAGE = 'request failed before receiving an RSC payload response.';
+const SERIALIZED_RSC_PROPS_SCAN_MAX_DEPTH = 8;
+const SERIALIZED_RSC_PROPS_SCAN_MAX_NODES = 64;
+
+const valueIncludesAnySerializedRSCProps = (value: string, serializedValues: string[]): boolean =>
+  serializedValues.some((serializedValue) => serializedValue !== '' && value.includes(serializedValue));
+
+const defineErrorCause = (error: Error & { cause?: unknown }, cause: unknown) => {
+  Object.defineProperty(error, 'cause', {
+    configurable: true,
+    value: cause,
+    writable: true,
+  });
+};
+
+const valueGraphIncludesSerializedRSCProps = (
+  value: unknown,
+  serializedValues: string[],
+  seen = new Set<unknown>(),
+  depth = 0,
+): boolean => {
+  if (typeof value === 'string') {
+    return valueIncludesAnySerializedRSCProps(value, serializedValues);
+  }
+
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
+    return false;
+  }
+
+  if (seen.has(value)) {
+    return false;
+  }
+
+  if (depth > SERIALIZED_RSC_PROPS_SCAN_MAX_DEPTH || seen.size >= SERIALIZED_RSC_PROPS_SCAN_MAX_NODES) {
+    return true;
+  }
+  seen.add(value);
+
+  if (value instanceof Error) {
+    if (
+      valueIncludesAnySerializedRSCProps(value.message, serializedValues) ||
+      valueIncludesAnySerializedRSCProps(value.stack ?? '', serializedValues)
+    ) {
+      return true;
+    }
+  }
+
+  let descriptors: PropertyDescriptorMap;
+  try {
+    // Inspect own data properties so non-enumerable Error.cause and fetch-library URL metadata are
+    // covered without invoking arbitrary getters on custom error objects.
+    descriptors = Object.getOwnPropertyDescriptors(value);
+  } catch {
+    return true;
+  }
+
+  return Object.values(descriptors).some(
+    (descriptor) =>
+      'value' in descriptor &&
+      valueGraphIncludesSerializedRSCProps(descriptor.value, serializedValues, seen, depth + 1),
+  );
+};
 
 const errorIncludesSerializedRSCProps = (
   error: unknown,
@@ -179,10 +240,12 @@ const errorIncludesSerializedRSCProps = (
     fetchUrl: string;
     propsString: string;
   },
+  errorMessage: string,
 ): boolean => {
-  const errorText = `${extractErrorMessage(error)}\n${error instanceof Error ? (error.stack ?? '') : ''}`;
-  return [fetchUrl, encodedParams, propsString, encodeURIComponent(propsString)].some(
-    (serializedValue) => serializedValue !== '' && errorText.includes(serializedValue),
+  const serializedValues = [fetchUrl, encodedParams, propsString, encodeURIComponent(propsString)];
+  return (
+    valueIncludesAnySerializedRSCProps(errorMessage, serializedValues) ||
+    valueGraphIncludesSerializedRSCProps(error, serializedValues)
   );
 };
 
@@ -241,17 +304,21 @@ export const fetchRSC = ({
       if (error instanceof Error && error.name === RSC_STREAM_DIAGNOSTIC_ERROR_NAME) throw error;
       if (isAbortError(error)) throw error;
       const errorMessage = extractErrorMessage(error);
-      const serializedPropsInError = errorIncludesSerializedRSCProps(error, {
-        encodedParams,
-        fetchUrl,
-        propsString,
-      });
+      const serializedPropsInError = errorIncludesSerializedRSCProps(
+        error,
+        {
+          encodedParams,
+          fetchUrl,
+          propsString,
+        },
+        errorMessage,
+      );
       const safeErrorMessage = serializedPropsInError ? RSC_PAYLOAD_FETCH_FAILURE_MESSAGE : errorMessage;
       const wrapper: Error & { cause?: unknown } = new Error(
         `Failed to fetch RSC payload for component "${componentName}" from "${sourcePath}": ${safeErrorMessage}`,
       );
       if (!serializedPropsInError) {
-        wrapper.cause = error;
+        defineErrorCause(wrapper, error);
       }
       throw wrapper;
     });
@@ -261,7 +328,7 @@ export const fetchRSC = ({
     const wrapper: Error & { cause?: unknown } = new Error(
       `Failed to prepare RSC request for component "${componentName}": ${extractErrorMessage(error)}`,
     );
-    wrapper.cause = error;
+    defineErrorCause(wrapper, error);
     return Promise.reject(wrapper);
   }
 };

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -85,12 +85,12 @@ const createFromFetch = async (
     componentName,
     cspNonce,
     replayConsoleScripts = true,
-    source,
+    sourceDescription,
   }: {
     componentName: string;
     cspNonce?: string;
     replayConsoleScripts?: boolean;
-    source: string;
+    sourceDescription: string;
   },
 ) => {
   const response = await fetchPromise;
@@ -99,7 +99,7 @@ const createFromFetch = async (
       ? `${response.status} ${response.statusText}`
       : `${response.status}`;
     throw new Error(
-      `RSC payload request for component "${componentName}" from "${source}" failed with HTTP ${statusDescription}.`,
+      `RSC payload request for component "${componentName}" from ${sourceDescription} failed with HTTP ${statusDescription}.`,
     );
   }
 
@@ -112,7 +112,10 @@ const createFromFetch = async (
   const parser = new LengthPrefixedStreamParser();
   let rscDiagnosticError: Error | undefined;
   const reportDiagnosticError = (metadata: Record<string, unknown>) => {
-    const diagnosticError = buildRSCStreamDiagnosticError(metadata, { componentName, source });
+    const diagnosticError = buildRSCStreamDiagnosticError(metadata, {
+      componentName,
+      source: sourceDescription,
+    });
     if (diagnosticError && !rscDiagnosticError) {
       rscDiagnosticError = diagnosticError;
     }
@@ -231,6 +234,9 @@ export const fetchRSC = ({
     const encodedParams = new URLSearchParams({ props: propsString }).toString();
     const sourcePath = `/${strippedUrlPath}/${encodeURIComponent(componentName)}`;
     const fetchUrl = `${sourcePath}?${encodedParams}`;
+    // Keep the displayed source query-string free so serialized props aren't echoed into
+    // error messages or attached error-monitoring events. The suffix makes that redaction explicit.
+    const sourceDescription = `"${sourcePath}" (props redacted)`;
     const fetchPromise = (() => {
       try {
         return Promise.resolve(fetchOptions ? fetch(fetchUrl, fetchOptions) : fetch(fetchUrl)).catch(
@@ -249,9 +255,7 @@ export const fetchRSC = ({
       componentName,
       cspNonce,
       replayConsoleScripts,
-      // Keep `source` query-string free so serialized props aren't echoed into error messages
-      // or attached error-monitoring events.
-      source: sourcePath,
+      sourceDescription,
     }).catch((error: unknown) => {
       // RSC stream diagnostic errors already carry component/source context — preserve them
       // (including .cause and the merged stack) instead of flattening to a plain Error.
@@ -262,7 +266,7 @@ export const fetchRSC = ({
           ? RSC_PAYLOAD_FETCH_FAILURE_MESSAGE
           : extractErrorMessage(error);
       const wrapper: Error & { cause?: unknown } = new Error(
-        `Failed to fetch RSC payload for component "${componentName}" from "${sourcePath}": ${safeErrorMessage}`,
+        `Failed to fetch RSC payload for component "${componentName}" from ${sourceDescription}: ${safeErrorMessage}`,
       );
       if (!(error instanceof RSCPreResponseFetchError)) {
         defineErrorCause(wrapper, error);

--- a/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
+++ b/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
@@ -30,7 +30,7 @@ import {
   RSCRouteSSRFalseBailoutError,
 } from '../src/RSCRouteSSRFalseBailoutError.ts';
 import RSCRoute from '../src/RSCRoute.tsx';
-import { isServerComponentFetchError } from '../src/ServerComponentFetchError.ts';
+import { isServerComponentFetchError, ServerComponentFetchError } from '../src/ServerComponentFetchError.ts';
 import { flushMacrotasks } from './testUtils.ts';
 
 class TestErrorBoundary extends React.Component<
@@ -112,6 +112,26 @@ const runWithoutWindow = <T,>(callback: () => T): T => {
 };
 
 describe('RSCRoute deferred SSR behavior', () => {
+  it('keeps retry props directly readable without making them enumerable', () => {
+    const sentinel = 'SECRET_SENTINEL_RSC_RETRY_PROPS_ENUMERATION';
+    const componentProps = { token: sentinel };
+    const error = new ServerComponentFetchError(
+      'Failed to fetch server component',
+      'AccountPanel',
+      componentProps,
+      new Error('HTTP 500'),
+    );
+
+    expect(error.serverComponentProps).toBe(componentProps);
+    expect(Object.getOwnPropertyDescriptor(error, 'serverComponentProps')).toMatchObject({
+      enumerable: false,
+      value: componentProps,
+    });
+    expect(Object.keys(error)).not.toContain('serverComponentProps');
+    expect({ ...error }).not.toHaveProperty('serverComponentProps');
+    expect(JSON.stringify(error)).not.toContain(sentinel);
+  });
+
   it('throws a classified server bailout when ssr is false on the server', () => {
     expect(() => runWithoutWindow(() => renderRouteToString({ ssr: false }))).toThrow(
       RSCRouteSSRFalseBailoutError,

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -143,41 +143,104 @@ describe('fetchRSC HTTP responses', () => {
     expect(reportedText).not.toContain(encodeURIComponent(sentinel));
   });
 
-  it('redacts serialized props from URL-bearing fetch rejection text and cause chains', async () => {
-    const { fetchRSC } = await loadClientModule();
-    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
-    const componentProps = { token: sentinel };
-    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
-      props: JSON.stringify(componentProps),
-    })}`;
-    fetchMock.mockRejectedValue(new Error(`request to ${fetchUrl} failed`));
+  type PreResponseFetchRejectionCase = {
+    label: string;
+    createRejection: (fetchUrl: string) => unknown;
+  };
 
-    let thrownError: (Error & { cause?: unknown }) | undefined;
-    try {
-      await fetchRSC({
-        componentName: 'AccountPanel',
-        componentProps,
-        rscPayloadGenerationUrlPath: '/rsc_payload',
-      });
-    } catch (error) {
-      thrownError = error as Error & { cause?: unknown };
-    }
+  const preResponseFetchRejectionCases: PreResponseFetchRejectionCase[] = [
+    {
+      label: 'URL-bearing rejection message',
+      createRejection: (fetchUrl: string) => new Error(`request to ${fetchUrl} failed`),
+    },
+    {
+      label: 'lowercase percent-encoded rejection message',
+      createRejection: (fetchUrl: string) =>
+        new TypeError(
+          `fetch failed for ${fetchUrl.replace(/%[0-9A-F]{2}/g, (match) => match.toLowerCase())}`,
+        ),
+    },
+    {
+      label: 'nested cause chain',
+      createRejection: (fetchUrl: string) => {
+        const innerError = new Error(`request to ${fetchUrl} failed`);
+        const fetchError = new TypeError('fetch failed') as TypeError & { cause?: unknown };
+        Object.defineProperty(fetchError, 'cause', {
+          configurable: true,
+          enumerable: false,
+          value: innerError,
+          writable: true,
+        });
+        return fetchError;
+      },
+    },
+    {
+      label: 'plain metadata field',
+      createRejection: (fetchUrl: string) => {
+        const fetchError = new TypeError('fetch failed') as TypeError & { request?: { url: string } };
+        fetchError.request = { url: fetchUrl };
+        return fetchError;
+      },
+    },
+    {
+      label: 'URL-bearing Web API object metadata',
+      createRejection: (fetchUrl: string) => {
+        const fullFetchUrl = `https://example.test${fetchUrl}`;
+        const fetchError = new TypeError('fetch failed') as TypeError & {
+          request?: Request;
+          urlObject?: URL;
+        };
+        fetchError.request = new Request(fullFetchUrl);
+        fetchError.urlObject = new URL(fullFetchUrl);
+        return fetchError;
+      },
+    },
+    {
+      label: 'safe-looking network message',
+      createRejection: () => new Error('network offline'),
+    },
+  ];
 
-    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
-    expect(thrownError).toBeInstanceOf(Error);
-    expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
-    );
-    expect(thrownError?.cause).toBeUndefined();
+  it.each(preResponseFetchRejectionCases)(
+    'uses a stable generic pre-response failure for $label',
+    async ({ createRejection }) => {
+      const { fetchRSC } = await loadClientModule();
+      const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
+      const componentProps = { token: sentinel };
+      const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+        props: JSON.stringify(componentProps),
+      })}`;
+      fetchMock.mockRejectedValue(createRejection(fetchUrl));
 
-    const reportedText = [thrownError?.message, thrownError?.stack]
-      .filter((line): line is string => Boolean(line))
-      .join('\n');
-    expect(reportedText).not.toContain(sentinel);
-    expect(reportedText).not.toContain(encodeURIComponent(sentinel));
-  });
+      let thrownError: (Error & { cause?: unknown }) | undefined;
+      try {
+        await fetchRSC({
+          componentName: 'AccountPanel',
+          componentProps,
+          rscPayloadGenerationUrlPath: '/rsc_payload',
+        });
+      } catch (error) {
+        thrownError = error as Error & { cause?: unknown };
+      }
 
-  it('redacts serialized props from synchronous fetch throws', async () => {
+      expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError?.message).toBe(
+        'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+      );
+      expect(thrownError?.cause).toBeUndefined();
+      expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
+
+      const reportedText = [thrownError?.message, thrownError?.stack, JSON.stringify(thrownError)]
+        .filter((line): line is string => Boolean(line))
+        .join('\n');
+      expect(reportedText).not.toContain(sentinel);
+      expect(reportedText).not.toContain(encodeURIComponent(sentinel));
+      expect(reportedText).not.toContain(fetchUrl);
+    },
+  );
+
+  it('uses a stable generic pre-response failure for synchronous fetch throws', async () => {
     const { fetchRSC } = await loadClientModule();
     const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
     const componentProps = { token: sentinel };
@@ -207,235 +270,26 @@ describe('fetchRSC HTTP responses', () => {
     expect(thrownError?.cause).toBeUndefined();
     expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
 
-    const reportedText = [thrownError?.message, thrownError?.stack]
+    const reportedText = [thrownError?.message, thrownError?.stack, JSON.stringify(thrownError)]
       .filter((line): line is string => Boolean(line))
       .join('\n');
     expect(reportedText).not.toContain(sentinel);
     expect(reportedText).not.toContain(encodeURIComponent(sentinel));
+    expect(reportedText).not.toContain(fetchUrl);
   });
 
-  it('preserves safe synchronous fetch throw messages and causes', async () => {
+  it('propagates AbortError fetch rejections without wrapping', async () => {
     const { fetchRSC } = await loadClientModule();
-    const originalError = new TypeError('sync fetch unavailable');
-    fetchMock.mockImplementation(() => {
-      throw originalError;
-    });
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    fetchMock.mockRejectedValue(abortError);
 
-    let thrownError: (Error & { cause?: unknown }) | undefined;
-    try {
-      await fetchRSC({
+    await expect(
+      fetchRSC({
         componentName: 'AccountPanel',
         componentProps: { id: 1 },
         rscPayloadGenerationUrlPath: '/rsc_payload',
-      });
-    } catch (error) {
-      thrownError = error as Error & { cause?: unknown };
-    }
-
-    expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": sync fetch unavailable',
-    );
-    expect(thrownError?.cause).toBe(originalError);
-    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')?.enumerable).toBe(false);
-  });
-
-  it('redacts serialized props from nested fetch rejection causes', async () => {
-    const { fetchRSC } = await loadClientModule();
-    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
-    const componentProps = { token: sentinel };
-    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
-      props: JSON.stringify(componentProps),
-    })}`;
-    const innerError = new Error(`request to ${fetchUrl} failed`);
-    const fetchError = new TypeError('fetch failed') as TypeError & { cause?: unknown };
-    Object.defineProperty(fetchError, 'cause', {
-      configurable: true,
-      value: innerError,
-      writable: true,
-    });
-    fetchMock.mockRejectedValue(fetchError);
-
-    let thrownError: (Error & { cause?: unknown }) | undefined;
-    try {
-      await fetchRSC({
-        componentName: 'AccountPanel',
-        componentProps,
-        rscPayloadGenerationUrlPath: '/rsc_payload',
-      });
-    } catch (error) {
-      thrownError = error as Error & { cause?: unknown };
-    }
-
-    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
-    expect(thrownError).toBeInstanceOf(Error);
-    expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
-    );
-    expect(thrownError?.cause).toBeUndefined();
-    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
-
-    const reportedText = [thrownError?.message, thrownError?.stack]
-      .filter((line): line is string => Boolean(line))
-      .join('\n');
-    expect(reportedText).not.toContain(sentinel);
-    expect(reportedText).not.toContain(encodeURIComponent(sentinel));
-  });
-
-  it('redacts serialized props from fetch rejection metadata fields', async () => {
-    const { fetchRSC } = await loadClientModule();
-    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
-    const componentProps = { token: sentinel };
-    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
-      props: JSON.stringify(componentProps),
-    })}`;
-    const fetchError = new TypeError('fetch failed') as TypeError & { request?: { url: string } };
-    fetchError.request = { url: fetchUrl };
-    fetchMock.mockRejectedValue(fetchError);
-
-    let thrownError: (Error & { cause?: unknown }) | undefined;
-    try {
-      await fetchRSC({
-        componentName: 'AccountPanel',
-        componentProps,
-        rscPayloadGenerationUrlPath: '/rsc_payload',
-      });
-    } catch (error) {
-      thrownError = error as Error & { cause?: unknown };
-    }
-
-    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
-    expect(thrownError).toBeInstanceOf(Error);
-    expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
-    );
-    expect(thrownError?.cause).toBeUndefined();
-  });
-
-  it('redacts serialized props from URL-bearing Web API object metadata', async () => {
-    const { fetchRSC } = await loadClientModule();
-    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
-    const componentProps = { token: sentinel };
-    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
-      props: JSON.stringify(componentProps),
-    })}`;
-    const fullFetchUrl = `https://example.test${fetchUrl}`;
-    const fetchError = new TypeError('fetch failed') as TypeError & { request?: Request; urlObject?: URL };
-    fetchError.request = new Request(fullFetchUrl);
-    fetchError.urlObject = new URL(fullFetchUrl);
-    fetchMock.mockRejectedValue(fetchError);
-
-    let thrownError: (Error & { cause?: unknown }) | undefined;
-    try {
-      await fetchRSC({
-        componentName: 'AccountPanel',
-        componentProps,
-        rscPayloadGenerationUrlPath: '/rsc_payload',
-      });
-    } catch (error) {
-      thrownError = error as Error & { cause?: unknown };
-    }
-
-    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
-    expect(thrownError).toBeInstanceOf(Error);
-    expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
-    );
-    expect(thrownError?.cause).toBeUndefined();
-    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
-  });
-
-  it.each([
-    { componentProps: {}, label: 'empty object', message: 'parser returned {} placeholder' },
-    { componentProps: null, label: 'null', message: "Cannot read properties of null (reading 'id')" },
-    { componentProps: 0, label: 'zero', message: 'HTTP 500 upstream timeout' },
-    {
-      componentProps: undefined,
-      label: 'undefined',
-      message: "Cannot read properties of undefined (reading 'id')",
-    },
-    { componentProps: false, label: 'false', message: 'Expected false but got true' },
-    { componentProps: true, label: 'true', message: 'Expected true but got false' },
-    { componentProps: [], label: 'empty array', message: 'parser returned [] placeholder' },
-    { componentProps: '', label: 'empty string', message: 'received "" from adapter' },
-    { componentProps: 0, label: 'zero with stack digits only', message: 'socket hang up' },
-  ])(
-    'preserves safe fetch rejection messages and causes for $label props',
-    async ({ componentProps, message }) => {
-      const { fetchRSC } = await loadClientModule();
-      const originalError = new Error(message);
-      fetchMock.mockRejectedValue(originalError);
-
-      let thrownError: (Error & { cause?: unknown }) | undefined;
-      try {
-        await fetchRSC({
-          componentName: 'AccountPanel',
-          componentProps,
-          rscPayloadGenerationUrlPath: '/rsc_payload',
-        });
-      } catch (error) {
-        thrownError = error as Error & { cause?: unknown };
-      }
-
-      expect(thrownError?.message).toBe(
-        `Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": ${message}`,
-      );
-      expect(thrownError?.cause).toBe(originalError);
-      expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')?.enumerable).toBe(false);
-    },
-  );
-
-  it.each([
-    { componentProps: 0, label: 'zero' },
-    { componentProps: null, label: 'null' },
-    { componentProps: undefined, label: 'undefined' },
-  ])('still redacts full URL leaks for short $label props', async ({ componentProps }) => {
-    const { fetchRSC } = await loadClientModule();
-    const propsString = JSON.stringify(componentProps) ?? 'undefined';
-    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
-      props: propsString,
-    })}`;
-    fetchMock.mockRejectedValue(new Error(`request to ${fetchUrl} failed`));
-
-    let thrownError: (Error & { cause?: unknown }) | undefined;
-    try {
-      await fetchRSC({
-        componentName: 'AccountPanel',
-        componentProps,
-        rscPayloadGenerationUrlPath: '/rsc_payload',
-      });
-    } catch (error) {
-      thrownError = error as Error & { cause?: unknown };
-    }
-
-    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
-    expect(thrownError).toBeInstanceOf(Error);
-    expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
-    );
-    expect(thrownError?.cause).toBeUndefined();
-  });
-
-  it('preserves safe fetch rejection messages and causes', async () => {
-    const { fetchRSC } = await loadClientModule();
-    const originalError = new Error('network offline');
-    fetchMock.mockRejectedValue(originalError);
-
-    let thrownError: (Error & { cause?: unknown }) | undefined;
-    try {
-      await fetchRSC({
-        componentName: 'AccountPanel',
-        componentProps: { id: 1 },
-        rscPayloadGenerationUrlPath: '/rsc_payload',
-      });
-    } catch (error) {
-      thrownError = error as Error & { cause?: unknown };
-    }
-
-    expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": network offline',
-    );
-    expect(thrownError?.cause).toBe(originalError);
-    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')?.enumerable).toBe(false);
+      }),
+    ).rejects.toBe(abortError);
   });
 
   it('propagates non-ok HTTP responses through the getReactServerComponent fetch path', async () => {

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -249,6 +249,110 @@ describe('fetchRSC HTTP responses', () => {
     expect(thrownError?.cause).toBeUndefined();
   });
 
+  it('redacts serialized props from URL-bearing Web API object metadata', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
+    const componentProps = { token: sentinel };
+    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+      props: JSON.stringify(componentProps),
+    })}`;
+    const fullFetchUrl = `https://example.test${fetchUrl}`;
+    const fetchError = new TypeError('fetch failed') as TypeError & { request?: Request; urlObject?: URL };
+    fetchError.request = new Request(fullFetchUrl);
+    fetchError.urlObject = new URL(fullFetchUrl);
+    fetchMock.mockRejectedValue(fetchError);
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+    );
+    expect(thrownError?.cause).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
+  });
+
+  it.each([
+    { componentProps: {}, label: 'empty object', message: 'parser returned {} placeholder' },
+    { componentProps: null, label: 'null', message: "Cannot read properties of null (reading 'id')" },
+    { componentProps: 0, label: 'zero', message: 'HTTP 500 upstream timeout' },
+    {
+      componentProps: undefined,
+      label: 'undefined',
+      message: "Cannot read properties of undefined (reading 'id')",
+    },
+    { componentProps: false, label: 'false', message: 'Expected false but got true' },
+    { componentProps: true, label: 'true', message: 'Expected true but got false' },
+    { componentProps: [], label: 'empty array', message: 'parser returned [] placeholder' },
+    { componentProps: '', label: 'empty string', message: 'received "" from adapter' },
+    { componentProps: 0, label: 'zero with stack digits only', message: 'socket hang up' },
+  ])(
+    'preserves safe fetch rejection messages and causes for $label props',
+    async ({ componentProps, message }) => {
+      const { fetchRSC } = await loadClientModule();
+      const originalError = new Error(message);
+      fetchMock.mockRejectedValue(originalError);
+
+      let thrownError: (Error & { cause?: unknown }) | undefined;
+      try {
+        await fetchRSC({
+          componentName: 'AccountPanel',
+          componentProps,
+          rscPayloadGenerationUrlPath: '/rsc_payload',
+        });
+      } catch (error) {
+        thrownError = error as Error & { cause?: unknown };
+      }
+
+      expect(thrownError?.message).toBe(
+        `Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": ${message}`,
+      );
+      expect(thrownError?.cause).toBe(originalError);
+      expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')?.enumerable).toBe(false);
+    },
+  );
+
+  it.each([
+    { componentProps: 0, label: 'zero' },
+    { componentProps: null, label: 'null' },
+    { componentProps: undefined, label: 'undefined' },
+  ])('still redacts full URL leaks for short $label props', async ({ componentProps }) => {
+    const { fetchRSC } = await loadClientModule();
+    const propsString = JSON.stringify(componentProps) ?? 'undefined';
+    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+      props: propsString,
+    })}`;
+    fetchMock.mockRejectedValue(new Error(`request to ${fetchUrl} failed`));
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+    );
+    expect(thrownError?.cause).toBeUndefined();
+  });
+
   it('preserves safe fetch rejection messages and causes', async () => {
     const { fetchRSC } = await loadClientModule();
     const originalError = new Error('network offline');

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -177,6 +177,78 @@ describe('fetchRSC HTTP responses', () => {
     expect(reportedText).not.toContain(encodeURIComponent(sentinel));
   });
 
+  it('redacts serialized props from nested fetch rejection causes', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
+    const componentProps = { token: sentinel };
+    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+      props: JSON.stringify(componentProps),
+    })}`;
+    const innerError = new Error(`request to ${fetchUrl} failed`);
+    const fetchError = new TypeError('fetch failed') as TypeError & { cause?: unknown };
+    Object.defineProperty(fetchError, 'cause', {
+      configurable: true,
+      value: innerError,
+      writable: true,
+    });
+    fetchMock.mockRejectedValue(fetchError);
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+    );
+    expect(thrownError?.cause).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
+
+    const reportedText = [thrownError?.message, thrownError?.stack]
+      .filter((line): line is string => Boolean(line))
+      .join('\n');
+    expect(reportedText).not.toContain(sentinel);
+    expect(reportedText).not.toContain(encodeURIComponent(sentinel));
+  });
+
+  it('redacts serialized props from fetch rejection metadata fields', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
+    const componentProps = { token: sentinel };
+    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+      props: JSON.stringify(componentProps),
+    })}`;
+    const fetchError = new TypeError('fetch failed') as TypeError & { request?: { url: string } };
+    fetchError.request = { url: fetchUrl };
+    fetchMock.mockRejectedValue(fetchError);
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+    );
+    expect(thrownError?.cause).toBeUndefined();
+  });
+
   it('preserves safe fetch rejection messages and causes', async () => {
     const { fetchRSC } = await loadClientModule();
     const originalError = new Error('network offline');
@@ -197,6 +269,7 @@ describe('fetchRSC HTTP responses', () => {
       'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": network offline',
     );
     expect(thrownError?.cause).toBe(originalError);
+    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')?.enumerable).toBe(false);
   });
 
   it('propagates non-ok HTTP responses through the getReactServerComponent fetch path', async () => {

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -177,6 +177,68 @@ describe('fetchRSC HTTP responses', () => {
     expect(reportedText).not.toContain(encodeURIComponent(sentinel));
   });
 
+  it('redacts serialized props from synchronous fetch throws', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
+    const componentProps = { token: sentinel };
+    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+      props: JSON.stringify(componentProps),
+    })}`;
+    fetchMock.mockImplementation(() => {
+      throw new TypeError(`sync fetch failed for ${fetchUrl}`);
+    });
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+    );
+    expect(thrownError?.cause).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
+
+    const reportedText = [thrownError?.message, thrownError?.stack]
+      .filter((line): line is string => Boolean(line))
+      .join('\n');
+    expect(reportedText).not.toContain(sentinel);
+    expect(reportedText).not.toContain(encodeURIComponent(sentinel));
+  });
+
+  it('preserves safe synchronous fetch throw messages and causes', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const originalError = new TypeError('sync fetch unavailable');
+    fetchMock.mockImplementation(() => {
+      throw originalError;
+    });
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps: { id: 1 },
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": sync fetch unavailable',
+    );
+    expect(thrownError?.cause).toBe(originalError);
+    expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')?.enumerable).toBe(false);
+  });
+
   it('redacts serialized props from nested fetch rejection causes', async () => {
     const { fetchRSC } = await loadClientModule();
     const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -100,9 +100,47 @@ describe('fetchRSC HTTP responses', () => {
         rscPayloadGenerationUrlPath: '/rsc_payload',
       }),
     ).rejects.toThrow(
-      `Failed to fetch RSC payload for component "MissingPanel" from "${fetchUrl}": RSC payload request for component "MissingPanel" from "/rsc_payload/MissingPanel" failed with HTTP 404 Not Found.`,
+      'Failed to fetch RSC payload for component "MissingPanel" from "/rsc_payload/MissingPanel": RSC payload request for component "MissingPanel" from "/rsc_payload/MissingPanel" failed with HTTP 404 Not Found.',
     );
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
     expect(createFromReadableStream).not.toHaveBeenCalled();
+  });
+
+  it('keeps serialized props out of non-ok HTTP error text while preserving the request URL', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
+    const componentProps = { token: sentinel };
+    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+      props: JSON.stringify(componentProps),
+    })}`;
+    fetchMock.mockResolvedValue(
+      createWebResponseFromText('server failed', {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+    );
+
+    let thrownError: Error | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": RSC payload request for component "AccountPanel" from "/rsc_payload/AccountPanel" failed with HTTP 500 Internal Server Error.',
+    );
+
+    const reportedText = `${thrownError?.message ?? ''}\n${thrownError?.stack ?? ''}`;
+    expect(reportedText).not.toContain(sentinel);
+    expect(reportedText).not.toContain(encodeURIComponent(sentinel));
   });
 
   it('propagates non-ok HTTP responses through the getReactServerComponent fetch path', async () => {
@@ -126,7 +164,7 @@ describe('fetchRSC HTTP responses', () => {
         enforceRefetch: true,
       }),
     ).rejects.toThrow(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel?props=%7B%7D": RSC payload request for component "AccountPanel" from "/rsc_payload/AccountPanel" failed with HTTP 401 Unauthorized.',
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": RSC payload request for component "AccountPanel" from "/rsc_payload/AccountPanel" failed with HTTP 401 Unauthorized.',
     );
     expect(createFromReadableStream).not.toHaveBeenCalled();
   });
@@ -152,7 +190,7 @@ describe('fetchRSC HTTP responses', () => {
     ).rejects.toThrow(
       `Failed to fetch RSC payload for component "${componentName}" from "/rsc_payload/${encodeURIComponent(
         componentName,
-      )}?props=%7B%22id%22%3A1%7D": RSC payload request for component "${componentName}" from "/rsc_payload/${encodeURIComponent(
+      )}": RSC payload request for component "${componentName}" from "/rsc_payload/${encodeURIComponent(
         componentName,
       )}" failed with HTTP 401 Unauthorized.`,
     );

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -143,6 +143,62 @@ describe('fetchRSC HTTP responses', () => {
     expect(reportedText).not.toContain(encodeURIComponent(sentinel));
   });
 
+  it('redacts serialized props from URL-bearing fetch rejection text and cause chains', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const sentinel = 'SECRET_SENTINEL_RSC_PROPS_LEAK';
+    const componentProps = { token: sentinel };
+    const fetchUrl = `/rsc_payload/AccountPanel?${new URLSearchParams({
+      props: JSON.stringify(componentProps),
+    })}`;
+    fetchMock.mockRejectedValue(new Error(`request to ${fetchUrl} failed`));
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps,
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+    );
+    expect(thrownError?.cause).toBeUndefined();
+
+    const reportedText = [thrownError?.message, thrownError?.stack]
+      .filter((line): line is string => Boolean(line))
+      .join('\n');
+    expect(reportedText).not.toContain(sentinel);
+    expect(reportedText).not.toContain(encodeURIComponent(sentinel));
+  });
+
+  it('preserves safe fetch rejection messages and causes', async () => {
+    const { fetchRSC } = await loadClientModule();
+    const originalError = new Error('network offline');
+    fetchMock.mockRejectedValue(originalError);
+
+    let thrownError: (Error & { cause?: unknown }) | undefined;
+    try {
+      await fetchRSC({
+        componentName: 'AccountPanel',
+        componentProps: { id: 1 },
+        rscPayloadGenerationUrlPath: '/rsc_payload',
+      });
+    } catch (error) {
+      thrownError = error as Error & { cause?: unknown };
+    }
+
+    expect(thrownError?.message).toBe(
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": network offline',
+    );
+    expect(thrownError?.cause).toBe(originalError);
+  });
+
   it('propagates non-ok HTTP responses through the getReactServerComponent fetch path', async () => {
     const { createFromReadableStream, default: getReactServerComponent } = await loadClientModule();
     fetchMock.mockResolvedValue(

--- a/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
+++ b/packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts
@@ -100,7 +100,7 @@ describe('fetchRSC HTTP responses', () => {
         rscPayloadGenerationUrlPath: '/rsc_payload',
       }),
     ).rejects.toThrow(
-      'Failed to fetch RSC payload for component "MissingPanel" from "/rsc_payload/MissingPanel": RSC payload request for component "MissingPanel" from "/rsc_payload/MissingPanel" failed with HTTP 404 Not Found.',
+      'Failed to fetch RSC payload for component "MissingPanel" from "/rsc_payload/MissingPanel" (props redacted): RSC payload request for component "MissingPanel" from "/rsc_payload/MissingPanel" (props redacted) failed with HTTP 404 Not Found.',
     );
     expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
     expect(createFromReadableStream).not.toHaveBeenCalled();
@@ -135,7 +135,7 @@ describe('fetchRSC HTTP responses', () => {
     expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
     expect(thrownError).toBeInstanceOf(Error);
     expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": RSC payload request for component "AccountPanel" from "/rsc_payload/AccountPanel" failed with HTTP 500 Internal Server Error.',
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel" (props redacted): RSC payload request for component "AccountPanel" from "/rsc_payload/AccountPanel" (props redacted) failed with HTTP 500 Internal Server Error.',
     );
 
     const reportedText = `${thrownError?.message ?? ''}\n${thrownError?.stack ?? ''}`;
@@ -226,7 +226,7 @@ describe('fetchRSC HTTP responses', () => {
       expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
       expect(thrownError).toBeInstanceOf(Error);
       expect(thrownError?.message).toBe(
-        'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+        'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel" (props redacted): request failed before receiving an RSC payload response.',
       );
       expect(thrownError?.cause).toBeUndefined();
       expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
@@ -265,7 +265,7 @@ describe('fetchRSC HTTP responses', () => {
     expect(fetchMock).toHaveBeenCalledWith(fetchUrl);
     expect(thrownError).toBeInstanceOf(Error);
     expect(thrownError?.message).toBe(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": request failed before receiving an RSC payload response.',
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel" (props redacted): request failed before receiving an RSC payload response.',
     );
     expect(thrownError?.cause).toBeUndefined();
     expect(Object.getOwnPropertyDescriptor(thrownError!, 'cause')).toBeUndefined();
@@ -313,7 +313,7 @@ describe('fetchRSC HTTP responses', () => {
         enforceRefetch: true,
       }),
     ).rejects.toThrow(
-      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel": RSC payload request for component "AccountPanel" from "/rsc_payload/AccountPanel" failed with HTTP 401 Unauthorized.',
+      'Failed to fetch RSC payload for component "AccountPanel" from "/rsc_payload/AccountPanel" (props redacted): RSC payload request for component "AccountPanel" from "/rsc_payload/AccountPanel" (props redacted) failed with HTTP 401 Unauthorized.',
     );
     expect(createFromReadableStream).not.toHaveBeenCalled();
   });
@@ -339,9 +339,9 @@ describe('fetchRSC HTTP responses', () => {
     ).rejects.toThrow(
       `Failed to fetch RSC payload for component "${componentName}" from "/rsc_payload/${encodeURIComponent(
         componentName,
-      )}": RSC payload request for component "${componentName}" from "/rsc_payload/${encodeURIComponent(
+      )}" (props redacted): RSC payload request for component "${componentName}" from "/rsc_payload/${encodeURIComponent(
         componentName,
-      )}" failed with HTTP 401 Unauthorized.`,
+      )}" (props redacted) failed with HTTP 401 Unauthorized.`,
     );
     expect(fetchMock).toHaveBeenCalledWith(
       `/rsc_payload/${encodeURIComponent(componentName)}?${new URLSearchParams({


### PR DESCRIPTION
## Why

Fixes #4449.

Client-side RSC fetch failures could include the full RSC payload URL in thrown error text. That URL contains serialized `?props=...`, so values from component props could be captured by consoles, error boundaries, or error reporters during failed fetches.

## What changed

- Keep the actual RSC fetch URL unchanged so the server still receives props.
- Report the query-free RSC source path in fetch failure wrapper errors.
- Add sentinel regression coverage proving props stay in the request URL but out of error message/stack text.
- Keep `ServerComponentFetchError.serverComponentProps` directly readable for retry while making it non-enumerable so generic error serializers do not casually copy retry props.

## Validation

- `pnpm exec prettier --write CHANGELOG.md packages/react-on-rails-pro/src/ServerComponentFetchError.ts packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts`
- `pnpm exec eslint packages/react-on-rails-pro/src/ServerComponentFetchError.ts packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx packages/react-on-rails-pro/tests/getReactServerComponent.client.test.ts`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm --filter react-on-rails-pro run build`
- `script/check-pro-license-headers`
- `git diff --check`
- focused `tsx` probes for fetch error redaction and non-enumerable retry props
- pre-commit hook
- pre-push hook

No Jest/RSpec/Playwright suite run locally per React on Rails Pro local-test rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RSC fetch failures now redact any serialized component props from thrown error text and stack traces, reducing risk of sensitive prop values appearing in logs or error reporting.
  * Non-OK and fetch-rejection error messages now focus on the RSC payload route (without `?props=...`), with consistent handling of `cause` behavior depending on whether props were detected.
* **Tests**
  * Expanded Jest coverage for error redaction across multiple failure shapes and verifies `serverComponentProps` is directly readable but remains non-enumerable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->