### PR TITLE
Fix getStore optional lookup with no hydrated stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **`ReactOnRails.getStore(name, false)` no longer throws when no stores are hydrated**: With
+  `throwIfMissing = false`, `getStore` now returns `undefined` when the hydrated-store registry is
+  empty — matching its documented contract and its existing behavior when other stores are hydrated —
+  in both the open-source and Pro JS packages. Default strict calls still throw the descriptive
+  "There are no stores hydrated" / "Could not find hydrated store" errors. By
+  [ihabadham](https://github.com/ihabadham).
 - **[Pro]** **Node renderer graceful shutdown and scheduled restarts**: Worker shutdown now counts
   each active request once across response, abort, and timeout hooks; scheduled restart timeouts use
   documented seconds; draining workers skip only the early master SIGKILL while keeping the hard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   `throwIfMissing = false`, `getStore` now returns `undefined` when the hydrated-store registry is
   empty — matching its documented contract and its existing behavior when other stores are hydrated —
   in both the open-source and Pro JS packages. Default strict calls still throw the descriptive
-  "There are no stores hydrated" / "Could not find hydrated store" errors. By
+  "There are no stores hydrated" / "Could not find hydrated store" errors.
+  [PR 4457](https://github.com/shakacode/react_on_rails/pull/4457) by
   [ihabadham](https://github.com/ihabadham).
 - **[Pro]** **Node renderer graceful shutdown and scheduled restarts**: Worker shutdown now counts
   each active request once across response, abort, and timeout hooks; scheduled restart timeouts use

--- a/docs/oss/api-reference/javascript-api.md
+++ b/docs/oss/api-reference/javascript-api.md
@@ -58,8 +58,8 @@ registerStoreGenerators(storesGenerators);
 
 /**
  * Allows retrieval of the store by name. This store will be hydrated by any Rails form props.
- * Pass optional param throwIfMissing = false if you want to use this call to get back null if the
- * store with name is not registered.
+ * Pass optional param throwIfMissing = false if you want to use this call to get back undefined if
+ * the store with name is not hydrated.
  * @param name
  * @param throwIfMissing Defaults to true. Set to false to have this call return undefined if
  *        there is no store with the given name.

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -48,7 +48,7 @@ ReactOnRails.registerStore({
 When registering your component with React on Rails, you can get the store via `ReactOnRails.getStore`:
 
 ```js
-// getStore will initialize the store if not already initialized, so creates or retrieves store
+// getStore retrieves the store that React on Rails created and hydrated from the redux_store props
 const appStore = ReactOnRails.getStore('appStore');
 return (
   <Provider store={appStore}>

--- a/packages/react-on-rails-pro/src/StoreRegistry.ts
+++ b/packages/react-on-rails-pro/src/StoreRegistry.ts
@@ -60,6 +60,10 @@ export function getStore(name: string, throwIfMissing = true): Store | undefined
   try {
     return hydratedStoreRegistry.get(name);
   } catch (error) {
+    if (!throwIfMissing) {
+      return undefined;
+    }
+
     if (hydratedStoreRegistry.getAll().size === 0) {
       const msg = `There are no stores hydrated and you are requesting the store ${name}.
 This can happen if you are server rendering and either:
@@ -69,10 +73,7 @@ This can happen if you are server rendering and either:
       throw new Error(msg);
     }
 
-    if (throwIfMissing) {
-      throw error;
-    }
-    return undefined;
+    throw error;
   }
 }
 

--- a/packages/react-on-rails-pro/tests/StoreRegistry.test.ts
+++ b/packages/react-on-rails-pro/tests/StoreRegistry.test.ts
@@ -121,4 +121,24 @@ describe('StoreRegistry', () => {
 
     await expect(pendingStoreGenerator).resolves.toBe(storeGenerator);
   });
+
+  it('returns undefined from getStore when no stores are hydrated and throwIfMissing is false', () => {
+    expect(StoreRegistry.getStore('Missing', false)).toBeUndefined();
+  });
+
+  it('returns undefined from getStore when other stores are hydrated and throwIfMissing is false', () => {
+    StoreRegistry.setStore('Other', createStore());
+    expect(StoreRegistry.getStore('Missing', false)).toBeUndefined();
+  });
+
+  it('throws from getStore when no stores are hydrated and throwIfMissing is default', () => {
+    expect(() => StoreRegistry.getStore('Missing')).toThrow(/There are no stores hydrated/);
+  });
+
+  it('throws from getStore when the store is missing and others are hydrated', () => {
+    StoreRegistry.setStore('Other', createStore());
+    expect(() => StoreRegistry.getStore('Missing')).toThrow(
+      /Could not find hydrated store registered with name Missing/,
+    );
+  });
 });

--- a/packages/react-on-rails/src/StoreRegistry.ts
+++ b/packages/react-on-rails/src/StoreRegistry.ts
@@ -44,6 +44,10 @@ export default {
       return hydratedStores.get(name);
     }
 
+    if (!throwIfMissing) {
+      return undefined;
+    }
+
     const storeKeys = Array.from(hydratedStores.keys()).join(', ');
 
     if (storeKeys.length === 0) {
@@ -55,15 +59,10 @@ This can happen if you are server rendering and either:
       throw new Error(msg);
     }
 
-    if (throwIfMissing) {
-      console.log('storeKeys', storeKeys);
-      throw new Error(
-        `Could not find hydrated store with name '${name}'. ` +
-          `Hydrated store names include [${storeKeys}].`,
-      );
-    }
-
-    return undefined;
+    console.log('storeKeys', storeKeys);
+    throw new Error(
+      `Could not find hydrated store with name '${name}'. Hydrated store names include [${storeKeys}].`,
+    );
   },
 
   /**

--- a/packages/react-on-rails/tests/StoreRegistry.test.js
+++ b/packages/react-on-rails/tests/StoreRegistry.test.js
@@ -58,6 +58,12 @@ describe('StoreRegistry', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('StoreRegistry returns undefined when no stores are hydrated, passing throwIfMissing = false', () => {
+    const actual = StoreRegistry.getStore('foobar', false);
+    const expected = undefined;
+    expect(actual).toEqual(expected);
+  });
+
   it('StoreRegistry getStore, setStore', () => {
     const store = storeGenerator({});
     StoreRegistry.setStore('storeGenerator', store);


### PR DESCRIPTION
## Why

`ReactOnRails.getStore(name, false)` is documented as a non-throwing optional lookup, but the empty hydrated-store registry path threw the strict "There are no stores hydrated" diagnostic before checking `throwIfMissing`.

That made the same optional lookup behave differently depending on whether some unrelated store had already been hydrated:

- no stores hydrated + `false` → threw
- another store hydrated + `false` → returned `undefined`

This affects both the open-source and Pro JS store registries.

## What changed

- Return `undefined` for `throwIfMissing = false` before strict missing-store diagnostics in both registries.
- Keep default/strict `getStore(name)` behavior unchanged, including the existing helpful error messages.
- Add regression coverage for the empty-registry optional lookup.
- Add Pro StoreRegistry coverage for the full empty/non-empty × strict/optional matrix.
- Fix stale Redux docs that said optional lookup returned `null` and that `getStore` initialized stores.

## Verification

- Reproduced on `origin/main` (`59e00e1cf` at investigation time): empty registry + `getStore('Missing', false)` threw in both packages.
- Confirmed post-fix behavior: empty registry + `false` returns `undefined`; strict/default calls still throw.
- Bloodhound review found one changelog wording issue; fixed and re-reviewed clean.

Local commands run:

```sh
pnpm --dir packages/react-on-rails exec jest tests/StoreRegistry.test.js --runInBand
pnpm --dir packages/react-on-rails-pro exec jest tests/StoreRegistry.test.ts --runInBand
pnpm --dir packages/react-on-rails run type-check
pnpm --dir packages/react-on-rails-pro run type-check
pnpm run lint
pnpm start format.listDifferent
git diff --check origin/main...HEAD
```

Pre-push hooks also passed, including online Markdown link checks for the changed docs/changelog files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `getStore(..., false)` now returns `undefined` when the requested store isn’t available, including when no stores have been hydrated.
  * Default behavior still throws helpful errors when a store is missing.

* **Documentation**
  * Updated API docs and changelog entries to reflect the current `getStore` behavior.
  * Clarified example wording around hydrated stores.

* **Tests**
  * Added coverage for missing-store scenarios and the default error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->