### PR TITLE
Refresh generated Pro LLM docs

### DIFF
--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -2100,7 +2100,63 @@ Use `cached_buffered_stream_react_component` when the complete static response s
 %>
 ```
 
+For static public RSC pages that do not hydrate the generated page pack, use `cached_static_rsc_component`. It buffers through the same renderer, strips embedded `REACT_ON_RAILS_RSC_PAYLOADS` bootstrap scripts before caching, and respects an explicit `auto_load_bundle: false` so the view can append only a small sidecar pack:
+
+```erb
+<%=
+  cached_static_rsc_component(
+    "MarketingPage",
+    cache_key: ["marketing-page", I18n.locale],
+    cache_tags: ["marketing-page"],
+    cache_options: { expires_in: 30.minutes },
+    auto_load_bundle: false,
+    rsc_diagnostic_packs: ["generated/PublicPageClientEffects"],
+    id: "marketing-page"
+  ) do
+    @marketing_page_props
+  end
+%>
+<%= javascript_pack_tag("generated/PublicPageClientEffects") %>
+```
+
 Buffered rendering is not progressive: the browser receives the page only after every RSC/SSR chunk is available. Prefer `stream_react_component` or `stream_react_component_with_async_props` when early shell flush, slow async props, or progressive Suspense boundaries matter.
+
+#### Static RSC Render Diagnostics
+
+`cached_static_rsc_component` emits a redacted render summary in development and when `ReactOnRailsPro.configuration.tracing` is enabled. You can also enable it per render with `rsc_render_diagnostics: true` or capture it directly with a callback:
+
+```erb
+<%=
+  cached_static_rsc_component(
+    "MarketingPage",
+    cache_key: ["marketing-page", I18n.locale],
+    auto_load_bundle: false,
+    rsc_diagnostic_packs: ["generated/PublicPageClientEffects"],
+    rsc_render_diagnostics: ->(summary) { Rails.logger.info(summary.to_json) },
+    id: "marketing-page"
+  ) do
+    @marketing_page_props
+  end
+%>
+```
+
+The same payload is published as an `ActiveSupport::Notifications` event so benchmark harnesses can archive it with ShakaPerf or Lighthouse output:
+
+```ruby
+ActiveSupport::Notifications.subscribe("render_static_rsc_component.react_on_rails_pro") do |_name, _start, _finish, _id, summary|
+  Rails.logger.info(summary.to_json)
+end
+```
+
+The summary includes:
+
+- `cache.enabled`, `cache.hit`, and `cache.key_digest` so public-page runs can distinguish cold renders from warm cached output without logging raw cache keys.
+- `auto_load_bundle`, which shows whether the generated page pack was intentionally skipped.
+- `html.raw_bytes`, `html.cached_bytes`, `rsc_payload.bootstrap_script_count`, and `rsc_payload.bootstrap_script_bytes`, which show how much Flight/bootstrap script markup was removed before caching.
+- `emitted_assets.js` and `emitted_assets.css`, populated from the Shakapacker manifest for the generated component pack when `auto_load_bundle` is true and for any explicit `rsc_diagnostic_packs`.
+- `client_references.entries`, populated from the RSC client manifest when it is available on disk. An empty array is useful evidence for static public pages that should avoid eager RSC client references.
+
+Manifest-derived fields are best-effort. When a dev server, missing file, or custom deployment makes a manifest unavailable, the summary includes an `unavailable_reason` instead of failing the render. The summary never includes serialized props, Flight payload contents, or the raw expanded cache key.
 
 ### Browser-Observable RSC Stream Marks
 
@@ -2665,6 +2721,8 @@ Nonces are per-request values; caching renders per-request markup. Two distinct 
 ### Fragment caching helpers bake the nonce into the cached fragment
 
 `cached_react_component`, `cached_react_component_hash`, `cached_stream_react_component`, `cached_buffered_stream_react_component`, and `cached_async_react_component` cache the **final rendered HTML** (for streaming: the full chunk array) under a cache key built from your `cache_key` option plus bundle digests. The cached markup includes the executable inline scripts **with the nonce of the request that populated the cache**, and the cache key does **not** include the nonce.
+
+`cached_static_rsc_component` strips embedded RSC payload/bootstrap scripts that reference `REACT_ON_RAILS_RSC_PAYLOADS` before caching, so those payload scripts are not served with stale nonces. Any other executable inline scripts preserved in the cached HTML still follow this nonce caveat.
 
 A cache hit therefore serves a stale nonce to a different request, whose CSP header carries a different nonce — the browser blocks those inline scripts and immediate hydration/console replay silently degrade (components still hydrate via the client bundle's normal page-load path, but the strict-CSP guarantee of "zero violations" no longer holds).
 
@@ -4240,7 +4298,7 @@ const config = {
   allWorkersRestartInterval: 45,
   // Stagger individual restarts by 6 minutes to avoid downtime
   delayBetweenIndividualWorkerRestarts: 6,
-  // Force-kill workers that don't restart within 30 seconds
+  // Force-kill workers that don't restart within 30 seconds (value is seconds)
   gracefulWorkerRestartTimeout: 30,
 };
 ```


### PR DESCRIPTION
## Summary

Refreshes `llms-full-pro.txt` after the Batch B post-merge audit found the generated Pro LLM reference artifact was stale on `main`.

The committed source docs were already present; this PR only runs the canonical generator output forward so the generated LLM bundle includes the cached static RSC helper, diagnostics, CSP caveat, and the later timeout wording already present in docs.

Follow-up to #4386.

## Verification

- PASS `node script/generate-llms-full.mjs`
- PASS `node script/generate-llms-full.mjs --check`
- PASS `git diff --check`
- PASS `.agents/bin/validate --changed`
- PASS pre-commit hook `trailing-newlines`
- PASS pre-push hooks `branch-lint`, `markdown-links`
- FAIL `.agents/bin/lint` due unrelated current-main TypeScript/RuboCop lint failures outside this PR's single generated file, including `benchmarks/k6.ts`, `eslint.config.ts`, and `packages/react-on-rails-pro-node-renderer/src/**`.

## QA Evidence

- Scope checked: generated LLM reference artifact only.
- Changed files: `llms-full-pro.txt`.
- Tested at: `5985c73e1`.
- CI routing: `.agents/bin/validate --changed` classified this as documentation-only and recommended no additional CI jobs.