### PR TITLE
Docs: add Pro RSC changelog coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,12 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4438](https://github.com/shakacode/react_on_rails/pull/4438) by
   [justin808](https://github.com/justin808).
 
+- **[Pro]** **Truncated RSC parser streams now warn at EOF**: The Pro RSC length-prefixed stream
+  parser flushes at stream end so incomplete trailing records emit the existing parser warning,
+  while expected request-abort cleanup remains quiet.
+  [PR 4392](https://github.com/shakacode/react_on_rails/pull/4392) by
+  [justin808](https://github.com/justin808).
+
 - **`ReactOnRails.getStore(name, false)` no longer throws when no stores are hydrated**: With
   `throwIfMissing = false`, `getStore` now returns `undefined` when the hydrated-store registry is
   empty — matching its documented contract and its existing behavior when other stores are hydrated —
@@ -125,6 +131,21 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   "There are no stores hydrated" / "Could not find hydrated store" errors.
   [PR 4457](https://github.com/shakacode/react_on_rails/pull/4457) by
   [ihabadham](https://github.com/ihabadham).
+
+- **[Pro]** **RSC stylesheet inference retries after transient stats read failures**: Pro now caches
+  client-chunk stylesheet metadata only after a successful `loadable-stats.json` read, so a
+  deploy-race or temporary parse/read failure does not disable inferred RSC client stylesheets for
+  the worker lifetime.
+  [PR 4401](https://github.com/shakacode/react_on_rails/pull/4401) by
+  [justin808](https://github.com/justin808).
+
+- **[Pro]** **RSC loadable-stats retry diagnostics stay visible**: Malformed or unreadable
+  `loadable-stats.json` warnings are suppressed only for the retry window, and native ESM stack
+  paths rewritten through source maps are normalized back to the runtime `lib/` directory before
+  resolving stats.
+  [PR 4447](https://github.com/shakacode/react_on_rails/pull/4447) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Node renderer graceful shutdown and scheduled restarts**: Worker shutdown now counts
   each active request once across response, abort, and timeout hooks; scheduled restart timeouts use
   documented seconds; draining workers skip only the early master SIGKILL while keeping the hard


### PR DESCRIPTION
## Why

Fixes #4454. The merged Pro RSC changes from PRs #4392, #4401, and #4447 were user-visible reliability and diagnostics fixes, but `CHANGELOG.md` did not yet have traceable `[Pro]` coverage for them.

## What Changed

- Added three `[Pro]` entries under `### [Unreleased]` / `#### Fixed`:
  - PR #4392: truncated Pro RSC parser streams warn at EOF while expected request-abort cleanup remains quiet.
  - PR #4401: RSC client stylesheet inference retries after transient `loadable-stats.json` read failures.
  - PR #4447: loadable-stats retry diagnostics remain visible and source-map-rewritten stack paths normalize back to runtime `lib/`.
- No version header was stamped and no compare links were changed.

## Traceability Evidence

- `gh pr view 4392 --repo shakacode/react_on_rails --json number,title,url,mergedAt,mergeCommit,headRefName,baseRefName`
  - #4392 `Warn on truncated Pro RSC parser streams`
  - URL: https://github.com/shakacode/react_on_rails/pull/4392
  - Base/head: `main` / `codex/batch-e-rsc-parser-flush-4370`
  - Merged: `2026-07-03T10:08:27Z`
  - Merge commit: `2d912cbfa867da0f4f0efc734a02ae69e464f369`
- `gh pr view 4401 --repo shakacode/react_on_rails --json number,title,url,mergedAt,mergeCommit,headRefName,baseRefName`
  - #4401 `Fix Pro RSC stylesheet stats retry after read failures`
  - URL: https://github.com/shakacode/react_on_rails/pull/4401
  - Base/head: `main` / `codex/batch-e-loadable-stats-retry-4371`
  - Merged: `2026-07-03T10:51:49Z`
  - Merge commit: `31d444215d97b6bd15224fd38d24661d28496efb`
- `gh pr view 4447 --repo shakacode/react_on_rails --json number,title,url,mergedAt,mergeCommit,headRefName,baseRefName`
  - #4447 `Fix Pro RSC loadable stats retry visibility`
  - URL: https://github.com/shakacode/react_on_rails/pull/4447
  - Base/head: `main` / `codex/batch-e-loadable-stats-postmerge-followup`
  - Merged: `2026-07-03T21:33:25Z`
  - Merge commit: `561ec5446136ea4d0e7f2091873686f944ef0ef9`

## Validation

- `git fetch --prune origin main` passed.
- `.agents/bin/agent-workflow-seam-doctor` passed: `PASS agent workflow seam is complete`.
- `git diff --check` passed.
- `.agents/bin/ci-detect origin/main` passed and classified the diff as documentation-only: `Recommended CI jobs: NONE (skip CI)`.
- `.agents/skills/update-changelog/bin/changelog-merged-prs --self-check` passed: `parsers: ok`, `gh smoke: ok for shakacode/react_on_rails`, `self-check passed`.
- `pnpm install --frozen-lockfile --ignore-scripts --filter='{.}'` passed to install root markdown tooling without changing the lockfile.
- `pnpm exec prettier --check CHANGELOG.md` passed: `All matched files use Prettier code style!`.
- `bin/lefthook/check-trailing-newlines all-changed` passed.
- Commit hook passed trailing-newline and Prettier checks. Markdown link checking was skipped through the hook's built-in skip path because the compatible lychee was not on `PATH`; the installed Homebrew `lychee 0.24.2` rejects the committed `.lychee.toml` before checking links (`include_fragments = false` parse error). The new GitHub PR links were verified by the `gh pr view` commands above.

## Handoff

- `merge_authority: none`; do not merge from this worker lane.
- Batch QA Lane is required and owned by `qa-docs-release`. This PR only provides the changelog worker evidence; final batch QA remains with that owner.
- Labels: none. This is a changelog-only documentation diff and `ci-detect` recommended no CI jobs.