### PR TITLE
Docs: add Rails-owned mutation recipes

### DIFF
--- a/docs/oss/building-features/forms.md
+++ b/docs/oss/building-features/forms.md
@@ -26,6 +26,10 @@ The contract between them is one blessed error shape:
 The hook works against **any** endpoint returning that shape; the concern is a
 convenience, not a requirement.
 
+For the framework-level comparison with Next.js Server Actions and TanStack
+Start server functions, see
+[Mutations without Server Actions](./mutations.md).
+
 Compatibility: `react-on-rails/useRailsForm` requires React 16.8 or newer
 because it is a hook. Apps still on React 16.0-16.7 can continue using the
 package's other React 16 APIs, but this subpath throws a clear error until React
@@ -261,6 +265,8 @@ React on Rails intentionally keeps mutations in Rails controllers —
 [Server Functions RFC (Issue 3867)](https://github.com/shakacode/react_on_rails/issues/3867)
 explores the complementary RSC-side story. The two are designed to compose: if
 Server Functions land, this hook remains the plain-controller bridge.
+For side-by-side migration examples, see
+[Mutations without Server Actions](./mutations.md).
 
 ## Scope and roadmap
 

--- a/docs/oss/building-features/mutations.md
+++ b/docs/oss/building-features/mutations.md
@@ -70,7 +70,7 @@ class ProjectsController < ApplicationController
 
     if project.save
       render json: {
-        project: { id: project.id, name: project.name },
+        project: { id: project.id, name: project.name, status: project.status },
         redirect_to: project_path(project)
       }, status: :created
     else
@@ -250,8 +250,9 @@ After a mutation, choose the refresh mechanism that matches the UI:
 - TanStack Query island: invalidate or update the affected query keys.
 - RSC route: navigate to a route that Rails renders again, or trigger the app's client router to load
   the next page state.
-- Fragment/component cache: expire or revalidate from Rails callbacks, jobs, or controller code, not
-  from a Node-renderer Server Action.
+- Fragment/component cache: expire Rails-owned cache keys from callbacks, jobs, or controller code,
+  then use the matching page, query, or route refresh path above to re-read the data. Do not rely
+  on a Node-renderer Server Action for cache invalidation.
 
 For the migration-specific warning, see
 [Mutations: Rails Controllers, Not Server Actions](../migrating/rsc-data-fetching.md#mutations-rails-controllers-not-server-actions).

--- a/docs/oss/building-features/mutations.md
+++ b/docs/oss/building-features/mutations.md
@@ -117,6 +117,15 @@ errors, redirects, jobs, and cache expiry:
 ```ts
 import { createRailsAction } from 'react-on-rails/railsAction';
 
+type ProjectFormData = {
+  name: string;
+  status: 'draft' | 'active';
+};
+
+type ProjectResponse = {
+  project: { id: number; name: string; status: string };
+};
+
 const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
   path: '/projects',
 });

--- a/docs/oss/building-features/mutations.md
+++ b/docs/oss/building-features/mutations.md
@@ -333,9 +333,13 @@ export function useCreateProjectMutation(setValidationErrors: (errors: Validatio
     },
     onError: (error) => {
       if (error instanceof RailsActionRequestError && error.response.status === 422) {
-        const { errors = {} } = error.responseBody as ErrorResponse;
+        const responseBody = error.responseBody;
+        const errors =
+          responseBody && typeof responseBody === 'object' && 'errors' in responseBody
+            ? (responseBody as ErrorResponse).errors
+            : undefined;
 
-        setValidationErrors(errors);
+        setValidationErrors(errors ?? { base: ['Something went wrong. Please try again.'] });
       }
     },
   });

--- a/docs/oss/building-features/mutations.md
+++ b/docs/oss/building-features/mutations.md
@@ -305,7 +305,7 @@ import { createRailsAction, RailsActionRequestError } from 'react-on-rails/rails
 
 type ProjectFormData = {
   name: string;
-  status: string;
+  status: 'draft' | 'active';
 };
 
 type ProjectResponse = {
@@ -324,6 +324,7 @@ const isValidationErrors = (errors: unknown): errors is ValidationErrors =>
   Boolean(errors) &&
   typeof errors === 'object' &&
   !Array.isArray(errors) &&
+  Object.keys(errors).length > 0 &&
   Object.values(errors).every(
     (messages) => Array.isArray(messages) && messages.every((message) => typeof message === 'string'),
   );

--- a/docs/oss/building-features/mutations.md
+++ b/docs/oss/building-features/mutations.md
@@ -1,0 +1,276 @@
+---
+sidebar_label: 'Mutations'
+description: 'How to handle Rails-owned form and data mutations in React on Rails without Next.js Server Actions or TanStack Start server functions.'
+---
+
+# Mutations without Server Actions
+
+React on Rails keeps mutations in Rails. React Server Components change how read-only UI can be
+rendered and streamed, but they do not move writes into the Node renderer. A React form, button, or
+TanStack Query mutation should submit to a Rails route, let the controller run the same
+authentication, authorization, strong parameters, ActiveRecord transactions, and validations that a
+server-rendered Rails form would use, then return JSON or navigate.
+
+Do **not** add `'use server'` to React on Rails application code. In React on Rails, the Node renderer
+is a rendering process. It does not own Rails models, sessions, cookies, CSRF verification, or
+transactions. Use a Client Component, a standard Rails form, or a TanStack Query mutation that calls a
+Rails controller endpoint.
+
+## Side-by-side map
+
+| Concern                 | Next.js Server Actions                                                                                              | TanStack Start server functions                                                                                               | React on Rails                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client call site        | `<form action={createPost}>`, `formAction`, or an event handler that invokes a Server Function.                     | `createServerFn({ method: 'POST' })`, often called from a component, loader, hook, event handler, or TanStack Query mutation. | `form_with`, `useRailsForm`, `createRailsAction`, or a CSRF-aware `fetch`/TanStack Query mutation.                                                               |
+| Where server logic runs | The Next.js app server, inside an async function marked with `'use server'` or exported from a `'use server'` file. | The TanStack Start server, inside the `createServerFn` handler.                                                               | The Rails controller action, backed by Rails models, policies, jobs, mailers, and transactions.                                                                  |
+| Request shape           | Framework-owned POST request to the Server Action endpoint.                                                         | Framework-owned same-origin RPC request to the server function endpoint.                                                      | Ordinary Rails HTTP route, usually JSON for React islands or a normal HTML form post for full-page flows.                                                        |
+| Security boundary       | Verify authentication and authorization inside the action; Next.js applies same-origin Server Action protections.   | Validate input in the server function; Start documents same-origin RPC and CSRF middleware for server functions.              | Use Rails sessions, `csrf_meta_tags`, controller filters, strong parameters, and policy checks. React helpers attach CSRF headers for JSON requests.             |
+| Validation errors       | Return serializable error state or throw/redirect according to the action pattern.                                  | Return serializable error state, throw, redirect, or feed TanStack Query mutation state.                                      | Return `422` JSON such as `{ "errors": { "name": ["can't be blank"] } }`; `useRailsForm` maps this to field errors.                                              |
+| After the write         | Call Next cache revalidation helpers, redirect, or return updated UI/data.                                          | Invalidate TanStack Query cache, redirect, or update route state.                                                             | Let Rails redirect for full-page flows, return a safe `redirect_to` JSON hint, invalidate TanStack Query cache, or let the next Rails render stream fresh props. |
+
+The practical translation is:
+
+- **Next.js Server Action**: "call this server function from my form."
+- **TanStack Start server function**: "call this typed same-origin server function from my app."
+- **React on Rails**: "call this Rails controller route from my React UI."
+
+## Choose the Rails entry point
+
+Use the narrowest path that matches the UI:
+
+- **Standard Rails forms**: best when a full-page submit and redirect are acceptable, or when the
+  feature should work without JavaScript.
+- **[`useRailsForm`](./forms.md)**: best for React-controlled forms that need field errors,
+  `processing`, reset behavior, CSRF handling, and a small `useForm`-style API.
+- **[`createRailsAction`](./generated-rails-response-types.md#use-with-typed-rails-actions) with
+  TanStack Query**: best for buttons, tables, optimistic updates, and typed mutation responses.
+- **Manual `fetch` with React on Rails authenticity helpers**: fine for one-off calls, but centralize
+  same-origin, JSON, and CSRF behavior once the pattern repeats.
+
+## Recipe: React form, Rails controller
+
+This is the Rails-native equivalent of a Next.js `<form action={createPost}>` Server Action or a
+TanStack Start `createServerFn({ method: 'POST' })` mutation: keep the server logic in Rails and make
+the Client Component submit JSON to that route.
+
+### Rails route and controller
+
+```ruby
+# config/routes.rb
+resources :projects, only: [:new, :create, :show]
+```
+
+```ruby
+# app/controllers/projects_controller.rb
+class ProjectsController < ApplicationController
+  include ReactOnRails::Controller::FormResponders
+
+  def create
+    project = current_account.projects.build(project_params)
+    # Run your normal authorization here, for example `authorize project`.
+
+    if project.save
+      render json: {
+        project: { id: project.id, name: project.name },
+        redirect_to: project_path(project)
+      }, status: :created
+    else
+      render_model_errors(project)
+    end
+  end
+
+  private
+
+  def project_params
+    if params.key?(:project)
+      params.require(:project).permit(:name, :status)
+    else
+      params.permit(:name, :status)
+    end
+  end
+end
+```
+
+### Client Component
+
+```tsx
+'use client';
+
+import type { FormEvent } from 'react';
+import { useRailsForm } from 'react-on-rails/useRailsForm';
+
+type ProjectFormData = {
+  name: string;
+  status: 'draft' | 'active';
+};
+
+export default function ProjectForm({ action }: { action: string }) {
+  const form = useRailsForm<ProjectFormData>({ name: '', status: 'draft' });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    void form
+      .post(action, {
+        onSuccess: ({ redirectTo }) => {
+          if (redirectTo) {
+            window.location.assign(redirectTo);
+          } else {
+            form.reset();
+          }
+        },
+      })
+      .catch(() => {
+        form.setError('base', 'Something went wrong. Please try again.');
+      });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Name
+        <input value={form.data.name} onChange={(event) => form.setData('name', event.target.value)} />
+      </label>
+      {form.errors.name?.map((message) => (
+        <p className="error" key={message}>
+          {message}
+        </p>
+      ))}
+
+      <label>
+        Status
+        <select
+          value={form.data.status}
+          onChange={(event) => form.setData('status', event.target.value as ProjectFormData['status'])}
+        >
+          <option value="draft">Draft</option>
+          <option value="active">Active</option>
+        </select>
+      </label>
+      {form.errors.status?.map((message) => (
+        <p className="error" key={message}>
+          {message}
+        </p>
+      ))}
+
+      {form.errors.base?.map((message) => (
+        <p className="error" key={message}>
+          {message}
+        </p>
+      ))}
+
+      <button type="submit" disabled={form.processing}>
+        {form.processing ? 'Creating...' : 'Create project'}
+      </button>
+    </form>
+  );
+}
+```
+
+`base` is not special to Rails; it is just a conventional field name for errors that are not attached
+to one input. Use any key your app renders consistently.
+
+### Render it from Rails or RSC
+
+For an ordinary React island:
+
+```erb
+<%= react_component("ProjectForm", props: { action: projects_path }) %>
+```
+
+For a React Server Components page, keep the form as a Client Component and pass ordinary serializable
+props from the Server Component:
+
+```tsx
+// ProjectPage.tsx -- Server Component
+import ProjectForm from './ProjectForm.client';
+
+export default function ProjectPage({ projectsPath }: { projectsPath: string }) {
+  return <ProjectForm action={projectsPath} />;
+}
+```
+
+The write still goes to `ProjectsController#create`. The Server Component can render the initial page
+from Rails-provided props or async props, but the mutation belongs to Rails.
+
+## Recipe: TanStack Query mutation
+
+When the UI is a live table, command button, optimistic update, or cache-managed island, use TanStack
+Query for client state and keep the write endpoint in Rails.
+
+```tsx
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createRailsAction, RailsActionRequestError } from 'react-on-rails/railsAction';
+
+type ProjectFormData = {
+  name: string;
+  status: string;
+};
+
+type ProjectResponse = {
+  project: { id: number; name: string; status: string };
+};
+
+const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
+  path: '/projects',
+});
+
+export function useCreateProjectMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createProject,
+    onSuccess: ({ project }) => {
+      queryClient.setQueryData(['project', String(project.id)], { project });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+    },
+    onError: (error) => {
+      if (error instanceof RailsActionRequestError && error.response.status === 422) {
+        // Map your app's validation-error JSON into local form state.
+      }
+    },
+  });
+}
+```
+
+This is close to a TanStack Start server-function call at the component boundary, but the server code
+is still the Rails controller. If your app generates TypeScript response types from Rails, replace the
+hand-written `ProjectResponse` with
+[`RailsResponseType<'projects.create'>`](./generated-rails-response-types.md#use-with-typed-rails-actions).
+
+## RSC and cache refresh
+
+React on Rails RSC pages usually read data from Rails controller props or
+[`stream_react_component_with_async_props`](../migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
+After a mutation, choose the refresh mechanism that matches the UI:
+
+- Full-page Rails flow: redirect from the controller or return a same-origin `redirect_to` JSON hint
+  and navigate to it.
+- TanStack Query island: invalidate or update the affected query keys.
+- RSC route: navigate to a route that Rails renders again, or trigger the app's client router to load
+  the next page state.
+- Fragment/component cache: expire or revalidate from Rails callbacks, jobs, or controller code, not
+  from a Node-renderer Server Action.
+
+For the migration-specific warning, see
+[Mutations: Rails Controllers, Not Server Actions](../migrating/rsc-data-fetching.md#mutations-rails-controllers-not-server-actions).
+
+## Testing checklist
+
+- Controller/request spec: valid write, invalid `422` error JSON, authorization failure, and redirect
+  hint when used.
+- Client component test: submit state, CSRF-backed request helper behavior, validation-error rendering,
+  and cache invalidation or navigation callback.
+- System test: only for full user flows where routing, streaming, or hydration is the risk.
+
+## Related docs
+
+- [Forms and Mutations with `useRailsForm`](./forms.md)
+- [Using TanStack Query](./tanstack-query.md)
+- [Generated Rails response types](./generated-rails-response-types.md)
+- [RSC data fetching and mutation guidance](../migrating/rsc-data-fetching.md#mutations-rails-controllers-not-server-actions)
+- [React on Rails Pro and Next.js: RSC Architectures Compared](../../pro/react-server-components/nextjs-comparison.md)
+- [React on Rails Pro and TanStack Start: Two Ways to Own the Full Stack](../../pro/react-server-components/tanstack-start-comparison.md)
+- [Next.js Mutating Data](https://nextjs.org/docs/app/getting-started/mutating-data)
+- [TanStack Start Server Functions](https://tanstack.com/start/latest/docs/framework/react/guide/server-functions)

--- a/docs/oss/building-features/mutations.md
+++ b/docs/oss/building-features/mutations.md
@@ -33,6 +33,97 @@ The practical translation is:
 - **TanStack Start server function**: "call this typed same-origin server function from my app."
 - **React on Rails**: "call this Rails controller route from my React UI."
 
+## Same mutation in three stacks
+
+The same "create a project" mutation lands in a different server boundary in each stack. In Next.js,
+the form can call a Server Action; the database write, authorization, and cache refresh live in the
+Next.js server runtime:
+
+```tsx
+// app/projects/actions.ts
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { db } from '@/lib/db';
+
+export async function createProjectAction(formData: FormData) {
+  const name = String(formData.get('name') ?? '').trim();
+  const status = String(formData.get('status') ?? 'draft');
+
+  if (!name) {
+    return { errors: { name: ["can't be blank"] } };
+  }
+
+  const project = await db.project.create({ data: { name, status } });
+
+  revalidatePath('/projects');
+  redirect(`/projects/${project.id}`);
+}
+```
+
+```tsx
+// app/projects/form.tsx
+import { createProjectAction } from './actions';
+
+export function ProjectForm() {
+  return (
+    <form action={createProjectAction}>
+      <input name="name" />
+      <select name="status" defaultValue="draft">
+        <option value="draft">Draft</option>
+        <option value="active">Active</option>
+      </select>
+      <button type="submit">Create project</button>
+    </form>
+  );
+}
+```
+
+In TanStack Start, the component can call a server function. The handler still runs in Start's server
+runtime, not in Rails:
+
+```ts
+// src/projects/projects.functions.ts
+import { createServerFn } from '@tanstack/react-start';
+import { z } from 'zod';
+import { db } from '~/server/db';
+
+const projectSchema = z.object({
+  name: z.string().min(1),
+  status: z.enum(['draft', 'active']),
+});
+
+export const createProject = createServerFn({ method: 'POST' })
+  .validator(projectSchema)
+  .handler(async ({ data }) => {
+    const project = await db.project.create({ data });
+
+    return { project };
+  });
+```
+
+```tsx
+// src/projects/ProjectForm.tsx
+import { createProject } from './projects.functions';
+
+await createProject({ data: { name: 'Apollo', status: 'draft' } });
+```
+
+In React on Rails, the Client Component calls an ordinary Rails route. The Rails controller, shown in
+the recipe below, owns authentication, authorization, strong parameters, transactions, validation
+errors, redirects, jobs, and cache expiry:
+
+```ts
+import { createRailsAction } from 'react-on-rails/railsAction';
+
+const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
+  path: '/projects',
+});
+
+await createProject({ project: { name: 'Apollo', status: 'draft' } });
+```
+
 ## Choose the Rails entry point
 
 Use the narrowest path that matches the UI:
@@ -212,11 +303,17 @@ type ProjectResponse = {
   project: { id: number; name: string; status: string };
 };
 
+type ValidationErrors = Record<string, string[]>;
+
+type ErrorResponse = {
+  errors?: ValidationErrors;
+};
+
 const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
   path: '/projects',
 });
 
-export function useCreateProjectMutation() {
+export function useCreateProjectMutation(setValidationErrors: (errors: ValidationErrors) => void) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -227,7 +324,9 @@ export function useCreateProjectMutation() {
     },
     onError: (error) => {
       if (error instanceof RailsActionRequestError && error.response.status === 422) {
-        // Map your app's validation-error JSON into local form state.
+        const { errors = {} } = error.responseBody as ErrorResponse;
+
+        setValidationErrors(errors);
       }
     },
   });

--- a/docs/oss/building-features/mutations.md
+++ b/docs/oss/building-features/mutations.md
@@ -315,8 +315,18 @@ type ProjectResponse = {
 type ValidationErrors = Record<string, string[]>;
 
 type ErrorResponse = {
-  errors?: ValidationErrors;
+  errors?: unknown;
 };
+
+const fallbackError: ValidationErrors = { base: ['Something went wrong. Please try again.'] };
+
+const isValidationErrors = (errors: unknown): errors is ValidationErrors =>
+  Boolean(errors) &&
+  typeof errors === 'object' &&
+  !Array.isArray(errors) &&
+  Object.values(errors).every(
+    (messages) => Array.isArray(messages) && messages.every((message) => typeof message === 'string'),
+  );
 
 const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
   path: '/projects',
@@ -339,8 +349,11 @@ export function useCreateProjectMutation(setValidationErrors: (errors: Validatio
             ? (responseBody as ErrorResponse).errors
             : undefined;
 
-        setValidationErrors(errors ?? { base: ['Something went wrong. Please try again.'] });
+        setValidationErrors(isValidationErrors(errors) ? errors : fallbackError);
+        return;
       }
+
+      setValidationErrors(fallbackError);
     },
   });
 }

--- a/docs/pro/react-server-components/nextjs-comparison.md
+++ b/docs/pro/react-server-components/nextjs-comparison.md
@@ -190,26 +190,27 @@ Rails, which you already have.
 > choice. React on Rails Pro's RSC feature set is actively expanding — check the
 > [release notes](../release-notes/index.md) for the current state.
 
-| Capability                                 | React on Rails Pro                                                                                                                                     | Next.js (App Router)                             |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
-| Server Components + Flight streaming       | Yes                                                                                                                                                    | Yes                                              |
-| SSR + hydration with **no** double-fetch   | Yes (inlined `REACT_ON_RAILS_RSC_PAYLOADS`)                                                                                                            | Yes (inlined `__next_f`)                         |
-| Refetch RSC on client navigation           | Yes (`/rsc_payload/:name` is the default endpoint)                                                                                                     | Yes (segment-level diff)                         |
-| Segment-level navigation diffing           | No route-segment diffing as of 2026 — RoR Pro refetches by component name; **Rails owns routing**                                                      | Yes — built into the framework router            |
-| Built-in link prefetching                  | Not built-in as of 2026 — use Rails/Turbo or a client router                                                                                           | Yes (viewport + hover)                           |
-| Server-side mutations                      | Rails controllers/endpoints own mutations; see [Rails data patterns](../../oss/migrating/rsc-data-fetching.md) (no server-action shorthand as of 2026) | "Server Actions" (RPC + re-render in one trip)   |
-| Static shell + streamed dynamic holes      | [Async props](../../oss/migrating/rsc-data-fetching.md) stream slow data (related goal, different mechanism)                                           | Partial Prerendering (PPR)                       |
-| Stream each slow prop independently        | Yes (async props)                                                                                                                                      | Related via Suspense/PPR (different granularity) |
-| Use your existing Rails app/routes/auth/DB | Yes — the entire point                                                                                                                                 | No — Next owns the server                        |
-| Bundler choice                             | webpack **or** Rspack (Shakapacker)                                                                                                                    | Turbopack default; webpack/Rspack also           |
-| Hosting model                              | Your Rails app + a Node renderer process                                                                                                               | One Node (or Edge) server process                |
+| Capability                                 | React on Rails Pro                                                                                                                                                                                                                      | Next.js (App Router)                             |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Server Components + Flight streaming       | Yes                                                                                                                                                                                                                                     | Yes                                              |
+| SSR + hydration with **no** double-fetch   | Yes (inlined `REACT_ON_RAILS_RSC_PAYLOADS`)                                                                                                                                                                                             | Yes (inlined `__next_f`)                         |
+| Refetch RSC on client navigation           | Yes (`/rsc_payload/:name` is the default endpoint)                                                                                                                                                                                      | Yes (segment-level diff)                         |
+| Segment-level navigation diffing           | No route-segment diffing as of 2026 — RoR Pro refetches by component name; **Rails owns routing**                                                                                                                                       | Yes — built into the framework router            |
+| Built-in link prefetching                  | Not built-in as of 2026 — use Rails/Turbo or a client router                                                                                                                                                                            | Yes (viewport + hover)                           |
+| Server-side mutations                      | Rails controllers/endpoints own mutations; see [Mutations without Server Actions](../../oss/building-features/mutations.md) and [Rails data patterns](../../oss/migrating/rsc-data-fetching.md) (no server-action shorthand as of 2026) | "Server Actions" (RPC + re-render in one trip)   |
+| Static shell + streamed dynamic holes      | [Async props](../../oss/migrating/rsc-data-fetching.md) stream slow data (related goal, different mechanism)                                                                                                                            | Partial Prerendering (PPR)                       |
+| Stream each slow prop independently        | Yes (async props)                                                                                                                                                                                                                       | Related via Suspense/PPR (different granularity) |
+| Use your existing Rails app/routes/auth/DB | Yes — the entire point                                                                                                                                                                                                                  | No — Next owns the server                        |
+| Bundler choice                             | webpack **or** Rspack (Shakapacker)                                                                                                                                                                                                     | Turbopack default; webpack/Rspack also           |
+| Hosting model                              | Your Rails app + a Node renderer process                                                                                                                                                                                                | One Node (or Edge) server process                |
 
 The pattern: **Next.js gives you more RSC-era features in the box** because it owns the whole stack.
 **React on Rails Pro gives you RSC inside a real Rails app** — keeping Rails' routing, data layer, and
 ecosystem — at the cost of running a couple more moving parts (the [node renderer](../node-renderer.md)
 and a third bundle). Where React on Rails Pro hands a responsibility back to Rails (mutations, routing,
 auth), that is usually a feature for a Rails team, not a gap: you already have those tools and do not
-want a second, parallel copy of them.
+want a second, parallel copy of them. For a practical mutation recipe, see
+[Mutations without Server Actions](../../oss/building-features/mutations.md).
 
 ## Developer experience: one process vs. several
 
@@ -252,6 +253,7 @@ chunk-loading primitives differ.
 - [RSC Rendering Flow](./rendering-flow.md) — the detailed rendering lifecycle and bundle types
 - [Flight Protocol Syntax](./flight-protocol-syntax.md) — the RSC wire format
 - [Rspack Compatibility](./rspack-compatibility.md) — bundler support status and the native `RSCRspackPlugin`
+- [Mutations without Server Actions](../../oss/building-features/mutations.md) — Rails controller recipes side-by-side with Next.js Server Actions
 - [RSC Glossary](./glossary.md) — terminology reference
 - [RSC overview](./index.md) — the full React Server Components documentation set
 - [React on Rails Pro and TanStack Start](./tanstack-start-comparison.md) — the same kind of architecture comparison, for TanStack Start

--- a/docs/pro/react-server-components/tanstack-start-comparison.md
+++ b/docs/pro/react-server-components/tanstack-start-comparison.md
@@ -83,7 +83,7 @@ database stay in Rails where they already live. (RSC is a Pro feature requiring 
 For the interactive pieces that **mutate**, both stacks still cross a network boundary: Start calls a
 typed server function; React on Rails posts to a Rails controller (often with TanStack Query driving the
 request). Start's server-function shorthand is genuinely less boilerplate for that path today; the trade
-is that the function — and the business logic inside it — lives in your UI's runtime rather than in
+is that the function — and the business logic inside it — lives in Start's server runtime rather than in
 Rails. For side-by-side mutation recipes, see
 [Mutations without Server Actions](../../oss/building-features/mutations.md).
 

--- a/docs/pro/react-server-components/tanstack-start-comparison.md
+++ b/docs/pro/react-server-components/tanstack-start-comparison.md
@@ -84,7 +84,8 @@ For the interactive pieces that **mutate**, both stacks still cross a network bo
 typed server function; React on Rails posts to a Rails controller (often with TanStack Query driving the
 request). Start's server-function shorthand is genuinely less boilerplate for that path today; the trade
 is that the function — and the business logic inside it — lives in your UI's runtime rather than in
-Rails.
+Rails. For side-by-side mutation recipes, see
+[Mutations without Server Actions](../../oss/building-features/mutations.md).
 
 ## The backend you assemble vs. the backend you have
 
@@ -186,6 +187,7 @@ and would rather adopt the TanStack libraries on top of it than rebuild the back
 ## Related documentation
 
 - [TanStack Router on React on Rails](../../oss/building-features/tanstack-router.md) — using TanStack Router, with Pro SSR support
+- [Mutations without Server Actions](../../oss/building-features/mutations.md) — Rails controller recipes compared with Next.js Server Actions and TanStack server functions
 - [RoR Pro vs. Next.js RSC](./nextjs-comparison.md) — how the RSC contract works, compared across stacks
 - [React Server Components overview](./index.md) — the full RSC documentation set
 - [Decision Guide](../../oss/getting-started/comparing-react-on-rails-to-alternatives.md) — choosing between React on Rails, TanStack Start, Next.js, and other alternatives

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -94,6 +94,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'building-features/accessibility',
             'building-features/forms',
+            'building-features/mutations',
             'building-features/react-and-redux',
             'building-features/tanstack-query',
             'building-features/generated-rails-response-types',

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -10047,7 +10047,7 @@ database stay in Rails where they already live. (RSC is a Pro feature requiring 
 For the interactive pieces that **mutate**, both stacks still cross a network boundary: Start calls a
 typed server function; React on Rails posts to a Rails controller (often with TanStack Query driving the
 request). Start's server-function shorthand is genuinely less boilerplate for that path today; the trade
-is that the function — and the business logic inside it — lives in your UI's runtime rather than in
+is that the function — and the business logic inside it — lives in Start's server runtime rather than in
 Rails. For side-by-side mutation recipes, see
 [Mutations without Server Actions](../../oss/building-features/mutations.md).
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -2100,7 +2100,63 @@ Use `cached_buffered_stream_react_component` when the complete static response s
 %>
 ```
 
+For static public RSC pages that do not hydrate the generated page pack, use `cached_static_rsc_component`. It buffers through the same renderer, strips embedded `REACT_ON_RAILS_RSC_PAYLOADS` bootstrap scripts before caching, and respects an explicit `auto_load_bundle: false` so the view can append only a small sidecar pack:
+
+```erb
+<%=
+  cached_static_rsc_component(
+    "MarketingPage",
+    cache_key: ["marketing-page", I18n.locale],
+    cache_tags: ["marketing-page"],
+    cache_options: { expires_in: 30.minutes },
+    auto_load_bundle: false,
+    rsc_diagnostic_packs: ["generated/PublicPageClientEffects"],
+    id: "marketing-page"
+  ) do
+    @marketing_page_props
+  end
+%>
+<%= javascript_pack_tag("generated/PublicPageClientEffects") %>
+```
+
 Buffered rendering is not progressive: the browser receives the page only after every RSC/SSR chunk is available. Prefer `stream_react_component` or `stream_react_component_with_async_props` when early shell flush, slow async props, or progressive Suspense boundaries matter.
+
+#### Static RSC Render Diagnostics
+
+`cached_static_rsc_component` emits a redacted render summary in development and when `ReactOnRailsPro.configuration.tracing` is enabled. You can also enable it per render with `rsc_render_diagnostics: true` or capture it directly with a callback:
+
+```erb
+<%=
+  cached_static_rsc_component(
+    "MarketingPage",
+    cache_key: ["marketing-page", I18n.locale],
+    auto_load_bundle: false,
+    rsc_diagnostic_packs: ["generated/PublicPageClientEffects"],
+    rsc_render_diagnostics: ->(summary) { Rails.logger.info(summary.to_json) },
+    id: "marketing-page"
+  ) do
+    @marketing_page_props
+  end
+%>
+```
+
+The same payload is published as an `ActiveSupport::Notifications` event so benchmark harnesses can archive it with ShakaPerf or Lighthouse output:
+
+```ruby
+ActiveSupport::Notifications.subscribe("render_static_rsc_component.react_on_rails_pro") do |_name, _start, _finish, _id, summary|
+  Rails.logger.info(summary.to_json)
+end
+```
+
+The summary includes:
+
+- `cache.enabled`, `cache.hit`, and `cache.key_digest` so public-page runs can distinguish cold renders from warm cached output without logging raw cache keys.
+- `auto_load_bundle`, which shows whether the generated page pack was intentionally skipped.
+- `html.raw_bytes`, `html.cached_bytes`, `rsc_payload.bootstrap_script_count`, and `rsc_payload.bootstrap_script_bytes`, which show how much Flight/bootstrap script markup was removed before caching.
+- `emitted_assets.js` and `emitted_assets.css`, populated from the Shakapacker manifest for the generated component pack when `auto_load_bundle` is true and for any explicit `rsc_diagnostic_packs`.
+- `client_references.entries`, populated from the RSC client manifest when it is available on disk. An empty array is useful evidence for static public pages that should avoid eager RSC client references.
+
+Manifest-derived fields are best-effort. When a dev server, missing file, or custom deployment makes a manifest unavailable, the summary includes an `unavailable_reason` instead of failing the render. The summary never includes serialized props, Flight payload contents, or the raw expanded cache key.
 
 ### Browser-Observable RSC Stream Marks
 
@@ -2665,6 +2721,8 @@ Nonces are per-request values; caching renders per-request markup. Two distinct 
 ### Fragment caching helpers bake the nonce into the cached fragment
 
 `cached_react_component`, `cached_react_component_hash`, `cached_stream_react_component`, `cached_buffered_stream_react_component`, and `cached_async_react_component` cache the **final rendered HTML** (for streaming: the full chunk array) under a cache key built from your `cache_key` option plus bundle digests. The cached markup includes the executable inline scripts **with the nonce of the request that populated the cache**, and the cache key does **not** include the nonce.
+
+`cached_static_rsc_component` strips embedded RSC payload/bootstrap scripts that reference `REACT_ON_RAILS_RSC_PAYLOADS` before caching, so those payload scripts are not served with stale nonces. Any other executable inline scripts preserved in the cached HTML still follow this nonce caveat.
 
 A cache hit therefore serves a stale nonce to a different request, whose CSP header carries a different nonce — the browser blocks those inline scripts and immediate hydration/console replay silently degrade (components still hydrate via the client bundle's normal page-load path, but the strict-CSP guarantee of "zero violations" no longer holds).
 
@@ -4240,7 +4298,7 @@ const config = {
   allWorkersRestartInterval: 45,
   // Stagger individual restarts by 6 minutes to avoid downtime
   delayBetweenIndividualWorkerRestarts: 6,
-  // Force-kill workers that don't restart within 30 seconds
+  // Force-kill workers that don't restart within 30 seconds (value is seconds)
   gracefulWorkerRestartTimeout: 30,
 };
 ```
@@ -9836,26 +9894,27 @@ Rails, which you already have.
 > choice. React on Rails Pro's RSC feature set is actively expanding — check the
 > [release notes](../release-notes/index.md) for the current state.
 
-| Capability                                 | React on Rails Pro                                                                                                                                     | Next.js (App Router)                             |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
-| Server Components + Flight streaming       | Yes                                                                                                                                                    | Yes                                              |
-| SSR + hydration with **no** double-fetch   | Yes (inlined `REACT_ON_RAILS_RSC_PAYLOADS`)                                                                                                            | Yes (inlined `__next_f`)                         |
-| Refetch RSC on client navigation           | Yes (`/rsc_payload/:name` is the default endpoint)                                                                                                     | Yes (segment-level diff)                         |
-| Segment-level navigation diffing           | No route-segment diffing as of 2026 — RoR Pro refetches by component name; **Rails owns routing**                                                      | Yes — built into the framework router            |
-| Built-in link prefetching                  | Not built-in as of 2026 — use Rails/Turbo or a client router                                                                                           | Yes (viewport + hover)                           |
-| Server-side mutations                      | Rails controllers/endpoints own mutations; see [Rails data patterns](../../oss/migrating/rsc-data-fetching.md) (no server-action shorthand as of 2026) | "Server Actions" (RPC + re-render in one trip)   |
-| Static shell + streamed dynamic holes      | [Async props](../../oss/migrating/rsc-data-fetching.md) stream slow data (related goal, different mechanism)                                           | Partial Prerendering (PPR)                       |
-| Stream each slow prop independently        | Yes (async props)                                                                                                                                      | Related via Suspense/PPR (different granularity) |
-| Use your existing Rails app/routes/auth/DB | Yes — the entire point                                                                                                                                 | No — Next owns the server                        |
-| Bundler choice                             | webpack **or** Rspack (Shakapacker)                                                                                                                    | Turbopack default; webpack/Rspack also           |
-| Hosting model                              | Your Rails app + a Node renderer process                                                                                                               | One Node (or Edge) server process                |
+| Capability                                 | React on Rails Pro                                                                                                                                                                                                                      | Next.js (App Router)                             |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Server Components + Flight streaming       | Yes                                                                                                                                                                                                                                     | Yes                                              |
+| SSR + hydration with **no** double-fetch   | Yes (inlined `REACT_ON_RAILS_RSC_PAYLOADS`)                                                                                                                                                                                             | Yes (inlined `__next_f`)                         |
+| Refetch RSC on client navigation           | Yes (`/rsc_payload/:name` is the default endpoint)                                                                                                                                                                                      | Yes (segment-level diff)                         |
+| Segment-level navigation diffing           | No route-segment diffing as of 2026 — RoR Pro refetches by component name; **Rails owns routing**                                                                                                                                       | Yes — built into the framework router            |
+| Built-in link prefetching                  | Not built-in as of 2026 — use Rails/Turbo or a client router                                                                                                                                                                            | Yes (viewport + hover)                           |
+| Server-side mutations                      | Rails controllers/endpoints own mutations; see [Mutations without Server Actions](../../oss/building-features/mutations.md) and [Rails data patterns](../../oss/migrating/rsc-data-fetching.md) (no server-action shorthand as of 2026) | "Server Actions" (RPC + re-render in one trip)   |
+| Static shell + streamed dynamic holes      | [Async props](../../oss/migrating/rsc-data-fetching.md) stream slow data (related goal, different mechanism)                                                                                                                            | Partial Prerendering (PPR)                       |
+| Stream each slow prop independently        | Yes (async props)                                                                                                                                                                                                                       | Related via Suspense/PPR (different granularity) |
+| Use your existing Rails app/routes/auth/DB | Yes — the entire point                                                                                                                                                                                                                  | No — Next owns the server                        |
+| Bundler choice                             | webpack **or** Rspack (Shakapacker)                                                                                                                                                                                                     | Turbopack default; webpack/Rspack also           |
+| Hosting model                              | Your Rails app + a Node renderer process                                                                                                                                                                                                | One Node (or Edge) server process                |
 
 The pattern: **Next.js gives you more RSC-era features in the box** because it owns the whole stack.
 **React on Rails Pro gives you RSC inside a real Rails app** — keeping Rails' routing, data layer, and
 ecosystem — at the cost of running a couple more moving parts (the [node renderer](../node-renderer.md)
 and a third bundle). Where React on Rails Pro hands a responsibility back to Rails (mutations, routing,
 auth), that is usually a feature for a Rails team, not a gap: you already have those tools and do not
-want a second, parallel copy of them.
+want a second, parallel copy of them. For a practical mutation recipe, see
+[Mutations without Server Actions](../../oss/building-features/mutations.md).
 
 ## Developer experience: one process vs. several
 
@@ -9898,6 +9957,7 @@ chunk-loading primitives differ.
 - [RSC Rendering Flow](./rendering-flow.md) — the detailed rendering lifecycle and bundle types
 - [Flight Protocol Syntax](./flight-protocol-syntax.md) — the RSC wire format
 - [Rspack Compatibility](./rspack-compatibility.md) — bundler support status and the native `RSCRspackPlugin`
+- [Mutations without Server Actions](../../oss/building-features/mutations.md) — Rails controller recipes side-by-side with Next.js Server Actions
 - [RSC Glossary](./glossary.md) — terminology reference
 - [RSC overview](./index.md) — the full React Server Components documentation set
 - [React on Rails Pro and TanStack Start](./tanstack-start-comparison.md) — the same kind of architecture comparison, for TanStack Start
@@ -9988,7 +10048,8 @@ For the interactive pieces that **mutate**, both stacks still cross a network bo
 typed server function; React on Rails posts to a Rails controller (often with TanStack Query driving the
 request). Start's server-function shorthand is genuinely less boilerplate for that path today; the trade
 is that the function — and the business logic inside it — lives in your UI's runtime rather than in
-Rails.
+Rails. For side-by-side mutation recipes, see
+[Mutations without Server Actions](../../oss/building-features/mutations.md).
 
 ## The backend you assemble vs. the backend you have
 
@@ -10090,6 +10151,7 @@ and would rather adopt the TanStack libraries on top of it than rebuild the back
 ## Related documentation
 
 - [TanStack Router on React on Rails](../../oss/building-features/tanstack-router.md) — using TanStack Router, with Pro SSR support
+- [Mutations without Server Actions](../../oss/building-features/mutations.md) — Rails controller recipes compared with Next.js Server Actions and TanStack server functions
 - [RoR Pro vs. Next.js RSC](./nextjs-comparison.md) — how the RSC contract works, compared across stacks
 - [React Server Components overview](./index.md) — the full RSC documentation set
 - [Decision Guide](../../oss/getting-started/comparing-react-on-rails-to-alternatives.md) — choosing between React on Rails, TanStack Start, Next.js, and other alternatives

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9198,8 +9198,18 @@ type ProjectResponse = {
 type ValidationErrors = Record<string, string[]>;
 
 type ErrorResponse = {
-  errors?: ValidationErrors;
+  errors?: unknown;
 };
+
+const fallbackError: ValidationErrors = { base: ['Something went wrong. Please try again.'] };
+
+const isValidationErrors = (errors: unknown): errors is ValidationErrors =>
+  Boolean(errors) &&
+  typeof errors === 'object' &&
+  !Array.isArray(errors) &&
+  Object.values(errors).every(
+    (messages) => Array.isArray(messages) && messages.every((message) => typeof message === 'string'),
+  );
 
 const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
   path: '/projects',
@@ -9222,8 +9232,11 @@ export function useCreateProjectMutation(setValidationErrors: (errors: Validatio
             ? (responseBody as ErrorResponse).errors
             : undefined;
 
-        setValidationErrors(errors ?? { base: ['Something went wrong. Please try again.'] });
+        setValidationErrors(isValidationErrors(errors) ? errors : fallbackError);
+        return;
       }
+
+      setValidationErrors(fallbackError);
     },
   });
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9216,9 +9216,13 @@ export function useCreateProjectMutation(setValidationErrors: (errors: Validatio
     },
     onError: (error) => {
       if (error instanceof RailsActionRequestError && error.response.status === 422) {
-        const { errors = {} } = error.responseBody as ErrorResponse;
+        const responseBody = error.responseBody;
+        const errors =
+          responseBody && typeof responseBody === 'object' && 'errors' in responseBody
+            ? (responseBody as ErrorResponse).errors
+            : undefined;
 
-        setValidationErrors(errors);
+        setValidationErrors(errors ?? { base: ['Something went wrong. Please try again.'] });
       }
     },
   });

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9188,7 +9188,7 @@ import { createRailsAction, RailsActionRequestError } from 'react-on-rails/rails
 
 type ProjectFormData = {
   name: string;
-  status: string;
+  status: 'draft' | 'active';
 };
 
 type ProjectResponse = {
@@ -9207,6 +9207,7 @@ const isValidationErrors = (errors: unknown): errors is ValidationErrors =>
   Boolean(errors) &&
   typeof errors === 'object' &&
   !Array.isArray(errors) &&
+  Object.keys(errors).length > 0 &&
   Object.values(errors).every(
     (messages) => Array.isArray(messages) && messages.every((message) => typeof message === 'string'),
   );

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8629,6 +8629,10 @@ The contract between them is one blessed error shape:
 The hook works against **any** endpoint returning that shape; the concern is a
 convenience, not a requirement.
 
+For the framework-level comparison with Next.js Server Actions and TanStack
+Start server functions, see
+[Mutations without Server Actions](./mutations.md).
+
 Compatibility: `react-on-rails/useRailsForm` requires React 16.8 or newer
 because it is a hook. Apps still on React 16.0-16.7 can continue using the
 package's other React 16 APIs, but this subpath throws a clear error until React
@@ -8864,6 +8868,8 @@ React on Rails intentionally keeps mutations in Rails controllers —
 [Server Functions RFC (Issue 3867)](https://github.com/shakacode/react_on_rails/issues/3867)
 explores the complementary RSC-side story. The two are designed to compose: if
 Server Functions land, this hook remains the plain-controller bridge.
+For side-by-side migration examples, see
+[Mutations without Server Actions](./mutations.md).
 
 ## Scope and roadmap
 
@@ -8874,6 +8880,284 @@ Deferred to a follow-up release: `transform`, `recentlySuccessful`, `onFinish`,
 and file uploads with `progress` (which needs an `XMLHttpRequest`/duplex-stream
 transport). Navigation, prefetching, and router integration belong to
 [Issue 3873](https://github.com/shakacode/react_on_rails/issues/3873).
+
+================================================================================
+PAGE: https://reactonrails.com/docs/building-features/mutations
+SOURCE: docs/oss/building-features/mutations.md
+================================================================================
+
+# Mutations without Server Actions
+
+React on Rails keeps mutations in Rails. React Server Components change how read-only UI can be
+rendered and streamed, but they do not move writes into the Node renderer. A React form, button, or
+TanStack Query mutation should submit to a Rails route, let the controller run the same
+authentication, authorization, strong parameters, ActiveRecord transactions, and validations that a
+server-rendered Rails form would use, then return JSON or navigate.
+
+Do **not** add `'use server'` to React on Rails application code. In React on Rails, the Node renderer
+is a rendering process. It does not own Rails models, sessions, cookies, CSRF verification, or
+transactions. Use a Client Component, a standard Rails form, or a TanStack Query mutation that calls a
+Rails controller endpoint.
+
+## Side-by-side map
+
+| Concern                 | Next.js Server Actions                                                                                              | TanStack Start server functions                                                                                               | React on Rails                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client call site        | `<form action={createPost}>`, `formAction`, or an event handler that invokes a Server Function.                     | `createServerFn({ method: 'POST' })`, often called from a component, loader, hook, event handler, or TanStack Query mutation. | `form_with`, `useRailsForm`, `createRailsAction`, or a CSRF-aware `fetch`/TanStack Query mutation.                                                               |
+| Where server logic runs | The Next.js app server, inside an async function marked with `'use server'` or exported from a `'use server'` file. | The TanStack Start server, inside the `createServerFn` handler.                                                               | The Rails controller action, backed by Rails models, policies, jobs, mailers, and transactions.                                                                  |
+| Request shape           | Framework-owned POST request to the Server Action endpoint.                                                         | Framework-owned same-origin RPC request to the server function endpoint.                                                      | Ordinary Rails HTTP route, usually JSON for React islands or a normal HTML form post for full-page flows.                                                        |
+| Security boundary       | Verify authentication and authorization inside the action; Next.js applies same-origin Server Action protections.   | Validate input in the server function; Start documents same-origin RPC and CSRF middleware for server functions.              | Use Rails sessions, `csrf_meta_tags`, controller filters, strong parameters, and policy checks. React helpers attach CSRF headers for JSON requests.             |
+| Validation errors       | Return serializable error state or throw/redirect according to the action pattern.                                  | Return serializable error state, throw, redirect, or feed TanStack Query mutation state.                                      | Return `422` JSON such as `{ "errors": { "name": ["can't be blank"] } }`; `useRailsForm` maps this to field errors.                                              |
+| After the write         | Call Next cache revalidation helpers, redirect, or return updated UI/data.                                          | Invalidate TanStack Query cache, redirect, or update route state.                                                             | Let Rails redirect for full-page flows, return a safe `redirect_to` JSON hint, invalidate TanStack Query cache, or let the next Rails render stream fresh props. |
+
+The practical translation is:
+
+- **Next.js Server Action**: "call this server function from my form."
+- **TanStack Start server function**: "call this typed same-origin server function from my app."
+- **React on Rails**: "call this Rails controller route from my React UI."
+
+## Choose the Rails entry point
+
+Use the narrowest path that matches the UI:
+
+- **Standard Rails forms**: best when a full-page submit and redirect are acceptable, or when the
+  feature should work without JavaScript.
+- **[`useRailsForm`](./forms.md)**: best for React-controlled forms that need field errors,
+  `processing`, reset behavior, CSRF handling, and a small `useForm`-style API.
+- **[`createRailsAction`](./generated-rails-response-types.md#use-with-typed-rails-actions) with
+  TanStack Query**: best for buttons, tables, optimistic updates, and typed mutation responses.
+- **Manual `fetch` with React on Rails authenticity helpers**: fine for one-off calls, but centralize
+  same-origin, JSON, and CSRF behavior once the pattern repeats.
+
+## Recipe: React form, Rails controller
+
+This is the Rails-native equivalent of a Next.js `<form action={createPost}>` Server Action or a
+TanStack Start `createServerFn({ method: 'POST' })` mutation: keep the server logic in Rails and make
+the Client Component submit JSON to that route.
+
+### Rails route and controller
+
+```ruby
+# config/routes.rb
+resources :projects, only: [:new, :create, :show]
+```
+
+```ruby
+# app/controllers/projects_controller.rb
+class ProjectsController < ApplicationController
+  include ReactOnRails::Controller::FormResponders
+
+  def create
+    project = current_account.projects.build(project_params)
+    # Run your normal authorization here, for example `authorize project`.
+
+    if project.save
+      render json: {
+        project: { id: project.id, name: project.name, status: project.status },
+        redirect_to: project_path(project)
+      }, status: :created
+    else
+      render_model_errors(project)
+    end
+  end
+
+  private
+
+  def project_params
+    if params.key?(:project)
+      params.require(:project).permit(:name, :status)
+    else
+      params.permit(:name, :status)
+    end
+  end
+end
+```
+
+### Client Component
+
+```tsx
+'use client';
+
+import type { FormEvent } from 'react';
+import { useRailsForm } from 'react-on-rails/useRailsForm';
+
+type ProjectFormData = {
+  name: string;
+  status: 'draft' | 'active';
+};
+
+export default function ProjectForm({ action }: { action: string }) {
+  const form = useRailsForm<ProjectFormData>({ name: '', status: 'draft' });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    void form
+      .post(action, {
+        onSuccess: ({ redirectTo }) => {
+          if (redirectTo) {
+            window.location.assign(redirectTo);
+          } else {
+            form.reset();
+          }
+        },
+      })
+      .catch(() => {
+        form.setError('base', 'Something went wrong. Please try again.');
+      });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Name
+        <input value={form.data.name} onChange={(event) => form.setData('name', event.target.value)} />
+      </label>
+      {form.errors.name?.map((message) => (
+        <p className="error" key={message}>
+          {message}
+        </p>
+      ))}
+
+      <label>
+        Status
+        <select
+          value={form.data.status}
+          onChange={(event) => form.setData('status', event.target.value as ProjectFormData['status'])}
+        >
+          <option value="draft">Draft</option>
+          <option value="active">Active</option>
+        </select>
+      </label>
+      {form.errors.status?.map((message) => (
+        <p className="error" key={message}>
+          {message}
+        </p>
+      ))}
+
+      {form.errors.base?.map((message) => (
+        <p className="error" key={message}>
+          {message}
+        </p>
+      ))}
+
+      <button type="submit" disabled={form.processing}>
+        {form.processing ? 'Creating...' : 'Create project'}
+      </button>
+    </form>
+  );
+}
+```
+
+`base` is not special to Rails; it is just a conventional field name for errors that are not attached
+to one input. Use any key your app renders consistently.
+
+### Render it from Rails or RSC
+
+For an ordinary React island:
+
+```erb
+<%= react_component("ProjectForm", props: { action: projects_path }) %>
+```
+
+For a React Server Components page, keep the form as a Client Component and pass ordinary serializable
+props from the Server Component:
+
+```tsx
+// ProjectPage.tsx -- Server Component
+import ProjectForm from './ProjectForm.client';
+
+export default function ProjectPage({ projectsPath }: { projectsPath: string }) {
+  return <ProjectForm action={projectsPath} />;
+}
+```
+
+The write still goes to `ProjectsController#create`. The Server Component can render the initial page
+from Rails-provided props or async props, but the mutation belongs to Rails.
+
+## Recipe: TanStack Query mutation
+
+When the UI is a live table, command button, optimistic update, or cache-managed island, use TanStack
+Query for client state and keep the write endpoint in Rails.
+
+```tsx
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createRailsAction, RailsActionRequestError } from 'react-on-rails/railsAction';
+
+type ProjectFormData = {
+  name: string;
+  status: string;
+};
+
+type ProjectResponse = {
+  project: { id: number; name: string; status: string };
+};
+
+const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
+  path: '/projects',
+});
+
+export function useCreateProjectMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createProject,
+    onSuccess: ({ project }) => {
+      queryClient.setQueryData(['project', String(project.id)], { project });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+    },
+    onError: (error) => {
+      if (error instanceof RailsActionRequestError && error.response.status === 422) {
+        // Map your app's validation-error JSON into local form state.
+      }
+    },
+  });
+}
+```
+
+This is close to a TanStack Start server-function call at the component boundary, but the server code
+is still the Rails controller. If your app generates TypeScript response types from Rails, replace the
+hand-written `ProjectResponse` with
+[`RailsResponseType<'projects.create'>`](./generated-rails-response-types.md#use-with-typed-rails-actions).
+
+## RSC and cache refresh
+
+React on Rails RSC pages usually read data from Rails controller props or
+[`stream_react_component_with_async_props`](../migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
+After a mutation, choose the refresh mechanism that matches the UI:
+
+- Full-page Rails flow: redirect from the controller or return a same-origin `redirect_to` JSON hint
+  and navigate to it.
+- TanStack Query island: invalidate or update the affected query keys.
+- RSC route: navigate to a route that Rails renders again, or trigger the app's client router to load
+  the next page state.
+- Fragment/component cache: expire Rails-owned cache keys from callbacks, jobs, or controller code,
+  then use the matching page, query, or route refresh path above to re-read the data. Do not rely
+  on a Node-renderer Server Action for cache invalidation.
+
+For the migration-specific warning, see
+[Mutations: Rails Controllers, Not Server Actions](../migrating/rsc-data-fetching.md#mutations-rails-controllers-not-server-actions).
+
+## Testing checklist
+
+- Controller/request spec: valid write, invalid `422` error JSON, authorization failure, and redirect
+  hint when used.
+- Client component test: submit state, CSRF-backed request helper behavior, validation-error rendering,
+  and cache invalidation or navigation callback.
+- System test: only for full user flows where routing, streaming, or hydration is the risk.
+
+## Related docs
+
+- [Forms and Mutations with `useRailsForm`](./forms.md)
+- [Using TanStack Query](./tanstack-query.md)
+- [Generated Rails response types](./generated-rails-response-types.md)
+- [RSC data fetching and mutation guidance](../migrating/rsc-data-fetching.md#mutations-rails-controllers-not-server-actions)
+- [React on Rails Pro and Next.js: RSC Architectures Compared](../../pro/react-server-components/nextjs-comparison.md)
+- [React on Rails Pro and TanStack Start: Two Ways to Own the Full Stack](../../pro/react-server-components/tanstack-start-comparison.md)
+- [Next.js Mutating Data](https://nextjs.org/docs/app/getting-started/mutating-data)
+- [TanStack Start Server Functions](https://tanstack.com/start/latest/docs/framework/react/guide/server-functions)
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/building-features/react-and-redux
@@ -19197,8 +19481,8 @@ registerStoreGenerators(storesGenerators);
 
 /**
  * Allows retrieval of the store by name. This store will be hydrated by any Rails form props.
- * Pass optional param throwIfMissing = false if you want to use this call to get back null if the
- * store with name is not registered.
+ * Pass optional param throwIfMissing = false if you want to use this call to get back undefined if
+ * the store with name is not hydrated.
  * @param name
  * @param throwIfMissing Defaults to true. Set to false to have this call return undefined if
  *        there is no store with the given name.
@@ -19312,7 +19596,7 @@ ReactOnRails.registerStore({
 When registering your component with React on Rails, you can get the store via `ReactOnRails.getStore`:
 
 ```js
-// getStore will initialize the store if not already initialized, so creates or retrieves store
+// getStore retrieves the store that React on Rails created and hydrated from the redux_store props
 const appStore = ReactOnRails.getStore('appStore');
 return (
   <Provider store={appStore}>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8916,6 +8916,97 @@ The practical translation is:
 - **TanStack Start server function**: "call this typed same-origin server function from my app."
 - **React on Rails**: "call this Rails controller route from my React UI."
 
+## Same mutation in three stacks
+
+The same "create a project" mutation lands in a different server boundary in each stack. In Next.js,
+the form can call a Server Action; the database write, authorization, and cache refresh live in the
+Next.js server runtime:
+
+```tsx
+// app/projects/actions.ts
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { db } from '@/lib/db';
+
+export async function createProjectAction(formData: FormData) {
+  const name = String(formData.get('name') ?? '').trim();
+  const status = String(formData.get('status') ?? 'draft');
+
+  if (!name) {
+    return { errors: { name: ["can't be blank"] } };
+  }
+
+  const project = await db.project.create({ data: { name, status } });
+
+  revalidatePath('/projects');
+  redirect(`/projects/${project.id}`);
+}
+```
+
+```tsx
+// app/projects/form.tsx
+import { createProjectAction } from './actions';
+
+export function ProjectForm() {
+  return (
+    <form action={createProjectAction}>
+      <input name="name" />
+      <select name="status" defaultValue="draft">
+        <option value="draft">Draft</option>
+        <option value="active">Active</option>
+      </select>
+      <button type="submit">Create project</button>
+    </form>
+  );
+}
+```
+
+In TanStack Start, the component can call a server function. The handler still runs in Start's server
+runtime, not in Rails:
+
+```ts
+// src/projects/projects.functions.ts
+import { createServerFn } from '@tanstack/react-start';
+import { z } from 'zod';
+import { db } from '~/server/db';
+
+const projectSchema = z.object({
+  name: z.string().min(1),
+  status: z.enum(['draft', 'active']),
+});
+
+export const createProject = createServerFn({ method: 'POST' })
+  .validator(projectSchema)
+  .handler(async ({ data }) => {
+    const project = await db.project.create({ data });
+
+    return { project };
+  });
+```
+
+```tsx
+// src/projects/ProjectForm.tsx
+import { createProject } from './projects.functions';
+
+await createProject({ data: { name: 'Apollo', status: 'draft' } });
+```
+
+In React on Rails, the Client Component calls an ordinary Rails route. The Rails controller, shown in
+the recipe below, owns authentication, authorization, strong parameters, transactions, validation
+errors, redirects, jobs, and cache expiry:
+
+```ts
+import { createRailsAction } from 'react-on-rails/railsAction';
+
+const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
+  path: '/projects',
+});
+
+await createProject({ project: { name: 'Apollo', status: 'draft' } });
+```
+
 ## Choose the Rails entry point
 
 Use the narrowest path that matches the UI:
@@ -9095,11 +9186,17 @@ type ProjectResponse = {
   project: { id: number; name: string; status: string };
 };
 
+type ValidationErrors = Record<string, string[]>;
+
+type ErrorResponse = {
+  errors?: ValidationErrors;
+};
+
 const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
   path: '/projects',
 });
 
-export function useCreateProjectMutation() {
+export function useCreateProjectMutation(setValidationErrors: (errors: ValidationErrors) => void) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -9110,7 +9207,9 @@ export function useCreateProjectMutation() {
     },
     onError: (error) => {
       if (error instanceof RailsActionRequestError && error.response.status === 422) {
-        // Map your app's validation-error JSON into local form state.
+        const { errors = {} } = error.responseBody as ErrorResponse;
+
+        setValidationErrors(errors);
       }
     },
   });

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9000,6 +9000,15 @@ errors, redirects, jobs, and cache expiry:
 ```ts
 import { createRailsAction } from 'react-on-rails/railsAction';
 
+type ProjectFormData = {
+  name: string;
+  status: 'draft' | 'active';
+};
+
+type ProjectResponse = {
+  project: { id: number; name: string; status: string };
+};
+
 const createProject = createRailsAction<{ project: ProjectFormData }, ProjectResponse>({
   path: '/projects',
 });


### PR DESCRIPTION
## Rationale

Closes #4445.

Teams comparing React on Rails RSC with Next.js Server Actions or TanStack Start server functions need a Rails-native mutation recipe. This documents the intended boundary: RSC can render reads, but writes still go through Rails controller actions so Rails keeps ownership of sessions, CSRF protection, authorization, strong parameters, validations, transactions, and cache invalidation.

## Implementation

- Added `docs/oss/building-features/mutations.md` with a side-by-side comparison of Next.js Server Actions, TanStack Start server functions, and React on Rails controller-backed mutations.
- Included focused recipes for `useRailsForm`, `ReactOnRails::Controller::FormResponders`, `createRailsAction`, TanStack Query invalidation, RSC refresh guidance, and mutation testing.
- Linked the new recipe from the existing forms guide and the Next.js/TanStack Start RSC comparison docs.
- Added `building-features/mutations` to `docs/sidebars.ts` so the new published OSS doc is covered by the repo sidebar check.

## Validation

- `git fetch --prune origin main` -> passed.
- `.agents/bin/agent-workflow-seam-doctor` -> `PASS agent workflow seam is complete`.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed before commit.
- `git diff --check HEAD~1 HEAD` -> passed after commit.
- `script/check-docs-sidebar` -> passed: `building-features/mutations` found in `docs/sidebars.ts`.
- `script/check-docs-sidebar origin/main HEAD` -> passed after commit.
- `PATH=/tmp/lychee-0.23.0/bin:$PATH lychee --config .lychee.toml docs/oss/building-features/mutations.md docs/oss/building-features/forms.md docs/pro/react-server-components/nextjs-comparison.md docs/pro/react-server-components/tanstack-start-comparison.md` -> passed: `45 Total`, `44 OK`, `0 Errors`, `1 Excluded`.
- Pre-commit hook via `PATH=/tmp/lychee-0.23.0/bin:$PATH git commit ...` -> passed trailing newline check, changed-file markdown links, Prettier, and ESLint.
- Pre-push hook via `PATH=/tmp/lychee-0.23.0/bin:$PATH git push -u origin codex/docs-mutations-4445` -> passed branch lint and online markdown links: `45 Total`, `44 OK`, `0 Errors`, `1 Excluded`.

Full `bin/check-links` note: the script only supports the full repo input. The first run failed before checking links because the globally installed `lychee` is `0.24.2`, while this repo config requires `0.23.0` (`include_fragments = false` parse error). I installed `lychee 0.23.0` into `/tmp/lychee-0.23.0/bin`; with that pinned binary, the full repo command was interrupted after a bounded silent run. The changed-file pinned-lychee checks and the pre-push online hook both passed for this branch's Markdown files.

## QA

QA not required for this lane: docs-only change, no runtime code, no generated app output, no UI behavior change. Sidebar and Markdown link validation cover the changed docs surface.

## Confidence / UNKNOWN

Confidence: high for the scoped docs/sidebar changes. The new page is linked from the relevant existing docs and is covered by the sidebar check.

UNKNOWN: full-repo `bin/check-links` did not complete after the pinned-tool retry, so full historical docs link health is not asserted here. Branch-scoped Markdown link checks passed online and offline with the repo-pinned `lychee` version.

Labels: none. Docs-only lane; no hosted-CI expansion requested.



## Coordinator Follow-up

- Addressed Greptile review feedback in `eccd75232` by keeping the JSON project shape consistent with the TanStack Query example and clarifying that Rails-owned cache expiration must be paired with a documented page/query/route refresh path.
- Regenerated `llms-full.txt` and `llms-full-pro.txt` because adding `docs/oss/building-features/mutations.md` to `docs/sidebars.ts` made the generated machine-readable docs references stale.

Additional validation:
- `node script/generate-llms-full.mjs --check` passed.
- `bash script/generate-llms-full-test.bash` passed: `7 generate-llms-full tests passed`.
- `PATH=/tmp/lychee-0.23.0/bin:/tmp/ror-lychee-0.23.0.OEIGfV:$PATH lychee --config .lychee.toml docs/oss/building-features/mutations.md docs/oss/building-features/forms.md docs/pro/react-server-components/nextjs-comparison.md docs/pro/react-server-components/tanstack-start-comparison.md` passed: `45 Total`, `44 OK`, `0 Errors`, `1 Excluded`.
- Full `bin/check-links` with pinned lychee was stopped after a bounded silent wait; branch-scoped changed-doc link checks passed and hosted `markdown-link-check` will rerun on the pushed head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide explaining how to implement Rails-owned write mutations from React, including side-by-side comparisons, validation/error handling patterns, cache/navigation refresh guidance, and end-to-end recipes.
  * Updated React Server Components comparison pages to add direct cross-references to the new “mutations without server actions” guidance.
  * Updated the docs sidebar to include the new guide.
  * Refreshed related React on Rails Pro documentation with improved caching guidance, comparison wording, and clarified store-return behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->