### PR TITLE
Match create-app color fallback to chalk

### DIFF
--- a/packages/create-react-on-rails-app/src/utils.ts
+++ b/packages/create-react-on-rails-app/src/utils.ts
@@ -1,24 +1,72 @@
 import { execFileSync, spawnSync } from 'child_process';
 import picocolors from 'picocolors';
 
+const CHALK_CI_COLOR_ENV_KEYS = [
+  'TRAVIS',
+  'CIRCLECI',
+  'APPVEYOR',
+  'GITLAB_CI',
+  'GITHUB_ACTIONS',
+  'BUILDKITE',
+];
+const CHALK_TEAMCITY_COLOR_PATTERN = /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/;
+const CHALK_TERM_256_COLOR_PATTERN = /-256(color)?$/i;
+const CHALK_TERM_COLOR_PATTERN = /^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i;
+
+function hasChalkCompatibleTtyColorSignal(): boolean {
+  const { CI, CI_NAME, COLORTERM, TEAMCITY_VERSION, TERM, TERM_PROGRAM } = process.env;
+
+  if (TERM === 'dumb') {
+    return false;
+  }
+
+  if (process.platform === 'win32') {
+    return true;
+  }
+
+  if (CI !== undefined) {
+    return CHALK_CI_COLOR_ENV_KEYS.some((key) => process.env[key] !== undefined) || CI_NAME === 'codeship';
+  }
+
+  if (TEAMCITY_VERSION !== undefined) {
+    return CHALK_TEAMCITY_COLOR_PATTERN.test(TEAMCITY_VERSION);
+  }
+
+  if (COLORTERM === 'truecolor') {
+    return true;
+  }
+
+  if (TERM_PROGRAM === 'iTerm.app' || TERM_PROGRAM === 'Apple_Terminal') {
+    return true;
+  }
+
+  const term = TERM ?? '';
+
+  return (
+    CHALK_TERM_256_COLOR_PATTERN.test(term) || CHALK_TERM_COLOR_PATTERN.test(term) || COLORTERM !== undefined
+  );
+}
+
 /**
  * Decide whether to colorize output, matching what `chalk@4` produced before the
  * chalk→picocolors swap. The scaffolder is a user's first contact with the
- * framework and its logs are often captured, so keeping the exact same
+ * framework and its logs are often captured, so keeping the same basic
  * colorize/plain decision avoids surprising behavior changes.
  *
  * picocolors' own `isColorSupported` bakes in a different precedence than chalk
  * (it lets NO_COLOR override FORCE_COLOR, and enables color on a bare CI even for
- * piped stdout), so instead of deferring to it we reproduce chalk@4's precedence
- * directly and only use picocolors for the actual escape codes:
+ * piped stdout), so instead of deferring to it we reproduce the relevant chalk@4
+ * environment precedence directly and only use picocolors for the actual escape codes:
  *
  *   1. FORCE_COLOR present  → `0`/`false` disables; any other value (incl. empty)
  *      forces color ON, overriding NO_COLOR and a non-TTY stdout.
  *   2. else NO_COLOR present (any value, incl. empty) → disabled.
- *   3. else colorize only for an interactive TTY (a bare CI does not force color).
+ *   3. else colorize only for an interactive TTY with one of chalk@4's positive
+ *      environment signals. A bare TTY with unset or unrecognized TERM stays
+ *      plain, matching supports-color@7.2.0's fallback behavior.
  */
 function chalkCompatibleColorEnabled(): boolean {
-  const { FORCE_COLOR, NO_COLOR, TERM } = process.env;
+  const { FORCE_COLOR, NO_COLOR } = process.env;
 
   if (FORCE_COLOR !== undefined) {
     return FORCE_COLOR !== '0' && FORCE_COLOR !== 'false';
@@ -26,7 +74,7 @@ function chalkCompatibleColorEnabled(): boolean {
   if (NO_COLOR !== undefined) {
     return false;
   }
-  return (process.stdout?.isTTY ?? false) && TERM !== 'dumb';
+  return (process.stdout?.isTTY ?? false) && hasChalkCompatibleTtyColorSignal();
 }
 
 export const pc = picocolors.createColors(chalkCompatibleColorEnabled());

--- a/packages/create-react-on-rails-app/tests/colors.test.ts
+++ b/packages/create-react-on-rails-app/tests/colors.test.ts
@@ -2,8 +2,9 @@
  * Regression tests for the color-enable decision in src/utils.ts.
  *
  * The `pc` color instance is built at module load by reproducing chalk@4's
- * colorize/plain precedence (FORCE_COLOR wins, then NO_COLOR, then TTY) rather
- * than deferring to picocolors' own detection, which uses a different precedence.
+ * colorize/plain precedence (FORCE_COLOR wins, then NO_COLOR, then TTY plus a
+ * chalk-compatible positive color signal) rather than deferring to picocolors'
+ * own detection, which uses a different precedence.
  * This decision has regressed repeatedly in the package's history — FORCE_COLOR=0
  * wrongly enabling color, empty NO_COLOR= mishandling, a bare CI forcing color in
  * piped output, and NO_COLOR overriding an explicit FORCE_COLOR — so this suite
@@ -15,6 +16,22 @@
  */
 
 const ANSI_RED_OPEN = '[31m';
+const COLOR_SIGNAL_ENV_KEYS = [
+  'APPVEYOR',
+  'BUILDKITE',
+  'CI',
+  'CIRCLECI',
+  'CI_NAME',
+  'COLORTERM',
+  'DRONE',
+  'GITHUB_ACTIONS',
+  'GITLAB_CI',
+  'TEAMCITY_VERSION',
+  'TERM',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'TRAVIS',
+];
 
 function colorEnabled(): boolean {
   let enabled = false;
@@ -31,6 +48,7 @@ function colorEnabled(): boolean {
 describe('pc color-enable decision', () => {
   const originalEnv = process.env;
   const originalIsTTY = process.stdout.isTTY;
+  const originalPlatform = process.platform;
 
   // Use plain assignment rather than Object.defineProperty: other suites (e.g.
   // index-tty.test.ts) define process.stdout.isTTY as a non-configurable data
@@ -40,6 +58,10 @@ describe('pc color-enable decision', () => {
     (process.stdout as { isTTY?: boolean }).isTTY = isTTY;
   }
 
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  }
+
   beforeEach(() => {
     // Deterministic baseline independent of the runner: clear every signal the
     // color decision keys off, and force a non-TTY stdout. Each test sets only
@@ -47,14 +69,17 @@ describe('pc color-enable decision', () => {
     const base = { ...originalEnv };
     delete base.FORCE_COLOR;
     delete base.NO_COLOR;
-    delete base.CI;
-    delete base.TERM;
+    for (const key of COLOR_SIGNAL_ENV_KEYS) {
+      delete base[key];
+    }
     process.env = base;
+    setPlatform('linux');
     setTTY(false);
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    setPlatform(originalPlatform);
     setTTY(originalIsTTY);
   });
 
@@ -91,9 +116,34 @@ describe('pc color-enable decision', () => {
     expect(colorEnabled()).toBe(true);
   });
 
-  it('enables color for an interactive TTY (no CI, no FORCE_COLOR)', () => {
+  it('enables color for an interactive TTY with a recognized TERM', () => {
     setTTY(true);
+    process.env.TERM = 'xterm-256color';
     expect(colorEnabled()).toBe(true);
+  });
+
+  it('disables color for an interactive TTY with unset TERM and no other chalk signal', () => {
+    setTTY(true);
+    expect(colorEnabled()).toBe(false);
+  });
+
+  it('disables color for an interactive TTY with unrecognized TERM and no other chalk signal', () => {
+    setTTY(true);
+    process.env.TERM = 'acme-terminal';
+    expect(colorEnabled()).toBe(false);
+  });
+
+  it('enables color for an interactive TTY with COLORTERM despite unrecognized TERM', () => {
+    setTTY(true);
+    process.env.TERM = 'acme-terminal';
+    process.env.COLORTERM = '1';
+    expect(colorEnabled()).toBe(true);
+  });
+
+  it('disables color for an interactive TTY with TERM=dumb', () => {
+    setTTY(true);
+    process.env.TERM = 'dumb';
+    expect(colorEnabled()).toBe(false);
   });
 
   it('disables color for a bare CI with non-TTY stdout (chalk-compat override)', () => {
@@ -103,17 +153,39 @@ describe('pc color-enable decision', () => {
     expect(colorEnabled()).toBe(false);
   });
 
+  it('disables color for a generic CI even when stdout is a TTY', () => {
+    setTTY(true);
+    process.env.CI = 'true';
+    process.env.TERM = 'xterm-256color';
+    expect(colorEnabled()).toBe(false);
+  });
+
+  it('enables color for a recognized CI vendor when stdout is a TTY', () => {
+    setTTY(true);
+    process.env.CI = 'true';
+    process.env.GITHUB_ACTIONS = 'true';
+    expect(colorEnabled()).toBe(true);
+  });
+
+  it('disables color for Drone CI with no chalk-recognized CI signal', () => {
+    setTTY(true);
+    process.env.CI = 'true';
+    process.env.DRONE = 'true';
+    expect(colorEnabled()).toBe(false);
+  });
+
   it('disables color on Windows with non-TTY stdout and no color vars', () => {
     // picocolors enables color for `process.platform === 'win32'` regardless of
     // TTY; chalk@4 required a TTY/FORCE_COLOR first. Guards ANSI escapes in
     // redirected Windows output (e.g. `create-react-on-rails-app app > log.txt`).
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    try {
-      expect(colorEnabled()).toBe(false);
-    } finally {
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
-    }
+    setPlatform('win32');
+    expect(colorEnabled()).toBe(false);
+  });
+
+  it('enables color on Windows when stdout is a TTY', () => {
+    setPlatform('win32');
+    setTTY(true);
+    expect(colorEnabled()).toBe(true);
   });
 
   it('still enables color in CI when FORCE_COLOR=1', () => {


### PR DESCRIPTION
## Why

Issue #4455 tracks the remaining color-fallback parity decision from the picocolors migration. The previous fallback colored any non-dumb TTY, while chalk@4/supports-color@7.2.0 stays plain unless the environment exposes a recognized color signal.

## What Changed

- Mirror the relevant chalk@4 TTY fallback signals for create-react-on-rails-app output colors.
- Preserve the existing `FORCE_COLOR` and `NO_COLOR` precedence.
- Add regression coverage for unset/unrecognized `TERM`, `TERM=dumb`, `COLORTERM`, recognized CI vendors, generic CI, and Windows TTY cases.

Closes #4455.

## Validation

- `pnpm --filter create-react-on-rails-app run test -- colors.test.ts`
- `pnpm --filter create-react-on-rails-app run type-check`
- `pnpm exec prettier --check packages/create-react-on-rails-app/src/utils.ts packages/create-react-on-rails-app/tests/colors.test.ts`
- `pnpm exec eslint packages/create-react-on-rails-app/src/utils.ts packages/create-react-on-rails-app/tests/colors.test.ts --no-warn-ignored`
- `git diff --check -- packages/create-react-on-rails-app/src/utils.ts packages/create-react-on-rails-app/tests/colors.test.ts`
- `codex review --base origin/main` reported no actionable correctness issues

## QA Evidence

QA lane not required: this stayed inside the create-react-on-rails-app color utility and adjacent package tests, with no broad runtime, workflow, or generated-app behavior expansion beyond CLI color detection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal color detection so output now follows more consistent, widely expected behavior across different shells, TTYs, and CI environments.
  * Better respects common color-related environment settings, including forced color, disabled color, and terminal capability signals.
  * Expanded support for interactive and Windows terminal cases to avoid incorrect plain-text output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->