### PR TITLE
Tighten final gate CI evidence

### DIFF
--- a/.agents/skills/pr-batch/bin/pr-ci-readiness
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness
@@ -6,13 +6,15 @@
 # Encapsulates the repeated "is this PR's CI ready?" rule that is otherwise
 # restated in prose across pr-batch, adversarial-pr-review, and pr-processing:
 #
-#   1. Run `gh pr checks <PR> --required`. If it reports no usable required
-#      checks -- either no JSON at all, or only cancelled/superseded rows --
+#   1. Run `gh pr checks <PR> --required`. If it reports no required checks,
 #      fall back to the full `gh pr checks <PR>` list.
 #   2. An empty check list => UNKNOWN / not ready.
-#   3. Ignore superseded/cancelled rows (bucket "cancel").
-#   4. Otherwise READY only when no failing (bucket "fail") and no pending
-#      (bucket "pending") rows remain. Passing and skipping rows are fine.
+#   3. Treat cancelled rows as non-ready unless the list contains no active rows,
+#      in which case the verdict is UNKNOWN.
+#   4. When required rows exist, cross-check them against the full list and use
+#      the full list if any extra full-check row is fail/pending/cancel.
+#   5. Otherwise READY only when no failing (bucket "fail") and no pending
+#      (bucket "pending" or "cancel") rows remain. Passing and skipping rows are fine.
 #
 # `gh pr checks` exits non-zero when checks are failing or pending, so this
 # captures stdout and inspects the rows rather than trusting the exit status.
@@ -41,18 +43,42 @@ module PrCiReadiness
     []
   end
 
-  # True when the raw payload holds a JSON array with at least one row that
-  # counts toward the gate. A required-check list made up entirely of cancelled
-  # rows would otherwise short-circuit the full-list fallback and then drop to
-  # zero active rows, producing a spurious UNKNOWN; treating it as "no usable
-  # checks" lets the caller fall back to the full list instead.
+  # True when the raw payload holds a JSON array with at least one row.
   def usable_checks?(raw)
-    !active_rows(parse_rows(raw)).empty?
+    !parse_rows(raw).empty?
   end
 
-  # Rows that count toward the gate: cancelled/superseded rows are dropped.
+  # Rows that count toward READY/NOT_READY. Cancel-only is UNKNOWN, but a cancel
+  # row alongside active rows keeps the PR out of READY.
   def active_rows(rows)
     rows.reject { |row| row["bucket"].to_s == "cancel" }
+  end
+
+  def cancelled_rows(rows)
+    rows.select { |row| row["bucket"].to_s == "cancel" }
+  end
+
+  def non_ready_row?(row)
+    %w[cancel fail pending].include?(row["bucket"].to_s)
+  end
+
+  def row_key(row)
+    name = row["name"].to_s
+    return name unless name.empty?
+
+    link = row["link"].to_s
+    link.empty? ? row.to_s : link
+  end
+
+  def required_rows_complete?(required_rows, full_rows)
+    required_keys = required_rows.map { |row| row_key(row) }
+    return false if required_keys.empty?
+
+    full_keys = full_rows.map { |row| row_key(row) }
+    return false unless (required_keys - full_keys).empty?
+
+    extra_full_rows = full_rows.reject { |row| required_keys.include?(row_key(row)) }
+    extra_full_rows.none? { |row| non_ready_row?(row) }
   end
 
   def failing_names(rows)
@@ -63,8 +89,12 @@ module PrCiReadiness
     rows.select { |row| row["bucket"].to_s == "pending" }.map { |row| row["name"].to_s }
   end
 
-  def verdict_for(rows, failing, pending)
-    if rows.empty?
+  def cancelled_names(rows)
+    cancelled_rows(rows).map { |row| row["name"].to_s }
+  end
+
+  def verdict_for(active, failing, pending)
+    if active.empty?
       "UNKNOWN"
     elsif failing.empty? && pending.empty?
       "READY"
@@ -75,13 +105,14 @@ module PrCiReadiness
 
   # Build the normalized result hash from the captured check rows.
   def assess(pr_number:, required_used:, rows:)
-    rows = active_rows(rows)
-    failing = failing_names(rows)
-    pending = pending_names(rows)
+    active = active_rows(rows)
+    failing = failing_names(active)
+    pending = pending_names(active)
+    pending += cancelled_names(rows) unless active.empty?
 
     {
       "pr" => pr_number.to_i,
-      "verdict" => verdict_for(rows, failing, pending),
+      "verdict" => verdict_for(active, failing, pending),
       "required_used" => required_used,
       "failing" => failing,
       "pending" => pending
@@ -103,10 +134,11 @@ module PrCiReadiness
     Usage: pr-ci-readiness <pr-number> [options]
 
     Decide whether a PR's CI is ready to merge. Runs `gh pr checks <PR> --required`
-    first; when no usable required checks exist (no rows, or only cancelled rows),
-    falls back to the full `gh pr checks <PR>` list. An empty list is
-    UNKNOWN/not-ready. Cancelled/superseded rows are ignored.
-    The PR is READY only when no failing or pending checks remain.
+    first; when no required checks exist, falls back to the full `gh pr checks <PR>`
+    list. An empty or cancel-only list is UNKNOWN/not-ready. When required rows
+    exist, the helper cross-checks the full list and uses it if extra full-check rows
+    are fail/pending/cancel. The PR is READY only when no failing or pending checks
+    remain.
 
     Arguments:
       <pr-number>        PR number to inspect (integer).
@@ -128,8 +160,8 @@ module PrCiReadiness
       }
 
     verdict is UNKNOWN when neither the required nor the full check list reports any
-    checks (cancelled rows do not count). required_used is true when the required
-    check list was non-empty and was used as the readiness gate.
+    active non-cancelled checks. required_used is true when the required check list
+    was complete and used as the readiness gate.
 
     Requires: gh (GitHub CLI)
   USAGE
@@ -204,15 +236,23 @@ module PrCiReadiness
     end
 
     # Fetch the required-check list first; fall back to the full list when the
-    # required form yields no rows. required_used flips to false on fallback.
+    # required form yields no rows or when the full list has extra non-ready rows.
+    # required_used flips to false on fallback.
     def assess(repo, pr_number)
       required_raw = fetch_checks(repo, pr_number, required: true)
-      if PrCiReadiness.usable_checks?(required_raw)
-        rows = PrCiReadiness.parse_rows(required_raw)
-        required_used = true
-      else
+      required_rows = PrCiReadiness.parse_rows(required_raw)
+      if required_rows.empty?
         rows = PrCiReadiness.parse_rows(fetch_checks(repo, pr_number, required: false))
         required_used = false
+      else
+        full_rows = PrCiReadiness.parse_rows(fetch_checks(repo, pr_number, required: false))
+        if PrCiReadiness.required_rows_complete?(required_rows, full_rows)
+          rows = required_rows
+          required_used = true
+        else
+          rows = full_rows
+          required_used = false
+        end
       end
       PrCiReadiness.assess(pr_number:, required_used:, rows:)
     end
@@ -286,7 +326,7 @@ module PrCiReadiness
                                    { "name" => "lint", "bucket" => "fail" },
                                    { "name" => "stale", "bucket" => "cancel" }
                                  ])
-      ok = out["verdict"] == "NOT_READY" && out["failing"] == ["lint"] && out["pending"].empty?
+      ok = out["verdict"] == "NOT_READY" && out["failing"] == ["lint"] && out["pending"] == ["stale"]
       ok ? [] : ["failing did not yield NOT_READY (lint)"]
     end
 
@@ -308,9 +348,6 @@ module PrCiReadiness
       errors << "usable_checks? treated [] as usable" if PrCiReadiness.usable_checks?("[]")
       errors << "usable_checks? treated blank as usable" if PrCiReadiness.usable_checks?("")
       errors << "usable_checks? treated non-JSON as usable" if PrCiReadiness.usable_checks?("no required checks")
-      if PrCiReadiness.usable_checks?('[{"name":"stale","bucket":"cancel"}]')
-        errors << "usable_checks? treated cancel-only as usable"
-      end
       errors
     end
 

--- a/.agents/skills/pr-batch/bin/pr-ci-readiness
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness
@@ -11,8 +11,9 @@
 #   2. An empty check list => UNKNOWN / not ready.
 #   3. Treat cancelled rows as non-ready unless the list contains no active rows,
 #      in which case the verdict is UNKNOWN.
-#   4. When required rows exist, cross-check them against the full list and use
-#      the full list if any full-check row is fail/pending/cancel.
+#   4. When required rows exist, cross-check them against the full list. A
+#      missing or non-ready matching required check blocks readiness; advisory
+#      rows outside the required set do not block required readiness.
 #   5. Otherwise READY only when no failing (bucket "fail") and no pending
 #      (bucket "pending" or "cancel") rows remain. Passing and skipping rows are fine.
 #
@@ -76,7 +77,8 @@ module PrCiReadiness
 
     return false unless missing_required_keys(required_rows, full_rows).empty?
 
-    full_rows.none? { |row| non_ready_row?(row) }
+    matching_full_rows = full_rows.select { |row| required_keys.include?(row_key(row)) }
+    matching_full_rows.none? { |row| non_ready_row?(row) }
   end
 
   def missing_required_keys(required_rows, full_rows)
@@ -140,9 +142,9 @@ module PrCiReadiness
     Decide whether a PR's CI is ready to merge. Runs `gh pr checks <PR> --required`
     first; when no required checks exist, falls back to the full `gh pr checks <PR>`
     list. An empty or cancel-only list is UNKNOWN/not-ready. When required rows
-    exist, the helper cross-checks the full list and uses it if extra full-check rows
-    are fail/pending/cancel. The PR is READY only when no failing or pending checks
-    remain.
+    exist, the helper cross-checks the full list for the same required check
+    identities. The PR is READY when no required check is missing, failing, or
+    pending; advisory full-list rows do not block required readiness.
 
     Arguments:
       <pr-number>        PR number to inspect (integer).
@@ -240,7 +242,8 @@ module PrCiReadiness
     end
 
     # Fetch the required-check list first; fall back to the full list when the
-    # required form yields no rows or when the full list has extra non-ready rows.
+    # required form yields no rows or when the full list has matching required
+    # rows that are missing or non-ready. Advisory full-list rows do not block.
     # required_used flips to false on fallback.
     def assess(repo, pr_number)
       required_raw = fetch_checks(repo, pr_number, required: true)

--- a/.agents/skills/pr-batch/bin/pr-ci-readiness
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness
@@ -74,10 +74,15 @@ module PrCiReadiness
     required_keys = required_rows.map { |row| row_key(row) }
     return false if required_keys.empty?
 
-    full_keys = full_rows.map { |row| row_key(row) }
-    return false unless (required_keys - full_keys).empty?
+    return false unless missing_required_keys(required_rows, full_rows).empty?
 
     full_rows.none? { |row| non_ready_row?(row) }
+  end
+
+  def missing_required_keys(required_rows, full_rows)
+    required_keys = required_rows.map { |row| row_key(row) }
+    full_keys = full_rows.map { |row| row_key(row) }
+    required_keys - full_keys
   end
 
   def failing_names(rows)
@@ -245,7 +250,10 @@ module PrCiReadiness
         required_used = false
       else
         full_rows = PrCiReadiness.parse_rows(fetch_checks(repo, pr_number, required: false))
-        if PrCiReadiness.required_rows_complete?(required_rows, full_rows)
+        if !PrCiReadiness.missing_required_keys(required_rows, full_rows).empty?
+          rows = []
+          required_used = false
+        elsif PrCiReadiness.required_rows_complete?(required_rows, full_rows)
           rows = required_rows
           required_used = true
         else

--- a/.agents/skills/pr-batch/bin/pr-ci-readiness
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness
@@ -12,7 +12,7 @@
 #   3. Treat cancelled rows as non-ready unless the list contains no active rows,
 #      in which case the verdict is UNKNOWN.
 #   4. When required rows exist, cross-check them against the full list and use
-#      the full list if any extra full-check row is fail/pending/cancel.
+#      the full list if any full-check row is fail/pending/cancel.
 #   5. Otherwise READY only when no failing (bucket "fail") and no pending
 #      (bucket "pending" or "cancel") rows remain. Passing and skipping rows are fine.
 #
@@ -77,8 +77,7 @@ module PrCiReadiness
     full_keys = full_rows.map { |row| row_key(row) }
     return false unless (required_keys - full_keys).empty?
 
-    extra_full_rows = full_rows.reject { |row| required_keys.include?(row_key(row)) }
-    extra_full_rows.none? { |row| non_ready_row?(row) }
+    full_rows.none? { |row| non_ready_row?(row) }
   end
 
   def failing_names(rows)

--- a/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
@@ -62,8 +62,9 @@ class PrCiReadinessTest < Minitest::Test
                                  { "name" => "rspec", "bucket" => "pass" },
                                  { "name" => "stale", "bucket" => "cancel" }
                                ])
-    assert_equal "READY", out["verdict"]
+    assert_equal "NOT_READY", out["verdict"]
     assert_empty out["failing"]
+    assert_equal ["stale"], out["pending"]
   end
 
   def test_cancel_row_dropped_from_failing_and_pending
@@ -83,8 +84,31 @@ class PrCiReadinessTest < Minitest::Test
     refute PrCiReadiness.usable_checks?("")
     refute PrCiReadiness.usable_checks?(nil)
     refute PrCiReadiness.usable_checks?("no required checks") # non-JSON message
-    # Cancel-only rows are not usable: they must not short-circuit the fallback.
-    refute PrCiReadiness.usable_checks?('[{"name":"stale","bucket":"cancel"}]')
+    assert PrCiReadiness.usable_checks?('[{"name":"stale","bucket":"cancel"}]')
+  end
+
+  def test_required_rows_incomplete_when_full_has_extra_pending_check
+    required_rows = [
+      { "name" => "required-pr-gate", "bucket" => "pass" }
+    ]
+    full_rows = [
+      { "name" => "required-pr-gate", "bucket" => "pass" },
+      { "name" => "rspec-package-tests", "bucket" => "pending" }
+    ]
+
+    refute PrCiReadiness.required_rows_complete?(required_rows, full_rows)
+  end
+
+  def test_required_rows_complete_when_extra_full_checks_are_done
+    required_rows = [
+      { "name" => "required-pr-gate", "bucket" => "pass" }
+    ]
+    full_rows = [
+      { "name" => "required-pr-gate", "bucket" => "pass" },
+      { "name" => "docs-format-check", "bucket" => "skipping" }
+    ]
+
+    assert PrCiReadiness.required_rows_complete?(required_rows, full_rows)
   end
 
   def test_parse_rows_handles_non_array_json
@@ -148,7 +172,7 @@ class PrCiReadinessCliTest < Minitest::Test
   def test_required_checks_used_when_present
     with_fake_gh(
       required_json: '[{"name":"rspec","state":"SUCCESS","bucket":"pass","link":"x"}]',
-      full_json: '[{"name":"rspec","bucket":"pass"},{"name":"extra","bucket":"fail"}]'
+      full_json: '[{"name":"rspec","bucket":"pass"},{"name":"extra","bucket":"pass"}]'
     ) do |env|
       out, status = run_script(env, "123", "--repo", "owner/repo")
       assert status.success?, out
@@ -184,51 +208,48 @@ class PrCiReadinessCliTest < Minitest::Test
     end
   end
 
-  def test_cancel_only_required_falls_back_to_full_list
-    # A required list of only cancelled rows is not usable: it must fall back to
-    # the full check list (which here surfaces a real failure) instead of
-    # silently collapsing to UNKNOWN.
+  def test_cancel_only_required_is_unknown
     with_fake_gh(
       required_json: '[{"name":"stale","state":"CANCELLED","bucket":"cancel","link":"x"}]',
-      full_json: '[{"name":"lint","state":"FAILURE","bucket":"fail","link":"x"}]'
-    ) do |env|
-      out, = run_script(env, "123", "--repo", "owner/repo")
-      data = JSON.parse(out)
-      assert_equal "NOT_READY", data["verdict"]
-      # required form had no usable rows, so the full list was used.
-      assert_equal false, data["required_used"]
-      assert_equal ["lint"], data["failing"]
-    end
-  end
-
-  def test_cancel_only_required_and_empty_full_is_unknown_via_cli
-    # Cancel-only required falls back; if the full list is also empty, UNKNOWN.
-    with_fake_gh(
-      required_json: '[{"name":"stale","state":"CANCELLED","bucket":"cancel","link":"x"}]',
-      full_json: "[]"
+      full_json: '[{"name":"stale","state":"CANCELLED","bucket":"cancel","link":"x"}]'
     ) do |env|
       out, = run_script(env, "123", "--repo", "owner/repo")
       data = JSON.parse(out)
       assert_equal "UNKNOWN", data["verdict"]
+      assert_equal true, data["required_used"]
+    end
+  end
+
+  def test_required_subset_with_extra_pending_full_check_is_not_ready_via_cli
+    with_fake_gh(
+      required_json: '[{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"x"}]',
+      full_json: '[{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"x"},' \
+                 '{"name":"rspec-package-tests","state":"PENDING","bucket":"pending","link":"y"}]'
+    ) do |env|
+      out, = run_script(env, "123", "--repo", "owner/repo")
+      data = JSON.parse(out)
+      assert_equal "NOT_READY", data["verdict"]
       assert_equal false, data["required_used"]
+      assert_equal ["rspec-package-tests"], data["pending"]
     end
   end
 
   def test_cancel_row_does_not_mask_passing_via_cli
     with_fake_gh(
       required_json: '[{"name":"rspec","bucket":"pass"},{"name":"stale","bucket":"cancel"}]',
-      full_json: "[]"
+      full_json: '[{"name":"rspec","bucket":"pass"},{"name":"stale","bucket":"cancel"}]'
     ) do |env|
       out, = run_script(env, "123", "--repo", "owner/repo")
       data = JSON.parse(out)
-      assert_equal "READY", data["verdict"]
+      assert_equal "NOT_READY", data["verdict"]
+      assert_equal ["stale"], data["pending"]
     end
   end
 
   def test_text_mode_via_cli
     with_fake_gh(
       required_json: '[{"name":"lint","bucket":"fail"}]',
-      full_json: "[]"
+      full_json: '[{"name":"lint","bucket":"fail"}]'
     ) do |env|
       out, status = run_script(env, "123", "--repo", "owner/repo", "--text")
       assert status.success?, out
@@ -240,7 +261,7 @@ class PrCiReadinessCliTest < Minitest::Test
   def test_repo_defaults_to_gh_repo_view
     with_fake_gh(
       required_json: '[{"name":"rspec","bucket":"pass"}]',
-      full_json: "[]"
+      full_json: '[{"name":"rspec","bucket":"pass"}]'
     ) do |env|
       out, status = run_script(env, "123")
       assert status.success?, out

--- a/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
@@ -111,6 +111,18 @@ class PrCiReadinessTest < Minitest::Test
     refute PrCiReadiness.required_rows_complete?(required_rows, full_rows)
   end
 
+  def test_required_rows_incomplete_when_full_is_missing_required_check
+    required_rows = [
+      { "name" => "required-pr-gate", "bucket" => "pass" }
+    ]
+    full_rows = [
+      { "name" => "docs-format-check", "bucket" => "pass" }
+    ]
+
+    assert_equal ["required-pr-gate"], PrCiReadiness.missing_required_keys(required_rows, full_rows)
+    refute PrCiReadiness.required_rows_complete?(required_rows, full_rows)
+  end
+
   def test_required_rows_complete_when_extra_full_checks_are_done
     required_rows = [
       { "name" => "required-pr-gate", "bucket" => "pass" }
@@ -243,6 +255,20 @@ class PrCiReadinessCliTest < Minitest::Test
       assert_equal "NOT_READY", data["verdict"]
       assert_equal false, data["required_used"]
       assert_equal ["rspec-package-tests"], data["pending"]
+    end
+  end
+
+  def test_required_subset_missing_from_full_snapshot_is_unknown_via_cli
+    with_fake_gh(
+      required_json: '[{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"x"}]',
+      full_json: '[{"name":"docs-format-check","state":"SUCCESS","bucket":"pass","link":"y"}]'
+    ) do |env|
+      out, = run_script(env, "123", "--repo", "owner/repo")
+      data = JSON.parse(out)
+      assert_equal "UNKNOWN", data["verdict"]
+      assert_equal false, data["required_used"]
+      assert_equal [], data["failing"]
+      assert_equal [], data["pending"]
     end
   end
 

--- a/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
@@ -87,7 +87,7 @@ class PrCiReadinessTest < Minitest::Test
     assert PrCiReadiness.usable_checks?('[{"name":"stale","bucket":"cancel"}]')
   end
 
-  def test_required_rows_incomplete_when_full_has_extra_pending_check
+  def test_required_rows_complete_when_full_has_extra_advisory_pending_check
     required_rows = [
       { "name" => "required-pr-gate", "bucket" => "pass" }
     ]
@@ -96,7 +96,7 @@ class PrCiReadinessTest < Minitest::Test
       { "name" => "rspec-package-tests", "bucket" => "pending" }
     ]
 
-    refute PrCiReadiness.required_rows_complete?(required_rows, full_rows)
+    assert PrCiReadiness.required_rows_complete?(required_rows, full_rows)
   end
 
   def test_required_rows_incomplete_when_matching_full_required_check_is_pending
@@ -244,7 +244,7 @@ class PrCiReadinessCliTest < Minitest::Test
     end
   end
 
-  def test_required_subset_with_extra_pending_full_check_is_not_ready_via_cli
+  def test_required_subset_with_extra_advisory_pending_full_check_is_ready_via_cli
     with_fake_gh(
       required_json: '[{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"x"}]',
       full_json: '[{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"x"},' \
@@ -252,9 +252,9 @@ class PrCiReadinessCliTest < Minitest::Test
     ) do |env|
       out, = run_script(env, "123", "--repo", "owner/repo")
       data = JSON.parse(out)
-      assert_equal "NOT_READY", data["verdict"]
-      assert_equal false, data["required_used"]
-      assert_equal ["rspec-package-tests"], data["pending"]
+      assert_equal "READY", data["verdict"]
+      assert_equal true, data["required_used"]
+      assert_empty data["pending"]
     end
   end
 

--- a/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
+++ b/.agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
@@ -99,6 +99,18 @@ class PrCiReadinessTest < Minitest::Test
     refute PrCiReadiness.required_rows_complete?(required_rows, full_rows)
   end
 
+  def test_required_rows_incomplete_when_matching_full_required_check_is_pending
+    required_rows = [
+      { "name" => "required-pr-gate", "bucket" => "pass" }
+    ]
+    full_rows = [
+      { "name" => "required-pr-gate", "bucket" => "pass" },
+      { "name" => "required-pr-gate", "bucket" => "pending" }
+    ]
+
+    refute PrCiReadiness.required_rows_complete?(required_rows, full_rows)
+  end
+
   def test_required_rows_complete_when_extra_full_checks_are_done
     required_rows = [
       { "name" => "required-pr-gate", "bucket" => "pass" }
@@ -216,7 +228,7 @@ class PrCiReadinessCliTest < Minitest::Test
       out, = run_script(env, "123", "--repo", "owner/repo")
       data = JSON.parse(out)
       assert_equal "UNKNOWN", data["verdict"]
-      assert_equal true, data["required_used"]
+      assert_equal false, data["required_used"]
     end
   end
 

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -382,6 +382,17 @@ jobs:
             }
 
             async function triggerHostedCi(pr, { forceFull }) {
+              if (pr.state !== 'open') {
+                await addReaction('confused');
+                await postComment([
+                  'Unable to run hosted CI from this command because the PR is not open.',
+                  '',
+                  `Current PR state: \`${pr.state || 'unknown'}\`; merged: \`${pr.merged ? 'yes' : 'no'}\`.`,
+                  'Hosted CI dispatch requires the live PR head ref before merge or close. After that point, branch-ref hosted-CI evidence is degraded/invalid; use the existing current-head checks, the merge commit, or a verification PR if more hosted evidence is required.'
+                ].join('\n'));
+                return;
+              }
+
               const headRepoFullName = pr.head.repo?.full_name;
 
               if (!headRepoFullName) {

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           bash script/ci-required-hosted-gate-test.bash
           node .github/workflows/hosted-ci-safety.test.cjs
+          ruby script/pr_merge_ledger_test.rb
 
       - name: Fetch workflow dispatch base
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -76,6 +76,7 @@ jobs:
           bash script/ci-required-hosted-gate-test.bash
           node .github/workflows/hosted-ci-safety.test.cjs
           ruby script/pr_merge_ledger_test.rb
+          ruby .agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
 
       - name: Fetch workflow dispatch base
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -12,6 +12,7 @@ function assertMatches(name, text, pattern) {
 const labelDispatchWorkflow = read('.github/workflows/hosted-ci-label-dispatch.yml');
 const requiredWorkflow = read('.github/workflows/ci-required.yml');
 const hostedSelectorsAction = read('.github/actions/hosted-ci-selectors/action.yml');
+const ciCommandsWorkflow = read('.github/workflows/ci-commands.yml');
 
 assertMatches(
   'hosted-ci-label-dispatch trigger',
@@ -39,6 +40,12 @@ assertMatches(
   'required gate cleanup recheck',
   labelDispatchWorkflow,
   /createWorkflowDispatch\({[\s\S]*workflow_id: 'ci-required\.yml'[\s\S]*force_required_hosted_ci_recheck: 'true'/,
+);
+assertMatches('closed PR hosted-CI guard', ciCommandsWorkflow, /pr\.state !== 'open'/);
+assertMatches(
+  'closed PR degraded evidence comment',
+  ciCommandsWorkflow,
+  /branch-ref hosted-CI evidence is degraded\/invalid/,
 );
 
 assertMatches(

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4506,6 +4506,14 @@ RSpec.describe "script/pr-merge-ledger" do
     fake_gh = <<~SH
       #!/bin/sh
       if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+        count_file="$(dirname "$0")/pr-check-calls"
+        count=0
+        if [ -f "$count_file" ]; then
+          count=$(cat "$count_file")
+        fi
+        count=$((count + 1))
+        printf '%s\\n' "$count" > "$count_file"
+
         required=false
         for arg in "$@"; do
           if [ "$arg" = "--required" ]; then
@@ -4522,7 +4530,7 @@ RSpec.describe "script/pr-merge-ledger" do
       [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"},{"name":"required-pr-gate","state":"PENDING","bucket":"pending","link":"https://example.com/check-rerun"}]
       JSON
         fi
-        exit 0
+        exit 8
       fi
 
       query=""
@@ -4587,6 +4595,7 @@ RSpec.describe "script/pr-merge-ledger" do
         ["required-pr-gate"]
       )
       expect(ledger.fetch("violations").map { |violation| violation.fetch("code") }).to include("ci_check_pending")
+      expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("2")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  def with_raw_fake_gh(script_body)
+    Dir.mktmpdir("pr-merge-ledger-gh") do |bin_dir|
+      gh_path = File.join(bin_dir, "gh")
+      File.write(gh_path, script_body)
+      File.chmod(0o755, gh_path)
+
+      yield({ "PATH" => "#{bin_dir}:#{ENV.fetch('PATH', '')}" }, bin_dir)
+    end
+  end
+
   def fake_gh_script_with_ready_checks(script_body)
     <<~SH
       #!/bin/sh
@@ -34,6 +44,70 @@ RSpec.describe "script/pr-merge-ledger" do
       fi
 
       #{script_body}
+    SH
+  end
+
+  def fake_gh_script_with_check_rows(required_json:, full_json:, pr_checks_exit_status: 0)
+    <<~SH
+      #!/bin/sh
+      if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+        count_file="$(dirname "$0")/pr-check-calls"
+        count=0
+        if [ -f "$count_file" ]; then
+          count=$(cat "$count_file")
+        fi
+        count=$((count + 1))
+        printf '%s\\n' "$count" > "$count_file"
+
+        required=false
+        for arg in "$@"; do
+          if [ "$arg" = "--required" ]; then
+            required=true
+          fi
+        done
+
+        if [ "$required" = "true" ]; then
+          cat <<'JSON'
+      #{required_json}
+      JSON
+        else
+          cat <<'JSON'
+      #{full_json}
+      JSON
+        fi
+        exit #{pr_checks_exit_status}
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
     SH
   end
 
@@ -4595,6 +4669,43 @@ RSpec.describe "script/pr-merge-ledger" do
         ["required-pr-gate"]
       )
       expect(ledger.fetch("violations").map { |violation| violation.fetch("code") }).to include("ci_check_pending")
+      expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("2")
+    end
+  end
+
+  it "allows strict live closeout when full checks include an advisory pending row" do
+    fake_gh = fake_gh_script_with_check_rows(
+      required_json: <<~JSON,
+        [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"}]
+      JSON
+      full_json: <<~JSON,
+        [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"},{"name":"rspec-package-tests","state":"PENDING","bucket":"pending","link":"https://example.com/advisory"}]
+      JSON
+      pr_checks_exit_status: 8
+    )
+
+    with_raw_fake_gh(fake_gh) do |env, bin_dir|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      ledger = JSON.parse(stdout).fetch("pull_requests").fetch(0)
+      expect(ledger.fetch("ci_readiness")).to include(
+        "verdict" => "READY",
+        "required_used" => true
+      )
+      expect(ledger.fetch("ci_readiness").fetch("pending")).to be_empty
+      expect(ledger.fetch("violations")).to be_empty
       expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("2")
     end
   end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4599,6 +4599,94 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks strict live closeout when full checks omit required rows" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+        required=false
+        for arg in "$@"; do
+          if [ "$arg" = "--required" ]; then
+            required=true
+          fi
+        done
+
+        if [ "$required" = "true" ]; then
+          cat <<'JSON'
+      [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"}]
+      JSON
+        else
+          cat <<'JSON'
+      [{"name":"docs-format-check","state":"SUCCESS","bucket":"pass","link":"https://example.com/docs"}]
+      JSON
+        fi
+        exit 0
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    Dir.mktmpdir("pr-merge-ledger-gh") do |bin_dir|
+      gh_path = File.join(bin_dir, "gh")
+      File.write(gh_path, fake_gh)
+      File.chmod(0o755, gh_path)
+
+      stdout, stderr, status = Open3.capture3(
+        { "PATH" => "#{bin_dir}:#{ENV.fetch('PATH', '')}" },
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+      expect(stderr).to include("ledger violations:")
+
+      report = JSON.parse(stdout)
+      ledger = report.fetch("pull_requests").fetch(0)
+      expect(ledger.fetch("ci_readiness")).to include(
+        "verdict" => "UNKNOWN",
+        "required_used" => false,
+        "message" => "full current-head check list omitted required checks: required-pr-gate"
+      )
+      expect(ledger.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_ci_readiness"
+      )
+    end
+  end
+
   it "aggregates multiple live PR ledgers in one invocation" do
     fake_gh = <<~SH
       #!/bin/sh

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4502,6 +4502,94 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks strict live closeout when full checks include a newer pending required row" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+        required=false
+        for arg in "$@"; do
+          if [ "$arg" = "--required" ]; then
+            required=true
+          fi
+        done
+
+        if [ "$required" = "true" ]; then
+          cat <<'JSON'
+      [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"}]
+      JSON
+        else
+          cat <<'JSON'
+      [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"},{"name":"required-pr-gate","state":"PENDING","bucket":"pending","link":"https://example.com/check-rerun"}]
+      JSON
+        fi
+        exit 0
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    Dir.mktmpdir("pr-merge-ledger-gh") do |bin_dir|
+      gh_path = File.join(bin_dir, "gh")
+      File.write(gh_path, fake_gh)
+      File.chmod(0o755, gh_path)
+
+      stdout, stderr, status = Open3.capture3(
+        { "PATH" => "#{bin_dir}:#{ENV.fetch('PATH', '')}" },
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+      expect(stderr).to include("ledger violations:")
+
+      report = JSON.parse(stdout)
+      ledger = report.fetch("pull_requests").fetch(0)
+      expect(ledger.fetch("ci_readiness")).to include(
+        "verdict" => "NOT_READY",
+        "required_used" => false
+      )
+      expect(ledger.fetch("ci_readiness").fetch("pending").map { |check| check.fetch("name") }).to eq(
+        ["required-pr-gate"]
+      )
+      expect(ledger.fetch("violations").map { |violation| violation.fetch("code") }).to include("ci_check_pending")
+    end
+  end
+
   it "aggregates multiple live PR ledgers in one invocation" do
     fake_gh = <<~SH
       #!/bin/sh

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -16,11 +16,51 @@ RSpec.describe "script/pr-merge-ledger" do
   def with_fake_gh(script_body)
     Dir.mktmpdir("pr-merge-ledger-gh") do |bin_dir|
       gh_path = File.join(bin_dir, "gh")
-      File.write(gh_path, script_body)
+      File.write(gh_path, fake_gh_script_with_ready_checks(script_body))
       File.chmod(0o755, gh_path)
 
       yield({ "PATH" => "#{bin_dir}:#{ENV.fetch('PATH', '')}" })
     end
+  end
+
+  def fake_gh_script_with_ready_checks(script_body)
+    <<~SH
+      #!/bin/sh
+      if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+        cat <<'JSON'
+      [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"}]
+      JSON
+        exit 0
+      fi
+
+      #{script_body}
+    SH
+  end
+
+  def write_fixture(file, fixture, binary: false)
+    fixture = fixture.merge(default_ci_readiness) if fixture_needs_default_ci_readiness?(fixture)
+    json = JSON.generate(fixture)
+    file.write(binary ? json.b : json)
+  end
+
+  def fixture_needs_default_ci_readiness?(fixture)
+    fixture.is_a?(Hash) &&
+      fixture["pull_request"].is_a?(Hash) &&
+      !fixture.key?("ci_readiness") &&
+      !fixture.key?("checks")
+  end
+
+  def default_ci_readiness
+    {
+      "ci_readiness" => {
+        "status" => "known",
+        "verdict" => "READY",
+        "required_used" => true,
+        "failing" => [],
+        "pending" => [],
+        "checks" => []
+      }
+    }
   end
 
   it "reports the known #3613 CHANGES_REQUESTED merge-ledger violation" do
@@ -87,7 +127,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-unknown", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -137,7 +177,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-unknown-review-decision-change-request", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -175,7 +215,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-null-review-decision", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -211,7 +251,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-missing-files", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -256,7 +296,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-blank-review-decision", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -302,7 +342,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-null-review-decision-change-request", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -349,7 +389,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-blank-review-decision-change-request", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -386,7 +426,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-review-required", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -423,7 +463,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-unsupported-review-decision", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -466,7 +506,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-non-strict-violations", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -502,7 +542,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-missing-changelog", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -540,7 +580,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     %w[changelog_present deferred_to_update_changelog].each do |classification|
       Tempfile.create(["pr-merge-ledger-#{classification}", ".json"]) do |file|
-        file.write(JSON.generate(fixture))
+        write_fixture(file, fixture)
         file.flush
 
         stdout, stderr, status = Open3.capture3(
@@ -578,7 +618,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-unknown-changelog", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -611,7 +651,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-clean", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -649,7 +689,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-draft", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -687,7 +727,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-closed-unmerged", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -723,7 +763,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-missing-head-sha", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -754,7 +794,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-missing-pull-request", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
@@ -787,7 +827,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-malformed-pull-request", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
@@ -806,7 +846,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-programming-error", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
@@ -851,7 +891,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-superseded", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -910,7 +950,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-current-change-request", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -974,7 +1014,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-current-approval", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1039,7 +1079,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-current-approval-tie", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1090,7 +1130,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-stale-change-request", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1152,7 +1192,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-parsed-timestamp", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1203,7 +1243,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-negative-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1259,7 +1299,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-all-current-reviews", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, _stderr, status = Open3.capture3(
@@ -1321,7 +1361,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-non-gating-review-findings", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1376,7 +1416,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-gating-review-findings", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1425,7 +1465,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-p0", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1480,7 +1520,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-badge-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1530,7 +1570,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-numbered-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1580,7 +1620,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-heading-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1630,7 +1670,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-task-list-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1680,7 +1720,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-slash-combined-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1734,7 +1774,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-or-separated-finding", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-or-separated-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -1786,7 +1826,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-two-findings", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1836,7 +1876,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-duplicate-severity", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1885,7 +1925,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-priority-looking-title", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1934,7 +1974,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-cross-priority-title", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -1984,7 +2024,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-indented-marker", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2039,7 +2079,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-outdated-thread-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2093,7 +2133,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-old-head-thread", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2152,7 +2192,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-url-comment-id", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2195,7 +2235,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-commentless-thread", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2257,7 +2297,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-stale-thread-comment", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2313,7 +2353,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-resolved-thread-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2376,7 +2416,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-superseded-review-finding", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2422,7 +2462,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-waived-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2474,7 +2514,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-resolved-multi-severity-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2524,7 +2564,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-no-issues-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2570,7 +2610,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-unresolved-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2620,7 +2660,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-not-fully-resolved-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2670,7 +2710,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-none-of-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2720,7 +2760,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-none-the-less-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2770,7 +2810,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-none-remaining-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2814,7 +2854,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-none-resolved-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2863,7 +2903,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2913,7 +2953,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-comma-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -2963,7 +3003,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-however-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3012,7 +3052,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-with-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3061,7 +3101,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-period-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3113,7 +3153,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-space-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3162,7 +3202,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-conjunction-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3220,7 +3260,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-colon-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3274,7 +3314,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-parenthetical-mixed-summary", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3324,7 +3364,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-previous-review-still-applies", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3374,7 +3414,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-resolved-first-clause", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3418,7 +3458,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-top-level-comment", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3475,7 +3515,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-issue-comment-body", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3521,7 +3561,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-large-comment-body", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3587,7 +3627,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-truncated-comments", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3645,7 +3685,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-incomplete-unresolved-thread", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -3694,7 +3734,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -3753,7 +3793,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-line-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-line-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -3810,7 +3850,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-multi-line-broad-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-multi-line-broad-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -3867,7 +3907,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-same-line-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-same-line-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -3925,7 +3965,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-same-line-broad-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-same-line-broad-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -3981,7 +4021,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -4033,7 +4073,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(["fixed"]))
         dispositions_file.flush
@@ -4080,7 +4120,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -4131,7 +4171,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -4178,7 +4218,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -4316,7 +4356,7 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-bad-submitted-at", ".json"]) do |file|
-      file.write(JSON.generate(fixture))
+      write_fixture(file, fixture)
       file.flush
 
       stdout, stderr, status = Open3.capture3(
@@ -5095,7 +5135,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
-        fixture_file.write(JSON.generate(fixture))
+        write_fixture(fixture_file, fixture)
         fixture_file.flush
         dispositions_file.write(JSON.generate(dispositions))
         dispositions_file.flush
@@ -5263,7 +5303,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
     Tempfile.create(["pr-merge-ledger-non-ascii", ".json"]) do |file|
       file.binmode
-      file.write(JSON.generate(fixture).b)
+      write_fixture(file, fixture, binary: true)
       file.flush
 
       stdout, stderr, status = with_unbundled_env do

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "script/pr-merge-ledger" do
     SH
   end
 
-  def fake_gh_script_with_check_rows(required_json:, full_json:, pr_checks_exit_status: 0)
+  def fake_gh_script_with_check_rows(required_json:, full_json:, pr_checks_exit_status: 0, fail_first_pr_checks: nil)
     <<~SH
       #!/bin/sh
       if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
@@ -58,6 +58,11 @@ RSpec.describe "script/pr-merge-ledger" do
         fi
         count=$((count + 1))
         printf '%s\\n' "$count" > "$count_file"
+
+        if [ "$count" -eq 1 ] && [ -n #{fail_first_pr_checks.to_s.inspect} ]; then
+          printf '%s\\n' #{fail_first_pr_checks.to_s.inspect} >&2
+          exit 1
+        fi
 
         required=false
         for arg in "$@"; do
@@ -4707,6 +4712,41 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(ledger.fetch("ci_readiness").fetch("pending")).to be_empty
       expect(ledger.fetch("violations")).to be_empty
       expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("2")
+    end
+  end
+
+  it "retries transient gh pr checks failures before deriving CI readiness" do
+    fake_gh = fake_gh_script_with_check_rows(
+      required_json: <<~JSON,
+        [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"}]
+      JSON
+      full_json: <<~JSON,
+        [{"name":"required-pr-gate","state":"SUCCESS","bucket":"pass","link":"https://example.com/check"}]
+      JSON
+      fail_first_pr_checks: "HTTP 429 Too Many Requests"
+    )
+
+    with_raw_fake_gh(fake_gh) do |env, bin_dir|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      ledger = JSON.parse(stdout).fetch("pull_requests").fetch(0)
+      expect(ledger.fetch("ci_readiness")).to include(
+        "verdict" => "READY",
+        "required_used" => true
+      )
+      expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("3")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -47,7 +47,13 @@ RSpec.describe "script/pr-merge-ledger" do
     SH
   end
 
-  def fake_gh_script_with_check_rows(required_json:, full_json:, pr_checks_exit_status: 0, fail_first_pr_checks: nil)
+  def fake_gh_script_with_check_rows(
+    required_json:,
+    full_json:,
+    pr_checks_exit_status: 0,
+    fail_first_pr_checks: nil,
+    pr_checks_sleep_seconds: nil
+  )
     <<~SH
       #!/bin/sh
       if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
@@ -61,6 +67,11 @@ RSpec.describe "script/pr-merge-ledger" do
 
         if [ "$count" -eq 1 ] && [ -n #{fail_first_pr_checks.to_s.inspect} ]; then
           printf '%s\\n' #{fail_first_pr_checks.to_s.inspect} >&2
+          exit 1
+        fi
+
+        if [ -n #{pr_checks_sleep_seconds.to_s.inspect} ]; then
+          sleep #{pr_checks_sleep_seconds.to_s.inspect}
           exit 1
         fi
 
@@ -4745,6 +4756,36 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(ledger.fetch("ci_readiness")).to include(
         "verdict" => "READY",
         "required_used" => true
+      )
+      expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("3")
+    end
+  end
+
+  it "bounds repeated gh pr checks timeouts before reporting unknown CI readiness" do
+    fake_gh = fake_gh_script_with_check_rows(
+      required_json: "[]",
+      full_json: "[]",
+      pr_checks_sleep_seconds: "2"
+    )
+
+    with_raw_fake_gh(fake_gh) do |env, bin_dir|
+      stdout, stderr, status = Open3.capture3(
+        env.merge("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS" => "1"),
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("unknown_fields").map { |field| field.fetch("field") }).to include(
+        "ci_readiness.verdict"
       )
       expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("3")
     end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "script/pr-merge-ledger" do
     full_json:,
     pr_checks_exit_status: 0,
     fail_first_pr_checks: nil,
+    pr_checks_stderr: nil,
     pr_checks_sleep_seconds: nil
   )
     <<~SH
@@ -90,6 +91,9 @@ RSpec.describe "script/pr-merge-ledger" do
           cat <<'JSON'
       #{full_json}
       JSON
+        fi
+        if [ -n #{pr_checks_stderr.to_s.inspect} ]; then
+          printf '%s\\n' #{pr_checks_stderr.to_s.inspect} >&2
         fi
         exit #{pr_checks_exit_status}
       fi
@@ -4788,6 +4792,40 @@ RSpec.describe "script/pr-merge-ledger" do
         "ci_readiness.verdict"
       )
       expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("3")
+    end
+  end
+
+  it "retries timeout-like gh pr checks stderr before reporting unknown CI readiness" do
+    fake_gh = fake_gh_script_with_check_rows(
+      required_json: "[]",
+      full_json: "[]",
+      pr_checks_exit_status: 1,
+      pr_checks_stderr: "gh pr checks timed out after 404 seconds"
+    )
+
+    with_raw_fake_gh(fake_gh) do |env, bin_dir|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("unknown_fields").map { |field| field.fetch("field") }).to include(
+        "ci_readiness.verdict"
+      )
+      expect(report.fetch("pull_requests").fetch(0).fetch("ci_readiness").fetch("message")).to include(
+        "gh pr checks required failed with exit 1: gh pr checks timed out after 404 seconds"
+      )
+      expect(File.read(File.join(bin_dir, "pr-check-calls")).strip).to eq("6")
     end
   end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -220,8 +220,7 @@ class PrMergeLedger
     full_keys = Array(full_rows).map { |row| ci_check_row_key(row) }
     return false unless (required_keys - full_keys).empty?
 
-    extra_full_rows = Array(full_rows).reject { |row| required_keys.include?(ci_check_row_key(row)) }
-    extra_full_rows.none? { |row| non_ready_ci_check_row?(row) }
+    Array(full_rows).none? { |row| non_ready_ci_check_row?(row) }
   end
 
   def self.normalize_ci_check_row(row)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -189,10 +189,6 @@ class PrMergeLedger
     []
   end
 
-  def self.usable_ci_check_rows?(raw)
-    !parse_ci_check_rows(raw).empty?
-  end
-
   def self.active_ci_check_rows(rows)
     Array(rows).reject { |row| row.is_a?(Hash) && row["bucket"].to_s == "cancel" }
   end
@@ -219,7 +215,8 @@ class PrMergeLedger
 
     return false unless missing_required_ci_check_keys(required_rows, full_rows).empty?
 
-    Array(full_rows).none? { |row| non_ready_ci_check_row?(row) }
+    matching_full_rows = Array(full_rows).select { |row| required_keys.include?(ci_check_row_key(row)) }
+    matching_full_rows.none? { |row| non_ready_ci_check_row?(row) }
   end
 
   def self.missing_required_ci_check_keys(required_rows, full_rows)
@@ -1415,7 +1412,11 @@ class PrMergeLedger
       ci_check_violation(pull_request, check, "ci_check_failed", "CI check failed")
     end
     pending = ci_readiness.fetch("pending").map do |check|
-      ci_check_violation(pull_request, check, "ci_check_pending", "CI check is still pending")
+      if check["bucket"].to_s == "cancel"
+        ci_check_violation(pull_request, check, "ci_check_cancelled", "CI check was cancelled or superseded")
+      else
+        ci_check_violation(pull_request, check, "ci_check_pending", "CI check is still pending")
+      end
     end
     details_missing = if ci_readiness.fetch("verdict") == "NOT_READY" && failed.empty? && pending.empty?
                         [

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1487,15 +1487,19 @@ class PrMergeLedger
 
     def fetch_ci_readiness(pr_number)
       required_result = fetch_pr_checks(pr_number, required: true)
-      if required_result.fetch(:success) && PrMergeLedger.usable_ci_check_rows?(required_result.fetch(:stdout))
-        rows = PrMergeLedger.parse_ci_check_rows(required_result.fetch(:stdout))
+      required_rows = PrMergeLedger.parse_ci_check_rows(required_result.fetch(:stdout))
+      if PrMergeLedger.usable_ci_check_rows?(required_result.fetch(:stdout))
+        rows = required_rows
         required_used = true
         message = nil
       else
         full_result = fetch_pr_checks(pr_number, required: false)
-        raise Error, pr_checks_error_message(required_result, full_result) unless full_result.fetch(:success)
+        full_rows = PrMergeLedger.parse_ci_check_rows(full_result.fetch(:stdout))
+        if !full_result.fetch(:success) && !PrMergeLedger.usable_ci_check_rows?(full_result.fetch(:stdout))
+          raise Error, pr_checks_error_message(required_result, full_result)
+        end
 
-        rows = PrMergeLedger.parse_ci_check_rows(full_result.fetch(:stdout))
+        rows = full_rows
         required_used = false
         message = pr_checks_error_message(required_result) unless required_result.fetch(:success)
       end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -25,6 +25,7 @@ class PrMergeLedger
     deferred_to_update_changelog
     not_user_visible
   ].freeze
+  CI_VERDICTS = %w[READY NOT_READY UNKNOWN].freeze
   DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable].freeze
   REVIEW_OBJECT_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED].freeze
   NON_BLOCKING_REVIEW_DECISION_STATES = %w[APPROVED NOT_REQUIRED].freeze
@@ -32,6 +33,18 @@ class PrMergeLedger
     "CHANGES_REQUESTED" => ["review_decision_changes_requested", "GitHub reviewDecision is CHANGES_REQUESTED"],
     "REVIEW_REQUIRED" => ["review_decision_review_required", "GitHub reviewDecision is REVIEW_REQUIRED"]
   }.freeze
+  UNKNOWN_VIOLATION_CODES = [
+    [/\Aci_readiness/, "unknown_ci_readiness"],
+    [/\Apriority_finding_dispositions\.body_scan/, "unknown_priority_finding_body_scan"],
+    [/\Apriority_finding_dispositions/, "unknown_priority_finding_disposition"],
+    [/\Achangelog_classification/, "unknown_changelog_classification"],
+    [/\Alockfile_diff/, "unknown_lockfile_diff"],
+    [/\Areview_threads\.comments/, "unknown_review_thread_comments"],
+    [/\Apr\.head_sha/, "unknown_head_sha"],
+    # Missing and unsupported reviewDecision values share this gate code;
+    # unknown_fields[].message carries the precise diagnostic.
+    [/\Apr\.review_decision/, "unknown_review_decision"]
+  ].freeze
   BLOCKING_REVIEW_DECISION_STATES = BLOCKING_REVIEW_DECISION_VIOLATIONS.keys.freeze
   KNOWN_REVIEW_DECISION_STATES = (NON_BLOCKING_REVIEW_DECISION_STATES + BLOCKING_REVIEW_DECISION_STATES).freeze
   INTERNAL_REVIEW_DECISION_RAW_KEY = "review_decision_raw"
@@ -167,6 +180,69 @@ class PrMergeLedger
     io.read
   rescue IOError
     ""
+  end
+
+  def self.parse_ci_check_rows(raw)
+    rows = JSON.parse(raw.to_s)
+    rows.is_a?(Array) ? rows : []
+  rescue JSON::ParserError
+    []
+  end
+
+  def self.usable_ci_check_rows?(raw)
+    !active_ci_check_rows(parse_ci_check_rows(raw)).empty?
+  end
+
+  def self.active_ci_check_rows(rows)
+    Array(rows).reject { |row| row.is_a?(Hash) && row["bucket"].to_s == "cancel" }
+  end
+
+  def self.normalize_ci_check_row(row)
+    case row
+    when Hash
+      {
+        "name" => row["name"].to_s,
+        "state" => row["state"],
+        "bucket" => row["bucket"],
+        "link" => row["link"]
+      }.compact
+    else
+      { "name" => row.to_s }
+    end
+  end
+
+  def self.ci_readiness_from_check_rows(pr_number, required_used:, rows:, message: nil)
+    checks = active_ci_check_rows(rows).map { |row| normalize_ci_check_row(row) }
+    failing = checks.select { |row| row["bucket"].to_s == "fail" }
+    pending = checks.select { |row| row["bucket"].to_s == "pending" }
+    verdict = ci_verdict_for(checks, failing, pending)
+    status = ci_status_for(verdict)
+
+    {
+      "pr" => pr_number.to_i,
+      "status" => status,
+      "verdict" => verdict,
+      "required_used" => required_used == true,
+      "failing" => failing,
+      "pending" => pending,
+      "checks" => checks,
+      "message" => message || ci_unknown_message(status)
+    }.compact
+  end
+
+  def self.ci_verdict_for(checks, failing, pending)
+    return UNKNOWN if checks.empty?
+    return "READY" if failing.empty? && pending.empty?
+
+    "NOT_READY"
+  end
+
+  def self.ci_status_for(verdict)
+    verdict == UNKNOWN ? UNKNOWN : "known"
+  end
+
+  def self.ci_unknown_message(status)
+    status == UNKNOWN ? "no active current-head check rows were returned" : nil
   end
 
   def self.run(argv)
@@ -363,13 +439,14 @@ class PrMergeLedger
     File.basename(path)
   end
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def ledger_for(dataset, dispositions, enforce_unused_dispositions: true)
     pull_request = normalize_pull_request(dataset.fetch("pull_request"))
     files = file_paths(dataset)
     review_threads = normalized_review_threads(dataset, pull_request)
     reviews = normalized_reviews(dataset, pull_request)
     issue_comments = normalized_issue_comments(dataset)
+    ci_readiness = normalized_ci_readiness(dataset, pull_request)
 
     unresolved_threads = review_threads.select { |thread| unresolved_current_head_thread?(thread) }
     output_reviews = reviews.map { |review| review.except("body_text") }
@@ -397,20 +474,32 @@ class PrMergeLedger
         "all_changes_requested" => all_changes_requested
       },
       "issue_comments" => output_issue_comments,
+      "ci_readiness" => ci_readiness,
       "priority_finding_dispositions" => finding_report,
       "changelog_classification" => changelog,
       "lockfile_diff" => lockfile
     }
 
-    unknown_fields = unknown_fields_for(pull_request, review_threads, finding_report, changelog, lockfile)
-    violations = violations_for(pull_request, unresolved_threads, changes_requested, changelog, unknown_fields)
+    gate_context = {
+      review_threads:,
+      finding_report:,
+      ci_readiness:,
+      changelog:,
+      lockfile:,
+      unresolved_threads:,
+      changes_requested:,
+      unknown_fields: nil
+    }
+    unknown_fields = unknown_fields_for(pull_request, gate_context)
+    gate_context[:unknown_fields] = unknown_fields
+    violations = violations_for(pull_request, gate_context)
     ledger.merge(
       "violations" => violations,
       "unknown_fields" => unknown_fields,
       "complete_allowed" => violations.empty?
     )
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def file_paths(dataset)
     return nil unless dataset.key?("files") && !dataset["files"].nil?
@@ -428,6 +517,25 @@ class PrMergeLedger
 
   def normalized_issue_comments(dataset)
     Array(dataset["comments"]).map { |comment| normalize_issue_comment(comment) }
+  end
+
+  def normalized_ci_readiness(dataset, pull_request)
+    return normalize_ci_readiness(dataset.fetch("ci_readiness"), pull_request) if dataset.key?("ci_readiness")
+
+    if dataset.key?("checks")
+      return self.class.ci_readiness_from_check_rows(
+        pull_request.fetch("number"),
+        required_used: dataset["required_checks_used"],
+        rows: dataset.fetch("checks")
+      )
+    end
+
+    self.class.ci_readiness_from_check_rows(
+      pull_request.fetch("number"),
+      required_used: false,
+      rows: [],
+      message: "fixture is missing ci_readiness"
+    )
   end
 
   def normalize_pull_request(raw_pr)
@@ -555,6 +663,62 @@ class PrMergeLedger
       "body_excerpt" => excerpt(comment["body"]),
       "body" => comment["body"].to_s
     }
+  end
+
+  def normalize_ci_readiness(raw_readiness, pull_request)
+    return unknown_ci_readiness(pull_request, "ci_readiness must be a JSON object") unless raw_readiness.is_a?(Hash)
+
+    checks = Array(raw_readiness["checks"]).map { |row| self.class.normalize_ci_check_row(row) }
+    failing = normalize_ci_check_list(raw_readiness["failing"], checks, "fail")
+    pending = normalize_ci_check_list(raw_readiness["pending"], checks, "pending")
+    verdict = normalize_ci_verdict(raw_readiness["verdict"], checks, failing, pending)
+    status = normalize_ci_status(raw_readiness["status"], verdict)
+
+    {
+      "pr" => (raw_readiness["pr"] || pull_request.fetch("number")).to_i,
+      "status" => status,
+      "verdict" => verdict,
+      "required_used" => raw_readiness["required_used"] == true,
+      "failing" => failing,
+      "pending" => pending,
+      "checks" => checks,
+      "message" => raw_readiness["message"]
+    }.compact
+  end
+
+  def normalize_ci_check_list(raw_rows, checks, bucket)
+    rows = if raw_rows.nil?
+             checks.select { |row| row["bucket"].to_s == bucket }
+           else
+             Array(raw_rows)
+           end
+
+    rows.map { |row| self.class.normalize_ci_check_row(row) }
+  end
+
+  def normalize_ci_verdict(raw_verdict, checks, failing, pending)
+    return raw_verdict if CI_VERDICTS.include?(raw_verdict)
+
+    return UNKNOWN if checks.empty?
+    return "READY" if failing.empty? && pending.empty?
+
+    "NOT_READY"
+  end
+
+  def normalize_ci_status(raw_status, verdict)
+    return "known" if raw_status == "known" && verdict != UNKNOWN
+    return UNKNOWN if raw_status == UNKNOWN || verdict == UNKNOWN
+
+    "known"
+  end
+
+  def unknown_ci_readiness(pull_request, message)
+    self.class.ci_readiness_from_check_rows(
+      pull_request.fetch("number"),
+      required_used: false,
+      rows: [],
+      message:
+    )
   end
 
   def latest_reviews_by_reviewer(reviews)
@@ -1000,7 +1164,12 @@ class PrMergeLedger
     LOCKFILE_BASENAMES.include?(basename) || basename.end_with?(".lock")
   end
 
-  def unknown_fields_for(pull_request, review_threads, finding_dispositions, changelog, lockfile)
+  def unknown_fields_for(pull_request, gate_context)
+    review_threads = gate_context.fetch(:review_threads)
+    finding_dispositions = gate_context.fetch(:finding_report)
+    ci_readiness = gate_context.fetch(:ci_readiness)
+    changelog = gate_context.fetch(:changelog)
+    lockfile = gate_context.fetch(:lockfile)
     # pull_request must be the pre-output object so INTERNAL_REVIEW_DECISION_RAW_KEY
     # remains available for specific unsupported reviewDecision diagnostics.
     unknowns = pull_request_unknown_fields(pull_request)
@@ -1017,6 +1186,14 @@ class PrMergeLedger
     end
 
     unknowns.concat(priority_finding_unknown_fields(pull_request, finding_dispositions))
+
+    if ci_readiness.fetch("status") == UNKNOWN || ci_readiness.fetch("verdict") == UNKNOWN
+      unknowns << unknown_field(
+        pull_request,
+        "ci_readiness.verdict",
+        ci_readiness["message"] || "CI readiness is UNKNOWN"
+      )
+    end
 
     if changelog.fetch("classification") == UNKNOWN
       unknowns << unknown_field(
@@ -1094,15 +1271,16 @@ class PrMergeLedger
     }.compact
   end
 
-  def violations_for(pull_request, unresolved_threads, changes_requested, changelog, unknown_fields)
+  def violations_for(pull_request, gate_context)
     [
       review_decision_violation(pull_request),
       draft_pr_violation(pull_request),
       closed_unmerged_pr_violation(pull_request),
-      changelog_violation(pull_request, changelog),
-      *changes_requested_violations(pull_request, changes_requested),
-      *unresolved_thread_violations(pull_request, unresolved_threads),
-      *unknown_field_violations(pull_request, unknown_fields)
+      changelog_violation(pull_request, gate_context.fetch(:changelog)),
+      *changes_requested_violations(pull_request, gate_context.fetch(:changes_requested)),
+      *unresolved_thread_violations(pull_request, gate_context.fetch(:unresolved_threads)),
+      *ci_readiness_violations(pull_request, gate_context.fetch(:ci_readiness)),
+      *unknown_field_violations(pull_request, gate_context.fetch(:unknown_fields))
     ].compact
   end
 
@@ -1173,6 +1351,30 @@ class PrMergeLedger
     end
   end
 
+  def ci_readiness_violations(pull_request, ci_readiness)
+    failed = ci_readiness.fetch("failing").map do |check|
+      ci_check_violation(pull_request, check, "ci_check_failed", "CI check failed")
+    end
+    pending = ci_readiness.fetch("pending").map do |check|
+      ci_check_violation(pull_request, check, "ci_check_pending", "CI check is still pending")
+    end
+
+    failed + pending
+  end
+
+  def ci_check_violation(pull_request, check, code, message)
+    check_name = check["name"].to_s.empty? ? UNKNOWN : check["name"].to_s
+    violation(
+      pull_request,
+      code,
+      "#{message}: #{check_name}",
+      check["link"],
+      "check_name" => check_name,
+      "state" => check["state"],
+      "bucket" => check["bucket"]
+    )
+  end
+
   def unknown_field_violations(pull_request, unknown_fields)
     unknown_fields.map do |unknown|
       violation(
@@ -1185,26 +1387,7 @@ class PrMergeLedger
   end
 
   def unknown_violation_code(field)
-    case field
-    when /\Apriority_finding_dispositions\.body_scan/
-      "unknown_priority_finding_body_scan"
-    when /\Apriority_finding_dispositions/
-      "unknown_priority_finding_disposition"
-    when /\Achangelog_classification/
-      "unknown_changelog_classification"
-    when /\Alockfile_diff/
-      "unknown_lockfile_diff"
-    when /\Areview_threads\.comments/
-      "unknown_review_thread_comments"
-    when /\Apr\.head_sha/
-      "unknown_head_sha"
-    when /\Apr\.review_decision/
-      # Missing and unsupported reviewDecision values share this gate code;
-      # unknown_fields[].message carries the precise diagnostic.
-      "unknown_review_decision"
-    else
-      "unknown_ledger_field"
-    end
+    UNKNOWN_VIOLATION_CODES.find { |pattern, _code| field.match?(pattern) }&.last || "unknown_ledger_field"
   end
 
   def violation(pull_request, code, message, url, extra = {})
@@ -1243,7 +1426,8 @@ class PrMergeLedger
         "files" => files,
         "review_threads" => fetch_review_threads(pr_number),
         "reviews" => fetch_reviews(pr_number),
-        "comments" => fetch_comments(pr_number)
+        "comments" => fetch_comments(pr_number),
+        "ci_readiness" => fetch_ci_readiness(pr_number)
       }
     end
 
@@ -1287,6 +1471,30 @@ class PrMergeLedger
 
     def fetch_comments(pr_number)
       fetch_paginated_connection(pr_number, comments_query, "comments")
+    end
+
+    def fetch_ci_readiness(pr_number)
+      required_raw = fetch_pr_checks(pr_number, required: true)
+      if PrMergeLedger.usable_ci_check_rows?(required_raw)
+        rows = PrMergeLedger.parse_ci_check_rows(required_raw)
+        required_used = true
+      else
+        rows = PrMergeLedger.parse_ci_check_rows(fetch_pr_checks(pr_number, required: false))
+        required_used = false
+      end
+
+      PrMergeLedger.ci_readiness_from_check_rows(pr_number, required_used:, rows:)
+    rescue Error => e
+      PrMergeLedger.ci_readiness_from_check_rows(pr_number, required_used: false, rows: [], message: e.message)
+    end
+
+    def fetch_pr_checks(pr_number, required:)
+      args = ["pr", "checks", pr_number.to_s, "--repo", "#{@owner}/#{@name}"]
+      args << "--required" if required
+      args += ["--json", "name,state,bucket,link"]
+
+      stdout, = capture_gh(args)
+      stdout.to_s
     end
 
     def fetch_paginated_connection(pr_number, query, connection_name)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -217,10 +217,15 @@ class PrMergeLedger
     required_keys = Array(required_rows).map { |row| ci_check_row_key(row) }
     return false if required_keys.empty?
 
-    full_keys = Array(full_rows).map { |row| ci_check_row_key(row) }
-    return false unless (required_keys - full_keys).empty?
+    return false unless missing_required_ci_check_keys(required_rows, full_rows).empty?
 
     Array(full_rows).none? { |row| non_ready_ci_check_row?(row) }
+  end
+
+  def self.missing_required_ci_check_keys(required_rows, full_rows)
+    required_keys = Array(required_rows).map { |row| ci_check_row_key(row) }
+    full_keys = Array(full_rows).map { |row| ci_check_row_key(row) }
+    required_keys - full_keys
   end
 
   def self.normalize_ci_check_row(row)
@@ -1555,6 +1560,12 @@ class PrMergeLedger
       if required_rows.empty?
         required_message = pr_checks_error_message(required_result) unless required_result.fetch(:success)
         return [full_rows, false, required_message]
+      end
+
+      missing_required_keys = PrMergeLedger.missing_required_ci_check_keys(required_rows, full_rows)
+      unless missing_required_keys.empty?
+        message = "full current-head check list omitted required checks: #{missing_required_keys.join(', ')}"
+        return [[], false, message]
       end
       return [required_rows, true, nil] if PrMergeLedger.required_ci_check_rows_complete?(required_rows, full_rows)
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1576,7 +1576,10 @@ class PrMergeLedger
       args << "--required" if required
       args += ["--json", "name,state,bucket,link"]
 
-      stdout, stderr, status = capture_gh_with_retries(args)
+      stdout, stderr, status = capture_gh(
+        args,
+        timeout_message: "gh pr checks timed out after #{PrMergeLedger.github_api_timeout_seconds} seconds"
+      )
       {
         stdout: stdout.to_s,
         stderr: stderr.to_s,
@@ -1725,12 +1728,12 @@ class PrMergeLedger
       error_text.match?(/\b4(?:0\d|1\d|2[0-8]|[3-9]\d)\b|\b(?:Not Found|Unauthorized|Forbidden)\b/i)
     end
 
-    def capture_gh(args)
+    def capture_gh(args, timeout_message: nil)
       timeout = PrMergeLedger.github_api_timeout_seconds
       PrMergeLedger.capture_command_with_timeout(
         ["gh", *args],
         timeout:,
-        timeout_message: "gh api graphql timed out after #{timeout} seconds"
+        timeout_message: timeout_message || "gh api graphql timed out after #{timeout} seconds"
       )
     end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -707,21 +707,41 @@ class PrMergeLedger
       message: raw_readiness["message"]
     )
     checks = computed.fetch("checks")
-    failing = normalize_ci_readiness_check_list(raw_readiness, computed, checks, "failing", "fail")
-    pending = normalize_ci_readiness_check_list(raw_readiness, computed, checks, "pending", "pending")
-    verdict = normalize_ci_readiness_verdict(raw_readiness, computed, checks, failing, pending)
-    status = normalize_ci_readiness_status(raw_readiness, computed, verdict)
+    components = normalize_ci_readiness_components(raw_readiness, computed, checks)
 
     {
       "pr" => (raw_readiness["pr"] || pull_request.fetch("number")).to_i,
-      "status" => status,
-      "verdict" => verdict,
+      "status" => components.fetch("status"),
+      "verdict" => components.fetch("verdict"),
       "required_used" => raw_readiness["required_used"] == true,
-      "failing" => failing,
-      "pending" => pending,
+      "failing" => components.fetch("failing"),
+      "pending" => components.fetch("pending"),
       "checks" => checks,
       "message" => raw_readiness["message"] || computed["message"]
     }.compact
+  end
+
+  def normalize_ci_readiness_components(raw_readiness, computed, checks)
+    return computed_ci_readiness_components(computed) unless checks.empty?
+
+    failing = normalize_ci_readiness_check_list(raw_readiness, computed, checks, "failing", "fail")
+    pending = normalize_ci_readiness_check_list(raw_readiness, computed, checks, "pending", "pending")
+    verdict = normalize_ci_readiness_verdict(raw_readiness, computed, checks, failing, pending)
+    {
+      "status" => normalize_ci_readiness_status(raw_readiness, computed, verdict),
+      "verdict" => verdict,
+      "failing" => failing,
+      "pending" => pending
+    }
+  end
+
+  def computed_ci_readiness_components(computed)
+    {
+      "status" => computed.fetch("status"),
+      "verdict" => computed.fetch("verdict"),
+      "failing" => computed.fetch("failing"),
+      "pending" => computed.fetch("pending")
+    }
   end
 
   def normalize_ci_readiness_check_list(raw_readiness, computed, checks, key, bucket)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1588,10 +1588,7 @@ class PrMergeLedger
       args << "--required" if required
       args += ["--json", "name,state,bucket,link"]
 
-      stdout, stderr, status = capture_gh(
-        args,
-        timeout_message: "gh pr checks timed out after #{PrMergeLedger.github_api_timeout_seconds} seconds"
-      )
+      stdout, stderr, status = capture_pr_checks(args, required:)
       {
         stdout: stdout.to_s,
         stderr: stderr.to_s,
@@ -1599,6 +1596,34 @@ class PrMergeLedger
         success: status.success?,
         required:
       }
+    end
+
+    def capture_pr_checks(args, required:)
+      attempt = 0
+      loop do
+        attempt += 1
+        stdout, stderr, status = capture_gh(
+          args,
+          timeout_message: "gh pr checks timed out after #{PrMergeLedger.github_api_timeout_seconds} seconds"
+        )
+        return [stdout, stderr, status] if usable_pr_checks_result?(stdout, stderr, status, required:)
+        return [stdout, stderr, status] if attempt >= GITHUB_API_MAX_ATTEMPTS
+        return [stdout, stderr, status] if non_retryable_gh_error?(stderr)
+
+        sleep(GITHUB_API_RETRY_BASE_DELAY_SECONDS * (2**(attempt - 1)))
+      end
+    rescue Error
+      raise if attempt >= GITHUB_API_MAX_ATTEMPTS
+
+      sleep(GITHUB_API_RETRY_BASE_DELAY_SECONDS * (2**(attempt - 1)))
+      retry
+    end
+
+    def usable_pr_checks_result?(stdout, stderr, status, required:)
+      return true if status.success?
+      return true unless PrMergeLedger.parse_ci_check_rows(stdout).empty?
+
+      required && stderr.to_s.match?(/\bno required checks\b/i)
     end
 
     def pr_checks_error_message(*results)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1654,6 +1654,10 @@ class PrMergeLedger
         def success?
           false
         end
+
+        def exitstatus
+          nil
+        end
       end.new
     end
 
@@ -1664,8 +1668,14 @@ class PrMergeLedger
         scope = result.fetch(:required) ? "required" : "full"
         details = [result.fetch(:stderr), result.fetch(:stdout)].map(&:strip).reject(&:empty?).join(" | ")
         details = "no command output" if details.empty?
-        "gh pr checks #{scope} failed with exit #{result.fetch(:status).exitstatus}: #{details}"
+        "gh pr checks #{scope} failed with exit #{status_exitstatus(result.fetch(:status))}: #{details}"
       end.join("; ")
+    end
+
+    def status_exitstatus(status)
+      return status.exitstatus if status.respond_to?(:exitstatus) && status.exitstatus
+
+      "unknown"
     end
 
     def fetch_paginated_connection(pr_number, query, connection_name)
@@ -1789,6 +1799,8 @@ class PrMergeLedger
 
     def non_retryable_gh_error?(stderr)
       error_text = stderr.to_s
+      return false if error_text.match?(/\bgh (?:api graphql|pr checks|repo view) timed out after \d+ seconds\b/i)
+
       if error_text.match?(/\b(?:abuse detection|rate limit|rate-limit|secondary rate|too many requests)\b/i)
         return false
       end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -190,11 +190,38 @@ class PrMergeLedger
   end
 
   def self.usable_ci_check_rows?(raw)
-    !active_ci_check_rows(parse_ci_check_rows(raw)).empty?
+    !parse_ci_check_rows(raw).empty?
   end
 
   def self.active_ci_check_rows(rows)
     Array(rows).reject { |row| row.is_a?(Hash) && row["bucket"].to_s == "cancel" }
+  end
+
+  def self.cancelled_ci_check_rows(rows)
+    Array(rows).select { |row| row.is_a?(Hash) && row["bucket"].to_s == "cancel" }
+  end
+
+  def self.non_ready_ci_check_row?(row)
+    %w[cancel fail pending].include?(row["bucket"].to_s)
+  end
+
+  def self.ci_check_row_key(row)
+    name = row["name"].to_s
+    return name unless name.empty?
+
+    link = row["link"].to_s
+    link.empty? ? row.to_s : link
+  end
+
+  def self.required_ci_check_rows_complete?(required_rows, full_rows)
+    required_keys = Array(required_rows).map { |row| ci_check_row_key(row) }
+    return false if required_keys.empty?
+
+    full_keys = Array(full_rows).map { |row| ci_check_row_key(row) }
+    return false unless (required_keys - full_keys).empty?
+
+    extra_full_rows = Array(full_rows).reject { |row| required_keys.include?(ci_check_row_key(row)) }
+    extra_full_rows.none? { |row| non_ready_ci_check_row?(row) }
   end
 
   def self.normalize_ci_check_row(row)
@@ -212,9 +239,12 @@ class PrMergeLedger
   end
 
   def self.ci_readiness_from_check_rows(pr_number, required_used:, rows:, message: nil)
-    checks = active_ci_check_rows(rows).map { |row| normalize_ci_check_row(row) }
-    failing = checks.select { |row| row["bucket"].to_s == "fail" }
-    pending = checks.select { |row| row["bucket"].to_s == "pending" }
+    checks = Array(rows).map { |row| normalize_ci_check_row(row) }
+    active_checks = active_ci_check_rows(checks)
+    cancelled_checks = cancelled_ci_check_rows(checks)
+    failing = active_checks.select { |row| row["bucket"].to_s == "fail" }
+    pending = active_checks.select { |row| row["bucket"].to_s == "pending" }
+    pending += cancelled_checks unless active_checks.empty?
     verdict = ci_verdict_for(checks, failing, pending)
     status = ci_status_for(verdict)
 
@@ -231,7 +261,8 @@ class PrMergeLedger
   end
 
   def self.ci_verdict_for(checks, failing, pending)
-    return UNKNOWN if checks.empty?
+    active_checks = active_ci_check_rows(checks)
+    return UNKNOWN if active_checks.empty?
     return "READY" if failing.empty? && pending.empty?
 
     "NOT_READY"
@@ -242,7 +273,7 @@ class PrMergeLedger
   end
 
   def self.ci_unknown_message(status)
-    status == UNKNOWN ? "no active current-head check rows were returned" : nil
+    status == UNKNOWN ? "no active current-head non-cancelled check rows were returned" : nil
   end
 
   def self.run(argv)
@@ -668,11 +699,17 @@ class PrMergeLedger
   def normalize_ci_readiness(raw_readiness, pull_request)
     return unknown_ci_readiness(pull_request, "ci_readiness must be a JSON object") unless raw_readiness.is_a?(Hash)
 
-    checks = Array(raw_readiness["checks"]).map { |row| self.class.normalize_ci_check_row(row) }
-    failing = normalize_ci_check_list(raw_readiness["failing"], checks, "fail")
-    pending = normalize_ci_check_list(raw_readiness["pending"], checks, "pending")
-    verdict = normalize_ci_verdict(raw_readiness["verdict"], checks, failing, pending)
-    status = normalize_ci_status(raw_readiness["status"], verdict)
+    computed = self.class.ci_readiness_from_check_rows(
+      pull_request.fetch("number"),
+      required_used: raw_readiness["required_used"],
+      rows: Array(raw_readiness["checks"]),
+      message: raw_readiness["message"]
+    )
+    checks = computed.fetch("checks")
+    failing = normalize_ci_readiness_check_list(raw_readiness, computed, checks, "failing", "fail")
+    pending = normalize_ci_readiness_check_list(raw_readiness, computed, checks, "pending", "pending")
+    verdict = normalize_ci_readiness_verdict(raw_readiness, computed, checks, failing, pending)
+    status = normalize_ci_readiness_status(raw_readiness, computed, verdict)
 
     {
       "pr" => (raw_readiness["pr"] || pull_request.fetch("number")).to_i,
@@ -682,8 +719,26 @@ class PrMergeLedger
       "failing" => failing,
       "pending" => pending,
       "checks" => checks,
-      "message" => raw_readiness["message"]
+      "message" => raw_readiness["message"] || computed["message"]
     }.compact
+  end
+
+  def normalize_ci_readiness_check_list(raw_readiness, computed, checks, key, bucket)
+    return computed.fetch(key) unless raw_readiness.key?(key)
+
+    normalize_ci_check_list(raw_readiness[key], checks, bucket)
+  end
+
+  def normalize_ci_readiness_verdict(raw_readiness, computed, checks, failing, pending)
+    return computed.fetch("verdict") unless raw_readiness.key?("verdict")
+
+    normalize_ci_verdict(raw_readiness["verdict"], checks, failing, pending)
+  end
+
+  def normalize_ci_readiness_status(raw_readiness, computed, verdict)
+    return computed.fetch("status") unless raw_readiness.key?("status")
+
+    normalize_ci_status(raw_readiness["status"], verdict)
   end
 
   def normalize_ci_check_list(raw_rows, checks, bucket)
@@ -699,7 +754,7 @@ class PrMergeLedger
   def normalize_ci_verdict(raw_verdict, checks, failing, pending)
     return raw_verdict if CI_VERDICTS.include?(raw_verdict)
 
-    return UNKNOWN if checks.empty?
+    return UNKNOWN if self.class.active_ci_check_rows(checks).empty?
     return "READY" if failing.empty? && pending.empty?
 
     "NOT_READY"
@@ -1488,25 +1543,33 @@ class PrMergeLedger
     def fetch_ci_readiness(pr_number)
       required_result = fetch_pr_checks(pr_number, required: true)
       required_rows = PrMergeLedger.parse_ci_check_rows(required_result.fetch(:stdout))
-      if PrMergeLedger.usable_ci_check_rows?(required_result.fetch(:stdout))
-        rows = required_rows
-        required_used = true
-        message = nil
-      else
-        full_result = fetch_pr_checks(pr_number, required: false)
-        full_rows = PrMergeLedger.parse_ci_check_rows(full_result.fetch(:stdout))
-        if !full_result.fetch(:success) && !PrMergeLedger.usable_ci_check_rows?(full_result.fetch(:stdout))
-          raise Error, pr_checks_error_message(required_result, full_result)
-        end
-
-        rows = full_rows
-        required_used = false
-        message = pr_checks_error_message(required_result) unless required_result.fetch(:success)
-      end
+      rows, required_used, message = select_ci_readiness_rows(pr_number, required_result, required_rows)
 
       PrMergeLedger.ci_readiness_from_check_rows(pr_number, required_used:, rows:, message:)
     rescue Error => e
       PrMergeLedger.ci_readiness_from_check_rows(pr_number, required_used: false, rows: [], message: e.message)
+    end
+
+    def select_ci_readiness_rows(pr_number, required_result, required_rows)
+      full_rows = fetch_full_pr_check_rows(pr_number, required_result)
+
+      if required_rows.empty?
+        required_message = pr_checks_error_message(required_result) unless required_result.fetch(:success)
+        return [full_rows, false, required_message]
+      end
+      return [required_rows, true, nil] if PrMergeLedger.required_ci_check_rows_complete?(required_rows, full_rows)
+
+      [full_rows, false, "required check subset was incomplete; using full current-head check list"]
+    end
+
+    def fetch_full_pr_check_rows(pr_number, required_result)
+      full_result = fetch_pr_checks(pr_number, required: false)
+      full_rows = PrMergeLedger.parse_ci_check_rows(full_result.fetch(:stdout))
+      unless full_result.fetch(:success) || !full_rows.empty?
+        raise Error, pr_checks_error_message(required_result, full_result)
+      end
+
+      full_rows
     end
 
     def fetch_pr_checks(pr_number, required:)
@@ -1514,7 +1577,7 @@ class PrMergeLedger
       args << "--required" if required
       args += ["--json", "name,state,bucket,link"]
 
-      stdout, stderr, status = capture_gh(args)
+      stdout, stderr, status = capture_gh_with_retries(args)
       {
         stdout: stdout.to_s,
         stderr: stderr.to_s,

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1358,8 +1358,20 @@ class PrMergeLedger
     pending = ci_readiness.fetch("pending").map do |check|
       ci_check_violation(pull_request, check, "ci_check_pending", "CI check is still pending")
     end
+    details_missing = if ci_readiness.fetch("verdict") == "NOT_READY" && failed.empty? && pending.empty?
+                        [
+                          violation(
+                            pull_request,
+                            "ci_not_ready",
+                            "CI readiness is NOT_READY, but no failed or pending check details were returned",
+                            pull_request["url"]
+                          )
+                        ]
+                      else
+                        []
+                      end
 
-    failed + pending
+    failed + pending + details_missing
   end
 
   def ci_check_violation(pull_request, check, code, message)
@@ -1474,16 +1486,21 @@ class PrMergeLedger
     end
 
     def fetch_ci_readiness(pr_number)
-      required_raw = fetch_pr_checks(pr_number, required: true)
-      if PrMergeLedger.usable_ci_check_rows?(required_raw)
-        rows = PrMergeLedger.parse_ci_check_rows(required_raw)
+      required_result = fetch_pr_checks(pr_number, required: true)
+      if required_result.fetch(:success) && PrMergeLedger.usable_ci_check_rows?(required_result.fetch(:stdout))
+        rows = PrMergeLedger.parse_ci_check_rows(required_result.fetch(:stdout))
         required_used = true
+        message = nil
       else
-        rows = PrMergeLedger.parse_ci_check_rows(fetch_pr_checks(pr_number, required: false))
+        full_result = fetch_pr_checks(pr_number, required: false)
+        raise Error, pr_checks_error_message(required_result, full_result) unless full_result.fetch(:success)
+
+        rows = PrMergeLedger.parse_ci_check_rows(full_result.fetch(:stdout))
         required_used = false
+        message = pr_checks_error_message(required_result) unless required_result.fetch(:success)
       end
 
-      PrMergeLedger.ci_readiness_from_check_rows(pr_number, required_used:, rows:)
+      PrMergeLedger.ci_readiness_from_check_rows(pr_number, required_used:, rows:, message:)
     rescue Error => e
       PrMergeLedger.ci_readiness_from_check_rows(pr_number, required_used: false, rows: [], message: e.message)
     end
@@ -1493,8 +1510,25 @@ class PrMergeLedger
       args << "--required" if required
       args += ["--json", "name,state,bucket,link"]
 
-      stdout, = capture_gh(args)
-      stdout.to_s
+      stdout, stderr, status = capture_gh(args)
+      {
+        stdout: stdout.to_s,
+        stderr: stderr.to_s,
+        status:,
+        success: status.success?,
+        required:
+      }
+    end
+
+    def pr_checks_error_message(*results)
+      results.compact.filter_map do |result|
+        next if result.fetch(:success)
+
+        scope = result.fetch(:required) ? "required" : "full"
+        details = [result.fetch(:stderr), result.fetch(:stdout)].map(&:strip).reject(&:empty?).join(" | ")
+        details = "no command output" if details.empty?
+        "gh pr checks #{scope} failed with exit #{result.fetch(:status).exitstatus}: #{details}"
+      end.join("; ")
     end
 
     def fetch_paginated_connection(pr_number, query, connection_name)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1622,21 +1622,24 @@ class PrMergeLedger
       attempt = 0
       loop do
         attempt += 1
-        stdout, stderr, status = capture_gh(
-          args,
-          timeout_message: "gh pr checks timed out after #{PrMergeLedger.github_api_timeout_seconds} seconds"
-        )
+        stdout, stderr, status = capture_pr_checks_once(args, attempt)
         return [stdout, stderr, status] if usable_pr_checks_result?(stdout, stderr, status, required:)
         return [stdout, stderr, status] if attempt >= GITHUB_API_MAX_ATTEMPTS
         return [stdout, stderr, status] if non_retryable_gh_error?(stderr)
 
         sleep(GITHUB_API_RETRY_BASE_DELAY_SECONDS * (2**(attempt - 1)))
       end
-    rescue Error
+    end
+
+    def capture_pr_checks_once(args, attempt)
+      capture_gh(
+        args,
+        timeout_message: "gh pr checks timed out after #{PrMergeLedger.github_api_timeout_seconds} seconds"
+      )
+    rescue Error => e
       raise if attempt >= GITHUB_API_MAX_ATTEMPTS
 
-      sleep(GITHUB_API_RETRY_BASE_DELAY_SECONDS * (2**(attempt - 1)))
-      retry
+      ["", e.message, failed_status]
     end
 
     def usable_pr_checks_result?(stdout, stderr, status, required:)
@@ -1644,6 +1647,14 @@ class PrMergeLedger
       return true unless PrMergeLedger.parse_ci_check_rows(stdout).empty?
 
       required && stderr.to_s.match?(/\bno required checks\b/i)
+    end
+
+    def failed_status
+      @failed_status ||= Class.new do
+        def success?
+          false
+        end
+      end.new
     end
 
     def pr_checks_error_message(*results)

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -72,6 +72,7 @@
         "unresolved_current_head_review_threads",
         "review_objects",
         "issue_comments",
+        "ci_readiness",
         "priority_finding_dispositions",
         "changelog_classification",
         "lockfile_diff",
@@ -191,6 +192,46 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/issue_comment"
+          }
+        },
+        "ci_readiness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["pr", "status", "verdict", "required_used", "failing", "pending", "checks"],
+          "properties": {
+            "pr": {
+              "type": "integer"
+            },
+            "status": {
+              "enum": ["known", "UNKNOWN"]
+            },
+            "verdict": {
+              "enum": ["READY", "NOT_READY", "UNKNOWN"]
+            },
+            "required_used": {
+              "type": "boolean"
+            },
+            "failing": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ci_check"
+              }
+            },
+            "pending": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ci_check"
+              }
+            },
+            "checks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ci_check"
+              }
+            },
+            "message": {
+              "type": ["string", "null"]
+            }
           }
         },
         "priority_finding_dispositions": {
@@ -437,6 +478,25 @@
         }
       }
     },
+    "ci_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "state": {
+          "type": ["string", "null"]
+        },
+        "bucket": {
+          "type": ["string", "null"]
+        },
+        "link": {
+          "type": ["string", "null"]
+        }
+      }
+    },
     "priority_finding": {
       "type": "object",
       "additionalProperties": false,
@@ -531,6 +591,15 @@
         },
         "current_head": {
           "type": "boolean"
+        },
+        "check_name": {
+          "type": ["string", "null"]
+        },
+        "state": {
+          "type": ["string", "null"]
+        },
+        "bucket": {
+          "type": ["string", "null"]
         }
       },
       "additionalProperties": false

--- a/script/pr_merge_ledger_test.rb
+++ b/script/pr_merge_ledger_test.rb
@@ -7,89 +7,7 @@ require "tmpdir"
 
 SCRIPT = File.expand_path("pr-merge-ledger", __dir__)
 
-class PrMergeLedgerTest < Minitest::Test
-  def test_ready_ci_allows_strict_closeout
-    output, status = run_fixture(
-      fixture(
-        ci_readiness: ci_readiness(
-          verdict: "READY",
-          checks: [
-            ci_check("Lint JS and Ruby / build", bucket: "pass", state: "SUCCESS")
-          ]
-        )
-      )
-    )
-
-    assert status.success?, output
-    data = JSON.parse(output)
-    assert data.fetch("complete_allowed")
-    assert_empty data.fetch("violations")
-    assert_equal "READY", ledger(data).fetch("ci_readiness").fetch("verdict")
-  end
-
-  def test_failed_ci_blocks_strict_closeout_with_check_name
-    output, status = run_fixture(
-      fixture(
-        number: 4444,
-        ci_readiness: ci_readiness(
-          verdict: "NOT_READY",
-          checks: [
-            ci_check(
-              "JS unit tests for Renderer package / build (22)",
-              bucket: "fail",
-              state: "FAILURE",
-              link: "https://github.com/shakacode/react_on_rails/actions/runs/28660148440/job/84998580503"
-            )
-          ]
-        )
-      )
-    )
-
-    refute status.success?, output
-    data = JSON.parse(output)
-    refute data.fetch("complete_allowed")
-    ci_readiness = ledger(data).fetch("ci_readiness")
-    assert_equal "NOT_READY", ci_readiness.fetch("verdict")
-    failing_check_names = ci_readiness.fetch("failing").map { |check| check.fetch("name") }
-    assert_equal ["JS unit tests for Renderer package / build (22)"], failing_check_names
-    assert_equal ["ci_check_failed"], violation_codes(data)
-  end
-
-  def test_pending_ci_blocks_strict_closeout
-    output, status = run_fixture(
-      fixture(
-        ci_readiness: ci_readiness(
-          verdict: "NOT_READY",
-          checks: [
-            ci_check("Integration Tests / build", bucket: "pending", state: "PENDING")
-          ]
-        )
-      )
-    )
-
-    refute status.success?, output
-    data = JSON.parse(output)
-    assert_equal ["ci_check_pending"], violation_codes(data)
-  end
-
-  def test_unknown_ci_blocks_strict_closeout
-    output, status = run_fixture(
-      fixture(
-        ci_readiness: ci_readiness(
-          status: "UNKNOWN",
-          verdict: "UNKNOWN",
-          checks: [],
-          message: "no active current-head check rows were returned"
-        )
-      )
-    )
-
-    refute status.success?, output
-    data = JSON.parse(output)
-    assert_equal ["ci_readiness.verdict"], unknown_field_names(data)
-    assert_equal ["unknown_ci_readiness"], violation_codes(data)
-  end
-
+module PrMergeLedgerFixtureHelpers
   private
 
   def ledger(data)
@@ -166,5 +84,108 @@ class PrMergeLedgerTest < Minitest::Test
       "bucket" => bucket,
       "link" => link
     }.compact
+  end
+end
+
+class PrMergeLedgerTest < Minitest::Test
+  include PrMergeLedgerFixtureHelpers
+
+  def test_ready_ci_allows_strict_closeout
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: ci_readiness(
+          verdict: "READY",
+          checks: [
+            ci_check("Lint JS and Ruby / build", bucket: "pass", state: "SUCCESS")
+          ]
+        )
+      )
+    )
+
+    assert status.success?, output
+    data = JSON.parse(output)
+    assert data.fetch("complete_allowed")
+    assert_empty data.fetch("violations")
+    assert_equal "READY", ledger(data).fetch("ci_readiness").fetch("verdict")
+  end
+
+  def test_failed_ci_blocks_strict_closeout_with_check_name
+    output, status = run_fixture(
+      fixture(
+        number: 4444,
+        ci_readiness: ci_readiness(
+          verdict: "NOT_READY",
+          checks: [
+            ci_check(
+              "JS unit tests for Renderer package / build (22)",
+              bucket: "fail",
+              state: "FAILURE",
+              link: "https://github.com/shakacode/react_on_rails/actions/runs/28660148440/job/84998580503"
+            )
+          ]
+        )
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    refute data.fetch("complete_allowed")
+    ci_readiness = ledger(data).fetch("ci_readiness")
+    assert_equal "NOT_READY", ci_readiness.fetch("verdict")
+    failing_check_names = ci_readiness.fetch("failing").map { |check| check.fetch("name") }
+    assert_equal ["JS unit tests for Renderer package / build (22)"], failing_check_names
+    assert_equal ["ci_check_failed"], violation_codes(data)
+  end
+
+  def test_pending_ci_blocks_strict_closeout
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: ci_readiness(
+          verdict: "NOT_READY",
+          checks: [
+            ci_check("Integration Tests / build", bucket: "pending", state: "PENDING")
+          ]
+        )
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    assert_equal ["ci_check_pending"], violation_codes(data)
+  end
+
+  def test_not_ready_ci_without_check_details_blocks_strict_closeout
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: ci_readiness(
+          verdict: "NOT_READY",
+          checks: []
+        )
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    assert_equal ["ci_not_ready"], violation_codes(data)
+    message = ledger(data).fetch("violations").fetch(0).fetch("message")
+    assert_match(/NOT_READY/, message)
+  end
+
+  def test_unknown_ci_blocks_strict_closeout
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: ci_readiness(
+          status: "UNKNOWN",
+          verdict: "UNKNOWN",
+          checks: [],
+          message: "no active current-head check rows were returned"
+        )
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    assert_equal ["ci_readiness.verdict"], unknown_field_names(data)
+    assert_equal ["unknown_ci_readiness"], violation_codes(data)
   end
 end

--- a/script/pr_merge_ledger_test.rb
+++ b/script/pr_merge_ledger_test.rb
@@ -64,9 +64,9 @@ module PrMergeLedgerFixtureHelpers
     }
   end
 
-  def ci_readiness(verdict:, checks:, status: "known", required_used: true, message: nil)
+  def ci_readiness(verdict:, checks:, number: 123, status: "known", required_used: true, message: nil)
     {
-      "pr" => 123,
+      "pr" => number,
       "status" => status,
       "verdict" => verdict,
       "required_used" => required_used,
@@ -114,6 +114,7 @@ class PrMergeLedgerTest < Minitest::Test
       fixture(
         number: 4444,
         ci_readiness: ci_readiness(
+          number: 4444,
           verdict: "NOT_READY",
           checks: [
             ci_check(
@@ -131,6 +132,7 @@ class PrMergeLedgerTest < Minitest::Test
     data = JSON.parse(output)
     refute data.fetch("complete_allowed")
     ci_readiness = ledger(data).fetch("ci_readiness")
+    assert_equal 4444, ci_readiness.fetch("pr")
     assert_equal "NOT_READY", ci_readiness.fetch("verdict")
     failing_check_names = ci_readiness.fetch("failing").map { |check| check.fetch("name") }
     assert_equal ["JS unit tests for Renderer package / build (22)"], failing_check_names
@@ -187,5 +189,51 @@ class PrMergeLedgerTest < Minitest::Test
     data = JSON.parse(output)
     assert_equal ["ci_readiness.verdict"], unknown_field_names(data)
     assert_equal ["unknown_ci_readiness"], violation_codes(data)
+  end
+
+  def test_cancel_only_ci_without_explicit_verdict_is_unknown
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: {
+          "pr" => 123,
+          "status" => "known",
+          "required_used" => true,
+          "checks" => [
+            ci_check("required-pr-gate", bucket: "cancel", state: "CANCELLED")
+          ]
+        }
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    ci_readiness = ledger(data).fetch("ci_readiness")
+    assert_equal "UNKNOWN", ci_readiness.fetch("verdict")
+    assert_equal ["ci_readiness.verdict"], unknown_field_names(data)
+    assert_equal ["unknown_ci_readiness"], violation_codes(data)
+  end
+
+  def test_cancelled_row_with_passing_check_is_not_ready
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: {
+          "pr" => 123,
+          "status" => "known",
+          "required_used" => true,
+          "checks" => [
+            ci_check("required-pr-gate", bucket: "pass", state: "SUCCESS"),
+            ci_check("rspec-package-tests", bucket: "cancel", state: "CANCELLED")
+          ]
+        }
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    ci_readiness = ledger(data).fetch("ci_readiness")
+    assert_equal "NOT_READY", ci_readiness.fetch("verdict")
+    pending_check_names = ci_readiness.fetch("pending").map { |check| check.fetch("name") }
+    assert_equal ["rspec-package-tests"], pending_check_names
+    assert_equal ["ci_check_pending"], violation_codes(data)
   end
 end

--- a/script/pr_merge_ledger_test.rb
+++ b/script/pr_merge_ledger_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "json"
+require "minitest/autorun"
+require "open3"
+require "tmpdir"
+
+SCRIPT = File.expand_path("pr-merge-ledger", __dir__)
+
+class PrMergeLedgerTest < Minitest::Test
+  def test_ready_ci_allows_strict_closeout
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: ci_readiness(
+          verdict: "READY",
+          checks: [
+            ci_check("Lint JS and Ruby / build", bucket: "pass", state: "SUCCESS")
+          ]
+        )
+      )
+    )
+
+    assert status.success?, output
+    data = JSON.parse(output)
+    assert data.fetch("complete_allowed")
+    assert_empty data.fetch("violations")
+    assert_equal "READY", ledger(data).fetch("ci_readiness").fetch("verdict")
+  end
+
+  def test_failed_ci_blocks_strict_closeout_with_check_name
+    output, status = run_fixture(
+      fixture(
+        number: 4444,
+        ci_readiness: ci_readiness(
+          verdict: "NOT_READY",
+          checks: [
+            ci_check(
+              "JS unit tests for Renderer package / build (22)",
+              bucket: "fail",
+              state: "FAILURE",
+              link: "https://github.com/shakacode/react_on_rails/actions/runs/28660148440/job/84998580503"
+            )
+          ]
+        )
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    refute data.fetch("complete_allowed")
+    ci_readiness = ledger(data).fetch("ci_readiness")
+    assert_equal "NOT_READY", ci_readiness.fetch("verdict")
+    failing_check_names = ci_readiness.fetch("failing").map { |check| check.fetch("name") }
+    assert_equal ["JS unit tests for Renderer package / build (22)"], failing_check_names
+    assert_equal ["ci_check_failed"], violation_codes(data)
+  end
+
+  def test_pending_ci_blocks_strict_closeout
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: ci_readiness(
+          verdict: "NOT_READY",
+          checks: [
+            ci_check("Integration Tests / build", bucket: "pending", state: "PENDING")
+          ]
+        )
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    assert_equal ["ci_check_pending"], violation_codes(data)
+  end
+
+  def test_unknown_ci_blocks_strict_closeout
+    output, status = run_fixture(
+      fixture(
+        ci_readiness: ci_readiness(
+          status: "UNKNOWN",
+          verdict: "UNKNOWN",
+          checks: [],
+          message: "no active current-head check rows were returned"
+        )
+      )
+    )
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    assert_equal ["ci_readiness.verdict"], unknown_field_names(data)
+    assert_equal ["unknown_ci_readiness"], violation_codes(data)
+  end
+
+  private
+
+  def ledger(data)
+    data.fetch("pull_requests").fetch(0)
+  end
+
+  def violation_codes(data)
+    ledger(data).fetch("violations").map { |violation| violation.fetch("code") }
+  end
+
+  def unknown_field_names(data)
+    ledger(data).fetch("unknown_fields").map { |field| field.fetch("field") }
+  end
+
+  def run_fixture(fixture_hash)
+    Dir.mktmpdir("pr-merge-ledger-test") do |dir|
+      fixture_path = File.join(dir, "fixture.json")
+      File.write(fixture_path, JSON.pretty_generate(fixture_hash))
+      stdout, stderr, status = Open3.capture3(
+        "ruby",
+        SCRIPT,
+        "--fixture",
+        fixture_path,
+        "--strict",
+        "--changelog-classification",
+        "not_user_visible"
+      )
+      [stdout, status].tap do
+        assert_empty stderr unless stderr.include?("ledger violations:")
+      end
+    end
+  end
+
+  def fixture(ci_readiness:, number: 123)
+    {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => number,
+        "title" => "Fixture PR",
+        "url" => "https://github.com/shakacode/react_on_rails/pull/#{number}",
+        "state" => "OPEN",
+        "isDraft" => false,
+        "baseRefName" => "main",
+        "headRefName" => "codex/fixture",
+        "headRefOid" => "abc123",
+        "mergedAt" => nil,
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => ["script/pr-merge-ledger"],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [],
+      "ci_readiness" => ci_readiness
+    }
+  end
+
+  def ci_readiness(verdict:, checks:, status: "known", required_used: true, message: nil)
+    {
+      "pr" => 123,
+      "status" => status,
+      "verdict" => verdict,
+      "required_used" => required_used,
+      "failing" => checks.select { |check| check["bucket"] == "fail" },
+      "pending" => checks.select { |check| check["bucket"] == "pending" },
+      "checks" => checks,
+      "message" => message
+    }.compact
+  end
+
+  def ci_check(name, bucket:, state:, link: nil)
+    {
+      "name" => name,
+      "state" => state,
+      "bucket" => bucket,
+      "link" => link
+    }.compact
+  end
+end

--- a/script/pr_merge_ledger_test.rb
+++ b/script/pr_merge_ledger_test.rb
@@ -139,6 +139,23 @@ class PrMergeLedgerTest < Minitest::Test
     assert_equal ["ci_check_failed"], violation_codes(data)
   end
 
+  def test_check_rows_override_inconsistent_ready_ci_payload
+    checks = [ci_check("lint", bucket: "fail", state: "FAILURE")]
+    readiness = ci_readiness(verdict: "READY", checks:)
+    readiness["failing"] = []
+    readiness["pending"] = []
+
+    output, status = run_fixture(fixture(ci_readiness: readiness))
+
+    refute status.success?, output
+    data = JSON.parse(output)
+    ci_readiness = ledger(data).fetch("ci_readiness")
+    assert_equal "NOT_READY", ci_readiness.fetch("verdict")
+    failing_check_names = ci_readiness.fetch("failing").map { |check| check.fetch("name") }
+    assert_equal ["lint"], failing_check_names
+    assert_equal ["ci_check_failed"], violation_codes(data)
+  end
+
   def test_pending_ci_blocks_strict_closeout
     output, status = run_fixture(
       fixture(

--- a/script/pr_merge_ledger_test.rb
+++ b/script/pr_merge_ledger_test.rb
@@ -234,6 +234,6 @@ class PrMergeLedgerTest < Minitest::Test
     assert_equal "NOT_READY", ci_readiness.fetch("verdict")
     pending_check_names = ci_readiness.fetch("pending").map { |check| check.fetch("name") }
     assert_equal ["rspec-package-tests"], pending_check_names
-    assert_equal ["ci_check_pending"], violation_codes(data)
+    assert_equal ["ci_check_cancelled"], violation_codes(data)
   end
 end


### PR DESCRIPTION
## Summary

Closes #4456.

- Add CI readiness to `script/pr-merge-ledger` so strict closeout blocks failed, pending, or unknown current-head checks.
- Use the same required-checks-first fallback shape as `pr-ci-readiness`, with failed/pending check names and links in ledger violations.
- Add schema and fixture replay coverage for READY, failed, pending, and UNKNOWN CI states.
- Guard hosted-CI command dispatch for non-open PRs so post-merge/deleted-branch `+ci-run-hosted` evidence is explicitly refused as degraded.
- Wire the merge-ledger fixture tests and CI readiness helper tests into the required CI gate.

## Codex Decision Log

- **Non-blocking:** Optimized hosted CI was required after local validation because this PR changes workflow/script gate behavior.
  - **Decision:** Requested current-head optimized hosted CI with `+ci-run-hosted` after the final push and waited for completion.
  - **Why:** Workflow/script gate changes need remote confirmation beyond local replay.
  - **Review later:** None. Selector-skipped rows are recorded below and the post-merge workflow exercise is tracked in #4476.

## QA Evidence

- QA lane: main coordinator, `/Users/justin/.codex/worktrees/f4fa/react_on_rails-4456-final-gate`, private coordination claim/heartbeat `UNKNOWN` because `.agents/skills/pr-batch/bin/agent-coord-bounded --timeout 20 doctor --json` timed out; fallback GitHub/local evidence completed.
- Scope checked: final-gate ledger script/schema, `pr-ci-readiness`, required CI gate wiring, and hosted-CI command dispatch guard. This covers the developer-visible closeout and workflow surfaces changed by the PR.
- Tested at: base `origin/main` `379f409f4a3166b4a849bfdc4d9cdb98c491e14e`; head `8a8f43f31271d1b28118d716a96bf369b9cd911a`.
- Automated checks:
  - `.agents/bin/agent-workflow-seam-doctor`: PASS.
  - `pr-security-preflight --repo shakacode/react_on_rails 4456 4467 4465 4466`: `SECURITY_PREFLIGHT_OK`.
  - `pr-security-preflight --repo shakacode/react_on_rails 4475`: `SECURITY_PREFLIGHT_OK`; metadata-only GitHub Actions comments and exact-target high-risk files acknowledged.
  - `ruby -c script/pr-merge-ledger`: Syntax OK.
  - `ruby -c react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb`: Syntax OK.
  - `ruby script/pr_merge_ledger_test.rb`: 8 runs, 34 assertions, 0 failures.
  - `(cd react_on_rails && bundle exec rspec spec/react_on_rails/pr_merge_ledger_script_spec.rb)`: 118 examples, 0 failures.
  - `BUNDLE_GEMFILE=Gemfile bundle exec rubocop script/pr-merge-ledger .agents/skills/pr-batch/bin/pr-ci-readiness .agents/skills/pr-batch/bin/pr-ci-readiness-test.rb script/pr_merge_ledger_test.rb react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb`: 5 files, no offenses.
  - `git diff --check origin/main..HEAD`: passed.
  - `bash script/ci-required-hosted-gate-test.bash`: 7 tests passed.
  - `node .github/workflows/hosted-ci-safety.test.cjs`: passed.
  - `ruby .agents/skills/pr-batch/bin/pr-ci-readiness-test.rb`: 31 runs, 94 assertions, 0 failures.
  - `actionlint .github/workflows/ci-required.yml .github/workflows/ci-commands.yml`: passed.
  - Ruby YAML parse for `.github/workflows/ci-required.yml` and `.github/workflows/ci-commands.yml`: OK.
  - `.agents/bin/ci-detect`: detected RSpec tests plus CI infrastructure; recommended full hosted set.
  - Open PR overlap sweep for changed paths: `[]`.
  - `.agents/skills/pr-batch/bin/pr-ci-readiness 4475 --repo shakacode/react_on_rails --json`: `READY`, `required_used: true`, no failing or pending checks.
  - `script/pr-merge-ledger 4475 --repo shakacode/react_on_rails --strict --pretty --changelog-classification not_user_visible --finding-dispositions /tmp/ror-4475-finding-dispositions.json`: `complete_allowed: true`, no violations, no `UNKNOWN` fields, CI `READY`, zero unresolved current-head review threads.
- Hosted CI: current-head optimized hosted CI requested with `+ci-run-hosted` at https://github.com/shakacode/react_on_rails/pull/4475#issuecomment-4885850339 and status checked at https://github.com/shakacode/react_on_rails/pull/4475#issuecomment-4885850371. Bot evidence: https://github.com/shakacode/react_on_rails/pull/4475#issuecomment-4885857502 triggered 9 workflows for `8a8f43f31271`; https://github.com/shakacode/react_on_rails/pull/4475#issuecomment-4885858002 recorded optimized hosted CI enabled. Final `gh pr checks`: 42 `SUCCESS`, 6 selector-skipped, 0 failures, 0 pending. Skipped rows were optimized-selector skips: `webpack-minimum-dummy-app-tests`, four benchmark confirmation/report rows, and `docs-format-check`.
- Review gate: `claude-review`, CodeRabbit, CodeQL, Zizmor, actionlint, and required-pr-gate completed successfully for current head. Unresolved review-thread GraphQL query returned `unresolved_count: 0`. Claude crash review thread fixed, replied, and resolved at https://github.com/shakacode/react_on_rails/pull/4475#discussion_r3524798925.
- Manual checks: not applicable; this is tooling/workflow gate behavior with no app UI surface. The affected command paths were replayed by the automated checks above.
- Findings: Claude review timeout-handling crash fixed in `script/pr-merge-ledger` and `react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb`. P2 findings supplied to the strict ledger were fixed with dispositions. Optional stale advisory nits were not pushed after final candidate to avoid restarting current-head gates; no confirmed blocker remains.
- QA required: yes.
- QA required rationale: workflow/script gate changes require replay plus current-head hosted CI evidence.
- QA lane status: satisfied.
- Release-blocking status: clear.
- Process-gap disposition: `script` plus `schema` plus `checklist+replay`. The gate records CI readiness in durable ledger output, schema validates it, fixture/live replay covers failed, pending, unknown, and ready states, and the stale-base/collision sweep found no overlapping open PR paths.

## Workflow Change Audit

- Changed workflow files: `.github/workflows/ci-commands.yml`, `.github/workflows/ci-required.yml`.
- `on:` unchanged for both workflows.
- `permissions:` unchanged for both workflows.
- Secrets: none added or changed.
- Third-party actions: none added or version-changed (`actions/github-script@v9` unchanged).
- Command behavior: `+ci-run-hosted` and `+ci-force-full` now refuse non-open PRs before dispatch and post durable degraded-evidence comments instead of silently dispatching impossible work.
- Required gate behavior: `ruby script/pr_merge_ledger_test.rb` and `ruby .agents/skills/pr-batch/bin/pr-ci-readiness-test.rb` now run in `ci-required` gate validation.
- Stale-base/collision sweep: checked open PRs for the changed paths; no overlaps found (`[]`).
- Post-merge workflow exercise issue: #4476.

## Review Churn

- Follow-up commits after first push: review-fix commits batched; final review fix hardened timeout-like `gh pr checks` stderr handling.
- Current-head review threads: 0 unresolved.
- Human decision points: 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI readiness reporting (READY/NOT_READY/UNKNOWN) to merge/ledger output, including per-check failing/pending details.
  * Extended the merge/ledger JSON schema with a required `ci_readiness` block.
  * Hosted CI dispatch now stops early with a clear message when the pull request isn’t open.
* **Bug Fixes**
  * Improved strict closeout gating and violation reporting across failing, pending, cancelled, and unknown CI states.
  * Enhanced UTF-8 parsing robustness for ASCII locale edge cases.
* **Tests**
  * Expanded strict closeout, cancelled-check, workflow safety, and UTF-8 regression coverage; added/updated CI checks to validate merge ledger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
