### PR TITLE
Stabilize Pro RSC payload script stripping

### DIFF
--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -56,23 +56,34 @@ function resetCacheKeyDiagnosticObject(cacheKey: string) {
   return `delete (self.REACT_ON_RAILS_RSC_ERRORS||={})[${JSON.stringify(cacheKey)}]`;
 }
 
+const RSC_PAYLOAD_SCRIPT_MARKER_ATTRIBUTE = 'data-react-on-rails-rsc-payload="true"';
+
 function nonceAttribute(sanitizedNonce?: string) {
   return sanitizedNonce ? ` nonce="${sanitizedNonce}"` : '';
 }
 
-function createScriptTag(script: string, sanitizedNonce?: string) {
-  return `<script${nonceAttribute(sanitizedNonce)}>${escapeScript(script)}</script>`;
+function rscPayloadScriptMarkerAttribute(markAsRSCPayload?: boolean) {
+  return markAsRSCPayload ? ` ${RSC_PAYLOAD_SCRIPT_MARKER_ATTRIBUTE}` : '';
+}
+
+function createScriptTag(script: string, sanitizedNonce?: string, markAsRSCPayload?: boolean) {
+  return `<script${rscPayloadScriptMarkerAttribute(markAsRSCPayload)}${nonceAttribute(sanitizedNonce)}>${escapeScript(script)}</script>`;
 }
 
 function createRSCPayloadInitializationScript(cacheKey: string, sanitizedNonce?: string) {
   return createScriptTag(
     `${resetCacheKeyDiagnosticObject(cacheKey)};${cacheKeyJSArray(cacheKey)}`,
     sanitizedNonce,
+    true,
   );
 }
 
 function createRSCPayloadChunk(chunk: string, cacheKey: string, sanitizedNonce?: string) {
-  return createScriptTag(`(${cacheKeyJSArray(cacheKey)}).push(${JSON.stringify(chunk)})`, sanitizedNonce);
+  return createScriptTag(
+    `(${cacheKeyJSArray(cacheKey)}).push(${JSON.stringify(chunk)})`,
+    sanitizedNonce,
+    true,
+  );
 }
 
 function nonEmptyMetadataString(value: unknown) {
@@ -98,6 +109,7 @@ function createRSCDiagnosticScript(
   return createScriptTag(
     `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify({ hasErrors, renderingError })}`,
     sanitizedNonce,
+    true,
   );
 }
 

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -33,9 +33,10 @@ const toLengthPrefixedWithMetadata = (content: string, metadata: Record<string, 
 
 const rscPayloadKey = 'test-fun4a7ngv9-test-node';
 const rscPayloadKeyReference = `[${JSON.stringify(rscPayloadKey)}]`;
-const expectedInitializationScript = `<script>delete (self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference};(self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]</script>`;
+const rscPayloadScriptMarker = 'data-react-on-rails-rsc-payload="true"';
+const expectedInitializationScript = `<script ${rscPayloadScriptMarker}>delete (self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference};(self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]</script>`;
 const expectedPayloadPushScript = (chunk: string) =>
-  `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]).push(${JSON.stringify(
+  `<script ${rscPayloadScriptMarker}>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]).push(${JSON.stringify(
     chunk,
   )})</script>`;
 
@@ -400,6 +401,9 @@ describe('injectRSCPayload', () => {
     const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
     const resultStr = await collectStreamData(result);
 
+    expect(resultStr).toContain(
+      `<script ${rscPayloadScriptMarker}>(self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference}||=`,
+    );
     expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
     expect(resultStr).toContain('["test-fun4a7ngv9-test-node"]||=');
     expect(resultStr).toContain('useState is not a function');

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -32,6 +32,7 @@ module ReactOnRailsProHelper
   SCRIPT_OPEN_TAG_LENGTH = 7
   SCRIPT_CLOSE_TAG = "</script"
   SCRIPT_CLOSE_TAG_LENGTH = 8
+  STATIC_RSC_PAYLOAD_SCRIPT_MARKER_ATTRIBUTE = "data-react-on-rails-rsc-payload"
   STATIC_RSC_ASSET_DIAGNOSTIC_CACHE_MUTEX = Mutex.new
   @static_rsc_asset_diagnostic_cache = {}
 
@@ -711,6 +712,7 @@ module ReactOnRailsProHelper
   end
 
   def static_rsc_payload_script?(script_node)
+    return true if static_rsc_payload_script_marker?(script_node)
     return false unless executable_script_type?(script_node["type"])
 
     stripped_body = script_node.content.to_s.strip
@@ -718,6 +720,10 @@ module ReactOnRailsProHelper
     stripped_body.match?(/\Adelete\s*\(\s*self\.REACT_ON_RAILS_RSC_ERRORS\b/) ||
       stripped_body.match?(/\A\(\(\s*self\.REACT_ON_RAILS_RSC_PAYLOADS\b/) ||
       stripped_body.match?(/\A\(\s*self\.REACT_ON_RAILS_RSC_ERRORS\b/)
+  end
+
+  def static_rsc_payload_script_marker?(script_node)
+    script_node[STATIC_RSC_PAYLOAD_SCRIPT_MARKER_ATTRIBUTE].to_s.casecmp?("true")
   end
 
   def executable_script_type?(script_type)

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -712,8 +712,8 @@ module ReactOnRailsProHelper
   end
 
   def static_rsc_payload_script?(script_node)
-    return true if static_rsc_payload_script_marker?(script_node)
     return false unless executable_script_type?(script_node["type"])
+    return true if static_rsc_payload_script_marker?(script_node)
 
     stripped_body = script_node.content.to_s.strip
 

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1884,6 +1884,33 @@ describe ReactOnRailsProHelper do
         expect(result).to eq("#{preserved_html}\n#{suffix_html}")
       end
 
+      it "strips explicitly marked RSC payload scripts even when generated body shape changes" do
+        raw_html = <<~HTML
+          <div>Static RSC HTML</div>
+          <script data-react-on-rails-rsc-payload="true">window.__nextRSCChunk("flight chunk")</script>
+          <script>window.__nextRSCChunk("not an RSC payload script")</script>
+        HTML
+        result = nil
+
+        Sync do
+          stub_pro_bundle_hashes
+          allow(self).to receive(:buffered_stream_react_component).and_return(raw_html.html_safe)
+
+          result = cached_static_rsc_component(
+            component_name,
+            cache_key: ["static-rsc-marked-payload-script", component_name],
+            id: "#{component_name}-react-component-0",
+            cache_options: { expires_in: 60 }
+          ) do
+            props
+          end
+        end
+
+        expect(result).to include("Static RSC HTML")
+        expect(result).not_to include("flight chunk")
+        expect(result).to include('window.__nextRSCChunk("not an RSC payload script")')
+      end
+
       it "strips RSC scripts after Unicode characters whose case mapping changes length" do
         raw_html = <<~HTML
           <p>İstanbul launch page</p>

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1887,6 +1887,7 @@ describe ReactOnRailsProHelper do
       it "strips explicitly marked RSC payload scripts even when generated body shape changes" do
         raw_html = <<~HTML
           <div>Static RSC HTML</div>
+          <script type="application/json" data-react-on-rails-rsc-payload="true">{"keep":"structured data"}</script>
           <script data-react-on-rails-rsc-payload="true">window.__nextRSCChunk("flight chunk")</script>
           <script>window.__nextRSCChunk("not an RSC payload script")</script>
         HTML
@@ -1907,6 +1908,7 @@ describe ReactOnRailsProHelper do
         end
 
         expect(result).to include("Static RSC HTML")
+        expect(result).to include('{"keep":"structured data"}')
         expect(result).not_to include("flight chunk")
         expect(result).to include('window.__nextRSCChunk("not an RSC payload script")')
       end


### PR DESCRIPTION
## Summary

- Add a stable `data-react-on-rails-rsc-payload="true"` marker to Pro-generated RSC initialization, payload chunk, and diagnostic scripts.
- Make static RSC cache stripping prefer that explicit marker while keeping the existing body-shape fallback for older generated HTML.
- Add JS and Ruby regression coverage so future RSC payload body changes do not drift from the static stripping contract.

Closes #4459.
Depends on #4452, which is merged.

## Why

Issue #4459 flagged that Ruby static RSC payload stripping was coupled to JavaScript script body shape. This makes the cross-language contract explicit without marking console replay or opt-in observability scripts as payload scripts.

## Codex Decision Log

- **Non-blocking:** Changelog entry?
  - **Decision:** No changelog.
  - **Why:** This is Pro internal contract hardening and test coverage; the generated marker/strip fallback should not need user-facing release notes.
  - **Review later:** None.
- **Non-blocking:** Marker value strictness?
  - **Decision:** Use `data-react-on-rails-rsc-payload="true"` and strip that exact generated value.
  - **Why:** The Pro injector emits the exact marker; the existing body-prefix fallback remains for pre-marker HTML.
  - **Review later:** If external tooling starts emitting this marker, confirm whether boolean/no-value attributes should also count.

## Validation

- `PR_BATCH_SKILL_DIR=.agents/skills/pr-batch .agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4459` -> `SECURITY_PREFLIGHT_OK`
- `.agents/bin/ci-detect origin/main`
- `bundle exec rubocop` -> 531 files inspected, no offenses
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `git diff --check`
- `script/check-pro-license-headers`
- `pnpm --filter react-on-rails-pro type-check`
- `pnpm --filter react-on-rails-pro build`
- `pnpm --filter react-on-rails-pro test:streaming` -> 5 suites, 129 tests
- `pnpm --filter react-on-rails-pro exec jest tests/injectRSCPayload.test.ts --runInBand` -> 75 tests
- `(cd react_on_rails_pro/spec/dummy && bundle exec rspec spec/helpers/react_on_rails_pro_helper_spec.rb -e "strips explicitly marked RSC payload scripts")` -> 1 example, 0 failures
- `codex review --base origin/main` -> no actionable findings

## Notes

A full local `spec/helpers/react_on_rails_pro_helper_spec.rb` run needs a live Pro node renderer. The full helper file reached the static RSC examples, then failed only on node-renderer connection setup; hosted Pro CI is requested for the full remote lane after this PR opens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RSC-related inline scripts so payload scripts are reliably identified and processed.
  * Fixed cached RSC content to exclude marked payload scripts even when the output structure changes.
  * Preserved unrelated scripts during caching, reducing the chance of accidentally removing valid client-side code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->