### PR TITLE
Fix TanStack starter demo fleet metadata

### DIFF
--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -68,6 +68,7 @@ defaults:
         - react-on-rails-pro-node-renderer
         - react-on-rails-rsc
         - shakapacker
+        - shakapacker-rspack
       gem:
         - react_on_rails
         - react_on_rails_pro

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -175,13 +175,18 @@ repos:
 
   - name: shakacode/react-on-rails-starter-tanstack
     tier: hard_gate
-    headline: TanStack starter example
+    headline: TanStack Pro + RSC starter example
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: react_on_rails_pro }
+      - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-    needs_pro: false
+      - { ecosystem: npm, name: shakapacker-rspack }
+    needs_pro: true
     smoke: [/]
     verify: true
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -26,7 +26,7 @@ and no untriaged suspected RC regression.
 | `shakacode/react-on-rails-demo-hacker-news-rsc` | Public Hacker News RSC example.                                                   | RC bump PR, dependency install, app build/smoke, and CI status.                                                                                        |
 | `shakacode/react-on-rails-demo-gumroad-rsc`     | Public Gumroad RSC example.                                                       | RC bump PR, dependency install, app build/smoke, and CI status.                                                                                        |
 | `shakacode/react-webpack-rails-tutorial`        | Public legacy tutorial reference.                                                 | RC bump PR, dependency install, primary tutorial route smoke, and CI status.                                                                           |
-| `shakacode/react-on-rails-starter-tanstack`     | Public TanStack starter example.                                                  | RC bump PR, dependency install, starter build/smoke, and CI status.                                                                                    |
+| `shakacode/react-on-rails-starter-tanstack`     | Public TanStack Pro + RSC starter example.                                        | RC bump PR, dependency install, starter build/smoke, and CI status.                                                                                    |
 
 ### Shelved Or Non-Gating Repos
 


### PR DESCRIPTION
## Summary

- Updates the demo fleet manifest so `shakacode/react-on-rails-starter-tanstack` is classified as a Pro + RSC starter.
- Adds the starter's Pro/RSC package dependencies to the manifest: `react_on_rails_pro`, `react-on-rails-pro`, `react-on-rails-pro-node-renderer`, `react-on-rails-rsc`, and `shakapacker-rspack`.
- Updates the RC testing plan wording for the starter hard gate.

## Rationale

The Shakapacker 10.2 release batch showed that our source data understated the TanStack starter's stack. The starter directly uses React on Rails Pro, the Node renderer, React Server Components, Shakapacker, and Rspack, so release/demo-fleet automation should track those packages explicitly.

## Verification

- Checked the live `shakacode/react-on-rails-starter-tanstack` `package.json`, `Gemfile`, and `config/shakapacker.yml` through GitHub.
- `pnpm exec prettier --check internal/contributor-info/demo-fleet.yml internal/contributor-info/rc-testing-plan.md`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- `git diff --check`
- pre-commit hooks: trailing-newlines, offline markdown links, prettier
- pre-push hooks: branch-lint, online markdown links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated TanStack starter wording to reflect the Pro + RSC variant in the release-candidate testing plan and related references.
* **Configuration**
  * Expanded the demo entry’s package list to include Pro/RSC-related dependencies and the RSP-capable Shakapacker package, and marked the entry as requiring Pro features.
  * Allowed the new RSP-capable Shakapacker package in the default age-gate bypass allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->