### PR TITLE
Bump react-on-rails-rsc final references

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       "These force patched versions of transitive dev dependencies. Remove when upstream packages update.",
       "ajv overrides were intentionally excluded: ajv v8 breaks webpack's schema-utils/ajv-keywords.",
       "The 2 moderate ajv alerts (ReDoS in $data option) are tolerable — ajv only validates our own config files.",
-      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scopes the Pro/RSC dummy to the coordinated React 19.2.7 + react-on-rails-rsc 19.2.0-rc.4 pair so CI soak-tests the RSC path on React 19.2 (#3865; gate landed in #4026). The workspace-wide pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 — the published/default pin for 17.0.0 — until #3865 promotes 19.2 to the default."
+      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scopes the Pro/RSC dummy to the coordinated React 19.2.7 + react-on-rails-rsc 19.2.0 pair so CI soak-tests the RSC path on React 19.2 (#3865; gate landed in #4026). The workspace-wide pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 — the published/default pin for 17.0.0 — until #3865 promotes 19.2 to the default."
     ],
     "overrides": {
       "react": "$react",
@@ -141,7 +141,7 @@
       "react_on_rails>react-dom": "^19.2.0",
       "react_on_rails_pro_dummy>react": "^19.2.7",
       "react_on_rails_pro_dummy>react-dom": "^19.2.7",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.0-rc.4",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.0",
       "sentry-testkit>body-parser": "npm:empty-npm-package@1.0.0",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0",
       "lodash@>=4.0.0 <=4.17.22": ">=4.17.23 <5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   react_on_rails>react-dom: ^19.2.0
   react_on_rails_pro_dummy>react: ^19.2.7
   react_on_rails_pro_dummy>react-dom: ^19.2.7
-  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.0-rc.4
+  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.0
   sentry-testkit>body-parser: npm:empty-npm-package@1.0.0
   sentry-testkit>express: npm:empty-npm-package@1.0.0
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23 <5'
@@ -750,8 +750,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.2.0-rc.4
-        version: 19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
+        specifier: 19.2.0
+        version: 19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8534,8 +8534,8 @@ packages:
       react-dom: ~19.0.4
       webpack: ^5.59.0
 
-  react-on-rails-rsc@19.2.0-rc.4:
-    resolution: {integrity: sha512-Jm9822vmAvXPbQ3gyx8B5RwbGcmxEXZ1eMEoVxd3rsnnxuZ7B35dr11Ygy2FBPPq4v5sJa/PFWGir/m8Cg1b9Q==}
+  react-on-rails-rsc@19.2.0:
+    resolution: {integrity: sha512-4PlfNFWGHl029al/yi10G3fcREbTwzqQ45uqYs6i9Baqds2OROyWp1xdorfX4Ok46IVJjje14SeaJVyN8pGDGg==}
     peerDependencies:
       react: ~19.0.4
       react-dom: ~19.0.4
@@ -19952,7 +19952,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
+  react-on-rails-rsc@19.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5794,7 +5794,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.0.7",
                   "react-dom" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.0-rc.4"
+                  "react-on-rails-rsc" => "19.2.0"
                 }
               )
             )
@@ -5802,7 +5802,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.0.7")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.0-rc.4",
+              "version" => "19.2.0",
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             example.run
@@ -5819,7 +5819,7 @@ RSpec.describe ReactOnRails::Doctor do
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(error_msgs).to include(
           a_string_including(
-            "react-on-rails-rsc 19.2.0-rc.4 requires react ^19.2.7",
+            "react-on-rails-rsc 19.2.0 requires react ^19.2.7",
             "installed react is 19.0.7"
           )
         )
@@ -5829,7 +5829,7 @@ RSpec.describe ReactOnRails::Doctor do
 
       it "does not report peer compatibility success when peer checks are unexpectedly empty" do
         rsc_package = {
-          "version" => "19.2.0-rc.4",
+          "version" => "19.2.0",
           "peerDependencies" => { "react" => "^19.0.4" }
         }
         allow(doctor).to receive(:rsc_peer_check_results).and_return([])
@@ -5849,7 +5849,7 @@ RSpec.describe ReactOnRails::Doctor do
               JSON.generate(
                 "dependencies" => {
                   "react" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.0-rc.4"
+                  "react-on-rails-rsc" => "19.2.0"
                 }
               )
             )
@@ -5881,7 +5881,7 @@ RSpec.describe ReactOnRails::Doctor do
                   "react-dom" => "19.0.7"
                 },
                 "optionalDependencies" => {
-                  "react-on-rails-rsc" => "19.2.0-rc.4"
+                  "react-on-rails-rsc" => "19.2.0"
                 }
               )
             )
@@ -5960,7 +5960,7 @@ RSpec.describe ReactOnRails::Doctor do
           .with(Dir.pwd)
           .and_return(
             [
-              JSON.generate("latest" => "19.0.5", "next" => "19.2.0-rc.4"),
+              JSON.generate("latest" => "19.0.5", "next" => "19.2.1-rc.1"),
               instance_double(Process::Status, success?: true)
             ]
           )
@@ -5970,7 +5970,7 @@ RSpec.describe ReactOnRails::Doctor do
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(warning_msgs).to include(
           a_string_including(
-            "react-on-rails-rsc 19.0.5 is behind the npm next dist-tag 19.2.0-rc.4",
+            "react-on-rails-rsc 19.0.5 is behind the npm next dist-tag 19.2.1-rc.1",
             "React Server Components track React minor versions"
           )
         )
@@ -6076,12 +6076,12 @@ RSpec.describe ReactOnRails::Doctor do
         expect(doctor.send(:npm_range_satisfied?, "1.0.0-rc.1", "*")).to be false
         expect(doctor.send(:npm_range_satisfied?, "1.0.0-rc.1", "x")).to be false
         expect(doctor.send(:npm_range_satisfied?, "1.0.0-rc.1", "~*")).to be false
-        expect(doctor.send(:npm_range_satisfied?, "19.2.0-rc.4", "^19.0.4")).to be false
-        expect(doctor.send(:npm_range_satisfied?, "19.2.0-rc.4", ">=19.0.4")).to be false
-        expect(doctor.send(:npm_range_satisfied?, "19.2.0-rc.4", "19.x")).to be false
-        expect(doctor.send(:npm_range_satisfied?, "19.2.0-rc.4", "19.0.4 - 20.0.0")).to be false
-        expect(doctor.send(:npm_range_satisfied?, "19.2.0-rc.4", ">=19.2.0-rc.0 <20.0.0")).to be true
-        expect(doctor.send(:npm_range_satisfied?, "19.2.0-rc.4", "19.2.0-rc.0 - 20.0.0")).to be true
+        expect(doctor.send(:npm_range_satisfied?, "19.2.1-rc.4", "^19.0.4")).to be false
+        expect(doctor.send(:npm_range_satisfied?, "19.2.1-rc.4", ">=19.0.4")).to be false
+        expect(doctor.send(:npm_range_satisfied?, "19.2.1-rc.4", "19.x")).to be false
+        expect(doctor.send(:npm_range_satisfied?, "19.2.1-rc.4", "19.0.4 - 20.0.0")).to be false
+        expect(doctor.send(:npm_range_satisfied?, "19.2.1-rc.4", ">=19.2.1-rc.0 <20.0.0")).to be true
+        expect(doctor.send(:npm_range_satisfied?, "19.2.1-rc.4", "19.2.1-rc.0 - 20.0.0")).to be true
       end
     end
 
@@ -6258,7 +6258,7 @@ RSpec.describe ReactOnRails::Doctor do
               "dependencies" => {
                 "react" => "19.0.7",
                 "react-dom" => "19.0.7",
-                "react-on-rails-rsc" => "19.2.0-rc.4"
+                "react-on-rails-rsc" => "19.2.0"
               }
             )
           )
@@ -6266,7 +6266,7 @@ RSpec.describe ReactOnRails::Doctor do
           install_package("react-dom", "version" => "19.0.7")
           install_package(
             "react-on-rails-rsc",
-            "version" => "19.2.0-rc.4",
+            "version" => "19.2.0",
             "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
           )
           example.run
@@ -6301,7 +6301,7 @@ RSpec.describe ReactOnRails::Doctor do
       report = JSON.parse(output.join("\n"))
       rsc_check = report["checks"].find { |check| check["id"] == "react_server_components" }
       expect(rsc_check["status"]).to eq("fail")
-      expect(rsc_check["message"]).to include("react-on-rails-rsc 19.2.0-rc.4 requires react ^19.2.7")
+      expect(rsc_check["message"]).to include("react-on-rails-rsc 19.2.0 requires react ^19.2.7")
       expect(report["status"]).to eq("fail")
     end
   end

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -56,7 +56,7 @@
     "react-intl": "^10",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "19.2.0-rc.4",
+    "react-on-rails-rsc": "19.2.0",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",


### PR DESCRIPTION
## Summary
- updates the Pro dummy `react-on-rails-rsc` pin from `19.2.0-rc.4` to final `19.2.0`
- refreshes the root `pnpm-lock.yaml` entries for the final package tarball
- updates doctor specs so the final `19.2.0` path is current and prerelease scenarios use the next prerelease line

## Rationale
`react-on-rails-rsc` 19.2.0 is now final, so the repo should stop carrying RC-specific pins and test fixtures for the Pro/RSC happy path.

## Verification
- `script/ci-changes-detector origin/main`
- `git diff --check`
- `pnpm start format.listDifferent`
- `bundle exec rubocop react_on_rails/spec/lib/react_on_rails/doctor_spec.rb`
- `(cd react_on_rails && bundle exec rspec spec/lib/react_on_rails/doctor_spec.rb)`
- `pnpm install`
- `pnpm run type-check`
- `pnpm run build`
- `pnpm run eslint --report-unused-disable-directives`
- `pnpm run test`
- pre-commit Lefthook: trailing newlines, Prettier, RuboCop/autofix, Pro license headers
- pre-push Lefthook: branch Ruby lint and markdown-link gate
- `rg -n "19\\.2\\.0-rc\\.4" .` returned no matches in this checkout

## Notes
- `claude-review` was not installed in this shell.
- `codex review --uncommitted` was attempted, but the tool recursively launched nested reviews instead of producing a finding set; I stopped the runaway review processes and continued with the local checks above. Before recursion it verified the regenerated lockfile was stable with `pnpm@10.33.4 --lockfile-only`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated React 19.2 compatibility expectations to match the final `19.2.0` release.
  * Refined peer-dependency and version-range checks to reflect the latest release and warning messages.

* **Tests**
  * Updated compatibility test fixtures and assertions for the new React/RSC version targets.
  * Adjusted test data for the latest `next` dist-tag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence
- Release gate: development mode for `main`/beta; standard merge qualification applies.
- Current head: `6dbf7ffe85f3aa39f0e0ee172d76cb1fafd98091`
- Validated: local checks listed above; hosted optimized CI current-head suites completed; benchmark label suites completed; `claude-review`, CodeRabbit, and Greptile completed; GraphQL review threads checked.
- Evidence: required-pr-gate, package/generator specs, Pro package/integration suites, examples, precompile, Playwright, CodeQL, and benchmarks passed on the current head; unresolved current/outdated review threads: 0.
- UNKNOWN: none affecting merge safety.
- Residual risk: low; dependency pin/lockfile/spec fixture update for the final RSC package.
