### PR TITLE
Add flagship demo to RC tracking template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rc-release-tracking.yml
+++ b/.github/ISSUE_TEMPLATE/rc-release-tracking.yml
@@ -77,6 +77,12 @@ body:
           - Tester/date:
           - Issue/waiver:
 
+        - [ ] `shakacode/react-on-rails-demo-flagship`
+          - PR:
+          - Public-safe evidence:
+          - Required CI:
+          - Issue/waiver:
+
         - [ ] `shakacode/react-on-rails-demo-marketplace-rsc`
           - PR:
           - Install/build/smoke evidence:
@@ -188,6 +194,10 @@ body:
       description: Fill this after the final release ships. The tracker stays open until final bumps are merged or explicitly followed up.
       value: |
         - [ ] `shakacode/hichee`
+          - Final PR:
+          - Result:
+
+        - [ ] `shakacode/react-on-rails-demo-flagship`
           - Final PR:
           - Result:
 


### PR DESCRIPTION
## Why

Post-merge audit of #4358 found that `rc-testing-plan.md` now treats `shakacode/react-on-rails-demo-flagship` as a hard gate, but `.github/ISSUE_TEMPLATE/rc-release-tracking.yml` still omitted it from the tracking issue template. A maintainer creating the next release gate issue could miss the flagship evidence slot.

## What Changed

- Add `shakacode/react-on-rails-demo-flagship` to the RC hard-gates checklist with public-safe evidence wording.
- Add the flagship demo to the final-version bump checklist.

Follow-up from #4358.

## Validation

- `pnpm exec prettier --check .github/ISSUE_TEMPLATE/rc-release-tracking.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/rc-release-tracking.yml"); puts "YAML OK"'`
- `git diff --check -- .github/ISSUE_TEMPLATE/rc-release-tracking.yml`

Pre-commit and pre-push hooks also passed for the staged/pushed change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release tracking template to capture additional RC gate details.
  * Added fields for hard-gate review evidence, required CI checks, waiver tracking, and final-version bump PR status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->