### PR TITLE
Surface renderer timing on streamed RSC responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   error reporter. [PR 4285](https://github.com/shakacode/react_on_rails/pull/4285) by
   [ihabadham](https://github.com/ihabadham).
 
+- **[Pro]** Streamed RSC responses now append the Node renderer's `ror_renderer_prepare`
+  metric to the browser-visible `Server-Timing` header while preserving existing
+  Rails/application entries, so `rsc_stream_observability` exposes renderer prepare
+  time without relying on HTTP trailers. Closes
+  [Issue 4479](https://github.com/shakacode/react_on_rails/issues/4479).
+  [PR 4487](https://github.com/shakacode/react_on_rails/pull/4487) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Streaming component caches honor `cache_options` on reads**: `cached_stream_react_component`
   wrote cached chunks with the user-supplied `cache_options` but read them back without any options, so
   key-altering options such as `namespace:` meant the cache never hit and every request re-streamed from

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -369,14 +369,15 @@ The browser-observable marks above close the client loop. To attribute the serve
 | `ror_stream_shell`     | Rails (gem)              | Duration of the shell `render_to_string`, which blocks on the first renderer chunk for each streamed component — the wait tail. |
 | `ror_renderer_prepare` | Node renderer (response) | Execution-context build (cold or cached) plus the synchronous render that produces the stream object, before the first chunk.   |
 
-`ror_stream_shell` appears on the navigation response your browser sees (visible in the Network panel and in `PerformanceResourceTiming.serverTiming`). `ror_renderer_prepare` rides on the renderer's HTTP response to Rails; it is visible to anything inspecting that hop (logs, tracing, a direct probe of the renderer).
+Both `ror_stream_shell` and `ror_renderer_prepare` appear on the navigation response your browser sees, visible in the Network panel and in `PerformanceResourceTiming.serverTiming`. Rails captures the renderer response's `Server-Timing` value while waiting for the first streamed chunk, then appends it to the browser-facing response before the first stream write commits headers.
 
 Both metrics are emitted only when `rsc_stream_observability: true` is set for the streamed render.
 
-Two figures are intentionally **not** on the browser-facing header:
+One figure is intentionally **not** on the browser-facing header:
 
 - **Total / stream-complete renderer time** is only known after the body is flushed, and `ActionController::Live` does not support HTTP trailers (see the caveat above). It remains available via the `react-on-rails:rsc:stream` mark's `sinceStreamStartMs`.
-- **Merging `ror_renderer_prepare` into the browser-facing header** would require Rails to read the renderer's response headers from the streaming hop; the gem's renderer HTTP client does not yet surface those. Until it does, read `ror_renderer_prepare` from the renderer hop and `ror_stream_shell` from the browser response.
+
+Benchmark harnesses should read both `ror_stream_shell` and `ror_renderer_prepare` from the streamed navigation entry's `PerformanceResourceTiming.serverTiming` collection. The browser-facing header may include upstream renderer `Server-Timing` entries if your renderer response already sets them; React on Rails Pro appends rather than replaces those values.
 
 Existing `Server-Timing` entries set by your app or middleware (for example route-level `action_total`) are preserved — the gem appends to them rather than replacing.
 

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1164,12 +1164,15 @@ module ReactOnRailsProHelper
     # Async::Promise replaces Async::Variable (deprecated in async v2.29.0).
     first_chunk_promise = Async::Promise.new
     all_chunks = [] if on_complete # Only collect if callback provided
+    renderer_server_timing_collector = ReactOnRailsPro::Stream.renderer_server_timing_collector
 
     # Start an async task on the barrier to stream all chunks
     @async_barrier.async do
-      stream = yield
-      fully_consumed = process_stream_chunks(stream, first_chunk_promise, all_chunks)
-      on_complete&.call(all_chunks) if fully_consumed
+      ReactOnRailsPro::Stream.with_renderer_server_timing_collector(renderer_server_timing_collector) do
+        stream = yield
+        fully_consumed = process_stream_chunks(stream, first_chunk_promise, all_chunks)
+        on_complete&.call(all_chunks) if fully_consumed
+      end
     rescue StandardError => e
       # Propagate the error to the calling fiber via the promise.
       # A promise can only be resolved/rejected once — check before acting.

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -64,9 +64,44 @@ module ReactOnRailsPro
 
   module Stream # rubocop:disable Metrics/ModuleLength
     extend ActiveSupport::Concern
+    RENDERER_SERVER_TIMING_COLLECTOR_KEY = :react_on_rails_pro_rsc_stream_renderer_server_timing_entries
+    private_constant :RENDERER_SERVER_TIMING_COLLECTOR_KEY
 
     included do
       include ActionController::Live
+    end
+
+    class << self
+      def record_renderer_response_headers(headers)
+        collector = Thread.current.thread_variable_get(RENDERER_SERVER_TIMING_COLLECTOR_KEY)
+        return unless collector
+
+        server_timing_values(headers).each do |value|
+          next if value.blank?
+
+          collector << value
+        end
+      end
+
+      private
+
+      def server_timing_values(headers)
+        return [] unless headers
+
+        pairs = if headers.respond_to?(:to_a)
+                  headers.to_a
+                elsif headers.respond_to?(:to_h)
+                  headers.to_h.to_a
+                else
+                  Array(headers)
+                end
+
+        pairs.each_with_object([]) do |(name, value), values|
+          next unless name.to_s.casecmp("server-timing").zero?
+
+          values.concat(Array(value).flatten.compact.map(&:to_s))
+        end
+      end
     end
 
     # Streams React components within a specified template to the client.
@@ -163,7 +198,9 @@ module ReactOnRailsPro
         enabled: @react_on_rails_rsc_stream_observability,
         started_at: @react_on_rails_rsc_stream_started_at,
         initial_chunk_bytes: @react_on_rails_rsc_stream_initial_chunk_bytes,
-        initial_render_duration_ms: @react_on_rails_rsc_stream_initial_render_duration_ms
+        initial_render_duration_ms: @react_on_rails_rsc_stream_initial_render_duration_ms,
+        renderer_server_timing_entries: @react_on_rails_rsc_stream_renderer_server_timing_entries,
+        renderer_server_timing_collector: Thread.current.thread_variable_get(RENDERER_SERVER_TIMING_COLLECTOR_KEY)
       }
     end
 
@@ -172,6 +209,11 @@ module ReactOnRailsPro
       @react_on_rails_rsc_stream_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       @react_on_rails_rsc_stream_initial_chunk_bytes = nil
       @react_on_rails_rsc_stream_initial_render_duration_ms = nil
+      @react_on_rails_rsc_stream_renderer_server_timing_entries = []
+      Thread.current.thread_variable_set(
+        RENDERER_SERVER_TIMING_COLLECTOR_KEY,
+        @react_on_rails_rsc_stream_observability ? @react_on_rails_rsc_stream_renderer_server_timing_entries : nil
+      )
     end
 
     def restore_rsc_stream_observability_state(state)
@@ -179,6 +221,11 @@ module ReactOnRailsPro
       @react_on_rails_rsc_stream_started_at = state[:started_at]
       @react_on_rails_rsc_stream_initial_chunk_bytes = state[:initial_chunk_bytes]
       @react_on_rails_rsc_stream_initial_render_duration_ms = state[:initial_render_duration_ms]
+      @react_on_rails_rsc_stream_renderer_server_timing_entries = state[:renderer_server_timing_entries]
+      Thread.current.thread_variable_set(
+        RENDERER_SERVER_TIMING_COLLECTOR_KEY,
+        state[:renderer_server_timing_collector]
+      )
     end
 
     def render_stream_template_chunk(template:, render_options:)
@@ -207,9 +254,9 @@ module ReactOnRailsPro
     #   ActionController::Live does not support HTTP trailers, so that figure is exposed via the
     #   `rsc_stream_observability` PerformanceMark (`sinceStreamStartMs`) instead of a header.
     # - The renderer worker's own internal breakdown (exec-context build + render start) is
-    #   emitted as a `Server-Timing` header on the Node renderer's HTTP response; merging it
-    #   into this header is a documented follow-up because RendererHttpClient::Response does not
-    #   yet capture renderer response headers.
+    #   emitted as a `Server-Timing` header on the Node renderer's HTTP response. The renderer
+    #   response headers are captured while waiting for first chunks, then appended here before
+    #   ActionController::Live commits the browser response.
     def emit_rsc_stream_server_timing_header
       return unless rsc_stream_observability_enabled?
 
@@ -219,7 +266,7 @@ module ReactOnRailsPro
       desc = server_timing_quoted_string("RoR Pro streamed RSC shell render (includes first renderer chunk)")
       entry = "ror_stream_shell;dur=#{duration};desc=\"#{desc}\""
       existing = response.headers["Server-Timing"]
-      entries = Array(existing).flatten.compact.reject(&:blank?) + [entry]
+      entries = Array(existing).flatten.compact.reject(&:blank?) + [entry] + renderer_server_timing_entries
       response.headers["Server-Timing"] = entries.join(", ")
     rescue StandardError => e
       # Observability must never break a real response. Swallow and log.
@@ -230,6 +277,10 @@ module ReactOnRailsPro
       rescue StandardError
         # Logging itself can fail if the logger is unavailable; keep the response alive.
       end
+    end
+
+    def renderer_server_timing_entries
+      Array(@react_on_rails_rsc_stream_renderer_server_timing_entries).flatten.compact.reject(&:blank?)
     end
 
     def server_timing_quoted_string(value)

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -73,17 +73,54 @@ module ReactOnRailsPro
 
     class << self
       def record_renderer_response_headers(headers)
-        collector = Thread.current.thread_variable_get(RENDERER_SERVER_TIMING_COLLECTOR_KEY)
+        collector = renderer_server_timing_collector
         return unless collector
 
         server_timing_values(headers).each do |value|
-          next if value.blank?
+          entry = sanitize_server_timing_header_entry(value)
+          next if entry.blank?
 
-          collector << value
+          collector << entry
         end
       end
 
+      def renderer_server_timing_collector
+        Thread.current[RENDERER_SERVER_TIMING_COLLECTOR_KEY]
+      end
+
+      def renderer_server_timing_collector=(collector)
+        Thread.current[RENDERER_SERVER_TIMING_COLLECTOR_KEY] = collector
+      end
+
+      def with_renderer_server_timing_collector(collector)
+        previous_collector = renderer_server_timing_collector
+        self.renderer_server_timing_collector = collector
+        yield
+      ensure
+        self.renderer_server_timing_collector = previous_collector
+      end
+
+      def renderer_server_timing_collector_snapshot
+        collector = renderer_server_timing_collector
+        return unless collector
+
+        { collector:, length: collector.length }
+      end
+
+      def restore_renderer_server_timing_collector_snapshot(snapshot)
+        return unless snapshot
+
+        collector = renderer_server_timing_collector
+        return unless collector.equal?(snapshot[:collector])
+
+        collector.slice!(snapshot[:length]..)
+      end
+
       private
+
+      def sanitize_server_timing_header_entry(value)
+        value.to_s.gsub(/[\r\n\0]/, "")
+      end
 
       def server_timing_values(headers)
         return [] unless headers
@@ -140,45 +177,15 @@ module ReactOnRailsPro
       initialize_rsc_stream_observability_state(rsc_stream_observability)
 
       Sync do |parent_task|
-        # Initialize async primitives for concurrent component streaming
-        @async_barrier = Async::Barrier.new
-        buffer_size = ReactOnRailsPro.configuration.concurrent_component_streaming_buffer_size
-        @main_output_queue = Async::LimitedQueue.new(buffer_size)
-        @react_on_rails_pending_stream_cache_writes = []
-
-        # Render template - components will start streaming immediately.
-        # If a shell error occurs, consumer_stream_async raises PrerenderError here
-        # (BEFORE the response is committed), enabling a proper HTTP redirect.
-        # View may contain extra newlines, chunk already contains a newline
-        # Having multiple newlines between chunks causes hydration errors
-        # So we strip extra newlines from the template string and add a single newline
-        # `formats: [:text]` causes render_to_string to set response.content_type
-        # to `text/plain`; override it here before the first stream write, which
-        # is when ActionController::Live commits headers. render_to_string itself
-        # never writes to response.stream, so this assignment is always safe.
-        response.content_type = content_type if content_type
-        # Render the shell chunk first so its measured duration is available, then emit the
-        # Server-Timing header, then write. Both steps run BEFORE the first
-        # response.stream.write, which is when ActionController::Live commits response headers.
-        initial_chunk = render_stream_template_chunk(template:, render_options:)
-        emit_rsc_stream_server_timing_header
-        response.stream.write(initial_chunk)
-
-        drain_streams_concurrently(parent_task)
-        write_rsc_stream_observability_mark
-        flush_pending_stream_cache_writes
-        # Do not close the response stream in an ensure block.
-        # If an error occurs we may need the stream open to send diagnostic/error details
-        # (for example, ApplicationController#rescue_from in the dummy app).
-        response.stream.close if close_stream_at_end
-      rescue StandardError
-        # Stop all streaming tasks to prevent leaked async work.
-        # For pre-commit errors (e.g., shell error raised during render_to_string),
-        # the barrier may still have pending tasks that must be cancelled.
-        # For post-commit errors (from drain_streams_concurrently), the barrier
-        # is already stopped inside that method — stopping again is a no-op.
-        stop_streaming_and_flush_cache_writes
-        raise
+        ReactOnRailsPro::Stream.with_renderer_server_timing_collector(renderer_server_timing_collector_for_stream) do
+          stream_view_containing_react_components_in_sync(
+            parent_task,
+            template:,
+            close_stream_at_end:,
+            content_type:,
+            render_options:
+          )
+        end
       end
     ensure
       @react_on_rails_pending_stream_cache_writes = nil
@@ -193,6 +200,54 @@ module ReactOnRailsPro
       require "async/limited_queue"
     end
 
+    def stream_view_containing_react_components_in_sync(
+      parent_task,
+      template:,
+      close_stream_at_end:,
+      content_type:,
+      render_options:
+    )
+      # Initialize async primitives for concurrent component streaming
+      @async_barrier = Async::Barrier.new
+      buffer_size = ReactOnRailsPro.configuration.concurrent_component_streaming_buffer_size
+      @main_output_queue = Async::LimitedQueue.new(buffer_size)
+      @react_on_rails_pending_stream_cache_writes = []
+
+      # Render template - components will start streaming immediately.
+      # If a shell error occurs, consumer_stream_async raises PrerenderError here
+      # (BEFORE the response is committed), enabling a proper HTTP redirect.
+      # View may contain extra newlines, chunk already contains a newline
+      # Having multiple newlines between chunks causes hydration errors
+      # So we strip extra newlines from the template string and add a single newline
+      # `formats: [:text]` causes render_to_string to set response.content_type
+      # to `text/plain`; override it here before the first stream write, which
+      # is when ActionController::Live commits headers. render_to_string itself
+      # never writes to response.stream, so this assignment is always safe.
+      response.content_type = content_type if content_type
+      # Render the shell chunk first so its measured duration is available, then emit the
+      # Server-Timing header, then write. Both steps run BEFORE the first
+      # response.stream.write, which is when ActionController::Live commits response headers.
+      initial_chunk = render_stream_template_chunk(template:, render_options:)
+      emit_rsc_stream_server_timing_header
+      response.stream.write(initial_chunk)
+
+      drain_streams_concurrently(parent_task)
+      write_rsc_stream_observability_mark
+      flush_pending_stream_cache_writes
+      # Do not close the response stream in an ensure block.
+      # If an error occurs we may need the stream open to send diagnostic/error details
+      # (for example, ApplicationController#rescue_from in the dummy app).
+      response.stream.close if close_stream_at_end
+    rescue StandardError
+      # Stop all streaming tasks to prevent leaked async work.
+      # For pre-commit errors (e.g., shell error raised during render_to_string),
+      # the barrier may still have pending tasks that must be cancelled.
+      # For post-commit errors (from drain_streams_concurrently), the barrier
+      # is already stopped inside that method — stopping again is a no-op.
+      stop_streaming_and_flush_cache_writes
+      raise
+    end
+
     def current_rsc_stream_observability_state
       {
         enabled: @react_on_rails_rsc_stream_observability,
@@ -200,7 +255,7 @@ module ReactOnRailsPro
         initial_chunk_bytes: @react_on_rails_rsc_stream_initial_chunk_bytes,
         initial_render_duration_ms: @react_on_rails_rsc_stream_initial_render_duration_ms,
         renderer_server_timing_entries: @react_on_rails_rsc_stream_renderer_server_timing_entries,
-        renderer_server_timing_collector: Thread.current.thread_variable_get(RENDERER_SERVER_TIMING_COLLECTOR_KEY)
+        renderer_server_timing_collector: ReactOnRailsPro::Stream.renderer_server_timing_collector
       }
     end
 
@@ -210,10 +265,6 @@ module ReactOnRailsPro
       @react_on_rails_rsc_stream_initial_chunk_bytes = nil
       @react_on_rails_rsc_stream_initial_render_duration_ms = nil
       @react_on_rails_rsc_stream_renderer_server_timing_entries = []
-      Thread.current.thread_variable_set(
-        RENDERER_SERVER_TIMING_COLLECTOR_KEY,
-        @react_on_rails_rsc_stream_observability ? @react_on_rails_rsc_stream_renderer_server_timing_entries : nil
-      )
     end
 
     def restore_rsc_stream_observability_state(state)
@@ -222,10 +273,13 @@ module ReactOnRailsPro
       @react_on_rails_rsc_stream_initial_chunk_bytes = state[:initial_chunk_bytes]
       @react_on_rails_rsc_stream_initial_render_duration_ms = state[:initial_render_duration_ms]
       @react_on_rails_rsc_stream_renderer_server_timing_entries = state[:renderer_server_timing_entries]
-      Thread.current.thread_variable_set(
-        RENDERER_SERVER_TIMING_COLLECTOR_KEY,
-        state[:renderer_server_timing_collector]
-      )
+      ReactOnRailsPro::Stream.renderer_server_timing_collector = state[:renderer_server_timing_collector]
+    end
+
+    def renderer_server_timing_collector_for_stream
+      return unless @react_on_rails_rsc_stream_observability
+
+      @react_on_rails_rsc_stream_renderer_server_timing_entries
     end
 
     def render_stream_template_chunk(template:, render_options:)

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -65,7 +65,9 @@ module ReactOnRailsPro
   module Stream # rubocop:disable Metrics/ModuleLength
     extend ActiveSupport::Concern
     RENDERER_SERVER_TIMING_COLLECTOR_KEY = :react_on_rails_pro_rsc_stream_renderer_server_timing_entries
+    RENDERER_SERVER_TIMING_ATTEMPT_COLLECTOR_KEY = :react_on_rails_pro_rsc_stream_renderer_server_timing_attempt
     private_constant :RENDERER_SERVER_TIMING_COLLECTOR_KEY
+    private_constant :RENDERER_SERVER_TIMING_ATTEMPT_COLLECTOR_KEY
 
     included do
       include ActionController::Live
@@ -81,6 +83,7 @@ module ReactOnRailsPro
           next if entry.blank?
 
           collector << entry
+          renderer_server_timing_attempt_collector&.append(entry, collector:)
         end
       end
 
@@ -104,19 +107,62 @@ module ReactOnRailsPro
         collector = renderer_server_timing_collector
         return unless collector
 
-        { collector:, length: collector.length }
+        attempt_collector = RendererServerTimingAttemptCollector.new(
+          collector:,
+          previous_attempt_collector: renderer_server_timing_attempt_collector
+        )
+        self.renderer_server_timing_attempt_collector = attempt_collector
+
+        attempt_collector
       end
 
-      def restore_renderer_server_timing_collector_snapshot(snapshot)
-        return unless snapshot
+      def restore_renderer_server_timing_collector_snapshot(attempt_collector)
+        return unless attempt_collector
 
         collector = renderer_server_timing_collector
-        return unless collector.equal?(snapshot[:collector])
+        return unless collector.equal?(attempt_collector.collector)
 
-        collector.slice!(snapshot[:length]..)
+        attempt_collector.remove_appended_entries
+      ensure
+        if attempt_collector && renderer_server_timing_attempt_collector.equal?(attempt_collector)
+          self.renderer_server_timing_attempt_collector = attempt_collector.previous_attempt_collector
+        end
+      end
+
+      class RendererServerTimingAttemptCollector
+        attr_reader :collector, :previous_attempt_collector
+
+        def initialize(collector:, previous_attempt_collector:)
+          @collector = collector
+          @previous_attempt_collector = previous_attempt_collector
+          @appended_entries = []
+        end
+
+        def append(entry, collector:)
+          return unless collector.equal?(@collector)
+
+          @appended_entries << entry
+        end
+
+        def remove_appended_entries
+          appended_entries = {}.compare_by_identity
+          @appended_entries.each do |entry|
+            appended_entries[entry] = true
+          end
+
+          @collector.delete_if { |entry| appended_entries[entry] }
+        end
       end
 
       private
+
+      def renderer_server_timing_attempt_collector
+        Thread.current[RENDERER_SERVER_TIMING_ATTEMPT_COLLECTOR_KEY]
+      end
+
+      def renderer_server_timing_attempt_collector=(attempt_collector)
+        Thread.current[RENDERER_SERVER_TIMING_ATTEMPT_COLLECTOR_KEY] = attempt_collector
+      end
 
       def sanitize_server_timing_header_entry(value)
         value.to_s.gsub(/[\r\n\0]/, "")

--- a/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
@@ -176,7 +176,7 @@ module ReactOnRailsPro
     end
 
     class PersistentThreadClient
-      ResponseEnvelope = Struct.new(:status, :body)
+      ResponseEnvelope = Struct.new(:status, :body, :headers)
 
       def initialize(endpoint:, protocol:, pool_limit:)
         @queue = Queue.new
@@ -306,9 +306,13 @@ module ReactOnRailsPro
         body = raw_response&.body
         chunks = []
         body&.each { |chunk| chunks << chunk }
-        ResponseEnvelope.new(raw_response.status, BufferedResponseBody.new(chunks))
+        ResponseEnvelope.new(raw_response.status, BufferedResponseBody.new(chunks), response_headers(raw_response))
       ensure
         body&.close
+      end
+
+      def response_headers(raw_response)
+        raw_response.headers if raw_response.respond_to?(:headers)
       end
 
       def register_pending_result(result)
@@ -331,10 +335,11 @@ module ReactOnRailsPro
 
     # Not thread-safe. Each Response instance is owned and consumed by one renderer request path.
     class Response
-      attr_reader :status
+      attr_reader :status, :headers
 
-      def initialize(status: nil, body: nil, error: nil, &executor)
+      def initialize(status: nil, body: nil, headers: nil, error: nil, &executor)
         @status = status
+        @headers = normalize_headers(headers)
         @body_chunks = Array(body || [])
         @body = nil
         @error = error
@@ -368,6 +373,26 @@ module ReactOnRailsPro
 
       private
 
+      def normalize_headers(headers)
+        return {} unless headers
+
+        pairs = if headers.respond_to?(:to_a)
+                  headers.to_a
+                elsif headers.respond_to?(:to_h)
+                  headers.to_h.to_a
+                else
+                  Array(headers)
+                end
+
+        pairs.each_with_object({}) do |(name, value), normalized|
+          next if name.nil?
+
+          key = name.to_s.downcase
+          normalized[key] ||= []
+          normalized[key].concat(Array(value).compact.map(&:to_s))
+        end
+      end
+
       def append_chunk(chunk)
         @body = nil
         @body_chunks << chunk
@@ -377,6 +402,10 @@ module ReactOnRailsPro
         return if @consumed
 
         status_assigner = ->(status) { @status = status }
+        headers_assigner = lambda do |headers|
+          @headers = normalize_headers(headers)
+          record_stream_observability_headers
+        end
         buffer_success_body = !block_given?
         yielder = lambda do |chunk|
           append_chunk(chunk) if buffer_success_body || error?
@@ -387,11 +416,18 @@ module ReactOnRailsPro
         # each re-raises @error, while body can return buffered chunks for error-body access.
         @consumed = true
         begin
-          @executor&.call(yielder, status_assigner)
+          @executor&.call(yielder, status_assigner, headers_assigner)
         rescue StandardError => e
           @error ||= e
           raise
         end
+      end
+
+      def record_stream_observability_headers
+        return unless defined?(ReactOnRailsPro::Stream)
+        return unless ReactOnRailsPro::Stream.respond_to?(:record_renderer_response_headers)
+
+        ReactOnRailsPro::Stream.record_renderer_response_headers(@headers)
       end
     end
 
@@ -539,15 +575,19 @@ module ReactOnRailsPro
     def post(path, form: nil, json: nil, stream: false)
       ensure_open!
       headers, body = request_body(form:, json:)
-      build_response(stream:) do |yielder, status_assigner|
-        execute_request(:post, path, [headers, body], stream:, response_handlers: [yielder, status_assigner])
+      build_response(stream:) do |yielder, status_assigner, headers_assigner|
+        execute_request(:post, path, [headers, body],
+                        stream:,
+                        response_handlers: [yielder, status_assigner, headers_assigner])
       end
     end
 
     def get(path)
       ensure_open!
-      build_response(stream: false) do |yielder, status_assigner|
-        execute_request(:get, path, [[], nil], stream: false, response_handlers: [yielder, status_assigner])
+      build_response(stream: false) do |yielder, status_assigner, headers_assigner|
+        execute_request(:get, path, [[], nil],
+                        stream: false,
+                        response_handlers: [yielder, status_assigner, headers_assigner])
       end
     end
 
@@ -560,8 +600,10 @@ module ReactOnRailsPro
     def post_bidi(path, headers:)
       ensure_open!
       writable = Protocol::HTTP::Body::Writable.new
-      response = build_response(stream: true) do |yielder, status_assigner|
-        execute_request(:post, path, [headers, writable], stream: true, response_handlers: [yielder, status_assigner])
+      response = build_response(stream: true) do |yielder, status_assigner, headers_assigner|
+        execute_request(:post, path, [headers, writable],
+                        stream: true,
+                        response_handlers: [yielder, status_assigner, headers_assigner])
       end
       [writable.output, response]
     end
@@ -633,7 +675,7 @@ module ReactOnRailsPro
 
     def execute_request(method, path, request_body, stream:, response_handlers:)
       headers, body = request_body
-      yielder, status_assigner = response_handlers
+      yielder, status_assigner, headers_assigner = response_handlers
 
       # Capture scheduler BEFORE entering Sync. If a scheduler already exists, we can
       # use persistent mode. If Sync creates an ephemeral scheduler, we must use
@@ -649,6 +691,7 @@ module ReactOnRailsPro
                          end
 
           status_assigner.call(raw_response.status)
+          headers_assigner&.call(response_headers(raw_response))
           stream_body(raw_response, yielder)
         end
       end
@@ -858,6 +901,10 @@ module ReactOnRailsPro
       body&.each { |chunk| yielder.call(chunk) }
     ensure
       body&.close
+    end
+
+    def response_headers(raw_response)
+      raw_response.headers if raw_response.respond_to?(:headers)
     end
   end
 end

--- a/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
@@ -158,6 +158,7 @@ module ReactOnRailsPro
           # response attempt.
           reset_response_status
           @received_first_chunk = false
+          renderer_timing_snapshot = renderer_server_timing_collector_snapshot
           stream_response, @emitter = normalize_executor_result(@request_executor.call(send_bundle, tasks))
 
           begin
@@ -173,12 +174,16 @@ module ReactOnRailsPro
           end
           break
         rescue ReactOnRailsPro::RendererHttpClient::HTTPError => e
-          stop_tasks(tasks) if retrying_with_bundle_upload?(e, send_bundle)
+          if retrying_with_bundle_upload?(e, send_bundle)
+            restore_renderer_server_timing_collector_snapshot(renderer_timing_snapshot)
+            stop_tasks(tasks)
+          end
           send_bundle = handle_http_error(e, send_bundle)
         rescue ReactOnRailsPro::RendererHttpClient::TimeoutError,
                ReactOnRailsPro::RendererHttpClient::ConnectionError => e
           raise_or_retry_streaming_transport_error(e, available_retries)
           available_retries -= 1
+          restore_renderer_server_timing_collector_snapshot(renderer_timing_snapshot)
           stop_tasks(tasks)
         end
 
@@ -288,6 +293,20 @@ module ReactOnRailsPro
       tasks.each(&:stop)
       tasks.each(&:wait)
       tasks.clear
+    end
+
+    def renderer_server_timing_collector_snapshot
+      return unless defined?(ReactOnRailsPro::Stream)
+      return unless ReactOnRailsPro::Stream.respond_to?(:renderer_server_timing_collector_snapshot)
+
+      ReactOnRailsPro::Stream.renderer_server_timing_collector_snapshot
+    end
+
+    def restore_renderer_server_timing_collector_snapshot(snapshot)
+      return unless defined?(ReactOnRailsPro::Stream)
+      return unless ReactOnRailsPro::Stream.respond_to?(:restore_renderer_server_timing_collector_snapshot)
+
+      ReactOnRailsPro::Stream.restore_renderer_server_timing_collector_snapshot(snapshot)
     end
 
     def retrying_with_bundle_upload?(error, send_bundle)

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -772,6 +772,28 @@ describe ReactOnRailsProHelper do
         @react_on_rails_rsc_stream_started_at = nil
       end
 
+      it "shares the renderer timing collector with the async stream task" do
+        renderer_timing_entry = 'ror_renderer_prepare;dur=7;desc="child task"'
+        collector = []
+        rendered_html_stream = Struct.new(:chunks) do
+          def each_chunk(&block)
+            chunks.each(&block)
+          end
+        end.new(["<div>first</div>", "<div>second</div>"])
+        allow(self).to receive(:internal_stream_react_component) do
+          ReactOnRailsPro::Stream.record_renderer_response_headers("server-timing" => renderer_timing_entry)
+          rendered_html_stream
+        end
+        ReactOnRailsPro::Stream.renderer_server_timing_collector = collector
+
+        stream_react_component(component_name, props:, **component_options)
+        @async_barrier.wait
+
+        expect(collector).to eq([renderer_timing_entry])
+      ensure
+        ReactOnRailsPro::Stream.renderer_server_timing_collector = nil
+      end
+
       it "adds stream observability to the Rails context when the Pro stream state enables it" do
         @react_on_rails_rsc_stream_observability = true
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       expect(response).not_to respond_to(:status=)
     end
 
+    it "exposes response headers with case-insensitive keys" do
+      response = described_class.new(
+        status: 200,
+        headers: [["Server-Timing", "ror_renderer_prepare;dur=5"], ["server-timing", "upstream;dur=1"]]
+      )
+
+      expect(response.headers["server-timing"]).to eq(["ror_renderer_prepare;dur=5", "upstream;dur=1"])
+    end
+
     it "does not expose a public chunk writer" do
       response = described_class.new(status: 200)
 
@@ -377,7 +386,7 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       )
       stub_const(
         "FakePersistentResponse",
-        Struct.new(:status, :body)
+        Struct.new(:status, :body, :headers)
       )
       stub_const(
         "FakePersistentClient",
@@ -398,8 +407,8 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       allow(Async::HTTP::Client).to receive(:new).and_return(async_client)
       allow(Async::HTTP::Client).to receive(:open).and_raise("ephemeral client should not be used")
       allow(async_client).to receive(:post).and_return(
-        FakePersistentResponse.new(200, first_body),
-        FakePersistentResponse.new(200, second_body)
+        FakePersistentResponse.new(200, first_body, { "server-timing" => "ror_renderer_prepare;dur=1" }),
+        FakePersistentResponse.new(200, second_body, { "server-timing" => "ror_renderer_prepare;dur=2" })
       )
       allow(async_client).to receive(:close)
 
@@ -408,6 +417,8 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
 
       expect(first_response.body).to eq("first")
       expect(second_response.body).to eq("second")
+      expect(first_response.headers["server-timing"]).to eq(["ror_renderer_prepare;dur=1"])
+      expect(second_response.headers["server-timing"]).to eq(["ror_renderer_prepare;dur=2"])
       expect(first_body.closed).to be(true)
       expect(second_body.closed).to be(true)
       expect(Async::HTTP::Client).to have_received(:new).once.with(

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
@@ -15,6 +15,7 @@
 
 require_relative "spec_helper"
 require "async"
+require "react_on_rails_pro/concerns/stream"
 require "react_on_rails_pro/stream_request"
 require "react_on_rails_pro/renderer_http_client"
 
@@ -46,6 +47,15 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
     ReactOnRailsPro::RendererHttpClient::Response.new do |yielder, status_assigner|
       status_assigner.call(status)
       chunks.each { |c| yielder.call(c) }
+    end
+  end
+
+  def mock_stream_response_with_headers(headers, *chunks, error: nil)
+    ReactOnRailsPro::RendererHttpClient::Response.new do |yielder, status_assigner, headers_assigner|
+      status_assigner.call(200)
+      headers_assigner.call(headers)
+      chunks.each { |c| yielder.call(c) }
+      raise error if error
     end
   end
 
@@ -498,6 +508,37 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
       expect(chunks.first).to include("html" => "ok")
       expect(stream.http_status).to eq(200)
       expect(stream.http_status_recorded?).to be(true)
+    end
+
+    it "rolls back renderer Server-Timing entries from retried attempts" do
+      collector = []
+      call_count = 0
+      request = described_class.send(:new) do |_send_bundle, _tasks|
+        call_count += 1
+        if call_count == 1
+          mock_stream_response_with_headers(
+            { "server-timing" => 'ror_renderer_prepare;dur=1;desc="failed attempt"' },
+            error: ReactOnRailsPro::RendererHttpClient::ConnectionError.new("Connection reset")
+          )
+        else
+          mock_stream_response_with_headers(
+            { "server-timing" => 'ror_renderer_prepare;dur=2;desc="successful retry"' },
+            to_length_prefixed("ok")
+          )
+        end
+      end
+
+      chunks = []
+      Sync do
+        ReactOnRailsPro::Stream.renderer_server_timing_collector = collector
+        request.send(:consume_with_bundle_reupload) { |c| chunks << c }
+      ensure
+        ReactOnRailsPro::Stream.renderer_server_timing_collector = nil
+      end
+
+      expect(call_count).to eq(2)
+      expect(chunks.first).to include("html" => "ok")
+      expect(collector).to eq(['ror_renderer_prepare;dur=2;desc="successful retry"'])
     end
 
     it "stops and clears tasks before retrying on transport error" do

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
@@ -50,11 +50,12 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
     end
   end
 
-  def mock_stream_response_with_headers(headers, *chunks, error: nil)
+  def mock_stream_response_with_headers(headers, *chunks, error: nil, before_error: nil)
     ReactOnRailsPro::RendererHttpClient::Response.new do |yielder, status_assigner, headers_assigner|
       status_assigner.call(200)
       headers_assigner.call(headers)
       chunks.each { |c| yielder.call(c) }
+      before_error&.call if error
       raise error if error
     end
   end
@@ -510,19 +511,29 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
       expect(stream.http_status_recorded?).to be(true)
     end
 
-    it "rolls back renderer Server-Timing entries from retried attempts" do
+    it "rolls back only renderer Server-Timing entries from the retried attempt" do
       collector = []
       call_count = 0
+      failed_attempt_timing = 'ror_renderer_prepare;dur=1;desc="shared renderer timing"'
+      other_stream_timing = failed_attempt_timing.dup
+      successful_retry_timing = 'ror_renderer_prepare;dur=2;desc="successful retry"'
       request = described_class.send(:new) do |_send_bundle, _tasks|
         call_count += 1
         if call_count == 1
           mock_stream_response_with_headers(
-            { "server-timing" => 'ror_renderer_prepare;dur=1;desc="failed attempt"' },
-            error: ReactOnRailsPro::RendererHttpClient::ConnectionError.new("Connection reset")
+            { "server-timing" => failed_attempt_timing },
+            error: ReactOnRailsPro::RendererHttpClient::ConnectionError.new("Connection reset"),
+            before_error: lambda do
+              Fiber.new do
+                ReactOnRailsPro::Stream.with_renderer_server_timing_collector(collector) do
+                  ReactOnRailsPro::Stream.record_renderer_response_headers("server-timing" => other_stream_timing)
+                end
+              end.resume
+            end
           )
         else
           mock_stream_response_with_headers(
-            { "server-timing" => 'ror_renderer_prepare;dur=2;desc="successful retry"' },
+            { "server-timing" => successful_retry_timing },
             to_length_prefixed("ok")
           )
         end
@@ -538,7 +549,7 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
 
       expect(call_count).to eq(2)
       expect(chunks.first).to include("html" => "ok")
-      expect(collector).to eq(['ror_renderer_prepare;dur=2;desc="successful retry"'])
+      expect(collector).to eq([other_stream_timing, successful_retry_timing])
     end
 
     it "stops and clears tasks before retrying on transport error" do

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
@@ -25,11 +25,18 @@ class StreamController
   def initialize(component_queues:, initial_response: "TEMPLATE", renderer_response_headers: nil)
     @component_queues = component_queues
     @initial_response = initial_response
-    @renderer_response_headers = renderer_response_headers
+    @renderer_response_headers =
+      if renderer_response_headers.is_a?(Array)
+        renderer_response_headers
+      else
+        [renderer_response_headers]
+      end
   end
 
   def render_to_string(**_opts)
-    ReactOnRailsPro::Stream.record_renderer_response_headers(@renderer_response_headers)
+    @renderer_response_headers.each do |headers|
+      ReactOnRailsPro::Stream.record_renderer_response_headers(headers)
+    end
 
     # Simulate component helpers creating async tasks
     # In real implementation, first chunks are part of template HTML
@@ -245,6 +252,93 @@ RSpec.describe ReactOnRailsPro::Stream do
       expect(server_timing).to include("action_total;dur=5")
       expect(server_timing).to include("ror_stream_shell;dur=")
       expect(server_timing).to end_with(renderer_server_timing)
+    end
+
+    it "appends renderer Server-Timing when stream_view creates the top-level Sync fiber" do
+      renderer_server_timing = "ror_renderer_prepare;dur=7;desc=\"Node renderer prepare\""
+      _queues, controller, stream = setup_stream_test(
+        component_count: 0,
+        renderer_response_headers: { "server-timing" => renderer_server_timing }
+      )
+      allow(stream).to receive(:write)
+
+      controller.stream_view_containing_react_components(
+        template: "ignored",
+        rsc_stream_observability: true
+      )
+
+      server_timing = controller.response.headers["Server-Timing"]
+      expect(server_timing).to include("ror_stream_shell;dur=")
+      expect(server_timing).to end_with(renderer_server_timing)
+    end
+
+    it "accumulates renderer Server-Timing entries from multiple renderer responses" do
+      renderer_entries = [
+        "ror_renderer_prepare;dur=7;desc=\"first component\"",
+        "ror_renderer_prepare;dur=11;desc=\"second component\""
+      ]
+      _queues, controller, stream = setup_stream_test(
+        component_count: 2,
+        renderer_response_headers: renderer_entries.map { |entry| { "server-timing" => entry } }
+      )
+      allow(stream).to receive(:write)
+      controller.response.headers["Server-Timing"] = "action_total;dur=5"
+
+      run_stream(controller, rsc_stream_observability: true) do |parent|
+        parent.async do
+          sleep 0.01
+          controller.instance_variable_get(:@component_queues).each(&:close)
+        end
+      end
+
+      server_timing = controller.response.headers["Server-Timing"]
+      expect(server_timing).to include("action_total;dur=5")
+      expect(server_timing).to include("ror_stream_shell;dur=")
+      expect(server_timing).to end_with(renderer_entries.join(", "))
+    end
+
+    it "strips control characters from renderer-supplied Server-Timing entries" do
+      _queues, controller, stream = setup_stream_test(
+        component_count: 0,
+        renderer_response_headers: { "server-timing" => "renderer;dur=7;desc=\"ok\r\nX-Injected: yes\0\"" }
+      )
+      allow(stream).to receive(:write)
+
+      run_stream(controller, rsc_stream_observability: true) do |_parent|
+        sleep 0.1
+      end
+
+      server_timing = controller.response.headers["Server-Timing"]
+      expect(server_timing).to include('renderer;dur=7;desc="okX-Injected: yes"')
+      expect(server_timing).not_to include("\r")
+      expect(server_timing).not_to include("\n")
+      expect(server_timing).not_to include("\0")
+    end
+
+    it "keeps renderer Server-Timing collectors isolated across fibers on the same thread" do
+      main_collector = []
+      fiber_collector = []
+      described_class.renderer_server_timing_collector = main_collector
+
+      fiber = Fiber.new do
+        described_class.renderer_server_timing_collector = fiber_collector
+        described_class.record_renderer_response_headers(
+          "server-timing" => 'ror_renderer_prepare;dur=2;desc="fiber"'
+        )
+        Fiber.yield
+      ensure
+        described_class.renderer_server_timing_collector = nil
+      end
+
+      fiber.resume
+      described_class.record_renderer_response_headers(
+        "server-timing" => 'ror_renderer_prepare;dur=1;desc="main"'
+      )
+
+      expect(main_collector).to eq(['ror_renderer_prepare;dur=1;desc="main"'])
+      expect(fiber_collector).to eq(['ror_renderer_prepare;dur=2;desc="fiber"'])
+    ensure
+      described_class.renderer_server_timing_collector = nil
     end
 
     it "appends to array-valued Server-Timing headers without stringifying the array" do

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
@@ -22,12 +22,15 @@ class StreamController
 
   attr_reader :response
 
-  def initialize(component_queues:, initial_response: "TEMPLATE")
+  def initialize(component_queues:, initial_response: "TEMPLATE", renderer_response_headers: nil)
     @component_queues = component_queues
     @initial_response = initial_response
+    @renderer_response_headers = renderer_response_headers
   end
 
   def render_to_string(**_opts)
+    ReactOnRailsPro::Stream.record_renderer_response_headers(@renderer_response_headers)
+
     # Simulate component helpers creating async tasks
     # In real implementation, first chunks are part of template HTML
     # For testing, we enqueue all chunks including first ones
@@ -57,9 +60,9 @@ RSpec.describe ReactOnRailsPro::Stream do
       end
     end
 
-    def setup_stream_test(component_count: 2, initial_response: "TEMPLATE")
+    def setup_stream_test(component_count: 2, initial_response: "TEMPLATE", renderer_response_headers: nil)
       component_queues = Array.new(component_count) { Async::Queue.new }
-      controller = StreamController.new(component_queues:, initial_response:)
+      controller = StreamController.new(component_queues:, initial_response:, renderer_response_headers:)
 
       mocked_response, mocked_stream = build_mocked_response
       allow(controller).to receive(:response).and_return(mocked_response)
@@ -223,6 +226,25 @@ RSpec.describe ReactOnRailsPro::Stream do
 
       server_timing = controller.response.headers["Server-Timing"]
       expect(server_timing).to start_with("action_total;dur=5, ror_stream_shell;dur=")
+    end
+
+    it "appends renderer Server-Timing entries to the browser-visible stream header" do
+      renderer_server_timing = "ror_renderer_prepare;dur=7;desc=\"Node renderer prepare\""
+      _queues, controller, stream = setup_stream_test(
+        component_count: 0,
+        renderer_response_headers: { "server-timing" => [renderer_server_timing] }
+      )
+      allow(stream).to receive(:write)
+      controller.response.headers["Server-Timing"] = "action_total;dur=5"
+
+      run_stream(controller, rsc_stream_observability: true) do |_parent|
+        sleep 0.1
+      end
+
+      server_timing = controller.response.headers["Server-Timing"]
+      expect(server_timing).to include("action_total;dur=5")
+      expect(server_timing).to include("ror_stream_shell;dur=")
+      expect(server_timing).to end_with(renderer_server_timing)
     end
 
     it "appends to array-valued Server-Timing headers without stringifying the array" do


### PR DESCRIPTION
Closes #4479.

## Why

Streamed RSC responses already expose Rails shell timing, but renderer prepare time was not browser-visible on the final streamed response. This makes the renderer-side prepare phase visible in the same Server-Timing header while preserving existing entries.

## Implementation

- Capture renderer prepare Server-Timing metrics from Node renderer HTTP responses.
- Append renderer metrics to existing streamed RSC Server-Timing entries before headers commit.
- Preserve existing Server-Timing values and document the combined Rails/renderer timing surface.

## Validation

- (cd react_on_rails_pro && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion lib/react_on_rails_pro/renderer_http_client.rb lib/react_on_rails_pro/concerns/stream.rb spec/react_on_rails_pro/renderer_http_client_spec.rb spec/react_on_rails_pro/stream_spec.rb)
- (cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/renderer_http_client_spec.rb spec/react_on_rails_pro/stream_spec.rb)
- (cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/stream_request_spec.rb spec/react_on_rails_pro/request_spec.rb)
- script/check-pro-license-headers
- pnpm exec prettier --check docs/pro/streaming-ssr.md
- pnpm start format.listDifferent
- git diff --check

No benchmark rerun: issue #4479 explicitly requested no benchmark rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced RSC Server-Timing observability in the browser to include renderer timing (in addition to existing shell timing) when enabled.
  * Renderer `Server-Timing` values are sanitized and accumulated across renderer responses, with isolation to prevent cross-stream leakage.
* **Bug Fixes**
  * Streamed RSC responses now preserve any existing `Server-Timing` entries and append renderer timing details instead of replacing them.
  * Retry flows now roll back only renderer timing from the failed attempt.
* **Documentation**
  * Updated server-timing attribution guidance and benchmark reading instructions to match the expanded metrics.
* **Tests**
  * Added coverage for header normalization, accumulation, sanitization, and retry rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->