### PR TITLE
Fix minimum conversion React overrides

### DIFF
--- a/script/convert
+++ b/script/convert
@@ -7,6 +7,7 @@ require "json"
 # This script converts the codebase to use minimum supported dependency versions.
 # It's run during CI when testing the "minimum" dependency matrix to ensure
 # backward compatibility.
+# Tests: bash script/convert-test.bash
 #
 # React/Shakapacker version compatibility is now tested through generator smoke tests
 # (see examples_config.yml for minimum version examples like basic-minimum).
@@ -57,6 +58,20 @@ def remove_file(path)
   warn "Warning: File not found: #{path}"
 end
 
+MINIMUM_REACT_OVERRIDE_KEYS = %w[
+  react_on_rails>react
+  react_on_rails>react-dom
+  react-on-rails-pro>react
+  react-on-rails-pro>react-dom
+  react-on-rails-pro>react-on-rails-rsc
+  react-on-rails-pro-node-renderer>react
+  react-on-rails-pro-node-renderer>react-dom
+  react-on-rails-pro-node-renderer>react-on-rails-rsc
+  react_on_rails_pro_dummy>react
+  react_on_rails_pro_dummy>react-dom
+  react_on_rails_pro_dummy>react-on-rails-rsc
+].freeze
+
 # The below packages don't work on the oldest supported Node version and aren't needed there anyway
 # Note: All dev dependencies remain in root package.json even after workspace migration
 gsub_file_content("../package.json", /"[^"]*eslint[^"]*": "[^"]*",?/, "")
@@ -83,8 +98,7 @@ update_json_file("../package.json") do |package_json|
   overrides = package_json.dig("pnpm", "overrides")
   next false unless overrides
 
-  overrides.delete("react_on_rails>react")
-  overrides.delete("react_on_rails>react-dom")
+  MINIMUM_REACT_OVERRIDE_KEYS.each { |key| overrides.delete(key) }
 end
 gsub_file_content("../react_on_rails/spec/dummy/config/routes.rb",
                   /^\s*get "client_side_activity" => "pages#client_side_activity"\n/, "")

--- a/script/convert-test.bash
+++ b/script/convert-test.bash
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Test harness for script/convert. Requires bash and ruby. Run with
+# `bash script/convert-test.bash`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONVERT="$SCRIPT_DIR/convert"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+FAILURES=()
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$CURRENT_TEST: $message")
+  echo "  FAIL: $message" >&2
+}
+
+assert_json_key_absent() {
+  local json_file="$1"
+  local key="$2"
+
+  if ruby -rjson -e 'abort if JSON.parse(File.read(ARGV[0])).dig("pnpm", "overrides").key?(ARGV[1])' \
+    "$json_file" "$key"; then
+    return 0
+  fi
+
+  fail "expected pnpm.overrides to omit $key"
+  return 1
+}
+
+assert_json_key_present() {
+  local json_file="$1"
+  local key="$2"
+
+  if ruby -rjson -e 'abort unless JSON.parse(File.read(ARGV[0])).dig("pnpm", "overrides").key?(ARGV[1])' \
+    "$json_file" "$key"; then
+    return 0
+  fi
+
+  fail "expected pnpm.overrides to keep $key"
+  return 1
+}
+
+run_test() {
+  local test_fn="$1"
+  CURRENT_TEST="$test_fn"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $test_fn"
+
+  local tmpdir before_failed
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/convert-test.XXXXXX")"
+  before_failed="$TESTS_FAILED"
+
+  set +e
+  (
+    set -euo pipefail
+    cd "$tmpdir" || exit 1
+    "$test_fn"
+  )
+  local rc=$?
+  set -e
+
+  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
+    echo "  FAIL: subshell exited $rc" >&2
+  fi
+
+  if [ "$rc" -ne 0 ] && [ "${KEEP_CONVERT_TEST_TMP:-}" = "1" ]; then
+    echo "  Keeping failed fixture at $tmpdir" >&2
+  else
+    rm -rf "$tmpdir"
+  fi
+}
+
+write_fixture() {
+  mkdir -p script packages/react-on-rails-pro react_on_rails/spec/dummy/config
+  cp "$CONVERT" script/convert
+
+  cat > package.json <<'JSON'
+{
+  "name": "react-on-rails-fixture",
+  "dependencies": {
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "16.3.0",
+    "eslint": "9.0.0",
+    "globals": "16.0.0",
+    "knip": "5.0.0",
+    "publint": "0.3.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "react": "$react",
+      "react-dom": "$react-dom",
+      "app>react": "^18.3.1",
+      "app>react-dom": "^18.3.1",
+      "react_on_rails>react": "^19.2.0",
+      "react_on_rails>react-dom": "^19.2.0",
+      "react-on-rails-pro>react": "~19.2.7",
+      "react-on-rails-pro>react-dom": "~19.2.7",
+      "react-on-rails-pro>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro-node-renderer>react": "~19.2.7",
+      "react-on-rails-pro-node-renderer>react-dom": "~19.2.7",
+      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1-rc.0",
+      "react_on_rails_pro_dummy>react": "~19.2.7",
+      "react_on_rails_pro_dummy>react-dom": "~19.2.7",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1-rc.0",
+      "sentry-testkit>express": "npm:empty-npm-package@1.0.0"
+    }
+  }
+}
+JSON
+
+  cat > packages/react-on-rails-pro/package.json <<'JSON'
+{
+  "name": "react-on-rails-pro",
+  "scripts": {
+    "test:non-rsc": "jest tests --testPathIgnorePatterns=\"tests/.*(RSC|stream).*\""
+  },
+  "dependencies": {
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  }
+}
+JSON
+
+  cat > react_on_rails/spec/dummy/package.json <<'JSON'
+{
+  "name": "react_on_rails_dummy",
+  "dependencies": {
+    "@dr.pogodin/react-helmet": "3.0.0",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  }
+}
+JSON
+
+  cat > react_on_rails/spec/dummy/config/routes.rb <<'RUBY'
+Rails.application.routes.draw do
+  get "client_side_activity" => "pages#client_side_activity"
+  get "server_side_activity" => "pages#server_side_activity"
+end
+RUBY
+
+  mkdir -p \
+    react_on_rails/spec/dummy/app/views/pages \
+    react_on_rails/spec/dummy/client/app/startup \
+    react_on_rails/spec/dummy/spec/requests \
+    react_on_rails/spec/dummy/spec/system
+  touch \
+    react_on_rails/spec/dummy/app/views/pages/client_side_activity.html.erb \
+    react_on_rails/spec/dummy/app/views/pages/server_side_activity.html.erb \
+    react_on_rails/spec/dummy/client/app/startup/ActivityTabSwitcher.tsx \
+    react_on_rails/spec/dummy/spec/requests/activity_component_spec.rb \
+    react_on_rails/spec/dummy/spec/system/activity_spec.rb
+}
+
+test_strips_react_19_only_workspace_overrides() {
+  write_fixture
+
+  ruby script/convert
+
+  local removed_key
+  for removed_key in \
+    "react_on_rails>react" \
+    "react_on_rails>react-dom" \
+    "react-on-rails-pro>react" \
+    "react-on-rails-pro>react-dom" \
+    "react-on-rails-pro>react-on-rails-rsc" \
+    "react-on-rails-pro-node-renderer>react" \
+    "react-on-rails-pro-node-renderer>react-dom" \
+    "react-on-rails-pro-node-renderer>react-on-rails-rsc" \
+    "react_on_rails_pro_dummy>react" \
+    "react_on_rails_pro_dummy>react-dom" \
+    "react_on_rails_pro_dummy>react-on-rails-rsc"; do
+    assert_json_key_absent package.json "$removed_key"
+  done
+
+  assert_json_key_present package.json "react"
+  assert_json_key_present package.json "react-dom"
+  assert_json_key_present package.json "app>react"
+  assert_json_key_present package.json "sentry-testkit>express"
+}
+
+run_test test_strips_react_19_only_workspace_overrides
+
+if [ "$TESTS_FAILED" -eq 0 ]; then
+  echo "PASS: $TESTS_RUN tests"
+else
+  echo "FAIL: $TESTS_FAILED of $TESTS_RUN tests failed" >&2
+  printf ' - %s\n' "${FAILURES[@]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

`main` is red in the Node 20 minimum-dependency package-js lane after PR #4490 added React 19.2-scoped pnpm overrides for Pro/RSC workspaces. `script/convert` lowered the root React packages for the minimum lane, but it only removed the old OSS-scoped overrides, so pnpm could still force React 19.2-only Pro/RSC dependencies into a lane that should skip those tests.

Fixes #4492.

## What Changed

- Centralized the scoped React/RSC override keys that minimum conversion must remove.
- Removed the Pro package, Pro node renderer, and Pro dummy scoped React/RSC overrides along with the existing OSS scoped overrides.
- Added `script/convert-test.bash`, a focused fixture-based regression test for the conversion behavior.

## Validation

- `bash -n script/convert-test.bash` -> pass
- `ruby -c script/convert` -> pass
- `bash script/convert-test.bash` -> pass
- `git diff --check origin/main...HEAD` -> pass
- `script/ci-changes-detector origin/main` -> CI infrastructure; recommends broad validation/hosted confirmation
- pre-commit hook -> pass (`trailing-newlines`)
- pre-push hook -> pass (`branch-lint`, `markdown-links`)

## Review Gate

- Primary local review: `codex review --base origin/main` -> no discrete correctness issues found.
- Additional Claude review: attempted `claude -p "/code-review origin/main...HEAD"`; unavailable because the account hit the weekly limit, resetting at 9pm Pacific/Honolulu.

## CI / Release Gate Notes

- Changelog classification: `not_user_visible` (CI/minimum-lane repair only).
- Workflow change audit: not applicable; this PR does not modify `.github/workflows/**` or `.github/actions/**`.
- Hosted CI: this is CI infrastructure and `script/ci-changes-detector origin/main` selected broad validation, so I will request optimized hosted CI with `+ci-run-hosted` after PR creation.

## Codex Decision Log

- **Non-blocking:** Whether to add this new test to `ci-required.yml` in the red-main fix PR.
  - **Decision:** Keep #4492 scoped to `script/convert` plus its focused test harness and leave workflow gate changes to #4493.
  - **Why:** The batch file-touch map gives #4493 ownership of CI-gate workflow changes, and #4492 needs the narrow red-main conversion fix first.
  - **Review later:** #4493 should decide whether `script/convert-test.bash` belongs in a required gate or a broader script-test bundle.

## Batch Evidence

- Batch: `react_on_rails-07-06-1908-red-main-release-gates`
- Lane: `issue4492-red-main` / `codex-4492-red-main`
- Private coordination: claim acquired against local coordination state; heartbeat refreshed through review clean state.
- Security preflight: `SECURITY_PREFLIGHT_OK` for #4492-#4496 before worker launch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency conversion so more React-related override entries are removed consistently during package updates.
  * Kept the expected React overrides intact while clearing workspace-specific entries that should not carry over.
* **Tests**
  * Added automated coverage for the conversion workflow to verify the correct override keys are removed or preserved.
  * Test runs now execute in isolated temporary directories for cleaner, more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->