### PR TITLE
Docs: repair Pro release integrity notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -495,10 +495,6 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4477](https://github.com/shakacode/react_on_rails/pull/4477) by
   [justin808](https://github.com/justin808).
 
-#### Removed
-
-- **[Pro]** **Removed the `react-on-rails-pro/rscPayloadNode` export and its `createRscPayloadNode` helper**: The duplicate RSC payload route-data API added during the 17.0 RC line (in [PR 3783](https://github.com/shakacode/react_on_rails/pull/3783)) is gone; `RSCRoute` is the canonical Pro RSC client-router integration. Client-router loaders return plain route data (`componentName`, `componentProps`) and route components render `RSCRoute`, which keeps React on Rails Pro in control of payload fetching, caching, embedded SSR payload reuse, and retry behavior. This affects only the not-yet-released Pro RSC feature line. Fixes [Issue 4439](https://github.com/shakacode/react_on_rails/issues/4439). [PR 4440](https://github.com/shakacode/react_on_rails/pull/4440) by [ihabadham](https://github.com/ihabadham).
-
 ### [17.0.0.rc.6] - 2026-06-21
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **Removed the inert `config.server_render_method` option**: The open-source configuration no longer accepts `config.server_render_method`. The option never selected a server render method — the open-source gem always renders with ExecJS — and its validator raised `ReactOnRails::Error` at boot for any value other than blank or `"ExecJS"`. Setting it now raises `NoMethodError` at boot, so delete any `config.server_render_method = ...` line from `config/initializers/react_on_rails.rb`; `rake react_on_rails:doctor` also flags the stale line. For a standalone Node rendering process, use React on Rails Pro's Node renderer, configured via `ReactOnRailsPro.configure`. Fixes [Issue 4415](https://github.com/shakacode/react_on_rails/issues/4415). [PR 4423](https://github.com/shakacode/react_on_rails/pull/4423) by [justin808](https://github.com/justin808).
 - **Removed three deprecated configuration options** (`config.generated_assets_dirs`, `config.skip_display_none`, `config.defer_generated_component_packs`): These were deprecated in v16 and are gone in v17. Setting any of them now raises `NoMethodError` at boot; delete the stale lines from `config/initializers/react_on_rails.rb` (`rake react_on_rails:doctor` flags them). Migration: delete `config.generated_assets_dirs` — public asset paths come from `public_output_path` in `config/shakapacker.yml`; delete `config.skip_display_none` — it had no runtime effect; replace `config.defer_generated_component_packs = true` with `config.generated_component_packs_loading_strategy = :defer`, and simply delete `config.defer_generated_component_packs = false` (the removed option was truthy-gated — only `= true` set `:defer`; `= false` was a no-op that fell through to the default strategy, so it did **not** mean `:sync`; set `:sync` explicitly only if you relied on synchronous loading). The default strategy is `:async` for Pro or `:defer` for non-Pro on Shakapacker 8.2.0+, and `:sync` on older Shakapacker. Fixes [Issue 4419](https://github.com/shakacode/react_on_rails/issues/4419). [PR 4432](https://github.com/shakacode/react_on_rails/pull/4432) by [justin808](https://github.com/justin808).
 - **Removed the never-wired `RenderRequest` / `JsCodeBuilder` / `RenderingStrategy` rendering layer**: The internal strategy-pattern classes `ReactOnRails::RenderRequest`, `ReactOnRails::JsCodeBuilder`, `ReactOnRails::RenderingStrategy` (with `ExecJsStrategy`), and — in Pro — `ReactOnRailsPro::JsCodeBuilder` and `ReactOnRailsPro::RenderingStrategy::NodeStrategy`, plus the undocumented `ReactOnRails.rendering_strategy` and `ReactOnRails.js_code_builder` module accessors, are removed. This scaffolding was built for the strategy-pattern refactor in [Issue 2905](https://github.com/shakacode/react_on_rails/issues/2905) (closed without wiring it in) and was never invoked on any production server-rendering path — SSR runs through `ServerRenderingJsCode` and `ServerRenderingPool`, which never touched this layer. These constants and accessors were internal and undocumented; if you reference them in application code, remove the reference (the layer performed no work). Fixes [Issue 4414](https://github.com/shakacode/react_on_rails/issues/4414). [PR 4437](https://github.com/shakacode/react_on_rails/pull/4437) by [justin808](https://github.com/justin808).
+- **Removed undocumented `ReactOnRails::Utils` helpers**: React on Rails 17 removes the unused `ReactOnRails::Utils.server_rendering_is_enabled?` and `ReactOnRails::Utils.rails_version_less_than` helper methods. Remove any application calls to those helpers; release-example generation now owns its private Rails-version check outside the public `Utils` surface. Fixes [Issue 4418](https://github.com/shakacode/react_on_rails/issues/4418). [PR 4431](https://github.com/shakacode/react_on_rails/pull/4431) by [justin808](https://github.com/justin808).
 
 #### Added
 
@@ -151,6 +152,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   path uses. [PR 4452](https://github.com/shakacode/react_on_rails/pull/4452) by
   [ihabadham](https://github.com/ihabadham).
 
+- **Render helpers no longer mutate caller-supplied option hashes**:
+  `create_render_options` now duplicates helper options before adding default store dependencies and
+  internal observability state, so reused or frozen render option hashes are left untouched. Fixes
+  [Issue 4343](https://github.com/shakacode/react_on_rails/issues/4343).
+  [PR 4396](https://github.com/shakacode/react_on_rails/pull/4396) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Sync RSC route failures surface as `ServerComponentFetchError`**: Synchronous throws
   in the RSC payload path (payload key creation on BigInt/circular props, sync
   `getServerComponent` throws, `fetchRSC` request preparation) previously bypassed
@@ -172,7 +180,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **[Pro]** **Truncated RSC parser streams now warn at EOF**: The Pro RSC length-prefixed stream
   parser flushes at stream end so incomplete trailing records emit the existing parser warning,
-  while expected request-abort cleanup remains quiet.
+  while expected request-abort cleanup remains quiet. Fixes
+  [Issue 4370](https://github.com/shakacode/react_on_rails/issues/4370).
   [PR 4392](https://github.com/shakacode/react_on_rails/pull/4392) by
   [justin808](https://github.com/justin808).
 
@@ -187,14 +196,16 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **[Pro]** **RSC stylesheet inference retries after transient stats read failures**: Pro now caches
   client-chunk stylesheet metadata only after a successful `loadable-stats.json` read, so a
   deploy-race or temporary parse/read failure does not disable inferred RSC client stylesheets for
-  the worker lifetime.
+  the worker lifetime. Fixes
+  [Issue 4371](https://github.com/shakacode/react_on_rails/issues/4371).
   [PR 4401](https://github.com/shakacode/react_on_rails/pull/4401) by
   [justin808](https://github.com/justin808).
 
 - **[Pro]** **RSC loadable-stats retry diagnostics stay visible**: Malformed or unreadable
   `loadable-stats.json` warnings are suppressed only for the retry window, and native ESM stack
   paths rewritten through source maps are normalized back to the runtime `lib/` directory before
-  resolving stats.
+  resolving stats. Follow-up to
+  [PR 4401](https://github.com/shakacode/react_on_rails/pull/4401).
   [PR 4447](https://github.com/shakacode/react_on_rails/pull/4447) by
   [justin808](https://github.com/justin808).
 
@@ -224,13 +235,6 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   propagating those failures on clean stream completion. Fixes
   [Issue 4364](https://github.com/shakacode/react_on_rails/issues/4364).
   [PR 4389](https://github.com/shakacode/react_on_rails/pull/4389) by
-  [justin808](https://github.com/justin808).
-
-- **[Pro]** **Async-props prerender stream cache isolation**: Pro prerender stream caching now
-  bypasses renders that use async props, so per-request async stream output cannot be replayed from
-  another request's cached stream. Fixes
-  [Issue 4359](https://github.com/shakacode/react_on_rails/issues/4359).
-  [PR 4376](https://github.com/shakacode/react_on_rails/pull/4376) by
   [justin808](https://github.com/justin808).
 
 - **Preload links stay compatible with older Shakapacker**: `react_on_rails_preload_links` now
@@ -328,9 +332,47 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **[Pro]** **Cached component hits load generated packs consistently**:
   Pro cached component helpers now share the `ReactOnRailsPro::Cache.fetch_react_component` path and
   run the cache-hit pack-loading callback, so cached `cached_react_component` and
-  `cached_react_component_hash` output preserves generated pack behavior. Fixes
+  `cached_react_component_hash` output preserves generated pack behavior.
+  Explicit per-call `auto_load_bundle: false` now also wins over the global auto-load default on both
+  cache hits and misses, so static or sidecar-owned renders can reliably skip generated pack tags. Fixes
   [Issue 4316](https://github.com/shakacode/react_on_rails/issues/4316).
   [PR 4384](https://github.com/shakacode/react_on_rails/pull/4384) by
+  [justin808](https://github.com/justin808).
+
+- **`hydrate_on: visible` cleanup no longer retains detached roots**:
+  Visible hydration now clears the scheduled root entry when the observed DOM node is detached before it
+  becomes visible, avoiding stale references and allowing a replacement node with the same DOM id to schedule
+  normally. Fixes [Issue 4328](https://github.com/shakacode/react_on_rails/issues/4328).
+  [PR 4374](https://github.com/shakacode/react_on_rails/pull/4374) by
+  [justin808](https://github.com/justin808).
+
+- **[Pro]** **Fire-and-forget `RSCRoute` retries avoid unhandled rejections**:
+  Production recover-on-error retries now attach an internal rejection handler for callers that intentionally
+  do not await the retry promise, while preserving the rejected promise contract for callers that do.
+  Fixes [Issue 4330](https://github.com/shakacode/react_on_rails/issues/4330).
+  [PR 4378](https://github.com/shakacode/react_on_rails/pull/4378) by
+  [justin808](https://github.com/justin808).
+
+#### Removed
+
+- **[Pro]** **Removed the RC-only RSC payload route-data helper**:
+  The `react-on-rails-pro/rscPayloadNode` package subpath and `createRscPayloadNode` helper, introduced
+  during the 17.0.0 RC cycle, are removed before 17.0.0 final. Client-router loaders should return plain
+  route data and render through `RSCRoute`, so Pro owns payload fetching, embedded SSR payload reuse,
+  caching, and retry behavior. Fixes [Issue 4439](https://github.com/shakacode/react_on_rails/issues/4439).
+  [PR 4440](https://github.com/shakacode/react_on_rails/pull/4440) by
+  [ihabadham](https://github.com/ihabadham).
+
+#### Security
+
+- **[Pro]** **Async-props prerender stream cache isolation**:
+  Pro prerender stream caching now bypasses renders that use async props, keeping per-request async stream
+  output isolated from prerender-cache hits. Prerelease builds `v16.7.0.rc.0` through `v16.7.0.rc.3` and
+  `v17.0.0.rc.0` through `v17.0.0.rc.6` included async-props streaming before this fix; no stable tag
+  contains the affected async-props feature. Upgrade to a 17.0.0 RC or final release that includes this fix
+  before enabling global prerender caching on async-props streaming pages. Fixes
+  [Issue 4359](https://github.com/shakacode/react_on_rails/issues/4359).
+  [PR 4376](https://github.com/shakacode/react_on_rails/pull/4376) by
   [justin808](https://github.com/justin808).
 
 - **Precompile hook no longer forces UTF-8 onto a non-UTF-8 locale**:
@@ -530,7 +572,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Added
 
-- **[Pro]** **Route-loader RSC payload helper**: `react-on-rails-pro/rscPayloadNode` now exports `createRscPayloadNode(...)` so client routers and loaders can consume the Pro RSC payload route as React route data without reaching into private `RSCRoute` internals. The helper defaults to same-origin credentials, exposes a narrow set of fetch controls (`credentials`, `headers`, and `signal`), and keeps console replay metadata out of inline scripts for CSP-friendly loader usage. RSC payload fetches now URL-encode component names before requesting `/rsc_payload/:componentName`, which preserves standard Rails path-segment decoding while avoiding invalid path characters in the browser request URL. Fixes [Issue 3493](https://github.com/shakacode/react_on_rails/issues/3493). [PR 3783](https://github.com/shakacode/react_on_rails/pull/3783) by [justin808](https://github.com/justin808).
+- **[Pro]** **Route-loader RSC payload helper**: `react-on-rails-pro/rscPayloadNode` now exports `createRscPayloadNode(...)` so client routers and loaders can consume the Pro RSC payload route as React route data without reaching into private `RSCRoute` internals. The helper defaults to same-origin credentials, exposes a narrow set of fetch controls (`credentials`, `headers`, and `signal`), and keeps console replay metadata out of inline scripts for CSP-friendly loader usage. RSC payload fetches now URL-encode component names before requesting `/rsc_payload/:componentName`, which preserves standard Rails path-segment decoding while avoiding invalid path characters in the browser request URL. This RC-only helper was removed before 17.0.0 final in [PR 4440](https://github.com/shakacode/react_on_rails/pull/4440); final users should use the `RSCRoute` client-router loader pattern instead. Fixes [Issue 3493](https://github.com/shakacode/react_on_rails/issues/3493). [PR 3783](https://github.com/shakacode/react_on_rails/pull/3783) by [justin808](https://github.com/justin808).
 - **[Pro]** **RSC registration entry path override**: Generated RSC precompile hooks, discovery builds, and client-reference stale checks now honor `REACT_ON_RAILS_RSC_REGISTRATION_ENTRY_PATH` so apps that write `server-component-registration-entry.js` outside the default generated path can point React on Rails Pro at the exact entry while retaining the existing fallback scan and stale-manifest cleanup. Fixes [Issue 3621](https://github.com/shakacode/react_on_rails/issues/3621). [PR 3712](https://github.com/shakacode/react_on_rails/pull/3712) by [justin808](https://github.com/justin808).
 - **[Pro]** **RSC `unstable_cache` with Redis L2 and tiered caching**: Added `unstable_cache` for RSC rendering with deterministic cache-key serialization (React flight protocol encoding with sorted object keys), a `RedisCacheHandler` for cross-worker L2 caching, a `TieredCacheHandler` for L1/L2 composition with configurable L1 TTL caps, and per-worker single-flight render coalescing. Resolves [Issue 3702](https://github.com/shakacode/react_on_rails/issues/3702). [PR 3705](https://github.com/shakacode/react_on_rails/pull/3705).
 - **[Pro]** **RSC manifest client reference discovery during precompile**: Generated RSC Webpack configs now run `RSCReferenceDiscoveryPlugin` through the Shakapacker precompile hook to emit `rsc-client-references.json`, use that manifest for RSC client-reference bundling, and warn when the selected manifest is stale. The generator now pins `react-on-rails-rsc` to `19.0.5-rc.6`, the prerelease containing the discovery plugin export and RSC manifest CSS fixes, and the Pro peer range explicitly accepts that prerelease. [PR 3556](https://github.com/shakacode/react_on_rails/pull/3556) by [ihabadham](https://github.com/ihabadham).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,6 +375,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4376](https://github.com/shakacode/react_on_rails/pull/4376) by
   [justin808](https://github.com/justin808).
 
+#### Fixed
+
 - **Precompile hook no longer forces UTF-8 onto a non-UTF-8 locale**:
   The shared Shakapacker precompile hook now widens a spawned `bundle exec` / shakapacker subprocess
   to UTF-8 **only** under a bare C/POSIX locale, where the locale-derived encoding is US-ASCII — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,28 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **[Pro]** **Missing renderer password error now leads with the local-development fix**: When the Pro renderer password is unset and both `RAILS_ENV` and `NODE_ENV` are unset, the fail-closed error from both the Ruby configuration guard and the Node renderer now includes explicit `export RAILS_ENV=development NODE_ENV=development` guidance. Password-optional behavior for explicit development/test envs and password-required behavior for production-like or mixed envs are unchanged. Fixes [Issue 4201](https://github.com/shakacode/react_on_rails/issues/4201). [PR 4211](https://github.com/shakacode/react_on_rails/pull/4211) by [justin808](https://github.com/justin808).
 
+#### Removed
+
+- **[Pro]** **Removed the RC-only RSC payload route-data helper**:
+  The `react-on-rails-pro/rscPayloadNode` package subpath and `createRscPayloadNode` helper, introduced
+  during the 17.0.0 RC cycle, are removed before 17.0.0 final. Client-router loaders should return plain
+  route data and render through `RSCRoute`, so Pro owns payload fetching, embedded SSR payload reuse,
+  caching, and retry behavior. Fixes [Issue 4439](https://github.com/shakacode/react_on_rails/issues/4439).
+  [PR 4440](https://github.com/shakacode/react_on_rails/pull/4440) by
+  [ihabadham](https://github.com/ihabadham).
+
+#### Security
+
+- **[Pro]** **Async-props prerender stream cache isolation**:
+  Pro prerender stream caching now bypasses renders that use async props, keeping per-request async stream
+  output isolated from prerender-cache hits. Prerelease builds `v16.7.0.rc.0` through `v16.7.0.rc.3` and
+  `v17.0.0.rc.0` through `v17.0.0.rc.6` included async-props streaming before this fix; no stable tag
+  contains the affected async-props feature. Upgrade to a 17.0.0 RC or final release that includes this fix
+  before enabling global prerender caching on async-props streaming pages. Fixes
+  [Issue 4359](https://github.com/shakacode/react_on_rails/issues/4359).
+  [PR 4376](https://github.com/shakacode/react_on_rails/pull/4376) by
+  [justin808](https://github.com/justin808).
+
 #### Fixed
 
 - **`hydrate_on: visible` no longer leaks a detached root or blocks re-hydrating a replacement node**: When a `hydrate_on: visible` target was detached from the DOM before it became visible, the intersection observer left a stale scheduled root entry that kept the removed node reachable and could stop a replacement node with the same DOM id from scheduling its own hydration. The observer now runs its scheduled callback after disconnecting from a detached target; the callback's existing `isConnected` guard deletes the stale entry without hydrating the removed node, so a fresh node with the same id schedules cleanly. Fixes [Issue 4328](https://github.com/shakacode/react_on_rails/issues/4328). [PR 4374](https://github.com/shakacode/react_on_rails/pull/4374) by [justin808](https://github.com/justin808).
@@ -352,30 +374,6 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   Fixes [Issue 4330](https://github.com/shakacode/react_on_rails/issues/4330).
   [PR 4378](https://github.com/shakacode/react_on_rails/pull/4378) by
   [justin808](https://github.com/justin808).
-
-#### Removed
-
-- **[Pro]** **Removed the RC-only RSC payload route-data helper**:
-  The `react-on-rails-pro/rscPayloadNode` package subpath and `createRscPayloadNode` helper, introduced
-  during the 17.0.0 RC cycle, are removed before 17.0.0 final. Client-router loaders should return plain
-  route data and render through `RSCRoute`, so Pro owns payload fetching, embedded SSR payload reuse,
-  caching, and retry behavior. Fixes [Issue 4439](https://github.com/shakacode/react_on_rails/issues/4439).
-  [PR 4440](https://github.com/shakacode/react_on_rails/pull/4440) by
-  [ihabadham](https://github.com/ihabadham).
-
-#### Security
-
-- **[Pro]** **Async-props prerender stream cache isolation**:
-  Pro prerender stream caching now bypasses renders that use async props, keeping per-request async stream
-  output isolated from prerender-cache hits. Prerelease builds `v16.7.0.rc.0` through `v16.7.0.rc.3` and
-  `v17.0.0.rc.0` through `v17.0.0.rc.6` included async-props streaming before this fix; no stable tag
-  contains the affected async-props feature. Upgrade to a 17.0.0 RC or final release that includes this fix
-  before enabling global prerender caching on async-props streaming pages. Fixes
-  [Issue 4359](https://github.com/shakacode/react_on_rails/issues/4359).
-  [PR 4376](https://github.com/shakacode/react_on_rails/pull/4376) by
-  [justin808](https://github.com/justin808).
-
-#### Fixed
 
 - **Precompile hook no longer forces UTF-8 onto a non-UTF-8 locale**:
   The shared Shakapacker precompile hook now widens a spawned `bundle exec` / shakapacker subprocess

--- a/docs/pro/fragment-caching.md
+++ b/docs/pro/fragment-caching.md
@@ -26,6 +26,11 @@ Fragment caching skips all four steps when the cache is warm. This is different 
 
 **Recommendation**: Start with prerender caching (`config.prerender_caching = true`), then add fragment caching to your most expensive components.
 
+Prerender caching does not apply to `stream_react_component_with_async_props` or other async-props renders. Those
+renders can include per-request async output that is not represented in the prerender cache key, so React on Rails Pro
+renders them uncached on that layer. For async-props pages, use fragment-caching helpers only around content with an
+explicit cache key that is safe to share across requests, or leave the async stream uncached.
+
 ## Usage
 
 Use `cached_react_component` instead of `react_component`. The key differences:

--- a/docs/pro/installation.md
+++ b/docs/pro/installation.md
@@ -347,6 +347,13 @@ ReactOnRailsPro.configure do |config|
 end
 ```
 
+> [!IMPORTANT]
+> `config.prerender_caching` is safe for ordinary prerendered and streamed renders, but React on Rails Pro skips that
+> cache for `stream_react_component_with_async_props` and other async-props renders. Async props can include
+> per-request data that is not part of the prerender cache key. Keep prerender caching enabled as a default performance
+> win, but use explicit fragment cache keys for async-props pages only when the rendered output is safe to share across
+> requests.
+
 ### Configuration Options
 
 See [Rails Configuration Options](../oss/configuration/configuration-pro.md) for all available settings.
@@ -356,7 +363,8 @@ Pay attention to:
 - `config.server_renderer = "NodeRenderer"` - Required to use node renderer
 - `config.renderer_url` - URL where your node renderer is running
 - `config.renderer_password` - Shared secret for authentication
-- `config.prerender_caching` - Enable caching (recommended)
+- `config.prerender_caching` - Enable prerender caching for supported SSR/streaming renders; async-props renders skip
+  this cache
 
 ## Webpack Configuration
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -55,6 +55,11 @@ Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer
   <img src="images/async-props-sequence.svg" alt="Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks for a page, Rails starts the page with placeholders, the renderer returns an HTML shell with loading states, and the browser shows the shell. Then a loop runs for each slow data value: Rails sends the value, the renderer returns the HTML for that section, and the browser replaces the loading state." width="840" />
 </p>
 
+`config.prerender_caching` does not cache async-props streams. React on Rails Pro bypasses prerender caching for
+`stream_react_component_with_async_props` because the async output can depend on request-specific data outside the
+prerender cache key. Use explicit fragment cache keys only for async-props content that is safe to reuse across
+requests.
+
 The view helper is `stream_react_component_with_async_props`, which yields an emitter:
 
 ```erb

--- a/internal/analysis/2026-07-07-async-props-prerender-cache-security-decision.md
+++ b/internal/analysis/2026-07-07-async-props-prerender-cache-security-decision.md
@@ -1,0 +1,40 @@
+# Async Props Prerender Cache Security Decision
+
+Date: 2026-07-07
+
+## Scope
+
+This note records the release-note and GitHub Security Advisory decision for the React on Rails Pro async-props
+prerender-cache isolation fix in PR 4376 / commit `cdcba5438dd559a5e54029b1b6931b8ddc6d7beb`.
+
+## Live Evidence
+
+- `git tag --contains cdcba5438` returned no tags.
+- `git merge-base --is-ancestor cdcba5438 v17.0.0.rc.6` exited 1, so the latest visible 17.0.0 RC does not contain the fix.
+- `git merge-base --is-ancestor cdcba5438 origin/main` exited 0, so `origin/main` contains the fix.
+- `gh release list --repo shakacode/react_on_rails --limit 20` showed visible releases through `v17.0.0.rc.6`.
+- `gh api -H 'Accept: application/vnd.github+json' '/repos/shakacode/react_on_rails/security-advisories' --paginate` returned `[]`.
+- `gh api -H 'Accept: application/vnd.github+json' '/repos/shakacode/react_on_rails/security-advisories?state=open' --paginate` returned `[]`.
+- `git tag --contains 814c19c50` showed the async-props feature in `v16.7.0.rc.0` through `v16.7.0.rc.3` and
+  `v17.0.0.rc.0` through `v17.0.0.rc.6`.
+- `git merge-base --is-ancestor 814c19c50 v16.6.0` exited 1, so the last stable `16.x` release did not contain the
+  async-props feature.
+
+## Decision
+
+Do not request or publish a GHSA/CVE for this lane based on current evidence. The affected async-props feature and the
+fix are both in the prerelease train only, and no stable release tag contains the affected feature. If later evidence
+shows a stable release or supported customer build contains the affected behavior, reopen advisory triage and use the
+private GitHub advisory path described in `SECURITY.md`.
+
+## Public Release-Note Framing
+
+Use this public-safe framing:
+
+> Pro prerender stream caching now bypasses renders that use async props, keeping per-request async stream output
+> isolated from prerender-cache hits. Prerelease builds `v16.7.0.rc.0` through `v16.7.0.rc.3` and `v17.0.0.rc.0`
+> through `v17.0.0.rc.6` included async-props streaming before this fix; no stable tag contains the affected
+> async-props feature. Upgrade to a 17.0.0 RC or final release that includes this fix before enabling global
+> prerender caching on async-props streaming pages.
+
+Do not include reproduction steps, cache-key internals, or exploit payload details in public release notes.

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1309,6 +1309,13 @@ ReactOnRailsPro.configure do |config|
 end
 ```
 
+> [!IMPORTANT]
+> `config.prerender_caching` is safe for ordinary prerendered and streamed renders, but React on Rails Pro skips that
+> cache for `stream_react_component_with_async_props` and other async-props renders. Async props can include
+> per-request data that is not part of the prerender cache key. Keep prerender caching enabled as a default performance
+> win, but use explicit fragment cache keys for async-props pages only when the rendered output is safe to share across
+> requests.
+
 ### Configuration Options
 
 See [Rails Configuration Options](../oss/configuration/configuration-pro.md) for all available settings.
@@ -1318,7 +1325,8 @@ Pay attention to:
 - `config.server_renderer = "NodeRenderer"` - Required to use node renderer
 - `config.renderer_url` - URL where your node renderer is running
 - `config.renderer_password` - Shared secret for authentication
-- `config.prerender_caching` - Enable caching (recommended)
+- `config.prerender_caching` - Enable prerender caching for supported SSR/streaming renders; async-props renders skip
+  this cache
 
 ## Webpack Configuration
 
@@ -1917,6 +1925,11 @@ This is the recommended answer to "my component needs Rails data during render":
 Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML back to Rails for forwarding to the browser:
 
 [Diagram: Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks for a page, Rails starts the page with placeholders, the renderer returns an HTML shell with loading states, and the browser shows the shell. Then a loop runs for each slow data value: Rails sends the value, the renderer returns the HTML for that section, and the browser replaces the loading state.]
+
+`config.prerender_caching` does not cache async-props streams. React on Rails Pro bypasses prerender caching for
+`stream_react_component_with_async_props` because the async output can depend on request-specific data outside the
+prerender cache key. Use explicit fragment cache keys only for async-props content that is safe to reuse across
+requests.
 
 The view helper is `stream_react_component_with_async_props`, which yields an emitter:
 
@@ -4016,6 +4029,11 @@ Fragment caching skips all four steps when the cache is warm. This is different 
 | **Best for**               | Quick win with minimal code changes | Maximum performance on high-traffic pages                             |
 
 **Recommendation**: Start with prerender caching (`config.prerender_caching = true`), then add fragment caching to your most expensive components.
+
+Prerender caching does not apply to `stream_react_component_with_async_props` or other async-props renders. Those
+renders can include per-request async output that is not represented in the prerender cache key, so React on Rails Pro
+renders them uncached on that layer. For async-props pages, use fragment-caching helpers only around content with an
+explicit cache key that is safe to share across requests, or leave the async stream uncached.
 
 ## Usage
 


### PR DESCRIPTION
## Why

The 17.0 release notes and Pro docs had drift around the async-props prerender-cache isolation fix and RC-only RSC payload helper removal. The release train needs public-safe security/changelog framing, refreshed Pro docs, regenerated LLM artifacts, and a recorded GHSA decision.

Fixes #4494.
Fixes #4495.

## What Changed

- Promoted the async-props prerender-cache isolation note into the staged `17.0.0.rc.7` security section with prerelease/stable-tag framing; `Unreleased` remains empty while the rc.7 release section is being assembled before publication.
- Recorded the GHSA/CVE decision in `internal/analysis/2026-07-07-async-props-prerender-cache-security-decision.md`.
- Clarified Pro docs that `config.prerender_caching` skips async-props renders and that async-props pages should use explicit fragment keys only when safe.
- Updated the older RC payload-helper changelog entry to point final users to the `RSCRoute` loader pattern.
- Backfilled or corrected staged rc.7 changelog coverage for #4392, #4396, #4374, #4378, #4401, #4431, #4422, #4440, and #4447.
- Regenerated `llms-full-pro.txt`; `llms-full.txt` was refreshed on `main` by #4509 and is no longer part of this branch after the rebase.
- Review fix: restored the `#### Fixed` heading after the new Security section so unrelated fixes render under the correct heading.
- Rebased onto `origin/main` at `5933f8011`, keeping `main`'s newer #4444/#4473 and #4422 changelog entries during conflict resolution.
- Review fix: folded the duplicate lower `#### Removed` changelog block into the existing Unreleased Removed section so MD024 heading uniqueness stays clean.

## Live Evidence

- `git tag --contains cdcba5438` returned no tags.
- Visible GitHub releases still top out at `v17.0.0.rc.6`; `cdcba5438` is on `origin/main` but not in that RC.
- Visible repository security advisories returned `[]` for all visible and open states with the current token.
- The async-props feature commit appears only in prerelease tags `v16.7.0.rc.0` through `v16.7.0.rc.3` and `v17.0.0.rc.0` through `v17.0.0.rc.6`; it is not in stable `v16.6.0`.

## Validation

Current head: `d1a37aa6b4e4d186ecbced35304ba150afdc2330`.

- `.agents/bin/agent-workflow-seam-doctor` -> pass
- `node script/generate-llms-full.mjs` -> regenerated outputs
- `bash script/generate-llms-full-test.bash` -> 7 tests passed
- `node script/generate-llms-full.mjs --check` -> pass; `llms-full.txt` 1573 KiB, `llms-full-pro.txt` 579 KiB, 74 docs URLs and 8 sidebar top-level sections validated
- `node script/generate-llms-full.mjs --validate` -> pass
- `pnpm exec prettier --check CHANGELOG.md docs/pro/fragment-caching.md docs/pro/installation.md docs/pro/streaming-ssr.md internal/analysis/2026-07-07-async-props-prerender-cache-security-decision.md` -> pass
- `script/check-docs-sidebar` -> pass
- `git diff --check` -> pass after rebase
- `pnpm start format.listDifferent` -> pass after rebase and duplicate-heading fix
- `pnpm exec markdownlint-cli2 CHANGELOG.md` -> unavailable locally (`Command "markdownlint-cli2" not found`); duplicate `#### Removed` heading removed by direct changelog inspection
- Review-fix pass: `codex review --base origin/main` -> no discrete correctness issues found

## Review Gate

- Worker review and coordinator review: `codex review --base origin/main` -> no discrete correctness issues found.
- Review threads for the changelog heading and generated-doc source-drift comments were replied to and resolved.

## CI / Release Gate Notes

- Changelog classification: `changelog_present`.
- Workflow change audit: not applicable; this PR does not modify `.github/workflows/**` or `.github/actions/**`.
- Local pre-commit/pre-push hook note: `branch-lint`, Prettier, docs/sidebar, and llms checks passed where applicable, but local `markdown-links` could not run because installed `lychee` v0.24.2 cannot parse the repo `.lychee.toml` `include_fragments = false` value. Hosted docs/link checks are requested for remote confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed undocumented Pro RSC helper methods and the RC-only `rscPayloadNode` export; client-router loaders should return plain route data and rendering should use `RSCRoute`.

* **Bug Fixes**
  * Render helpers no longer mutate caller-provided options; refined streaming retry diagnostics and improved behavior for detached-root cleanup and fire-and-forget RSC retries.

* **Security**
  * Clarified async-props prerender-cache isolation for specific prerelease ranges.

* **Documentation**
  * Updated streaming SSR, fragment caching, and installation guidance: `config.prerender_caching` is skipped for async-props streaming renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


