### PR TITLE
CI: route merge-gate coverage through required gate

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -21,6 +21,7 @@ on:
         default: false
 
 permissions:
+  checks: read
   contents: read
   issues: read
 
@@ -48,7 +49,7 @@ jobs:
   required-pr-gate:
     name: required-pr-gate
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -59,7 +60,7 @@ jobs:
         run: |
           ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].sort.each { |f| YAML.safe_load_file(f, permitted_classes: [], aliases: false); puts f }"
 
-      - name: Validate CI shell scripts
+      - name: Validate CI scripts
         run: |
           for script in \
             bin/ci-local \
@@ -70,13 +71,19 @@ jobs:
           do
             bash -n "$script"
           done
+          ruby -c script/ci-required-merge-group-gate
 
       - name: Run CI gate tests
         run: |
           bash script/ci-required-hosted-gate-test.bash
+          bash script/lint-mirrored-blocks-test.bash
+          ruby script/ci_required_merge_group_gate_test.rb
           node .github/workflows/hosted-ci-safety.test.cjs
           ruby script/pr_merge_ledger_test.rb
           ruby .agents/skills/pr-batch/bin/pr-ci-readiness-test.rb
+
+      - name: Check mirrored blocks
+        run: ruby bin/lint-mirrored-blocks
 
       - name: Fetch workflow dispatch base
         if: github.event_name == 'workflow_dispatch'
@@ -121,6 +128,14 @@ jobs:
             }}
         run: |
           script/ci-required-hosted-gate
+
+      - name: Enforce merge-group package JS minimum gate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUIRE_PACKAGE_JS_BUILD_20: ${{ steps.changes.outputs.run_js_tests }}
+          CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS: |
+            JS unit tests for Renderer package / build (20)|build (20)
+        run: ruby script/ci-required-merge-group-gate
 
       - name: Lightweight repo sanity check
         run: |

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -21,6 +21,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   checks: read
   contents: read
   issues: read
@@ -133,8 +134,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REQUIRE_PACKAGE_JS_BUILD_20: ${{ steps.changes.outputs.run_js_tests }}
-          CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS: |
-            JS unit tests for Renderer package / build (20)|build (20)
         run: ruby script/ci-required-merge-group-gate
 
       - name: Lightweight repo sanity check

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -41,6 +41,28 @@ assertMatches(
   labelDispatchWorkflow,
   /createWorkflowDispatch\({[\s\S]*workflow_id: 'ci-required\.yml'[\s\S]*force_required_hosted_ci_recheck: 'true'/,
 );
+assertMatches('ci-required check-run read permission', requiredWorkflow, /checks: read/);
+assertMatches('ci-required mirrored-block lint', requiredWorkflow, /ruby bin\/lint-mirrored-blocks/);
+assertMatches(
+  'ci-required mirrored-block lint tests',
+  requiredWorkflow,
+  /bash script\/lint-mirrored-blocks-test\.bash/,
+);
+assertMatches(
+  'ci-required merge-group gate',
+  requiredWorkflow,
+  /ruby script\/ci-required-merge-group-gate/,
+);
+assertMatches(
+  'ci-required merge-group gate tests',
+  requiredWorkflow,
+  /ruby script\/ci_required_merge_group_gate_test\.rb/,
+);
+assertMatches(
+  'ci-required merge-group JS selector',
+  requiredWorkflow,
+  /REQUIRE_PACKAGE_JS_BUILD_20: \$\{\{ steps\.changes\.outputs\.run_js_tests \}\}/,
+);
 assertMatches('closed PR hosted-CI guard', ciCommandsWorkflow, /pr\.state !== 'open'/);
 assertMatches(
   'closed PR degraded evidence comment',

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -42,17 +42,14 @@ assertMatches(
   /createWorkflowDispatch\({[\s\S]*workflow_id: 'ci-required\.yml'[\s\S]*force_required_hosted_ci_recheck: 'true'/,
 );
 assertMatches('ci-required check-run read permission', requiredWorkflow, /checks: read/);
+assertMatches('ci-required actions-run read permission', requiredWorkflow, /actions: read/);
 assertMatches('ci-required mirrored-block lint', requiredWorkflow, /ruby bin\/lint-mirrored-blocks/);
 assertMatches(
   'ci-required mirrored-block lint tests',
   requiredWorkflow,
   /bash script\/lint-mirrored-blocks-test\.bash/,
 );
-assertMatches(
-  'ci-required merge-group gate',
-  requiredWorkflow,
-  /ruby script\/ci-required-merge-group-gate/,
-);
+assertMatches('ci-required merge-group gate', requiredWorkflow, /ruby script\/ci-required-merge-group-gate/);
 assertMatches(
   'ci-required merge-group gate tests',
   requiredWorkflow,

--- a/internal/contributor-info/ci-optimization.md
+++ b/internal/contributor-info/ci-optimization.md
@@ -194,9 +194,12 @@ script/ci-changes-detector origin/main
 Merge queue is a repository setting, not a file in this PR. The repo-local
 required gate enforces selected merge-group-only checks that run in separate
 workflows by polling the current merge-group SHA. Today that includes the
-package JS minimum Node lane, so a failing `build (20)` check blocks
-`ci-required / required-pr-gate` and therefore blocks the merge queue even when
-branch protection requires only the stable required gate context.
+package JS minimum Node lane, so a failing
+`JS unit tests for Renderer package / build (20)` check blocks `ci-required /
+required-pr-gate` and therefore blocks the merge queue even when branch
+protection requires only the stable required gate context. The gate maps check
+runs back to Actions workflow runs by `check_suite_id`; a bare `build (20)` from
+another workflow does not satisfy this gate.
 
 Directly requiring every hosted full-matrix check context remains an
 administrator branch-protection setting. Use that setting only when maintainers

--- a/internal/contributor-info/ci-optimization.md
+++ b/internal/contributor-info/ci-optimization.md
@@ -26,9 +26,12 @@ The `required-pr-gate` job intentionally stays lightweight:
 
 - validates workflow YAML can be loaded by Ruby
 - syntax-checks CI shell helpers
+- checks mirrored Ruby/TypeScript protocol blocks with `bin/lint-mirrored-blocks`
 - runs `script/ci-changes-detector`
 - fails ordinary pull requests with generator-sensitive changes until hosted CI
   is requested
+- on `merge_group`, waits for the package JS minimum Node check
+  (`JS unit tests for Renderer package / build (20)`) when JS tests are relevant
 - checks basic repository structure
 
 Repository branch protection should require `ci-required / required-pr-gate`.
@@ -188,9 +191,17 @@ script/ci-changes-detector origin/main
 
 ## Merge Queue
 
-Merge queue is a repository setting, not a file in this PR. After this policy
-lands, maintainers should enable merge queue for `react_on_rails` so merge
-candidates run the same hosted workflow entry points before landing.
+Merge queue is a repository setting, not a file in this PR. The repo-local
+required gate enforces selected merge-group-only checks that run in separate
+workflows by polling the current merge-group SHA. Today that includes the
+package JS minimum Node lane, so a failing `build (20)` check blocks
+`ci-required / required-pr-gate` and therefore blocks the merge queue even when
+branch protection requires only the stable required gate context.
+
+Directly requiring every hosted full-matrix check context remains an
+administrator branch-protection setting. Use that setting only when maintainers
+want GitHub branch protection itself, rather than the repo-local required gate,
+to enumerate each heavyweight job.
 
 If merge queue is not yet enabled, maintainers should request optimized hosted
 CI with `+ci-run-hosted` before merging PRs that need remote confirmation. Use

--- a/script/ci-required-merge-group-gate
+++ b/script/ci-required-merge-group-gate
@@ -17,6 +17,8 @@ DEFAULT_REQUIRED_CHECKS = [
 SUCCESS_CONCLUSION = "success"
 USER_AGENT = "react-on-rails-ci-required-merge-group-gate"
 
+class FetchCheckRunsError < StandardError; end
+
 def truthy?(value)
   %w[1 true yes on].include?(value.to_s.downcase)
 end
@@ -94,6 +96,17 @@ def next_link_from(headers)
   nil
 end
 
+def github_api_base_url
+  ENV.fetch("CI_REQUIRED_GITHUB_API_BASE_URL", "https://api.github.com").delete_suffix("/")
+end
+
+def github_api_uri(path, query = {})
+  encoded_query = URI.encode_www_form(query)
+  uri = "#{github_api_base_url}#{path}"
+  uri = "#{uri}?#{encoded_query}" unless encoded_query.empty?
+  URI(uri)
+end
+
 def fetch_json_page(uri, token)
   request = Net::HTTP::Get.new(uri)
   request["Accept"] = "application/vnd.github+json"
@@ -105,11 +118,11 @@ def fetch_json_page(uri, token)
     http.request(request)
   end
 
-  unless response.is_a?(Net::HTTPSuccess)
-    abort "Unable to read check runs for merge-group gate: HTTP #{response.code} #{response.message}"
-  end
+  raise FetchCheckRunsError, "HTTP #{response.code} #{response.message}" unless response.is_a?(Net::HTTPSuccess)
 
   [JSON.parse(response.body), next_link_from(response)]
+rescue JSON::ParserError => e
+  raise FetchCheckRunsError, "invalid JSON response: #{e.message}"
 end
 
 def fetch_paginated_json(uri, token)
@@ -126,7 +139,7 @@ def fetch_paginated_json(uri, token)
   payloads
 end
 
-def fetch_check_runs_from_github
+def github_fetch_context
   repository = ENV.fetch("GITHUB_REPOSITORY", "")
   sha = ENV.fetch("GITHUB_SHA", "")
   token = ENV.fetch("GITHUB_TOKEN", nil) || ENV.fetch("GH_TOKEN", nil)
@@ -136,14 +149,25 @@ def fetch_check_runs_from_github
   missing << "GITHUB_TOKEN or GH_TOKEN" if token.to_s.empty?
   abort "Missing #{missing.join(', ')} for merge-group gate" unless missing.empty?
 
-  check_runs_uri = URI("https://api.github.com/repos/#{repository}/commits/#{sha}/check-runs?per_page=100")
-  actions_runs_uri = URI(
-    "https://api.github.com/repos/#{repository}/actions/runs?#{URI.encode_www_form(head_sha: sha, per_page: 100)}"
-  )
+  { repository:, sha:, token: }
+end
+
+def fetch_check_runs_from_github
+  context = github_fetch_context
+  repository = context.fetch(:repository)
+  sha = context.fetch(:sha)
+  token = context.fetch(:token)
+
+  check_runs_uri = github_api_uri("/repos/#{repository}/commits/#{sha}/check-runs", per_page: 100)
+  actions_runs_uri = github_api_uri("/repos/#{repository}/actions/runs", head_sha: sha, per_page: 100)
   check_runs = fetch_paginated_json(check_runs_uri, token).flat_map { |payload| check_runs_from_payload(payload) }
   actions_runs = fetch_paginated_json(actions_runs_uri, token).flat_map { |payload| actions_runs_from_payload(payload) }
 
   { check_runs:, workflow_names_by_suite_id: workflow_names_by_suite_id(actions_runs) }
+rescue FetchCheckRunsError
+  raise
+rescue StandardError => e
+  raise FetchCheckRunsError, "#{e.class}: #{e.message}"
 end
 
 def fetch_check_runs
@@ -231,6 +255,17 @@ def evaluate_check_runs(check_runs, required_groups, workflow_names_by_suite_id)
   { pending:, failures: }
 end
 
+def fetch_evaluation_result(required_groups)
+  fetch_result = fetch_check_runs
+  evaluate_check_runs(
+    fetch_result.fetch(:check_runs),
+    required_groups,
+    fetch_result.fetch(:workflow_names_by_suite_id)
+  )
+rescue FetchCheckRunsError => e
+  { pending: ["GitHub API fetch failed: #{e.message}"], failures: [] }
+end
+
 def print_waiting(result, required_groups, timeout_seconds)
   warn "Waiting for required merge-group check(s) before ci-required can pass:"
   required_groups.each { |aliases| warn "  - #{aliases.join(' or ')}" }
@@ -250,12 +285,7 @@ poll_seconds = integer_env("CI_REQUIRED_MERGE_GROUP_GATE_POLL_SECONDS", 20)
 deadline = Time.now + timeout_seconds
 
 loop do
-  fetch_result = fetch_check_runs
-  result = evaluate_check_runs(
-    fetch_result.fetch(:check_runs),
-    required_groups,
-    fetch_result.fetch(:workflow_names_by_suite_id)
-  )
+  result = fetch_evaluation_result(required_groups)
 
   if result[:failures].any?
     warn "Required merge-group check failed:"

--- a/script/ci-required-merge-group-gate
+++ b/script/ci-required-merge-group-gate
@@ -1,0 +1,218 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Enforce selected asynchronous merge-group checks through the stable
+# ci-required / required-pr-gate context. Branch protection can require only the
+# required gate while this helper waits for merge-group-only full-matrix checks
+# that run in separate workflows.
+
+require "json"
+require "net/http"
+require "time"
+require "uri"
+
+DEFAULT_REQUIRED_CHECKS = [
+  ["JS unit tests for Renderer package / build (20)", "build (20)"]
+].freeze
+SUCCESS_CONCLUSION = "success"
+USER_AGENT = "react-on-rails-ci-required-merge-group-gate"
+
+def truthy?(value)
+  %w[1 true yes on].include?(value.to_s.downcase)
+end
+
+def integer_env(name, default)
+  Integer(ENV.fetch(name, default.to_s), 10)
+rescue ArgumentError
+  abort "#{name} must be an integer"
+end
+
+def required_check_groups
+  raw_value = ENV.fetch("CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS", "").strip
+  return DEFAULT_REQUIRED_CHECKS if raw_value.empty?
+
+  raw_value
+    .lines
+    .map(&:strip)
+    .reject(&:empty?)
+    .map { |line| line.split("|").map(&:strip).reject(&:empty?) }
+    .reject(&:empty?)
+end
+
+def check_runs_from_payload(payload)
+  case payload
+  when Array
+    payload.flat_map { |item| check_runs_from_payload(item) }
+  when Hash
+    payload.key?("check_runs") ? Array(payload["check_runs"]) : [payload]
+  else
+    []
+  end
+end
+
+def next_link_from(headers)
+  link_header = headers["link"]
+  return nil unless link_header
+
+  link_header.split(",").each do |entry|
+    url, rel = entry.strip.split(";", 2)
+    next unless rel&.include?('rel="next"')
+    next unless url
+    next unless url.start_with?("<") && url.end_with?(">")
+
+    return url[1...-1]
+  end
+
+  nil
+end
+
+def fetch_json_page(uri, token)
+  request = Net::HTTP::Get.new(uri)
+  request["Accept"] = "application/vnd.github+json"
+  request["Authorization"] = "Bearer #{token}"
+  request["User-Agent"] = USER_AGENT
+  request["X-GitHub-Api-Version"] = "2022-11-28"
+
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+    http.request(request)
+  end
+
+  unless response.is_a?(Net::HTTPSuccess)
+    abort "Unable to read check runs for merge-group gate: HTTP #{response.code} #{response.message}"
+  end
+
+  [JSON.parse(response.body), next_link_from(response)]
+end
+
+def fetch_check_runs_from_github
+  repository = ENV.fetch("GITHUB_REPOSITORY", "")
+  sha = ENV.fetch("GITHUB_SHA", "")
+  token = ENV.fetch("GITHUB_TOKEN", nil) || ENV.fetch("GH_TOKEN", nil)
+  missing = []
+  missing << "GITHUB_REPOSITORY" if repository.empty?
+  missing << "GITHUB_SHA" if sha.empty?
+  missing << "GITHUB_TOKEN or GH_TOKEN" if token.to_s.empty?
+  abort "Missing #{missing.join(', ')} for merge-group gate" unless missing.empty?
+
+  uri = URI("https://api.github.com/repos/#{repository}/commits/#{sha}/check-runs?per_page=100")
+  check_runs = []
+
+  loop do
+    payload, next_link = fetch_json_page(uri, token)
+    check_runs.concat(check_runs_from_payload(payload))
+    break unless next_link
+
+    uri = URI(next_link)
+  end
+
+  check_runs
+end
+
+def fetch_check_runs
+  injected_json = ENV.fetch("CI_REQUIRED_CHECK_RUNS_JSON", nil)
+  return check_runs_from_payload(JSON.parse(injected_json)) if injected_json && !injected_json.empty?
+
+  fetch_check_runs_from_github
+end
+
+def parse_time(value)
+  Time.parse(value.to_s)
+rescue ArgumentError, TypeError
+  Time.at(0)
+end
+
+def check_names(check_run)
+  name = check_run["name"].to_s
+  workflow_name = check_run["workflow_name"] || check_run.dig("check_suite", "workflow_name")
+  names = [name, check_run["display_name"].to_s]
+  names << "#{workflow_name} / #{name}" if workflow_name && !workflow_name.empty? && !name.empty?
+  names.reject(&:empty?).uniq
+end
+
+def latest_check_for(check_runs, aliases)
+  candidates = check_runs.select do |check_run|
+    (check_names(check_run) & aliases).any?
+  end
+
+  candidates.max_by do |check_run|
+    [
+      parse_time(check_run["completed_at"] || check_run["started_at"] || check_run["created_at"]).to_i,
+      check_run["id"].to_i
+    ]
+  end
+end
+
+def check_url(check_run)
+  url = check_run["html_url"] || check_run["details_url"]
+  url && !url.empty? ? " (#{url})" : ""
+end
+
+def evaluate_check_runs(check_runs, required_groups)
+  pending = []
+  failures = []
+
+  required_groups.each do |aliases|
+    label = aliases.first
+    check_run = latest_check_for(check_runs, aliases)
+
+    unless check_run
+      pending << "#{label}: missing"
+      next
+    end
+
+    status = check_run["status"].to_s.downcase
+    conclusion = check_run["conclusion"].to_s.downcase
+
+    if status == "completed" && conclusion == SUCCESS_CONCLUSION
+      next
+    elsif status == "completed" && !conclusion.empty?
+      failures << "#{label}: concluded #{conclusion}#{check_url(check_run)}"
+    else
+      pending << "#{label}: #{status.empty? ? 'pending' : status}#{check_url(check_run)}"
+    end
+  end
+
+  { pending:, failures: }
+end
+
+def print_waiting(result, required_groups, timeout_seconds)
+  warn "Waiting for required merge-group check(s) before ci-required can pass:"
+  required_groups.each { |aliases| warn "  - #{aliases.join(' or ')}" }
+  result[:pending].each { |line| warn "  pending: #{line}" }
+  warn "Timeout: #{timeout_seconds}s"
+end
+
+if ENV.fetch("GITHUB_EVENT_NAME", "") != "merge_group" ||
+   !truthy?(ENV.fetch("REQUIRE_PACKAGE_JS_BUILD_20", "false"))
+  puts "Merge-group full-matrix gate skipped."
+  exit 0
+end
+
+required_groups = required_check_groups
+timeout_seconds = integer_env("CI_REQUIRED_MERGE_GROUP_GATE_TIMEOUT_SECONDS", 1200)
+poll_seconds = integer_env("CI_REQUIRED_MERGE_GROUP_GATE_POLL_SECONDS", 20)
+deadline = Time.now + timeout_seconds
+
+loop do
+  result = evaluate_check_runs(fetch_check_runs, required_groups)
+
+  if result[:failures].any?
+    warn "Required merge-group check failed:"
+    result[:failures].each { |line| warn "  - #{line}" }
+    exit 1
+  end
+
+  if result[:pending].empty?
+    puts "Required merge-group check(s) passed."
+    exit 0
+  end
+
+  if Time.now >= deadline
+    warn "Timed out waiting for required merge-group check(s):"
+    result[:pending].each { |line| warn "  - #{line}" }
+    exit 1
+  end
+
+  print_waiting(result, required_groups, timeout_seconds)
+  sleep((deadline - Time.now).clamp(0, poll_seconds))
+end

--- a/script/ci-required-merge-group-gate
+++ b/script/ci-required-merge-group-gate
@@ -12,7 +12,7 @@ require "time"
 require "uri"
 
 DEFAULT_REQUIRED_CHECKS = [
-  ["JS unit tests for Renderer package / build (20)", "build (20)"]
+  ["JS unit tests for Renderer package / build (20)"]
 ].freeze
 SUCCESS_CONCLUSION = "success"
 USER_AGENT = "react-on-rails-ci-required-merge-group-gate"
@@ -27,16 +27,23 @@ rescue ArgumentError
   abort "#{name} must be an integer"
 end
 
+def parse_required_check_groups(raw_value)
+  raw_value.lines
+           .map(&:strip)
+           .reject(&:empty?)
+           .map { |line| line.split("|").map(&:strip).reject(&:empty?) }
+           .reject(&:empty?)
+end
+
 def required_check_groups
   raw_value = ENV.fetch("CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS", "").strip
   return DEFAULT_REQUIRED_CHECKS if raw_value.empty?
 
-  raw_value
-    .lines
-    .map(&:strip)
-    .reject(&:empty?)
-    .map { |line| line.split("|").map(&:strip).reject(&:empty?) }
-    .reject(&:empty?)
+  groups = parse_required_check_groups(raw_value)
+
+  abort "CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS did not contain any check aliases" if groups.empty?
+
+  groups
 end
 
 def check_runs_from_payload(payload)
@@ -47,6 +54,27 @@ def check_runs_from_payload(payload)
     payload.key?("check_runs") ? Array(payload["check_runs"]) : [payload]
   else
     []
+  end
+end
+
+def actions_runs_from_payload(payload)
+  case payload
+  when Array
+    payload.flat_map { |item| actions_runs_from_payload(item) }
+  when Hash
+    payload.key?("workflow_runs") ? Array(payload["workflow_runs"]) : [payload]
+  else
+    []
+  end
+end
+
+def workflow_names_by_suite_id(actions_runs)
+  actions_runs.each_with_object({}) do |run, names|
+    suite_id = run["check_suite_id"]
+    name = run["name"].to_s
+    next if suite_id.nil? || name.empty?
+
+    names[suite_id.to_i] = name
   end
 end
 
@@ -84,6 +112,20 @@ def fetch_json_page(uri, token)
   [JSON.parse(response.body), next_link_from(response)]
 end
 
+def fetch_paginated_json(uri, token)
+  payloads = []
+
+  loop do
+    payload, next_link = fetch_json_page(uri, token)
+    payloads << payload
+    break unless next_link
+
+    uri = URI(next_link)
+  end
+
+  payloads
+end
+
 def fetch_check_runs_from_github
   repository = ENV.fetch("GITHUB_REPOSITORY", "")
   sha = ENV.fetch("GITHUB_SHA", "")
@@ -94,23 +136,32 @@ def fetch_check_runs_from_github
   missing << "GITHUB_TOKEN or GH_TOKEN" if token.to_s.empty?
   abort "Missing #{missing.join(', ')} for merge-group gate" unless missing.empty?
 
-  uri = URI("https://api.github.com/repos/#{repository}/commits/#{sha}/check-runs?per_page=100")
-  check_runs = []
+  check_runs_uri = URI("https://api.github.com/repos/#{repository}/commits/#{sha}/check-runs?per_page=100")
+  actions_runs_uri = URI(
+    "https://api.github.com/repos/#{repository}/actions/runs?#{URI.encode_www_form(head_sha: sha, per_page: 100)}"
+  )
+  check_runs = fetch_paginated_json(check_runs_uri, token).flat_map { |payload| check_runs_from_payload(payload) }
+  actions_runs = fetch_paginated_json(actions_runs_uri, token).flat_map { |payload| actions_runs_from_payload(payload) }
 
-  loop do
-    payload, next_link = fetch_json_page(uri, token)
-    check_runs.concat(check_runs_from_payload(payload))
-    break unless next_link
-
-    uri = URI(next_link)
-  end
-
-  check_runs
+  { check_runs:, workflow_names_by_suite_id: workflow_names_by_suite_id(actions_runs) }
 end
 
 def fetch_check_runs
   injected_json = ENV.fetch("CI_REQUIRED_CHECK_RUNS_JSON", nil)
-  return check_runs_from_payload(JSON.parse(injected_json)) if injected_json && !injected_json.empty?
+  if injected_json && !injected_json.empty?
+    injected_actions_json = ENV.fetch("CI_REQUIRED_ACTION_RUNS_JSON", nil)
+    actions_runs =
+      if injected_actions_json && !injected_actions_json.empty?
+        actions_runs_from_payload(JSON.parse(injected_actions_json))
+      else
+        []
+      end
+
+    return {
+      check_runs: check_runs_from_payload(JSON.parse(injected_json)),
+      workflow_names_by_suite_id: workflow_names_by_suite_id(actions_runs)
+    }
+  end
 
   fetch_check_runs_from_github
 end
@@ -121,17 +172,22 @@ rescue ArgumentError, TypeError
   Time.at(0)
 end
 
-def check_names(check_run)
+def check_suite_id(check_run)
+  check_run.dig("check_suite", "id") || check_run["check_suite_id"]
+end
+
+def check_names(check_run, workflow_names_by_suite_id)
   name = check_run["name"].to_s
-  workflow_name = check_run["workflow_name"] || check_run.dig("check_suite", "workflow_name")
+  suite_id = check_suite_id(check_run)
+  workflow_name = suite_id.nil? ? nil : workflow_names_by_suite_id[suite_id.to_i]
   names = [name, check_run["display_name"].to_s]
   names << "#{workflow_name} / #{name}" if workflow_name && !workflow_name.empty? && !name.empty?
   names.reject(&:empty?).uniq
 end
 
-def latest_check_for(check_runs, aliases)
+def latest_check_for(check_runs, aliases, workflow_names_by_suite_id)
   candidates = check_runs.select do |check_run|
-    (check_names(check_run) & aliases).any?
+    (check_names(check_run, workflow_names_by_suite_id) & aliases).any?
   end
 
   candidates.max_by do |check_run|
@@ -147,13 +203,13 @@ def check_url(check_run)
   url && !url.empty? ? " (#{url})" : ""
 end
 
-def evaluate_check_runs(check_runs, required_groups)
+def evaluate_check_runs(check_runs, required_groups, workflow_names_by_suite_id)
   pending = []
   failures = []
 
   required_groups.each do |aliases|
     label = aliases.first
-    check_run = latest_check_for(check_runs, aliases)
+    check_run = latest_check_for(check_runs, aliases, workflow_names_by_suite_id)
 
     unless check_run
       pending << "#{label}: missing"
@@ -194,7 +250,12 @@ poll_seconds = integer_env("CI_REQUIRED_MERGE_GROUP_GATE_POLL_SECONDS", 20)
 deadline = Time.now + timeout_seconds
 
 loop do
-  result = evaluate_check_runs(fetch_check_runs, required_groups)
+  fetch_result = fetch_check_runs
+  result = evaluate_check_runs(
+    fetch_result.fetch(:check_runs),
+    required_groups,
+    fetch_result.fetch(:workflow_names_by_suite_id)
+  )
 
   if result[:failures].any?
     warn "Required merge-group check failed:"

--- a/script/ci_required_merge_group_gate_test.rb
+++ b/script/ci_required_merge_group_gate_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+
+SCRIPT = File.expand_path("ci-required-merge-group-gate", __dir__)
+
+def check_run(name:, status: "completed", conclusion: "success", id: 1, workflow_name: nil)
+  {
+    "id" => id,
+    "name" => name,
+    "workflow_name" => workflow_name,
+    "status" => status,
+    "conclusion" => conclusion,
+    "created_at" => "2026-07-07T00:00:#{format('%02d', id)}Z",
+    "started_at" => "2026-07-07T00:00:#{format('%02d', id)}Z",
+    "completed_at" => status == "completed" ? "2026-07-07T00:00:#{format('%02d', id)}Z" : nil,
+    "html_url" => "https://example.test/check-runs/#{id}"
+  }.compact
+end
+
+def payload(*check_runs)
+  JSON.generate("check_runs" => check_runs)
+end
+
+class Runner
+  def initialize
+    @tests = []
+    @failures = []
+  end
+
+  def run_case(name, env:, expected_status:, expected_output:)
+    @tests << name
+    puts "-> #{name}"
+
+    base_env = {
+      "GITHUB_EVENT_NAME" => "merge_group",
+      "REQUIRE_PACKAGE_JS_BUILD_20" => "true",
+      "CI_REQUIRED_MERGE_GROUP_GATE_TIMEOUT_SECONDS" => "0",
+      "CI_REQUIRED_MERGE_GROUP_GATE_POLL_SECONDS" => "0",
+      "GITHUB_REPOSITORY" => "shakacode/react_on_rails",
+      "GITHUB_SHA" => "abc123"
+    }
+
+    stdout, stderr, status = Open3.capture3(base_env.merge(env), "ruby", SCRIPT)
+    output = "#{stdout}\n#{stderr}"
+
+    return if status.exitstatus == expected_status && output.include?(expected_output)
+
+    @failures << <<~MSG
+      #{name}: expected status #{expected_status} and output containing #{expected_output.inspect}
+        got status #{status.exitstatus}
+        stdout: #{stdout}
+        stderr: #{stderr}
+    MSG
+  end
+
+  def finish
+    if @failures.any?
+      warn
+      warn "#{@failures.length} of #{@tests.length} tests failed"
+      warn @failures.join("\n")
+      exit 1
+    end
+
+    puts
+    puts "#{@tests.length} merge-group gate tests passed"
+  end
+end
+
+runner = Runner.new
+
+runner.run_case(
+  "skips non-merge-group events",
+  env: {
+    "GITHUB_EVENT_NAME" => "pull_request",
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload
+  },
+  expected_status: 0,
+  expected_output: "Merge-group full-matrix gate skipped."
+)
+
+runner.run_case(
+  "skips when JS tests are not relevant",
+  env: {
+    "REQUIRE_PACKAGE_JS_BUILD_20" => "false",
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload
+  },
+  expected_status: 0,
+  expected_output: "Merge-group full-matrix gate skipped."
+)
+
+runner.run_case(
+  "passes when the package JS minimum Node check succeeds",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(check_run(name: "build (20)"))
+  },
+  expected_status: 0,
+  expected_output: "Required merge-group check(s) passed."
+)
+
+runner.run_case(
+  "matches the workflow-prefixed check alias",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
+      check_run(
+        name: "build (20)",
+        workflow_name: "JS unit tests for Renderer package"
+      )
+    ),
+    "CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS" => "JS unit tests for Renderer package / build (20)"
+  },
+  expected_status: 0,
+  expected_output: "Required merge-group check(s) passed."
+)
+
+runner.run_case(
+  "fails when the package JS minimum Node check fails",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
+      check_run(name: "build (20)", conclusion: "failure")
+    )
+  },
+  expected_status: 1,
+  expected_output: "concluded failure"
+)
+
+runner.run_case(
+  "fails closed when the required check is missing",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload
+  },
+  expected_status: 1,
+  expected_output: "Timed out waiting for required merge-group check(s):"
+)
+
+runner.run_case(
+  "fails closed while the required check is still running",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
+      check_run(name: "build (20)", status: "in_progress", conclusion: nil)
+    )
+  },
+  expected_status: 1,
+  expected_output: "build (20): in_progress"
+)
+
+runner.run_case(
+  "uses the latest attempt for duplicate check names",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
+      check_run(name: "build (20)", conclusion: "failure", id: 1),
+      check_run(name: "build (20)", conclusion: "success", id: 2)
+    )
+  },
+  expected_status: 0,
+  expected_output: "Required merge-group check(s) passed."
+)
+
+runner.finish

--- a/script/ci_required_merge_group_gate_test.rb
+++ b/script/ci_required_merge_group_gate_test.rb
@@ -2,9 +2,17 @@
 
 require "json"
 require "open3"
+require "socket"
 
 SCRIPT = File.expand_path("ci-required-merge-group-gate", __dir__)
 PACKAGE_JS_WORKFLOW = "JS unit tests for Renderer package"
+SERVICE_UNAVAILABLE_RESPONSE = [
+  "HTTP/1.1 503 Service Unavailable",
+  "Content-Type: application/json",
+  "Content-Length: 23",
+  "",
+  '{"message":"try later"}'
+].join("\r\n")
 
 def check_run(name:, status: "completed", conclusion: "success", id: 1, check_suite_id: 100)
   {
@@ -36,6 +44,28 @@ def action_runs_payload(*action_runs)
   JSON.generate("workflow_runs" => action_runs)
 end
 
+def with_http_response(response)
+  server = TCPServer.new("127.0.0.1", 0)
+  thread = Thread.new do
+    client = server.accept
+    client.readpartial(4096)
+    client.write(response)
+  ensure
+    client&.close
+    server.close
+  end
+
+  yield "http://127.0.0.1:#{server.addr[1]}"
+ensure
+  thread&.join(1)
+end
+
+def ruby_subprocess_command
+  return ["ruby"] if ENV["CI"] == "true"
+
+  %w[bundle exec ruby]
+end
+
 class Runner
   def initialize
     @tests = []
@@ -53,10 +83,11 @@ class Runner
       "CI_REQUIRED_MERGE_GROUP_GATE_POLL_SECONDS" => "0",
       "GITHUB_REPOSITORY" => "shakacode/react_on_rails",
       "GITHUB_SHA" => "abc123",
+      "GITHUB_TOKEN" => "test-token",
       "CI_REQUIRED_ACTION_RUNS_JSON" => action_runs_payload(action_run)
     }
 
-    stdout, stderr, status = Open3.capture3(base_env.merge(env), "ruby", SCRIPT)
+    stdout, stderr, status = Open3.capture3(base_env.merge(env), *ruby_subprocess_command, SCRIPT)
     output = "#{stdout}\n#{stderr}"
 
     return if status.exitstatus == expected_status && output.include?(expected_output)
@@ -175,6 +206,17 @@ runner.run_case(
   expected_status: 1,
   expected_output: "build (20): in_progress"
 )
+
+with_http_response(SERVICE_UNAVAILABLE_RESPONSE) do |api_base_url|
+  runner.run_case(
+    "retries GitHub API fetch failures until timeout",
+    env: {
+      "CI_REQUIRED_GITHUB_API_BASE_URL" => api_base_url
+    },
+    expected_status: 1,
+    expected_output: "GitHub API fetch failed: HTTP 503 Service Unavailable"
+  )
+end
 
 runner.run_case(
   "uses the latest attempt for duplicate check names",

--- a/script/ci_required_merge_group_gate_test.rb
+++ b/script/ci_required_merge_group_gate_test.rb
@@ -4,12 +4,13 @@ require "json"
 require "open3"
 
 SCRIPT = File.expand_path("ci-required-merge-group-gate", __dir__)
+PACKAGE_JS_WORKFLOW = "JS unit tests for Renderer package"
 
-def check_run(name:, status: "completed", conclusion: "success", id: 1, workflow_name: nil)
+def check_run(name:, status: "completed", conclusion: "success", id: 1, check_suite_id: 100)
   {
     "id" => id,
     "name" => name,
-    "workflow_name" => workflow_name,
+    "check_suite" => { "id" => check_suite_id },
     "status" => status,
     "conclusion" => conclusion,
     "created_at" => "2026-07-07T00:00:#{format('%02d', id)}Z",
@@ -19,8 +20,20 @@ def check_run(name:, status: "completed", conclusion: "success", id: 1, workflow
   }.compact
 end
 
-def payload(*check_runs)
+def action_run(name: PACKAGE_JS_WORKFLOW, check_suite_id: 100)
+  {
+    "id" => check_suite_id,
+    "name" => name,
+    "check_suite_id" => check_suite_id
+  }
+end
+
+def check_runs_payload(*check_runs)
   JSON.generate("check_runs" => check_runs)
+end
+
+def action_runs_payload(*action_runs)
+  JSON.generate("workflow_runs" => action_runs)
 end
 
 class Runner
@@ -39,7 +52,8 @@ class Runner
       "CI_REQUIRED_MERGE_GROUP_GATE_TIMEOUT_SECONDS" => "0",
       "CI_REQUIRED_MERGE_GROUP_GATE_POLL_SECONDS" => "0",
       "GITHUB_REPOSITORY" => "shakacode/react_on_rails",
-      "GITHUB_SHA" => "abc123"
+      "GITHUB_SHA" => "abc123",
+      "CI_REQUIRED_ACTION_RUNS_JSON" => action_runs_payload(action_run)
     }
 
     stdout, stderr, status = Open3.capture3(base_env.merge(env), "ruby", SCRIPT)
@@ -74,7 +88,7 @@ runner.run_case(
   "skips non-merge-group events",
   env: {
     "GITHUB_EVENT_NAME" => "pull_request",
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload
   },
   expected_status: 0,
   expected_output: "Merge-group full-matrix gate skipped."
@@ -84,7 +98,7 @@ runner.run_case(
   "skips when JS tests are not relevant",
   env: {
     "REQUIRE_PACKAGE_JS_BUILD_20" => "false",
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload
   },
   expected_status: 0,
   expected_output: "Merge-group full-matrix gate skipped."
@@ -93,31 +107,48 @@ runner.run_case(
 runner.run_case(
   "passes when the package JS minimum Node check succeeds",
   env: {
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(check_run(name: "build (20)"))
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload(check_run(name: "build (20)"))
   },
   expected_status: 0,
   expected_output: "Required merge-group check(s) passed."
 )
 
 runner.run_case(
-  "matches the workflow-prefixed check alias",
+  "matches the workflow-prefixed check alias from the actions run check suite",
   env: {
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
-      check_run(
-        name: "build (20)",
-        workflow_name: "JS unit tests for Renderer package"
-      )
-    ),
-    "CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS" => "JS unit tests for Renderer package / build (20)"
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload(check_run(name: "build (20)", check_suite_id: 200)),
+    "CI_REQUIRED_ACTION_RUNS_JSON" => action_runs_payload(action_run(check_suite_id: 200))
   },
   expected_status: 0,
   expected_output: "Required merge-group check(s) passed."
+)
+
+runner.run_case(
+  "does not match a bare check name from another workflow",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload(check_run(name: "build (20)", check_suite_id: 300)),
+    "CI_REQUIRED_ACTION_RUNS_JSON" => action_runs_payload(
+      action_run(name: "Unrelated Workflow", check_suite_id: 300)
+    )
+  },
+  expected_status: 1,
+  expected_output: "#{PACKAGE_JS_WORKFLOW} / build (20): missing"
+)
+
+runner.run_case(
+  "fails closed when configured required groups parse empty",
+  env: {
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload(check_run(name: "build (20)")),
+    "CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS" => "|||"
+  },
+  expected_status: 1,
+  expected_output: "CI_REQUIRED_MERGE_GROUP_REQUIRED_CHECKS did not contain any check aliases"
 )
 
 runner.run_case(
   "fails when the package JS minimum Node check fails",
   env: {
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload(
       check_run(name: "build (20)", conclusion: "failure")
     )
   },
@@ -128,7 +159,7 @@ runner.run_case(
 runner.run_case(
   "fails closed when the required check is missing",
   env: {
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload
   },
   expected_status: 1,
   expected_output: "Timed out waiting for required merge-group check(s):"
@@ -137,7 +168,7 @@ runner.run_case(
 runner.run_case(
   "fails closed while the required check is still running",
   env: {
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload(
       check_run(name: "build (20)", status: "in_progress", conclusion: nil)
     )
   },
@@ -148,7 +179,7 @@ runner.run_case(
 runner.run_case(
   "uses the latest attempt for duplicate check names",
   env: {
-    "CI_REQUIRED_CHECK_RUNS_JSON" => payload(
+    "CI_REQUIRED_CHECK_RUNS_JSON" => check_runs_payload(
       check_run(name: "build (20)", conclusion: "failure", id: 1),
       check_run(name: "build (20)", conclusion: "success", id: 2)
     )


### PR DESCRIPTION
## Why

Branch protection currently has one stable required context: `ci-required / required-pr-gate`. That left broader merge-safety checks advisory unless maintainers also configured many heavyweight hosted contexts directly in branch protection. This PR routes selected repo-local gate coverage through the stable required context and documents the remaining branch-protection tradeoff.

Fixes #4493.

## What Changed

- Added mirrored-block lint and its regression tests to `ci-required / required-pr-gate`, so protocol drift blocks the stable required gate.
- Added `script/ci-required-merge-group-gate`, a merge-group-only required-gate helper that polls the current merge-group SHA for the package JS minimum Node check when `script/ci-changes-detector` selects JS tests.
- The merge-group helper maps Checks API runs back to Actions workflow runs by `check_suite_id`, so a bare `build (20)` from another workflow cannot satisfy the package-JS gate.
- Added focused tests for skipped, missing, pending, failing, duplicate, workflow-prefixed, cross-workflow, and empty-required-group cases.
- Documented that direct full-matrix branch-protection requirements remain an admin choice, while this repo-local gate enforces the selected minimum package JS lane through the stable required context.

## Validation

- `ruby -c script/ci-required-merge-group-gate && ruby -c script/ci_required_merge_group_gate_test.rb` -> pass
- `bundle exec ruby script/ci_required_merge_group_gate_test.rb` -> 11 tests passed
- `CI=true ruby script/ci_required_merge_group_gate_test.rb` -> 11 tests passed
- `BUNDLE_GEMFILE=Gemfile bundle exec rubocop script/ci-required-merge-group-gate script/ci_required_merge_group_gate_test.rb` -> no offenses
- `bash script/ci-required-hosted-gate-test.bash` -> 7 tests passed
- `bash script/lint-mirrored-blocks-test.bash` -> 5 tests passed
- `node .github/workflows/hosted-ci-safety.test.cjs` -> pass
- `actionlint .github/workflows/ci-required.yml` -> pass
- `ruby bin/lint-mirrored-blocks` -> pass
- `git diff --check origin/main...HEAD` -> pass
- Borrowed formatter binary from hydrated sibling worktree: `prettier --check .github/workflows/hosted-ci-safety.test.cjs internal/contributor-info/ci-optimization.md .github/workflows/ci-required.yml` -> pass
- `script/ci-changes-detector origin/main` -> CI infrastructure; full hosted suites recommended, no benchmarks

## Review Gate

- Worker review and coordinator review: `codex review --base origin/main` -> no discrete correctness, security, or maintainability issues found.
- Review-fix pass: `codex review --base origin/main` -> no discrete correctness issues found.
- Review threads for workflow alias matching, empty required groups, Bundler subprocess execution, transient GitHub API retries, and real-fetch path coverage were replied to and resolved.

## CI / Release Gate Notes

- Changelog classification: `not_user_visible`.
- Semantic GitHub Actions change: yes. `ci-required.yml` gains `actions: read` and `checks: read`; triggers are unchanged; no third-party actions or secret expansion are added.
- Required post-merge exercise issue: #4512.
- Local pre-commit/pre-push hook note: branch RuboCop passed, but local `markdown-links` could not run because installed `lychee` v0.24.2 cannot parse the repo `.lychee.toml` `include_fragments = false` value. Hosted docs/link checks are requested for remote confirmation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter CI gate handling for merge-queue changes, including additional checks before a PR can proceed.
  * Expanded CI validation to cover more gate-related conditions and longer-running checks.

* **Bug Fixes**
  * Improved handling of check status results so failing or missing required checks block merges more reliably.
  * Added retry and timeout behavior for transient CI service issues.

* **Documentation**
  * Clarified required gate and merge queue behavior, including when JS-related checks are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->