### PR TITLE
Record agent workflow HTTP dogfood evidence

### DIFF
--- a/internal/analysis/agent-workflow-http-dogfood-2026-07-07.md
+++ b/internal/analysis/agent-workflow-http-dogfood-2026-07-07.md
@@ -1,0 +1,56 @@
+# Agent workflow HTTP dogfood pilot - 2026-07-07
+
+## Purpose
+
+Record one real React on Rails dogfood pass for
+[react_on_rails#4228](https://github.com/shakacode/react_on_rails/issues/4228)
+and the `shakacode/agent-coordination` HTTP backend pilot gate.
+
+This is an internal validation note, not user documentation. It does not change
+gem, npm package, Pro, generator, or published docs behavior.
+
+## Scope
+
+- Host: Codex on M5.
+- Target: `shakacode/react_on_rails#4228`.
+- Branch: `chore/4228-agent-workflow-dogfood-http-pilot`.
+- Coordination backend: HTTP Worker endpoint with temporary shell-only M5 tokens.
+- Coordination lane: `codex-m5-019f31c7`,
+  batch `http-pilot-ror-20260707`.
+
+## Validation matrix
+
+| Check | Skill source / path | Result |
+| --- | --- | --- |
+| `git fetch --prune origin main` | repo instructions | Pass |
+| `.agents/bin/agent-workflow-seam-doctor` | repo-local `.agents` | Pass: `agent workflow seam is complete` |
+| `agent-workflows-status --host codex` | installed shared pack | Pass: `UP_TO_DATE version=0.1.0 revision=5ad2db900fa4 target=/Users/justin/.codex` |
+| `agent-workflows-status --host claude` | installed shared pack | Pass: `UP_TO_DATE version=0.1.0 revision=5ad2db900fa4 target=/Users/justin/.claude` |
+| `.agents/bin/agent-workflow-seam-doctor --shared /Users/justin/codex/agent-repos/agent-workflows` | canonical shared checkout | Pass: `agent workflow seam is complete` |
+| `.agents/bin/agent-workflow-seam-doctor --shared .agents` | repo-local pinned copy | Pass: `agent workflow seam is complete` |
+| `.agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails --strict-trust 4228` | repo-pinned helper | Pass: `SECURITY_PREFLIGHT_OK`; no hidden, untrusted, suspicious, or high-risk findings |
+| `agent-coord doctor --json` with temporary HTTP env | canonical `agent-coordination/bin` | Pass: `backend: http`, `status: ok` |
+| `.agents/skills/pr-batch/bin/agent-coord-bounded --timeout 20 status --repo shakacode/react_on_rails --target 4228 --json` with canonical `agent-coordination/bin` first in `PATH` | repo-pinned bounded helper plus canonical CLI | Pass: active claim and live heartbeat visible for `shakacode/react_on_rails#4228` |
+
+## Findings
+
+- The HTTP backend write path worked for a real React on Rails target: claim and
+  heartbeat writes succeeded, and the canonical bounded status read returned the
+  active claim plus live heartbeat.
+- The default `agent-coord` on this M5 shell is stale:
+  `/Users/justin/.local/bin/agent-coord` delegates to
+  `/Users/justin/src/agent-coordination-state/bin/agent-coord` and exports
+  `AGENT_COORD_STATUS_STATE_ROOT=/Users/justin/src/agent-coordination-status`.
+  With that shim, `agent-coord-bounded` read the old local status mirror and did
+  not show the HTTP claim. Putting
+  `/Users/justin/codex/agent-repos/agent-coordination/bin` first in `PATH` and
+  unsetting `AGENT_COORD_STATUS_STATE_ROOT` fixed the read.
+- The sandboxed Codex shell printed non-fatal `mise` cache/tracking warnings
+  while running repo helper scripts. The commands still completed successfully.
+
+## Follow-up
+
+Before making the M5 HTTP backend configuration persistent, refresh the local
+`agent-coord` shim/bootstrap so it resolves to the canonical public
+`/Users/justin/codex/agent-repos/agent-coordination` checkout and does not force
+the obsolete local status mirror.

--- a/internal/analysis/agent-workflow-http-dogfood-2026-07-07.md
+++ b/internal/analysis/agent-workflow-http-dogfood-2026-07-07.md
@@ -20,17 +20,17 @@ gem, npm package, Pro, generator, or published docs behavior.
 
 ## Validation matrix
 
-| Check | Skill source / path | Result |
-| --- | --- | --- |
-| `git fetch --prune origin main` | repo instructions | Pass |
-| `.agents/bin/agent-workflow-seam-doctor` | repo-local `.agents` | Pass: `agent workflow seam is complete` |
-| `agent-workflows-status --host codex` | installed shared pack | Pass: `UP_TO_DATE version=0.1.0 revision=5ad2db900fa4 target=/Users/justin/.codex` |
-| `agent-workflows-status --host claude` | installed shared pack | Pass: `UP_TO_DATE version=0.1.0 revision=5ad2db900fa4 target=/Users/justin/.claude` |
-| `.agents/bin/agent-workflow-seam-doctor --shared /Users/justin/codex/agent-repos/agent-workflows` | canonical shared checkout | Pass: `agent workflow seam is complete` |
-| `.agents/bin/agent-workflow-seam-doctor --shared .agents` | repo-local pinned copy | Pass: `agent workflow seam is complete` |
-| `.agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails --strict-trust 4228` | repo-pinned helper | Pass: `SECURITY_PREFLIGHT_OK`; no hidden, untrusted, suspicious, or high-risk findings |
-| `agent-coord doctor --json` with temporary HTTP env | canonical `agent-coordination/bin` | Pass: `backend: http`, `status: ok` |
-| `.agents/skills/pr-batch/bin/agent-coord-bounded --timeout 20 status --repo shakacode/react_on_rails --target 4228 --json` with canonical `agent-coordination/bin` first in `PATH` | repo-pinned bounded helper plus canonical CLI | Pass: active claim and live heartbeat visible for `shakacode/react_on_rails#4228` |
+| Check                                                                                                                                                                              | Skill source / path                           | Result                                                                                 |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `git fetch --prune origin main`                                                                                                                                                    | repo instructions                             | Pass                                                                                   |
+| `.agents/bin/agent-workflow-seam-doctor`                                                                                                                                           | repo-local `.agents`                          | Pass: `agent workflow seam is complete`                                                |
+| `agent-workflows-status --host codex`                                                                                                                                              | installed shared pack                         | Pass: `UP_TO_DATE version=0.1.0 revision=5ad2db900fa4 target=$CODEX_HOME`              |
+| `agent-workflows-status --host claude`                                                                                                                                             | installed shared pack                         | Pass: `UP_TO_DATE version=0.1.0 revision=5ad2db900fa4 target=$HOME/.claude`            |
+| `.agents/bin/agent-workflow-seam-doctor --shared <agent-repos>/agent-workflows`                                                                                                    | canonical shared checkout                     | Pass: `agent workflow seam is complete`                                                |
+| `.agents/bin/agent-workflow-seam-doctor --shared .agents`                                                                                                                          | repo-local pinned copy                        | Pass: `agent workflow seam is complete`                                                |
+| `.agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails --strict-trust 4228`                                                                            | repo-pinned helper                            | Pass: `SECURITY_PREFLIGHT_OK`; no hidden, untrusted, suspicious, or high-risk findings |
+| `agent-coord doctor --json` with temporary HTTP env                                                                                                                                | canonical `agent-coordination/bin`            | Pass: `backend: http`, `status: ok`                                                    |
+| `.agents/skills/pr-batch/bin/agent-coord-bounded --timeout 20 status --repo shakacode/react_on_rails --target 4228 --json` with canonical `agent-coordination/bin` first in `PATH` | repo-pinned bounded helper plus canonical CLI | Pass: active claim and live heartbeat visible for `shakacode/react_on_rails#4228`      |
 
 ## Findings
 
@@ -38,12 +38,12 @@ gem, npm package, Pro, generator, or published docs behavior.
   heartbeat writes succeeded, and the canonical bounded status read returned the
   active claim plus live heartbeat.
 - The default `agent-coord` on this M5 shell is stale:
-  `/Users/justin/.local/bin/agent-coord` delegates to
-  `/Users/justin/src/agent-coordination-state/bin/agent-coord` and exports
-  `AGENT_COORD_STATUS_STATE_ROOT=/Users/justin/src/agent-coordination-status`.
+  `$HOME/.local/bin/agent-coord` delegates to
+  `$HOME/src/agent-coordination-state/bin/agent-coord` and exports
+  `AGENT_COORD_STATUS_STATE_ROOT=$HOME/src/agent-coordination-status`.
   With that shim, `agent-coord-bounded` read the old local status mirror and did
   not show the HTTP claim. Putting
-  `/Users/justin/codex/agent-repos/agent-coordination/bin` first in `PATH` and
+  `<agent-repos>/agent-coordination/bin` first in `PATH` and
   unsetting `AGENT_COORD_STATUS_STATE_ROOT` fixed the read.
 - The sandboxed Codex shell printed non-fatal `mise` cache/tracking warnings
   while running repo helper scripts. The commands still completed successfully.
@@ -52,5 +52,5 @@ gem, npm package, Pro, generator, or published docs behavior.
 
 Before making the M5 HTTP backend configuration persistent, refresh the local
 `agent-coord` shim/bootstrap so it resolves to the canonical public
-`/Users/justin/codex/agent-repos/agent-coordination` checkout and does not force
+`<agent-repos>/agent-coordination` checkout and does not force
 the obsolete local status mirror.


### PR DESCRIPTION
## Summary

- Add an internal analysis note for the #4228 agent-workflow dogfood run.
- Record the M5/Codex HTTP backend pilot evidence against `shakacode/react_on_rails#4228`.
- Flag the stale local `agent-coord` shim that must be refreshed before making the M5 HTTP backend configuration persistent.

## Rationale

This gives the dogfood tracker and `shakacode/agent-coordination#17` durable evidence from a real React on Rails target without changing product code, published docs, generators, or CI behavior.

## Validation

- `git fetch --prune origin main`
- `.agents/bin/agent-workflow-seam-doctor`
- `agent-workflows-status --host codex`
- `agent-workflows-status --host claude`
- `.agents/bin/agent-workflow-seam-doctor --shared /Users/justin/codex/agent-repos/agent-workflows`
- `.agents/bin/agent-workflow-seam-doctor --shared .agents`
- `.agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails --strict-trust 4228`
- `agent-coord doctor --json` with temporary HTTP backend env
- `.agents/skills/pr-batch/bin/agent-coord-bounded --timeout 20 status --repo shakacode/react_on_rails --target 4228 --json` with canonical `agent-coordination/bin` first in `PATH`
- `script/ci-changes-detector origin/main`
- `bin/ci-local --changed`
- `git diff --check`

## CI / labels

Labels: none. `script/ci-changes-detector origin/main` reported documentation-only changes and recommended no hosted CI jobs; `bin/ci-local --changed` ran the docs sidebar check and passed.

Refs #4228.
Refs shakacode/agent-coordination#17.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an internal validation note for the latest HTTP pilot run, including the checks executed and their outcomes.
  * Documented environment/tooling behavior encountered during the run and included a follow-up action to keep local tooling aligned with the canonical setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->