### PR TITLE
Clean stale pnpm bin links during setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -240,7 +240,10 @@ install_dependencies() {
   # Skip pnpm install for workspace members (no lockfile) — they're covered by root install
   if [ -f "package.json" ] && [ -f "pnpm-lock.yaml" ]; then
     echo "  Installing JavaScript dependencies..."
-    "$STALE_PNPM_BIN_LINK_CLEANER" "$dir"
+    if ! "$STALE_PNPM_BIN_LINK_CLEANER" "$dir"; then
+      print_error "Failed to clean stale pnpm bin links in $name"
+      exit 1
+    fi
     if ! pnpm install --frozen-lockfile; then
       print_error "Failed to install JavaScript dependencies in $name"
       exit 1

--- a/bin/setup
+++ b/bin/setup
@@ -24,6 +24,7 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 OSS_GEMFILE="$ROOT_DIR/react_on_rails/Gemfile"
+STALE_PNPM_BIN_LINK_CLEANER="$ROOT_DIR/script/clean-stale-pnpm-bin-links"
 
 # Optional directories that should be skipped (not hard-fail) when Ruby doesn't match Gemfile.
 OPTIONAL_SETUP_DIRS=(
@@ -239,6 +240,7 @@ install_dependencies() {
   # Skip pnpm install for workspace members (no lockfile) — they're covered by root install
   if [ -f "package.json" ] && [ -f "pnpm-lock.yaml" ]; then
     echo "  Installing JavaScript dependencies..."
+    "$STALE_PNPM_BIN_LINK_CLEANER" "$dir"
     if ! pnpm install --frozen-lockfile; then
       print_error "Failed to install JavaScript dependencies in $name"
       exit 1

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -120,6 +120,7 @@ run_cmd corepack enable
 
 # Install JavaScript dependencies
 echo "📦 Installing JavaScript dependencies..."
+run_cmd ./script/clean-stale-pnpm-bin-links .
 run_cmd pnpm install
 
 # Build TypeScript (required for tests)

--- a/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe "pnpm bin cleanup setup support" do
     end
   end
 
+  it "does not rely on GNU-only find depth flags" do
+    expect(File.read(script_path)).not_to match(/\s-(?:min|max)depth\b/)
+  end
+
   describe "bin/setup" do
     let(:setup_script_path) { File.join(repo_root, "bin/setup") }
 

--- a/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tmpdir"
+require_relative "spec_helper"
+
+RSpec.describe "script/clean-stale-pnpm-bin-links" do
+  let(:repo_root) { File.expand_path("../../..", __dir__) }
+  let(:script_path) { File.join(repo_root, "script/clean-stale-pnpm-bin-links") }
+
+  def run_cleaner(root)
+    Open3.capture3(script_path, root)
+  end
+
+  it "removes broken generated pnpm bin symlinks before install relinks bins" do
+    Dir.mktmpdir do |tmpdir|
+      stale_link = File.join(tmpdir, "react_on_rails_pro/spec/dummy/node_modules/.bin/node")
+      FileUtils.mkdir_p(File.dirname(stale_link))
+      File.symlink("../@sentry/node/bin/node", stale_link)
+
+      stdout, stderr, status = run_cleaner(tmpdir)
+
+      expect(status).to be_success, stderr
+      expect(stderr).to be_empty
+      expect(File.symlink?(stale_link)).to be(false)
+      expect(stdout).to include(
+        "Removed stale pnpm bin link: react_on_rails_pro/spec/dummy/node_modules/.bin/node"
+      )
+    end
+  end
+
+  it "keeps valid generated pnpm bin symlinks" do
+    Dir.mktmpdir do |tmpdir|
+      target = File.join(tmpdir, "app/node_modules/tool/bin/tool")
+      valid_link = File.join(tmpdir, "app/node_modules/.bin/tool")
+      FileUtils.mkdir_p(File.dirname(target))
+      FileUtils.mkdir_p(File.dirname(valid_link))
+      File.write(target, "#!/usr/bin/env node\n")
+      File.symlink("../tool/bin/tool", valid_link)
+
+      stdout, stderr, status = run_cleaner(tmpdir)
+
+      expect(status).to be_success, stderr
+      expect(stderr).to be_empty
+      expect(File.symlink?(valid_link)).to be(true)
+      expect(File.exist?(valid_link)).to be(true)
+      expect(stdout).to be_empty
+    end
+  end
+end

--- a/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
@@ -49,21 +49,28 @@ RSpec.describe "pnpm bin cleanup setup support" do
     end
   end
 
-  it "leaves agent and editor workspace bin links alone" do
+  it "leaves agent, editor, and Codex workspace bin links alone" do
     Dir.mktmpdir do |tmpdir|
-      stale_agent_link = File.join(tmpdir, ".agents/node_modules/.bin/tool")
-      stale_editor_link = File.join(tmpdir, ".cursor/node_modules/.bin/tool")
-      FileUtils.mkdir_p(File.dirname(stale_agent_link))
-      FileUtils.mkdir_p(File.dirname(stale_editor_link))
-      File.symlink("../tool/bin/tool", stale_agent_link)
-      File.symlink("../tool/bin/tool", stale_editor_link)
+      ignored_links = {
+        ".agents" => "agent-tool",
+        ".cursor" => "editor-tool",
+        ".Codex" => "codex-upper-tool",
+        ".codex" => "codex-lower-tool"
+      }.map do |dir, tool|
+        File.join(tmpdir, "#{dir}/node_modules/.bin/#{tool}")
+      end
+      ignored_links.each do |link_path|
+        FileUtils.mkdir_p(File.dirname(link_path))
+        File.symlink("../tool/bin/tool", link_path)
+      end
 
       stdout, stderr, status = run_cleaner(tmpdir)
 
       expect(status).to be_success, stderr
       expect(stderr).to be_empty
-      expect(File.symlink?(stale_agent_link)).to be(true)
-      expect(File.symlink?(stale_editor_link)).to be(true)
+      ignored_links.each do |link_path|
+        expect(File.symlink?(link_path)).to be(true)
+      end
       expect(stdout).to be_empty
     end
   end
@@ -77,14 +84,26 @@ RSpec.describe "pnpm bin cleanup setup support" do
 
     it "reports cleaner failures with setup's friendly error path" do
       setup_script = File.read(setup_script_path)
-      expected_block = [
-        '    if ! "$STALE_PNPM_BIN_LINK_CLEANER" "$dir"; then',
-        '      print_error "Failed to clean stale pnpm bin links in $name"',
-        "      exit 1",
-        "    fi"
-      ].join("\n")
+      expected_pattern = /
+        if\s+!\s+"\$STALE_PNPM_BIN_LINK_CLEANER"\s+"\$dir";\s+then
+        \s+print_error\s+"Failed\ to\ clean\ stale\ pnpm\ bin\ links\ in\ \$name"
+        \s+exit\s+1
+        \s+fi
+      /x
 
-      expect(setup_script).to include(expected_block)
+      expect(setup_script).to match(expected_pattern)
+    end
+  end
+
+  describe "conductor-setup.sh" do
+    let(:conductor_setup_script_path) { File.join(repo_root, "conductor-setup.sh") }
+
+    it "cleans stale pnpm bin links before installing JavaScript dependencies" do
+      conductor_setup_script = File.read(conductor_setup_script_path)
+
+      expect(conductor_setup_script).to match(
+        %r{run_cmd \./script/clean-stale-pnpm-bin-links \.\s+run_cmd pnpm install}
+      )
     end
   end
 end

--- a/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/bin_setup_script_spec.rb
@@ -5,7 +5,7 @@ require "open3"
 require "tmpdir"
 require_relative "spec_helper"
 
-RSpec.describe "script/clean-stale-pnpm-bin-links" do
+RSpec.describe "pnpm bin cleanup setup support" do
   let(:repo_root) { File.expand_path("../../..", __dir__) }
   let(:script_path) { File.join(repo_root, "script/clean-stale-pnpm-bin-links") }
 
@@ -46,6 +46,41 @@ RSpec.describe "script/clean-stale-pnpm-bin-links" do
       expect(File.symlink?(valid_link)).to be(true)
       expect(File.exist?(valid_link)).to be(true)
       expect(stdout).to be_empty
+    end
+  end
+
+  it "leaves agent and editor workspace bin links alone" do
+    Dir.mktmpdir do |tmpdir|
+      stale_agent_link = File.join(tmpdir, ".agents/node_modules/.bin/tool")
+      stale_editor_link = File.join(tmpdir, ".cursor/node_modules/.bin/tool")
+      FileUtils.mkdir_p(File.dirname(stale_agent_link))
+      FileUtils.mkdir_p(File.dirname(stale_editor_link))
+      File.symlink("../tool/bin/tool", stale_agent_link)
+      File.symlink("../tool/bin/tool", stale_editor_link)
+
+      stdout, stderr, status = run_cleaner(tmpdir)
+
+      expect(status).to be_success, stderr
+      expect(stderr).to be_empty
+      expect(File.symlink?(stale_agent_link)).to be(true)
+      expect(File.symlink?(stale_editor_link)).to be(true)
+      expect(stdout).to be_empty
+    end
+  end
+
+  describe "bin/setup" do
+    let(:setup_script_path) { File.join(repo_root, "bin/setup") }
+
+    it "reports cleaner failures with setup's friendly error path" do
+      setup_script = File.read(setup_script_path)
+      expected_block = [
+        '    if ! "$STALE_PNPM_BIN_LINK_CLEANER" "$dir"; then',
+        '      print_error "Failed to clean stale pnpm bin links in $name"',
+        "      exit 1",
+        "    fi"
+      ].join("\n")
+
+      expect(setup_script).to include(expected_block)
     end
   end
 end

--- a/script/clean-stale-pnpm-bin-links
+++ b/script/clean-stale-pnpm-bin-links
@@ -12,15 +12,27 @@ fi
 
 cd "$ROOT_DIR"
 
-while IFS= read -r -d '' link_path; do
-  relative_path="${link_path#./}"
-  rm -f -- "$link_path"
-  printf 'Removed stale pnpm bin link: %s\n' "$relative_path"
+while IFS= read -r -d '' node_modules_dir; do
+  bin_dir="$node_modules_dir/.bin"
+  [ -d "$bin_dir" ] || continue
+
+  while IFS= read -r -d '' link_path; do
+    relative_path="${link_path#./}"
+    rm -f -- "$link_path"
+    printf 'Removed stale pnpm bin link: %s\n' "$relative_path"
+  done < <(
+    find "$bin_dir" \
+      -mindepth 1 \
+      -maxdepth 1 \
+      -type l \
+      ! -exec test -e {} \; \
+      -print0
+  )
 done < <(
   find . \
-    \( -path "./.git" -o -path "./.claude" -o -path "./.Codex" \) -prune -o \
-    -path "*/node_modules/.bin/*" \
-    -type l \
-    ! -exec test -e {} \; \
-    -print0
+    \( -path "./.git" -o -path "./.claude" -o -path "./.Codex" -o -path "./.agents" -o -path "./.cursor" \) -prune -o \
+    -type d \
+    -name node_modules \
+    -print0 \
+    -prune
 )

--- a/script/clean-stale-pnpm-bin-links
+++ b/script/clean-stale-pnpm-bin-links
@@ -12,22 +12,20 @@ fi
 
 cd "$ROOT_DIR"
 
+shopt -s dotglob nullglob
+
 while IFS= read -r -d '' node_modules_dir; do
   bin_dir="$node_modules_dir/.bin"
   [ -d "$bin_dir" ] || continue
 
-  while IFS= read -r -d '' link_path; do
+  for link_path in "$bin_dir"/*; do
+    [ -L "$link_path" ] || continue
+    [ ! -e "$link_path" ] || continue
+
     relative_path="${link_path#./}"
     rm -f -- "$link_path"
     printf 'Removed stale pnpm bin link: %s\n' "$relative_path"
-  done < <(
-    find "$bin_dir" \
-      -mindepth 1 \
-      -maxdepth 1 \
-      -type l \
-      ! -exec test -e {} \; \
-      -print0
-  )
+  done
 done < <(
   find . \
     \( -path "./.git" -o -path "./.claude" -o -path "./.Codex" -o -path "./.agents" -o -path "./.cursor" \) -prune -o \

--- a/script/clean-stale-pnpm-bin-links
+++ b/script/clean-stale-pnpm-bin-links
@@ -28,7 +28,7 @@ while IFS= read -r -d '' node_modules_dir; do
   done
 done < <(
   find . \
-    \( -path "./.git" -o -path "./.claude" -o -path "./.Codex" -o -path "./.agents" -o -path "./.cursor" \) -prune -o \
+    \( -path "./.git" -o -path "./.claude" -o -path "./.Codex" -o -path "./.codex" -o -path "./.agents" -o -path "./.cursor" \) -prune -o \
     -type d \
     -name node_modules \
     -print0 \

--- a/script/clean-stale-pnpm-bin-links
+++ b/script/clean-stale-pnpm-bin-links
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Remove dangling package-manager generated bin links before pnpm relinks bins.
+
+set -euo pipefail
+
+ROOT_DIR="${1:-$(pwd)}"
+
+if [ ! -d "$ROOT_DIR" ]; then
+  echo "Usage: script/clean-stale-pnpm-bin-links [repo-root]" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+while IFS= read -r -d '' link_path; do
+  relative_path="${link_path#./}"
+  rm -f -- "$link_path"
+  printf 'Removed stale pnpm bin link: %s\n' "$relative_path"
+done < <(
+  find . \
+    \( -path "./.git" -o -path "./.claude" -o -path "./.Codex" \) -prune -o \
+    -path "*/node_modules/.bin/*" \
+    -type l \
+    ! -exec test -e {} \; \
+    -print0
+)


### PR DESCRIPTION
## Summary

- Add `script/clean-stale-pnpm-bin-links` to remove dangling generated `node_modules/.bin` symlinks before pnpm relinks bins.
- Call the cleanup helper from `bin/setup` before the frozen pnpm install step.
- Add RSpec coverage for the stale `@sentry/node/bin/node`-style link and for preserving valid bin links.

## Rationale

`bin/setup` can surface pnpm ENOENT warnings when a previous install leaves `react_on_rails_pro/spec/dummy/node_modules/.bin/node` pointing at `../@sentry/node/bin/node`. The locked `@sentry/node@7.120.4` package does not ship that bin target, so pnpm trips over the stale generated symlink while relinking bins.

The setup script now removes dangling generated bin links first, letting pnpm recreate the current install tree cleanly.

## Validation

- `bundle exec rspec spec/react_on_rails/bin_setup_script_spec.rb` (red first on missing helper, green after the fix)
- `bash -n bin/setup script/clean-stale-pnpm-bin-links`
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop spec/react_on_rails/bin_setup_script_spec.rb`
- `pnpm install --frozen-lockfile` (no stale `@sentry/node/bin/node` ENOENT warning)
- `bin/setup --skip-pro` with the stale Pro dummy `.bin/node` link recreated (passed; cleanup removed the link before pnpm install)
- `git diff --check`
- `bin/ci-local --changed` (failed in the Pro node-renderer suite due to local prerequisites unrelated to this setup fix: Redis was unavailable for `tests/redisClient.test.ts`, and `react_on_rails_pro/spec/dummy/ssr-generated/server-bundle.js` was missing for streaming tests; earlier lint, format, type-check, and JS package portions passed before those environment failures)

## Changelog

Not user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation by automatically removing stale pnpm `.bin` symlinks before running installs, reducing failures caused by broken links.
  * If the cleanup step fails, setup now shows a clear, package-specific error and stops instead of continuing.
* **Tests**
  * Added coverage to ensure stale links are removed, valid links are preserved, unrelated workspace links remain untouched, and the setup failure path behaves as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->