### PR TITLE
Fix ShakaPerf renderer readiness probe

### DIFF
--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -9,10 +9,15 @@ function assertMatches(name, text, pattern) {
   assert.match(text, pattern, `${name} is missing ${pattern}`);
 }
 
+function assertDoesNotMatch(name, text, pattern) {
+  assert.doesNotMatch(text, pattern, `${name} unexpectedly matches ${pattern}`);
+}
+
 const labelDispatchWorkflow = read('.github/workflows/hosted-ci-label-dispatch.yml');
 const requiredWorkflow = read('.github/workflows/ci-required.yml');
 const hostedSelectorsAction = read('.github/actions/hosted-ci-selectors/action.yml');
 const ciCommandsWorkflow = read('.github/workflows/ci-commands.yml');
+const shakaperfReleaseGateWorkflow = read('.github/workflows/shakaperf-release-gates.yml');
 
 assertMatches(
   'hosted-ci-label-dispatch trigger',
@@ -89,5 +94,17 @@ assertMatches(
   /const isTrustedReleaseTarget = isReleaseTarget[\s\S]*!isDependabotPullRequest \|\| trustedDependabotHostedRequest/,
 );
 assertMatches('Dependabot trusted-dispatch retry', hostedSelectorsAction, /const maxAttempts = 4/);
+
+assertMatches('ShakaPerf renderer h2c probe', shakaperfReleaseGateWorkflow, /require\('node:http2'\)/);
+assertMatches(
+  'ShakaPerf renderer h2c /info request',
+  shakaperfReleaseGateWorkflow,
+  /client\.request\(\{[\s\S]*':method': 'GET',[\s\S]*':path': '\/info'/,
+);
+assertDoesNotMatch(
+  'ShakaPerf renderer plain curl probe',
+  shakaperfReleaseGateWorkflow,
+  /curl [^\n]*http:\/\/127\.0\.0\.1:3800\/info/,
+);
 
 console.log('hosted CI workflow safety tests passed');

--- a/.github/workflows/shakaperf-release-gates.yml
+++ b/.github/workflows/shakaperf-release-gates.yml
@@ -142,11 +142,52 @@ jobs:
           rails_pid="$!"
           echo "$rails_pid" > "$RUNNER_TEMP/shakaperf-rails.pid"
 
+          probe_renderer_info() {
+            node <<'NODE'
+          const http2 = require('node:http2');
+
+          const client = http2.connect('http://127.0.0.1:3800');
+          let status;
+          let timeout;
+          let completed = false;
+
+          const finish = (exitCode, destroyClient = false) => {
+            if (completed) return;
+            completed = true;
+            clearTimeout(timeout);
+            if (destroyClient) {
+              client.destroy();
+            } else {
+              client.close();
+            }
+            process.exit(exitCode);
+          };
+
+          const fail = () => finish(1, true);
+
+          client.on('error', fail);
+          const request = client.request({
+            ':method': 'GET',
+            ':path': '/info',
+          });
+          request.on('error', fail);
+          request.on('response', (headers) => {
+            status = headers[':status'];
+          });
+          request.on('data', () => {});
+          request.on('end', () => {
+            finish(status >= 200 && status < 300 ? 0 : 1);
+          });
+          request.end();
+          timeout = setTimeout(fail, 5000);
+          NODE
+          }
+
           for attempt in {1..60}; do
             echo "Waiting for RSC FOUC probe server (${attempt}/60)..."
             # /info proves the renderer socket responds, /empty proves Rails responds,
             # and the RSC page proves both sides are warm enough for the gate.
-            if curl --connect-timeout 2 --max-time 5 -fsS "http://127.0.0.1:3800/info" > /dev/null &&
+            if probe_renderer_info &&
               curl --connect-timeout 2 --max-time 5 -fsS "$SHAKAPERF_CONTROL_URL/empty" > /dev/null &&
               curl --connect-timeout 2 --max-time 5 -fsS "$SHAKAPERF_CONTROL_URL/rsc_posts_page_over_http" > /dev/null
             then


### PR DESCRIPTION
## Summary
- Updates the ShakaPerf release-gate startup probe so the Pro node renderer `/info` check uses Node's h2c client instead of plain HTTP/1.1 curl.
- Adds a workflow safety assertion so the release gate keeps an h2c-aware renderer probe and does not regress to plain curl against `127.0.0.1:3800/info`.

## Root Cause
The rc.7 ShakaPerf gate failed before the FOUC test ran. The Pro dummy app and node renderer stayed alive, but the workflow polled the h2c renderer listener with ordinary curl, producing `Received HTTP/0.9 when not allowed` until the startup loop timed out.

## Validation
- `node .github/workflows/hosted-ci-safety.test.cjs`
- `actionlint .github/workflows/shakaperf-release-gates.yml .github/workflows/ci-required.yml`
- `ruby -e "require 'yaml'; %w[.github/workflows/shakaperf-release-gates.yml .github/workflows/ci-required.yml].each { |f| YAML.safe_load_file(f, permitted_classes: [], aliases: false); puts f }"`
- Extracted `Start Pro dummy app` shell block and ran `bash -n`
- Extracted embedded h2c probe and ran `node --check`
- Exercised the extracted h2c probe against a local Node h2c `/info` server on port 3800
- `git diff --check`
- `.agents/bin/lint`
- `git push` pre-push hook: branch RuboCop and markdown link checks passed

## Notes
- Attempted `.agents/bin/validate --changed`, but before a PR exists the local helper falls back to `origin/main`; on this release branch that selected the whole release train delta and entered unrelated Pro node-renderer suites requiring local Redis and generated dummy bundles. I stopped that over-broad run after it failed in those unrelated areas.
- Attempted `yamllint .github/` through a temporary virtualenv. The repo currently has broad pre-existing default-yamllint failures across `.github/`; actionlint and YAML parsing passed for the touched workflow.
