### PR TITLE
Update demo-fleet metadata from RC 7 inspection

### DIFF
--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -86,10 +86,15 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
+      - { ecosystem: npm, name: shakapacker-rspack }
     needs_pro: true
+    package_manager: yarn_classic
+    ruby_test: bin/rspec
+    build: cd client && yarn start build.rspec.sequential
     smoke: [/]
     verify: true
 

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -113,6 +113,8 @@ repos:
       # No cpflow package until a CPFlow review-app pipeline exists for this repo.
     needs_pro: true
     package_manager: npm
+    ruby_test: ALLOW_DEMO_RENDERER_PASSWORD=true bin/rails test
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     # Recorded for future review-app wiring; skipped while cpflow_app_name is null.
     smoke: [/]
     review_app:
@@ -129,10 +131,13 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    ruby_test: bin/rails test && bin/rails test:system
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     smoke: [/, /news]
     verify: true
 
@@ -144,10 +149,12 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     smoke: [/, /products]
     verify: true
 
@@ -159,10 +166,11 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
-      - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    package_manager: npm
     smoke: [/]
     verify: true
 
@@ -172,10 +180,16 @@ repos:
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: react_on_rails_pro }
+      - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-    needs_pro: false
+      - { ecosystem: gem, name: cpflow }
+    needs_pro: true
     package_manager: yarn_classic
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     smoke: [/]
     verify: true
 
@@ -206,10 +220,12 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    package_manager: npm
     smoke: [/]
     verify: true
 
@@ -221,8 +237,8 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
+    package_manager: yarn_berry
     smoke: [/]
     verify: true
 
@@ -234,8 +250,8 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
+    package_manager: npm
     smoke: [/]
     verify: true
 
@@ -247,7 +263,6 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     package_manager: yarn_classic
     smoke: [/]
@@ -261,7 +276,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
+    package_manager: yarn_classic
     smoke: [/]
     verify: true

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -176,7 +176,7 @@ repos:
 
   - name: shakacode/react-webpack-rails-tutorial
     tier: hard_gate
-    headline: Legacy tutorial reference app
+    headline: Pro + RSC tutorial reference app
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }


### PR DESCRIPTION
## Summary
- Correct package managers discovered during the RC 7 demo-fleet pass: HiChee and migration/open-flights use Yarn Classic, SSR-HMR uses Yarn Berry, and the v16 bundle-splitting demo plus Pro/RSC npm demos use npm where applicable.
- Add the RSC/node-renderer packages actually consumed by the Pro/RSC demos, including the tutorial and soft-track Octochangelog app.
- Reclassify the tutorial entry as Pro/RSC: it now requires Pro access (`needs_pro: true`), carries the verified `cpflow` gem entry, and uses the `Pro + RSC tutorial reference app` headline.
- Remove stale cpflow package entries where the inspected app does not depend on cpflow.
- Record generated-pack build prerequisites and non-RSpec test commands for demos where clean automation would otherwise fail at the wrong layer.

Addresses #4526.

## Validation
- `git diff --check`
- `ruby -ryaml -e 'data = YAML.load_file("internal/contributor-info/demo-fleet.yml"); abort "missing repos" unless data.fetch("repos").any? { |repo| repo.fetch("name") == "shakacode/react-webpack-rails-tutorial" && repo.fetch("headline") == "Pro + RSC tutorial reference app" }; puts "demo-fleet.yml parsed and tutorial headline verified"'`
- `.agents/bin/validate --changed`
- pre-commit hook: trailing-newlines, prettier
- pre-push hook: branch-lint, markdown-links

## External Evidence
- Gumroad default branch and `chore/demo-fleet-17-rc7` package/lock files were inspected: the npm package set includes Pro, node-renderer, and RSC packages, but no direct npm `shakapacker` or `shakapacker-rspack`; the Shakapacker dependency present there is the gem.
- Tutorial `chore/demo-fleet-17-rc7` was inspected: Pro/RSC npm dependencies are present, and Gemfile/Gemfile.lock include `react_on_rails_pro`, `shakapacker`, and `cpflow`.
- HiChee private package/build metadata was inspected without copying private logs into this PR; `verify: true` remains intentional because the manifest requires non-null review-app metadata before treating the entry as authoritative.

## RC Release Gate Note
- Release phase: RC branch `release/17.0.0`.
- Confidence: medium-high for this metadata-only release PR after focused YAML validation, changed-file validation, hook validation, and targeted external demo metadata checks.
- Local adversarial review: focused review of each open bot thread found one wording fix, now committed in 12ae52c4a; the Gumroad JS-side `shakapacker`, HiChee command, HiChee `verify: true`, and tutorial Pro/RSC reclassification concerns were verified as intentional.
- Remaining gate before merge decision: current-head checks/review must be clean and the merge ledger must stay strict-clean. No auto-merge for this release-branch PR.