### PR TITLE
Fix Pro RSC route errors reaching ErrorBoundary

### DIFF
--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -383,7 +383,9 @@ export const createRSCProvider = ({
         // NOTE: payloads that RESOLVE with an `Error` value are intentionally
         // left cached here; whether those should also retry is a separate
         // `getServerComponent` contract decision tracked apart from #3929.
+        let payloadRejected = false;
         const evictPromiseIfRejected = (error: unknown) => {
+          payloadRejected = true;
           setTimeout(() => {
             setTimeout(() => {
               if (fetchRSCPromises.get(key, false) === promise) {
@@ -422,6 +424,14 @@ export const createRSCProvider = ({
           // resolving mounted routes can evict early visible keys before their
           // layout effects get to pin them as mounted.
           setTimeout(() => {
+            if (payloadRejected) {
+              // The rejected entry is already scheduled for deletion in the
+              // next macrotask. Releasing its pin must not reconcile over-cap
+              // eviction against healthy entries during this short grace
+              // window.
+              fetchRSCPromises.unpinWithoutEvict(key);
+              return;
+            }
             fetchRSCPromises.unpin(key);
           }, 0);
         });

--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -367,24 +367,29 @@ export const createRSCProvider = ({
         // refetch or reload (#3929). Evict the rejected entry so the next
         // same-key `getComponent` starts a fresh fetch.
         //
-        // Deferred one macrotask (`setTimeout(0)`, not `queueMicrotask`) so
-        // React's Suspense machinery observes the rejection on the cached
-        // promise before the entry is removed; a microtask could interleave
-        // with React's own queue and evict before Suspense reads it. Guarded on
-        // promise identity so a newer same-key promise (a fresh `getComponent`
-        // or a `refetchComponent`) installed during that window is not evicted
-        // by this stale failure. Pins are preserved because the `.finally`
-        // below still owns the matching `unpin` (mirrors the delete +
-        // deferred-unpin handoff in `restoreLastSuccessfulPromise`).
+        // Deferred past the first macrotask (`setTimeout(0)`, not
+        // `queueMicrotask`) so React's Suspense machinery observes the
+        // rejection on the cached promise before the entry is removed; a
+        // microtask could interleave with React's own queue and evict before
+        // Suspense reads it. The extra macrotask also lets the `.finally`
+        // below release the in-flight pin before the key becomes available for
+        // a fresh same-key `getComponent`; otherwise a repeated failing request
+        // can replace the rejected promise with a new pending promise before
+        // the user ErrorBoundary commits its fallback (#4522). Guarded on
+        // promise identity so a newer same-key promise (such as
+        // `refetchComponent`) installed during that window is not evicted by
+        // this stale failure.
         //
         // NOTE: payloads that RESOLVE with an `Error` value are intentionally
         // left cached here; whether those should also retry is a separate
         // `getServerComponent` contract decision tracked apart from #3929.
         const evictPromiseIfRejected = (error: unknown) => {
           setTimeout(() => {
-            if (fetchRSCPromises.get(key, false) === promise) {
-              fetchRSCPromises.deletePreservingPins(key);
-            }
+            setTimeout(() => {
+              if (fetchRSCPromises.get(key, false) === promise) {
+                fetchRSCPromises.deleteWithoutEvict(key);
+              }
+            }, 0);
           }, 0);
           throw error;
         };

--- a/packages/react-on-rails-pro/src/RSCProviderCache.ts
+++ b/packages/react-on-rails-pro/src/RSCProviderCache.ts
@@ -173,6 +173,14 @@ export class BoundedLRU<V> {
   }
 
   unpin(key: string): void {
+    this.releasePin(key, true);
+  }
+
+  unpinWithoutEvict(key: string): void {
+    this.releasePin(key, false);
+  }
+
+  private releasePin(key: string, reconcileEviction: boolean): void {
     this.assertNotEvicting('unpin');
     const count = this.pins.get(key);
     if (count === undefined) {
@@ -184,6 +192,9 @@ export class BoundedLRU<V> {
     }
 
     this.pins.delete(key);
+    if (!reconcileEviction) {
+      return;
+    }
     // The in-flight operation that held this pin just settled, so the key is
     // now the most-recently-used. `get` promotes only when the key is still
     // present; a key already deleted, e.g. by `restoreLastSuccessfulPromise`,

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -972,6 +972,93 @@ describe('RSCRoute successful-version error reset', () => {
     });
   });
 
+  it('h2. rejected over-cap initial load does not evict a healthy settled entry before deferred deletion', async () => {
+    process.env.NODE_ENV = 'production';
+
+    type PendingEntry = Deferred & { args: GetServerComponentArgs; settled: boolean };
+    const pending: PendingEntry[] = [];
+    getServerComponent = jest.fn((..._args: [GetServerComponentArgs]) => {
+      const d = makeDeferred();
+      const entry: PendingEntry = {
+        ...d,
+        args: _args[0],
+        settled: false,
+        resolve: (value) => {
+          entry.settled = true;
+          d.resolve(value);
+        },
+        reject: (error) => {
+          entry.settled = true;
+          d.reject(error);
+        },
+      };
+      pending.push(entry);
+      return d.promise;
+    });
+    RSCProvider = createRSCProvider({ getServerComponent });
+
+    let rscApi!: ReturnType<typeof useRSC>;
+    const Probe = () => {
+      rscApi = useRSC();
+      return null;
+    };
+    await renderInAct(
+      <RSCProvider>
+        <Probe />
+      </RSCProvider>,
+    );
+
+    const startLoad = async (id: number) => {
+      let promise!: Promise<React.ReactNode>;
+      await act(async () => {
+        promise = rscApi.getComponent('Card', { id });
+        await Promise.resolve();
+      });
+      return { promise, deferred: findPendingForId(pending, id) };
+    };
+
+    const started: Awaited<ReturnType<typeof startLoad>>[] = [];
+    for (let id = 0; id <= CACHE_CAP; id += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      started.push(await startLoad(id));
+    }
+    expect(getServerComponent).toHaveBeenCalledTimes(CACHE_CAP + 1);
+
+    await act(async () => {
+      started[0].deferred.resolve(<span>healthy payload 0</span>);
+      await started[0].promise;
+      await flushMacrotasks();
+    });
+    expect(fetchCount(0)).toBe(1);
+
+    void started[1].promise.catch(() => undefined);
+    await act(async () => {
+      started[1].deferred.reject(new Error('boom 1'));
+      await expect(started[1].promise).rejects.toThrow('boom 1');
+      // First macrotask: rejected-promise deletion is scheduled, and the
+      // failed load releases its pin. The actual cache delete is still one
+      // macrotask away so React can observe the rejection.
+      await flushMacrotasks();
+    });
+
+    await act(async () => {
+      void rscApi.getComponent('Card', { id: 0 });
+      await Promise.resolve();
+    });
+    expect(fetchCount(0)).toBe(1);
+
+    await act(async () => {
+      await flushMacrotasks();
+      pending
+        .filter((entry) => !entry.settled)
+        .forEach((entry) =>
+          entry.resolve(<span>{`cleanup ${(entry.args.componentProps as { id: number }).id}`}</span>),
+        );
+      await Promise.allSettled(pending.map((entry) => entry.promise));
+      await flushMacrotasks();
+    });
+  });
+
   it('i. evicted-success markers survive marker-cache churn while a replacement load is pending', async () => {
     process.env.NODE_ENV = 'production';
 

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1465,8 +1465,10 @@ describe('RSCRoute successful-version error reset', () => {
     syncThrowIds.add(0);
     await act(async () => {
       await expect(rscApi.getComponent('Card', { id: 0 })).rejects.toThrow('sync boom 0');
-      // The cached rejection is evicted one macrotask later; flush so the next
-      // same-key load starts fresh instead of reusing the rejected promise.
+      // The cached rejection is evicted after the Suspense-observation and
+      // unpin macrotasks; flush both so the next same-key load starts fresh
+      // instead of reusing the rejected promise.
+      await flushMacrotasks();
       await flushMacrotasks();
     });
 
@@ -1523,8 +1525,10 @@ describe('RSCRoute successful-version error reset', () => {
       await act(async () => {
         started.deferred.reject(new Error(message));
         await expect(started.promise).rejects.toThrow(message);
-        // evictPromiseIfRejected removes the cached promise via setTimeout(0),
-        // so wait one macrotask before asserting the slot is free.
+        // evictPromiseIfRejected keeps the rejected promise through the first
+        // macrotask so React can commit the user ErrorBoundary fallback; wait
+        // for the second macrotask before asserting the slot is free.
+        await flushMacrotasks();
         await flushMacrotasks();
       });
     };

--- a/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
+++ b/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
@@ -509,6 +509,104 @@ describe('RSCRoute deferred SSR behavior', () => {
     }
   });
 
+  it('shows the user ErrorBoundary fallback when an updated deferred route fetch rejects', async () => {
+    let rejectPayload: ((error: Error) => void) | undefined;
+    const failingPayloadPromise = new Promise<React.ReactNode>((_resolve, reject) => {
+      rejectPayload = reject;
+    });
+    type DeferredRouteProps = { simulateError: boolean };
+    let simulatedErrorFetchCount = 0;
+    const getServerComponent = jest.fn(({ componentProps }: { componentProps: unknown }) => {
+      const routeProps = componentProps as DeferredRouteProps;
+      if (!routeProps.simulateError) {
+        return Promise.resolve(<div>Loaded deferred route</div>);
+      }
+
+      simulatedErrorFetchCount += 1;
+      return simulatedErrorFetchCount === 1
+        ? failingPayloadPromise
+        : new Promise<React.ReactNode>(() => undefined);
+    });
+    const RSCProvider = createRSCProvider({ getServerComponent });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | undefined;
+    let triggerErrorRoute: (() => void) | undefined;
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const RouteSwitcher = () => {
+      const [simulateError, setSimulateError] = React.useState(false);
+      triggerErrorRoute = () => {
+        React.startTransition(() => {
+          setSimulateError(true);
+        });
+      };
+
+      return (
+        <TestErrorBoundary
+          fallback={({ error }) => <div data-testid="rsc-error-fallback">{error.message}</div>}
+        >
+          <React.Suspense fallback={<div>Loading deferred route...</div>}>
+            <RSCRoute componentName="DeferredRoute" componentProps={{ simulateError }} ssr={false} />
+          </React.Suspense>
+        </TestErrorBoundary>
+      );
+    };
+
+    try {
+      root = createRoot(container);
+
+      await act(async () => {
+        root?.render(
+          <RSCProvider>
+            <RouteSwitcher />
+          </RSCProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain('Loaded deferred route');
+      expect(getServerComponent).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        triggerErrorRoute?.();
+        await Promise.resolve();
+      });
+
+      expect(getServerComponent).toHaveBeenCalledTimes(2);
+      expect(getServerComponent).toHaveBeenNthCalledWith(2, {
+        componentName: 'DeferredRoute',
+        componentProps: { simulateError: true },
+      });
+
+      await act(async () => {
+        rejectPayload?.(new Error('Server component fetch failed'));
+        await failingPayloadPromise.catch(() => undefined);
+        await Promise.resolve();
+        await flushMacrotasks();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('[data-testid="rsc-error-fallback"]')?.textContent).toBe(
+        'Server component fetch failed',
+      );
+      expect(container.textContent).not.toContain('Loaded deferred route');
+    } finally {
+      const mountedRoot = root;
+      try {
+        if (mountedRoot) {
+          await act(async () => {
+            mountedRoot.unmount();
+            await Promise.resolve();
+          });
+        }
+        container.remove();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    }
+  });
+
   it('dedupes identical deferred routes under the same default provider', async () => {
     const sharedPayloadPromise = new Promise<React.ReactNode>(() => undefined);
     const getServerComponent = jest.fn(() => sharedPayloadPromise);
@@ -732,9 +830,10 @@ describe('RSCRoute deferred SSR behavior', () => {
         );
         await Promise.resolve();
         await Promise.resolve();
-        // The provider evicts synchronously-rejected payload promises one
-        // macrotask after the rejection; flush so no eviction timer leaks
-        // past unmount.
+        // The provider evicts synchronously-rejected payload promises after
+        // React can observe the rejection and the in-flight pin releases; flush
+        // both timers so no eviction timer leaks past unmount.
+        await flushMacrotasks();
         await flushMacrotasks();
       });
 

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -169,9 +169,9 @@ class CapturingErrorBoundary extends React.Component<
   const usingJestFakeTimers = () => jest.isMockFunction(setTimeout);
 
   // Waits for the deferred eviction scheduled by evictPromiseIfRejected to
-  // complete. The eviction uses setTimeout(0), so scheduling a second
-  // setTimeout(0) here guarantees via FIFO macrotask ordering that the eviction
-  // fires before this promise resolves.
+  // complete. The eviction intentionally waits until after React can observe
+  // the rejection and after the in-flight pin release, so this helper waits two
+  // macrotasks.
   const waitForRejectedGetComponentEviction = () => {
     if (usingJestFakeTimers()) {
       throw new Error(
@@ -180,7 +180,9 @@ class CapturingErrorBoundary extends React.Component<
     }
 
     return new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
+      setTimeout(() => {
+        setTimeout(resolve, 0);
+      }, 0);
     });
   };
 


### PR DESCRIPTION
## Why

Fixes #4522 for the 17.0.0 release branch. In 17.0.0.rc.7, an updated deferred `RSCRoute` fetch rejection could be evicted before React observed it, so the user ErrorBoundary fallback did not receive the server-component fetch failure.

## What changed

- Preserve rejected RSC fetch promises long enough for React/ErrorBoundary handling before evicting the failed cache entry.
- Release rejected entries' in-flight cache pin without over-cap eviction while the failed entry is waiting for its delayed delete, so a failed key cannot evict unrelated healthy payloads under high concurrent RSC load.
- Add regression coverage for the updated deferred-route rejection path and the over-cap rejected-load cache race.
- Adjust adjacent Pro RSC cache/refetch expectations to account for delayed rejected-promise eviction.

## Codex Decision Log

- **Non-blocking:** rejected `getComponent` promises remain cached for two macrotasks before retry becomes available.
  - **Decision:** keep the two-macrotask grace period.
  - **Why:** React/ErrorBoundary needs the first window to observe and commit the rejection, and the delayed delete avoids replacing the rejection with a new pending promise before the fallback can render. The added cache-race fix releases the failed key's pin without evicting healthy entries during that window.
  - **Review later:** only if an app needs immediate same-key retry within the extra tick; current tests intentionally flush twice for retry availability.

## Verification

Local and worker validation:
- RED: `pnpm --dir packages/react-on-rails-pro exec jest tests/deferredRouteSsr.test.tsx --testNamePattern="updated deferred route fetch rejects" --runInBand` failed before the fix: expected `Server component fetch failed`, got `undefined`.
- RED replay for review finding: temporarily removed only the source follow-up while keeping the new `h2` regression test, then ran `pnpm --dir packages/react-on-rails-pro exec jest tests/boundedCacheProvider.client.test.tsx --testNamePattern="h2\\. rejected over-cap" --runInBand`; it failed with `Expected: 1` / `Received: 2` for `fetchCount(0)`.
- GREEN: `pnpm --dir packages/react-on-rails-pro exec jest tests/boundedCacheProvider.client.test.tsx tests/deferredRouteSsr.test.tsx tests/imperativeRefetch.client.test.tsx --runInBand` passed, 84 tests.
- GREEN: `pnpm --filter react-on-rails-pro run type-check` passed.
- GREEN: `pnpm exec eslint packages/react-on-rails-pro/src/RSCProvider.tsx packages/react-on-rails-pro/src/RSCProviderCache.ts packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx --no-warn-ignored` passed.
- GREEN: `pnpm exec prettier --check packages/react-on-rails-pro/src/RSCProvider.tsx packages/react-on-rails-pro/src/RSCProviderCache.ts packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx` passed.
- GREEN: `script/check-pro-license-headers` passed.
- GREEN: `git diff --check` passed.
- GREEN: `.agents/bin/validate --fast` passed on current head `619dda006ab2e344ab6d02704c0c6a91575952e1`.
- GREEN local CI-equivalent pro-lint substeps: `pnpm --filter react-on-rails-pro build`, `(cd react_on_rails_pro && bundle exec rake rbs:validate)`, `pnpm run nps check-typescript`, `ruby script/check-pro-license-headers --self-test && ruby script/check-pro-license-headers --check`, and `(cd react_on_rails_pro && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion)` all passed.

Review gates:
- Codex local review against original head found no discrete correctness regressions; current-head Codex review is being rerun after the follow-up cache-race fix.
- Hosted review gates are current-head pending after the follow-up push; unresolved review threads are being triaged in-thread.
- Local Claude report-only review and `/simplify` could not run because the local Claude account hit the weekly limit; hosted Claude review is the independent Claude gate for this PR.

QA Evidence:
- QA claim completed for PR #4529.
- Cross-lane merge tree with #4530 was refreshed after the follow-up push: `git merge-tree --write-tree --messages origin/jg-codex/4522-rsc-error-boundary-release-17 origin/jg-codex/4523-rspack-doctor-node-modules-release-17` produced tree `ca9683c6cea6ec9f4fcac26590f08dbfec7cdfd3` and no conflicts.
- QA reran `pnpm --dir packages/react-on-rails-pro exec jest tests/deferredRouteSsr.test.tsx --runInBand`; passed, including `shows the user ErrorBoundary fallback when an updated deferred route fetch rejects`.

Hosted CI status:
- Current head: `619dda006ab2e344ab6d02704c0c6a91575952e1`.
- Hosted CI was requested with `+ci-run-hosted` after the final push.
- Current hosted state: pending, with `pro-lint` showing failed while its workflow is still in progress and logs are not yet downloadable. Local CI-equivalent pro-lint steps pass; this will be rerun or fixed after the log is available.

Release/changelog:
- Target/base: `release/17.0.0`.
- Release tracker state: `development`; release phase: `rc`.
- Changelog classification: `deferred_to_update_changelog` for the release-train changelog pass.

## Final Gate Refresh

Current head: `619dda006ab2e344ab6d02704c0c6a91575952e1`.

- GREEN: `pr-ci-readiness 4529 --repo shakacode/react_on_rails` returned `READY` with no failing or pending checks after the hosted `pro-lint` rerun passed.
- GREEN: unresolved review-thread GraphQL check returned `unresolved_count: 0`.
- GREEN: `script/pr-merge-ledger 4529 --strict --changelog-classification deferred_to_update_changelog --finding-dispositions /tmp/pr4529-finding-dispositions.json --pretty` returned `complete_allowed: true`, no violations, and no `unknown_fields`.
- Review finding dispositions: `discussion_r3539688971` fixed by the `unpinWithoutEvict` follow-up and red/green `h2` cache-race regression; `discussion_r3539897260` investigated/resolved as not applicable with in-thread evidence.
- Review coverage: CodeRabbit approved current head, hosted `claude-review` succeeded on current head, hosted Greptile/Codex review comments were triaged, and no unresolved current-head threads remain.
- QA merge tree with #4530 was refreshed after the final #4529 follow-up: `git merge-tree --write-tree --messages origin/jg-codex/4522-rsc-error-boundary-release-17 origin/jg-codex/4523-rspack-doctor-node-modules-release-17` produced tree `ca9683c6cea6ec9f4fcac26590f08dbfec7cdfd3` with no conflicts.
