### PR TITLE
Fix RSC doctor Rspack package resolution

### DIFF
--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3644,18 +3644,18 @@ module ReactOnRails
     end
 
     def detected_rspack_version_for_rsc
-      package_root = resolved_package_root
+      package_root = resolved_rsc_package_root
       installed_version = nil
       unless package_root_missing?(package_root)
         installed_version = installed_package_version(package_root, RSC_RSPACK_PACKAGE)
       end
-      installed_version || declared_rspack_version_for_rsc
+      installed_version || declared_rspack_version_for_rsc(package_root)
     rescue StandardError
       nil
     end
 
-    def declared_rspack_version_for_rsc
-      package_json_path = package_json_path_for("declared Rspack version")
+    def declared_rspack_version_for_rsc(package_root = resolved_rsc_package_root)
+      package_json_path = package_json_path_for("declared Rspack version", package_root)
       return nil unless package_json_path
 
       rsc_declared_package_version(package_json_path, RSC_RSPACK_PACKAGE)
@@ -3665,8 +3665,12 @@ module ReactOnRails
       rsc_rspack_version_requirement_error(
         rspack_version,
         error_prefix: "🚫",
-        package_json_path: package_json_path_for("RSC Rspack version")
+        package_json_path: package_json_path_for("RSC Rspack version", resolved_rsc_package_root)
       )
+    end
+
+    def resolved_rsc_package_root
+      rsc_configured_package_root(resolved_package_root)
     end
 
     def check_rsc_rspack_lazy_compilation

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -5,7 +5,7 @@ require "open3"
 require_relative "utils"
 
 module ReactOnRails
-  module RscRspackSupport
+  module RscRspackSupport # rubocop:disable Metrics/ModuleLength
     RSC_RSPACK_PACKAGE = "@rspack/core"
     RSC_RSPACK_V2_PACKAGES = %w[
       @rspack/core
@@ -37,6 +37,11 @@ module ReactOnRails
       [a-z0-9][a-z0-9._-]*
       \z
     }x
+    NODE_PACKAGE_RESOLUTION_SCRIPT = <<~JS
+      const packageName = process.argv[1];
+      const nodeModulesPath = process.argv[2];
+      console.log(require.resolve(packageName + '/package.json', { paths: [nodeModulesPath] }));
+    JS
 
     private
 
@@ -83,25 +88,32 @@ module ReactOnRails
       MSG
     end
 
-    def rsc_installed_package_version(package_root, package_name, &)
-      version = rsc_installed_package_json(package_root, package_name, &)&.fetch("version", nil)
+    def rsc_installed_package_version(package_root, package_name, node_modules_path: nil, &)
+      version = rsc_installed_package_json(package_root, package_name, node_modules_path:, &)&.fetch("version", nil)
       version if version&.match?(/\A\d+\.\d+\.\d+/)
     end
 
-    def rsc_flat_installed_package_version(package_root, package_name)
-      version = rsc_flat_installed_package_json(package_root, package_name)&.fetch("version", nil)
+    def rsc_flat_installed_package_version(package_root, package_name, node_modules_path: nil)
+      version = rsc_flat_installed_package_json(package_root, package_name, node_modules_path:)&.fetch("version", nil)
       version if version&.match?(/\A\d+\.\d+\.\d+/)
     end
 
-    def rsc_installed_package_json(package_root, package_name, &)
+    def rsc_installed_package_json(package_root, package_name, node_modules_path: nil, &)
       return nil unless valid_rsc_package_name?(package_name)
 
-      script = "console.log(require.resolve(process.argv[1] + '/package.json'))"
-      resolved_path = rsc_resolved_node_package_json_path(package_root, package_name, script, &)
+      resolved_path = rsc_resolved_node_package_json_path(
+        package_root,
+        package_name,
+        NODE_PACKAGE_RESOLUTION_SCRIPT,
+        node_modules_path:,
+        &
+      )
       # package_name has passed PACKAGE_NAME_PATTERN, so this fallback cannot escape node_modules.
       # It covers classic flat node_modules layouts; pnpm virtual-store layouts rely on Node resolution above.
       # Limitation: a stale orphaned directory can still be read if Node resolution fails.
-      resolved_path = rsc_flat_installed_package_json_path(package_root, package_name) if resolved_path.empty?
+      if resolved_path.empty?
+        resolved_path = rsc_flat_installed_package_json_path(package_root, package_name, node_modules_path:)
+      end
       return nil unless File.exist?(resolved_path)
 
       JSON.parse(File.read(resolved_path))
@@ -109,10 +121,10 @@ module ReactOnRails
       nil
     end
 
-    def rsc_flat_installed_package_json(package_root, package_name)
+    def rsc_flat_installed_package_json(package_root, package_name, node_modules_path: nil)
       return nil unless valid_rsc_package_name?(package_name)
 
-      package_json_path = rsc_flat_installed_package_json_path(package_root, package_name)
+      package_json_path = rsc_flat_installed_package_json_path(package_root, package_name, node_modules_path:)
       return nil unless File.exist?(package_json_path)
 
       JSON.parse(File.read(package_json_path))
@@ -120,8 +132,8 @@ module ReactOnRails
       nil
     end
 
-    def rsc_flat_installed_package_json_path(package_root, package_name)
-      File.join(package_root, "node_modules", package_name, "package.json")
+    def rsc_flat_installed_package_json_path(package_root, package_name, node_modules_path: nil)
+      File.join(rsc_node_modules_path(package_root, node_modules_path), package_name, "package.json")
     end
 
     def rsc_support_enabled_config_value
@@ -164,9 +176,16 @@ module ReactOnRails
       major.to_i
     end
 
-    def rsc_resolved_node_package_json_path(package_root, package_name, script, &)
+    def rsc_resolved_node_package_json_path(package_root, package_name, script, node_modules_path: nil, &)
       # Boot/doctor validation only. This is intentionally outside the request path.
-      stdout, _stderr, status = Open3.capture3("node", "-e", script, package_name, chdir: package_root)
+      stdout, _stderr, status = Open3.capture3(
+        "node",
+        "-e",
+        script,
+        package_name,
+        rsc_node_modules_path(package_root, node_modules_path),
+        chdir: package_root
+      )
       unless status.success?
         yield(package_name) if block_given?
         return ""
@@ -176,6 +195,26 @@ module ReactOnRails
     rescue StandardError
       yield(package_name) if block_given?
       ""
+    end
+
+    def rsc_configured_package_root(default_package_root)
+      configured_path = ReactOnRails.configuration.node_modules_location.to_s
+      return default_package_root if configured_path.empty?
+
+      rails_root = defined?(Rails) && Rails.respond_to?(:root) ? Rails.root.to_s : Dir.pwd
+      File.expand_path(configured_path, rails_root)
+    rescue StandardError
+      default_package_root
+    end
+
+    def rsc_node_modules_path(package_root, node_modules_path = nil)
+      resolved_node_modules_path = node_modules_path.to_s
+      return resolved_node_modules_path unless resolved_node_modules_path.empty?
+
+      package_root_string = package_root.to_s
+      return package_root_string if File.basename(package_root_string) == "node_modules"
+
+      File.join(package_root_string, "node_modules")
     end
 
     def rsc_detected_package_manager

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -262,7 +262,7 @@ module ReactOnRails
     end
 
     def detected_rspack_version_for_rsc
-      package_root = File.dirname(node_package_version.package_json)
+      package_root = rsc_configured_package_root(File.dirname(node_package_version.package_json))
       declared_spec = package_dependency_spec(RSC_RSPACK_PACKAGE)
       declared_version = rsc_normalized_declared_package_version(declared_spec) || declared_spec
       declared_major_version = rsc_package_major_version(declared_spec)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5360,6 +5360,9 @@ RSpec.describe ReactOnRails::Doctor do
     before do
       allow(Rails).to receive(:root).and_return(Pathname.new(Dir.pwd))
       allow(doctor).to receive(:resolved_package_root).and_return(Dir.pwd)
+      allow(ReactOnRails).to receive(:configuration).and_return(
+        instance_double(ReactOnRails::Configuration, node_modules_location: "")
+      )
       allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
       stub_const("ReactOnRailsPro", Module.new)
       stub_const("ReactOnRailsPro::Configuration", Class.new { attr_reader :enable_rsc_support })
@@ -5409,6 +5412,30 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_rsc_rspack_version)
         success_msgs = checker.messages.select { |m| m[:type] == :success }
         expect(success_msgs.any? { |m| m[:content].include?("Rspack 2.0.0 is compatible with RSC") }).to be true
+      end
+    end
+
+    context "when Rspack is installed under a configured client package root" do
+      before do
+        write_rspack_project(assets_bundler: "rspack", rspack_core_version: "latest")
+        FileUtils.mkdir_p("client/node_modules/@rspack/core")
+        File.write(
+          "client/node_modules/@rspack/core/package.json",
+          JSON.generate("name" => "@rspack/core", "version" => "2.0.8")
+        )
+        allow(ReactOnRails).to receive(:configuration).and_return(
+          instance_double(ReactOnRails::Configuration, node_modules_location: "client")
+        )
+        doctor.send(:resolved_package_root)
+      end
+
+      it "uses the current configured package root instead of stale root resolution" do
+        doctor.send(:check_rsc_rspack_version)
+
+        success_msgs = checker.messages.select { |m| m[:type] == :success }
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+        expect(success_msgs.any? { |m| m[:content].include?("Rspack 2.0.8 is compatible with RSC") }).to be true
+        expect(error_msgs).to be_empty
       end
     end
 
@@ -6456,8 +6483,9 @@ RSpec.describe ReactOnRails::Doctor do
           .with(
             "node",
             "-e",
-            "console.log(require.resolve(process.argv[1] + '/package.json'))",
+            ReactOnRails::RscRspackSupport::NODE_PACKAGE_RESOLUTION_SCRIPT,
             "react",
+            File.join(package_root, "node_modules"),
             chdir: package_root
           )
           .and_return(

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -280,9 +280,10 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           )
         end
 
-        def stub_rsc_rspack_project(root, rsc_enabled:, configuration_error: nil)
+        def stub_rsc_rspack_project(root, rsc_enabled:, configuration_error: nil, node_modules_location: "")
           allow(Rails).to receive(:root).and_return(Pathname.new(root))
-          allow(ReactOnRails).to receive_message_chain(:configuration, :node_modules_location).and_return("")
+          allow(ReactOnRails).to receive_message_chain(:configuration, :node_modules_location)
+            .and_return(node_modules_location)
           allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
           stub_gem_version("17.0.0")
 
@@ -466,8 +467,9 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             expect(Open3).to have_received(:capture3).with(
               "node",
               "-e",
-              "console.log(require.resolve(process.argv[1] + '/package.json'))",
+              ReactOnRails::RscRspackSupport::NODE_PACKAGE_RESOLUTION_SCRIPT,
               "@rspack/core",
+              File.join(root, "node_modules"),
               chdir: root
             )
           end
@@ -677,9 +679,31 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             expect(Open3).to have_received(:capture3).with(
               "node",
               "-e",
-              "console.log(require.resolve(process.argv[1] + '/package.json'))",
+              ReactOnRails::RscRspackSupport::NODE_PACKAGE_RESOLUTION_SCRIPT,
               "@rspack/core",
+              File.join(root, "node_modules"),
               chdir: root
+            )
+          end
+        end
+
+        it "uses the configured client package root to resolve installed Rspack" do
+          Dir.mktmpdir do |root|
+            write_rsc_rspack_project_files(root, assets_bundler: "rspack", rspack_core_version: "latest")
+            client_rspack_package_json = File.join(root, "client/node_modules/@rspack/core/package.json")
+            FileUtils.mkdir_p(File.dirname(client_rspack_package_json))
+            File.write(
+              client_rspack_package_json,
+              JSON.generate("name" => "@rspack/core", "version" => "2.0.8")
+            )
+            stub_rsc_rspack_project(root, rsc_enabled: true, node_modules_location: "client")
+            node_package_version = VersionChecker::NodePackageVersion.new(File.join(root, "package.json"))
+            allow(Rails.logger).to receive(:warn)
+
+            expect { described_class.new(node_package_version).validate_version_and_package_compatibility! }
+              .not_to raise_error
+            expect(Rails.logger).not_to have_received(:warn).with(
+              a_string_including("Could not verify @rspack/core")
             )
           end
         end


### PR DESCRIPTION
## Why

Fixes #4523 for the 17.0.0 release branch. The RSC doctor/version checker resolved `@rspack/core` from the current process context, which could miss the app-configured client `node_modules` location and report an incorrect Rspack verification failure.

## What changed

- Resolve RSC package versions through Node `require.resolve(..., { paths: [configured_node_modules] })`.
- Thread the configured client package root into Rspack detection.
- Update doctor/version-checker specs for configured client `node_modules` resolution.

## Verification

Local and worker validation:
- RED: `bundle exec rspec spec/react_on_rails/version_checker_spec.rb:688` failed before the fix because boot validation warned it could not verify `@rspack/core`.
- RED: `bundle exec rspec spec/lib/react_on_rails/doctor_spec.rb:5429` failed before the fix because doctor did not report Rspack 2.0.8 success.
- GREEN: `bundle exec rspec spec/react_on_rails/version_checker_spec.rb` passed, 116 examples.
- GREEN: `bundle exec rspec spec/lib/react_on_rails/doctor_spec.rb --format progress` passed, 362 examples.
- GREEN: `bundle exec rspec spec/react_on_rails/version_checker_spec.rb spec/lib/react_on_rails/doctor_spec.rb --format progress` passed, 478 examples.
- GREEN: `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/version_checker.rb lib/react_on_rails/rsc_rspack_support.rb lib/react_on_rails/doctor.rb spec/react_on_rails/version_checker_spec.rb spec/lib/react_on_rails/doctor_spec.rb` passed.
- GREEN: `git diff --check origin/release/17.0.0...HEAD` passed.
- Setup repair for broad validation: `pnpm --dir react_on_rails_pro/spec/dummy run build:test` regenerated missing dummy SSR/RSC bundles successfully.
- GREEN: `pnpm --filter react-on-rails-pro-node-renderer run test` passed, 38 suites / 515 tests.
- GREEN: `.agents/bin/validate --fast` passed after the setup repair. It included broad Ruby/generator checks, Pro RuboCop, Pro RBS validation, and Pro TypeScript checks; Pro tests were intentionally skipped by `--fast`.

Review gates:
- Codex local review against `origin/release/17.0.0`: no discrete correctness issues found.
- Hosted `claude-review` check completed successfully on head `5ea3d905b6c7c9dfebf40ee1dc66af7f1cb8c93f`.
- Local Claude report-only review and `/simplify` could not run because the local Claude account hit the weekly limit; hosted Claude review is the independent Claude gate for this PR.

QA Evidence:
- QA claim completed for PR #4530.
- Cross-lane merge tree with #4529 was clean: `git merge-tree --write-tree --messages origin/jg-codex/4522-rsc-error-boundary-release-17 origin/jg-codex/4523-rspack-doctor-node-modules-release-17` produced tree `f4bae5833591c2750836f6413c2fdeafbe21693e` and no conflicts.
- QA reran `bundle exec rspec spec/react_on_rails/version_checker_spec.rb spec/lib/react_on_rails/doctor_spec.rb --format progress`; passed, 478 examples / 0 failures.

Hosted CI status:
- Current head: `5ea3d905b6c7c9dfebf40ee1dc66af7f1cb8c93f`.
- Hosted CI is still in progress on current head; remaining generator matrix jobs are being watched.

Release/changelog:
- Target/base: `release/17.0.0`.
- Release tracker state: `development`; release phase: `rc`.
- Changelog classification: `deferred_to_update_changelog` for the release-train changelog pass.

## Final Gate Refresh

Current head: `5ea3d905b6c7c9dfebf40ee1dc66af7f1cb8c93f`.

- GREEN: `pr-ci-readiness 4530 --repo shakacode/react_on_rails` returned `READY` with no failing or pending checks.
- GREEN: unresolved review-thread GraphQL check returned `unresolved_count: 0`.
- GREEN: `script/pr-merge-ledger 4530 --strict --changelog-classification deferred_to_update_changelog --pretty` returned `complete_allowed: true`, no violations, and no `unknown_fields`.
- Review coverage: CodeRabbit approved current head, hosted `claude-review` succeeded on current head, Greptile review completed on current head, and no unresolved current-head threads remain.
- QA merge tree with #4529 was refreshed after the final #4529 follow-up: `git merge-tree --write-tree --messages origin/jg-codex/4522-rsc-error-boundary-release-17 origin/jg-codex/4523-rspack-doctor-node-modules-release-17` produced tree `ca9683c6cea6ec9f4fcac26590f08dbfec7cdfd3` with no conflicts.
