### PR TITLE
Avoid noisy incremental close-hook warnings

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -687,6 +687,10 @@ export default function run(config: Partial<Config>) {
     let incrementalExecutionContextReleased = false;
     let pullModeRequestCanIdle = false;
     let incrementalRequestClosePromise: Promise<void> | undefined;
+    let incrementalRequestCloseSettled = false;
+    let incrementalRequestCloseTimedOut = false;
+    let incrementalRequestCloseTimeoutMs = INCREMENTAL_REQUEST_CLOSE_TIMEOUT_MS;
+    let incrementalRequestCloseTimeoutWarned = false;
     let incrementalResponseFinishTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let incrementalPullModeIdleTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let stopIncrementalRequestReader: (() => void) | undefined;
@@ -743,11 +747,29 @@ export default function run(config: Partial<Config>) {
       incrementalSink.executionContext.release();
     };
 
+    const warnIfIncrementalRequestCloseTimedOut = () => {
+      if (
+        !incrementalRequestCloseTimedOut ||
+        incrementalRequestCloseSettled ||
+        incrementalRequestCloseTimeoutWarned ||
+        !incrementalResponseFinished
+      ) {
+        return;
+      }
+
+      incrementalRequestCloseTimeoutWarned = true;
+      log.warn({
+        msg: 'Timed out waiting for incremental render close hook after response started',
+        timeoutMs: incrementalRequestCloseTimeoutMs,
+      });
+    };
+
     const markIncrementalResponseFinished = () => {
       clearIncrementalResponseFinishTimeout();
       clearIncrementalPullModeIdleTimeout();
       incrementalResponseFinished = true;
       wakeIncrementalRequestReader();
+      warnIfIncrementalRequestCloseTimedOut();
       releaseIncrementalExecutionContextWhenDone();
     };
 
@@ -785,16 +807,24 @@ export default function run(config: Partial<Config>) {
         timeoutId = setTimeout(() => resolve('timeout'), timeoutMs);
       });
 
-      const result = await Promise.race([closeRequestPromise.then(() => 'closed' as const), timeoutPromise]);
+      // A slow close hook can be part of normal incremental streaming after the
+      // Rails request has ended. The response-finish watchdog emits the warning
+      // if cleanup truly stalls while the response is still open; this short
+      // race only prevents request-reader bookkeeping from waiting on a healthy
+      // stream.
+      const closeRequestSettledPromise = closeRequestPromise.then(() => {
+        incrementalRequestCloseSettled = true;
+        return 'closed' as const;
+      });
+      const result = await Promise.race([closeRequestSettledPromise, timeoutPromise]);
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
 
       if (result === 'timeout') {
-        log.warn({
-          msg: 'Timed out waiting for incremental render close hook after response started',
-          timeoutMs,
-        });
+        incrementalRequestCloseTimedOut = true;
+        incrementalRequestCloseTimeoutMs = timeoutMs;
+        warnIfIncrementalRequestCloseTimedOut();
       }
     };
 

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -79,6 +79,24 @@ const waitForMockCalls = async (mockFn: jest.Mock, expectedCalls: number) => {
   expect(mockFn).toHaveBeenCalledTimes(expectedCalls);
 };
 
+const waitForMockCallsWithRealTimers = async (
+  mockFn: jest.Mock,
+  expectedCalls: number,
+  timeoutMs = 2_000,
+) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (mockFn.mock.calls.length >= expectedCalls) {
+      return;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  expect(mockFn).toHaveBeenCalledTimes(expectedCalls);
+};
+
 // Helper to create worker with standard options
 const createWorker = (options: Parameters<typeof worker>[0] = {}) =>
   worker({
@@ -1787,5 +1805,335 @@ describe('worker', () => {
         jest.useRealTimers();
       }
     });
+
+    test('does not warn while a slow request close hook finishes a healthy incremental stream', async () => {
+      const requestStream = new PassThrough();
+      const responseStream = new Readable({
+        read() {
+          // Test pushes the final response after the request close hook resolves.
+        },
+      });
+      let finishRequestClose: (() => void) | undefined;
+      const handleRequestClosed = jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRequestClose = resolve;
+          }),
+      );
+      const releaseExecutionContext = jest.fn();
+      await jest.isolateModulesAsync(async () => {
+        const warn = jest.fn();
+        jest.doMock('../src/shared/log.js', () => ({
+          __esModule: true,
+          default: {
+            error: jest.fn(),
+            fatal: jest.fn(),
+            info: jest.fn(),
+            warn,
+          },
+          sharedLoggerOptions: {},
+        }));
+
+        const isolatedWorkerModule = await import('../src/worker');
+        const isolatedIncremental = await import('../src/worker/handleIncrementalRenderRequest');
+        isolatedWorkerModule.disableHttp2();
+
+        const handleSpy = jest
+          .spyOn(isolatedIncremental, 'handleIncrementalRenderRequest')
+          .mockResolvedValue({
+            response: {
+              status: 200,
+              headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+              stream: responseStream,
+            },
+            sink: {
+              add: jest.fn(),
+              handleRequestClosed,
+              executionContext: { release: releaseExecutionContext } as unknown as ExecutionContext,
+            },
+          });
+
+        try {
+          const password = 'long-enough-renderer-password';
+          const app = isolatedWorkerModule.default({
+            serverBundleCachePath: serverBundleCachePathForTest(),
+            supportModules: true,
+            stubTimers: false,
+            password,
+          });
+          const payload = {
+            gemVersion,
+            protocolVersion,
+            password,
+            renderingRequest: 'ReactOnRails.dummy',
+            dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
+            pullEnabled: true,
+          };
+
+          const responsePromise = app
+            .inject()
+            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+            .payload(requestStream)
+            .headers({
+              'Content-Type': 'application/x-ndjson',
+            })
+            .end();
+
+          requestStream.write(createNDJSONPayload(payload));
+          await waitForMockCallsWithRealTimers(handleSpy, 1);
+          requestStream.end();
+          await waitForMockCallsWithRealTimers(handleRequestClosed, 1);
+
+          await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+          expect(warn).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+              msg: 'Timed out waiting for incremental render close hook after response started',
+            }),
+          );
+          expect(responseStream.destroyed).toBe(false);
+          expect(releaseExecutionContext).not.toHaveBeenCalled();
+
+          finishRequestClose?.();
+          responseStream.push('finished after slow close hook');
+          responseStream.push(null);
+
+          const responseResult = await responsePromise;
+
+          expect(responseResult.statusCode).toBe(200);
+          expect(responseResult.payload).toBe('finished after slow close hook');
+          expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+          expect(warn).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+              msg: 'Timed out waiting for incremental render close hook after response started',
+            }),
+          );
+        } finally {
+          requestStream.destroy();
+          responseStream.destroy();
+          handleSpy.mockRestore();
+          jest.dontMock('../src/shared/log.js');
+        }
+      });
+    }, 5_000);
+
+    test('warns when a slow request close hook outlives an already finished incremental stream', async () => {
+      const requestStream = new PassThrough();
+      const responseStream = new Readable({
+        read() {
+          // Test pushes the full response before the request close hook resolves.
+        },
+      });
+      let finishRequestClose: (() => void) | undefined;
+      const handleRequestClosed = jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRequestClose = resolve;
+          }),
+      );
+      const releaseExecutionContext = jest.fn();
+      await jest.isolateModulesAsync(async () => {
+        const warn = jest.fn();
+        jest.doMock('../src/shared/log.js', () => ({
+          __esModule: true,
+          default: {
+            error: jest.fn(),
+            fatal: jest.fn(),
+            info: jest.fn(),
+            warn,
+          },
+          sharedLoggerOptions: {},
+        }));
+
+        const isolatedWorkerModule = await import('../src/worker');
+        const isolatedIncremental = await import('../src/worker/handleIncrementalRenderRequest');
+        isolatedWorkerModule.disableHttp2();
+
+        const handleSpy = jest
+          .spyOn(isolatedIncremental, 'handleIncrementalRenderRequest')
+          .mockResolvedValue({
+            response: {
+              status: 200,
+              headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+              stream: responseStream,
+            },
+            sink: {
+              add: jest.fn(),
+              handleRequestClosed,
+              executionContext: { release: releaseExecutionContext } as unknown as ExecutionContext,
+            },
+          });
+
+        try {
+          const password = 'long-enough-renderer-password';
+          const app = isolatedWorkerModule.default({
+            serverBundleCachePath: serverBundleCachePathForTest(),
+            supportModules: true,
+            stubTimers: false,
+            password,
+          });
+          const payload = {
+            gemVersion,
+            protocolVersion,
+            password,
+            renderingRequest: 'ReactOnRails.dummy',
+            dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
+            pullEnabled: true,
+          };
+
+          const responsePromise = app
+            .inject()
+            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+            .payload(requestStream)
+            .headers({
+              'Content-Type': 'application/x-ndjson',
+            })
+            .end();
+
+          requestStream.write(createNDJSONPayload(payload));
+          await waitForMockCallsWithRealTimers(handleSpy, 1);
+          responseStream.push('finished before slow close hook');
+          responseStream.push(null);
+          requestStream.end();
+          await waitForMockCallsWithRealTimers(handleRequestClosed, 1);
+
+          await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+          expect(warn).toHaveBeenCalledWith(
+            expect.objectContaining({
+              msg: 'Timed out waiting for incremental render close hook after response started',
+              timeoutMs: 1_000,
+            }),
+          );
+          expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+
+          finishRequestClose?.();
+
+          const responseResult = await responsePromise;
+
+          expect(responseResult.statusCode).toBe(200);
+          expect(responseResult.payload).toBe('finished before slow close hook');
+        } finally {
+          requestStream.destroy();
+          responseStream.destroy();
+          handleSpy.mockRestore();
+          jest.dontMock('../src/shared/log.js');
+        }
+      });
+    }, 5_000);
+
+    test('warns when a slow request close hook remains open after a later incremental stream finish', async () => {
+      const requestStream = new PassThrough();
+      const responseStream = new Readable({
+        read() {
+          // Test finishes the response after the close hook timeout fires.
+        },
+      });
+      let finishRequestClose: (() => void) | undefined;
+      const handleRequestClosed = jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRequestClose = resolve;
+          }),
+      );
+      const releaseExecutionContext = jest.fn();
+      await jest.isolateModulesAsync(async () => {
+        const warn = jest.fn();
+        jest.doMock('../src/shared/log.js', () => ({
+          __esModule: true,
+          default: {
+            error: jest.fn(),
+            fatal: jest.fn(),
+            info: jest.fn(),
+            warn,
+          },
+          sharedLoggerOptions: {},
+        }));
+
+        const isolatedWorkerModule = await import('../src/worker');
+        const isolatedIncremental = await import('../src/worker/handleIncrementalRenderRequest');
+        isolatedWorkerModule.disableHttp2();
+
+        const handleSpy = jest
+          .spyOn(isolatedIncremental, 'handleIncrementalRenderRequest')
+          .mockResolvedValue({
+            response: {
+              status: 200,
+              headers: { 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate' },
+              stream: responseStream,
+            },
+            sink: {
+              add: jest.fn(),
+              handleRequestClosed,
+              executionContext: { release: releaseExecutionContext } as unknown as ExecutionContext,
+            },
+          });
+
+        try {
+          const password = 'long-enough-renderer-password';
+          const app = isolatedWorkerModule.default({
+            serverBundleCachePath: serverBundleCachePathForTest(),
+            supportModules: true,
+            stubTimers: false,
+            password,
+          });
+          const payload = {
+            gemVersion,
+            protocolVersion,
+            password,
+            renderingRequest: 'ReactOnRails.dummy',
+            dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
+            pullEnabled: true,
+          };
+
+          const responsePromise = app
+            .inject()
+            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+            .payload(requestStream)
+            .headers({
+              'Content-Type': 'application/x-ndjson',
+            })
+            .end();
+
+          requestStream.write(createNDJSONPayload(payload));
+          await waitForMockCallsWithRealTimers(handleSpy, 1);
+          requestStream.end();
+          await waitForMockCallsWithRealTimers(handleRequestClosed, 1);
+
+          await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+          expect(warn).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+              msg: 'Timed out waiting for incremental render close hook after response started',
+            }),
+          );
+          expect(releaseExecutionContext).not.toHaveBeenCalled();
+
+          responseStream.push('finished after close hook timeout');
+          responseStream.push(null);
+          await waitForMockCallsWithRealTimers(warn, 1);
+
+          expect(warn).toHaveBeenCalledWith(
+            expect.objectContaining({
+              msg: 'Timed out waiting for incremental render close hook after response started',
+              timeoutMs: 1_000,
+            }),
+          );
+          expect(releaseExecutionContext).toHaveBeenCalledTimes(1);
+
+          finishRequestClose?.();
+
+          const responseResult = await responsePromise;
+
+          expect(responseResult.statusCode).toBe(200);
+          expect(responseResult.payload).toBe('finished after close hook timeout');
+        } finally {
+          requestStream.destroy();
+          responseStream.destroy();
+          handleSpy.mockRestore();
+          jest.dontMock('../src/shared/log.js');
+        }
+      });
+    }, 5_000);
   });
 });


### PR DESCRIPTION
## Why

Fixes #4524.

The marketplace RSC product-search smoke path completed successfully, but logs repeatedly showed the short incremental close-hook timeout warning after the Rails request ended. That warning was too eager for a healthy streaming response: a slow `handleRequestClosed` hook can be normal while the response stream is still finishing.

## What Changed

- Stop logging `Timed out waiting for incremental render close hook after response started` from the short request-close race while the incremental response is still open and the close hook later settles before the stream finishes.
- Keep the existing response-finish watchdog intact so truly stalled response cleanup still warns and destroys the response.
- Preserve the close-hook diagnostic when the close hook is still unresolved after the incremental response has finished, including the timing where the close hook times out first and the response finishes later.
- Add regression coverage for healthy slow-close streams, already-finished streams, and streams that finish after the close-hook timeout while the hook remains stalled.

## QA Evidence

qa-evidence v1

- Scope: #4524 incremental render cleanup warning in the Pro node renderer streaming path.
- Focused RED proof before the implementation change: `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/worker.test.ts -t "does not warn while a slow request close hook finishes a healthy incremental stream" --runInBand` failed because the old close-hook warning was emitted after 1s.
- Focused regression after the initial implementation change: `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/worker.test.ts -t "does not warn while a slow request close hook finishes a healthy incremental stream" --runInBand` passed.
- Review-fix focused regression: `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/worker.test.ts -t "slow request close hook" --runInBand` passed, 3 focused tests.
- Full touched test file after review fixes: `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/worker.test.ts --runInBand` passed, 56 tests.
- Package type-check: `pnpm --filter react-on-rails-pro-node-renderer type-check` passed.
- JS lint: `pnpm run lint` passed.
- Formatting: `pnpm start format.listDifferent` passed.
- Pro license headers: `script/check-pro-license-headers` passed.
- Diff whitespace: `git diff --check` passed.
- Optimized fast repo wrapper after the final review fix: `.agents/bin/validate --changed --fast` passed.
- Full optimized repo wrapper before review fixes: `.agents/bin/validate --changed` passed docs/sidebar, RuboCop, ESLint, Prettier, repo-wide TypeScript, Pro RuboCop, Pro RBS, and Pro TypeScript, then failed at existing wrapper seam `React on Rails Pro JS Tests` because `bin/ci-local` calls `cd react_on_rails_pro && pnpm run nps test`, but `react_on_rails_pro/package-scripts.yml` has no `test` script.
- GitHub Greptile review: found the already-finished close-hook stall case; addressed and resolved.
- GitHub Codex review: found the later-finish-after-timeout close-hook stall case; addressed in `01f548b13adb25c80e93a910dc6beba04fec9c7f`.
- Final local Codex review attempt: inconclusive. The review tool nested a broad `pnpm --dir packages/react-on-rails-pro-node-renderer test -- tests/worker.test.ts --runInBand` command, which expanded to generated-bundle-dependent suites and failed on missing `react_on_rails_pro/spec/dummy/ssr-generated/*` artifacts, then stopped making useful progress. Direct focused validation above passed.
- Claude review: skipped because the local Claude CLI reported the weekly quota is exhausted until July 11, 2026 Pacific/Honolulu.

## Decision Log

- Targeted `main`, not `release/17.0.0`, because the issue was explicitly classified as a main-only RSC follow-up and not a release blocker.
- Chose to remove only the short close-hook warning for healthy in-progress responses; the longer response-finish watchdog remains the warning/escalation path for a stalled response stream.
- Chose to keep the close-hook timeout warning when the response has already finished or finishes after the timeout while the close hook is still pending.
- QA lane `ror-b-qa` was claimed because this is a runtime/streaming implementation PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slow incremental render “request close” handling to avoid unnecessary timeout warnings when streaming completes normally.
  * Ensured request context release happens at the correct time, even when close processing is delayed.
* **Tests**
  * Added real-timer coverage for incremental streaming scenarios to verify warning behavior and that release occurs only after close completes (or after the timeout when appropriate).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
