### PR TITLE
Harden Claude trigger permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,11 +9,68 @@ on:
     types: [opened, assigned]
 
 jobs:
-  claude:
+  authorize_claude_actor:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      authorized: ${{ steps.permission-gate.outputs.authorized }}
+    steps:
+      - name: Verify actor can run Claude
+        id: permission-gate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const permissionByLogin = new Map();
+
+            async function hasWriteAccessFor(username) {
+              if (!username) {
+                return false;
+              }
+
+              if (permissionByLogin.has(username)) {
+                return permissionByLogin.get(username);
+              }
+
+              let hasWriteAccess = false;
+              try {
+                const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username
+                });
+                hasWriteAccess = ['admin', 'write'].includes(permission.permission);
+              } catch (error) {
+                core.warning(
+                  `Unable to verify ${username} write permission for Claude; ` +
+                    `treating the @claude request as untrusted: ${error.message || error}`
+                );
+              }
+
+              permissionByLogin.set(username, hasWriteAccess);
+              return hasWriteAccess;
+            }
+
+            if (!(await hasWriteAccessFor(context.actor))) {
+              core.setOutput('authorized', 'false');
+              core.setFailed(
+                `Unable to run Claude because ${context.actor} does not have write/admin repository permission.`
+              );
+              return;
+            }
+
+            core.setOutput('authorized', 'true');
+            core.info(`Authorized ${context.actor} to run Claude.`);
+
+  claude:
+    needs: authorize_claude_actor
+    if: needs.authorize_claude_actor.outputs.authorized == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,21 @@ jobs:
             const repo = context.repo.repo;
             const permissionByLogin = new Map();
 
+            function claudeRequester() {
+              if (
+                context.eventName === 'issue_comment' ||
+                context.eventName === 'pull_request_review_comment'
+              ) {
+                return context.payload.comment?.user?.login;
+              }
+
+              if (context.eventName === 'issues') {
+                return context.payload.issue?.user?.login;
+              }
+
+              return null;
+            }
+
             async function hasWriteAccessFor(username) {
               if (!username) {
                 return false;
@@ -57,16 +72,31 @@ jobs:
               return hasWriteAccess;
             }
 
-            if (!(await hasWriteAccessFor(context.actor))) {
+            const actor = context.actor;
+            const requester = claudeRequester();
+
+            if (!requester) {
+              core.setOutput('authorized', 'false');
+              core.setFailed('Unable to run Claude because the @claude requester could not be determined.');
+              return;
+            }
+
+            if (!(await hasWriteAccessFor(actor))) {
+              core.setOutput('authorized', 'false');
+              core.setFailed(`Unable to run Claude because ${actor} does not have write/admin repository permission.`);
+              return;
+            }
+
+            if (!(await hasWriteAccessFor(requester))) {
               core.setOutput('authorized', 'false');
               core.setFailed(
-                `Unable to run Claude because ${context.actor} does not have write/admin repository permission.`
+                `Unable to run Claude because @claude requester ${requester} does not have write/admin repository permission.`
               );
               return;
             }
 
             core.setOutput('authorized', 'true');
-            core.info(`Authorized ${context.actor} to run Claude.`);
+            core.info(`Authorized ${actor} and @claude requester ${requester} to run Claude.`);
 
   claude:
     needs: authorize_claude_actor

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -17,6 +17,7 @@ const labelDispatchWorkflow = read('.github/workflows/hosted-ci-label-dispatch.y
 const requiredWorkflow = read('.github/workflows/ci-required.yml');
 const hostedSelectorsAction = read('.github/actions/hosted-ci-selectors/action.yml');
 const ciCommandsWorkflow = read('.github/workflows/ci-commands.yml');
+const claudeWorkflow = read('.github/workflows/claude.yml');
 const shakaperfReleaseGateWorkflow = read('.github/workflows/shakaperf-release-gates.yml');
 
 assertMatches(
@@ -70,6 +71,24 @@ assertMatches(
   'closed PR degraded evidence comment',
   ciCommandsWorkflow,
   /branch-ref hosted-CI evidence is degraded\/invalid/,
+);
+assertMatches('Claude authorization job', claudeWorkflow, /authorize_claude_actor:/);
+assertMatches('Claude permission lookup', claudeWorkflow, /getCollaboratorPermissionLevel\({[\s\S]*username/);
+assertMatches('Claude write permission guard', claudeWorkflow, /hasWriteAccessFor\(context\.actor\)/);
+assertMatches(
+  'Claude job needs authorization',
+  claudeWorkflow,
+  /claude:[\s\S]*needs: authorize_claude_actor/,
+);
+assertMatches(
+  'Claude job checks authorization output',
+  claudeWorkflow,
+  /if: needs\.authorize_claude_actor\.outputs\.authorized == 'true'/,
+);
+assertMatches(
+  'Claude unauthorized failure',
+  claudeWorkflow,
+  /does not have write\/admin repository permission/,
 );
 
 assertMatches(

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -74,7 +74,10 @@ assertMatches(
 );
 assertMatches('Claude authorization job', claudeWorkflow, /authorize_claude_actor:/);
 assertMatches('Claude permission lookup', claudeWorkflow, /getCollaboratorPermissionLevel\({[\s\S]*username/);
-assertMatches('Claude write permission guard', claudeWorkflow, /hasWriteAccessFor\(context\.actor\)/);
+assertMatches('Claude actor permission guard', claudeWorkflow, /hasWriteAccessFor\(actor\)/);
+assertMatches('Claude comment requester guard', claudeWorkflow, /context\.payload\.comment\?\.user\?\.login/);
+assertMatches('Claude issue requester guard', claudeWorkflow, /context\.payload\.issue\?\.user\?\.login/);
+assertMatches('Claude requester permission guard', claudeWorkflow, /hasWriteAccessFor\(requester\)/);
 assertMatches(
   'Claude job needs authorization',
   claudeWorkflow,


### PR DESCRIPTION
## Why

Closes #4500.

The `@claude` workflow carries `CLAUDE_CODE_OAUTH_TOKEN`, so the workflow should fail closed before reaching the Claude action unless the triggering actor and original `@claude` requester have live write/admin repository permission. This adds a workflow-level defense-in-depth gate, matching the hosted CI label dispatch posture instead of relying only on the third-party action's internal checks.

## What changed

- Added an `authorize_claude_actor` job that only runs for existing `@claude` trigger paths.
- Reused the hosted CI dispatch permission-check pattern with `repos.getCollaboratorPermissionLevel` and `admin`/`write` permission acceptance.
- Made the gate check both the workflow actor and the original requester from `comment.user.login` or `issue.user.login`, so assigned issue events and workflow reruns cannot substitute a maintainer for untrusted trigger text.
- Made the secret-bearing `claude` job depend on a positive authorization output before checkout or action execution.
- Extended the existing workflow safety smoke test so the Claude permission gate is covered by local/CI checks.

## Validation

- `actionlint`
- `node .github/workflows/hosted-ci-safety.test.cjs`
- `pnpm exec prettier --check .github/workflows/claude.yml .github/workflows/hosted-ci-safety.test.cjs`
- `git diff --check`
- `script/ci-changes-detector origin/main`
- `uvx yamllint .github/` was run; it fails on the repo's existing unmanaged yamllint baseline across `.github/` under default yamllint rules.
- `git commit` pre-commit hook
- `git push` pre-push hook

## Post-merge exercise

- Follow-up tracker: #4534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an authorization gate for the AI-assisted workflow, ensuring it only runs when both the triggering user and the referenced request context have sufficient repository access.
  * When permissions are insufficient, the workflow now exits early with a clear denial message.
* **Tests**
  * Expanded CI safety coverage to verify the authorization job, permission checks, and the wired success/denied execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->