### PR TITLE
Forward-port remaining 17.0.0 RC7 fixes to main

### DIFF
--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -86,10 +86,15 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
+      - { ecosystem: npm, name: shakapacker-rspack }
     needs_pro: true
+    package_manager: yarn_classic
+    ruby_test: bin/rspec
+    build: cd client && yarn start build.rspec.sequential
     smoke: [/]
     verify: true
 
@@ -108,6 +113,8 @@ repos:
       # No cpflow package until a CPFlow review-app pipeline exists for this repo.
     needs_pro: true
     package_manager: npm
+    ruby_test: ALLOW_DEMO_RENDERER_PASSWORD=true bin/rails test
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     # Recorded for future review-app wiring; skipped while cpflow_app_name is null.
     smoke: [/]
     review_app:
@@ -124,10 +131,13 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    ruby_test: bin/rails test && bin/rails test:system
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     smoke: [/, /news]
     verify: true
 
@@ -139,10 +149,12 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     smoke: [/, /products]
     verify: true
 
@@ -154,23 +166,30 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
-      - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    package_manager: npm
     smoke: [/]
     verify: true
 
   - name: shakacode/react-webpack-rails-tutorial
     tier: hard_gate
-    headline: Legacy tutorial reference app
+    headline: Pro + RSC tutorial reference app
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: react_on_rails_pro }
+      - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-    needs_pro: false
+      - { ecosystem: gem, name: cpflow }
+    needs_pro: true
     package_manager: yarn_classic
+    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     smoke: [/]
     verify: true
 
@@ -201,10 +220,12 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
+      - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: true
+    package_manager: npm
     smoke: [/]
     verify: true
 
@@ -216,8 +237,8 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
+    package_manager: yarn_berry
     smoke: [/]
     verify: true
 
@@ -229,8 +250,8 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
+    package_manager: npm
     smoke: [/]
     verify: true
 
@@ -242,7 +263,6 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     package_manager: yarn_classic
     smoke: [/]
@@ -256,7 +276,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
-      - { ecosystem: gem, name: cpflow }
     needs_pro: false
+    package_manager: yarn_classic
     smoke: [/]
     verify: true

--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -367,24 +367,31 @@ export const createRSCProvider = ({
         // refetch or reload (#3929). Evict the rejected entry so the next
         // same-key `getComponent` starts a fresh fetch.
         //
-        // Deferred one macrotask (`setTimeout(0)`, not `queueMicrotask`) so
-        // React's Suspense machinery observes the rejection on the cached
-        // promise before the entry is removed; a microtask could interleave
-        // with React's own queue and evict before Suspense reads it. Guarded on
-        // promise identity so a newer same-key promise (a fresh `getComponent`
-        // or a `refetchComponent`) installed during that window is not evicted
-        // by this stale failure. Pins are preserved because the `.finally`
-        // below still owns the matching `unpin` (mirrors the delete +
-        // deferred-unpin handoff in `restoreLastSuccessfulPromise`).
+        // Deferred past the first macrotask (`setTimeout(0)`, not
+        // `queueMicrotask`) so React's Suspense machinery observes the
+        // rejection on the cached promise before the entry is removed; a
+        // microtask could interleave with React's own queue and evict before
+        // Suspense reads it. The extra macrotask also lets the `.finally`
+        // below release the in-flight pin before the key becomes available for
+        // a fresh same-key `getComponent`; otherwise a repeated failing request
+        // can replace the rejected promise with a new pending promise before
+        // the user ErrorBoundary commits its fallback (#4522). Guarded on
+        // promise identity so a newer same-key promise (such as
+        // `refetchComponent`) installed during that window is not evicted by
+        // this stale failure.
         //
         // NOTE: payloads that RESOLVE with an `Error` value are intentionally
         // left cached here; whether those should also retry is a separate
         // `getServerComponent` contract decision tracked apart from #3929.
+        let payloadRejected = false;
         const evictPromiseIfRejected = (error: unknown) => {
+          payloadRejected = true;
           setTimeout(() => {
-            if (fetchRSCPromises.get(key, false) === promise) {
-              fetchRSCPromises.deletePreservingPins(key);
-            }
+            setTimeout(() => {
+              if (fetchRSCPromises.get(key, false) === promise) {
+                fetchRSCPromises.deleteWithoutEvict(key);
+              }
+            }, 0);
           }, 0);
           throw error;
         };
@@ -417,6 +424,14 @@ export const createRSCProvider = ({
           // resolving mounted routes can evict early visible keys before their
           // layout effects get to pin them as mounted.
           setTimeout(() => {
+            if (payloadRejected) {
+              // The rejected entry is already scheduled for deletion in the
+              // next macrotask. Releasing its pin must not reconcile over-cap
+              // eviction against healthy entries during this short grace
+              // window.
+              fetchRSCPromises.unpinWithoutEvict(key);
+              return;
+            }
             fetchRSCPromises.unpin(key);
           }, 0);
         });

--- a/packages/react-on-rails-pro/src/RSCProviderCache.ts
+++ b/packages/react-on-rails-pro/src/RSCProviderCache.ts
@@ -173,6 +173,14 @@ export class BoundedLRU<V> {
   }
 
   unpin(key: string): void {
+    this.releasePin(key, true);
+  }
+
+  unpinWithoutEvict(key: string): void {
+    this.releasePin(key, false);
+  }
+
+  private releasePin(key: string, reconcileEviction: boolean): void {
     this.assertNotEvicting('unpin');
     const count = this.pins.get(key);
     if (count === undefined) {
@@ -184,6 +192,9 @@ export class BoundedLRU<V> {
     }
 
     this.pins.delete(key);
+    if (!reconcileEviction) {
+      return;
+    }
     // The in-flight operation that held this pin just settled, so the key is
     // now the most-recently-used. `get` promotes only when the key is still
     // present; a key already deleted, e.g. by `restoreLastSuccessfulPromise`,

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -972,6 +972,93 @@ describe('RSCRoute successful-version error reset', () => {
     });
   });
 
+  it('h2. rejected over-cap initial load does not evict a healthy settled entry before deferred deletion', async () => {
+    process.env.NODE_ENV = 'production';
+
+    type PendingEntry = Deferred & { args: GetServerComponentArgs; settled: boolean };
+    const pending: PendingEntry[] = [];
+    getServerComponent = jest.fn((..._args: [GetServerComponentArgs]) => {
+      const d = makeDeferred();
+      const entry: PendingEntry = {
+        ...d,
+        args: _args[0],
+        settled: false,
+        resolve: (value) => {
+          entry.settled = true;
+          d.resolve(value);
+        },
+        reject: (error) => {
+          entry.settled = true;
+          d.reject(error);
+        },
+      };
+      pending.push(entry);
+      return d.promise;
+    });
+    RSCProvider = createRSCProvider({ getServerComponent });
+
+    let rscApi!: ReturnType<typeof useRSC>;
+    const Probe = () => {
+      rscApi = useRSC();
+      return null;
+    };
+    await renderInAct(
+      <RSCProvider>
+        <Probe />
+      </RSCProvider>,
+    );
+
+    const startLoad = async (id: number) => {
+      let promise!: Promise<React.ReactNode>;
+      await act(async () => {
+        promise = rscApi.getComponent('Card', { id });
+        await Promise.resolve();
+      });
+      return { promise, deferred: findPendingForId(pending, id) };
+    };
+
+    const started: Awaited<ReturnType<typeof startLoad>>[] = [];
+    for (let id = 0; id <= CACHE_CAP; id += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      started.push(await startLoad(id));
+    }
+    expect(getServerComponent).toHaveBeenCalledTimes(CACHE_CAP + 1);
+
+    await act(async () => {
+      started[0].deferred.resolve(<span>healthy payload 0</span>);
+      await started[0].promise;
+      await flushMacrotasks();
+    });
+    expect(fetchCount(0)).toBe(1);
+
+    void started[1].promise.catch(() => undefined);
+    await act(async () => {
+      started[1].deferred.reject(new Error('boom 1'));
+      await expect(started[1].promise).rejects.toThrow('boom 1');
+      // First macrotask: rejected-promise deletion is scheduled, and the
+      // failed load releases its pin. The actual cache delete is still one
+      // macrotask away so React can observe the rejection.
+      await flushMacrotasks();
+    });
+
+    await act(async () => {
+      void rscApi.getComponent('Card', { id: 0 });
+      await Promise.resolve();
+    });
+    expect(fetchCount(0)).toBe(1);
+
+    await act(async () => {
+      await flushMacrotasks();
+      pending
+        .filter((entry) => !entry.settled)
+        .forEach((entry) =>
+          entry.resolve(<span>{`cleanup ${(entry.args.componentProps as { id: number }).id}`}</span>),
+        );
+      await Promise.allSettled(pending.map((entry) => entry.promise));
+      await flushMacrotasks();
+    });
+  });
+
   it('i. evicted-success markers survive marker-cache churn while a replacement load is pending', async () => {
     process.env.NODE_ENV = 'production';
 
@@ -1465,8 +1552,10 @@ describe('RSCRoute successful-version error reset', () => {
     syncThrowIds.add(0);
     await act(async () => {
       await expect(rscApi.getComponent('Card', { id: 0 })).rejects.toThrow('sync boom 0');
-      // The cached rejection is evicted one macrotask later; flush so the next
-      // same-key load starts fresh instead of reusing the rejected promise.
+      // The cached rejection is evicted after the Suspense-observation and
+      // unpin macrotasks; flush both so the next same-key load starts fresh
+      // instead of reusing the rejected promise.
+      await flushMacrotasks();
       await flushMacrotasks();
     });
 
@@ -1523,8 +1612,10 @@ describe('RSCRoute successful-version error reset', () => {
       await act(async () => {
         started.deferred.reject(new Error(message));
         await expect(started.promise).rejects.toThrow(message);
-        // evictPromiseIfRejected removes the cached promise via setTimeout(0),
-        // so wait one macrotask before asserting the slot is free.
+        // evictPromiseIfRejected keeps the rejected promise through the first
+        // macrotask so React can commit the user ErrorBoundary fallback; wait
+        // for the second macrotask before asserting the slot is free.
+        await flushMacrotasks();
         await flushMacrotasks();
       });
     };

--- a/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
+++ b/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
@@ -509,6 +509,104 @@ describe('RSCRoute deferred SSR behavior', () => {
     }
   });
 
+  it('shows the user ErrorBoundary fallback when an updated deferred route fetch rejects', async () => {
+    let rejectPayload: ((error: Error) => void) | undefined;
+    const failingPayloadPromise = new Promise<React.ReactNode>((_resolve, reject) => {
+      rejectPayload = reject;
+    });
+    type DeferredRouteProps = { simulateError: boolean };
+    let simulatedErrorFetchCount = 0;
+    const getServerComponent = jest.fn(({ componentProps }: { componentProps: unknown }) => {
+      const routeProps = componentProps as DeferredRouteProps;
+      if (!routeProps.simulateError) {
+        return Promise.resolve(<div>Loaded deferred route</div>);
+      }
+
+      simulatedErrorFetchCount += 1;
+      return simulatedErrorFetchCount === 1
+        ? failingPayloadPromise
+        : new Promise<React.ReactNode>(() => undefined);
+    });
+    const RSCProvider = createRSCProvider({ getServerComponent });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | undefined;
+    let triggerErrorRoute: (() => void) | undefined;
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const RouteSwitcher = () => {
+      const [simulateError, setSimulateError] = React.useState(false);
+      triggerErrorRoute = () => {
+        React.startTransition(() => {
+          setSimulateError(true);
+        });
+      };
+
+      return (
+        <TestErrorBoundary
+          fallback={({ error }) => <div data-testid="rsc-error-fallback">{error.message}</div>}
+        >
+          <React.Suspense fallback={<div>Loading deferred route...</div>}>
+            <RSCRoute componentName="DeferredRoute" componentProps={{ simulateError }} ssr={false} />
+          </React.Suspense>
+        </TestErrorBoundary>
+      );
+    };
+
+    try {
+      root = createRoot(container);
+
+      await act(async () => {
+        root?.render(
+          <RSCProvider>
+            <RouteSwitcher />
+          </RSCProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain('Loaded deferred route');
+      expect(getServerComponent).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        triggerErrorRoute?.();
+        await Promise.resolve();
+      });
+
+      expect(getServerComponent).toHaveBeenCalledTimes(2);
+      expect(getServerComponent).toHaveBeenNthCalledWith(2, {
+        componentName: 'DeferredRoute',
+        componentProps: { simulateError: true },
+      });
+
+      await act(async () => {
+        rejectPayload?.(new Error('Server component fetch failed'));
+        await failingPayloadPromise.catch(() => undefined);
+        await Promise.resolve();
+        await flushMacrotasks();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('[data-testid="rsc-error-fallback"]')?.textContent).toBe(
+        'Server component fetch failed',
+      );
+      expect(container.textContent).not.toContain('Loaded deferred route');
+    } finally {
+      const mountedRoot = root;
+      try {
+        if (mountedRoot) {
+          await act(async () => {
+            mountedRoot.unmount();
+            await Promise.resolve();
+          });
+        }
+        container.remove();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    }
+  });
+
   it('dedupes identical deferred routes under the same default provider', async () => {
     const sharedPayloadPromise = new Promise<React.ReactNode>(() => undefined);
     const getServerComponent = jest.fn(() => sharedPayloadPromise);
@@ -732,9 +830,10 @@ describe('RSCRoute deferred SSR behavior', () => {
         );
         await Promise.resolve();
         await Promise.resolve();
-        // The provider evicts synchronously-rejected payload promises one
-        // macrotask after the rejection; flush so no eviction timer leaks
-        // past unmount.
+        // The provider evicts synchronously-rejected payload promises after
+        // React can observe the rejection and the in-flight pin releases; flush
+        // both timers so no eviction timer leaks past unmount.
+        await flushMacrotasks();
         await flushMacrotasks();
       });
 

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -169,9 +169,9 @@ class CapturingErrorBoundary extends React.Component<
   const usingJestFakeTimers = () => jest.isMockFunction(setTimeout);
 
   // Waits for the deferred eviction scheduled by evictPromiseIfRejected to
-  // complete. The eviction uses setTimeout(0), so scheduling a second
-  // setTimeout(0) here guarantees via FIFO macrotask ordering that the eviction
-  // fires before this promise resolves.
+  // complete. The eviction intentionally waits until after React can observe
+  // the rejection and after the in-flight pin release, so this helper waits two
+  // macrotasks.
   const waitForRejectedGetComponentEviction = () => {
     if (usingJestFakeTimers()) {
       throw new Error(
@@ -180,7 +180,9 @@ class CapturingErrorBoundary extends React.Component<
     }
 
     return new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
+      setTimeout(() => {
+        setTimeout(resolve, 0);
+      }, 0);
     });
   };
 

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3644,18 +3644,18 @@ module ReactOnRails
     end
 
     def detected_rspack_version_for_rsc
-      package_root = resolved_package_root
+      package_root = resolved_rsc_package_root
       installed_version = nil
       unless package_root_missing?(package_root)
         installed_version = installed_package_version(package_root, RSC_RSPACK_PACKAGE)
       end
-      installed_version || declared_rspack_version_for_rsc
+      installed_version || declared_rspack_version_for_rsc(package_root)
     rescue StandardError
       nil
     end
 
-    def declared_rspack_version_for_rsc
-      package_json_path = package_json_path_for("declared Rspack version")
+    def declared_rspack_version_for_rsc(package_root = resolved_rsc_package_root)
+      package_json_path = package_json_path_for("declared Rspack version", package_root)
       return nil unless package_json_path
 
       rsc_declared_package_version(package_json_path, RSC_RSPACK_PACKAGE)
@@ -3665,8 +3665,12 @@ module ReactOnRails
       rsc_rspack_version_requirement_error(
         rspack_version,
         error_prefix: "🚫",
-        package_json_path: package_json_path_for("RSC Rspack version")
+        package_json_path: package_json_path_for("RSC Rspack version", resolved_rsc_package_root)
       )
+    end
+
+    def resolved_rsc_package_root
+      rsc_configured_package_root(resolved_package_root)
     end
 
     def check_rsc_rspack_lazy_compilation

--- a/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
+++ b/react_on_rails/lib/react_on_rails/rsc_rspack_support.rb
@@ -5,7 +5,7 @@ require "open3"
 require_relative "utils"
 
 module ReactOnRails
-  module RscRspackSupport
+  module RscRspackSupport # rubocop:disable Metrics/ModuleLength
     RSC_RSPACK_PACKAGE = "@rspack/core"
     RSC_RSPACK_V2_PACKAGES = %w[
       @rspack/core
@@ -37,6 +37,11 @@ module ReactOnRails
       [a-z0-9][a-z0-9._-]*
       \z
     }x
+    NODE_PACKAGE_RESOLUTION_SCRIPT = <<~JS
+      const packageName = process.argv[1];
+      const nodeModulesPath = process.argv[2];
+      console.log(require.resolve(packageName + '/package.json', { paths: [nodeModulesPath] }));
+    JS
 
     private
 
@@ -83,25 +88,32 @@ module ReactOnRails
       MSG
     end
 
-    def rsc_installed_package_version(package_root, package_name, &)
-      version = rsc_installed_package_json(package_root, package_name, &)&.fetch("version", nil)
+    def rsc_installed_package_version(package_root, package_name, node_modules_path: nil, &)
+      version = rsc_installed_package_json(package_root, package_name, node_modules_path:, &)&.fetch("version", nil)
       version if version&.match?(/\A\d+\.\d+\.\d+/)
     end
 
-    def rsc_flat_installed_package_version(package_root, package_name)
-      version = rsc_flat_installed_package_json(package_root, package_name)&.fetch("version", nil)
+    def rsc_flat_installed_package_version(package_root, package_name, node_modules_path: nil)
+      version = rsc_flat_installed_package_json(package_root, package_name, node_modules_path:)&.fetch("version", nil)
       version if version&.match?(/\A\d+\.\d+\.\d+/)
     end
 
-    def rsc_installed_package_json(package_root, package_name, &)
+    def rsc_installed_package_json(package_root, package_name, node_modules_path: nil, &)
       return nil unless valid_rsc_package_name?(package_name)
 
-      script = "console.log(require.resolve(process.argv[1] + '/package.json'))"
-      resolved_path = rsc_resolved_node_package_json_path(package_root, package_name, script, &)
+      resolved_path = rsc_resolved_node_package_json_path(
+        package_root,
+        package_name,
+        NODE_PACKAGE_RESOLUTION_SCRIPT,
+        node_modules_path:,
+        &
+      )
       # package_name has passed PACKAGE_NAME_PATTERN, so this fallback cannot escape node_modules.
       # It covers classic flat node_modules layouts; pnpm virtual-store layouts rely on Node resolution above.
       # Limitation: a stale orphaned directory can still be read if Node resolution fails.
-      resolved_path = rsc_flat_installed_package_json_path(package_root, package_name) if resolved_path.empty?
+      if resolved_path.empty?
+        resolved_path = rsc_flat_installed_package_json_path(package_root, package_name, node_modules_path:)
+      end
       return nil unless File.exist?(resolved_path)
 
       JSON.parse(File.read(resolved_path))
@@ -109,10 +121,10 @@ module ReactOnRails
       nil
     end
 
-    def rsc_flat_installed_package_json(package_root, package_name)
+    def rsc_flat_installed_package_json(package_root, package_name, node_modules_path: nil)
       return nil unless valid_rsc_package_name?(package_name)
 
-      package_json_path = rsc_flat_installed_package_json_path(package_root, package_name)
+      package_json_path = rsc_flat_installed_package_json_path(package_root, package_name, node_modules_path:)
       return nil unless File.exist?(package_json_path)
 
       JSON.parse(File.read(package_json_path))
@@ -120,8 +132,8 @@ module ReactOnRails
       nil
     end
 
-    def rsc_flat_installed_package_json_path(package_root, package_name)
-      File.join(package_root, "node_modules", package_name, "package.json")
+    def rsc_flat_installed_package_json_path(package_root, package_name, node_modules_path: nil)
+      File.join(rsc_node_modules_path(package_root, node_modules_path), package_name, "package.json")
     end
 
     def rsc_support_enabled_config_value
@@ -164,9 +176,16 @@ module ReactOnRails
       major.to_i
     end
 
-    def rsc_resolved_node_package_json_path(package_root, package_name, script, &)
+    def rsc_resolved_node_package_json_path(package_root, package_name, script, node_modules_path: nil, &)
       # Boot/doctor validation only. This is intentionally outside the request path.
-      stdout, _stderr, status = Open3.capture3("node", "-e", script, package_name, chdir: package_root)
+      stdout, _stderr, status = Open3.capture3(
+        "node",
+        "-e",
+        script,
+        package_name,
+        rsc_node_modules_path(package_root, node_modules_path),
+        chdir: package_root
+      )
       unless status.success?
         yield(package_name) if block_given?
         return ""
@@ -176,6 +195,26 @@ module ReactOnRails
     rescue StandardError
       yield(package_name) if block_given?
       ""
+    end
+
+    def rsc_configured_package_root(default_package_root)
+      configured_path = ReactOnRails.configuration.node_modules_location.to_s
+      return default_package_root if configured_path.empty?
+
+      rails_root = defined?(Rails) && Rails.respond_to?(:root) ? Rails.root.to_s : Dir.pwd
+      File.expand_path(configured_path, rails_root)
+    rescue StandardError
+      default_package_root
+    end
+
+    def rsc_node_modules_path(package_root, node_modules_path = nil)
+      resolved_node_modules_path = node_modules_path.to_s
+      return resolved_node_modules_path unless resolved_node_modules_path.empty?
+
+      package_root_string = package_root.to_s
+      return package_root_string if File.basename(package_root_string) == "node_modules"
+
+      File.join(package_root_string, "node_modules")
     end
 
     def rsc_detected_package_manager

--- a/react_on_rails/lib/react_on_rails/version_checker.rb
+++ b/react_on_rails/lib/react_on_rails/version_checker.rb
@@ -262,7 +262,7 @@ module ReactOnRails
     end
 
     def detected_rspack_version_for_rsc
-      package_root = File.dirname(node_package_version.package_json)
+      package_root = rsc_configured_package_root(File.dirname(node_package_version.package_json))
       declared_spec = package_dependency_spec(RSC_RSPACK_PACKAGE)
       declared_version = rsc_normalized_declared_package_version(declared_spec) || declared_spec
       declared_major_version = rsc_package_major_version(declared_spec)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5360,6 +5360,9 @@ RSpec.describe ReactOnRails::Doctor do
     before do
       allow(Rails).to receive(:root).and_return(Pathname.new(Dir.pwd))
       allow(doctor).to receive(:resolved_package_root).and_return(Dir.pwd)
+      allow(ReactOnRails).to receive(:configuration).and_return(
+        instance_double(ReactOnRails::Configuration, node_modules_location: "")
+      )
       allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
       stub_const("ReactOnRailsPro", Module.new)
       stub_const("ReactOnRailsPro::Configuration", Class.new { attr_reader :enable_rsc_support })
@@ -5409,6 +5412,30 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_rsc_rspack_version)
         success_msgs = checker.messages.select { |m| m[:type] == :success }
         expect(success_msgs.any? { |m| m[:content].include?("Rspack 2.0.0 is compatible with RSC") }).to be true
+      end
+    end
+
+    context "when Rspack is installed under a configured client package root" do
+      before do
+        write_rspack_project(assets_bundler: "rspack", rspack_core_version: "latest")
+        FileUtils.mkdir_p("client/node_modules/@rspack/core")
+        File.write(
+          "client/node_modules/@rspack/core/package.json",
+          JSON.generate("name" => "@rspack/core", "version" => "2.0.8")
+        )
+        allow(ReactOnRails).to receive(:configuration).and_return(
+          instance_double(ReactOnRails::Configuration, node_modules_location: "client")
+        )
+        doctor.send(:resolved_package_root)
+      end
+
+      it "uses the current configured package root instead of stale root resolution" do
+        doctor.send(:check_rsc_rspack_version)
+
+        success_msgs = checker.messages.select { |m| m[:type] == :success }
+        error_msgs = checker.messages.select { |m| m[:type] == :error }
+        expect(success_msgs.any? { |m| m[:content].include?("Rspack 2.0.8 is compatible with RSC") }).to be true
+        expect(error_msgs).to be_empty
       end
     end
 
@@ -6456,8 +6483,9 @@ RSpec.describe ReactOnRails::Doctor do
           .with(
             "node",
             "-e",
-            "console.log(require.resolve(process.argv[1] + '/package.json'))",
+            ReactOnRails::RscRspackSupport::NODE_PACKAGE_RESOLUTION_SCRIPT,
             "react",
+            File.join(package_root, "node_modules"),
             chdir: package_root
           )
           .and_return(

--- a/react_on_rails/spec/react_on_rails/version_checker_spec.rb
+++ b/react_on_rails/spec/react_on_rails/version_checker_spec.rb
@@ -280,9 +280,10 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
           )
         end
 
-        def stub_rsc_rspack_project(root, rsc_enabled:, configuration_error: nil)
+        def stub_rsc_rspack_project(root, rsc_enabled:, configuration_error: nil, node_modules_location: "")
           allow(Rails).to receive(:root).and_return(Pathname.new(root))
-          allow(ReactOnRails).to receive_message_chain(:configuration, :node_modules_location).and_return("")
+          allow(ReactOnRails).to receive_message_chain(:configuration, :node_modules_location)
+            .and_return(node_modules_location)
           allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
           stub_gem_version("17.0.0")
 
@@ -466,8 +467,9 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             expect(Open3).to have_received(:capture3).with(
               "node",
               "-e",
-              "console.log(require.resolve(process.argv[1] + '/package.json'))",
+              ReactOnRails::RscRspackSupport::NODE_PACKAGE_RESOLUTION_SCRIPT,
               "@rspack/core",
+              File.join(root, "node_modules"),
               chdir: root
             )
           end
@@ -677,9 +679,31 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
             expect(Open3).to have_received(:capture3).with(
               "node",
               "-e",
-              "console.log(require.resolve(process.argv[1] + '/package.json'))",
+              ReactOnRails::RscRspackSupport::NODE_PACKAGE_RESOLUTION_SCRIPT,
               "@rspack/core",
+              File.join(root, "node_modules"),
               chdir: root
+            )
+          end
+        end
+
+        it "uses the configured client package root to resolve installed Rspack" do
+          Dir.mktmpdir do |root|
+            write_rsc_rspack_project_files(root, assets_bundler: "rspack", rspack_core_version: "latest")
+            client_rspack_package_json = File.join(root, "client/node_modules/@rspack/core/package.json")
+            FileUtils.mkdir_p(File.dirname(client_rspack_package_json))
+            File.write(
+              client_rspack_package_json,
+              JSON.generate("name" => "@rspack/core", "version" => "2.0.8")
+            )
+            stub_rsc_rspack_project(root, rsc_enabled: true, node_modules_location: "client")
+            node_package_version = VersionChecker::NodePackageVersion.new(File.join(root, "package.json"))
+            allow(Rails.logger).to receive(:warn)
+
+            expect { described_class.new(node_package_version).validate_version_and_package_compatibility! }
+              .not_to raise_error
+            expect(Rails.logger).not_to have_received(:warn).with(
+              a_string_including("Could not verify @rspack/core")
             )
           end
         end


### PR DESCRIPTION
## Summary
- Forward-port the remaining RC7 release-branch fixes from `release/17.0.0` onto `main` using `script/release-forward-port`.
- Includes `#4529` Pro RSC route ErrorBoundary handling, `#4530` RSC doctor Rspack package resolution, and `#4521` demo-fleet metadata for `#4526`.
- `#4516` and `#4519` were already present on `main` through `#4528`; the final branch keeps only the remaining `-x` cherry-picks on top of current `origin/main`.

## Validation
- `git diff --check origin/main...HEAD`
- `ruby -ryaml -e ...` parsed `internal/contributor-info/demo-fleet.yml` and verified the Gumroad demo entry exists.
- `bundle exec rspec spec/lib/react_on_rails/doctor_spec.rb spec/react_on_rails/version_checker_spec.rb` from `react_on_rails`: 478 examples, 0 failures.
- `pnpm --filter react-on-rails-pro exec jest tests/boundedCacheProvider.client.test.tsx tests/deferredRouteSsr.test.tsx tests/imperativeRefetch.client.test.tsx --runInBand`: 3 suites, 84 tests passed.
- `pnpm --filter react-on-rails-pro run type-check`.
- `script/check-pro-license-headers`: all 841 in-scope Pro files have current license headers.
- `pnpm run build:test` from `react_on_rails_pro/spec/dummy` generated the node-renderer dummy SSR/RSC bundles required by streaming tests.
- `pnpm --filter react-on-rails-pro-node-renderer exec jest tests --runInBand`: 38 suites, 518 tests passed.
- `git push` pre-push hook: branch RuboCop and markdown-links passed.

## Validation Caveat
- `.agents/bin/validate --changed` initially failed in Pro node-renderer streaming tests because the dummy `ssr-generated/server-bundle.js` prerequisite was missing; after running the dummy build, the full node-renderer suite passed.
- A second `.agents/bin/validate --changed` run proceeded through docs, RuboCop, ESLint, Prettier, TypeScript, JS unit tests, and into RSpec, then hit repeated generator-spec `npm ERESOLVE` failures where npm resolved the published `react-on-rails-pro@17.0.0-rc.6` package with peerOptional `react-on-rails-rsc@^19.0.5` against `react-on-rails-rsc@19.2.1-rc.0`.
- This branch does not change package metadata; checked-in `packages/react-on-rails-pro/package.json` on both `origin/main` and this branch has `react-on-rails-rsc: >=19.2.1-rc.0 <20.0.0`. I interrupted the redundant generator-spec remainder after the repeated external package-resolution failure was clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cached server-component error handling so rejected fetches don’t prematurely evict healthy content, and ensure error boundaries render consistently on deferred-route re-fetch failures.
  * Refined cache pin release/eviction timing to better match React’s observation across macrotasks.
  * Fixed Rspack version detection to resolve installed package locations correctly in nested workspace and custom `node_modules` setups.

* **New Features**
  * Expanded demo reference-app configurations with updated package sets and more explicit orchestration/build/test settings where applicable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->