### PR TITLE
Add release train issue evaluation skill

### DIFF
--- a/.agents/skills/react-on-rails-release-train-issue-evaluation/SKILL.md
+++ b/.agents/skills/react-on-rails-release-train-issue-evaluation/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: react-on-rails-release-train-issue-evaluation
+description: Use when evaluating React on Rails GitHub issues for release-train targeting, especially deciding whether new, follow-up, or non-started issues belong on release/17.0.0, another release/X.Y.Z branch, or main.
+---
+
+# React on Rails Release Train Issue Evaluation
+
+## Core Rule
+
+Use this with `$evaluate-issue`. That skill answers "is this worth doing?"; this skill answers "does it belong on the active release train or on `main`?"
+
+`release/*` receives only stabilizing fixes. Features, cleanup, docs, process work, non-blocking hardening, and ordinary follow-ups target `main`.
+
+## Workflow
+
+1. Refresh repo context: `git fetch --prune origin main`, then `.agents/bin/agent-workflow-seam-doctor`. Fetch the release branch if ancestry matters.
+2. Resolve candidates from live GitHub. For strict 48-hour windows, search by date then timestamp-filter locally because GitHub search is date-granular.
+3. Exclude started lanes. An issue is started when it has an assignee, linked/open implementation PR, private claim/heartbeat/branch, or implementation comment. Run `agent-coord doctor --json`, then targeted `agent-coord status --repo shakacode/react_on_rails --target <issue> --json`. Dead or expired claims count as started-but-stalled, not non-started.
+4. Read release context: active `Release gate:` tracker, `release` + `TRACKING` labels, the `Agent Release Mode` block, `agent-coord` phase when available, source PR base branches, and whether source commits are already on `origin/release/X.Y.Z`.
+5. Evaluate each candidate with `$evaluate-issue`: evidence source, impact, complexity, process gap disposition, and priority.
+6. Choose the target:
+   - `release/X.Y.Z`: verified RC/final stabilizer such as an RC regression, hard-gate failure, install/upgrade blocker, security/data-loss/wrong-output bug, release-branch CI/release tooling blocker, or final-only public API/breaking-change decision.
+   - `release/X.Y.Z contingent`: only needed if maintainers decide to cherry-pick a related main-only fix into the train. Name the dependency.
+   - `main`: docs, changelog for main-only PRs, CI/tooling hygiene, tests, process automation, non-blocking runtime hardening, features, and performance/cleanup without release-gate proof.
+   - `park/close`: P3, speculative, duplicate, no-PR evidence, or not worth doing.
+
+Recommend labels/milestones/comments, but do not mutate GitHub unless the user explicitly authorizes writes.
+
+## Output
+
+Use a compact table:
+
+| Issue | Started? | Evidence | Disposition | Target | Rationale | Next action |
+| ----- | -------- | -------- | ----------- | ------ | --------- | ----------- |
+
+Call out `UNKNOWN` facts explicitly, especially release tracker mode, source PR base, branch ancestry, and whether the issue is a confirmed RC regression.
+
+## Common Mistakes
+
+- Treating a title that says "before 17.0.0 final" as sufficient. Verify release-gate impact and branch ancestry.
+- Sending main-only follow-up defects to `release/17.0.0` when the related fix is not on the release branch. Mark these contingent instead.
+- Using labels alone. Labels are hints; issue evidence and the release tracker decide.
+- Treating tracker `Mode: development` as "no release train." The branch can still exist; target selection still matters.

--- a/.agents/skills/react-on-rails-release-train-issue-evaluation/agents/openai.yaml
+++ b/.agents/skills/react-on-rails-release-train-issue-evaluation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "React on Rails Release Train Issue Evaluation"
+  short_description: "Classify issues for release train or main"
+  default_prompt: "Use $react-on-rails-release-train-issue-evaluation to decide whether recent React on Rails issues belong on release/17.0.0 or main."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
   workflow `SKILL.md` files installed in the user's or agent's normal skill
   directory; duplicating them here creates duplicate Codex skill picker entries.
   Current repo-specific skills include `$stress-test`,
-  `$optimize-rsc-performance`, and `$react-on-rails-update-changelog`.
+  `$optimize-rsc-performance`, `$react-on-rails-update-changelog`, and
+  `$react-on-rails-release-train-issue-evaluation`.
 - `.claude/skills`: symlink to `.agents/skills` so Claude Code exposes the
   repo-specific local skills kept by this checkout. Shared skills should come
   from the installed shared pack, not this symlink.
@@ -58,6 +59,11 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 - When deciding whether an issue or proposed fix is worth doing, use the
   installed/shared `$evaluate-issue` skill; a short invocation is
   `$evaluate-issue` or "Is this issue worth fixing?"
+- When deciding whether a React on Rails issue belongs on the active release
+  train (`release/X.Y.Z`, especially `release/17.0.0`) or should wait for
+  `main`, use the repo-local
+  `.agents/skills/react-on-rails-release-train-issue-evaluation/SKILL.md`; a
+  short invocation is `$react-on-rails-release-train-issue-evaluation`.
 - When the user wants a ready prompt for review-only GitHub issue triage or an
   all-open-issues audit, use the installed/shared `$plan-issue-triage` skill; a
   short invocation is `$plan-issue-triage` or "Plan an issue triage"


### PR DESCRIPTION
## Why

Recent React on Rails issue triage needs a reusable way to decide whether new or follow-up issues belong on the active 17.0.0 release train or should wait for main. The existing `evaluate-issue` skill covers issue value, but not release-branch targeting.

## What changed

- Added a repo-local `react-on-rails-release-train-issue-evaluation` skill.
- Documented the skill in `AGENTS.md` alongside the existing issue evaluation workflow.
- Included UI metadata for the Codex skill picker.

## Validation

- `git diff --check HEAD~1..HEAD`
- `python3 .../quick_validate.py .agents/skills/react-on-rails-release-train-issue-evaluation` -> `Skill is valid!`
- `.agents/bin/validate --changed` -> documentation-only, docs sidebar check passed, no further CI needed
- Pre-commit hook: trailing-newlines, markdown-links, prettier passed
- Pre-push hook: branch-lint and online markdown-links passed

Labels: none; docs/process-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for evaluating issues against the active release train versus the main branch.
  * Introduced a new repo-specific skill for classifying recent issues and selecting the appropriate target branch.
  * Updated repo instructions to include the new release-train evaluation workflow and shorthand command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->