### PR TITLE
Pro rolling deploy: multi-URL previous_urls + promotion boot-seed docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,6 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
-### [17.0.0.rc.8] - 2026-07-08
-
 #### Breaking Changes
 
 - **[Pro] Rolling-deploy previous-URL config is now `rolling_deploy_previous_urls` (plural) and seeds from multiple endpoints**:
@@ -40,6 +38,11 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   this is not a break for any stable release. See
   [Promotion deploys need a boot seed](https://reactonrails.com/docs/pro/rolling-deploy-adapters#promotion-deploys-need-a-release-time-boot-seed).
   [PR 4544](https://github.com/shakacode/react_on_rails/pull/4544) by [justin808](https://github.com/justin808).
+
+### [17.0.0.rc.8] - 2026-07-08
+
+#### Breaking Changes
+
 - **[Pro] Removed the undocumented `ReactOnRailsPro::Cache.fetch_react_component` class API**:
   Pro apps should use the supported cached helper APIs (`cached_react_component`,
   `cached_react_component_hash`, and related helpers) instead of calling the low-level cache class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Breaking Changes
 
+- **[Pro] Rolling-deploy previous-URL config is now `rolling_deploy_previous_urls` (plural) and seeds from multiple endpoints**:
+  `config.rolling_deploy_previous_url` is renamed to `config.rolling_deploy_previous_urls`, and the built-in HTTP
+  adapter now accepts a single URL string, a comma-separated string, or an Array. Discovery unions the bundle hashes
+  advertised by every endpoint, and fetch tries each endpoint in order, returning the first that has the requested hash.
+  Seeding from more than one endpoint (e.g. staging + production) lets an image built in one environment and promoted to
+  another carry the promotion target's draining bundle — the previous single-URL config could only seed the build
+  environment, so a promoted production image never held production's draining bundle. Rename any
+  `config.rolling_deploy_previous_url = ...` to `config.rolling_deploy_previous_urls = ...` (and the
+  `ROLLING_DEPLOY_PREVIOUS_URL` build arg to `ROLLING_DEPLOY_PREVIOUS_URLS`). Introduced during the 17.0.0 RC cycle, so
+  this is not a break for any stable release. See
+  [Promotion deploys need a boot seed](https://reactonrails.com/docs/pro/rolling-deploy-adapters#promotion-deploys-need-a-release-time-boot-seed).
+  [PR 4544](https://github.com/shakacode/react_on_rails/pull/4544) by [justin808](https://github.com/justin808).
 - **[Pro] Removed the undocumented `ReactOnRailsPro::Cache.fetch_react_component` class API**:
   Pro apps should use the supported cached helper APIs (`cached_react_component`,
   `cached_react_component_hash`, and related helpers) instead of calling the low-level cache class

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -3,5 +3,10 @@
 ## Contexts
 
 - [React on Rails Pro (RSC)](./packages/react-on-rails-pro/CONTEXT.md) — React Server Components integration: payload generation, embedding, caching, and client-router prefetch
+- [React on Rails Pro (Rolling Deploy)](./react_on_rails_pro/CONTEXT.md) — warming the Node Renderer bundle cache across a rolling deploy: pre-seed source, build-time vs. release-time seed, staging-to-production promotion
 
 Other contexts (core gem, node renderer, generators) are not yet documented; add them here when their first term is resolved.
+
+## Relationships
+
+- **Rolling Deploy → RSC**: when RSC is enabled, each deploy has two **draining bundles** (server + RSC); the pre-seed stages each hash independently and must carry the RSC companion manifests or hydration breaks.

--- a/docs/oss/building-features/node-renderer/container-deployment.md
+++ b/docs/oss/building-features/node-renderer/container-deployment.md
@@ -91,7 +91,7 @@ Rails and the Node Renderer run as independent workloads with their own scaling.
 
 **Disadvantages:**
 
-- **Version drift risk** — During rolling deploys, Rails and the Node Renderer may briefly run different versions. While protocol changes are rare, this is a risk to monitor.
+- **Version drift risk** — During rolling deploys, Rails and the Node Renderer roll independently and briefly run different bundle versions, so the renderer can receive SSR requests for a bundle it hasn't cached. Mitigate this with a [rolling-deploy adapter](../../../pro/rolling-deploy-adapters.md) (Pro): it pre-seeds the new renderer with the draining bundle and makes the renderer-before-Rails ordering explicit. This risk (and that mitigation) is **specific to this separate-workloads option** — Options 1–2 share one lifecycle and cannot drift.
 - **Race conditions** — Pods restart independently, which can cause transient connection errors.
 - **Network dependency** — Renderer must be reachable via internal service DNS.
 - **Overkill for most setups** — If you're running 2–4 replicas, independent scaling adds complexity without real benefit.

--- a/docs/pro/rolling-deploy-adapters.md
+++ b/docs/pro/rolling-deploy-adapters.md
@@ -32,6 +32,9 @@ A **rolling-deploy adapter** makes new renderer instances start warm for **every
 
 The built-in HTTP adapter is the simplest way to get there, and it's covered next. If your build can't reach the previous deployment, or you'd rather keep bundles in your own store, you can [write a custom adapter](./rolling-deploy-custom-adapters.md) instead.
 
+> [!NOTE]
+> Pre-seeding runs at **image-build time**, in the environment that builds the image. That is sufficient when the image is built and deployed in the **same** environment (a staging build that will run on staging). If you **promote** an image between environments — build once on staging, then promote that same image to production — build-time seeding alone is not enough. See [Promotion deploys need a boot seed](#promotion-deploys-need-a-release-time-boot-seed).
+
 ## Set up the HTTP adapter
 
 > Introduced as a scaffold in PR [#3379](https://github.com/shakacode/react_on_rails/pull/3379) — part 1 of a multi-PR series. A hard HTTPS gate, streaming download, and additional hardening land in follow-ups; see [Security](#security) below.
@@ -128,6 +131,41 @@ ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
 
 Each bundle hash ships with the companion assets built alongside it — `loadable-stats.json`, plus `react-client-manifest.json` and `react-server-client-manifest.json` when RSC is enabled. They map chunk and component IDs to the exact asset URLs that hash's build produced, so serving a draining hash with the **wrong** build's manifests would break client-side hydration. The HTTP adapter packs each hash's companions into the same tarball, so this stays correct with no work on your part. (Custom adapters must return them explicitly — see [Companion assets](./rolling-deploy-custom-adapters.md#companion-assets).)
 
+## Promotion deploys need a release-time (boot) seed
+
+Pre-seeding runs during `assets:precompile` — at **image-build time**, in the environment that builds the image. That is exactly right when the image is built and deployed in the same environment. It is **not** enough when you **promote** an image between environments (build once on staging, promote that same image to production).
+
+### Why promotion breaks build-time seeding
+
+- The staging build seeds using **staging's** `rolling_deploy_previous_url` and a snapshot of **staging's** then-live bundle.
+- When you later promote that image to production, its renderer cache still holds **staging's** previous bundle — never production's. Production's config never gets a vote, because the seed already happened, at build time, in the staging pipeline.
+
+Even if you point the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)), a build-time snapshot still goes stale across **two pending promotions**:
+
+1. Production is at `P0`. You build image `C1`, then image `C2`, while production is still `P0` — both snapshot `P0`.
+2. Promote `C1`. Production `P0 → C1`; the draining bundle is `P0`, which `C1` seeded. Warm. ✓
+3. Promote `C2`. Production `C1 → C2`; the draining bundle is now **`C1`** — which `C2` never seeded (it snapshotted `P0`). Cold → 410 storm.
+
+The image cannot know, at build time, which bundle will be draining at the later — and sometimes skipped — moment it is promoted.
+
+### The fix: seed at container boot
+
+The one place that always knows production's **actually-live** bundle is the **production renderer container at boot**. Run the standalone seed task from the renderer container's entrypoint, before it reports ready:
+
+```bash
+bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
+```
+
+At boot in production the task reads **production's** config, so `rolling_deploy_previous_url` resolves to production's own live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods — so it advertises the exact draining bundle the new renderer needs, and the task pulls it.
+
+Keep the build-time seed as well; the two layers are complementary:
+
+- **Build-time seed** — ideally [multi-source](./rolling-deploy-custom-adapters.md#multi-source-seeding) (staging + production) — makes the promoted image born prod-ready and is the **failure floor**: if the boot seed can't reach the live endpoint, the image still holds a recent production bundle, so a miss stays small and rare instead of becoming a full cold storm.
+- **Boot seed** is the **correctness path**: it closes the two-pending-promotions window by resolving the live draining bundle at promotion time.
+
+> [!IMPORTANT]
+> Gate the renderer's readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback, not wedge the deploy — the task already warns-and-continues on fetch failures, so a completed run is a safe readiness signal whether or not every hash was fetched.
+
 ## Deploy the renderer before Rails
 
 > [!IMPORTANT]
@@ -150,7 +188,9 @@ Make the ordering explicit in your pipeline rather than relying on timing:
 2. Wait until its new revision is **live and healthy** — readiness passing and all new renderer instances up.
 3. Only then deploy/promote the **Rails** workload.
 
-The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. The exact wiring depends on your deploy tooling.
+The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. Prefer a readiness gate over a fixed sleep — a fixed delay is either too short (races) or too long (slow deploys), while a readiness signal tracks the actual state. The exact wiring depends on your deploy tooling.
+
+This ordering is also **what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct**. The boot seed fetches the draining bundle from the target environment's live endpoint; that endpoint only advertises the draining hash while the old pods are still serving it. If new Rails cut over first, the live endpoint would already advertise the **new** hash and the boot seed would miss the very bundle it needs. Seeding-at-boot and renderer-before-Rails are one design: the boot seed depends on the ordering.
 
 ## Verify your setup with `react_on_rails:doctor`
 

--- a/docs/pro/rolling-deploy-adapters.md
+++ b/docs/pro/rolling-deploy-adapters.md
@@ -168,6 +168,8 @@ Keep the build-time seed as well; the two layers are complementary:
 
 ## Deploy the renderer before Rails
 
+**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share **one workload** — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle: there is no cross-workload race and no version drift, and the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) simply runs once at container start before either process serves traffic. The rest of this section is for the **separate-workloads** topology, where Rails and the renderer roll independently and the ordering must be made explicit.
+
 > [!IMPORTANT]
 > During a rolling deploy, the new Node Renderer must be live and cache-warm **before** the new Rails server starts serving traffic. If Rails goes first, the adapter's warm-cache guarantee doesn't hold for that window — you get exactly the 410 storm it's meant to prevent.
 

--- a/docs/pro/rolling-deploy-adapters.md
+++ b/docs/pro/rolling-deploy-adapters.md
@@ -50,14 +50,14 @@ The currently-deployed Rails server already has every bundle and companion asset
 ```ruby
 # config/initializers/react_on_rails_pro.rb
 ReactOnRailsPro.configure do |config|
-  config.rolling_deploy_adapter      = ReactOnRailsPro::RollingDeployAdapters::Http
-  config.rolling_deploy_token        = ENV.fetch("ROLLING_DEPLOY_TOKEN")    # shared secret, ≥ 32 bytes
-  config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URL"]   # base URL of the still-running deployment
+  config.rolling_deploy_adapter       = ReactOnRailsPro::RollingDeployAdapters::Http
+  config.rolling_deploy_token         = ENV.fetch("ROLLING_DEPLOY_TOKEN")     # shared secret, ≥ 32 bytes
+  config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]   # one or more still-running deployments
 end
 ```
 
 - **`rolling_deploy_token`** — the shared bearer token ("password"). Generate one with `SecureRandom.hex(32)` and set the **same** value on both the running server (which authenticates incoming pulls) and the build CI (which sends it). The config validator rejects tokens shorter than 32 bytes.
-- **`rolling_deploy_previous_url`** — the base URL where the previous deployment is reachable **from the build CI**, e.g. `https://app.example.com/react_on_rails_pro/rolling_deploy`. The adapter appends `/manifest` and `/bundles/:hash`. Leave it unset (or empty) to disable discovery on that build.
+- **`rolling_deploy_previous_urls`** — the base URL(s) where previous deployment(s) are reachable **from the build CI** (or from the renderer at boot), e.g. `https://app.example.com/react_on_rails_pro/rolling_deploy`. Accepts a single URL string, a comma-separated string, or an Array. The adapter appends `/manifest` and `/bundles/:hash` to each, unions the discovered hashes, and fetches each hash from the first endpoint that has it. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery on that build.
 - **`rolling_deploy_mount_path`** — the Rails path where the Pro engine auto-mounts the bundle-serving endpoint when the built-in HTTP adapter is configured. Defaults to `/react_on_rails_pro/rolling_deploy`. Set it to a custom path when your previous deployment is reachable elsewhere, or set it to `nil`/blank to opt out of auto-mounting and draw the routes yourself.
 
 ### 2. Server endpoint auto-mount
@@ -125,7 +125,7 @@ ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
 - Tarball extraction is **path-traversal-proofed**, accepts regular files only, and enforces a 200 MB uncompressed cap (zip-bomb guard).
 
 > [!WARNING]
-> **Use HTTPS in production.** The token is a bearer credential. Over plain HTTP to a non-loopback host the adapter logs a warning that the token is being sent over an unencrypted connection; a hard HTTPS gate is planned for a follow-up release. Until then, ensure `rolling_deploy_previous_url` always uses `https://` in production environments.
+> **Use HTTPS in production.** The token is a bearer credential. Over plain HTTP to a non-loopback host the adapter logs a warning that the token is being sent over an unencrypted connection; a hard HTTPS gate is planned for a follow-up release. Until then, ensure `rolling_deploy_previous_urls` entries always use `https://` in production environments.
 
 ### Companion assets are handled automatically
 
@@ -137,7 +137,7 @@ Pre-seeding runs during `assets:precompile` — at **image-build time**, in the 
 
 ### Why promotion breaks build-time seeding
 
-- The staging build seeds using **staging's** `rolling_deploy_previous_url` and a snapshot of **staging's** then-live bundle.
+- The staging build seeds using **staging's** `rolling_deploy_previous_urls` and a snapshot of **staging's** then-live bundle.
 - When you later promote that image to production, its renderer cache still holds **staging's** previous bundle — never production's. Production's config never gets a vote, because the seed already happened, at build time, in the staging pipeline.
 
 Even if you point the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)), a build-time snapshot still goes stale across **two pending promotions**:
@@ -156,7 +156,7 @@ The one place that always knows production's **actually-live** bundle is the **p
 bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
 ```
 
-At boot in production the task reads **production's** config, so `rolling_deploy_previous_url` resolves to production's own live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods — so it advertises the exact draining bundle the new renderer needs, and the task pulls it.
+At boot in production the task reads **production's** config, so `rolling_deploy_previous_urls` resolves to production's own live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods — so it advertises the exact draining bundle the new renderer needs, and the task pulls it.
 
 Keep the build-time seed as well; the two layers are complementary:
 

--- a/docs/pro/rolling-deploy-custom-adapters.md
+++ b/docs/pro/rolling-deploy-custom-adapters.md
@@ -113,6 +113,62 @@ This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. 
 
 In practice this means a `staging` deploy hits the same artifact store as production — it must have the same credentials and write access. This is intentional: a `staging` → `staging` rolling deploy needs the previous staging hash seeded, and a `staging` → `production` promotion benefits from staging having warmed the store. If you need to keep `staging` out of the artifact store entirely, set `config.rolling_deploy_adapter = nil` in a `staging`-specific initializer rather than relying on env-based skipping at the gem level.
 
+> [!NOTE]
+> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: an image built on staging seeds staging's previous bundle, not production's — and with the built-in HTTP adapter (`upload` is a no-op) there is no shared store to paper over it. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
+
+## Multi-source seeding
+
+The built-in HTTP adapter seeds from a single `rolling_deploy_previous_url`. When you **promote** an image between environments (build on staging, promote to production), you want the built image to carry bundles from **both** the build environment and the promotion target, so the promoted image is born ready to serve production's draining bundle.
+
+This is the build-time **failure floor**; the correctness path is the [boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed). Use both.
+
+Subclass the built-in adapter to fan discovery and fetch across a list of endpoints. Discovery unions the hashes from every endpoint; fetch tries each endpoint in order and returns the first hit:
+
+```ruby
+# lib/rolling_deploy_http_adapter.rb
+class RollingDeployHttpAdapter < ReactOnRailsPro::RollingDeployAdapters::Http
+  class << self
+    def previous_bundle_hashes
+      previous_urls.flat_map { |url| with_previous_url(url) { super() } }.uniq
+    end
+
+    def fetch(bundle_hash)
+      previous_urls.each do |url|
+        result = with_previous_url(url) { super(bundle_hash) }
+        return result if result
+      end
+      nil
+    end
+
+    private
+
+    def previous_urls
+      Array(ReactOnRailsPro.configuration.rolling_deploy_previous_url)
+        .flat_map { |raw| raw.to_s.split(",") }
+        .map(&:strip).reject(&:empty?).uniq
+    end
+
+    # Swap the single-URL config the parent reads, one endpoint at a time.
+    def with_previous_url(url)
+      config = ReactOnRailsPro.configuration
+      original = config.rolling_deploy_previous_url
+      config.rolling_deploy_previous_url = url
+      yield
+    ensure
+      config.rolling_deploy_previous_url = original
+    end
+  end
+end
+```
+
+Point `rolling_deploy_previous_url` at a comma-separated list (build environment first, promotion target second) during the image build:
+
+```ruby
+config.rolling_deploy_adapter = RollingDeployHttpAdapter
+# e.g. "https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
+config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
+```
+
 ## Edge cases and error handling
 
 | Scenario                                                                | Behavior                                                                                                                                                        |

--- a/docs/pro/rolling-deploy-custom-adapters.md
+++ b/docs/pro/rolling-deploy-custom-adapters.md
@@ -118,56 +118,19 @@ In practice this means a `staging` deploy hits the same artifact store as produc
 
 ## Multi-source seeding
 
-The built-in HTTP adapter seeds from a single `rolling_deploy_previous_url`. When you **promote** an image between environments (build on staging, promote to production), you want the built image to carry bundles from **both** the build environment and the promotion target, so the promoted image is born ready to serve production's draining bundle.
+The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles from **both** — the promoted image is then born ready to serve production's draining bundle:
+
+```ruby
+# config/initializers/react_on_rails_pro.rb
+config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http
+# a single URL, a comma-separated string, or an Array — all three are accepted:
+config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
+# e.g. ROLLING_DEPLOY_PREVIOUS_URLS="https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
+```
+
+Discovery **unions** the hashes advertised by every endpoint; fetch tries each endpoint **in order** and returns the first that has the requested hash (hashes are content-addressed, so whichever endpoint serves one returns identical bytes). A single unreachable endpoint degrades gracefully — it contributes no hashes but does not abort discovery for the others.
 
 This is the build-time **failure floor**; the correctness path is the [boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed). Use both.
-
-Subclass the built-in adapter to fan discovery and fetch across a list of endpoints. Discovery unions the hashes from every endpoint; fetch tries each endpoint in order and returns the first hit:
-
-```ruby
-# lib/rolling_deploy_http_adapter.rb
-class RollingDeployHttpAdapter < ReactOnRailsPro::RollingDeployAdapters::Http
-  class << self
-    def previous_bundle_hashes
-      previous_urls.flat_map { |url| with_previous_url(url) { super() } }.uniq
-    end
-
-    def fetch(bundle_hash)
-      previous_urls.each do |url|
-        result = with_previous_url(url) { super(bundle_hash) }
-        return result if result
-      end
-      nil
-    end
-
-    private
-
-    def previous_urls
-      Array(ReactOnRailsPro.configuration.rolling_deploy_previous_url)
-        .flat_map { |raw| raw.to_s.split(",") }
-        .map(&:strip).reject(&:empty?).uniq
-    end
-
-    # Swap the single-URL config the parent reads, one endpoint at a time.
-    def with_previous_url(url)
-      config = ReactOnRailsPro.configuration
-      original = config.rolling_deploy_previous_url
-      config.rolling_deploy_previous_url = url
-      yield
-    ensure
-      config.rolling_deploy_previous_url = original
-    end
-  end
-end
-```
-
-Point `rolling_deploy_previous_url` at a comma-separated list (build environment first, promotion target second) during the image build:
-
-```ruby
-config.rolling_deploy_adapter = RollingDeployHttpAdapter
-# e.g. "https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
-config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
-```
 
 ## Edge cases and error handling
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -3478,14 +3478,14 @@ The currently-deployed Rails server already has every bundle and companion asset
 ```ruby
 # config/initializers/react_on_rails_pro.rb
 ReactOnRailsPro.configure do |config|
-  config.rolling_deploy_adapter      = ReactOnRailsPro::RollingDeployAdapters::Http
-  config.rolling_deploy_token        = ENV.fetch("ROLLING_DEPLOY_TOKEN")    # shared secret, ≥ 32 bytes
-  config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URL"]   # base URL of the still-running deployment
+  config.rolling_deploy_adapter       = ReactOnRailsPro::RollingDeployAdapters::Http
+  config.rolling_deploy_token         = ENV.fetch("ROLLING_DEPLOY_TOKEN")     # shared secret, ≥ 32 bytes
+  config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]   # one or more still-running deployments
 end
 ```
 
 - **`rolling_deploy_token`** — the shared bearer token ("password"). Generate one with `SecureRandom.hex(32)` and set the **same** value on both the running server (which authenticates incoming pulls) and the build CI (which sends it). The config validator rejects tokens shorter than 32 bytes.
-- **`rolling_deploy_previous_url`** — the base URL where the previous deployment is reachable **from the build CI**, e.g. `https://app.example.com/react_on_rails_pro/rolling_deploy`. The adapter appends `/manifest` and `/bundles/:hash`. Leave it unset (or empty) to disable discovery on that build.
+- **`rolling_deploy_previous_urls`** — the base URL(s) where previous deployment(s) are reachable **from the build CI** (or from the renderer at boot), e.g. `https://app.example.com/react_on_rails_pro/rolling_deploy`. Accepts a single URL string, a comma-separated string, or an Array. The adapter appends `/manifest` and `/bundles/:hash` to each, unions the discovered hashes, and fetches each hash from the first endpoint that has it. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery on that build.
 - **`rolling_deploy_mount_path`** — the Rails path where the Pro engine auto-mounts the bundle-serving endpoint when the built-in HTTP adapter is configured. Defaults to `/react_on_rails_pro/rolling_deploy`. Set it to a custom path when your previous deployment is reachable elsewhere, or set it to `nil`/blank to opt out of auto-mounting and draw the routes yourself.
 
 ### 2. Server endpoint auto-mount
@@ -3553,7 +3553,7 @@ ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
 - Tarball extraction is **path-traversal-proofed**, accepts regular files only, and enforces a 200 MB uncompressed cap (zip-bomb guard).
 
 > [!WARNING]
-> **Use HTTPS in production.** The token is a bearer credential. Over plain HTTP to a non-loopback host the adapter logs a warning that the token is being sent over an unencrypted connection; a hard HTTPS gate is planned for a follow-up release. Until then, ensure `rolling_deploy_previous_url` always uses `https://` in production environments.
+> **Use HTTPS in production.** The token is a bearer credential. Over plain HTTP to a non-loopback host the adapter logs a warning that the token is being sent over an unencrypted connection; a hard HTTPS gate is planned for a follow-up release. Until then, ensure `rolling_deploy_previous_urls` entries always use `https://` in production environments.
 
 ### Companion assets are handled automatically
 
@@ -3565,7 +3565,7 @@ Pre-seeding runs during `assets:precompile` — at **image-build time**, in the 
 
 ### Why promotion breaks build-time seeding
 
-- The staging build seeds using **staging's** `rolling_deploy_previous_url` and a snapshot of **staging's** then-live bundle.
+- The staging build seeds using **staging's** `rolling_deploy_previous_urls` and a snapshot of **staging's** then-live bundle.
 - When you later promote that image to production, its renderer cache still holds **staging's** previous bundle — never production's. Production's config never gets a vote, because the seed already happened, at build time, in the staging pipeline.
 
 Even if you point the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)), a build-time snapshot still goes stale across **two pending promotions**:
@@ -3584,7 +3584,7 @@ The one place that always knows production's **actually-live** bundle is the **p
 bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
 ```
 
-At boot in production the task reads **production's** config, so `rolling_deploy_previous_url` resolves to production's own live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods — so it advertises the exact draining bundle the new renderer needs, and the task pulls it.
+At boot in production the task reads **production's** config, so `rolling_deploy_previous_urls` resolves to production's own live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods — so it advertises the exact draining bundle the new renderer needs, and the task pulls it.
 
 Keep the build-time seed as well; the two layers are complementary:
 
@@ -3780,56 +3780,19 @@ In practice this means a `staging` deploy hits the same artifact store as produc
 
 ## Multi-source seeding
 
-The built-in HTTP adapter seeds from a single `rolling_deploy_previous_url`. When you **promote** an image between environments (build on staging, promote to production), you want the built image to carry bundles from **both** the build environment and the promotion target, so the promoted image is born ready to serve production's draining bundle.
+The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles from **both** — the promoted image is then born ready to serve production's draining bundle:
+
+```ruby
+# config/initializers/react_on_rails_pro.rb
+config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http
+# a single URL, a comma-separated string, or an Array — all three are accepted:
+config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
+# e.g. ROLLING_DEPLOY_PREVIOUS_URLS="https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
+```
+
+Discovery **unions** the hashes advertised by every endpoint; fetch tries each endpoint **in order** and returns the first that has the requested hash (hashes are content-addressed, so whichever endpoint serves one returns identical bytes). A single unreachable endpoint degrades gracefully — it contributes no hashes but does not abort discovery for the others.
 
 This is the build-time **failure floor**; the correctness path is the [boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed). Use both.
-
-Subclass the built-in adapter to fan discovery and fetch across a list of endpoints. Discovery unions the hashes from every endpoint; fetch tries each endpoint in order and returns the first hit:
-
-```ruby
-# lib/rolling_deploy_http_adapter.rb
-class RollingDeployHttpAdapter < ReactOnRailsPro::RollingDeployAdapters::Http
-  class << self
-    def previous_bundle_hashes
-      previous_urls.flat_map { |url| with_previous_url(url) { super() } }.uniq
-    end
-
-    def fetch(bundle_hash)
-      previous_urls.each do |url|
-        result = with_previous_url(url) { super(bundle_hash) }
-        return result if result
-      end
-      nil
-    end
-
-    private
-
-    def previous_urls
-      Array(ReactOnRailsPro.configuration.rolling_deploy_previous_url)
-        .flat_map { |raw| raw.to_s.split(",") }
-        .map(&:strip).reject(&:empty?).uniq
-    end
-
-    # Swap the single-URL config the parent reads, one endpoint at a time.
-    def with_previous_url(url)
-      config = ReactOnRailsPro.configuration
-      original = config.rolling_deploy_previous_url
-      config.rolling_deploy_previous_url = url
-      yield
-    ensure
-      config.rolling_deploy_previous_url = original
-    end
-  end
-end
-```
-
-Point `rolling_deploy_previous_url` at a comma-separated list (build environment first, promotion target second) during the image build:
-
-```ruby
-config.rolling_deploy_adapter = RollingDeployHttpAdapter
-# e.g. "https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
-config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
-```
 
 ## Edge cases and error handling
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -3596,6 +3596,8 @@ Keep the build-time seed as well; the two layers are complementary:
 
 ## Deploy the renderer before Rails
 
+**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share **one workload** — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle: there is no cross-workload race and no version drift, and the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) simply runs once at container start before either process serves traffic. The rest of this section is for the **separate-workloads** topology, where Rails and the renderer roll independently and the ordering must be made explicit.
+
 > [!IMPORTANT]
 > During a rolling deploy, the new Node Renderer must be live and cache-warm **before** the new Rails server starts serving traffic. If Rails goes first, the adapter's warm-cache guarantee doesn't hold for that window — you get exactly the 410 storm it's meant to prevent.
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -3462,6 +3462,9 @@ A **rolling-deploy adapter** makes new renderer instances start warm for **every
 
 The built-in HTTP adapter is the simplest way to get there, and it's covered next. If your build can't reach the previous deployment, or you'd rather keep bundles in your own store, you can [write a custom adapter](./rolling-deploy-custom-adapters.md) instead.
 
+> [!NOTE]
+> Pre-seeding runs at **image-build time**, in the environment that builds the image. That is sufficient when the image is built and deployed in the **same** environment (a staging build that will run on staging). If you **promote** an image between environments — build once on staging, then promote that same image to production — build-time seeding alone is not enough. See [Promotion deploys need a boot seed](#promotion-deploys-need-a-release-time-boot-seed).
+
 ## Set up the HTTP adapter
 
 > Introduced as a scaffold in PR [#3379](https://github.com/shakacode/react_on_rails/pull/3379) — part 1 of a multi-PR series. A hard HTTPS gate, streaming download, and additional hardening land in follow-ups; see [Security](#security) below.
@@ -3556,6 +3559,41 @@ ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
 
 Each bundle hash ships with the companion assets built alongside it — `loadable-stats.json`, plus `react-client-manifest.json` and `react-server-client-manifest.json` when RSC is enabled. They map chunk and component IDs to the exact asset URLs that hash's build produced, so serving a draining hash with the **wrong** build's manifests would break client-side hydration. The HTTP adapter packs each hash's companions into the same tarball, so this stays correct with no work on your part. (Custom adapters must return them explicitly — see [Companion assets](./rolling-deploy-custom-adapters.md#companion-assets).)
 
+## Promotion deploys need a release-time (boot) seed
+
+Pre-seeding runs during `assets:precompile` — at **image-build time**, in the environment that builds the image. That is exactly right when the image is built and deployed in the same environment. It is **not** enough when you **promote** an image between environments (build once on staging, promote that same image to production).
+
+### Why promotion breaks build-time seeding
+
+- The staging build seeds using **staging's** `rolling_deploy_previous_url` and a snapshot of **staging's** then-live bundle.
+- When you later promote that image to production, its renderer cache still holds **staging's** previous bundle — never production's. Production's config never gets a vote, because the seed already happened, at build time, in the staging pipeline.
+
+Even if you point the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)), a build-time snapshot still goes stale across **two pending promotions**:
+
+1. Production is at `P0`. You build image `C1`, then image `C2`, while production is still `P0` — both snapshot `P0`.
+2. Promote `C1`. Production `P0 → C1`; the draining bundle is `P0`, which `C1` seeded. Warm. ✓
+3. Promote `C2`. Production `C1 → C2`; the draining bundle is now **`C1`** — which `C2` never seeded (it snapshotted `P0`). Cold → 410 storm.
+
+The image cannot know, at build time, which bundle will be draining at the later — and sometimes skipped — moment it is promoted.
+
+### The fix: seed at container boot
+
+The one place that always knows production's **actually-live** bundle is the **production renderer container at boot**. Run the standalone seed task from the renderer container's entrypoint, before it reports ready:
+
+```bash
+bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
+```
+
+At boot in production the task reads **production's** config, so `rolling_deploy_previous_url` resolves to production's own live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods — so it advertises the exact draining bundle the new renderer needs, and the task pulls it.
+
+Keep the build-time seed as well; the two layers are complementary:
+
+- **Build-time seed** — ideally [multi-source](./rolling-deploy-custom-adapters.md#multi-source-seeding) (staging + production) — makes the promoted image born prod-ready and is the **failure floor**: if the boot seed can't reach the live endpoint, the image still holds a recent production bundle, so a miss stays small and rare instead of becoming a full cold storm.
+- **Boot seed** is the **correctness path**: it closes the two-pending-promotions window by resolving the live draining bundle at promotion time.
+
+> [!IMPORTANT]
+> Gate the renderer's readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback, not wedge the deploy — the task already warns-and-continues on fetch failures, so a completed run is a safe readiness signal whether or not every hash was fetched.
+
 ## Deploy the renderer before Rails
 
 > [!IMPORTANT]
@@ -3578,7 +3616,9 @@ Make the ordering explicit in your pipeline rather than relying on timing:
 2. Wait until its new revision is **live and healthy** — readiness passing and all new renderer instances up.
 3. Only then deploy/promote the **Rails** workload.
 
-The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. The exact wiring depends on your deploy tooling.
+The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. Prefer a readiness gate over a fixed sleep — a fixed delay is either too short (races) or too long (slow deploys), while a readiness signal tracks the actual state. The exact wiring depends on your deploy tooling.
+
+This ordering is also **what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct**. The boot seed fetches the draining bundle from the target environment's live endpoint; that endpoint only advertises the draining hash while the old pods are still serving it. If new Rails cut over first, the live endpoint would already advertise the **new** hash and the boot seed would miss the very bundle it needs. Seeding-at-boot and renderer-before-Rails are one design: the boot seed depends on the ordering.
 
 ## Verify your setup with `react_on_rails:doctor`
 
@@ -3734,6 +3774,62 @@ This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. 
 `assets:precompile` invokes `upload` for the current build's bundle hashes whenever an adapter is configured **and** `Rails.env` is anything other than `development` or `test`. That includes `staging`, `production`, custom envs like `qa` or `preview`, and any other non-dev/non-test value.
 
 In practice this means a `staging` deploy hits the same artifact store as production — it must have the same credentials and write access. This is intentional: a `staging` → `staging` rolling deploy needs the previous staging hash seeded, and a `staging` → `production` promotion benefits from staging having warmed the store. If you need to keep `staging` out of the artifact store entirely, set `config.rolling_deploy_adapter = nil` in a `staging`-specific initializer rather than relying on env-based skipping at the gem level.
+
+> [!NOTE]
+> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: an image built on staging seeds staging's previous bundle, not production's — and with the built-in HTTP adapter (`upload` is a no-op) there is no shared store to paper over it. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
+
+## Multi-source seeding
+
+The built-in HTTP adapter seeds from a single `rolling_deploy_previous_url`. When you **promote** an image between environments (build on staging, promote to production), you want the built image to carry bundles from **both** the build environment and the promotion target, so the promoted image is born ready to serve production's draining bundle.
+
+This is the build-time **failure floor**; the correctness path is the [boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed). Use both.
+
+Subclass the built-in adapter to fan discovery and fetch across a list of endpoints. Discovery unions the hashes from every endpoint; fetch tries each endpoint in order and returns the first hit:
+
+```ruby
+# lib/rolling_deploy_http_adapter.rb
+class RollingDeployHttpAdapter < ReactOnRailsPro::RollingDeployAdapters::Http
+  class << self
+    def previous_bundle_hashes
+      previous_urls.flat_map { |url| with_previous_url(url) { super() } }.uniq
+    end
+
+    def fetch(bundle_hash)
+      previous_urls.each do |url|
+        result = with_previous_url(url) { super(bundle_hash) }
+        return result if result
+      end
+      nil
+    end
+
+    private
+
+    def previous_urls
+      Array(ReactOnRailsPro.configuration.rolling_deploy_previous_url)
+        .flat_map { |raw| raw.to_s.split(",") }
+        .map(&:strip).reject(&:empty?).uniq
+    end
+
+    # Swap the single-URL config the parent reads, one endpoint at a time.
+    def with_previous_url(url)
+      config = ReactOnRailsPro.configuration
+      original = config.rolling_deploy_previous_url
+      config.rolling_deploy_previous_url = url
+      yield
+    ensure
+      config.rolling_deploy_previous_url = original
+    end
+  end
+end
+```
+
+Point `rolling_deploy_previous_url` at a comma-separated list (build environment first, promotion target second) during the image build:
+
+```ruby
+config.rolling_deploy_adapter = RollingDeployHttpAdapter
+# e.g. "https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
+config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
+```
 
 ## Edge cases and error handling
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16187,7 +16187,7 @@ Rails and the Node Renderer run as independent workloads with their own scaling.
 
 **Disadvantages:**
 
-- **Version drift risk** — During rolling deploys, Rails and the Node Renderer may briefly run different versions. While protocol changes are rare, this is a risk to monitor.
+- **Version drift risk** — During rolling deploys, Rails and the Node Renderer roll independently and briefly run different bundle versions, so the renderer can receive SSR requests for a bundle it hasn't cached. Mitigate this with a [rolling-deploy adapter](../../../pro/rolling-deploy-adapters.md) (Pro): it pre-seeds the new renderer with the draining bundle and makes the renderer-before-Rails ordering explicit. This risk (and that mitigation) is **specific to this separate-workloads option** — Options 1–2 share one lifecycle and cannot drift.
 - **Race conditions** — Pods restart independently, which can cause transient connection errors.
 - **Network dependency** — Renderer must be reachable via internal service DNS.
 - **Overkill for most setups** — If you're running 2–4 replicas, independent scaling adds complexity without real benefit.

--- a/react_on_rails_pro/CONTEXT.md
+++ b/react_on_rails_pro/CONTEXT.md
@@ -24,8 +24,8 @@ fallback**.
 _Avoid_: warmup (means the per-request lazy cache fill, the opposite of this).
 
 **Pre-seed source**:
-The deployment the pre-seed pulls bundles from — resolved from that
-environment's `rolling_deploy_previous_url` (HTTP adapter) at the moment the
+The deployment(s) the pre-seed pulls bundles from — resolved from that
+environment's `rolling_deploy_previous_urls` (HTTP adapter) at the moment the
 seed runs. The source is whatever environment's config is in effect _when and
 where the seed executes_.
 
@@ -41,8 +41,8 @@ environment's _actually-live_ bundle at that moment. Readiness-gated.
 _Avoid_: "runtime seed" (ambiguous with the per-request 410 path).
 
 **Multi-source seed**:
-A build-time seed whose **pre-seed source** is a _list_ of endpoints (e.g. a
-subclassed HTTP adapter reading a comma-separated `ROLLING_DEPLOY_PREVIOUS_URLS`).
+A build-time seed whose **pre-seed source** is a _list_ of endpoints (the
+built-in HTTP adapter's `rolling_deploy_previous_urls` accepts more than one).
 Staging seeds from both staging and production so the promoted image is born
 prod-ready.
 

--- a/react_on_rails_pro/CONTEXT.md
+++ b/react_on_rails_pro/CONTEXT.md
@@ -1,0 +1,135 @@
+# React on Rails Pro — Rolling Deploy
+
+How the Node Renderer bundle cache is warmed so that during a rolling deploy —
+when old and new app versions run side by side — no SSR request pays the
+cold-bundle penalty. Covers the seeding mechanism and how it interacts with the
+deploy pipeline (build vs. release, staging-to-production promotion).
+
+## Language
+
+**Rolling deploy**:
+The window where old (draining) and new app instances run side by side, both
+sending SSR requests to the Node Renderer fleet.
+
+**Draining bundle**:
+The bundle hash that draining old Rails instances still request during the
+overlap; the new renderer fleet must serve it warm.
+_Avoid_: "old bundle" (old relative to what? — the draining bundle is defined by
+what is live-and-draining in _this environment_, not by build order).
+
+**Pre-seed**:
+Staging previous bundle hashes into the new renderer cache before it serves
+traffic, so **draining bundle** requests hit warm cache instead of the **410
+fallback**.
+_Avoid_: warmup (means the per-request lazy cache fill, the opposite of this).
+
+**Pre-seed source**:
+The deployment the pre-seed pulls bundles from — resolved from that
+environment's `rolling_deploy_previous_url` (HTTP adapter) at the moment the
+seed runs. The source is whatever environment's config is in effect _when and
+where the seed executes_.
+
+**Build-time seed**:
+Pre-seed baked into the image during `assets:precompile`. Uses the _building_
+environment's config and a _snapshot_ of its then-live bundle. Frozen into the
+image layer.
+
+**Release-time seed** (a.k.a. **boot seed**):
+Pre-seed run by the _target_ environment's renderer container at container boot
+via `rake react_on_rails_pro:pre_seed_renderer_cache`, resolving that
+environment's _actually-live_ bundle at that moment. Readiness-gated.
+_Avoid_: "runtime seed" (ambiguous with the per-request 410 path).
+
+**Multi-source seed**:
+A build-time seed whose **pre-seed source** is a _list_ of endpoints (e.g. a
+subclassed HTTP adapter reading a comma-separated `ROLLING_DEPLOY_PREVIOUS_URLS`).
+Staging seeds from both staging and production so the promoted image is born
+prod-ready.
+
+**Promotion model**:
+Production is deployed by promoting the _exact staging image_, not by building a
+fresh production image. Consequence: the image's **build-time seed** used the
+_staging_ pipeline's config and a snapshot taken at staging-build time — never
+production's.
+
+**410 fallback**:
+The self-healing but slow per-request cold path: cache miss → `410 Gone` → Rails
+ships the bundle to the renderer → retry, repeating per request until cached.
+The thing pre-seeding exists to avoid.
+
+**Seed correctness (R1)**:
+The requirement that the new renderer fleet holds the exact **draining bundle**
+for _this_ environment at _this_ release.
+
+**Deploy ordering (R2)**:
+The requirement that the new renderer fleet is live and cache-warm _before_ new
+Rails takes traffic, and old renderers stay up until old Rails drains. Also
+called **renderer-before-Rails**.
+
+## Relationships
+
+- A **rolling deploy** has one **draining bundle** per bundle kind (server, and
+  RSC when enabled) that the new renderer fleet must serve warm.
+- **Pre-seed** eliminates the **410 fallback** for the **draining bundle**;
+  without it, every draining-bundle request pays the cold path.
+- **Seed correctness (R1)** and **Deploy ordering (R2)** are independent and
+  _both_ required. R2 alone (a delay) cannot rescue a wrong seed; R1 alone
+  cannot rescue Rails cutting over before the renderer is warm.
+- Under the **promotion model**, a **build-time seed** _cannot_ satisfy R1: it
+  runs in the staging pipeline against a staging snapshot, but production's
+  **draining bundle** is only known at the (later, sometimes-skipped) promotion.
+- Fix: set staging's **pre-seed source** to **production**, so the promoted
+  image is born prod-ready (build-time seed = prod's live bundle). This bounds
+  the blast radius but goes stale across _two pending promotions_.
+- The residual staleness window (two images built before either is promoted) is
+  closed by a **release-time seed** at promotion, which resolves production's
+  actually-live **draining bundle**.
+- Staging seeding prod bundles means staging's _own_ rolling deploys cold-miss
+  (staging drains staging's-previous, which is not seeded). Accepted: staging
+  SSR performance during deploys is not a goal.
+
+### Three layers of defense
+
+Correctness is layered; each layer bounds the failure the prior one leaves open.
+
+1. **Multi-source build-time seed** — the image is born prod-ready; failure floor
+   if the boot seed can't reach the live endpoint. (Correct for a single pending
+   promotion.)
+2. **Boot seed (release-time)** — the correctness path: pulls the _actually-live_
+   **draining bundle** at container start, closing the two-pending-promotions
+   window. Subsumes layer 1's correctness; layer 1 remains only as a fallback.
+3. **Deploy ordering (R2)** — renderer live+warm before Rails; readiness gates on
+   the boot seed _completing_ (not succeeding — a failed seed degrades to the 410
+   fallback rather than wedging the deploy).
+
+**Interdependency:** the **boot seed** returns the correct **draining bundle**
+_only because_ the renderer boots before Rails (R2). Before new Rails is live,
+the environment's live endpoint is still served by the draining old pods, so it
+advertises the draining hash. If Rails cut over first, the live endpoint would
+advertise the _new_ hash and the boot seed would miss the very bundle it needs.
+Layer 2 depends on Layer 3.
+
+## Example dialogue
+
+> **Dev:** "We promote the staging image to prod, and pre-seed is on. Why is
+> prod SSR still slow after a rolling deploy?"
+> **Domain expert:** "Because the **build-time seed** ran in the staging
+> pipeline — the image holds staging's previous bundle, not prod's **draining
+> bundle**. The seed was correct for the wrong environment."
+> **Dev:** "So if staging's **pre-seed source** points at production, the
+> promoted image is already prod-ready?"
+> **Domain expert:** "For a single pending promotion, yes. Two pending
+> promotions still go stale — that's why promotion also runs a **release-time
+> seed** against prod's live bundle."
+> **Dev:** "And that's enough?"
+> **Domain expert:** "That's **R1**. You still need **R2** — the new renderer
+> fleet live and warm before Rails cuts over — or you get the 410 storm anyway."
+
+## Flagged ambiguities
+
+- "old bundle" was used to mean both the build-predecessor and the live-draining
+  bundle — resolved: the term of record is **draining bundle**, defined by what
+  is live in the target environment, not by build order.
+- "the delay" (R2) was initially read as a fix for the slow-SSR report — resolved:
+  the report is an R1 (wrong-seed) failure; the delay is a necessary but separate
+  R2 concern.

--- a/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
+++ b/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
@@ -1,0 +1,38 @@
+# Seed rolling-deploy bundles at renderer boot, not only at build
+
+**Status:** accepted
+
+When the production image is produced by **promoting the staging image**
+(`upstream: hichee-staging` in Control Plane), a build-time pre-seed cannot know
+production's live **draining bundle**: it runs in the staging pipeline against a
+staging snapshot, and promotion happens later and is sometimes skipped. We
+therefore have the **node-renderer container pull the target environment's
+actually-live bundle at boot** (`rake react_on_rails_pro:pre_seed_renderer_cache`,
+readiness-gated) as the correctness path, and keep the build-time seed as a
+fallback floor.
+
+## Considered options
+
+- **Build-time seed only (status quo).** Rejected: structurally wrong under the
+  promotion model — the image holds staging's previous bundle, and even a
+  multi-source build-time seed (staging + production) goes stale across two
+  pending promotions.
+- **Build a dedicated production image instead of promoting staging.** Rejected:
+  fights the promotion model (the point of promotion is shipping the exact
+  artifact tested on staging) and still goes stale if a prod image is ever built
+  ahead of its release.
+- **Boot seed only.** Rejected in favor of belt-and-suspenders: a boot seed that
+  can't reach the live endpoint would fall all the way back to the per-request
+  410 path. Keeping the build-time multi-source seed bounds that failure to a
+  small, rare miss.
+
+## Consequences
+
+- Correctness of the boot seed **depends on deploy ordering (R2)**: the renderer
+  must boot before Rails, so the environment's live endpoint still advertises the
+  draining hash. If Rails cut over first, the boot seed would fetch the new hash
+  and miss the draining one.
+- Readiness gates on the boot seed **completing, not succeeding** — a failed seed
+  degrades to the 410 fallback rather than wedging the deploy.
+- Staging seeds production bundles, so staging's own rolling deploys cold-miss.
+  Accepted: staging SSR performance during deploys is not a goal.

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -38,7 +38,7 @@ module ReactOnRailsPro
       remote_bundle_cache_adapter: Configuration::DEFAULT_REMOTE_BUNDLE_CACHE_ADAPTER,
       rolling_deploy_adapter: Configuration::DEFAULT_ROLLING_DEPLOY_ADAPTER,
       rolling_deploy_token: Configuration::DEFAULT_ROLLING_DEPLOY_TOKEN,
-      rolling_deploy_previous_url: Configuration::DEFAULT_ROLLING_DEPLOY_PREVIOUS_URL,
+      rolling_deploy_previous_urls: Configuration::DEFAULT_ROLLING_DEPLOY_PREVIOUS_URLS,
       rolling_deploy_mount_path: Configuration::DEFAULT_ROLLING_DEPLOY_MOUNT_PATH,
       ssr_timeout: Configuration::DEFAULT_SSR_TIMEOUT,
       ssr_pre_hook_js: nil,
@@ -79,7 +79,7 @@ module ReactOnRailsPro
     DEFAULT_REMOTE_BUNDLE_CACHE_ADAPTER = nil
     DEFAULT_ROLLING_DEPLOY_ADAPTER = nil
     DEFAULT_ROLLING_DEPLOY_TOKEN = nil
-    DEFAULT_ROLLING_DEPLOY_PREVIOUS_URL = nil
+    DEFAULT_ROLLING_DEPLOY_PREVIOUS_URLS = nil
     DEFAULT_ROLLING_DEPLOY_MOUNT_PATH = "/react_on_rails_pro/rolling_deploy"
     # Minimum bearer-token length when using the built-in HTTP rolling-deploy adapter.
     # 32 chars matches SecureRandom.hex(16) and rules out obviously low-entropy values
@@ -112,7 +112,7 @@ module ReactOnRailsPro
                   :renderer_http_pool_timeout, :renderer_http_pool_warn_timeout,
                   :dependency_globs, :excluded_dependency_globs, :rendering_returns_promises,
                   :remote_bundle_cache_adapter, :rolling_deploy_adapter,
-                  :rolling_deploy_token, :rolling_deploy_previous_url, :rolling_deploy_mount_path,
+                  :rolling_deploy_token, :rolling_deploy_previous_urls, :rolling_deploy_mount_path,
                   :ssr_pre_hook_js, :assets_to_copy,
                   :renderer_request_retry_limit, :throw_js_errors, :ssr_timeout,
                   :profile_server_rendering_js_code, :raise_non_shell_server_rendering_errors, :enable_rsc_support,
@@ -201,7 +201,7 @@ module ReactOnRailsPro
                    tracing: nil,
                    dependency_globs: nil, excluded_dependency_globs: nil, rendering_returns_promises: nil,
                    remote_bundle_cache_adapter: nil, rolling_deploy_adapter: nil,
-                   rolling_deploy_token: nil, rolling_deploy_previous_url: nil,
+                   rolling_deploy_token: nil, rolling_deploy_previous_urls: nil,
                    rolling_deploy_mount_path: nil,
                    ssr_pre_hook_js: nil, assets_to_copy: nil,
                    renderer_request_retry_limit: nil, throw_js_errors: nil, ssr_timeout: nil,
@@ -229,7 +229,7 @@ module ReactOnRailsPro
       self.remote_bundle_cache_adapter = remote_bundle_cache_adapter
       self.rolling_deploy_adapter = rolling_deploy_adapter
       self.rolling_deploy_token = rolling_deploy_token
-      self.rolling_deploy_previous_url = rolling_deploy_previous_url
+      self.rolling_deploy_previous_urls = rolling_deploy_previous_urls
       # Constructor nil/blank means "use the default"; configure-block assignment
       # can still set nil/blank later to opt out of the engine auto-mount.
       self.rolling_deploy_mount_path = rolling_deploy_mount_path.presence || DEFAULT_ROLLING_DEPLOY_MOUNT_PATH
@@ -407,8 +407,8 @@ module ReactOnRailsPro
 
     # Only fires when the user has selected the built-in HTTP adapter. Custom
     # adapters that re-use the new config knobs for their own reasons are not
-    # forced through this validation. We do not validate previous_url here:
-    # an unset URL is a valid "discovery off; this is the upload-only side of
+    # forced through this validation. We do not validate previous_urls here:
+    # an unset list is a valid "discovery off; this is the upload-only side of
     # a one-way deploy" mode (the adapter returns [] for previous_bundle_hashes).
     def validate_rolling_deploy_http_adapter_config
       return unless rolling_deploy_http_adapter?

--- a/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
@@ -38,10 +38,18 @@ module ReactOnRailsPro
     # Configuration (see docs/pro/rolling-deploy-adapters.md):
     #
     #   ReactOnRailsPro.configure do |config|
-    #     config.rolling_deploy_adapter      = ReactOnRailsPro::RollingDeployAdapters::Http
-    #     config.rolling_deploy_token        = ENV.fetch("ROLLING_DEPLOY_TOKEN")
-    #     config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URL"]
+    #     config.rolling_deploy_adapter       = ReactOnRailsPro::RollingDeployAdapters::Http
+    #     config.rolling_deploy_token         = ENV.fetch("ROLLING_DEPLOY_TOKEN")
+    #     config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
     #   end
+    #
+    # `rolling_deploy_previous_urls` accepts a single URL string, a comma-
+    # separated string, or an Array of URL strings. Discovery unions the bundle
+    # hashes advertised by every endpoint; fetch tries each endpoint in order and
+    # returns the first that has the requested hash. Seeding from more than one
+    # endpoint (e.g. staging + production) lets an image built in one environment
+    # and promoted to another carry the promotion target's draining bundle. See
+    # docs/pro/rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed.
     #
     # Error contract matches the rolling_deploy_adapter protocol: every
     # exception is caught and reported as a warning so a failed seed degrades
@@ -81,19 +89,59 @@ module ReactOnRailsPro
 
       class << self
         def previous_bundle_hashes
-          base = configured_previous_url
-          return [] if base.nil?
+          bases = configured_previous_urls
+          return [] if bases.empty?
 
           if token_missing?
             return warn_and_return("rolling_deploy_token is not configured; skipping manifest fetch",
                                    [])
           end
 
-          response = http_get(
-            URI("#{base}/manifest"),
-            read_timeout: MANIFEST_READ_TIMEOUT_SECONDS
-          )
-          return warn_and_return("manifest returned HTTP #{response.code}", []) unless response.is_a?(Net::HTTPSuccess)
+          # Union across every configured endpoint. A single endpoint failing
+          # (down, 404, malformed manifest) yields [] for that base and does not
+          # abort discovery for the others — the point of multiple endpoints is
+          # resilience, so one unreachable source must not blank the rest.
+          bases.flat_map { |base| manifest_hashes(base) }.uniq
+        end
+
+        def fetch(bundle_hash)
+          return nil if hash_invalid?(bundle_hash)
+
+          bases = configured_previous_urls
+          return nil if bases.empty?
+
+          if token_missing?
+            return warn_and_return("rolling_deploy_token is not configured; skipping fetch(#{bundle_hash.inspect})",
+                                   nil)
+          end
+
+          # Try each endpoint in order; return the first that has the hash. A
+          # given hash is content-addressed, so whichever endpoint serves it
+          # returns identical bytes — first hit wins.
+          bases.each do |base|
+            payload = fetch_from(base, bundle_hash)
+            return payload if payload
+          end
+          nil
+        end
+
+        # Intentional no-op. The running Rails server IS the artifact store —
+        # bundle + companion assets are already on local disk where the
+        # mountable BundlesController will serve them on the next deploy's
+        # build CI. Documented in docs/pro/rolling-deploy-adapters.md.
+        def upload(_bundle_hash, bundle:, assets:)
+          # See class doc above.
+        end
+
+        private
+
+        # One endpoint's manifest hashes, or [] on any failure so a single bad
+        # endpoint cannot abort discovery across the others.
+        def manifest_hashes(base)
+          response = http_get(URI("#{base}/manifest"), read_timeout: MANIFEST_READ_TIMEOUT_SECONDS)
+          unless response.is_a?(Net::HTTPSuccess)
+            return warn_and_return("manifest at #{base} returned HTTP #{response.code}", [])
+          end
 
           parsed = JSON.parse(response.body)
           # Filter manifest hashes through SAFE_HASH_PATTERN before returning
@@ -107,19 +155,13 @@ module ReactOnRailsPro
             .reject(&:empty?)
             .grep(ReactOnRailsPro::RollingDeploy::SAFE_HASH_PATTERN)
         rescue StandardError => e
-          warn_and_return("previous_bundle_hashes failed: #{e.class}: #{e.message}", [])
+          warn_and_return("previous_bundle_hashes for #{base} failed: #{e.class}: #{e.message}", [])
         end
 
-        def fetch(bundle_hash)
-          base = configured_previous_url
-          return nil if base.nil?
-          return nil if hash_invalid?(bundle_hash)
-
-          if token_missing?
-            return warn_and_return("rolling_deploy_token is not configured; skipping fetch(#{bundle_hash.inspect})",
-                                   nil)
-          end
-
+        # Fetch one hash from one endpoint. Returns the payload Hash or nil.
+        # Owns the temp dir lifecycle so a failed attempt cleans up before the
+        # caller tries the next endpoint into the same (hash-keyed) directory.
+        def fetch_from(base, bundle_hash)
           dir = bundle_dir(bundle_hash)
           FileUtils.mkdir_p(dir)
 
@@ -131,36 +173,37 @@ module ReactOnRailsPro
           result
         rescue StandardError => e
           cleanup_and_return(dir, nil) if dir
-          warn_and_return("fetch(#{bundle_hash.inspect}) failed: #{e.class}: #{e.message}", nil)
+          warn_and_return("fetch(#{bundle_hash.inspect}) from #{base} failed: #{e.class}: #{e.message}", nil)
         end
 
-        # Intentional no-op. The running Rails server IS the artifact store —
-        # bundle + companion assets are already on local disk where the
-        # mountable BundlesController will serve them on the next deploy's
-        # build CI. Documented in docs/pro/rolling-deploy-adapters.md.
-        def upload(_bundle_hash, bundle:, assets:)
-          # See class doc above.
+        # Normalize the configured previous URL(s) into a de-duplicated list of
+        # scheme-validated base URLs. Accepts a single string, a comma-separated
+        # string, or an Array (whose entries may themselves be comma-separated —
+        # convenient for `ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]`).
+        def configured_previous_urls
+          raw = ReactOnRailsPro.configuration.rolling_deploy_previous_urls
+          Array(raw)
+            .flat_map { |entry| entry.to_s.split(",") }
+            .map(&:strip)
+            .reject(&:empty?)
+            .uniq
+            .filter_map { |url| normalize_previous_url(url) }
         end
 
-        private
-
-        def configured_previous_url
-          url = ReactOnRailsPro.configuration.rolling_deploy_previous_url.to_s.strip
-          return nil if url.empty?
-
+        def normalize_previous_url(url)
           uri = URI.parse(url.chomp("/"))
           unless %w[http https].include?(uri.scheme)
             Rails.logger.warn(
-              "#{LOG_PREFIX} rolling_deploy_previous_url has unsupported scheme " \
-              "#{uri.scheme.inspect}; expected http or https. Skipping discovery."
+              "#{LOG_PREFIX} rolling_deploy_previous_urls entry #{url.inspect} has unsupported scheme " \
+              "#{uri.scheme.inspect}; expected http or https. Skipping this entry."
             )
             return nil
           end
           uri.to_s
         rescue URI::InvalidURIError => e
           Rails.logger.warn(
-            "#{LOG_PREFIX} rolling_deploy_previous_url is not a valid URI: #{e.message}. " \
-            "Skipping discovery."
+            "#{LOG_PREFIX} rolling_deploy_previous_urls entry #{url.inspect} is not a valid URI: " \
+            "#{e.message}. Skipping this entry."
           )
           nil
         end
@@ -330,7 +373,7 @@ module ReactOnRailsPro
         # by surfacing the cleartext-token risk in build CI logs.
         #
         # Loopback hosts are intentionally exempt so developers running a
-        # local Rails server for `rolling_deploy_previous_url` during
+        # local Rails server for `rolling_deploy_previous_urls` during
         # development don't see noise on every build CI rehearsal — the
         # token never leaves the host in that case.
         LOOPBACK_HOST_PATTERN = /\A(localhost|127(?:\.\d{1,3}){3}|::1|\[::1\])\z/

--- a/react_on_rails_pro/sig/react_on_rails_pro/configuration.rbs
+++ b/react_on_rails_pro/sig/react_on_rails_pro/configuration.rbs
@@ -34,7 +34,7 @@ module ReactOnRailsPro
     DEFAULT_REMOTE_BUNDLE_CACHE_ADAPTER: nil
     DEFAULT_ROLLING_DEPLOY_ADAPTER: nil
     DEFAULT_ROLLING_DEPLOY_TOKEN: nil
-    DEFAULT_ROLLING_DEPLOY_PREVIOUS_URL: nil
+    DEFAULT_ROLLING_DEPLOY_PREVIOUS_URLS: nil
     DEFAULT_ROLLING_DEPLOY_MOUNT_PATH: String
     DEFAULT_RENDERER_REQUEST_RETRY_LIMIT: Integer
     DEFAULT_THROW_JS_ERRORS: bool
@@ -70,7 +70,7 @@ module ReactOnRailsPro
     attr_accessor remote_bundle_cache_adapter: Module?
     attr_accessor rolling_deploy_adapter: Module?
     attr_accessor rolling_deploy_token: String?
-    attr_accessor rolling_deploy_previous_url: String?
+    attr_accessor rolling_deploy_previous_urls: (String | Array[String])?
     attr_accessor rolling_deploy_mount_path: String?
     attr_accessor ssr_pre_hook_js: String?
     attr_accessor assets_to_copy: Array[String]?
@@ -106,7 +106,7 @@ module ReactOnRailsPro
       ?remote_bundle_cache_adapter: Module?,
       ?rolling_deploy_adapter: Module?,
       ?rolling_deploy_token: String?,
-      ?rolling_deploy_previous_url: String?,
+      ?rolling_deploy_previous_urls: (String | Array[String])?,
       ?rolling_deploy_mount_path: String?,
       ?ssr_pre_hook_js: String?,
       ?assets_to_copy: Array[String]?,

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
@@ -54,7 +54,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_token: "token"
       )
     end
@@ -148,7 +148,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_token: "token"
       )
     end
@@ -223,11 +223,11 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     end
   end
 
-  describe "previous_url scheme validation" do
+  describe "previous_urls scheme validation" do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: previous_url,
+        rolling_deploy_previous_urls: previous_url,
         rolling_deploy_token: "token"
       )
     end
@@ -264,7 +264,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_token: "token"
       )
     end
@@ -293,7 +293,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_token: ""
       )
     end
@@ -315,6 +315,78 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
 
       expect(described_class.fetch("hash123")).to be_nil
       expect(Rails.logger).to have_received(:warn).with(/rolling_deploy_token is not configured/)
+    end
+  end
+
+  describe "multiple previous URLs" do
+    let(:config) do
+      instance_double(
+        ReactOnRailsPro::Configuration,
+        rolling_deploy_previous_urls: ["https://staging.example.com", "https://prod.example.com"],
+        rolling_deploy_token: "token"
+      )
+    end
+
+    before do
+      allow(ReactOnRailsPro).to receive(:configuration).and_return(config)
+      allow(Rails).to receive(:logger).and_return(instance_double(Logger, warn: nil))
+    end
+
+    describe ".previous_bundle_hashes" do
+      it "unions and de-duplicates hashes discovered from every endpoint" do
+        allow(described_class).to receive(:manifest_hashes)
+          .with("https://staging.example.com").and_return(%w[staging shared])
+        allow(described_class).to receive(:manifest_hashes)
+          .with("https://prod.example.com").and_return(%w[prod shared])
+
+        expect(described_class.previous_bundle_hashes).to eq(%w[staging shared prod])
+      end
+
+      it "keeps hashes from healthy endpoints when one endpoint fails" do
+        allow(described_class).to receive(:manifest_hashes)
+          .with("https://staging.example.com").and_return([])
+        allow(described_class).to receive(:manifest_hashes)
+          .with("https://prod.example.com").and_return(%w[prod])
+
+        expect(described_class.previous_bundle_hashes).to eq(%w[prod])
+      end
+    end
+
+    describe ".fetch" do
+      let(:payload) { { bundle: "/tmp/rolling/bundle.js", assets: [] } }
+
+      it "returns the first endpoint that has the hash without querying later endpoints" do
+        allow(described_class).to receive(:fetch_from).and_return(nil)
+        allow(described_class).to receive(:fetch_from)
+          .with("https://staging.example.com", "hash123").and_return(payload)
+
+        expect(described_class.fetch("hash123")).to eq(payload)
+        expect(described_class).not_to have_received(:fetch_from).with("https://prod.example.com", "hash123")
+      end
+
+      it "falls through to the next endpoint when an earlier one misses" do
+        allow(described_class).to receive(:fetch_from)
+          .with("https://staging.example.com", "hash123").and_return(nil)
+        allow(described_class).to receive(:fetch_from)
+          .with("https://prod.example.com", "hash123").and_return(payload)
+
+        expect(described_class.fetch("hash123")).to eq(payload)
+      end
+    end
+
+    describe "comma-separated string form" do
+      let(:config) do
+        instance_double(
+          ReactOnRailsPro::Configuration,
+          rolling_deploy_previous_urls: "https://staging.example.com , https://prod.example.com",
+          rolling_deploy_token: "token"
+        )
+      end
+
+      it "splits, trims, and de-duplicates into a list of base URLs" do
+        expect(described_class.send(:configured_previous_urls))
+          .to eq(["https://staging.example.com", "https://prod.example.com"])
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

A production report: SSR stays slow after a rolling deploy even with rolling-deploy pre-seeding on. Root cause is **not** deploy timing — the wrong bundle gets seeded. Under a **promotion model** (build once on staging, promote that same image to production), pre-seeding runs at build time in the staging pipeline, so the promoted image carries **staging's** previous bundle, never production's **draining bundle**. A build-time snapshot also goes stale across two pending promotions.

## Design (three layers)

| Layer | Mechanism |
| --- | --- |
| 1. Build-time (multi-source) seed | staging bakes staging+prod → image born prod-ready; failure floor |
| 2. **Boot seed** | renderer pulls the target env's *actually-live* draining bundle at container start, readiness-gated |
| 3. Deploy ordering (R2) | renderer live+warm before Rails; readiness gates on the boot seed *completing* |

Key interdependency: the boot seed returns the right bundle **only because** the renderer boots before Rails (the live endpoint still advertises the draining hash while old pods drain).

## What this PR does

**Docs (all layers):**

- `docs/pro/rolling-deploy-adapters.md` — new "Promotion deploys need a boot seed" section (two-pending-promotions trace + the container-boot seed via `rake react_on_rails_pro:pre_seed_renderer_cache`); build-time-vs-boot framing; extended "Deploy the renderer before Rails" (readiness-gate-on-completion + the ordering/boot-seed interdependency; prefer a gate over a fixed sleep).
- `docs/pro/rolling-deploy-custom-adapters.md` — clarified the promotion note is upload-side only; native "Multi-source seeding" guidance.
- `docs/oss/building-features/node-renderer/container-deployment.md` + rolling-deploy-adapters.md — **renderer topology awareness**: the renderer-before-Rails ordering applies only to the *separate-workloads* topology (Option 3); single-container/sidecar (Options 1–2) deploy atomically. Cross-linked both directions.
- `react_on_rails_pro/CONTEXT.md` + `docs/adr/0001-*` + `CONTEXT-MAP.md` — domain vocabulary and decision record.

**Gem feature — multi-URL built-in HTTP adapter (Layer 1, native):**

- Renamed `config.rolling_deploy_previous_url` → `config.rolling_deploy_previous_urls` (breaking within the 17.0.0 RC cycle only — the singular knob never shipped stable).
- The value accepts a single URL, a comma-separated string, or an Array. Discovery **unions** hashes across every endpoint; fetch tries each endpoint **in order** and returns the first hit (content-addressed). A single unreachable endpoint degrades gracefully.
- This replaces the app-level subclass that shakacode/hichee#9661 used for the same effect.
- RBS + CHANGELOG updated; `llms-full-pro.txt` regenerated.

## Verification

- `bundle exec rubocop` — 3 changed Ruby files, no offenses.
- `bundle exec rspec` — `http_spec.rb` (19 examples, incl. 5 new multi-URL) + `configuration_spec.rb` (86 examples), 0 failures.
- `bundle exec rake rbs:validate` — passed.
- `node script/generate-llms-full.mjs --check` — current.
- `prettier@3.6.2 --check` on changed markdown — clean; lefthook pre-commit (trailing-newlines, lychee, prettier, rubocop, pro-license-headers) all pass.

## Follow-up (separate, in the hichee repo)

Wire the **boot seed** (Layer 2) into the `node-renderer` container entrypoint and the **renderer-before-Rails** ordering (Layer 3); once this ships, hichee can drop its `RollingDeployHttpAdapter` subclass in favor of `rolling_deploy_previous_urls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified rolling-deploy seeding across image build vs release-time (boot), including promotion correctness and readiness/degradation (410 fallback) guidance.
  * Expanded rolling-deploy adapter documentation for multi-source discovery/fetch using `rolling_deploy_previous_urls`, including promotion guidance and HTTPS token transport notes.
  * Added reference material defining rolling-deploy terminology, deploy ordering requirements, and the 410 fallback model.
* **Breaking Changes**
  * Renamed `rolling_deploy_previous_url` → `rolling_deploy_previous_urls`, supporting a single URL, comma-separated string, or array (and multi-endpoint discovery in-order).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge Qualification

**Release-mode gate applied:** target `release/17.0.0` → phase **`rc`** (branch-derived; `agent-coord` is local-only for this repo). Tracker [#3823](https://github.com/shakacode/react_on_rails/issues/3823) mode **`development`**. rc-phase gate = **confidence note + adversarial-pr-review + zero open MUST-FIX** — **satisfied**. Development mode → standard qualification (the accelerated-RC independent-finalizer confidence block does not apply). `merge_authority: auto_merge_when_gates_pass`.

**Confidence note:**

- **Validated:** `bundle exec rubocop` (2 changed Ruby files, no offenses); `bundle exec rspec` on `http_spec.rb` + `configuration_spec.rb` (**105 examples, 0 failures**, incl. 5 new multi-URL specs); `bundle exec rake rbs:validate` (passed); `prettier@3.6.2 --check` on changed markdown (clean); `node script/generate-llms-full.mjs --check` (current); `required-pr-gate` **SUCCESS** on head `d2493205b` with the hosted suite (generator tests, rspec-gem, Pro package/integration, Playwright) green.
- **Evidence:** CI rollup 0 hard failures; adversarial-pr-review (high-risk mode) → **0 BLOCKING, 0 open MUST-FIX**; config-rename completeness verified (`git grep 'rolling_deploy_previous_url\b'` across all file types incl. generators/templates/dummy/RBS → **zero** remaining singular refs); the sole `CHANGES_REQUESTED` was a stale, moot CodeRabbit nitpick on rebased-away commit `94288603a` (the `with_previous_url` subclass it flagged was removed when the Multi-source section was rewritten to native config) — dismissed with rationale.
- **UNKNOWN:** none.
- **Residual risk:** none affecting merge safety. The breaking rename is RC-only (the singular config never shipped in a stable release), so it is a free change within 17.0.0. Standard post-merge follow-up: forward-port to `main` via `git cherry-pick -x`.
