### PR TITLE
[Pro] Don't double-wrap user Suspense roots in default RSC provider (#4535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   the same null Suspense boundary used by the server stream. This prevents recoverable hydration
   mismatches on streamed RSC apps such as the flagship demo. Fixes
   [Issue 4525](https://github.com/shakacode/react_on_rails/issues/4525). [PR 4532](https://github.com/shakacode/react_on_rails/pull/4532) by [justin808](https://github.com/justin808).
+- **[Pro]** **Default RSC provider no longer double-wraps user Suspense roots**: the default-provider
+  hydration guard from PR 4532 keyed its extra client `<React.Suspense>` wrapper on the hydration
+  root starting with a `<!--$-->` comment, which also matches an app-authored top-level `<Suspense>`
+  root (such as `<Suspense><RSCRoute ssr={false} /></Suspense>`). It now skips the wrapper when the
+  client root already renders its own top-level Suspense boundary, preventing a recoverable hydration
+  mismatch on that supported path. Fixes
+  [Issue 4535](https://github.com/shakacode/react_on_rails/issues/4535). [PR 4545](https://github.com/shakacode/react_on_rails/pull/4545) by [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.7] - 2026-07-06
 

--- a/packages/react-on-rails-pro/src/registerDefaultRSCProvider.client.tsx
+++ b/packages/react-on-rails-pro/src/registerDefaultRSCProvider.client.tsx
@@ -20,11 +20,21 @@ import { createRSCProvider } from './RSCProvider.tsx';
 import { setDefaultRSCProviderFactory } from './defaultRSCProviderRegistry.ts';
 import { hasLeadingSuspenseBoundary } from './rscHydrationDom.ts';
 
+// A user-authored top-level Suspense root (for example `<Suspense><RSCRoute ssr={false} /></Suspense>`)
+// makes the server DOM legitimately begin with a `<!--$-->` Suspense comment for `reactElement` itself.
+// Because the default RSC provider is registered only on the client, no extra server-streamed wrapper
+// boundary sits above that element, so the client tree already provides the matching boundary. Wrapping
+// it again in `<React.Suspense>` would make the client expect two nested boundaries where the server
+// emitted one, reintroducing a recoverable hydration mismatch. Only the server-streamed wrapper case —
+// where the client root is not itself a top-level Suspense — needs the extra wrapper. See issue #4535.
+const rootElementRendersOwnSuspenseBoundary = (element: React.ReactElement): boolean =>
+  React.isValidElement(element) && element.type === React.Suspense;
+
 if (typeof window !== 'undefined') {
   setDefaultRSCProviderFactory(({ reactElement, railsContext, domNodeId }) => {
-    const shouldMatchStreamedSuspenseBoundary = hasLeadingSuspenseBoundary(
-      document.getElementById(domNodeId),
-    );
+    const shouldMatchStreamedSuspenseBoundary =
+      hasLeadingSuspenseBoundary(document.getElementById(domNodeId)) &&
+      !rootElementRendersOwnSuspenseBoundary(reactElement);
     const RSCProvider = createRSCProvider({
       domNodeId,
       getServerComponent: async (args) => {

--- a/packages/react-on-rails-pro/tests/registerDefaultRSCProvider.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/registerDefaultRSCProvider.client.test.jsx
@@ -50,6 +50,32 @@ describe('registerDefaultRSCProvider/client hydration parity', () => {
     expect(reactElement.props.children.props.children).toBe(appElement);
   });
 
+  it('does not add a second Suspense wrapper when the root is a user-authored top-level Suspense', () => {
+    const { maybeWrapWithDefaultRSCProviderWithStatus } = require('../src/defaultRSCProviderRegistry.ts');
+    require('../src/registerDefaultRSCProvider.client.tsx');
+    // A `<Suspense><RSCRoute ssr={false} /></Suspense>` root legitimately makes the server DOM start
+    // with `<!--$-->` for the user element itself, so the client tree already provides the matching
+    // boundary. Adding another wrapper would make the client expect two nested boundaries where the
+    // server emitted one, reintroducing a recoverable hydration mismatch (issue #4535).
+    document.body.innerHTML =
+      '<div id="SuspenseRootApp-react-component-test"><!--$--><section data-testid="suspense-root">Deferred</section><!--/$--></div>';
+
+    const appElement = (
+      <React.Suspense fallback={null}>
+        <section data-testid="suspense-root">Deferred</section>
+      </React.Suspense>
+    );
+    const { reactElement, wrappedByDefaultRSCProvider } = maybeWrapWithDefaultRSCProviderWithStatus(
+      appElement,
+      { rscPayloadGenerationUrlPath: '/rsc_payload' },
+      'SuspenseRootApp-react-component-test',
+    );
+
+    expect(wrappedByDefaultRSCProvider).toBe(true);
+    // The user's own top-level Suspense already matches the single server boundary; no extra wrapper.
+    expect(reactElement.props.children).toBe(appElement);
+  });
+
   it('keeps client-resolved RSC routes aligned with ordinary server HTML', () => {
     const { maybeWrapWithDefaultRSCProviderWithStatus } = require('../src/defaultRSCProviderRegistry.ts');
     require('../src/registerDefaultRSCProvider.client.tsx');


### PR DESCRIPTION
## Summary

Follow-up to #4532. That PR's default-provider guard keyed the extra client
`<React.Suspense>` wrapper on `hasLeadingSuspenseBoundary`, which only checks that
the hydration root's first non-whitespace child is a `<!--$-->` comment. That DOM
shape is **also** produced when the application itself renders a top-level
`<Suspense>` root — e.g. `<Suspense><RSCRoute ssr={false} /></Suspense>`. In that
supported default-provider path the server emits one boundary (the user's), but the
client wrapped `reactElement` in a **second** boundary, reintroducing a recoverable
hydration mismatch. This was flagged pre-merge by Codex on #4532
([discussion](https://github.com/shakacode/react_on_rails/pull/4532#discussion_r3541960003))
and went unanswered before the merge-queue merge.

Fixes #4535.

## Root cause & fix

The default RSC provider is registered **only on the client**
(`registerDefaultRSCProvider.client.tsx`; no server-side registration), so no
server-streamed wrapper boundary ever sits *above* `reactElement` itself. The
server's leading `<!--$-->`, when present, therefore corresponds either to a
Pro/React streamed wrapper the client tree lacks (needs the wrapper) **or** to the
user's own top-level `<Suspense>` the client tree already provides (must not be
double-wrapped).

The fix gates the wrapper on the root element not already rendering its own
top-level Suspense boundary:

```ts
const shouldMatchStreamedSuspenseBoundary =
  hasLeadingSuspenseBoundary(document.getElementById(domNodeId)) &&
  !rootElementRendersOwnSuspenseBoundary(reactElement);
```

This mirrors the intent of the already-clean `wrapServerComponentRenderer` path
(which wraps unconditionally on both server and client, no DOM sniffing).

## Verification

TDD — new regression test is red before the fix, green after:

- `packages/react-on-rails-pro/tests/registerDefaultRSCProvider.client.test.jsx`
  - existing "wraps default-provider roots …" (streamed wrapper, non-Suspense root) — still wraps ✅
  - **new** "does not add a second Suspense wrapper when the root is a user-authored top-level Suspense" ✅
  - existing "keeps client-resolved RSC routes aligned …" (no leading boundary) — still no wrap ✅

Local results:
- `jest tests/registerDefaultRSCProvider.client.test.jsx` → 3 passed
- Related suites `ClientSideRenderer.test.ts` + `wrapServerComponentRenderer.client.test.jsx` → 50 passed
- Full `pnpm run test:non-rsc` → 31 suites, 419 passed, 1 skipped
- `pnpm run type-check` → 0 errors; eslint clean; prettier clean; pro-license-headers hook passed

## Codex Decision Log

- **Non-blocking:** disambiguation signal choice — client element-type check vs a new server-emitted marker (issue listed both).
  - **Decision:** client-only check (`reactElement.type === React.Suspense`).
  - **Why:** the default provider is client-only, so there is never an extra Pro wrapper boundary above the root; a client-side check is sufficient, minimal, and needs no server-render changes (lower risk of regressing the flagship fix).
  - **Review later:** the rare `<Provider><Suspense/></Provider>` shape (a wrapper that renders no DOM above a Suspense) is still ambiguous by element type; a server-emitted Pro-wrapper marker would fully close that gap if it ever appears in practice.

## Release note

The bug exists on `main` only — #4532 (which introduced the guard and
`rscHydrationDom.ts`) is not on `release/17.0.0`. **If #4532 is back-ported to
`release/17.0.0` for the 17.0.0 final, this follow-up must be back-ported with it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a hydration mismatch that could occur when an app’s root already used a top-level loading boundary.
  * Improved handling so the app no longer adds an extra, unnecessary loading wrapper in that supported case.
  * Reduced the chance of recoverable client-side rendering warnings during page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->