### PR TITLE
[Pro] Test: default-provider root with its own top-level Suspense hydrates cleanly (#4535)

### DIFF
--- a/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
+++ b/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
@@ -952,13 +952,17 @@ describe('RSCRoute deferred SSR behavior', () => {
     container.innerHTML = serverHtml;
     document.body.appendChild(container);
 
-    // Exercise the real default-provider factory (the production wrapping logic).
+    // Exercise the real default-provider factory (the production wrapping logic). Requiring this
+    // module runs its `setDefaultRSCProviderFactory` side effect; asserting `wrappedByDefaultRSCProvider`
+    // below guarantees the factory was actually registered, so the test cannot silently degrade into a
+    // pass if the registration is ever skipped (e.g. a cached no-op require after a prior clear).
     require('../src/registerDefaultRSCProvider.client.tsx');
-    const { reactElement } = maybeWrapWithDefaultRSCProviderWithStatus(
+    const { reactElement, wrappedByDefaultRSCProvider } = maybeWrapWithDefaultRSCProviderWithStatus(
       <AppReturningSuspense />,
       { rscPayloadGenerationUrlPath: '/rsc_payload' } as RailsContext,
       container.id,
     );
+    expect(wrappedByDefaultRSCProvider).toBe(true);
 
     const recoverableErrors: string[] = [];
     let root: Root | undefined;

--- a/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
+++ b/packages/react-on-rails-pro/tests/deferredRouteSsr.test.tsx
@@ -16,7 +16,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import * as React from 'react';
 import { act } from 'react';
-import { createRoot, type Root } from 'react-dom/client';
+import { createRoot, hydrateRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';
 import type { RailsContext } from 'react-on-rails/types';
 import {
@@ -920,6 +920,70 @@ describe('RSCRoute deferred SSR behavior', () => {
       } finally {
         consoleErrorSpy.mockRestore();
       }
+    }
+  });
+
+  // Regression guard for issue #4535. In the standard auto-bundled config a root is server-rendered
+  // through registerServerComponent -> wrapServerComponentRenderer/server, which unconditionally wraps
+  // it in `<React.Suspense fallback={null}>`. A component that renders its OWN top-level Suspense
+  // therefore emits TWO nested boundaries in the server HTML (the Pro wrapper plus the user's), which
+  // the flagship demo confirms (`<!--$--><!--$--><section>`). The default-provider client path adds one
+  // matching wrapper and the component renders its own Suspense, so the client tree also has two
+  // boundaries; the two must hydrate without a recoverable mismatch. This guards against a
+  // "disambiguate the wrapper" change that skips the client wrapper for such roots (which would drop
+  // the client to one boundary and reintroduce a mismatch against the two-boundary server HTML).
+  it('hydrates a default-provider root that renders its own top-level Suspense without a mismatch (#4535)', async () => {
+    const AppReturningSuspense = () => (
+      <React.Suspense fallback={<span data-testid="user-fallback">loading</span>}>
+        <section data-testid="deferred-root">Deferred content</section>
+      </React.Suspense>
+    );
+
+    // Model wrapServerComponentRenderer/server's unconditional Suspense wrap around the root.
+    const serverHtml = renderToString(
+      <React.Suspense fallback={null}>
+        <AppReturningSuspense />
+      </React.Suspense>,
+    );
+    expect(serverHtml.match(/<!--\$-->/g)).toHaveLength(2);
+
+    const container = document.createElement('div');
+    container.id = 'DefaultProviderSuspenseRoot-react-component-test';
+    container.innerHTML = serverHtml;
+    document.body.appendChild(container);
+
+    // Exercise the real default-provider factory (the production wrapping logic).
+    require('../src/registerDefaultRSCProvider.client.tsx');
+    const { reactElement } = maybeWrapWithDefaultRSCProviderWithStatus(
+      <AppReturningSuspense />,
+      { rscPayloadGenerationUrlPath: '/rsc_payload' } as RailsContext,
+      container.id,
+    );
+
+    const recoverableErrors: string[] = [];
+    let root: Root | undefined;
+    try {
+      await act(async () => {
+        root = hydrateRoot(container, reactElement, {
+          onRecoverableError: (error) => {
+            recoverableErrors.push(error instanceof Error ? error.message : String(error));
+          },
+        });
+        await Promise.resolve();
+      });
+
+      expect(recoverableErrors).toEqual([]);
+      expect(container.querySelector('[data-testid="deferred-root"]')?.textContent).toBe('Deferred content');
+    } finally {
+      clearDefaultRSCProviderFactory();
+      const mountedRoot = root;
+      if (mountedRoot) {
+        await act(async () => {
+          mountedRoot.unmount();
+          await Promise.resolve();
+        });
+      }
+      container.remove();
     }
   });
 });


### PR DESCRIPTION
## Summary

Adds a real-hydration regression guard for the scenario raised in #4535 — a default-provider RSC root that renders its **own** top-level `<Suspense>`.

This PR supersedes #4545 (closed). The investigation concluded the reported double-wrap **does not occur in the standard config**, so no code change is needed — but the composition is worth locking in with a test.

## Why #4535 is a non-issue in the standard config

Verified end-to-end by running the flagship demo with the current fix (`react-on-rails-demo-flagship`) and inspecting the real server HTML + browser console:

- In the auto-bundled config a root is server-rendered via `registerServerComponent` → `wrapServerComponentRenderer/server`, which **unconditionally** wraps it in `<React.Suspense fallback={null}>`.
- So a component that renders its own top-level `<Suspense>` emits **two** nested boundaries on the server — confirmed as `<!--$--><!--$--><section>` in the demo HTML — which the default-provider client wrapper matches exactly.
- Browser result with #4532 active: **0 recoverable hydration errors** for both the flagship (1 boundary) and a probe component returning a top-level `<Suspense>` (2 boundaries).

Codex's/greptile's premise on #4545 ("the server output has only one boundary") holds only if the root is **not** a registered server component — not what auto-bundling produces.

## The test

`deferredRouteSsr.test.tsx` gains one case that:
1. Models `wrapServerComponentRenderer/server`'s unconditional wrap and asserts the server HTML has **2** boundaries.
2. Hydrates the **real** default-provider client tree (`maybeWrapWithDefaultRSCProviderWithStatus` + the production `registerDefaultRSCProvider.client` factory) over that HTML and asserts **0** recoverable errors.

Verified it genuinely guards: forcing the client to skip the wrapper makes it fail with a hydration mismatch (19 recoverable errors); the correct code passes.

Placed in `deferredRouteSsr.test.tsx` (runs in `test:non-rsc`) because `registerDefaultRSCProvider.client.test.jsx` is excluded from every `pnpm test` suite by the `test:non-rsc` `.*RSC.*` ignore pattern — a separate pre-existing coverage gap worth a follow-up.

## Verification

- `jest tests/deferredRouteSsr.test.tsx` → 20 passed (incl. the new #4535 guard)
- `pnpm run type-check` → 0 errors; prettier + eslint + pro-license-headers hooks clean
- Regression-catch check: client-wrap removed → test fails (19 recoverable errors); restored → passes

Refs #4535.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when hydrating server-rendered pages that use top-level suspense/loading boundaries, reducing the chance of recoverable hydration mismatch warnings and ensuring deferred content renders correctly after hydration.
* **Tests**
  * Added a regression test to verify default-provider hydration behavior with an outer Suspense wrapper, including ensuring no recoverable errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->