### PR TITLE
Update changelog for 17.0.0.rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.0.0.rc.8] - 2026-07-08
+
 #### Breaking Changes
 
 - **[Pro] Removed the undocumented `ReactOnRailsPro::Cache.fetch_react_component` class API**:
@@ -33,6 +35,22 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   registration, and `expires_at` handling internally. Fixes
   [Issue 4497](https://github.com/shakacode/react_on_rails/issues/4497).
   [PR 4541](https://github.com/shakacode/react_on_rails/pull/4541) by
+  [justin808](https://github.com/justin808).
+
+#### Fixed
+
+- **[Pro]** **Deferred RSC route failures now reach app error boundaries**: Rejected deferred RSC route
+  fetches stay observable long enough for React error boundaries to render their fallback, while failed
+  entries release their in-flight cache pin without evicting unrelated healthy payloads under concurrent
+  load. Fixes [Issue 4522](https://github.com/shakacode/react_on_rails/issues/4522).
+  [PR 4529](https://github.com/shakacode/react_on_rails/pull/4529) by
+  [justin808](https://github.com/justin808).
+- **[Pro]** **RSC doctor and version checks resolve Rspack from the configured app dependencies**:
+  RSC artifact diagnostics and startup version checks now resolve `@rspack/core` from the configured
+  client `node_modules` path, avoiding false Rspack verification failures when the app's package root
+  differs from the current process context. Fixes
+  [Issue 4523](https://github.com/shakacode/react_on_rails/issues/4523).
+  [PR 4530](https://github.com/shakacode/react_on_rails/pull/4530) by
   [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.7] - 2026-07-06
@@ -2795,7 +2813,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.7...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.8...main
+[17.0.0.rc.8]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.7...v17.0.0.rc.8
 [17.0.0.rc.7]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.6...v17.0.0.rc.7
 [17.0.0.rc.6]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.5...v17.0.0.rc.6
 [17.0.0.rc.5]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.4...v17.0.0.rc.5


### PR DESCRIPTION
## Summary

- Stamps the next release-candidate changelog section, `17.0.0.rc.8`, on `release/17.0.0` using the repo rake task.
- Adds missing user-visible release notes for PRs #4529 and #4530.
- Carries the existing #4541 breaking-change entry into the new RC section, leaves prior RC sections intact, and keeps compare links chained from `v17.0.0.rc.7` to `v17.0.0.rc.8`.

## Classification Sweep

Range: `v17.0.0.rc.7..origin/release/17.0.0`.

| PR | Title | Result | Category | Reason |
| --- | --- | --- | --- | --- |
| #4519 | Fix ShakaPerf renderer readiness probe | no-entry | release-process | Fixes the hosted ShakaPerf release-gate workflow probe and safety test; no package runtime behavior changes. |
| #4529 | Fix Pro RSC route errors reaching ErrorBoundary | entry-needed | Pro runtime | Changes Pro RSC runtime cache/error handling so deferred route fetch failures reach app error boundaries reliably. |
| #4530 | Fix RSC doctor Rspack package resolution | entry-needed | Pro runtime | Fixes user-visible RSC diagnostics/startup checks by resolving `@rspack/core` from the configured app dependencies. |
| #4521 | Update demo-fleet metadata from RC 7 inspection | no-entry | internal | Updates contributor demo-fleet metadata and verification prerequisites; no shipped package behavior changes. |
| #4539 | Docs: v17 server_render_method removal + fix rc-testing generator gate command | no-entry | internal | Corrects upgrade/release-testing documentation and generated LLM docs; the actual `server_render_method` removal was already covered in rc.7. |
| #4541 | Remove undocumented Pro cache class API | entry-needed | Pro runtime | Removes an undocumented Pro cache class API before final; the existing breaking-change entry is included in rc.8. |

## Release-Train Notes

- Target branch: `release/17.0.0`.
- Release phase: `rc` by release-branch target.
- Per the release-train runbook, after this PR merges the release operator can cut the RC from `release/17.0.0`; the release task reads the top changelog header. Forward-port the changelog result back to `main` when required by the runbook.

## Validation

- `git fetch --prune origin main '+refs/heads/release/*:refs/remotes/origin/release/*'` -> passed.
- `.agents/bin/agent-workflow-seam-doctor` -> passed.
- `changelog-merged-prs --self-check` -> parsers OK, GitHub smoke OK.
- `changelog-merged-prs v17.0.0.rc.7..origin/release/17.0.0 --text` -> 6 mapped PR rows, 0 `UNKNOWN` rows.
- `bundle exec rake "update_changelog[rc]"` -> auto-computed and stamped `17.0.0.rc.8`.
- `git diff --check` -> passed.
- `pnpm exec prettier --check CHANGELOG.md` -> passed.
- Ruby header/link sanity check -> `changelog rc.8 header and links OK`.
- `script/ci-changes-detector origin/release/17.0.0` -> documentation-only changes; recommended CI jobs: none.
- Pre-commit hook -> trailing-newlines, offline markdown-links, and Prettier passed.
- Pre-push hook -> branch RuboCop passed (`11 files inspected, no offenses detected`) and online markdown-links passed (`0 Errors`, 17 redirect warnings).

Labels: none. Changelog-only release-target PR; no hosted CI expansion recommended by the detector.
