### PR TITLE
Fix Pro RSC-named tests missing from CI

### DIFF
--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -9,7 +9,7 @@
     "build-watch": "pnpm run clean && tsc --watch",
     "clean": "rm -rf ./lib",
     "test": "pnpm run test:non-rsc && pnpm run test:streaming && pnpm run test:rsc",
-    "test:non-rsc": "jest tests --testPathIgnorePatterns=\"tests/.*(RSC|stream|registerServerComponent|serverRenderReactComponent|SuspenseHydration).*\"",
+    "test:non-rsc": "jest tests --testPathIgnorePatterns=\"tests/.*(\\\\.rsc\\\\.test\\\\.|streamServerRenderedReactComponent|streamBackpressure|injectRSCPayload|parseLengthPrefixedStream|registerServerComponent|SuspenseHydration).*\"",
     "test:streaming": "node scripts/check-react-version.cjs || jest tests/streamServerRenderedReactComponent.test.jsx tests/streamBackpressure.e2e.test.tsx tests/injectRSCPayload.test.ts tests/SuspenseHydration.test.tsx tests/parseLengthPrefixedStream.test.ts --runInBand",
     "test:rsc": "node scripts/check-react-version.cjs || NODE_CONDITIONS=react-server jest tests/*.rsc.test.*",
     "type-check": "tsc --noEmit --noErrorTruncation",


### PR DESCRIPTION
## Summary

Fixes the Pro package Jest split so RSC-named client/non-react-server tests are no longer dropped by CI.

The previous `test:non-rsc` ignore pattern matched any filename containing uppercase `RSC`, which excluded `registerDefaultRSCProvider.client.test.jsx` even though it is a jsdom client test. The new pattern ignores `.rsc.test.*` files and the explicit streaming/server-component suites instead of every uppercase `RSC` filename.

## Why

`pnpm test` runs `test:non-rsc`, `test:streaming`, and `test:rsc`. `registerDefaultRSCProvider.client.test.jsx` was excluded from `test:non-rsc`, but was not in the explicit streaming list and did not match `tests/*.rsc.test.*`, so it never ran in the package CI path.

## What Changed

- Tightened `packages/react-on-rails-pro` `test:non-rsc` ignore regex from broad `RSC` matching to explicit `.rsc.test.*` plus known streaming/server-component filenames.
- Keeps `injectRSCPayload`, `stream*`, `parseLengthPrefixedStream`, and `SuspenseHydration` in the streaming suite only.
- Restores `RSCRequestTracker.test.ts`, `registerDefaultRSCProvider.client.manifest.test.js`, and `registerDefaultRSCProvider.client.test.jsx` to `test:non-rsc`.

## Codex Decision Log

- **Non-blocking:** `tests/registerServerComponent.client.test.jsx` is still uncovered by the suite split.
  - **Decision:** Left it excluded because it is matched by the explicit `registerServerComponent` pattern, not the broad uppercase-`RSC` catch-all targeted here.
  - **Why:** A standalone run currently fails before tests execute with `Cannot find module './testUtils.js' from 'tests/registerServerComponent.client.test.jsx'`, so including it would broaden this PR into a separate broken-test repair.
  - **Review later:** Consider a follow-up to either fix and suite `registerServerComponent.client.test.jsx` or delete/retire it if obsolete.

## Validation

- `pnpm install --frozen-lockfile`
- RED: `cd packages/react-on-rails-pro && pnpm exec jest tests --testPathIgnorePatterns="tests/.*(RSC|stream|registerServerComponent|serverRenderReactComponent|SuspenseHydration).*" --listTests | grep registerDefaultRSCProvider` produced no output / exit 1 after deps were installed.
- `cd packages/react-on-rails-pro && pnpm exec jest tests/RSCRequestTracker.test.ts tests/registerDefaultRSCProvider.client.manifest.test.js tests/registerDefaultRSCProvider.client.test.jsx --runInBand` passed: 3 suites, 23 tests.
- `cd packages/react-on-rails-pro && pnpm run test:non-rsc --listTests | grep -E 'registerDefaultRSCProvider|RSCRequestTracker|injectRSCPayload|streamServerRendered|streamBackpressure|SuspenseHydration|parseLengthPrefixedStream|\.rsc\.test'` listed only the restored `registerDefaultRSCProvider.client.*` and `RSCRequestTracker` files.
- `cd packages/react-on-rails-pro && pnpm test` passed: non-RSC 33 suites / 432 tests, streaming 5 suites / 130 tests, RSC 6 suites / 19 tests. Output includes `PASS tests/registerDefaultRSCProvider.client.test.jsx`.
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm start format.listDifferent`
- `pnpm run lint`
- `script/ci-changes-detector origin/main`

## Known Validation Gap

- `pnpm run test` from the repo root failed in `packages/react-on-rails-pro-node-renderer` because the local worktree is missing generated fixture `react_on_rails_pro/spec/dummy/ssr-generated/server-bundle.js`. The focused `react-on-rails-pro` package tests for this change passed, including the restored test file.

## QA Evidence

- QA lane: `codex-ror-pro-jest-coverage`, branch `jg-codex/fix-pro-rsc-jest-coverage`, private claim active during implementation.
- Scope checked: Pro package Jest script split and suite membership for restored RSC-named non-react-server tests.
- Tested at: commit `e3770b91f`.
- Automated checks: listed in Validation.
- Manual checks: suite-list comparison confirmed restored files are covered; remaining uncovered file is explicitly excluded by a different pattern and documented above.
- Findings: root workspace JS test needs generated Pro node-renderer fixture setup; not caused by this package script change.
- QA required: yes.
- QA required rationale: developer-workflow/test-command change affects CI coverage.
- QA lane status: satisfied for the changed Pro package script; root workspace broad test has the known setup gap above.
- Release-blocking status: not_applicable.
- Process-gap disposition: park; the remaining `registerServerComponent.client.test.jsx` orphan is related but outside the uppercase-`RSC` catch-all fix and needs a separate broken-test decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the non-RSC test run to ignore a narrower set of paths, focusing on the relevant streaming and `.rsc` test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->