### PR TITLE
Docs: correct v16 migration and preload requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1310,7 +1310,7 @@ See [Release Notes](docs/oss/upgrading/release-notes/16.0.0.md) for complete mig
 - **`defer_generated_component_packs` deprecated** → use `generated_component_packs_loading_strategy`
 - Migration:
   - `defer_generated_component_packs: true` → `generated_component_packs_loading_strategy: :defer`
-  - `defer_generated_component_packs: false` → remove the setting (it was a no-op); set `generated_component_packs_loading_strategy: :sync` only if you need synchronous loading
+  - `defer_generated_component_packs: false` → remove the setting only if you accept the post-upgrade default. `false` was a no-op, so record the app's pre-upgrade effective strategy and set `generated_component_packs_loading_strategy` explicitly to preserve it.
   - Recommended: `generated_component_packs_loading_strategy: :async` for best performance
 
 - **`force_load` renamed to `immediate_hydration`** for API clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1310,7 +1310,7 @@ See [Release Notes](docs/oss/upgrading/release-notes/16.0.0.md) for complete mig
 - **`defer_generated_component_packs` deprecated** → use `generated_component_packs_loading_strategy`
 - Migration:
   - `defer_generated_component_packs: true` → `generated_component_packs_loading_strategy: :defer`
-  - `defer_generated_component_packs: false` → `generated_component_packs_loading_strategy: :sync`
+  - `defer_generated_component_packs: false` → remove the setting (it was a no-op); set `generated_component_packs_loading_strategy: :sync` only if you need synchronous loading
   - Recommended: `generated_component_packs_loading_strategy: :async` for best performance
 
 - **`force_load` renamed to `immediate_hydration`** for API clarity

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -56,7 +56,7 @@ Uncommonly used options:
 <%= react_on_rails_preload_links("HelloWorld", "comments_list") %>
 ```
 
-Use `react_on_rails_preload_links` in a layout or view `<head>` when you know which auto-bundled React components the page will render. The helper resolves each component to its generated Shakapacker pack (`generated/ComponentName`) and emits preload link tags for the manifest assets. Pass component names as PascalCase, camelCase, or snake_case strings; hyphenated names are rejected because they cannot be normalized reliably.
+Use `react_on_rails_preload_links` in a layout or view `<head>` when you know which auto-bundled React components the page will render. The helper requires Shakapacker 7.0+ with `nested_entries: true`, resolves each component to its generated Shakapacker pack (`generated/ComponentName`), and emits preload link tags for the manifest assets. Pass component names as PascalCase, camelCase, or snake_case strings; hyphenated names are rejected because they cannot be normalized reliably.
 
 For JavaScript chunks, plain script assets render as `<link rel="preload" as="script">`. Module assets render as `<link rel="modulepreload">` when the manifest marks the asset as a module or the emitted file has an `.mjs` extension. CSS chunks render as `<link rel="preload" as="style">`. Component packs without CSS assets simply skip the stylesheet preload.
 

--- a/docs/oss/upgrading/release-notes/16.0.0.md
+++ b/docs/oss/upgrading/release-notes/16.0.0.md
@@ -90,7 +90,7 @@ _The image above demonstrates the dramatic performance improvement:_
 ### Script Loading Strategy Migration
 
 - If you were previously using `defer_generated_component_packs: true`, use `generated_component_packs_loading_strategy: :defer` instead
-- If you were previously using `defer_generated_component_packs: false`, remove the setting. It was a no-op; set `generated_component_packs_loading_strategy: :sync` only if you need synchronous loading.
+- If you were previously using `defer_generated_component_packs: false`, remove the setting only if you accept the post-upgrade default. `false` was a no-op, so record the app's pre-upgrade effective strategy and set `generated_component_packs_loading_strategy` explicitly to preserve it.
 - For optimal performance with Shakapacker ≥ 8.2.0, consider using `generated_component_packs_loading_strategy: :async`
 
 ### ESM-only package

--- a/docs/oss/upgrading/release-notes/16.0.0.md
+++ b/docs/oss/upgrading/release-notes/16.0.0.md
@@ -90,7 +90,7 @@ _The image above demonstrates the dramatic performance improvement:_
 ### Script Loading Strategy Migration
 
 - If you were previously using `defer_generated_component_packs: true`, use `generated_component_packs_loading_strategy: :defer` instead
-- If you were previously using `defer_generated_component_packs: false`, use `generated_component_packs_loading_strategy: :sync` instead
+- If you were previously using `defer_generated_component_packs: false`, remove the setting. It was a no-op; set `generated_component_packs_loading_strategy: :sync` only if you need synchronous loading.
 - For optimal performance with Shakapacker ≥ 8.2.0, consider using `generated_component_packs_loading_strategy: :async`
 
 ### ESM-only package

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -31571,7 +31571,7 @@ _The image above demonstrates the dramatic performance improvement:_
 ### Script Loading Strategy Migration
 
 - If you were previously using `defer_generated_component_packs: true`, use `generated_component_packs_loading_strategy: :defer` instead
-- If you were previously using `defer_generated_component_packs: false`, remove the setting. It was a no-op; set `generated_component_packs_loading_strategy: :sync` only if you need synchronous loading.
+- If you were previously using `defer_generated_component_packs: false`, remove the setting only if you accept the post-upgrade default. `false` was a no-op, so record the app's pre-upgrade effective strategy and set `generated_component_packs_loading_strategy` explicitly to preserve it.
 - For optimal performance with Shakapacker ≥ 8.2.0, consider using `generated_component_packs_loading_strategy: :async`
 
 ### ESM-only package

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19359,7 +19359,7 @@ Uncommonly used options:
 <%= react_on_rails_preload_links("HelloWorld", "comments_list") %>
 ```
 
-Use `react_on_rails_preload_links` in a layout or view `<head>` when you know which auto-bundled React components the page will render. The helper resolves each component to its generated Shakapacker pack (`generated/ComponentName`) and emits preload link tags for the manifest assets. Pass component names as PascalCase, camelCase, or snake_case strings; hyphenated names are rejected because they cannot be normalized reliably.
+Use `react_on_rails_preload_links` in a layout or view `<head>` when you know which auto-bundled React components the page will render. The helper requires Shakapacker 7.0+ with `nested_entries: true`, resolves each component to its generated Shakapacker pack (`generated/ComponentName`), and emits preload link tags for the manifest assets. Pass component names as PascalCase, camelCase, or snake_case strings; hyphenated names are rejected because they cannot be normalized reliably.
 
 For JavaScript chunks, plain script assets render as `<link rel="preload" as="script">`. Module assets render as `<link rel="modulepreload">` when the manifest marks the asset as a module or the emitted file has an `.mjs` extension. CSS chunks render as `<link rel="preload" as="style">`. Component packs without CSS assets simply skip the stylesheet preload.
 
@@ -31571,7 +31571,7 @@ _The image above demonstrates the dramatic performance improvement:_
 ### Script Loading Strategy Migration
 
 - If you were previously using `defer_generated_component_packs: true`, use `generated_component_packs_loading_strategy: :defer` instead
-- If you were previously using `defer_generated_component_packs: false`, use `generated_component_packs_loading_strategy: :sync` instead
+- If you were previously using `defer_generated_component_packs: false`, remove the setting. It was a no-op; set `generated_component_packs_loading_strategy: :sync` only if you need synchronous loading.
 - For optimal performance with Shakapacker ≥ 8.2.0, consider using `generated_component_packs_loading_strategy: :async`
 
 ### ESM-only package


### PR DESCRIPTION
## Summary

Closes #4501.

The v16 upgrade notes and changelog previously mapped the deprecated
`defer_generated_component_packs: false` setting to synchronous loading even though
that setting was a no-op. The preload-links reference also omitted its Shakapacker
prerequisite. This PR corrects both pieces of guidance and regenerates the canonical
LLM documentation output.

## Implementation

- Clarify that the deprecated `false` setting should be removed, with synchronous
  loading available only as an explicit choice.
- State that `react_on_rails_preload_links` requires Shakapacker 7.0+ and
  `nested_entries: true`.
- Regenerate `llms-full.txt` from the documentation sources.

## Validation

- `bash script/generate-llms-full-test.bash`
- `node script/generate-llms-full.mjs --check`
- `script/check-docs-sidebar`
- `pnpm exec prettier --check CHANGELOG.md docs/oss/api-reference/view-helpers-api.md docs/oss/upgrading/release-notes/16.0.0.md`
- `git diff --check`
- Repository pre-commit hook: trailing-newlines, offline Markdown links, and Prettier
- Repository pre-push hook: branch lint and online Markdown links

Labels: none — this is a focused docs-only correction; the required generated-output
and normal PR checks cover the changed surfaces.

Release mode: development; target branch `main` is beta phase.

### Pull Request checklist

- [x] Tests are not applicable; documentation generator validation covers the generated output.
- [x] Update documentation
- [x] Update CHANGELOG file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance for `defer_generated_component_packs: false`, clarifying it was a no-op and should only be removed if you accept the post-upgrade default; otherwise, set `generated_component_packs_loading_strategy` to preserve the prior effective behavior.
  * Refined `react_on_rails_preload_links` documentation to require Shakapacker 7.0+ when used with `nested_entries: true`.
  * Clarified how preload links resolve to generated component packs, how manifest assets are preloaded, and that hyphenated component names are rejected due to unreliable normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->