### PR TITLE
Docs: RSC CSS known-limitations — production is the primary silent-no-op case (F5)

### DIFF
--- a/docs/pro/react-server-components/css-and-styling.md
+++ b/docs/pro/react-server-components/css-and-styling.md
@@ -264,10 +264,10 @@ replay path (client-inserted styles during hydration/navigation), not to the ser
 Each of these conditions disables part or all of the streamed-CSS gating **without any error**.
 The page still works — CSS eventually arrives via the browser-side payload replay after hydration —
 but the streamed reveal is no longer gated, so a styled-late flash becomes possible. Two of these
-conditions are not edge cases but the **defaults of every production build** (numeric chunk ids
-from `chunkIds: 'deterministic'`, and id-based CSS filenames from Shakapacker's
-`chunkFilename: 'css/[id][hash].css'`) — verified against a production dummy build on 2026-07-09,
-where the streamed reveal was confirmed ungated under both bundlers:
+conditions are not edge cases but the **production defaults verified in the dummy app** (numeric
+chunk ids from `chunkIds: 'deterministic'`, and id-named extracted CSS like
+`css/[id]-[hash].css`) — verified against a production dummy build on 2026-07-09, where the
+streamed reveal was confirmed ungated under both bundlers:
 
 | Condition                                                                                          | What is disabled                                                                                   |
 | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |

--- a/docs/pro/react-server-components/css-and-styling.md
+++ b/docs/pro/react-server-components/css-and-styling.md
@@ -269,15 +269,15 @@ chunk ids from `chunkIds: 'deterministic'`, and id-named extracted CSS like
 `css/[id]-[hash].css`) — verified against a production dummy build on 2026-07-09, where the
 streamed reveal was confirmed ungated under both bundlers:
 
-| Condition                                                                                          | What is disabled                                                                                   |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `loadable-stats.json` missing/unreadable next to the renderer bundle (retries 100ms → 30s backoff) | Path B entirely, including reveal deferral; Path A still runs                                      |
-| Chunk names not matching `client<N>` (custom `chunkName` option, or numeric webpack `chunkIds`)    | Path B (Flight regex never matches); Path A href check fails too if the CSS filename shape changes |
-| CSS output filenames not matching `css/clientN-*.css`                                              | Path A promotion (href filter rejects the preload)                                                 |
-| Flight data lagging a reveal by more than 100ms                                                    | Reveal deferral for that flush (fail-open by design)                                               |
-| Rspack builds omitting CSS assets from the stats consumed by `injectRSCPayload`                    | Path B (empty chunk→CSS map) — see Known limitations                                               |
-| `auto_load_bundle` off (or non-Pro)                                                                | `data-generated-stylesheet-hrefs` + the pre-hydration stylesheet wait                              |
-| React configured with the external Fizz runtime (no inline `$RC(` scripts)                         | Reveal-split detection — deferral silently never fires                                             |
+| Condition                                                                                          | What is disabled                                                                             |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `loadable-stats.json` missing/unreadable next to the renderer bundle (retries 100ms → 30s backoff) | Path B entirely, including reveal deferral; Path A still runs                                |
+| Chunk names not matching `client<N>` (custom `chunkName` option, or numeric webpack `chunkIds`)    | Path B (Flight regex never matches); Path A then depends on manifest-backed preload matching |
+| CSS output filenames not matching `css/clientN-*.css`                                              | Path A's `clientN` filename fallback (manifest-listed preloads can still promote)            |
+| Flight data lagging a reveal by more than 100ms                                                    | Reveal deferral for that flush (fail-open by design)                                         |
+| Rspack builds omitting CSS assets from the stats consumed by `injectRSCPayload`                    | Path B (empty chunk→CSS map) — see Known limitations                                         |
+| `auto_load_bundle` off (or non-Pro)                                                                | `data-generated-stylesheet-hrefs` + the pre-hydration stylesheet wait                        |
+| React configured with the external Fizz runtime (no inline `$RC(` scripts)                         | Reveal-split detection — deferral silently never fires                                       |
 
 If you are debugging a flicker, check these in order; the first two are by far the most common.
 
@@ -1069,12 +1069,15 @@ to measure the end-to-end performance impact of RSC changes with a paired A/B co
 - **Production builds are the primary silent-no-op case (both bundlers, verified 2026-07-09):**
   in a default `NODE_ENV=production` build, chunk ids are numeric (`optimization.chunkIds:
 'deterministic'`) and extracted chunk CSS is id-named (`css/[id]-[hash].css`), so Path B's
-  Flight regex and Path A's href filter both fail — the streamed reveal is not CSS-gated, and only
-  the hint-driven preload's head start mitigates the flash. Note that CSS split into async
+  Flight regex is disabled. Path A's old `css/clientN-*.css` filename fallback is disabled too, so
+  streamed reveal gating then depends on the preload href matching
+  `rscClientManifestStylesheetHrefs` and arriving before the reveal. The reviewed production dummy
+  capture under both bundlers still emitted only a non-blocking preload, so the reveal was ungated
+  and only the hint-driven preload's head start mitigated the flash. Note that CSS split into async
   `clientN` chunks is **not** covered by the Rails layout `stylesheet_pack_tag` (layout pack tags
-  emit only the entrypoint's initial-chunk CSS); until it is fixed, the styles for such components
-  apply at hydration time. The dev/test posture (`chunkIds: 'named'`), which is what CI exercises,
-  is not affected.
+  emit only the entrypoint's initial-chunk CSS); until this gap is closed, the styles for such
+  components apply at hydration time. The dev/test posture (`chunkIds: 'named'`), which is what CI
+  exercises, is not affected.
 - **Rspack manifest `css` omission:** the `RSCRspackPlugin` collects `css` arrays only on the
   `react-on-rails-rsc` 19.2.1+ line, and omits them (with only a compile warning) when
   `output.publicPath` is `'auto'` or a function, or when CSS is extracted by something other than

--- a/docs/pro/react-server-components/css-and-styling.md
+++ b/docs/pro/react-server-components/css-and-styling.md
@@ -263,7 +263,11 @@ replay path (client-inserted styles during hydration/navigation), not to the ser
 
 Each of these conditions disables part or all of the streamed-CSS gating **without any error**.
 The page still works — CSS eventually arrives via the browser-side payload replay after hydration —
-but the streamed reveal is no longer gated, so a styled-late flash becomes possible:
+but the streamed reveal is no longer gated, so a styled-late flash becomes possible. Two of these
+conditions are not edge cases but the **defaults of every production build** (numeric chunk ids
+from `chunkIds: 'deterministic'`, and id-based CSS filenames from Shakapacker's
+`chunkFilename: 'css/[id][hash].css'`) — verified against a production dummy build on 2026-07-09,
+where the streamed reveal was confirmed ungated under both bundlers:
 
 | Condition                                                                                          | What is disabled                                                                                   |
 | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
@@ -1062,12 +1066,21 @@ to measure the end-to-end performance impact of RSC changes with a paired A/B co
   cannot produce RSC stylesheet links. Rebuild all three bundles after upgrading.
 - For client-side RSC navigation (`RSCRoute`), the RSC payload still needs stylesheet links. Verify
   this path separately for route-heavy apps.
-- **Rspack FOUC gap:** The `RSCRspackPlugin` emits the same manifest schema as the webpack plugin
-  for component references, but at the time of writing, Rspack builds can omit CSS assets for RSC
-  client chunks from the stats consumed by `injectRSCPayload`. When that map is empty, the FOUC
-  prevention pipeline is silently inactive. CSS for `'use client'` components still works via the
-  Rails layout `stylesheet_pack_tag`, but without client-chunk stylesheet injection. See
-  [Rspack compatibility](./rspack-compatibility.md) for details.
+- **Production builds are the primary silent-no-op case (both bundlers, verified 2026-07-09):**
+  in a default `NODE_ENV=production` build, chunk ids are numeric (`optimization.chunkIds:
+'deterministic'`) and extracted chunk CSS is id-named (`css/[id]-[hash].css`), so Path B's
+  Flight regex and Path A's href filter both fail — the streamed reveal is not CSS-gated, and only
+  the hint-driven preload's head start mitigates the flash. Note that CSS split into async
+  `clientN` chunks is **not** covered by the Rails layout `stylesheet_pack_tag` (layout pack tags
+  emit only the entrypoint's initial-chunk CSS); until it is fixed, the styles for such components
+  apply at hydration time. The dev/test posture (`chunkIds: 'named'`), which is what CI exercises,
+  is not affected.
+- **Rspack manifest `css` omission:** the `RSCRspackPlugin` collects `css` arrays only on the
+  `react-on-rails-rsc` 19.2.1+ line, and omits them (with only a compile warning) when
+  `output.publicPath` is `'auto'` or a function, or when CSS is extracted by something other than
+  `CssExtractRspackPlugin` (`css/mini-extract` module type). Without `css` arrays there are no
+  stylesheet hints and no preload head start at all. See
+  [Rspack compatibility](./rspack-compatibility.md#css--fouc-status).
 - **Rspack CSS Module class name divergence:** When using Rspack with CSS Modules, avoid
   `[contenthash]` in `localIdentName`. Rspack client and server builds may produce different
   content hashes for the same file, causing SSR class name mismatches. Use a stable `getLocalIdent`

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -120,6 +120,33 @@ To test RSC with Rspack in your project:
    endorsed the `react-server-dom-webpack` runtime with Rspack. The native
    `RSCRspackPlugin` is maintained by ShakaCode in `react-on-rails-rsc`.
 
+## CSS / FOUC Status
+
+The [CSS and Styling guide](./css-and-styling.md) documents the streamed-CSS (FOUC
+prevention) pipeline in full. The Rspack-specific facts, verified against
+`react-on-rails-rsc@19.2.1-rc.0` and a production dummy build (2026-07-09):
+
+- **Manifest `css` arrays require the 19.2.1+ line.** The `RSCRspackPlugin` in the
+  19.2.0 packages has no CSS collection at all. Without `css` arrays there are no
+  stylesheet hints — no preload head start and no browser-side gating.
+- **`output.publicPath` must be a concrete string.** With `'auto'` or a function, CSS
+  files are omitted from the manifest (the build emits a compilation warning but
+  succeeds).
+- **CSS must be extracted via `CssExtractRspackPlugin`** (`css/mini-extract` module
+  type). Rspack's native CSS support (`experiments.css`) is not seen by the plugin's
+  CSS-dependency recovery; split-chunks configs that move CSS outside the client
+  reference's chunk group can also drop entries.
+- **Default production builds do not gate the streamed reveal** — this is
+  bundler-independent, not Rspack-specific: numeric chunk ids and id-named CSS files
+  disable the stream-level gating layers, so a streamed component can paint unstyled
+  until its CSS applies. See
+  [production builds are the primary silent-no-op case](./css-and-styling.md#known-limitations)
+  for details and status.
+
+The end-to-end FOUC e2e gate currently runs only against dev-mode (`NODE_ENV=test`)
+builds; production-posture coverage is tracked in
+[issue #4557](https://github.com/shakacode/react_on_rails/issues/4557).
+
 ## Related Resources
 
 - [Issue #3488: Rspack RSC path to production-ready (native RSCRspackPlugin)](https://github.com/shakacode/react_on_rails/issues/3488)

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -136,10 +136,12 @@ prevention) pipeline in full. The Rspack-specific facts, verified against
   type). Rspack's native CSS support (`experiments.css`) is not seen by the plugin's
   CSS-dependency recovery; split-chunks configs that move CSS outside the client
   reference's chunk group can also drop entries.
-- **Default production builds do not gate the streamed reveal** — this is
-  bundler-independent, not Rspack-specific: numeric chunk ids and id-named CSS files
-  disable the stream-level gating layers, so a streamed component can paint unstyled
-  until its CSS applies. See
+- **The reviewed default production builds still left the streamed reveal ungated** —
+  this is bundler-independent, not Rspack-specific: numeric chunk ids disable Path B,
+  while Path A then depends on a manifest-listed preload href that arrives before the
+  reveal. The 2026-07-09 production dummy capture under both bundlers still emitted only
+  a non-blocking preload, so a streamed component can paint unstyled until its CSS
+  applies. See
   [production builds are the primary silent-no-op case](./css-and-styling.md#known-limitations)
   for details and status.
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -5961,15 +5961,15 @@ chunk ids from `chunkIds: 'deterministic'`, and id-named extracted CSS like
 `css/[id]-[hash].css`) — verified against a production dummy build on 2026-07-09, where the
 streamed reveal was confirmed ungated under both bundlers:
 
-| Condition                                                                                          | What is disabled                                                                                   |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `loadable-stats.json` missing/unreadable next to the renderer bundle (retries 100ms → 30s backoff) | Path B entirely, including reveal deferral; Path A still runs                                      |
-| Chunk names not matching `client<N>` (custom `chunkName` option, or numeric webpack `chunkIds`)    | Path B (Flight regex never matches); Path A href check fails too if the CSS filename shape changes |
-| CSS output filenames not matching `css/clientN-*.css`                                              | Path A promotion (href filter rejects the preload)                                                 |
-| Flight data lagging a reveal by more than 100ms                                                    | Reveal deferral for that flush (fail-open by design)                                               |
-| Rspack builds omitting CSS assets from the stats consumed by `injectRSCPayload`                    | Path B (empty chunk→CSS map) — see Known limitations                                               |
-| `auto_load_bundle` off (or non-Pro)                                                                | `data-generated-stylesheet-hrefs` + the pre-hydration stylesheet wait                              |
-| React configured with the external Fizz runtime (no inline `$RC(` scripts)                         | Reveal-split detection — deferral silently never fires                                             |
+| Condition                                                                                          | What is disabled                                                                             |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `loadable-stats.json` missing/unreadable next to the renderer bundle (retries 100ms → 30s backoff) | Path B entirely, including reveal deferral; Path A still runs                                |
+| Chunk names not matching `client<N>` (custom `chunkName` option, or numeric webpack `chunkIds`)    | Path B (Flight regex never matches); Path A then depends on manifest-backed preload matching |
+| CSS output filenames not matching `css/clientN-*.css`                                              | Path A's `clientN` filename fallback (manifest-listed preloads can still promote)            |
+| Flight data lagging a reveal by more than 100ms                                                    | Reveal deferral for that flush (fail-open by design)                                         |
+| Rspack builds omitting CSS assets from the stats consumed by `injectRSCPayload`                    | Path B (empty chunk→CSS map) — see Known limitations                                         |
+| `auto_load_bundle` off (or non-Pro)                                                                | `data-generated-stylesheet-hrefs` + the pre-hydration stylesheet wait                        |
+| React configured with the external Fizz runtime (no inline `$RC(` scripts)                         | Reveal-split detection — deferral silently never fires                                       |
 
 If you are debugging a flicker, check these in order; the first two are by far the most common.
 
@@ -6761,12 +6761,15 @@ to measure the end-to-end performance impact of RSC changes with a paired A/B co
 - **Production builds are the primary silent-no-op case (both bundlers, verified 2026-07-09):**
   in a default `NODE_ENV=production` build, chunk ids are numeric (`optimization.chunkIds:
 'deterministic'`) and extracted chunk CSS is id-named (`css/[id]-[hash].css`), so Path B's
-  Flight regex and Path A's href filter both fail — the streamed reveal is not CSS-gated, and only
-  the hint-driven preload's head start mitigates the flash. Note that CSS split into async
+  Flight regex is disabled. Path A's old `css/clientN-*.css` filename fallback is disabled too, so
+  streamed reveal gating then depends on the preload href matching
+  `rscClientManifestStylesheetHrefs` and arriving before the reveal. The reviewed production dummy
+  capture under both bundlers still emitted only a non-blocking preload, so the reveal was ungated
+  and only the hint-driven preload's head start mitigated the flash. Note that CSS split into async
   `clientN` chunks is **not** covered by the Rails layout `stylesheet_pack_tag` (layout pack tags
-  emit only the entrypoint's initial-chunk CSS); until it is fixed, the styles for such components
-  apply at hydration time. The dev/test posture (`chunkIds: 'named'`), which is what CI exercises,
-  is not affected.
+  emit only the entrypoint's initial-chunk CSS); until this gap is closed, the styles for such
+  components apply at hydration time. The dev/test posture (`chunkIds: 'named'`), which is what CI
+  exercises, is not affected.
 - **Rspack manifest `css` omission:** the `RSCRspackPlugin` collects `css` arrays only on the
   `react-on-rails-rsc` 19.2.1+ line, and omits them (with only a compile warning) when
   `output.publicPath` is `'auto'` or a function, or when CSS is extracted by something other than
@@ -10427,10 +10430,12 @@ prevention) pipeline in full. The Rspack-specific facts, verified against
   type). Rspack's native CSS support (`experiments.css`) is not seen by the plugin's
   CSS-dependency recovery; split-chunks configs that move CSS outside the client
   reference's chunk group can also drop entries.
-- **Default production builds do not gate the streamed reveal** — this is
-  bundler-independent, not Rspack-specific: numeric chunk ids and id-named CSS files
-  disable the stream-level gating layers, so a streamed component can paint unstyled
-  until its CSS applies. See
+- **The reviewed default production builds still left the streamed reveal ungated** —
+  this is bundler-independent, not Rspack-specific: numeric chunk ids disable Path B,
+  while Path A then depends on a manifest-listed preload href that arrives before the
+  reveal. The 2026-07-09 production dummy capture under both bundlers still emitted only
+  a non-blocking preload, so a streamed component can paint unstyled until its CSS
+  applies. See
   [production builds are the primary silent-no-op case](./css-and-styling.md#known-limitations)
   for details and status.
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -5956,10 +5956,10 @@ replay path (client-inserted styles during hydration/navigation), not to the ser
 Each of these conditions disables part or all of the streamed-CSS gating **without any error**.
 The page still works — CSS eventually arrives via the browser-side payload replay after hydration —
 but the streamed reveal is no longer gated, so a styled-late flash becomes possible. Two of these
-conditions are not edge cases but the **defaults of every production build** (numeric chunk ids
-from `chunkIds: 'deterministic'`, and id-based CSS filenames from Shakapacker's
-`chunkFilename: 'css/[id][hash].css'`) — verified against a production dummy build on 2026-07-09,
-where the streamed reveal was confirmed ungated under both bundlers:
+conditions are not edge cases but the **production defaults verified in the dummy app** (numeric
+chunk ids from `chunkIds: 'deterministic'`, and id-named extracted CSS like
+`css/[id]-[hash].css`) — verified against a production dummy build on 2026-07-09, where the
+streamed reveal was confirmed ungated under both bundlers:
 
 | Condition                                                                                          | What is disabled                                                                                   |
 | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -5955,7 +5955,11 @@ replay path (client-inserted styles during hydration/navigation), not to the ser
 
 Each of these conditions disables part or all of the streamed-CSS gating **without any error**.
 The page still works — CSS eventually arrives via the browser-side payload replay after hydration —
-but the streamed reveal is no longer gated, so a styled-late flash becomes possible:
+but the streamed reveal is no longer gated, so a styled-late flash becomes possible. Two of these
+conditions are not edge cases but the **defaults of every production build** (numeric chunk ids
+from `chunkIds: 'deterministic'`, and id-based CSS filenames from Shakapacker's
+`chunkFilename: 'css/[id][hash].css'`) — verified against a production dummy build on 2026-07-09,
+where the streamed reveal was confirmed ungated under both bundlers:
 
 | Condition                                                                                          | What is disabled                                                                                   |
 | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
@@ -6754,12 +6758,21 @@ to measure the end-to-end performance impact of RSC changes with a paired A/B co
   cannot produce RSC stylesheet links. Rebuild all three bundles after upgrading.
 - For client-side RSC navigation (`RSCRoute`), the RSC payload still needs stylesheet links. Verify
   this path separately for route-heavy apps.
-- **Rspack FOUC gap:** The `RSCRspackPlugin` emits the same manifest schema as the webpack plugin
-  for component references, but at the time of writing, Rspack builds can omit CSS assets for RSC
-  client chunks from the stats consumed by `injectRSCPayload`. When that map is empty, the FOUC
-  prevention pipeline is silently inactive. CSS for `'use client'` components still works via the
-  Rails layout `stylesheet_pack_tag`, but without client-chunk stylesheet injection. See
-  [Rspack compatibility](./rspack-compatibility.md) for details.
+- **Production builds are the primary silent-no-op case (both bundlers, verified 2026-07-09):**
+  in a default `NODE_ENV=production` build, chunk ids are numeric (`optimization.chunkIds:
+'deterministic'`) and extracted chunk CSS is id-named (`css/[id]-[hash].css`), so Path B's
+  Flight regex and Path A's href filter both fail — the streamed reveal is not CSS-gated, and only
+  the hint-driven preload's head start mitigates the flash. Note that CSS split into async
+  `clientN` chunks is **not** covered by the Rails layout `stylesheet_pack_tag` (layout pack tags
+  emit only the entrypoint's initial-chunk CSS); until it is fixed, the styles for such components
+  apply at hydration time. The dev/test posture (`chunkIds: 'named'`), which is what CI exercises,
+  is not affected.
+- **Rspack manifest `css` omission:** the `RSCRspackPlugin` collects `css` arrays only on the
+  `react-on-rails-rsc` 19.2.1+ line, and omits them (with only a compile warning) when
+  `output.publicPath` is `'auto'` or a function, or when CSS is extracted by something other than
+  `CssExtractRspackPlugin` (`css/mini-extract` module type). Without `css` arrays there are no
+  stylesheet hints and no preload head start at all. See
+  [Rspack compatibility](./rspack-compatibility.md#css--fouc-status).
 - **Rspack CSS Module class name divergence:** When using Rspack with CSS Modules, avoid
   `[contenthash]` in `localIdentName`. Rspack client and server builds may produce different
   content hashes for the same file, causing SSR class name mismatches. Use a stable `getLocalIdent`
@@ -10397,6 +10410,33 @@ To test RSC with Rspack in your project:
 3. **No official React Rspack support**: The React team has not officially tested or
    endorsed the `react-server-dom-webpack` runtime with Rspack. The native
    `RSCRspackPlugin` is maintained by ShakaCode in `react-on-rails-rsc`.
+
+## CSS / FOUC Status
+
+The [CSS and Styling guide](./css-and-styling.md) documents the streamed-CSS (FOUC
+prevention) pipeline in full. The Rspack-specific facts, verified against
+`react-on-rails-rsc@19.2.1-rc.0` and a production dummy build (2026-07-09):
+
+- **Manifest `css` arrays require the 19.2.1+ line.** The `RSCRspackPlugin` in the
+  19.2.0 packages has no CSS collection at all. Without `css` arrays there are no
+  stylesheet hints — no preload head start and no browser-side gating.
+- **`output.publicPath` must be a concrete string.** With `'auto'` or a function, CSS
+  files are omitted from the manifest (the build emits a compilation warning but
+  succeeds).
+- **CSS must be extracted via `CssExtractRspackPlugin`** (`css/mini-extract` module
+  type). Rspack's native CSS support (`experiments.css`) is not seen by the plugin's
+  CSS-dependency recovery; split-chunks configs that move CSS outside the client
+  reference's chunk group can also drop entries.
+- **Default production builds do not gate the streamed reveal** — this is
+  bundler-independent, not Rspack-specific: numeric chunk ids and id-named CSS files
+  disable the stream-level gating layers, so a streamed component can paint unstyled
+  until its CSS applies. See
+  [production builds are the primary silent-no-op case](./css-and-styling.md#known-limitations)
+  for details and status.
+
+The end-to-end FOUC e2e gate currently runs only against dev-mode (`NODE_ENV=test`)
+builds; production-posture coverage is tracked in
+[issue #4557](https://github.com/shakacode/react_on_rails/issues/4557).
 
 ## Related Resources
 


### PR DESCRIPTION
## Summary

Docs-only. Fixes finding F5 of the CSS/FOUC research engagement (PR #4554), updated through the final implementation-backed review pass:

1. **`css-and-styling.md` → Known limitations**: clarifies the verified production posture. Numeric chunk ids disable Path B's Flight-name matching, and id-named CSS disables Path A's legacy `clientN` filename fallback. Path A can still promote a manifest-listed preload when its href matches and arrives before the reveal; the reviewed production dummy capture remained ungated because that full condition was not satisfied.
2. **`css-and-styling.md` → silent-no-op table**: distinguishes the filename fallback from manifest-backed preload matching and narrows the production claim to observed evidence.
3. **`rspack-compatibility.md`**: adds a CSS/FOUC status section covering manifest `css` prerequisites, concrete `publicPath`, `CssExtractRspackPlugin`, and the bundler-independent production gating caveat.
4. Regenerated `llms-full-pro.txt` from the source docs.

## Evidence

Runtime verification on the Pro dummy (Rspack 2.0.5, `react-on-rails-rsc@19.2.1-rc.0`, production mode) found the probe CSS only as a non-blocking preload with an ungated reveal in the captured configuration. The final docs no longer generalize that capture to every manifest-backed id-named stylesheet case. Full research context: `internal/contributor-info/rsc-css-fouc-findings.md` addendum (PR #4554).

Related: #4557 (post-17.0 simplification umbrella, step 0 = restore production streamed-reveal gating).

## Verification

- `node script/generate-llms-full.mjs` and `node script/generate-llms-full.mjs --check` — passed.
- Focused Prettier checks for both source docs — passed.
- `script/check-docs-sidebar` — passed.
- Focused online and branch/offline Lychee checks — passed.
- `git diff --check` and trailing-newline checks — passed.
- After a worker bypassed pre-commit because the worktree lacked Prettier, the coordinator installed the frozen workspace dependencies and reran the equivalent branch Prettier, Markdown-link, trailing-newline, and full `pnpm start format.listDifferent` checks successfully. No content change was needed.

## Merge confidence

- Release mode / phase: `development` / `beta` targeting `main`; standard merge qualification applies. Tracker: https://github.com/shakacode/react_on_rails/issues/3823.
- Current head: `494a0bda352defeaa9ae33c65b55d343d40e2abd`.
- Required CI: `required-pr-gate` passed for the current head.
- Review threads: 0 unresolved; the late manifest-backed Path A finding was fixed and resolved.
- Review coverage: Claude review and CodeRabbit checks completed for the current head; no confirmed blocker remains.
- Merge ledger: strict inputs complete; `complete_allowed: true`.
- UNKNOWN: none affecting merge safety.
- Residual risk: documentation describes a timing-sensitive production path; claims are limited to the captured evidence and current implementation/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when streamed CSS reveal/FOUC prevention becomes a silent no-op in default production builds (deterministic chunk IDs and id-named extracted CSS), plus the async `clientN` chunk/layout stylesheet coverage caveat and production-dummy verification.
  * Expanded “Known limitations” to cover missing/omitted stylesheet hints and preload/gating behavior, including Rspack manifest `css` array omission scenarios.
  * Added an Rspack-specific “CSS / FOUC Status” section detailing required prerequisites for streamed CSS behavior.
  * Updated FOUC end-to-end coverage status (dev/test), noting production verification status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
