### PR TITLE
Clarify ShakaPerf release gate wait

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -45,6 +45,7 @@ SHAKAPERF_RELEASE_GATE_START_TIMEOUT_SECONDS = 600
 SHAKAPERF_RELEASE_GATE_START_POLL_SECONDS = 5
 SHAKAPERF_RELEASE_GATE_RUN_LIST_LIMIT = 100
 SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS = 50 * 60
+SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES = 45
 # Keep in sync with every package.json, Gemfile.lock, and version file that the
 # release task rewrites while promoting an RC to a final release.
 # CHANGELOG.md is intentionally excluded. main_ci_walkback_commit? classifies
@@ -375,9 +376,55 @@ def wait_for_shakaperf_release_gate_run!(repo_slug:, ref:, head_sha:, ignored_ru
   )
 end
 
+def reusable_shakaperf_release_gate_run?(run, head_sha)
+  return false unless run["headSha"] == head_sha
+
+  status = run["status"].to_s
+  return run["conclusion"].to_s == "success" if status == "completed"
+
+  %w[queued in_progress requested waiting pending].include?(status)
+end
+
+def find_reusable_shakaperf_release_gate_run(runs, head_sha)
+  runs.find { |run| reusable_shakaperf_release_gate_run?(run, head_sha) }
+end
+
+def shakaperf_release_gate_run_url(repo_slug:, run:)
+  run["url"] || "https://github.com/#{repo_slug}/actions/runs/#{run.fetch('databaseId')}"
+end
+
+def print_shakaperf_release_gate_notice(ref:, head_sha:)
+  watch_timeout_minutes = SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS / 60
+
+  puts <<~NOTICE
+
+    Running ShakaPerf release gate on #{ref} at #{head_sha[0, 8]} before tagging and publishing...
+    This dispatches the GitHub Actions ShakaPerf Release Gates workflow and blocks until it passes.
+    Warm-cache runs usually take a few minutes.
+    The workflow can run up to #{SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES} minutes.
+    This release task will wait up to #{watch_timeout_minutes} minutes.
+    To skip only for an urgent release where ShakaPerf is known-unrelated:
+      RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake release[...]
+      # or pass override_ci_status as the 4th positional argument:
+      bundle exec rake "release[VERSION,false,false,true]"
+  NOTICE
+end
+
+def dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:)
+  output, status = capture_gh_output(
+    "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE, "--repo", repo_slug, "--ref", ref
+  )
+
+  return if status.success?
+
+  handle_shakaperf_release_gate_violation!(
+    message: "❌ Unable to dispatch ShakaPerf release gate workflow.\n\n#{output}"
+  )
+end
+
 def watch_shakaperf_release_gate_run!(repo_slug:, run:)
   run_id = run.fetch("databaseId").to_s
-  run_url = run["url"] || "https://github.com/#{repo_slug}/actions/runs/#{run_id}"
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
 
   output, status, timed_out = capture_gh_output_with_timeout(
     "run", "watch", run_id, "--repo", repo_slug, "--exit-status",
@@ -397,6 +444,21 @@ def watch_shakaperf_release_gate_run!(repo_slug:, run:)
   )
 end
 
+def handle_reusable_shakaperf_release_gate_run!(repo_slug:, run:, head_sha:)
+  return false unless run
+
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  if run["status"] == "completed"
+    puts "✓ ShakaPerf release gate already passed: #{run_url}"
+    return true
+  end
+
+  puts "Found an existing ShakaPerf release gate run for #{head_sha[0, 8]}; watching it instead: #{run_url}"
+  watch_shakaperf_release_gate_run!(repo_slug:, run:)
+  puts "✓ ShakaPerf release gate passed: #{run_url}"
+  true
+end
+
 def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, allow_override:, dry_run:)
   if dry_run
     puts "⚠️ DRY RUN: Would run ShakaPerf release gate on #{ref} at #{head_sha[0, 8]} before publishing."
@@ -409,20 +471,17 @@ def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, allow_override:
   end
 
   repo_slug = github_repo_slug(monorepo_root)
-  puts "\nRunning ShakaPerf release gate on #{ref} at #{head_sha[0, 8]} before tagging and publishing..."
-  existing_run_ids = fetch_shakaperf_release_gate_runs(repo_slug:, ref:).map do |run|
+  print_shakaperf_release_gate_notice(ref:, head_sha:)
+
+  existing_runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
+  reusable_run = find_reusable_shakaperf_release_gate_run(existing_runs, head_sha)
+  return if handle_reusable_shakaperf_release_gate_run!(repo_slug:, run: reusable_run, head_sha:)
+
+  existing_run_ids = existing_runs.map do |run|
     run["databaseId"].to_s
   end
   dispatch_started_at = shakaperf_release_gate_dispatch_started_at
-  output, status = capture_gh_output(
-    "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE, "--repo", repo_slug, "--ref", ref
-  )
-
-  unless status.success?
-    handle_shakaperf_release_gate_violation!(
-      message: "❌ Unable to dispatch ShakaPerf release gate workflow.\n\n#{output}"
-    )
-  end
+  dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:)
 
   run = wait_for_shakaperf_release_gate_run!(
     repo_slug:,

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -404,7 +404,9 @@ def shakaperf_release_gate_run_url(repo_slug:, run:)
 end
 
 def print_shakaperf_release_gate_notice(ref:, head_sha:)
+  start_timeout_minutes = SHAKAPERF_RELEASE_GATE_START_TIMEOUT_SECONDS / 60
   watch_timeout_minutes = SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS / 60
+  fresh_dispatch_timeout_minutes = start_timeout_minutes + watch_timeout_minutes
 
   puts <<~NOTICE
 
@@ -413,7 +415,9 @@ def print_shakaperf_release_gate_notice(ref:, head_sha:)
     If no reusable run exists, it dispatches a new workflow run and blocks until it passes.
     Warm-cache waits usually take a few minutes.
     The workflow can run up to #{SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES} minutes.
-    This release task will wait up to #{watch_timeout_minutes} minutes.
+    Fresh dispatches can take up to #{start_timeout_minutes} minutes to appear before watching starts.
+    Once a run is found, this release task will watch it for up to #{watch_timeout_minutes} minutes.
+    A fresh dispatch can therefore block for up to about #{fresh_dispatch_timeout_minutes} minutes total.
     To skip only for an urgent release where ShakaPerf is known-unrelated:
       RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake release[...]
       # or pass override_ci_status as the 4th positional argument:

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -322,7 +322,7 @@ def fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
     "--workflow", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
     "--branch", ref,
     "--event", "workflow_dispatch",
-    "--json", "createdAt,databaseId,headSha,status,conclusion,url",
+    "--json", "attempt,createdAt,databaseId,headSha,status,conclusion,updatedAt,url",
     "--limit", SHAKAPERF_RELEASE_GATE_RUN_LIST_LIMIT.to_s
   )
 
@@ -377,31 +377,26 @@ def wait_for_shakaperf_release_gate_run!(repo_slug:, ref:, head_sha:, ignored_ru
   )
 end
 
-def reusable_shakaperf_release_gate_run?(run, head_sha)
-  return false unless run["headSha"] == head_sha
-
-  status = run["status"].to_s
-  return run["conclusion"].to_s == "success" if status == "completed"
-
-  %w[queued in_progress requested waiting pending].include?(status)
+def active_shakaperf_release_gate_run?(run)
+  %w[queued in_progress requested waiting pending].include?(run["status"].to_s)
 end
 
-def find_reusable_shakaperf_release_gate_run(runs, head_sha)
-  latest_same_sha_run = runs.select { |run| run["headSha"] == head_sha }
-                            .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
-  return unless latest_same_sha_run
-
-  reusable_shakaperf_release_gate_run?(latest_same_sha_run, head_sha) ? latest_same_sha_run : nil
+def find_latest_shakaperf_release_gate_run(runs, head_sha)
+  runs.select { |run| run["headSha"] == head_sha }
+      .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
 end
 
 def shakaperf_release_gate_run_sort_key(run)
-  created_at = begin
-    Time.iso8601(run["createdAt"]).to_i
-  rescue ArgumentError, TypeError
-    0
-  end
+  updated_at = shakaperf_release_gate_run_timestamp(run, "updatedAt")
+  created_at = shakaperf_release_gate_run_timestamp(run, "createdAt")
 
-  [created_at, run["databaseId"].to_i]
+  [updated_at, run["attempt"].to_i, created_at, run["databaseId"].to_i]
+end
+
+def shakaperf_release_gate_run_timestamp(run, field_name)
+  Time.iso8601(run[field_name]).to_i
+rescue ArgumentError, TypeError
+  0
 end
 
 def shakaperf_release_gate_run_url(repo_slug:, run:)
@@ -460,23 +455,24 @@ def watch_shakaperf_release_gate_run!(repo_slug:, run:)
   )
 end
 
-def handle_reusable_shakaperf_release_gate_run!(repo_slug:, run:, head_sha:)
+def handle_existing_shakaperf_release_gate_run!(repo_slug:, run:, head_sha:)
   return false unless run
 
   run_id = run.fetch("databaseId").to_s
   run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
   if run["status"].to_s == "completed"
     conclusion = run["conclusion"].to_s
-    unless conclusion == "success"
-      handle_shakaperf_release_gate_violation!(
-        message: "❌ Refusing to reuse completed ShakaPerf release gate run #{run_id} " \
-                 "with conclusion #{conclusion.empty? ? 'unknown' : conclusion}.\n\nRun: #{run_url}"
-      )
+    if conclusion == "success"
+      puts "✓ ShakaPerf release gate already passed: #{run_url}"
+      return true
     end
 
-    puts "✓ ShakaPerf release gate already passed: #{run_url}"
-    return true
+    puts "Latest ShakaPerf release gate run #{run_id} completed with conclusion " \
+         "#{conclusion.empty? ? 'unknown' : conclusion}; dispatching a fresh gate run: #{run_url}"
+    return false
   end
+
+  return false unless active_shakaperf_release_gate_run?(run)
 
   puts "Found an existing ShakaPerf release gate run for #{head_sha[0, 8]}; watching it instead: #{run_url}"
   watch_shakaperf_release_gate_run!(repo_slug:, run:)
@@ -499,8 +495,8 @@ def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, allow_override:
   print_shakaperf_release_gate_notice(ref:, head_sha:)
 
   existing_runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
-  reusable_run = find_reusable_shakaperf_release_gate_run(existing_runs, head_sha)
-  return if handle_reusable_shakaperf_release_gate_run!(repo_slug:, run: reusable_run, head_sha:)
+  existing_run = find_latest_shakaperf_release_gate_run(existing_runs, head_sha)
+  return if handle_existing_shakaperf_release_gate_run!(repo_slug:, run: existing_run, head_sha:)
 
   existing_run_ids = existing_runs.map do |run|
     run["databaseId"].to_s

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -463,8 +463,17 @@ end
 def handle_reusable_shakaperf_release_gate_run!(repo_slug:, run:, head_sha:)
   return false unless run
 
+  run_id = run.fetch("databaseId").to_s
   run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
-  if run["status"] == "completed"
+  if run["status"].to_s == "completed"
+    conclusion = run["conclusion"].to_s
+    unless conclusion == "success"
+      handle_shakaperf_release_gate_violation!(
+        message: "❌ Refusing to reuse completed ShakaPerf release gate run #{run_id} " \
+                 "with conclusion #{conclusion.empty? ? 'unknown' : conclusion}.\n\nRun: #{run_url}"
+      )
+    end
+
     puts "✓ ShakaPerf release gate already passed: #{run_url}"
     return true
   end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -45,6 +45,7 @@ SHAKAPERF_RELEASE_GATE_START_TIMEOUT_SECONDS = 600
 SHAKAPERF_RELEASE_GATE_START_POLL_SECONDS = 5
 SHAKAPERF_RELEASE_GATE_RUN_LIST_LIMIT = 100
 SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS = 50 * 60
+# Keep in sync with timeout-minutes in .github/workflows/shakaperf-release-gates.yml.
 SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES = 45
 # Keep in sync with every package.json, Gemfile.lock, and version file that the
 # release task rewrites while promoting an RC to a final release.
@@ -386,7 +387,21 @@ def reusable_shakaperf_release_gate_run?(run, head_sha)
 end
 
 def find_reusable_shakaperf_release_gate_run(runs, head_sha)
-  runs.find { |run| reusable_shakaperf_release_gate_run?(run, head_sha) }
+  latest_same_sha_run = runs.select { |run| run["headSha"] == head_sha }
+                            .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
+  return unless latest_same_sha_run
+
+  reusable_shakaperf_release_gate_run?(latest_same_sha_run, head_sha) ? latest_same_sha_run : nil
+end
+
+def shakaperf_release_gate_run_sort_key(run)
+  created_at = begin
+    Time.iso8601(run["createdAt"]).to_i
+  rescue ArgumentError, TypeError
+    0
+  end
+
+  [created_at, run["databaseId"].to_i]
 end
 
 def shakaperf_release_gate_run_url(repo_slug:, run:)
@@ -399,8 +414,9 @@ def print_shakaperf_release_gate_notice(ref:, head_sha:)
   puts <<~NOTICE
 
     Running ShakaPerf release gate on #{ref} at #{head_sha[0, 8]} before tagging and publishing...
-    This dispatches the GitHub Actions ShakaPerf Release Gates workflow and blocks until it passes.
-    Warm-cache runs usually take a few minutes.
+    This checks for an existing matching GitHub Actions ShakaPerf Release Gates run.
+    If no reusable run exists, it dispatches a new workflow run and blocks until it passes.
+    Warm-cache waits usually take a few minutes.
     The workflow can run up to #{SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES} minutes.
     This release task will wait up to #{watch_timeout_minutes} minutes.
     To skip only for an urgent release where ShakaPerf is known-unrelated:

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -355,6 +355,15 @@ RSpec.describe "release.rake helper methods" do
         )
         .and_return(["", success_status, false])
 
+      expected_notice = Regexp.new(
+        [
+          "fresh dispatch can therefore block for up to about 60 minutes total",
+          "RELEASE_CI_STATUS_OVERRIDE=true",
+          "ShakaPerf release gate passed"
+        ].join(".*"),
+        Regexp::IGNORECASE | Regexp::MULTILINE
+      )
+
       expect do
         run_shakaperf_release_gate!(
           monorepo_root:,
@@ -363,9 +372,7 @@ RSpec.describe "release.rake helper methods" do
           allow_override: false,
           dry_run: false
         )
-      end.to output(
-        /This release task will wait up to 50 minutes.*RELEASE_CI_STATUS_OVERRIDE=true.*ShakaPerf release gate passed/m
-      ).to_stdout
+      end.to output(expected_notice).to_stdout
       expect(self).to have_received(:capture_gh_output)
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -437,6 +437,62 @@ RSpec.describe "release.rake helper methods" do
       end.to output(/watching it instead.*ShakaPerf release gate passed/m).to_stdout
     end
 
+    it "does not reuse an older successful gate run when the latest same-SHA run failed" do
+      failed_run = run.merge(
+        "databaseId" => 222_222,
+        "status" => "completed",
+        "conclusion" => "failure",
+        "createdAt" => "2026-07-10T21:30:00Z"
+      )
+      older_successful_run = run.merge(
+        "databaseId" => 111_111,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-10T21:00:00Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([failed_run, older_successful_run])
+      allow(self).to receive(:capture_gh_output)
+        .with(
+          "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
+          "--repo", repo_slug,
+          "--ref", "release-branch"
+        )
+        .and_return(["", success_status])
+      allow(self).to receive(:wait_for_shakaperf_release_gate_run!)
+        .with(
+          repo_slug:,
+          ref: "release-branch",
+          head_sha:,
+          ignored_run_ids: %w[222222 111111],
+          earliest_created_at: kind_of(Time)
+        )
+        .and_return(run)
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .with(
+          "run", "watch", "123456", "--repo", repo_slug, "--exit-status",
+          timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
+        )
+        .and_return(["", success_status, false])
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/ShakaPerf release gate passed/).to_stdout
+      expect(self).to have_received(:capture_gh_output)
+        .with(
+          "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
+          "--repo", repo_slug,
+          "--ref", "release-branch"
+        )
+    end
+
     it "skips dispatching when the CI status override is enabled" do
       expect(self).not_to receive(:capture_gh_output)
 

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -363,7 +363,9 @@ RSpec.describe "release.rake helper methods" do
           allow_override: false,
           dry_run: false
         )
-      end.to output(/ShakaPerf release gate passed/).to_stdout
+      end.to output(
+        /This release task will wait up to 50 minutes.*RELEASE_CI_STATUS_OVERRIDE=true.*ShakaPerf release gate passed/m
+      ).to_stdout
       expect(self).to have_received(:capture_gh_output)
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
@@ -383,6 +385,56 @@ RSpec.describe "release.rake helper methods" do
           "run", "watch", "123456", "--repo", repo_slug, "--exit-status",
           timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
         )
+    end
+
+    it "reuses an already successful gate run for the same head SHA without dispatching another run" do
+      successful_run = run.merge(
+        "status" => "completed",
+        "conclusion" => "success"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([successful_run])
+      expect(self).not_to receive(:capture_gh_output)
+      expect(self).not_to receive(:capture_gh_output_with_timeout)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(%r{ShakaPerf release gate already passed.*actions/runs/123456}m).to_stdout
+    end
+
+    it "watches an in-progress gate run for the same head SHA without dispatching another run" do
+      in_progress_run = run.merge(
+        "databaseId" => 321_654,
+        "status" => "in_progress",
+        "conclusion" => ""
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_run])
+      expect(self).not_to receive(:capture_gh_output)
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .with(
+          "run", "watch", "321654", "--repo", repo_slug, "--exit-status",
+          timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
+        )
+        .and_return(["", success_status, false])
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/watching it instead.*ShakaPerf release gate passed/m).to_stdout
     end
 
     it "skips dispatching when the CI status override is enabled" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -409,6 +409,20 @@ RSpec.describe "release.rake helper methods" do
       end.to output(%r{ShakaPerf release gate already passed.*actions/runs/123456}m).to_stdout
     end
 
+    it "aborts instead of reporting a completed non-success run as already passed" do
+      failed_run = run.merge(
+        "status" => "completed",
+        "conclusion" => "failure"
+      )
+
+      expect do
+        handle_reusable_shakaperf_release_gate_run!(repo_slug:, run: failed_run, head_sha:)
+      end.to raise_error(
+        SystemExit,
+        /Refusing to reuse completed ShakaPerf release gate run 123456 with conclusion failure/
+      )
+    end
+
     it "watches an in-progress gate run for the same head SHA without dispatching another run" do
       in_progress_run = run.merge(
         "databaseId" => 321_654,

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -409,20 +409,6 @@ RSpec.describe "release.rake helper methods" do
       end.to output(%r{ShakaPerf release gate already passed.*actions/runs/123456}m).to_stdout
     end
 
-    it "aborts instead of reporting a completed non-success run as already passed" do
-      failed_run = run.merge(
-        "status" => "completed",
-        "conclusion" => "failure"
-      )
-
-      expect do
-        handle_reusable_shakaperf_release_gate_run!(repo_slug:, run: failed_run, head_sha:)
-      end.to raise_error(
-        SystemExit,
-        /Refusing to reuse completed ShakaPerf release gate run 123456 with conclusion failure/
-      )
-    end
-
     it "watches an in-progress gate run for the same head SHA without dispatching another run" do
       in_progress_run = run.merge(
         "databaseId" => 321_654,
@@ -451,22 +437,26 @@ RSpec.describe "release.rake helper methods" do
       end.to output(/watching it instead.*ShakaPerf release gate passed/m).to_stdout
     end
 
-    it "does not reuse an older successful gate run when the latest same-SHA run failed" do
+    it "does not reuse a successful run when a rerun updated a same-SHA failure more recently" do
       failed_run = run.merge(
         "databaseId" => 222_222,
         "status" => "completed",
         "conclusion" => "failure",
-        "createdAt" => "2026-07-10T21:30:00Z"
+        "attempt" => 2,
+        "createdAt" => "2026-07-10T21:00:00Z",
+        "updatedAt" => "2026-07-10T21:45:00Z"
       )
-      older_successful_run = run.merge(
+      earlier_updated_successful_run = run.merge(
         "databaseId" => 111_111,
         "status" => "completed",
         "conclusion" => "success",
-        "createdAt" => "2026-07-10T21:00:00Z"
+        "attempt" => 1,
+        "createdAt" => "2026-07-10T21:30:00Z",
+        "updatedAt" => "2026-07-10T21:35:00Z"
       )
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
-        .and_return([failed_run, older_successful_run])
+        .and_return([failed_run, earlier_updated_successful_run])
       allow(self).to receive(:capture_gh_output)
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
@@ -498,7 +488,7 @@ RSpec.describe "release.rake helper methods" do
           allow_override: false,
           dry_run: false
         )
-      end.to output(/ShakaPerf release gate passed/).to_stdout
+      end.to output(/dispatching a fresh gate run.*ShakaPerf release gate passed/m).to_stdout
       expect(self).to have_received(:capture_gh_output)
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,


### PR DESCRIPTION
## Summary
- Print an operator notice before the release task blocks on the ShakaPerf GitHub Actions gate, including typical/maximum wait expectations and exact skip commands.
- Reuse an existing same-ref/same-SHA successful or in-progress ShakaPerf gate run instead of dispatching duplicate workflow runs.
- Treat the latest same-SHA ShakaPerf evidence as authoritative, including reruns ordered by `updatedAt`/`attempt`, so stale successes cannot mask newer failed or running attempts.
- If the latest same-SHA run completed unsuccessfully, dispatch a fresh gate run and wait for that fresh result before tagging/publishing.
- Clarify that fresh dispatches can spend up to 10 minutes waiting for the run to appear, then up to 50 minutes watching it, for about 60 minutes total worst case.

## Verification
- `script/ci-changes-detector origin/main` -> recommends Ruby lint plus RSpec gem tests for this diff.
- `bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb` from `react_on_rails/` -> 238 examples, 0 failures.
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop ../rakelib/release.rake spec/react_on_rails/release_rake_helpers_spec.rb` from `react_on_rails/` -> 2 files, no offenses.
- `git diff --check` -> passed.
- Pre-commit/pre-push branch lint -> Ruby file RuboCop passed; markdown link hook found no Markdown files to check.

## Closeout Evidence
- Release mode: #3823 `Agent Release Mode` is `development`; target branch is `main` / beta phase, so standard merge qualification applies.
- Security preflight: `SECURITY_PREFLIGHT_OK` for PR #4563 at `b2be66ba0a613b1cf2ac7887deeb5d6dd4426a45`; only `github-actions[bot]` hosted-CI comments were metadata-only.
- Changelog classification: `not_user_visible` (release-operator tooling behavior, no public package/API change).
- Labels: `ready-for-hosted-ci` retained; optimized hosted CI requested for the final candidate.
- Review churn: 4 follow-up commits after the first push, fixing the latest-run ordering concern, wording/comment nits, reuse-handler hardening, rerun-aware `updatedAt`/`attempt` ordering, and the fresh-dispatch wait estimate.

### QA Evidence

- QA lane: Codex closeout lane, branch `jg-codex/release-shakaperf-message`, worktree `/Users/justin/.codex/worktrees/c67c/react_on_rails`; private coordination status checked and no competing claim was present.
- Scope checked: `rakelib/release.rake` ShakaPerf gate messaging/reuse/rerun behavior and `react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb` coverage for dispatch, reuse, failed/latest rerun handling, wait-estimate messaging, and skip instructions.
- Tested at: `b2be66ba0a613b1cf2ac7887deeb5d6dd4426a45`.
- Automated checks: CI selector, focused RSpec, focused RuboCop, `git diff --check`, pre-commit, and pre-push branch lint listed above.
- Manual checks: release tracker mode/phase inspected; review threads triaged and resolved; no live release task was run because that would tag/publish, and the helper behavior is covered by specs.
- Findings: P1/P2 latest-run/rerun ordering issues, reuse-handler hardening, and wait-estimate feedback fixed in this PR; no remaining release-blocking finding known.
- QA required: yes
- QA required rationale: release-helper behavior affects operator-visible release gating.
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: script


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Release retries now reuse an existing ShakaPerf release-gate run for the same commit when it’s already running or has already succeeded.
  * Prevents redundant gate workflow dispatches by watching the appropriate existing run instead, and refuses reuse when the prior run concluded unsuccessfully.
  * Updated gate notices and status output, including the workflow up-to timeout (45 minutes) and `RELEASE_CI_STATUS_OVERRIDE` guidance.

* **Tests**
  * Expanded coverage for gate-run reuse/watching, including “already passed” behavior, watching in-progress runs, and dispatching a fresh run when the latest same-commit attempt failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
