### PR TITLE
[Pro] Avoid mutating manifest globals during streaming

### DIFF
--- a/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
@@ -26,7 +26,6 @@ import {
   StreamableComponentResult,
 } from 'react-on-rails/types';
 import injectRSCPayload from './injectRSCPayload.ts';
-import { setManifestFileNames } from './cache/manifestLoader.ts';
 import { getRSCClientManifestStylesheetHrefs } from './cache/manifestLoaderServer.ts';
 import { isRSCRouteSSRFalseBailoutError } from './RSCRouteSSRFalseBailoutError.ts';
 import {
@@ -166,8 +165,7 @@ const streamRenderReactComponent = (
 
   assertRailsContextWithServerStreamingCapabilities(railsContext);
 
-  const { reactClientManifestFileName, reactServerClientManifestFileName } = railsContext;
-  setManifestFileNames(reactClientManifestFileName, reactServerClientManifestFileName);
+  const { reactClientManifestFileName } = railsContext;
   // Manifest-backed promotion is additive. If a build does not ship the manifest,
   // preserve the existing filename-regex fallback in injectRSCPayload.
   const rscClientManifestStylesheetHrefsPromise = Promise.resolve()

--- a/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
@@ -46,7 +46,12 @@ jest.mock('../src/cache/manifestLoaderServer.ts', () => ({
   getRSCClientManifestStylesheetHrefs: jest.fn().mockResolvedValue(new Set()),
 }));
 
+jest.mock('../src/cache/manifestLoader.ts', () => ({
+  setManifestFileNames: jest.fn(),
+}));
+
 const { getRSCClientManifestStylesheetHrefs } = jest.requireMock('../src/cache/manifestLoaderServer.ts');
+const { setManifestFileNames } = jest.requireMock('../src/cache/manifestLoader.ts');
 
 const AsyncContent = async ({ throwAsyncError }) => {
   await new Promise((resolve) => {
@@ -258,6 +263,7 @@ describe('streamServerRenderedReactComponent', () => {
     ComponentRegistry.clear();
     renderToPipeableStream.mockClear();
     getRSCClientManifestStylesheetHrefs.mockReset().mockResolvedValue(new Set());
+    setManifestFileNames.mockReset();
   });
 
   // Parses a length-prefixed stream chunk: metadata\tcontent_len\ncontent
@@ -1009,6 +1015,15 @@ describe('streamServerRenderedReactComponent', () => {
     expect(chunks[1].consoleReplayScript).toBe('');
     expect(chunks[1].hasErrors).toBe(false);
     expect(chunks[1].isShellReady).toBe(true);
+  });
+
+  it('does not mutate global manifest filenames during a streamed render', async () => {
+    const { renderResult } = setupStreamTest();
+    await new Promise((resolve) => {
+      renderResult.once('end', resolve);
+    });
+
+    expect(setManifestFileNames).not.toHaveBeenCalled();
   });
 
   it('passes manifest stylesheet hrefs to streamed preload promotion', async () => {


### PR DESCRIPTION
## Why

Main PR #4570 added a per-request `setManifestFileNames` call solely to support streamed stylesheet discovery. The stylesheet lookup now receives its request-captured manifest filename explicitly, so the global mutation is unnecessary and can race singleton renderer initialization in another request.

This keeps `main` aligned with the review fix in release backport #4573.

## What changed

- Remove the `setManifestFileNames` import and call from the general streaming path.
- Continue passing `railsContext.reactClientManifestFileName` directly to stylesheet discovery.
- Add a regression proving streamed renders do not mutate global manifest filenames.
- Preserve required global manifest setup in the separate Pro RSC renderer capability before `getServerRenderer()`.

## Validation

- Focused stream suite: 38/38 passed; main/release parity checks: 4 manifest-loader and 3 focused stream tests passed.
- Full Pro suite: 47 suites, 611 tests passed.
- Clean Pro build/type-check, repo lint seam, ESLint, RuboCop, 72 lint tests/220 assertions, full Prettier, 849 Pro license headers, and diff checks passed.
- Exact production Rspack QA on the equivalent release fix promoted numeric chunk CSS before `$RC` and recorded zero unstyled frames with CSS delayed by 4.021 seconds.
- Main and release fixes have identical stable patch IDs and resulting source/test blobs.
- Exact-head adversarial review: zero `BLOCKING`, zero `DISCUSS`, zero follow-up findings.

## Changelog

No additional entry: this is an internal correctness follow-up to the already-documented production FOUC fix in #4570.

## Confidence note

- Validated: 611 Pro tests, focused parity tests, build/type/lint/format/license gates, exact-delta identity, release production QA, and exact-head adversarial review.
- Evidence: #4570, #4573, local validation, and release production QA artifacts.
- UNKNOWN: none affecting local correctness; current-head CI/review/ledger pending.
- Residual risk: none beyond the already-recorded manifest-omission limitation in #4570.
- Merge authority: `auto_merge_when_gates_pass`.

Final candidate: `27ad6e3ee08f985701b00c0215e9467b17f85dc0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed rendering reliability by preventing manifest settings from being modified during rendering.
  * Preserved existing fallback behavior when loading client manifest stylesheet information fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->