### PR TITLE
[Pro] Reconnect stale renderer keep-alive; clarify per-thread connection math (#4571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,9 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   client per Puma request thread, which keeps a renderer connection warm across requests. A warm client
   now transparently reconnects and retries a request a single time if it reuses a keep-alive connection
   the renderer, a load balancer, or a proxy has since idle-closed, so a stale socket no longer surfaces as
-  a render failure. Reachability failures (connection refused, host unreachable, timeouts), HTTP/2 stream
+  a render failure. The retry only covers failures that occur before the renderer returns a response; a
+  connection drop while reading the response body is not retried, so an already-executed render is never
+  silently re-run. Reachability failures (connection refused, host unreachable, timeouts), HTTP/2 stream
   resets, first-contact failures, and non-replayable upload bodies are not retried by this reconnect path;
   they continue to flow to the existing renderer request retry loop unchanged. Documentation
   for `renderer_http_pool_size` was corrected to clarify it is a per-client limit — total warm renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,8 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   for `renderer_http_pool_size` was corrected to clarify it is a per-client limit — total warm renderer
   connections scale with the number of live Puma request threads, not with that value alone. Fixes
   [Issue 4571](https://github.com/shakacode/react_on_rails/issues/4571).
+  [PR 4575](https://github.com/shakacode/react_on_rails/pull/4575) by
+  [AbanoubGhadban](https://github.com/AbanoubGhadban).
 
 - **[Pro]** **Failing RSC payloads no longer cause unbounded browser requests**: `RSCProvider` now
   keeps one cached Promise for a logical payload load and retries a transient network, server, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,17 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   [Issue 4609](https://github.com/shakacode/react_on_rails/issues/4609).
   [PR 4625](https://github.com/shakacode/react_on_rails/pull/4625) by
   [justin808](https://github.com/justin808).
+- **[Pro]** **Renderer keep-alive connections recover from idle-close instead of failing a render**: on
+  standard Puma (no `Fiber.scheduler`), non-streaming renderer requests reuse one persistent async-http
+  client per Puma request thread, which keeps a renderer connection warm across requests. A warm client
+  now transparently reconnects and retries a request a single time if it reuses a keep-alive connection
+  the renderer, a load balancer, or a proxy has since idle-closed, so a stale socket no longer surfaces as
+  a render failure. Reachability failures (connection refused, host unreachable, timeouts), HTTP/2 stream
+  resets, first-contact failures, and non-replayable upload bodies are not retried by this reconnect path;
+  they continue to flow to the existing renderer request retry loop unchanged. Documentation
+  for `renderer_http_pool_size` was corrected to clarify it is a per-client limit — total warm renderer
+  connections scale with the number of live Puma request threads, not with that value alone. Fixes
+  [Issue 4571](https://github.com/shakacode/react_on_rails/issues/4571).
 
 - **[Pro]** **Failing RSC payloads no longer cause unbounded browser requests**: `RSCProvider` now
   keeps one cached Promise for a logical payload load and retries a transient network, server, or

--- a/docs/oss/configuration/configuration-pro.md
+++ b/docs/oss/configuration/configuration-pro.md
@@ -100,14 +100,18 @@ ReactOnRailsPro.configure do |config|
   # Default for `renderer_use_fallback_exec_js` is true.
   config.renderer_use_fallback_exec_js = false
 
-  # Maximum number of concurrent async-http connections per client to the Node renderer.
+  # Maximum number of concurrent async-http connections per client to the Node renderer. This is a
+  # per-client limit, not a global cap on renderer connections.
   # HTTP/2 may multiplex multiple request streams over those pooled connections.
   # When a Fiber.scheduler already exists before the renderer request enters `Sync {}`, the
   # client is reused across requests within that long-lived scheduler (persistent connection /
   # keep-alive; see the tuning section below), so this limit bounds connection concurrency for
-  # streamed renders sharing one client.
-  # Otherwise the adapter uses a request-scoped client. Under standard Puma (no pre-existing scheduler), `Sync {}`
-  # creates that scheduler/client for the request and cleans it up when the request ends.
+  # renders sharing one client.
+  # Under standard Puma (no pre-existing scheduler): non-streaming requests reuse one persistent
+  # client per Puma request thread (keeping a renderer connection warm across requests on that
+  # thread), while streaming requests use a request-scoped client that `Sync {}` creates and cleans
+  # up when the response ends. Because the limit is per client, total warm renderer capacity scales
+  # with the number of live Puma request threads, not with this value alone.
   # See "Renderer Performance Tuning for Streamed RSC" below.
   # Default for `renderer_http_pool_size` is 10
   config.renderer_http_pool_size = 10
@@ -221,11 +225,11 @@ Guidance:
 - Account for your Rails concurrency: with many Puma threads/workers all streaming, a renderer with only one or two workers becomes the bottleneck. Scale `workersCount` (and renderer replicas) to your real concurrent streamed-render load.
 - Tune `ssr_timeout` for legitimate long gaps between streamed chunks — it applies as a per-read socket timeout, so it fires when a single read from the renderer blocks for `ssr_timeout` seconds. It is not a total response-duration cap; avoid masking renderer hangs with an unnecessarily high value.
 
-### 3. Rails ↔ renderer keep-alive (persistent on Falcon/async scheduler; per-request on standard Puma)
+### 3. Rails ↔ renderer keep-alive (persistent on Falcon/async scheduler; per-thread on standard Puma)
 
 Connection reuse is automatic when the renderer request runs under a long-lived `Fiber.scheduler`, such as Falcon or Puma configured with an async scheduler. In that setup, the async-http client is stored on the scheduler and reused across streaming requests, so HTTP/2 connections stay alive and renders multiplex over them instead of paying TCP handshake and H2 connection setup per request ([issue #3283](https://github.com/shakacode/react_on_rails/issues/3283)). No React on Rails configuration is required to enable this.
 
-Under standard Puma, the streaming helper's `Sync {}` block creates a per-request scheduler. The async-http client is cleaned up when that streaming response ends, so connection reuse does not persist across consecutive Rails requests. The benefit is still meaningful inside a single streamed response: renderer calls in that response can share the same client lifecycle and `renderer_http_pool_size` still bounds concurrent async-http connections within that request.
+Under standard Puma (no pre-existing scheduler), **non-streaming** renderer requests reuse one persistent async-http client per Puma request thread, so a renderer connection stays warm across consecutive requests handled by that thread. Because the client is per thread, total warm renderer connections scale with the number of live Puma request threads (workers × threads), and `renderer_http_pool_size` bounds concurrency per client rather than capping connections globally — size your renderer worker pool and replicas accordingly. A warm client transparently reconnects and retries once — for a replay-safe body (a render/JSON or empty body, never a multipart asset upload) — if it reuses a keep-alive connection the renderer, load balancer, or proxy has idle-closed. **Streaming** renderer requests instead run inside the streaming helper's `Sync {}` block, which creates a per-request scheduler; that client is cleaned up when the streamed response ends, so streaming reuse does not persist across consecutive Rails requests, though `renderer_http_pool_size` still bounds concurrent async-http connections within one streamed response.
 
 Call the renderer from the normal Rails request path. The adapter chooses scheduler-scoped reuse whenever a `Fiber.scheduler` already exists before it enters `Sync {}`; custom middleware or background code that installs a scheduler with an unclear lifecycle can therefore keep renderer clients alive longer than intended. Keep those calls inside the request's scheduler lifecycle, or use the standard path where `Sync {}` creates and cleans up the per-request client.
 

--- a/docs/pro/updating.md
+++ b/docs/pro/updating.md
@@ -419,9 +419,11 @@ Before upgrading:
   per-thread client used for non-streaming requests under standard Puma: once it has succeeded at least once, it
   transparently reconnects and retries a request with a replay-safe body (a render/JSON or empty body) a single time if
   it reuses a keep-alive connection that was idle-closed, so a stale warm socket does not surface as a render failure.
-  Non-replayable bodies (multipart asset uploads), reachability failures (connection refused, host unreachable,
-  timeouts), HTTP/2 stream resets, and first-contact failures are not retried by this reconnect path; they continue to
-  flow to the existing request retry loop (`renderer_request_retry_limit`).
+  The retry only covers failures before the renderer returns a response; a connection drop while reading the response
+  body is not retried, so an already-executed render is never silently re-run. Non-replayable bodies (multipart asset
+  uploads), reachability failures (connection refused, host unreachable, timeouts), HTTP/2 stream resets, and
+  first-contact failures are not retried by this reconnect path; they continue to flow to the existing request retry
+  loop (`renderer_request_retry_limit`).
 - Run the node renderer client from the normal Rails request path. **Note for Falcon/async-rails users:** the earlier
   advisory to keep Falcon deployments on the HTTPX renderer client is superseded; HTTPX has been removed and async-http
   now handles Falcon natively. Async Rails servers (Falcon, Puma with an async scheduler) are supported: the async-http

--- a/docs/pro/updating.md
+++ b/docs/pro/updating.md
@@ -404,15 +404,24 @@ Before upgrading:
 - Treat `config.renderer_http_pool_timeout` as the TCP connect timeout. After the socket connects, individual reads
   are bounded by `ssr_timeout`.
 - Treat `config.renderer_http_pool_size` as the per-client async-http connection-pool limit, not as the old
-  process-wide persistent pool size. With a long-lived `Fiber.scheduler` (for example Falcon or Puma configured with an
-  async scheduler), the client is reused across renderer requests within that scheduler and the setting bounds
-  concurrent async-http connections for streamed renders sharing one client. HTTP/2 may multiplex multiple request
-  streams over those pooled connections. Under standard Puma streaming, `Sync {}` creates a per-request scheduler and
-  cleans up the client when that streaming response ends, so reuse does not persist across consecutive Rails requests.
-  Setting it to `nil` keeps the default connection limit; it does not make the async-http client unlimited.
-- Expect renderer connection drops to surface immediately as `ReactOnRailsPro::Error`/connection failures. HTTPX
-  previously performed one implicit transport retry for some connection drops; the async-http adapter uses
-  `retries: 0` and leaves retry policy to the existing bundle-upload retry loop and caller behavior.
+  process-wide persistent pool size, and not as a global cap on renderer connections. With a long-lived
+  `Fiber.scheduler` (for example Falcon or Puma configured with an async scheduler), the client is reused across
+  renderer requests within that scheduler and the setting bounds concurrent async-http connections for renders sharing
+  one client. HTTP/2 may multiplex multiple request streams over those pooled connections. Under standard Puma,
+  non-streaming requests reuse one persistent client per Puma request thread (keeping a renderer connection warm across
+  requests on that thread), while streaming requests use a request-scoped client that `Sync {}` cleans up when the
+  streamed response ends. Because the limit is per client, total warm renderer connections scale with the number of live
+  Puma request threads (workers × threads); size your renderer worker pool and replicas accordingly. Setting it to `nil`
+  keeps the default connection limit; it does not make the async-http client unlimited.
+- Expect renderer connection drops to surface as `ReactOnRailsPro::Error`/connection failures. HTTPX previously
+  performed one implicit transport retry for some connection drops; the async-http adapter uses `retries: 0` and leaves
+  retry policy to the existing bundle-upload/request retry loop and caller behavior. The one exception is the persistent
+  per-thread client used for non-streaming requests under standard Puma: once it has succeeded at least once, it
+  transparently reconnects and retries a request with a replay-safe body (a render/JSON or empty body) a single time if
+  it reuses a keep-alive connection that was idle-closed, so a stale warm socket does not surface as a render failure.
+  Non-replayable bodies (multipart asset uploads), reachability failures (connection refused, host unreachable,
+  timeouts), HTTP/2 stream resets, and first-contact failures are not retried by this reconnect path; they continue to
+  flow to the existing request retry loop (`renderer_request_retry_limit`).
 - Run the node renderer client from the normal Rails request path. **Note for Falcon/async-rails users:** the earlier
   advisory to keep Falcon deployments on the HTTPX renderer client is superseded; HTTPX has been removed and async-http
   now handles Falcon natively. Async Rails servers (Falcon, Puma with an async scheduler) are supported: the async-http

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -66,9 +66,12 @@ module ReactOnRailsPro
     DEFAULT_RENDERER_URL = "http://localhost:3800"
     DEFAULT_RENDERER_METHOD = "ExecJS"
     DEFAULT_RENDERER_FALLBACK_EXEC_JS = true
-    # Maximum concurrent HTTP/2 streams per persistent client. When Fiber.scheduler is available,
-    # clients are reused across requests within the same scheduler, making this limit effective.
-    # Without a scheduler, clients are per-request and this limits streams on that single request.
+    # Maximum concurrent HTTP/2 streams/connections per renderer HTTP client. This is a PER-CLIENT
+    # limit, not a global cap. When a Fiber.scheduler is available (e.g. Falcon), one client is
+    # reused per scheduler. Under plain Puma (no scheduler), non-streaming requests reuse one
+    # persistent client PER Puma request thread and streaming requests use a request-scoped client;
+    # in both cases this bounds concurrency within a single client, so total warm renderer capacity
+    # scales with the number of live Puma request threads, not with this value alone.
     DEFAULT_RENDERER_HTTP_POOL_SIZE = 10
     # TCP connect timeout. Request and response processing are still bounded by ssr_timeout.
     DEFAULT_RENDERER_HTTP_POOL_TIMEOUT = 5
@@ -183,11 +186,16 @@ module ReactOnRailsPro
       @concurrent_component_streaming_buffer_size = value
     end
 
-    # Sets the maximum concurrent HTTP/2 streams per persistent client.
+    # Sets the maximum concurrent HTTP/2 streams/connections per renderer HTTP client.
     #
-    # When Fiber.scheduler is available (e.g., inside Sync {} blocks), HTTP clients are
-    # reused across requests within the same scheduler context, making this limit effective
-    # for connection pooling. Without a scheduler, clients are created per-request.
+    # This is a per-client limit, not a global ceiling on renderer connections.
+    # - With a Fiber.scheduler (e.g. Falcon), one client is reused per scheduler and this limit
+    #   bounds connection concurrency for renders sharing that client.
+    # - Under plain Puma (no scheduler), non-streaming requests reuse one persistent client per
+    #   Puma request thread (keeping a renderer connection warm across requests on that thread),
+    #   and streaming requests use a request-scoped client. In both cases the limit applies within
+    #   a single client, so total warm renderer capacity scales with the number of live Puma
+    #   request threads (workers * threads), not with this value alone.
     #
     # @param value [Integer, nil] A positive integer or nil (uses default)
     # @raise [ReactOnRailsPro::Error] if value is not a positive integer or nil

--- a/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
@@ -56,6 +56,23 @@ module ReactOnRailsPro
       Protocol::HTTP2::StreamError
     ].freeze
 
+    # Dropped-connection errors that a *warm* persistent no-scheduler client
+    # (see PersistentThreadClient) retries ONCE, after rebuilding its async-http client, on a
+    # replay-safe request body. Because that client is built with retries: 0, reusing an HTTP
+    # keep-alive connection that the renderer, a load balancer, or a proxy has since idle-closed
+    # fails hard instead of transparently reconnecting; this set makes that recovery transparent.
+    # Reachability/startup errors (ECONNREFUSED, EHOSTUNREACH, ENETUNREACH, ETIMEDOUT, SocketError)
+    # are intentionally excluded so a genuinely-down renderer still fails fast. HTTP/2 stream resets
+    # (Protocol::HTTP2::StreamError) are also excluded: an RST_STREAM is a request-level abort by the
+    # renderer (possibly mid-response), not a dropped idle connection, so it stays with the outer
+    # request retry loop rather than being transparently replayed here.
+    STALE_KEEPALIVE_RETRY_ERRORS = [
+      IOError, # includes EOFError
+      Errno::ECONNRESET,
+      Errno::EPIPE,
+      Protocol::HTTP::RefusedError
+    ].freeze
+
     # Per-scheduler storage for persistent HTTP clients. When an outer Fiber.scheduler
     # exists BEFORE we enter `Sync {}`, clients are stored on the scheduler object using
     # this instance variable key. This enables connection reuse across requests within
@@ -179,13 +196,16 @@ module ReactOnRailsPro
       ResponseEnvelope = Struct.new(:status, :body, :headers)
 
       def initialize(endpoint:, protocol:, pool_limit:)
+        @endpoint = endpoint
+        @protocol = protocol
+        @pool_limit = pool_limit
         @queue = Queue.new
         @ready = Queue.new
         @pending_results = {}.compare_by_identity
         @pending_results_mutex = Mutex.new
         @closed = false
         @closed_mutex = Mutex.new
-        @thread = Thread.new { run_loop(endpoint:, protocol:, pool_limit:) }
+        @thread = Thread.new { run_loop }
 
         status, payload = @ready.pop
         raise payload if status == :error
@@ -238,13 +258,12 @@ module ReactOnRailsPro
         unregister_pending_result(result) if result
       end
 
-      def run_loop(endpoint:, protocol:, pool_limit:)
+      def run_loop
         client = nil
-        client_closed = false
-        ready = false
+        client_closed = ready = warm = false
 
         Async do
-          client = Async::HTTP::Client.new(endpoint, protocol:, retries: 0, limit: pool_limit)
+          client = build_async_client
           @ready << [:ok, nil]
           ready = true
 
@@ -257,7 +276,7 @@ module ReactOnRailsPro
               break
             end
 
-            handle_request(client, message)
+            client, warm = handle_request(client, message, warm)
           end
         ensure
           client&.close unless client_closed
@@ -267,16 +286,53 @@ module ReactOnRailsPro
         notify_pending_results(worker_thread_exited_error) if ready
       end
 
-      def handle_request(client, message)
-        result = nil
+      def build_async_client
+        Async::HTTP::Client.new(@endpoint, protocol: @protocol, retries: 0, limit: @pool_limit)
+      end
+
+      # Returns [client, warm]. `warm` becomes true only after a request has fully succeeded on
+      # this reactor. A warm client that then hits a dropped-keepalive connection error on a
+      # replay-safe body (nil or a String, never a consumable upload body) is transparently
+      # reconnected and retried ONCE, so a socket idle-closed by the renderer/LB/proxy does not
+      # surface as a render failure. First-contact failures (client not yet warm) and non-replayable
+      # bodies are never retried here, so a genuinely-down renderer still fails fast and consumable
+      # upload bodies are never re-sent after a partial write.
+      def handle_request(client, message, warm)
         _type, method, path, headers, body, result = message
-        raw_response = method == :post ? client.post(path, headers:, body:) : client.get(path, headers:)
+        reconnected = false
+        begin
+          raw_response = method == :post ? client.post(path, headers:, body:) : client.get(path, headers:)
+          result << [:ok, buffer_response(raw_response)]
+          [client, true]
+        rescue *STALE_KEEPALIVE_RETRY_ERRORS => e
+          if retry_stale_connection?(warm, reconnected, body)
+            reconnected = true
+            client = reconnect_async_client(client)
+            retry
+          end
+          result << [:error, e] if result
+          [client, warm]
+        rescue StandardError => e
+          raise unless result
 
-        result << [:ok, buffer_response(raw_response)]
-      rescue StandardError => e
-        raise unless result
+          result << [:error, e]
+          [client, warm]
+        end
+      end
 
-        result << [:error, e]
+      # Retry once only for a warm client (>=1 prior success) whose body is safe to re-send:
+      # nil or a String. A consumable upload body (MultipartBody) would be corrupted after a
+      # partial write, so it is never retried.
+      def retry_stale_connection?(warm, reconnected, body)
+        warm && !reconnected && (body.nil? || body.is_a?(String))
+      end
+
+      def reconnect_async_client(old_client)
+        old_client&.close
+        build_async_client
+      rescue StandardError
+        # Best-effort: closing a poisoned keep-alive client can fail; the fresh client is what matters.
+        build_async_client
       end
 
       def wait_for_close_result(result)

--- a/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
@@ -291,40 +291,56 @@ module ReactOnRailsPro
       end
 
       # Returns [client, warm]. `warm` becomes true only after a request has fully succeeded on
-      # this reactor. A warm client that then hits a dropped-keepalive connection error on a
-      # replay-safe body (nil or a String, never a consumable upload body) is transparently
-      # reconnected and retried ONCE, so a socket idle-closed by the renderer/LB/proxy does not
-      # surface as a render failure. First-contact failures (client not yet warm) and non-replayable
-      # bodies are never retried here, so a genuinely-down renderer still fails fast and consumable
-      # upload bodies are never re-sent after a partial write.
+      # this reactor. A warm client that then hits a dropped-keepalive connection error while
+      # *sending* a replay-safe request (nil or a String body, never a consumable upload body) is
+      # transparently reconnected and retried ONCE, so a socket idle-closed by the renderer/LB/proxy
+      # does not surface as a render failure.
+      #
+      # The retry only covers acquiring the response (`send_request`), NOT reading its body: once the
+      # renderer has returned a response, the render has already executed, so a connection drop while
+      # buffering must surface as a normal error rather than silently re-running the render. Likewise,
+      # first-contact failures (client not yet warm), read timeouts, and non-replayable bodies are
+      # never retried, so a genuinely-down or slow renderer still fails fast.
       def handle_request(client, message, warm)
         _type, method, path, headers, body, result = message
         reconnected = false
         begin
           raw_response = method == :post ? client.post(path, headers:, body:) : client.get(path, headers:)
-          result << [:ok, buffer_response(raw_response)]
-          [client, true]
         rescue *STALE_KEEPALIVE_RETRY_ERRORS => e
-          if retry_stale_connection?(warm, reconnected, body)
+          if retry_stale_connection?(warm, reconnected, e, body)
             reconnected = true
+            # A build failure here is surfaced by the terminal rescue below, so it never kills the worker.
             client = reconnect_async_client(client)
             retry
           end
           result << [:error, e] if result
-          [client, warm]
-        rescue StandardError => e
-          raise unless result
-
-          result << [:error, e]
-          [client, warm]
+          # If we reconnected and still failed, drop `warm` so a sustained renderer outage stops
+          # paying a doomed reconnect+retry on every subsequent request on this thread.
+          return [client, reconnected ? false : warm]
         end
+
+        # Response acquired: a drop while buffering is not retried (see method comment). Non-stale
+        # send errors and buffering failures both fall through to the terminal rescue below. `warm`
+        # is preserved: these paths either already obtained a response (connection was healthy) or
+        # failed before any reconnect. The failed-reconnect case that resets `warm` is handled above;
+        # a reconnect *build* failure (Async::HTTP::Client.new is lazy, so this is effectively
+        # unreachable) also lands here, self-limited by `reconnected` to a single attempt.
+        result << [:ok, buffer_response(raw_response)]
+        [client, true]
+      rescue StandardError => e
+        raise unless result
+
+        result << [:error, e]
+        [client, warm]
       end
 
-      # Retry once only for a warm client (>=1 prior success) whose body is safe to re-send:
-      # nil or a String. A consumable upload body (MultipartBody) would be corrupted after a
-      # partial write, so it is never retried.
-      def retry_stale_connection?(warm, reconnected, body)
-        warm && !reconnected && (body.nil? || body.is_a?(String))
+      # Retry once only for a warm client (>=1 prior success) whose body is safe to re-send: nil or a
+      # String. A read timeout (IO::TimeoutError, a subclass of IOError) is excluded so a slow render
+      # flows to the outer timeout/`renderer_request_retry_limit` handling instead of being replayed
+      # here. A consumable upload body (MultipartBody) is excluded because it cannot be re-sent after
+      # a partial write.
+      def retry_stale_connection?(warm, reconnected, error, body)
+        warm && !reconnected && !error.is_a?(IO::TimeoutError) && (body.nil? || body.is_a?(String))
       end
 
       def reconnect_async_client(old_client)

--- a/react_on_rails_pro/sig/react_on_rails_pro/renderer_http_client.rbs
+++ b/react_on_rails_pro/sig/react_on_rails_pro/renderer_http_client.rbs
@@ -30,6 +30,8 @@ module ReactOnRailsPro
 
     CONNECTION_ERRORS: Array[Class]
 
+    STALE_KEEPALIVE_RETRY_ERRORS: Array[Class]
+
     SCHEDULER_CLIENTS_KEY: Symbol
 
     class ConnectTimeoutWrapper

--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -1399,4 +1399,321 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       expect(yielded_client).to be(fake_client)
     end
   end
+
+  describe "no-scheduler warm-connection scaling (issue #4571)" do
+    # Documents the intended connection math: on the plain-Puma (no Fiber.scheduler) non-streaming
+    # path each request thread gets its OWN persistent client, each built with the full pool_limit.
+    # So warm renderer capacity scales with the Puma thread count and renderer_http_pool_size is a
+    # per-client limit, not a global cap.
+    it "creates one persistent client per thread, each built with the full pool_limit" do
+      thread_count = 4
+      configured_pool_size = 1
+
+      stub_const("ScalingThreadClient", Class.new do
+        def alive? = true
+
+        def close; end
+      end)
+
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+      client = described_class.new(
+        origin: "http://localhost:3800", pool_size: configured_pool_size, connect_timeout: 1, read_timeout: 1
+      )
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+
+      created_pool_limits = Queue.new
+      allow(described_class::PersistentThreadClient).to receive(:new) do |pool_limit:, **|
+        created_pool_limits << pool_limit
+        ScalingThreadClient.new
+      end
+
+      stored = Queue.new
+      release = Queue.new
+      workers = Array.new(thread_count) do
+        Thread.new do
+          client.__send__(:persistent_thread_client)
+          stored << Thread.current
+          release.pop # keep this Puma thread alive so lazy sweeping does not evict its client
+        end
+      end
+
+      signalers = Array.new(thread_count) { Timeout.timeout(5) { stored.pop } }
+      cached = client.instance_variable_get(:@thread_clients)
+      limits = Array.new(thread_count) { created_pool_limits.pop }
+
+      expect(cached.size).to eq(thread_count)
+      expect(cached.values.map(&:object_id).uniq.size).to eq(thread_count)
+      expect(signalers.uniq.size).to eq(thread_count)
+      expect(limits).to all(eq(configured_pool_size))
+    ensure
+      thread_count.times { release << true } if release
+      workers&.each(&:join)
+    end
+  end
+
+  describe "stale keep-alive reconnect (no-scheduler persistent client)" do
+    def stub_persistent_response_classes
+      stub_const(
+        "StaleReconnectBody",
+        Class.new do
+          def initialize(chunks)
+            @chunks = chunks
+          end
+
+          def each(&block)
+            @chunks.each(&block)
+          end
+
+          def close; end
+        end
+      )
+      stub_const("StaleReconnectResponse", Struct.new(:status, :body, :headers))
+      stub_const(
+        "StaleReconnectClient",
+        Class.new do
+          def post(_path, headers:, body:); end
+
+          def get(_path, headers:); end
+
+          def close; end
+        end
+      )
+    end
+
+    def build_client
+      described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+    end
+
+    def ok_response(chunk)
+      StaleReconnectResponse.new(200, StaleReconnectBody.new([chunk]), {})
+    end
+
+    it "transparently reconnects and retries once when a warm client hits a dropped keep-alive connection" do
+      stub_persistent_response_classes
+      first_client = instance_double(StaleReconnectClient)
+      second_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(first_client, second_client)
+      allow(Async::HTTP::Client).to receive(:open).and_raise("ephemeral client should not be used")
+
+      post_calls = 0
+      allow(first_client).to receive(:post) do
+        post_calls += 1
+        raise Errno::ECONNRESET, "connection reset by peer" if post_calls == 2
+
+        ok_response("warm")
+      end
+      allow(first_client).to receive(:close)
+      allow(second_client).to receive(:post).and_return(ok_response("reconnected"))
+      allow(second_client).to receive(:close)
+
+      warmup = client.post("/render", json: { rendering: 1 })
+      retried = client.post("/render", json: { rendering: 2 })
+      followup = client.post("/render", json: { rendering: 3 })
+
+      expect(warmup.body).to eq("warm")
+      expect(retried.body).to eq("reconnected")
+      expect(followup.body).to eq("reconnected")
+      expect(Async::HTTP::Client).to have_received(:new).twice
+      expect(first_client).to have_received(:close).at_least(:once)
+      expect(second_client).to have_received(:post).twice
+    ensure
+      client&.close
+    end
+
+    it "does not retry a connection error on a client that has not completed a request yet" do
+      stub_persistent_response_classes
+      only_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(only_client)
+      allow(only_client).to receive(:post).and_raise(Errno::ECONNRESET, "connection reset by peer")
+      allow(only_client).to receive(:close)
+
+      expect { client.post("/render", json: { rendering: 1 }) }.to raise_error(described_class::ConnectionError)
+      expect(Async::HTTP::Client).to have_received(:new).once
+      expect(only_client).to have_received(:post).once
+    ensure
+      client&.close
+    end
+
+    it "does not retry a non-replayable (multipart upload) body even on a warm client" do
+      stub_persistent_response_classes
+      only_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(only_client)
+      allow(only_client).to receive(:close)
+
+      post_calls = 0
+      allow(only_client).to receive(:post) do
+        post_calls += 1
+        raise Errno::ECONNRESET, "connection reset by peer" if post_calls == 2
+
+        ok_response("warm")
+      end
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+      upload_form = { "asset" => { body: "console.log(1)", filename: "a.js", content_type: "application/javascript" } }
+
+      expect { client.post("/upload-assets", form: upload_form) }.to raise_error(described_class::ConnectionError)
+      expect(Async::HTTP::Client).to have_received(:new).once # no reconnect for a consumable body
+      expect(only_client).to have_received(:post).twice
+    ensure
+      client&.close
+    end
+
+    it "surfaces the error without a second retry when the reconnected client also drops" do
+      stub_persistent_response_classes
+      first_client = instance_double(StaleReconnectClient)
+      second_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(first_client, second_client)
+
+      post_calls = 0
+      allow(first_client).to receive(:post) do
+        post_calls += 1
+        raise Errno::ECONNRESET, "connection reset by peer" if post_calls == 2
+
+        ok_response("warm")
+      end
+      allow(first_client).to receive(:close)
+      allow(second_client).to receive(:post).and_raise(Errno::ECONNRESET, "connection reset by peer")
+      allow(second_client).to receive(:close)
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+
+      expect { client.post("/render", json: { rendering: 2 }) }.to raise_error(described_class::ConnectionError)
+      expect(Async::HTTP::Client).to have_received(:new).twice # exactly one reconnect
+      expect(second_client).to have_received(:post).once
+    ensure
+      client&.close
+    end
+
+    it "does not retry a reachability error (connection refused) even on a warm client" do
+      stub_persistent_response_classes
+      only_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(only_client)
+      allow(only_client).to receive(:close)
+
+      post_calls = 0
+      allow(only_client).to receive(:post) do
+        post_calls += 1
+        raise Errno::ECONNREFUSED, "connection refused" if post_calls == 2
+
+        ok_response("warm")
+      end
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+
+      expect { client.post("/render", json: { rendering: 2 }) }.to raise_error(described_class::ConnectionError)
+      expect(Async::HTTP::Client).to have_received(:new).once # ECONNREFUSED is excluded from retry
+      expect(only_client).to have_received(:post).twice
+    ensure
+      client&.close
+    end
+
+    it "does not retry an HTTP/2 stream reset (request-level abort) even on a warm client" do
+      stub_persistent_response_classes
+      only_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(only_client)
+      allow(only_client).to receive(:close)
+
+      post_calls = 0
+      allow(only_client).to receive(:post) do
+        post_calls += 1
+        raise Protocol::HTTP2::StreamError, "stream reset" if post_calls == 2
+
+        ok_response("warm")
+      end
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+
+      expect { client.post("/render", json: { rendering: 2 }) }.to raise_error(described_class::ConnectionError)
+      expect(Async::HTTP::Client).to have_received(:new).once # StreamError is excluded from the reconnect retry
+      expect(only_client).to have_received(:post).twice
+    ensure
+      client&.close
+    end
+
+    it "reconnects and retries a warm GET whose connection was refused after prior success" do
+      stub_persistent_response_classes
+      first_client = instance_double(StaleReconnectClient)
+      second_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(first_client, second_client)
+
+      get_calls = 0
+      allow(first_client).to receive(:get) do
+        get_calls += 1
+        raise Protocol::HTTP::RefusedError, "connection refused before processing" if get_calls == 2
+
+        ok_response("warm")
+      end
+      allow(first_client).to receive(:close)
+      allow(second_client).to receive(:get).and_return(ok_response("reconnected"))
+      allow(second_client).to receive(:close)
+
+      client.get("/asset-exists") # warm the client (nil body)
+      retried = client.get("/asset-exists")
+
+      expect(retried.body).to eq("reconnected")
+      expect(Async::HTTP::Client).to have_received(:new).twice
+      expect(second_client).to have_received(:get).once
+    ensure
+      client&.close
+    end
+
+    it "still reconnects and succeeds when closing the poisoned client raises" do
+      stub_persistent_response_classes
+      first_client = instance_double(StaleReconnectClient)
+      second_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(first_client, second_client)
+
+      post_calls = 0
+      allow(first_client).to receive(:post) do
+        post_calls += 1
+        raise Errno::ECONNRESET, "connection reset by peer" if post_calls == 2
+
+        ok_response("warm")
+      end
+      allow(first_client).to receive(:close).and_raise(IOError, "already closed")
+      allow(second_client).to receive(:post).and_return(ok_response("reconnected"))
+      allow(second_client).to receive(:close)
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+      retried = client.post("/render", json: { rendering: 2 })
+
+      expect(retried.body).to eq("reconnected")
+      expect(Async::HTTP::Client).to have_received(:new).twice
+      expect(second_client).to have_received(:post).once
+    ensure
+      client&.close
+    end
+  end
 end

--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -1715,5 +1715,134 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
     ensure
       client&.close
     end
+
+    it "does not retry when the connection drops while reading the response body" do
+      stub_persistent_response_classes
+      # A body that raises a connection error mid-drain models a drop AFTER the renderer already
+      # returned a response and executed the render; replaying it would double-execute the render.
+      dropping_body = Object.new
+      def dropping_body.each
+        raise Errno::ECONNRESET, "connection reset while streaming the response body"
+      end
+
+      def dropping_body.close; end
+      only_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(only_client)
+      allow(only_client).to receive(:close)
+
+      post_calls = 0
+      allow(only_client).to receive(:post) do
+        post_calls += 1
+        post_calls == 1 ? ok_response("warm") : StaleReconnectResponse.new(200, dropping_body, {})
+      end
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+
+      expect { client.post("/render", json: { rendering: 2 }) }.to raise_error(described_class::ConnectionError)
+      expect(Async::HTTP::Client).to have_received(:new).once # no reconnect: the render already ran
+      expect(only_client).to have_received(:post).twice
+    ensure
+      client&.close
+    end
+
+    it "does not retry a read timeout (IO::TimeoutError) on a warm client" do
+      stub_persistent_response_classes
+      only_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(only_client)
+      allow(only_client).to receive(:close)
+
+      post_calls = 0
+      allow(only_client).to receive(:post) do
+        post_calls += 1
+        raise IO::TimeoutError, "read timed out" if post_calls == 2
+
+        ok_response("warm")
+      end
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+
+      expect { client.post("/render", json: { rendering: 2 }) }.to raise_error(described_class::TimeoutError)
+      expect(Async::HTTP::Client).to have_received(:new).once # timeouts flow to the outer retry loop, not here
+      expect(only_client).to have_received(:post).twice
+    ensure
+      client&.close
+    end
+
+    it "stops auto-retrying on later requests after a reconnect attempt itself fails" do
+      stub_persistent_response_classes
+      first_client = instance_double(StaleReconnectClient)
+      second_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(first_client, second_client)
+      allow(first_client).to receive(:close)
+      allow(second_client).to receive(:close)
+
+      first_calls = 0
+      allow(first_client).to receive(:post) do
+        first_calls += 1
+        raise Errno::ECONNRESET, "connection reset by peer" if first_calls >= 2
+
+        ok_response("warm")
+      end
+      allow(second_client).to receive(:post).and_raise(Errno::ECONNRESET, "connection reset by peer")
+
+      client.post("/render", json: { rendering: 1 }) # warm the client on first_client
+
+      # Request 2: first_client drops -> reconnect to second_client -> also drops -> fail, warm reset.
+      expect { client.post("/render", json: { rendering: 2 }) }.to raise_error(described_class::ConnectionError)
+      # Request 3: client is no longer warm, so it fails fast with no further reconnect.
+      expect { client.post("/render", json: { rendering: 3 }) }.to raise_error(described_class::ConnectionError)
+
+      expect(Async::HTTP::Client).to have_received(:new).twice # initial + exactly one reconnect, none on req 3
+      expect(second_client).to have_received(:post).twice # req 2 retry + req 3, no reconnect between them
+    ensure
+      client&.close
+    end
+
+    it "surfaces the error without killing the worker when rebuilding the client during reconnect fails" do
+      stub_persistent_response_classes
+      first_client = instance_double(StaleReconnectClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = build_client
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+
+      new_calls = 0
+      allow(Async::HTTP::Client).to receive(:new) do
+        new_calls += 1
+        raise SocketError, "getaddrinfo failed" if new_calls >= 2 # the reconnect rebuild fails
+
+        first_client
+      end
+      allow(first_client).to receive(:close)
+
+      posts = 0
+      allow(first_client).to receive(:post) do
+        posts += 1
+        raise Errno::ECONNRESET, "connection reset by peer" if posts >= 2
+
+        ok_response("warm")
+      end
+
+      client.post("/render", json: { rendering: 1 }) # warm the client
+
+      # The reconnect rebuild raises: it surfaces as a ConnectionError instead of killing the worker...
+      expect { client.post("/render", json: { rendering: 2 }) }.to raise_error(described_class::ConnectionError)
+      # ...so a follow-up request still returns a deterministic error rather than hanging on a dead worker.
+      expect { client.post("/render", json: { rendering: 3 }) }.to raise_error(described_class::ConnectionError)
+    ensure
+      client&.close
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the reliability + documentation regression [#4571](https://github.com/shakacode/react_on_rails/issues/4571) introduced by PR #4394.

PR #4394 changed the plain-Puma (no `Fiber.scheduler`) **non-streaming** renderer path from connect-per-request to a **persistent async-http client per Puma request thread**, keeping a renderer connection warm across requests on that thread. Two consequences:

1. **New hard-fail on stale keep-alive.** Each persistent client is built with `retries: 0`, so reusing a keep-alive connection the renderer, a load balancer, or a proxy has since idle-closed fails hard (ECONNRESET/EPIPE/EOF) instead of transparently reconnecting. The old connect-per-request path never hit this.
2. **`renderer_http_pool_size` is now a per-client, not global, cap** — total warm renderer capacity scales with the number of live Puma request threads. The config docs still described the no-scheduler path as "per-request".

## Fix (minimal, no new config)

- **Stale keep-alive reconnect.** `PersistentThreadClient` now transparently reconnects and retries a request **once** when a **warm** client (≥1 prior success) hits a dropped-connection error on a **replay-safe** body (`nil` or `String`). Guards keep it surgical:
  - **First-contact** failures are not retried — a genuinely-down renderer still fails fast.
  - **Consumable upload bodies** (`MultipartBody`) are never retried — they can't be re-sent after a partial write.
  - **Reachability/startup errors** (`ECONNREFUSED`/`EHOSTUNREACH`/`ENETUNREACH`/`ETIMEDOUT`/`SocketError`) and **HTTP/2 stream resets** (`Protocol::HTTP2::StreamError`, a request-level abort) are excluded from the reconnect path and continue to flow to the existing `renderer_request_retry_limit` loop unchanged.
  - New `STALE_KEEPALIVE_RETRY_ERRORS` set scopes the retry to `IOError`/`EOFError`, `ECONNRESET`, `EPIPE`, and `Protocol::HTTP::RefusedError`.
- **Docs.** Corrected `renderer_http_pool_size` docs (constant + setter, `configuration-pro.md`, `updating.md`) to describe the per-thread persistent client and clarify that total warm renderer capacity scales with live Puma request threads, not with the pool size alone. CHANGELOG entry added.

### Scope decision: global cap is doc-only

#4571 suggested bounding total warm connections independent of thread count. This PR intentionally handles that as **documentation** rather than new config. A cross-thread cap would either be a no-op default or an arbitrary new public config contract with a silent ephemeral-fallback policy — additional surface and risk not warranted for a regression fix. (async-http clients/connections are reactor/thread-bound, which is why per-thread clients exist in the first place.)

## Testing

`cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/renderer_http_client_spec.rb` — **70 examples, 0 failures** (10 new).

Transport suite (`renderer_http_client_spec`, `request_spec`, `stream_request_spec`, `stream_spec`) — **184 examples, 0 failures, 1 pending** (pre-existing).

New specs:
- Regression spec documenting the per-thread scaling (N threads → N clients, each with the full `pool_limit`).
- Reconnect specs: warm reconnect + follow-up on rebuilt client; warm GET (nil body) reconnect; **not-warm** first-contact no-retry; **non-replayable** multipart upload no-retry; second-drop no-infinite-retry; close-failure recovery; `ECONNREFUSED` excluded; `StreamError` excluded.

Also: `bundle exec rubocop ... --ignore-parent-exclusion` clean, `bundle exec rake rbs:validate` passes, `git diff --check` clean, Prettier clean on changed docs.

## Process

Developed with Codex (gpt-5.5, xhigh) as peer reviewer at each step — reproduce, investigate, plan, implement, review, test — with agreement reached before advancing each step.

Fixes #4571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Renderer requests now transparently recover from certain stale keep-alive idle-close failures by reconnecting and retrying once, only for eligible dropped-connection errors that occur before the renderer returns a response (not during response-body reading).
  * Automatic retries remain disabled for non-replayable bodies (e.g., multipart uploads) and for existing excluded connection/HTTP2 failure categories; errors are surfaced as before.

* **Documentation**
  * Clarified `renderer_http_pool_size` as a per-client limit, how warm capacity scales with active Puma threads, and updated retry expectations for upgrades and streaming vs non-streaming behavior.

* **Tests**
  * Added/expanded coverage for keep-alive reconnect/retry semantics and pool-per-thread behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->