### PR TITLE
Switch CI benchmarks to relative continuous benchmarking

### DIFF
--- a/.github/actions/benchmark-suite-phase/action.yml
+++ b/.github/actions/benchmark-suite-phase/action.yml
@@ -9,9 +9,16 @@ description: >
   shared GitHub-hosted runners (#4071).
 
   Assumes the job already ran the ref-independent setup: Bencher CLI, k6/vegeta,
-  Ruby + foreman, pnpm, Node, and the "Configure benchmark commands" step (SERVER_CMD /
-  BENCH_CMD / WEB_CONCURRENCY). Everything ref-dependent happens here, per phase:
-  checkout + clean, JS install/build, gems, packs, assets, DB seed, server, benchmark.
+  Ruby + foreman, pnpm, Node, the "Configure benchmark commands" step (SERVER_CMD /
+  BENCH_CMD / WEB_CONCURRENCY), and the "Stash head benchmark harness" step.
+  Everything ref-dependent happens here, per phase: checkout + clean, JS
+  install/build, gems, packs, assets, DB seed, server, benchmark.
+
+  The bench script runs from harness-dir (the HEAD ref's stashed benchmarks/), NOT
+  from the phase's checkout: the harness is the measuring instrument, and both
+  phases must be measured with the same one or a harness change would masquerade
+  as a base-vs-head performance delta. App-side inputs still come from the phase's
+  checkout.
 
   Invariant for callers: invoke this action only while the HEAD ref is checked out
   (restore it between invocations). GitHub resolves `uses: ./...` from the workspace at
@@ -48,7 +55,15 @@ inputs:
     description: Whether to generate file-system based entrypoints (matrix row generate_packs).
     required: true
   benchmark-script:
-    description: The bench script to execute (matrix row benchmark_script).
+    description: >-
+      The bench script to execute (matrix row benchmark_script), as a benchmarks/-
+      prefixed repo path; resolved inside harness-dir, never the phase's checkout.
+    required: true
+  harness-dir:
+    description: >-
+      Directory holding the HEAD ref's stashed benchmarks/ tree (outside the
+      workspace). Both phases execute the bench script from here so one instrument
+      measures both refs.
     required: true
   benchmark-timeout-minutes:
     description: Timeout for the benchmark execution (matrix row benchmark_timeout_minutes).
@@ -263,20 +278,34 @@ runs:
       env:
         BENCHMARK_SCRIPT_INPUT: ${{ inputs.benchmark-script }}
         BENCHMARK_TIMEOUT_MINUTES: ${{ inputs.benchmark-timeout-minutes }}
+        HARNESS_DIR: ${{ inputs.harness-dir }}
         PRO_ENV_INPUT: ${{ inputs.pro-env }}
         SUITE_NAME_INPUT: ${{ inputs.suite-name }}
       run: |
         set -e
         echo "🏃 Running $SUITE_NAME_INPUT benchmark suite..."
 
+        # Run the HEAD ref's copy of the bench script (see harness-dir input): the
+        # phase's checked-out benchmarks/ tree is never executed, so both phases
+        # are measured with one instrument.
+        if [ "${BENCHMARK_SCRIPT_INPUT#benchmarks/}" = "$BENCHMARK_SCRIPT_INPUT" ]; then
+          echo "::error::benchmark-script '$BENCHMARK_SCRIPT_INPUT' is not under benchmarks/; cannot resolve it in the stashed harness"
+          exit 1
+        fi
+        harness_script="$HARNESS_DIR/${BENCHMARK_SCRIPT_INPUT#benchmarks/}"
+        if [ ! -f "$harness_script" ]; then
+          echo "::error::Stashed harness script $harness_script not found; did the 'Stash head benchmark harness' step run?"
+          exit 1
+        fi
+
         # `timeout` replaces the step-level timeout-minutes the pre-composite workflow
         # used (composite action steps don't support timeout-minutes).
         if [ "$PRO_ENV_INPUT" = "true" ]; then
-          if ! PRO=true timeout "${BENCHMARK_TIMEOUT_MINUTES}m" $BENCH_CMD "$BENCHMARK_SCRIPT_INPUT"; then
+          if ! PRO=true timeout "${BENCHMARK_TIMEOUT_MINUTES}m" $BENCH_CMD "$harness_script"; then
             echo "❌ ERROR: Benchmark execution failed"
             exit 1
           fi
-        elif ! timeout "${BENCHMARK_TIMEOUT_MINUTES}m" $BENCH_CMD "$BENCHMARK_SCRIPT_INPUT"; then
+        elif ! timeout "${BENCHMARK_TIMEOUT_MINUTES}m" $BENCH_CMD "$harness_script"; then
           echo "❌ ERROR: Benchmark execution failed"
           exit 1
         fi

--- a/.github/actions/benchmark-suite-phase/action.yml
+++ b/.github/actions/benchmark-suite-phase/action.yml
@@ -1,0 +1,383 @@
+name: Benchmark suite phase
+description: >
+  Builds and benchmarks ONE ref of one benchmark suite/shard, entirely on the current
+  runner. Invoked twice per benchmark job for relative continuous benchmarking (#3492,
+  https://bencher.dev/docs/how-to/track-benchmarks/#relative-continuous-benchmarking):
+  first with the comparison base ref (results stashed outside the workspace), then with
+  the head ref. Measuring both refs on the SAME runner is the whole point — it removes
+  the cross-runner variance that made the old statistical baseline noise-dominated on
+  shared GitHub-hosted runners (#4071).
+
+  Assumes the job already ran the ref-independent setup: Bencher CLI, k6/vegeta,
+  Ruby + foreman, pnpm, Node, and the "Configure benchmark commands" step (SERVER_CMD /
+  BENCH_CMD / WEB_CONCURRENCY). Everything ref-dependent happens here, per phase:
+  checkout + clean, JS install/build, gems, packs, assets, DB seed, server, benchmark.
+
+  Invariant for callers: invoke this action only while the HEAD ref is checked out
+  (restore it between invocations). GitHub resolves `uses: ./...` from the workspace at
+  step start, so invoking it while the BASE ref is checked out would silently run the
+  base ref's (possibly older or missing) copy of this file. Nested local actions
+  (setup-bundle/setup-ruby) are resolved while the phase's ref is checked out — that ref
+  builds itself with its own setup definitions, which is exactly what a fair comparison
+  wants.
+
+inputs:
+  ref:
+    description: Commit SHA (or ref) to build and benchmark.
+    required: true
+  phase:
+    description: Phase label, "base" or "head" (log/step labelling only).
+    required: true
+  results-dir:
+    description: >
+      Where bench_results/ is moved after the run. Pass a path OUTSIDE the workspace for
+      the base phase (the head phase git-cleans the workspace). "bench_results" leaves
+      the results in place.
+    required: false
+    default: bench_results
+  app-directory:
+    description: The benchmarked dummy app directory (matrix row app_directory).
+    required: true
+  server-kind:
+    description: rails or node-renderer (matrix row server_kind).
+    required: true
+  pro-env:
+    description: Whether the suite runs with PRO=true (matrix row pro_env).
+    required: true
+  generate-packs:
+    description: Whether to generate file-system based entrypoints (matrix row generate_packs).
+    required: true
+  benchmark-script:
+    description: The bench script to execute (matrix row benchmark_script).
+    required: true
+  benchmark-timeout-minutes:
+    description: Timeout for the benchmark execution (matrix row benchmark_timeout_minutes).
+    required: true
+  suite-name:
+    description: Human-readable suite name (matrix row suite_name).
+    required: true
+  summary-file:
+    description: The summary table file the bench script writes (matrix row summary_file).
+    required: true
+  summary-title:
+    description: Title for the printed summary (matrix row summary_title).
+    required: true
+  ruby-version:
+    description: Ruby version for the benchmarked app's bundle.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check out ${{ inputs.phase }} ref
+      shell: bash
+      env:
+        REF: ${{ inputs.ref }}
+        PHASE: ${{ inputs.phase }}
+      run: |
+        set -euo pipefail
+        if ! git cat-file -e "${REF}^{commit}" 2>/dev/null; then
+          echo "Fetching $REF..."
+          git fetch --no-tags --depth=1 origin "$REF"
+        fi
+        git checkout --force "$REF"
+        # Drop every gitignored build output left by the previous phase (webpack
+        # bundles, generated packs, sqlite DBs, bench_results, bundler path config) so
+        # this phase builds and measures only its own ref. node_modules survives the
+        # clean: `pnpm install --frozen-lockfile` below syncs it to this ref's lockfile
+        # far faster than a cold install, with identical results.
+        git clean -ffdx -e node_modules
+        echo "Benchmarking ($PHASE): $(git log -1 --oneline --no-decorate)"
+
+    - name: Install Node modules with pnpm (${{ inputs.phase }})
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Build workspace packages (${{ inputs.phase }})
+      shell: bash
+      run: pnpm run build
+
+    - name: Install Ruby Gems for the benchmarked app (${{ inputs.phase }})
+      uses: ./.github/actions/setup-bundle
+      with:
+        working-directory: ${{ inputs.app-directory }}
+        ruby-version: ${{ inputs.ruby-version }}
+        install-libyaml: 'false'
+
+    - name: Generate file-system based entrypoints for Pro (${{ inputs.phase }})
+      if: inputs.generate-packs == 'true'
+      shell: bash
+      working-directory: ${{ inputs.app-directory }}
+      run: bundle exec rake react_on_rails:generate_packs
+
+    - name: Prepare production assets (${{ inputs.phase }})
+      shell: bash
+      working-directory: ${{ inputs.app-directory }}
+      env:
+        SUITE_NAME_INPUT: ${{ inputs.suite-name }}
+      run: |
+        set -e
+        echo "🔨 Building $SUITE_NAME_INPUT production assets..."
+
+        if ! bin/prod-assets; then
+          echo "❌ ERROR: Failed to build production assets"
+          exit 1
+        fi
+
+        echo "✅ Production assets built successfully"
+
+    - name: Prepare and seed benchmark database (${{ inputs.phase }})
+      # The Pro Rails suite serves DB-backed routes (e.g. /posts_page). Without
+      # a migrated + seeded database those routes 500 on every request (the
+      # `posts` table does not exist), so the benchmark must create and seed it
+      # before the server starts. The phase checkout git-cleans any previous
+      # phase's database, so `db:prepare` always creates this phase's database
+      # fresh, loads the schema, and — because the database is newly created —
+      # runs db/seeds.rb (deterministic and faker-free so it works under
+      # RAILS_ENV=production). The row-count check below fails the job loudly if
+      # seeding was skipped (an empty table would otherwise serve a 200 "No posts
+      # found" payload that the benchmark scores as healthy).
+      if: inputs.server-kind == 'rails' && inputs.pro-env == 'true'
+      shell: bash
+      working-directory: ${{ inputs.app-directory }}
+      env:
+        RAILS_ENV: production
+        SUITE_NAME_INPUT: ${{ inputs.suite-name }}
+      run: |
+        set -euo pipefail
+        echo "🌱 Preparing and seeding $SUITE_NAME_INPUT benchmark database..."
+        bundle exec rails db:prepare
+        # Guard every table `/posts_page` reads (posts, plus the users and
+        # comments it joins), not just posts: a partial seed would otherwise
+        # let the route 500 (or render an empty page) while the job stayed
+        # green.
+        bundle exec rails runner - <<'RUBY'
+        counts = {
+          posts: Post.count,
+          users: User.count,
+          comments: Comment.count
+        }
+
+        empty_tables = counts.select { |_, count| count.zero? }.keys
+        if empty_tables.any?
+          abort(
+            "Benchmark DB seeding incomplete after db:prepare " \
+            "(empty: #{empty_tables.join(', ')}); seeds did not run"
+          )
+        end
+
+        puts "✅ Database seeded (#{counts.map { |table, count| "#{count} #{table}" }.join(', ')})"
+        RUBY
+
+    - name: Start Pro node renderer (${{ inputs.phase }})
+      if: inputs.server-kind == 'node-renderer'
+      shell: bash
+      working-directory: ${{ inputs.app-directory }}
+      env:
+        RAILS_ENV: production
+        NODE_ENV: production
+        RENDERER_LOG_LEVEL: error
+        RENDERER_PORT: 3800
+        PHASE: ${{ inputs.phase }}
+        SUITE_NAME_INPUT: ${{ inputs.suite-name }}
+      run: |
+        set -e
+        echo "🔧 Pre-seeding node renderer bundle cache..."
+        bundle exec rake react_on_rails_pro:pre_seed_renderer_cache MODE=symlink
+
+        echo "🚀 Starting $SUITE_NAME_INPUT node renderer ($PHASE)..."
+        renderer_log="${RUNNER_TEMP:-$PWD}/node-renderer-${PHASE}.log"
+        echo "TARGET_LOG=$renderer_log" >> "$GITHUB_ENV"
+        # setsid: own process group, so the stop step can terminate the whole tree.
+        setsid node renderer/node-renderer.js > "$renderer_log" 2>&1 &
+        renderer_pid=$!
+        # Persist the PID so "Execute benchmark suite" can confirm the renderer
+        # survived the run; a backgrounded child under `set -e` does not
+        # propagate its failure to the step.
+        echo "TARGET_PID=$renderer_pid" >> "$GITHUB_ENV"
+        echo "Node renderer started in background (PID $renderer_pid)"
+
+        echo "⏳ Waiting for node renderer to be ready..."
+        for i in {1..30}; do
+          # Fail fast if the renderer bound the port and then crashed, instead
+          # of looping until the timeout (or racing a dead/restarting target).
+          if ! kill -0 "$renderer_pid" 2>/dev/null; then
+            echo "::error::Node renderer (PID $renderer_pid) exited during startup"
+            cat "$renderer_log" || true
+            exit 1
+          fi
+          if ruby -e "require 'socket'; TCPSocket.new('localhost', 3800).close" 2>/dev/null; then
+            echo "✅ Node renderer is ready and listening (PID $renderer_pid)"
+            exit 0
+          fi
+          echo "  Attempt $i/30: Node renderer not ready yet..."
+          sleep 1
+        done
+
+        echo "::error::Node renderer failed to start within 30 seconds"
+        cat "$renderer_log" || true
+        exit 1
+
+    - name: Start Rails production server (${{ inputs.phase }})
+      if: inputs.server-kind == 'rails'
+      shell: bash
+      working-directory: ${{ inputs.app-directory }}
+      env:
+        SUITE_NAME_INPUT: ${{ inputs.suite-name }}
+      run: |
+        set -e
+        echo "🚀 Starting $SUITE_NAME_INPUT production server..."
+        # setsid: own process group. bin/prod runs `rails server` as a child (core) or
+        # foreman managing rails + node-renderer (pro), so the stop step must be able
+        # to TERM the whole group — killing the wrapper alone would orphan the server
+        # into the next phase and leave port 3001 occupied.
+        setsid $SERVER_CMD &
+        server_pid=$!
+        # Persist the PID so "Execute benchmark suite" can confirm the server
+        # survived the run; a backgrounded child under `set -e` does not
+        # propagate its failure to the step.
+        echo "TARGET_PID=$server_pid" >> "$GITHUB_ENV"
+        echo "Server started in background (PID $server_pid)"
+
+        echo "⏳ Waiting for server to be ready..."
+        for i in {1..30}; do
+          # Fail fast if the server bound the port and then crashed, instead of
+          # looping until the timeout (or racing a dead/restarting target).
+          if ! kill -0 "$server_pid" 2>/dev/null; then
+            echo "::error::Server (PID $server_pid) exited during startup"
+            exit 1
+          fi
+          if curl -fsS http://localhost:3001 > /dev/null; then
+            echo "✅ Server is ready and responding (PID $server_pid)"
+            exit 0
+          fi
+          echo "  Attempt $i/30: Server not ready yet..."
+          sleep 1
+        done
+
+        echo "::error::Server failed to start within 30 seconds"
+        exit 1
+
+    - name: Execute benchmark suite (${{ inputs.phase }})
+      shell: bash
+      env:
+        BENCHMARK_SCRIPT_INPUT: ${{ inputs.benchmark-script }}
+        BENCHMARK_TIMEOUT_MINUTES: ${{ inputs.benchmark-timeout-minutes }}
+        PRO_ENV_INPUT: ${{ inputs.pro-env }}
+        SUITE_NAME_INPUT: ${{ inputs.suite-name }}
+      run: |
+        set -e
+        echo "🏃 Running $SUITE_NAME_INPUT benchmark suite..."
+
+        # `timeout` replaces the step-level timeout-minutes the pre-composite workflow
+        # used (composite action steps don't support timeout-minutes).
+        if [ "$PRO_ENV_INPUT" = "true" ]; then
+          if ! PRO=true timeout "${BENCHMARK_TIMEOUT_MINUTES}m" $BENCH_CMD "$BENCHMARK_SCRIPT_INPUT"; then
+            echo "❌ ERROR: Benchmark execution failed"
+            exit 1
+          fi
+        elif ! timeout "${BENCHMARK_TIMEOUT_MINUTES}m" $BENCH_CMD "$BENCHMARK_SCRIPT_INPUT"; then
+          echo "❌ ERROR: Benchmark execution failed"
+          exit 1
+        fi
+
+        # The benchmark target was backgrounded in a prior step, so `set -e`
+        # never saw it crash. Confirm it survived the whole run: a mid-run
+        # death means the metrics were measured against a dead/restarting
+        # target and must not ship to Bencher, so fail the job.
+        if [ -z "$TARGET_PID" ]; then
+          echo "::error::TARGET_PID is unset; cannot verify the benchmark target stayed alive"
+          exit 1
+        fi
+        if ! kill -0 "$TARGET_PID" 2>/dev/null; then
+          echo "::error::Benchmark target (PID $TARGET_PID) died during the benchmark run; metrics are unreliable"
+          exit 1
+        fi
+        if [ -n "${TARGET_LOG:-}" ] && [ -f "$TARGET_LOG" ]; then
+          if grep -q "died UNEXPECTEDLY" "$TARGET_LOG"; then
+            echo "::error::Benchmark target logged an unexpected worker restart; metrics are unreliable"
+            grep -n "died UNEXPECTEDLY" "$TARGET_LOG" || true
+            exit 1
+          fi
+        fi
+
+        echo "✅ Benchmark suite completed successfully"
+
+    - name: Stop benchmark target (${{ inputs.phase }})
+      shell: bash
+      env:
+        SERVER_KIND_INPUT: ${{ inputs.server-kind }}
+      run: |
+        set -uo pipefail
+        if [ -z "${TARGET_PID:-}" ]; then
+          echo "No benchmark target PID recorded; nothing to stop"
+          exit 0
+        fi
+
+        echo "🛑 Stopping benchmark target (PID $TARGET_PID and its process group)..."
+        # The target was started with setsid, so -PID addresses its whole process
+        # group (rails/foreman children included). Fall back to the bare PID if the
+        # group is already gone.
+        kill -TERM -- "-$TARGET_PID" 2>/dev/null || kill -TERM "$TARGET_PID" 2>/dev/null || true
+        for _ in {1..15}; do
+          kill -0 "$TARGET_PID" 2>/dev/null || break
+          sleep 1
+        done
+        if kill -0 "$TARGET_PID" 2>/dev/null; then
+          echo "Target did not exit after TERM; escalating to KILL"
+          kill -KILL -- "-$TARGET_PID" 2>/dev/null || kill -KILL "$TARGET_PID" 2>/dev/null || true
+        fi
+
+        # The next phase's server must be able to bind immediately; a lingering
+        # listener would make its startup probe pass against THIS phase's server and
+        # benchmark the wrong ref.
+        if [ "$SERVER_KIND_INPUT" = "node-renderer" ]; then port=3800; else port=3001; fi
+        for _ in {1..30}; do
+          if ! ruby -e "require 'socket'; TCPSocket.new('localhost', $port).close" 2>/dev/null; then
+            echo "✅ Benchmark target stopped; port $port is free"
+            # Clear the hand-off vars so the next phase can never validate against
+            # this phase's dead PID/log.
+            { echo "TARGET_PID="; echo "TARGET_LOG="; } >> "$GITHUB_ENV"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::Port $port is still in use after stopping the benchmark target"
+        exit 1
+
+    - name: Validate and stash benchmark results (${{ inputs.phase }})
+      shell: bash
+      env:
+        PHASE: ${{ inputs.phase }}
+        RESULTS_DIR: ${{ inputs.results-dir }}
+        SUMMARY_FILE_INPUT: ${{ inputs.summary-file }}
+        SUMMARY_TITLE_INPUT: ${{ inputs.summary-title }}
+        SUITE_NAME_INPUT: ${{ inputs.suite-name }}
+      run: |
+        set -euo pipefail
+        echo "🔍 Validating $SUITE_NAME_INPUT ($PHASE) benchmark results..."
+
+        if [ ! -f "$SUMMARY_FILE_INPUT" ]; then
+          echo "❌ ERROR: benchmark summary file not found"
+          exit 1
+        fi
+        echo "📊 $SUMMARY_TITLE_INPUT ($PHASE):"
+        column -t -s $'\t' "$SUMMARY_FILE_INPUT"
+        echo ""
+
+        if [ ! -f "bench_results/benchmark.json" ]; then
+          echo "❌ ERROR: benchmark JSON file not found"
+          exit 1
+        fi
+
+        echo "✅ Benchmark results validated"
+        echo ""
+        echo "Generated files:"
+        ls -lh bench_results/
+
+        if [ "$RESULTS_DIR" != "bench_results" ]; then
+          rm -rf "$RESULTS_DIR"
+          mkdir -p "$(dirname "$RESULTS_DIR")"
+          mv bench_results "$RESULTS_DIR"
+          echo "Stashed bench_results/ -> $RESULTS_DIR"
+        fi

--- a/.github/workflows/benchmark-suite.yml
+++ b/.github/workflows/benchmark-suite.yml
@@ -1,15 +1,40 @@
 name: Benchmark Suite (reusable)
 
-# Runs one manually requested hosted benchmark suite/shard end to end and tracks it with
-# Bencher. Automatic push/PR benchmark selection and fresh-runner confirmation jobs are
-# intentionally disabled because GitHub-hosted runners are too noisy for trusted trends.
-# The whole matrix row from benchmarks/generate_matrix.rb is passed as a JSON string and
-# unpacked into job-level env once.
+# Runs one benchmark suite/shard end to end and tracks it with Bencher using RELATIVE
+# continuous benchmarking (#3492,
+# https://bencher.dev/docs/how-to/track-benchmarks/#relative-continuous-benchmarking):
+# the job builds and benchmarks the comparison BASE ref first, then the HEAD ref, on
+# the SAME runner (the benchmark-suite-phase composite action, invoked twice), and
+# track_benchmarks.rb submits the pair to Bencher — base results as a throwaway per-run
+# baseline branch, head results compared against it with percentage thresholds. The
+# side-by-side run replaces the old statistical baseline built from main's history
+# across runners, whose cross-runner variance was noise-dominated on shared
+# GitHub-hosted runners (#4071).
+#
+# Both phases run the HEAD ref's benchmarks/ tree (stashed outside the workspace by
+# the "Stash head benchmark harness" step): the harness is the measuring instrument,
+# so measuring both refs with one instrument keeps harness changes from reading as
+# performance deltas. Each phase still builds and serves its own ref's app code.
+# Additionally, each route is sampled BENCHMARK_SAMPLES times per phase; medians ship
+# to Bencher and a boundary crossing must reproduce across samples (disjoint
+# base/head sample ranges) or the report downgrades it to "unconfirmed".
+#
+# Hosted suites are manual-only (workflow_dispatch via benchmark.yml): the trusted
+# Bencher trend runs on dedicated local hardware, and this workflow serves explicit
+# hosted diagnostics. The whole matrix row from benchmarks/generate_matrix.rb is
+# passed as a JSON string and unpacked into job-level env once.
 on:
   workflow_call:
     inputs:
       matrix_row:
         description: 'JSON-encoded benchmark matrix row (one entry of generate_matrix.rb include[])'
+        required: true
+        type: string
+      base_sha:
+        description: >-
+          Commit SHA of the comparison base benchmarked alongside the head ref (merge
+          parent for PRs, the previous main commit for pushes, the merge-base with main
+          for dispatches). Resolved once by benchmark.yml's detect-changes job.
         required: true
         type: string
     secrets:
@@ -30,6 +55,13 @@ env:
   ROUTES: ${{ github.event.inputs.routes }}
   RATE: ${{ github.event.inputs.rate || 'max' }}
   DURATION: ${{ github.event.inputs.duration }}
+  # Repeated k6 samples per route (bench.rb): medians ship to Bencher and the
+  # per-sample values let the relative comparison require a flagged change to
+  # reproduce across samples (#4580). Per-sample duration defaults to 12s when
+  # sampling (3x12s vs the old single 30s); an explicit DURATION input overrides
+  # per sample. Only the k6 suites read this; the vegeta node-renderer suite
+  # keeps its single fixed-rate run.
+  BENCHMARK_SAMPLES: '3'
   REQUEST_TIMEOUT: ${{ github.event.inputs.request_timeout }}
   CONNECTIONS: ${{ github.event.inputs.connections }}
   MAX_CONNECTIONS: ${{ github.event.inputs.connections }}
@@ -40,8 +72,7 @@ env:
 jobs:
   run-suite:
     runs-on: ubuntu-24.04
-    # Token permissions are set by each caller in benchmark.yml: initial mode can
-    # update PR comments, while confirm mode only reads the candidate and writes checks.
+    # Token permissions are set by the caller in benchmark.yml.
     env:
       SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
@@ -199,216 +230,78 @@ jobs:
           echo "SERVER_CMD: $SERVER_CMD"
           echo "BENCH_CMD: $BENCH_CMD"
 
-      - name: Install Node modules with pnpm
-        run: pnpm install --frozen-lockfile
+      - name: Validate comparison base input
+        env:
+          BASE_SHA: ${{ inputs.base_sha }}
+        run: |
+          if [ -z "$BASE_SHA" ]; then
+            echo "::error::base_sha input is empty; relative continuous benchmarking cannot run without a comparison base."
+            exit 1
+          fi
+          echo "Comparison base: $BASE_SHA"
 
-      - name: Build workspace packages
-        run: pnpm run build
+      # The bench harness (benchmarks/) is the measuring instrument. BOTH phases must
+      # run the HEAD ref's copy: each phase checks out its own ref, so running the
+      # checked-out benchmarks/ would measure the two refs with two different
+      # instruments, and any harness change (k6 connection behavior, sampling,
+      # durations) would masquerade as a base-vs-head performance delta. Stash the
+      # head copy outside the workspace (phases git-clean it) while the head ref is
+      # still checked out; the phase action runs scripts from this stash. App-side
+      # inputs (bin/prod*, gems, packs, renderer config) still come from each
+      # phase's own checkout — only the instrument is pinned.
+      - name: Stash head benchmark harness
+        run: |
+          rm -rf "$RUNNER_TEMP/bench-harness"
+          cp -R benchmarks "$RUNNER_TEMP/bench-harness"
+          echo "Stashed head benchmarks/ -> $RUNNER_TEMP/bench-harness"
 
-      - name: Install Ruby Gems for the benchmarked app
-        uses: ./.github/actions/setup-bundle
+      # Relative continuous benchmarking, phase 1 of 2: build + benchmark the comparison
+      # BASE ref on this runner. Its results are stashed under runner.temp because the
+      # head phase git-cleans the workspace.
+      - name: Benchmark base ref
+        uses: ./.github/actions/benchmark-suite-phase
         with:
-          working-directory: ${{ env.APP_DIRECTORY }}
+          ref: ${{ inputs.base_sha }}
+          phase: base
+          results-dir: ${{ runner.temp }}/bench_results_base
+          app-directory: ${{ env.APP_DIRECTORY }}
+          server-kind: ${{ env.SERVER_KIND }}
+          pro-env: ${{ env.PRO_ENV }}
+          generate-packs: ${{ env.GENERATE_PACKS }}
+          benchmark-script: ${{ env.BENCHMARK_SCRIPT }}
+          harness-dir: ${{ runner.temp }}/bench-harness
+          benchmark-timeout-minutes: ${{ fromJSON(inputs.matrix_row).benchmark_timeout_minutes }}
+          suite-name: ${{ env.SUITE_NAME }}
+          summary-file: ${{ env.SUMMARY_FILE }}
+          summary-title: ${{ env.SUMMARY_TITLE }}
           ruby-version: ${{ steps.tool-versions.outputs.minimum-ruby-version }}
-          install-libyaml: 'false'
 
-      - name: Generate file-system based entrypoints for Pro
-        if: env.GENERATE_PACKS == 'true'
-        working-directory: ${{ env.APP_DIRECTORY }}
-        run: bundle exec rake react_on_rails:generate_packs
+      # The base phase leaves the workspace checked out at the base ref. Restore the
+      # head checkout BEFORE the next `uses: ./...` step: GitHub resolves local actions
+      # from the workspace when the step starts, so without this the head phase would
+      # execute the BASE ref's (possibly older or missing) copy of benchmark-suite-phase.
+      - name: Restore head checkout
+        run: git checkout --force "$GITHUB_SHA"
 
-      - name: Prepare production assets
-        working-directory: ${{ env.APP_DIRECTORY }}
-        run: |
-          set -e
-          echo "🔨 Building $SUITE_NAME production assets..."
-
-          if ! bin/prod-assets; then
-            echo "❌ ERROR: Failed to build production assets"
-            exit 1
-          fi
-
-          echo "✅ Production assets built successfully"
-
-      - name: Prepare and seed benchmark database
-        # The Pro Rails suite serves DB-backed routes (e.g. /posts_page). Without
-        # a migrated + seeded database those routes 500 on every request (the
-        # `posts` table does not exist), so the benchmark must create and seed it
-        # before the server starts. On a fresh CI runner `db:prepare` creates the
-        # database, loads the schema, and — because the database is newly created —
-        # runs db/seeds.rb (deterministic and faker-free so it works under
-        # RAILS_ENV=production). Note: `db:prepare` only seeds on first creation, so
-        # the row-count check below fails the job loudly if seeding was skipped (an
-        # empty table would otherwise serve a 200 "No posts found" payload that the
-        # benchmark scores as healthy).
-        if: env.SERVER_KIND == 'rails' && env.PRO_ENV == 'true'
-        working-directory: ${{ env.APP_DIRECTORY }}
-        env:
-          RAILS_ENV: production
-        run: |
-          set -euo pipefail
-          echo "🌱 Preparing and seeding $SUITE_NAME benchmark database..."
-          bundle exec rails db:prepare
-          # Guard every table `/posts_page` reads (posts, plus the users and
-          # comments it joins), not just posts: a partial seed would otherwise
-          # let the route 500 (or render an empty page) while the job stayed
-          # green.
-          bundle exec rails runner - <<'RUBY'
-          counts = {
-            posts: Post.count,
-            users: User.count,
-            comments: Comment.count
-          }
-
-          empty_tables = counts.select { |_, count| count.zero? }.keys
-          if empty_tables.any?
-            abort(
-              "Benchmark DB seeding incomplete after db:prepare " \
-              "(empty: #{empty_tables.join(', ')}); seeds did not run"
-            )
-          end
-
-          puts "✅ Database seeded (#{counts.map { |table, count| "#{count} #{table}" }.join(', ')})"
-          RUBY
-
-      - name: Start Pro node renderer
-        if: env.SERVER_KIND == 'node-renderer'
-        working-directory: ${{ env.APP_DIRECTORY }}
-        env:
-          RAILS_ENV: production
-          NODE_ENV: production
-          RENDERER_LOG_LEVEL: error
-          RENDERER_PORT: 3800
-        run: |
-          set -e
-          echo "🔧 Pre-seeding node renderer bundle cache..."
-          bundle exec rake react_on_rails_pro:pre_seed_renderer_cache MODE=symlink
-
-          echo "🚀 Starting $SUITE_NAME node renderer..."
-          renderer_log="${RUNNER_TEMP:-$PWD}/node-renderer.log"
-          echo "TARGET_LOG=$renderer_log" >> "$GITHUB_ENV"
-          node renderer/node-renderer.js > "$renderer_log" 2>&1 &
-          renderer_pid=$!
-          # Persist the PID so "Execute benchmark suite" can confirm the renderer
-          # survived the run; a backgrounded child under `set -e` does not
-          # propagate its failure to the step.
-          echo "TARGET_PID=$renderer_pid" >> "$GITHUB_ENV"
-          echo "Node renderer started in background (PID $renderer_pid)"
-
-          echo "⏳ Waiting for node renderer to be ready..."
-          for i in {1..30}; do
-            # Fail fast if the renderer bound the port and then crashed, instead
-            # of looping until the timeout (or racing a dead/restarting target).
-            if ! kill -0 "$renderer_pid" 2>/dev/null; then
-              echo "::error::Node renderer (PID $renderer_pid) exited during startup"
-              cat "$renderer_log" || true
-              exit 1
-            fi
-            if ruby -e "require 'socket'; TCPSocket.new('localhost', 3800).close"; then
-              echo "✅ Node renderer is ready and listening (PID $renderer_pid)"
-              exit 0
-            fi
-            echo "  Attempt $i/30: Node renderer not ready yet..."
-            sleep 1
-          done
-
-          echo "::error::Node renderer failed to start within 30 seconds"
-          cat "$renderer_log" || true
-          exit 1
-
-      - name: Start Rails production server
-        if: env.SERVER_KIND == 'rails'
-        working-directory: ${{ env.APP_DIRECTORY }}
-        run: |
-          set -e
-          echo "🚀 Starting $SUITE_NAME production server..."
-          $SERVER_CMD &
-          server_pid=$!
-          # Persist the PID so "Execute benchmark suite" can confirm the server
-          # survived the run; a backgrounded child under `set -e` does not
-          # propagate its failure to the step.
-          echo "TARGET_PID=$server_pid" >> "$GITHUB_ENV"
-          echo "Server started in background (PID $server_pid)"
-
-          echo "⏳ Waiting for server to be ready..."
-          for i in {1..30}; do
-            # Fail fast if the server bound the port and then crashed, instead of
-            # looping until the timeout (or racing a dead/restarting target).
-            if ! kill -0 "$server_pid" 2>/dev/null; then
-              echo "::error::Server (PID $server_pid) exited during startup"
-              exit 1
-            fi
-            if curl -fsS http://localhost:3001 > /dev/null; then
-              echo "✅ Server is ready and responding (PID $server_pid)"
-              exit 0
-            fi
-            echo "  Attempt $i/30: Server not ready yet..."
-            sleep 1
-          done
-
-          echo "::error::Server failed to start within 30 seconds"
-          exit 1
-
-      - name: Execute benchmark suite
-        timeout-minutes: ${{ fromJSON(inputs.matrix_row).benchmark_timeout_minutes }}
-        run: |
-          set -e
-          echo "🏃 Running $SUITE_NAME benchmark suite..."
-
-          if [ "$PRO_ENV" = "true" ]; then
-            if ! PRO=true $BENCH_CMD "$BENCHMARK_SCRIPT"; then
-              echo "❌ ERROR: Benchmark execution failed"
-              exit 1
-            fi
-          elif ! $BENCH_CMD "$BENCHMARK_SCRIPT"; then
-            echo "❌ ERROR: Benchmark execution failed"
-            exit 1
-          fi
-
-          # The benchmark target was backgrounded in a prior step, so `set -e`
-          # never saw it crash. Confirm it survived the whole run: a mid-run
-          # death means the metrics were measured against a dead/restarting
-          # target and must not ship to Bencher, so fail the job.
-          if [ -z "$TARGET_PID" ]; then
-            echo "::error::TARGET_PID is unset; cannot verify the benchmark target stayed alive"
-            exit 1
-          fi
-          if ! kill -0 "$TARGET_PID" 2>/dev/null; then
-            echo "::error::Benchmark target (PID $TARGET_PID) died during the benchmark run; metrics are unreliable"
-            exit 1
-          fi
-          if [ -n "${TARGET_LOG:-}" ] && [ -f "$TARGET_LOG" ]; then
-            if grep -q "died UNEXPECTEDLY" "$TARGET_LOG"; then
-              echo "::error::Benchmark target logged an unexpected worker restart; metrics are unreliable"
-              grep -n "died UNEXPECTEDLY" "$TARGET_LOG" || true
-              exit 1
-            fi
-          fi
-
-          echo "✅ Benchmark suite completed successfully"
-
-      - name: Validate benchmark results
-        run: |
-          set -e
-          echo "🔍 Validating $SUITE_NAME benchmark results..."
-
-          if [ ! -f "$SUMMARY_FILE" ]; then
-            echo "❌ ERROR: benchmark summary file not found"
-            exit 1
-          fi
-          echo "📊 $SUMMARY_TITLE:"
-          column -t -s $'\t' "$SUMMARY_FILE"
-          echo ""
-
-          if [ ! -f "bench_results/benchmark.json" ]; then
-            echo "❌ ERROR: benchmark JSON file not found"
-            exit 1
-          fi
-
-          echo "✅ Benchmark results validated"
-          echo ""
-          echo "Generated files:"
-          ls -lh bench_results/
+      # Phase 2 of 2: build + benchmark the HEAD ref on the same runner. Results stay in
+      # bench_results/ for the tracking step.
+      - name: Benchmark head ref
+        uses: ./.github/actions/benchmark-suite-phase
+        with:
+          ref: ${{ github.sha }}
+          phase: head
+          results-dir: bench_results
+          app-directory: ${{ env.APP_DIRECTORY }}
+          server-kind: ${{ env.SERVER_KIND }}
+          pro-env: ${{ env.PRO_ENV }}
+          generate-packs: ${{ env.GENERATE_PACKS }}
+          benchmark-script: ${{ env.BENCHMARK_SCRIPT }}
+          harness-dir: ${{ runner.temp }}/bench-harness
+          benchmark-timeout-minutes: ${{ fromJSON(inputs.matrix_row).benchmark_timeout_minutes }}
+          suite-name: ${{ env.SUITE_NAME }}
+          summary-file: ${{ env.SUMMARY_FILE }}
+          summary-title: ${{ env.SUMMARY_TITLE }}
+          ruby-version: ${{ steps.tool-versions.outputs.minimum-ruby-version }}
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7
@@ -419,13 +312,27 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+      - name: Upload base benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: base-${{ env.RESULTS_ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/bench_results_base/
+          retention-days: 30
+          if-no-files-found: warn
+
       - name: Track benchmarks with Bencher
         env:
           BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_KEY == '' && secrets.BENCHER_API_TOKEN || '' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          # The base phase's results — this runner's own comparison baseline.
+          BENCHMARK_BASELINE_JSON: ${{ runner.temp }}/bench_results_base/benchmark.json
+          BENCHER_BASELINE_REPORT_JSON: ${{ runner.temp }}/bench_results_base/bencher_report.json
+          # The base phase's per-sample values, paired with the head sidecar for
+          # sample confirmation (unreproduced boundary crossings are downgraded).
+          BENCHMARK_BASELINE_DISPLAY_JSON: ${{ runner.temp }}/bench_results_base/benchmark_display.json
         run: ruby benchmarks/track_benchmarks.rb
 
       - name: Benchmark workflow summary

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -109,7 +109,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 50
+          # Full history: the base-resolution step below computes `git merge-base` with
+          # origin/main, and a shallow boundary between a long-lived branch and its fork
+          # point can make merge-base fail — or worse, silently resolve to a wrong base
+          # inside the shallow window. This job is cheap and manual-dispatch-only.
+          fetch-depth: 0
           persist-credentials: false
       - name: Read runtime versions
         id: tool-versions

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,9 +30,12 @@ on:
         default: 'max'
         type: string
       duration:
-        description: 'Duration (e.g., "30s", "1m", "90s")'
+        description: >-
+          k6 duration PER SAMPLE (e.g., "12s", "30s", "1m") — each route runs
+          BENCHMARK_SAMPLES (3) k6 samples and reports the medians. Empty = auto
+          (12s per sample). Also the vegeta node-renderer suite's single-run duration.
         required: false
-        default: '30s'
+        default: ''
         type: string
       request_timeout:
         description: 'Request timeout (e.g., "60s", "1m", "90s")'
@@ -101,6 +104,7 @@ jobs:
     outputs:
       run_benchmark_suites: ${{ steps.benchmark-matrices.outputs.run_benchmark_suites }}
       benchmark_matrix: ${{ steps.benchmark-matrices.outputs.benchmark_matrix }}
+      base_sha: ${{ steps.benchmark-base.outputs.base_sha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -134,6 +138,25 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
         shell: bash
+      # Relative continuous benchmarking (#3492): each suite job builds and benchmarks
+      # BOTH this base and the dispatched head ref on the same runner, so the base must
+      # be one concrete SHA resolved once here. Fail-loud by design: silently comparing
+      # against an unintended base would be worse than aborting a manual dispatch.
+      - name: Resolve benchmark comparison base
+        id: benchmark-base
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            # Dispatch on main itself: compare against the previous main commit.
+            base=$(git rev-parse --verify "HEAD^")
+          else
+            # Dispatch on a branch: compare against its merge-base with main.
+            base=$(git merge-base HEAD origin/main)
+          fi
+          echo "Comparison base: $base"
+          echo "base_sha=$base" >> "$GITHUB_OUTPUT"
+        shell: bash
 
   # Manual hosted run of every selected suite/shard. Automatic push/PR benchmarks
   # are intentionally disabled; use the dedicated local M1 runner for the trusted
@@ -155,6 +178,7 @@ jobs:
     uses: ./.github/workflows/benchmark-suite.yml
     with:
       matrix_row: ${{ toJSON(matrix) }}
+      base_sha: ${{ needs.prepare-benchmark-matrix.outputs.base_sha }}
     secrets:
       REACT_ON_RAILS_PRO_LICENSE_V2: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}  # yamllint disable-line rule:line-length
       BENCHER_API_KEY: ${{ secrets.BENCHER_API_KEY }}

--- a/benchmarks/LOCAL_BENCHMARK.md
+++ b/benchmarks/LOCAL_BENCHMARK.md
@@ -117,6 +117,13 @@ ruby benchmarks/run-local-benchmark.rb core --no-setup --no-upload
 Options: `--testbed NAME` (default `m1-bench`), `--branch NAME`, `--[no-]upload`,
 `--fail-on-alert`, `--[no-]setup`, `--duration`, `--rate`, `--connections`. See `--help`.
 
+Local runs keep bench.rb's single-sample default (one 30s k6 run per route);
+`BENCHMARK_SAMPLES=3` opts into CI's repeated-sample mode (medians per route,
+12s per sample unless `--duration` overrides). Note: k6 now opens a fresh
+connection per request (`noConnectionReuse`, #4580) — absolute RPS/latency
+stepped once when that landed, so a t-test alert straddling that commit on a
+local trend series is expected; the series re-baselines within a few runs.
+
 ## Quiet A/B comparisons
 
 For release-candidate comparisons, do not trust a single `main` vs RC pass. Use the A/B

--- a/benchmarks/LOCAL_BENCHMARK.md
+++ b/benchmarks/LOCAL_BENCHMARK.md
@@ -172,8 +172,9 @@ ruby benchmarks/run-local-benchmark-comparison.rb core \
 
 The script reuses the CI building blocks (no duplicated benchmark logic): per-suite config
 from `generate_matrix.rb`, the dummy app's `bin/prod*` for the build + server, `bench.rb` for
-the measurement, and `lib/bencher_runner.rb` for the upload (same tuned thresholds, with the
-testbed overridden via `BENCHER_TESTBED`). It reports under the **checked-out git ref** (branch
+the measurement, and `lib/bencher_runner.rb` for the upload (in its default statistical mode:
+tuned t-test thresholds against this testbed's own history — unlike CI, which runs a relative
+base-vs-head comparison per run — with the testbed overridden via `BENCHER_TESTBED`). It reports under the **checked-out git ref** (branch
 name, or tag/SHA when detached) unless `--branch` overrides it: a nightly `main` run feeds the
 dedicated main trend, while an RC tag or feature branch forms its own series instead of
 polluting that baseline.

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -16,20 +16,30 @@ require_relative "lib/benchmark_config"
 require_relative "lib/benchmark_helpers"
 require_relative "lib/bmf_helpers"
 
+# The monorepo checkout under test. These reads target the APP side (the phase's
+# checked-out package/config/bundles), NOT the benchmark harness: CI stashes the
+# head ref's benchmarks/ outside the workspace and runs both phases with it (one
+# measuring instrument), so script-relative "../" would escape the stash instead
+# of reaching the workspace. GITHUB_WORKSPACE points at the checkout in CI; local
+# in-tree runs fall back to this script's parent directory as before.
+def workspace_root
+  ENV.fetch("GITHUB_WORKSPACE") { File.expand_path("..", __dir__) }
+end
+
 # Read configuration from source files
 def read_protocol_version
-  package_json_path = File.expand_path(
-    "../packages/react-on-rails-pro-node-renderer/package.json",
-    __dir__
+  package_json_path = File.join(
+    workspace_root,
+    "packages/react-on-rails-pro-node-renderer/package.json"
   )
   package_json = JSON.parse(File.read(package_json_path))
   package_json["protocolVersion"] || raise("protocolVersion not found in #{package_json_path}")
 end
 
 def read_password_from_config
-  config_path = File.expand_path(
-    "../react_on_rails_pro/spec/dummy/renderer/node-renderer.js",
-    __dir__
+  config_path = File.join(
+    workspace_root,
+    "react_on_rails_pro/spec/dummy/renderer/node-renderer.js"
   )
   config_content = File.read(config_path)
   match = config_content.match(/password:\s*['"]([^'"]+)['"]/)
@@ -73,9 +83,9 @@ end
 
 # Find all production bundles in the node-renderer bundles directory
 def find_all_production_bundles
-  bundles_dir = File.expand_path(
-    "../react_on_rails_pro/spec/dummy/.node-renderer-bundles",
-    __dir__
+  bundles_dir = File.join(
+    workspace_root,
+    "react_on_rails_pro/spec/dummy/.node-renderer-bundles"
   )
 
   unless Dir.exist?(bundles_dir)

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -16,6 +16,16 @@ SUMMARY_TXT = "#{OUTDIR}/summary.txt".freeze
 BMF_SUFFIX = PRO ? ": Pro" : ": Core"
 BENCHMARK_SHARD_INDEX = Integer(env_or_default("BENCHMARK_SHARD_INDEX", 0))
 BENCHMARK_TOTAL_SHARDS = Integer(env_or_default("BENCHMARK_TOTAL_SHARDS", 1))
+# Repeated k6 samples per route. Each sample is an independent k6 run; the median
+# per metric is what ships to Bencher, and the per-sample values ride along in the
+# display sidecar so the relative comparison can require a flagged change to
+# reproduce across samples (#4580). Default 1 keeps the single-run behavior for
+# local trend runs; CI sets 3.
+BENCHMARK_SAMPLES = Integer(env_or_default("BENCHMARK_SAMPLES", 1))
+# Per-sample k6 duration. Multi-sample runs default shorter so total sampling time
+# stays comparable (3x12s vs the single 30s); an explicit DURATION always wins and
+# is per sample.
+K6_DURATION = env_or_default("DURATION", BENCHMARK_SAMPLES > 1 ? "12s" : "30s")
 
 def add_to_summary(*parts)
   add_summary_line(SUMMARY_TXT, *parts)
@@ -31,15 +41,19 @@ end
 
 # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-# Benchmark a single route with k6. Returns [rps, p50, p90, status] on success
-# and RAISES on any k6/parse failure so the suite can record the failure and
-# exit non-zero instead of shipping fabricated metrics to Bencher.
-def run_k6_benchmark(target, route_name)
-  puts "\n===> k6: #{route_name}"
+# Benchmark a single route with one k6 run (one sample). Returns
+# [rps, p50, p90, status] on success and RAISES on any k6/parse failure so the
+# suite can record the failure and exit non-zero instead of shipping fabricated
+# metrics to Bencher.
+def run_k6_benchmark(target, route_name, sample: 1)
+  sample_label = BENCHMARK_SAMPLES > 1 ? " (sample #{sample}/#{BENCHMARK_SAMPLES})" : ""
+  puts "\n===> k6: #{route_name}#{sample_label}"
 
   k6_script = File.expand_path("k6.ts", __dir__)
-  k6_summary_json = "#{OUTDIR}/#{route_name}_k6_summary.json"
-  k6_txt = "#{OUTDIR}/#{route_name}_k6.txt"
+  # Single-sample runs keep the unsuffixed artifact names local tooling knows.
+  file_suffix = BENCHMARK_SAMPLES > 1 ? "_s#{sample}" : ""
+  k6_summary_json = "#{OUTDIR}/#{route_name}_k6_summary#{file_suffix}.json"
+  k6_txt = "#{OUTDIR}/#{route_name}_k6#{file_suffix}.txt"
 
   # Drop any summary file left by a previous run for this route. k6 only writes
   # the export on a clean finish, so without this a crashed/killed k6 could
@@ -51,7 +65,7 @@ def run_k6_benchmark(target, route_name)
   k6_env_vars = [
     "-e TARGET_URL=#{Shellwords.escape(target)}",
     "-e RATE=#{RATE}",
-    "-e DURATION=#{DURATION}",
+    "-e DURATION=#{K6_DURATION}",
     "-e CONNECTIONS=#{CONNECTIONS}",
     "-e MAX_CONNECTIONS=#{MAX_CONNECTIONS}",
     "-e REQUEST_TIMEOUT=#{REQUEST_TIMEOUT}"
@@ -94,9 +108,68 @@ end
 
 # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-# Benchmark a single route end-to-end (warm-up + k6). Returns
-# [rps, p50, p90, status] on success and RAISES on failure (delegated to
-# run_k6_benchmark) so the suite can record it.
+# Median of a numeric array (mean of the middle two for even sizes).
+def median(values)
+  sorted = values.sort
+  mid = sorted.length / 2
+  sorted.length.odd? ? sorted[mid] : ((sorted[mid - 1] + sorted[mid]) / 2.0)
+end
+
+# Median across samples for one metric position, or "MISSING" if any sample
+# failed to produce a number (mirrors the single-sample MISSING token).
+def median_metric(sample_tuples, index)
+  values = sample_tuples.map { |tuple| tuple[index] }
+  return "MISSING" unless values.all?(Numeric)
+
+  median(values).round(2)
+end
+
+# Status tokens that carry no per-code counts to merge.
+COUNTLESS_STATUSES = %w[MISSING FAILED].freeze
+
+# Sum per-code status counts across samples, e.g. ["200=100,3xx=2", "200=98"] ->
+# "200=198,3xx=2" (first-appearance code order). Samples without parseable
+# counts ("MISSING") are skipped; all-missing stays "MISSING".
+def merge_statuses(statuses)
+  counts = Hash.new(0)
+  statuses.each do |status|
+    next if status.nil? || COUNTLESS_STATUSES.include?(status)
+
+    status.split(",").each do |part|
+      code, count = part.split("=")
+      counts[code] += count.to_i
+    end
+  end
+  return "MISSING" if counts.empty?
+
+  counts.map { |code, count| "#{code}=#{count}" }.join(",")
+end
+
+# Aggregate per-sample [rps, p50, p90, status] tuples into the route's reported
+# result: medians per metric (robust to a one-off noisy sample), summed status
+# counts, plus the raw per-sample values keyed by Bencher measure so the
+# relative comparison can require a flagged change to reproduce across samples.
+def aggregate_samples(sample_tuples)
+  samples = nil
+  if sample_tuples.length > 1
+    samples = { "rps" => 0, "p50_latency" => 1, "p90_latency" => 2 }.filter_map do |measure, index|
+      values = sample_tuples.map { |tuple| tuple[index] }
+      [measure, values] if values.all?(Numeric)
+    end.to_h
+  end
+
+  {
+    rps: median_metric(sample_tuples, 0),
+    p50: median_metric(sample_tuples, 1),
+    p90: median_metric(sample_tuples, 2),
+    status: merge_statuses(sample_tuples.map { |tuple| tuple[3] }),
+    samples:
+  }
+end
+
+# Benchmark a single route end-to-end (warm-up + BENCHMARK_SAMPLES k6 runs).
+# Returns {rps:, p50:, p90:, status:, samples:} on success and RAISES on failure
+# (delegated to run_k6_benchmark) so the suite can record it.
 def benchmark_route(route)
   separator = "=" * 80
   puts "\n#{separator}"
@@ -109,8 +182,10 @@ def benchmark_route(route)
   # Warm up this route before measuring: a few priming requests trigger
   # first-request compilation/cache population so they don't skew the run. Kept
   # small on purpose — at ~37 routes/shard the old 10×0.5s (5s/route) warm-up
-  # dominated CI time (#4012); the 30s k6 run below is what actually loads the
-  # server, and it self-warms the remaining workers in its first fraction of a second.
+  # dominated CI time (#4012); the k6 runs below are what actually load the
+  # server, and they self-warm the remaining workers in their first fraction of
+  # a second (with medians, any residual cold-start lands in sample 1 and is
+  # discounted by the aggregation).
   puts "Warming up server for #{route} with 3 requests..."
   3.times do
     server_responding?(target)
@@ -118,7 +193,9 @@ def benchmark_route(route)
   end
   puts "Warm-up complete for #{route}"
 
-  run_k6_benchmark(target, sanitize_route_name(route))
+  route_name = sanitize_route_name(route)
+  tuples = (1..BENCHMARK_SAMPLES).map { |sample| run_k6_benchmark(target, route_name, sample:) }
+  aggregate_samples(tuples)
 end
 
 # Run every route, collecting per-route failures instead of aborting the whole
@@ -131,12 +208,13 @@ def run_benchmark_suite(routes, bmf_collector, runner: method(:benchmark_route))
   failed_routes = []
 
   routes.each do |route|
-    rps, p50, p90, status = runner.call(route)
-    add_to_summary(route, rps, p50, p90, status)
+    result = runner.call(route)
+    add_to_summary(route, result[:rps], result[:p50], result[:p90], result[:status])
     # Add to BMF collector for Bencher output. p90 is sent to Bencher boundary-less
     # (recorded for a summary-table baseline but never thresholded) and also kept in the
-    # display sidecar so the summary table can show it; see BmfCollector.
-    bmf_collector.add(name: route, rps:, p50:, p90:, status:)
+    # display sidecar so the summary table can show it; see BmfCollector. samples: is
+    # the per-sample raw values (multi-sample runs only), display-sidecar-bound.
+    bmf_collector.add(name: route, **result.slice(:rps, :p50, :p90, :status, :samples))
   rescue StandardError => e
     # ::error:: must go to stdout — GitHub Actions only parses workflow commands
     # from stdout, not stderr, so writing here is what renders the UI annotation.
@@ -166,6 +244,8 @@ if __FILE__ == $PROGRAM_NAME
   raise "No routes assigned to shard #{BENCHMARK_SHARD_INDEX + 1}/#{BENCHMARK_TOTAL_SHARDS}" if routes.empty?
 
   validate_benchmark_config!
+  validate_positive_integer(BENCHMARK_SAMPLES, "BENCHMARK_SAMPLES")
+  validate_duration(K6_DURATION, "DURATION")
 
   # Check required tools are installed
   check_required_tools(%w[k6 column tee bash])
@@ -179,7 +259,8 @@ if __FILE__ == $PROGRAM_NAME
       - BENCHMARK_TOTAL_SHARDS: #{BENCHMARK_TOTAL_SHARDS}
       - ROUTES_IN_SHARD: #{routes.length}/#{all_routes.length}
       - RATE: #{RATE}
-      - DURATION: #{DURATION}
+      - BENCHMARK_SAMPLES: #{BENCHMARK_SAMPLES}
+      - DURATION (per sample): #{K6_DURATION}
       - REQUEST_TIMEOUT: #{REQUEST_TIMEOUT}
       - CONNECTIONS: #{CONNECTIONS}
       - MAX_CONNECTIONS: #{MAX_CONNECTIONS}

--- a/benchmarks/k6.ts
+++ b/benchmarks/k6.ts
@@ -59,6 +59,17 @@ const scenarios: Record<string, Scenario> =
 export const options: Options = {
   // "Highly recommended" in https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#discard-response-bodies
   discardResponseBodies: true,
+  // Open a fresh connection per request instead of per-VU keep-alive. A keep-alive
+  // connection is pinned to whichever Puma worker process accepted it, and Linux's
+  // LIFO accept-queue wakeup skews reconnect placement, so the per-worker connection
+  // split drifts randomly within a run (splits as bad as 9/1/0 observed) — each run
+  // lands in a different queueing "mode". Measured on a CI-topology testbed (4 cores,
+  // k6 pinned to 1, Puma 3 workers x 3 threads on 3): run-to-run spread dropped from
+  // ~38% (RPS) / ~36% (p50) to ~9% with per-request connections (#4580). Loopback
+  // connect cost is negligible next to the 5-300ms request times, k6 excludes it from
+  // http_req_duration, and net.ipv4.tcp_tw_reuse=2 recycles TIME_WAIT ports on
+  // loopback (verified at 7.7k conn/s, 12x the busiest route).
+  noConnectionReuse: true,
   scenarios,
   // Disable default thresholds to avoid noise in output
   thresholds: {},

--- a/benchmarks/lib/bencher_report.rb
+++ b/benchmarks/lib/bencher_report.rb
@@ -96,26 +96,53 @@ class BencherReport # rubocop:disable Metrics/ClassLength
     @tracked_measures = tracked_measures&.map { |measure| normalize(measure) }
     @boundaries = index_boundaries(raw)
     @alerts, @filtered_alerts = parse_alerts(raw).partition { |alert| current_regression_alert?(alert) }
+    @unconfirmed_alerts = []
+    @unconfirmed_pairs = Set.new
     # Per-benchmark perf links are informational (they only decide whether a name links
     # out), so they live in a separate, fully-lenient builder — a missing field yields an
     # unlinked name, never a FormatError that would fail the job over a cosmetic link.
     @perf_urls = BencherPerfUrl.new(raw)
   end
 
-  attr_reader :alerts
+  attr_reader :alerts, :unconfirmed_alerts
 
   def regression? = !@alerts.empty?
 
   def filtered_alert? = !@filtered_alerts.empty?
+
+  def unconfirmed_alert? = !@unconfirmed_alerts.empty?
+
+  # Sample-level confirmation for relative runs (#4580). Each side's per-sample raw
+  # values (Hash: benchmark name -> measure name -> numeric array, from the bench
+  # scripts' display sidecars) act as built-in reruns of the comparison: a
+  # benchmark+measure whose base and head sample RANGES OVERLAP did not reproduce its
+  # change across every rerun, so its boundary crossing is downgraded — #significance
+  # reports :unconfirmed (the table renders ⚠️ instead of 🔴/🟢) and its active alerts
+  # move out of #alerts (so #regression? and the candidate hand-off skip it; the
+  # caller normalizes Bencher's --err exit via BencherRun.normalized_exit_code).
+  # Disjoint ranges mean every head sample sits past every base sample — the change
+  # reproduced in all samples — so the alert stands. Pairs without >= 2 numeric
+  # samples on both sides keep today's single-sample behavior (fail open).
+  def apply_sample_confirmation!(head_samples:, base_samples:)
+    @unconfirmed_pairs = unconfirmed_pairs(head_samples, base_samples)
+    unconfirmed, @alerts = @alerts.partition { |alert| unconfirmed_alert_pair?(alert) }
+    @unconfirmed_alerts += unconfirmed
+    self
+  end
 
   # Boundary for a benchmark+measure, or nil if absent from the report.
   def boundary(benchmark_name, measure_key)
     @boundaries.dig(benchmark_name, normalize(measure_key))
   end
 
-  # :regression | :improvement | nil for benchmark+measure given its direction.
+  # :regression | :improvement | :unconfirmed | nil for benchmark+measure given its
+  # direction. :unconfirmed means the value crossed its boundary but the change did
+  # not reproduce across repeated samples (see #apply_sample_confirmation!).
   def significance(benchmark_name, measure_key, direction)
-    boundary(benchmark_name, measure_key)&.significance(direction)
+    verdict = boundary(benchmark_name, measure_key)&.significance(direction)
+    return :unconfirmed if verdict && @unconfirmed_pairs.include?([benchmark_name, normalize(measure_key)])
+
+    verdict
   end
 
   # The Bencher perf-plot URL for one benchmark (all its measures), or nil when the
@@ -223,6 +250,46 @@ class BencherReport # rubocop:disable Metrics/ClassLength
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def threshold_side?(boundary, direction) = direction == :lower ? boundary.lower_limit : boundary.upper_limit
+
+  # The benchmark+measure pairs whose base and head sample ranges overlap — the
+  # change did not reproduce across every repeated sample. Only pairs with >= 2
+  # numeric samples on BOTH sides can be classified; everything else is left
+  # confirmed (fail open to single-sample behavior).
+  def unconfirmed_pairs(head_samples, base_samples)
+    pairs = Set.new
+    head_samples.each do |name, head_measures|
+      base_measures = base_samples[name]
+      next unless head_measures.is_a?(Hash) && base_measures.is_a?(Hash)
+
+      overlapping_measures(head_measures, base_measures).each { |measure| pairs << [name, measure] }
+    end
+    pairs
+  end
+
+  # Normalized measure keys whose head and base sample ranges overlap.
+  def overlapping_measures(head_measures, base_measures)
+    base_by_key = base_measures.transform_keys { |measure| normalize(measure) }
+    head_measures.filter_map do |measure, head_values|
+      base_values = base_by_key[normalize(measure)]
+      next unless comparable_samples?(head_values) && comparable_samples?(base_values)
+      next if head_values.max < base_values.min || head_values.min > base_values.max
+
+      normalize(measure)
+    end
+  end
+
+  def comparable_samples?(values)
+    values.is_a?(Array) && values.length >= 2 && values.all?(Numeric)
+  end
+
+  # An alert is downgradable only when it names a benchmark+measure that sample
+  # confirmation classified as unconfirmed. Alerts missing either field can't be
+  # matched to sample data, so they stay confirmed (fail open).
+  def unconfirmed_alert_pair?(alert)
+    return false unless alert.benchmark && alert.measure
+
+    @unconfirmed_pairs.include?([alert.benchmark, normalize(alert.measure)])
+  end
 
   # An active alert on a measure the caller does not track (an orphaned server-side
   # threshold). Only applies when tracked_measures was given; a measure-less alert can't be

--- a/benchmarks/lib/bencher_report.rb
+++ b/benchmarks/lib/bencher_report.rb
@@ -6,9 +6,10 @@ require_relative "bencher_perf_url"
 
 # Parses the report emitted by `bencher run --format json` (Bencher CLI v0.6.8;
 # shape verified stable through current main). Exposes what benchmark reporting
-# needs: active regression alerts, and per benchmark+measure t-test prediction
-# intervals so the summary table can flag values that moved significantly vs
-# baseline in EITHER direction.
+# needs: active regression alerts, and per benchmark+measure boundary intervals
+# (percentage limits for the CI relative comparison, t-test prediction intervals
+# for the local statistical trend runs) so the summary table can flag values that
+# moved significantly vs baseline in EITHER direction.
 #
 # The report shape is not a documented stability contract, so accesses are guarded:
 # anything that decides a regression or the table structure raises FormatError (fail
@@ -52,7 +53,8 @@ class BencherReport # rubocop:disable Metrics/ClassLength
     end
 
     # Bencher configures a threshold on one side only, so the opposite limit is the
-    # mirror of the present one about baseline (the t-test interval is symmetric).
+    # mirror of the present one about baseline (both threshold tests we use are
+    # symmetric — see #mirror).
     def effective_lower
       lower_limit || mirror(upper_limit)
     end
@@ -61,10 +63,12 @@ class BencherReport # rubocop:disable Metrics/ClassLength
       upper_limit || mirror(lower_limit)
     end
 
-    # Bencher's t-test prediction interval is symmetric about the baseline by
-    # construction, so the unconfigured side is the configured side mirrored across
-    # baseline: a limit at distance d from baseline maps to baseline ∓ d. (Verified
-    # for the pinned CLI; re-confirm when bumping the pin.)
+    # Both threshold tests we use produce limits symmetric about the baseline by
+    # construction — the t-test's prediction interval, and the percentage test's
+    # baseline*(1±p) limits both sit at the same distance d from baseline — so the
+    # unconfigured side is the configured side mirrored across baseline: a limit at
+    # distance d maps to baseline ∓ d. (Verified for the pinned CLI; re-confirm when
+    # bumping the pin.)
     def mirror(limit)
       return nil if limit.nil?
 

--- a/benchmarks/lib/bencher_runner.rb
+++ b/benchmarks/lib/bencher_runner.rb
@@ -30,11 +30,12 @@ class BencherRunner
   private_constant :MAX_SAMPLE
 
   # Per-measure t-test boundaries (the confidence level Bencher uses for its
-  # prediction interval). Tuned from a sweep of recent main-branch reports so fewer
-  # than 1/20 commits raise a false regression across all benchmarks: rps and p50
-  # individually need ~0.9995 / ~0.9999 to clear that bar. failed_pct stays at 0.95
-  # because healthy runs sit at ~0 with near-zero variance, so its boundary rarely
-  # matters.
+  # prediction interval), used by MODE :statistical — the local dedicated-hardware
+  # trend runs (benchmarks/run-local-benchmark.rb, #4073). Tuned from a sweep of recent
+  # main-branch reports so fewer than 1/20 commits raise a false regression across all
+  # benchmarks: rps and p50 individually need ~0.9995 / ~0.9999 to clear that bar.
+  # failed_pct stays at 0.95 because healthy runs sit at ~0 with near-zero variance,
+  # so its boundary rarely matters.
   # Bencher's t-test threshold is a prediction interval, so each one-sided boundary B
   # gives a per-test false-positive rate of ~(1 - B):
   # https://bencher.dev/docs/explanation/thresholds/
@@ -48,9 +49,42 @@ class BencherRunner
     ["failed_pct", :upper, "0.95"]
   ].freeze
 
-  def initialize(benchmark_json:, report_json:)
+  # Per-measure percentage boundaries, used by MODE :relative_head — the CI relative
+  # continuous benchmarking comparison (#3492,
+  # https://bencher.dev/docs/how-to/track-benchmarks/#relative-continuous-benchmarking).
+  # The baseline is the base ref's results measured moments earlier ON THE SAME RUNNER
+  # (a single sample on a per-run throwaway branch), so the boundary is a plain
+  # percentage of that run: limit = baseline * (1 -/+ boundary). 0.25 (25%) follows the
+  # Bencher how-to's example and stays deliberately loose while shared GitHub-hosted
+  # runners are the testbed — same-runner comparison removes cross-runner variance, but
+  # CPU contention can still move throughput within a job. Tighten once real runs show
+  # the same-runner spread. Directions match THRESHOLDS (pinned by a spec).
+  # failed_pct's healthy baseline is ~0, which makes its upper limit ~0 — effectively
+  # "any newly-failing request alerts", the same strictness the t-test gave it.
+  RELATIVE_THRESHOLDS = [
+    ["rps", :lower, "0.25"],
+    ["p50_latency", :upper, "0.25"],
+    ["failed_pct", :upper, "0.25"]
+  ].freeze
+
+  # How each mode runs Bencher:
+  #   :statistical       — t-test thresholds vs the branch's own history + --err
+  #                        (local dedicated-hardware trend tracking; the default so
+  #                        run-local-benchmark.rb keeps its behavior).
+  #   :relative_baseline — no thresholds, no --err: just records the base ref's results
+  #                        as the fresh same-runner baseline series.
+  #   :relative_head     — percentage thresholds vs that baseline + --thresholds-reset
+  #                        (so stale server-side threshold models never alert) + --err.
+  MODES = %i[statistical relative_baseline relative_head].freeze
+
+  def initialize(benchmark_json:, report_json:, mode: :statistical)
+    unless MODES.include?(mode)
+      raise ArgumentError, "unknown mode #{mode.inspect} (expected one of #{MODES.join(', ')})"
+    end
+
     @benchmark_json = benchmark_json
     @report_json = report_json
+    @mode = mode
   end
 
   # Returns a Result with :stderr, :exit_code, and :report accessors. The
@@ -70,7 +104,7 @@ class BencherRunner
 
   private
 
-  attr_reader :benchmark_json, :report_json
+  attr_reader :benchmark_json, :report_json, :mode
 
   def emit_stderr(stderr)
     return if stderr.empty?
@@ -85,16 +119,42 @@ class BencherRunner
     ENV.fetch("BENCHER_TESTBED", DEFAULT_TESTBED)
   end
 
-  def threshold_args(measure, direction, boundary)
+  def threshold_args(test, measure, direction, boundary)
     # "_" is Bencher's sentinel for "no boundary on this side".
     lower, upper = direction == :lower ? [boundary, "_"] : ["_", boundary]
     [
       "--threshold-measure", measure,
-      "--threshold-test", "t_test",
-      "--threshold-max-sample-size", MAX_SAMPLE,
+      "--threshold-test", test,
+      # A percentage boundary is computed from the (single-sample) baseline directly,
+      # so the sample-size cap only applies to the t-test's history window.
+      *(test == "t_test" ? ["--threshold-max-sample-size", MAX_SAMPLE] : []),
       "--threshold-lower-boundary", lower,
       "--threshold-upper-boundary", upper
     ]
+  end
+
+  def mode_args
+    case mode
+    when :relative_baseline
+      # The baseline run only records data; it must never gate the job, so no
+      # thresholds and no --err (any non-zero exit is operational, handled by callers).
+      []
+    when :relative_head
+      [
+        "--err",
+        # Deactivate any threshold not (re)specified here so an orphaned server-side
+        # model (e.g. from the earlier statistical setup) can't raise a stray alert.
+        "--thresholds-reset",
+        *RELATIVE_THRESHOLDS.flat_map do |measure, direction, boundary|
+          threshold_args("percentage", measure, direction, boundary)
+        end
+      ]
+    else
+      [
+        "--err",
+        *THRESHOLDS.flat_map { |measure, direction, boundary| threshold_args("t_test", measure, direction, boundary) }
+      ]
+    end
   end
 
   def args(branch, start_point_args)
@@ -106,10 +166,9 @@ class BencherRunner
       "--testbed", testbed,
       "--adapter", "json",
       "--file", benchmark_json,
-      "--err",
       "--quiet",
       "--format", "json",
-      *THRESHOLDS.flat_map { |measure, direction, boundary| threshold_args(measure, direction, boundary) }
+      *mode_args
     ]
   end
 
@@ -160,11 +219,22 @@ class BencherRunner
   end
 
   def parse_report(stdout)
-    BencherReport.parse(stdout, tracked_measures: THRESHOLDS.map(&:first))
+    BencherReport.parse(stdout, tracked_measures:)
   rescue BencherReport::FormatError, JSON::ParserError => e
     raise ReportParseError,
           "Bencher JSON report has an unexpected shape — re-verify against " \
           "benchmarks/spec/bencher_report_spec.rb before bumping the CLI pin. #{e.message}"
+  end
+
+  # The measures this mode alerts on, for filtering orphaned server-side thresholds
+  # out of regression detection. A baseline run configures no thresholds, so it can't
+  # alert at all — nil (track everything) keeps its report parsing permissive.
+  def tracked_measures
+    case mode
+    when :relative_baseline then nil
+    when :relative_head then RELATIVE_THRESHOLDS.map(&:first)
+    else THRESHOLDS.map(&:first)
+    end
   end
 
   def safe_remove_tmp(path)

--- a/benchmarks/lib/benchmark_table.rb
+++ b/benchmarks/lib/benchmark_table.rb
@@ -9,6 +9,7 @@
 class BenchmarkTable
   REGRESSION = "🔴"
   IMPROVEMENT = "🟢"
+  UNCONFIRMED = "⚠️"
   UP = "▲"
   DOWN = "▼"
 
@@ -34,7 +35,9 @@ class BenchmarkTable
   # (including the untracked p90) shows a ▲/▼ delta and an "(n)" baseline.
   LEGEND = "#{UP}/#{DOWN} non-zero change vs baseline · 0.0% exact/near-zero match · " \
            "#{REGRESSION} significant regression · " \
-           "#{IMPROVEMENT} significant improvement (tracked measures) · (n) = baseline".freeze
+           "#{IMPROVEMENT} significant improvement (tracked measures) · " \
+           "#{UNCONFIRMED} crossed threshold but base/head samples overlap (unconfirmed) · " \
+           "(n) = baseline".freeze
 
   EMPTY = "_No benchmark results._"
 
@@ -94,8 +97,10 @@ class BenchmarkTable
   end
 
   # value + ▲/▼ delta + (baseline), with the arrow swapped for 🔴/🟢 and the value bolded
-  # when the measure crossed its boundary. No baseline (new benchmark / boundary-less p90)
-  # or zero baseline (no meaningful percent) → just the value.
+  # when the measure crossed its boundary. An :unconfirmed verdict (crossed the boundary
+  # but the change did not reproduce across repeated samples) renders ⚠️ plus the plain
+  # arrow, unbolded — visible but not crying wolf. No baseline (new benchmark /
+  # boundary-less p90) or zero baseline (no meaningful percent) → just the value.
   def metric_cell(name, col, value)
     text = format_number(value).to_s
     baseline = @report.boundary(name, col[:measure])&.baseline
@@ -104,12 +109,13 @@ class BenchmarkTable
     return text if baseline.nil? || baseline.zero?
 
     verdict = col[:direction] ? @report.significance(name, col[:measure], col[:direction]) : nil
-    value_text = verdict ? "**#{text}**" : text
+    value_text = %i[regression improvement].include?(verdict) ? "**#{text}**" : text
     "#{value_text} #{delta(verdict, value, baseline)} (#{format_number(baseline)})"
   end
 
   # "▲2.3%" / "▼1.4%" for a plain change; "🔴 8.4%" / "🟢 5.0%" for a significant one (the
-  # emoji gets a trailing space so it renders clear of the percent). Non-significant
+  # emoji gets a trailing space so it renders clear of the percent); "⚠️ ▲8.4%" for a
+  # boundary crossing that did not reproduce across samples. Non-significant
   # rounded-to-zero changes display as plain "0.0%" so equality/tiny noise never gets a
   # misleading arrow, while significant verdicts keep their marker.
   # The percent is the absolute change vs baseline; direction is conveyed by the arrow,
@@ -121,6 +127,7 @@ class BenchmarkTable
     case verdict
     when :regression then "#{REGRESSION} #{percent}%"
     when :improvement then "#{IMPROVEMENT} #{percent}%"
+    when :unconfirmed then "#{UNCONFIRMED} #{value > baseline ? UP : DOWN}#{percent}%"
     else "#{value > baseline ? UP : DOWN}#{percent}%"
     end
   end

--- a/benchmarks/lib/bmf_helpers.rb
+++ b/benchmarks/lib/bmf_helpers.rb
@@ -34,7 +34,11 @@ class BmfCollector
   # @param status [String, nil] Status string like "200=100,5xx=2"
   # @param p90 [Numeric, nil] 90th percentile latency in ms (sent to Bencher
   #   boundary-less via to_bmf, and retained for the display sidecar so the table shows it)
-  def add(name:, rps:, p50:, status:, p90: nil)
+  # @param samples [Hash, nil] Per-sample raw values keyed by Bencher measure name
+  #   (e.g. {"rps" => [529.1, 533.0, 505.2]}) when the bench script ran repeated
+  #   samples. Display-sidecar only (never part of the BMF payload): the relative
+  #   comparison uses it to require a flagged change to reproduce across samples.
+  def add(name:, rps:, p50:, status:, p90: nil, samples: nil)
     # Keep every row, including failures (rps "FAILED"/"MISSING"): the display sidecar
     # must still show a failed route/test rather than dropping it silently. The
     # numeric-rps filter lives in #to_bmf so only valid measures reach Bencher.
@@ -44,7 +48,8 @@ class BmfCollector
       p50: p50.is_a?(Numeric) ? p50 : nil,
       p90: p90.is_a?(Numeric) ? p90 : nil,
       status:,
-      failed_pct: calculate_failed_percentage(status)
+      failed_pct: calculate_failed_percentage(status),
+      samples: samples.is_a?(Hash) && !samples.empty? ? samples : nil
     }
   end
 
@@ -120,7 +125,12 @@ class BmfCollector
   # Status — issue #3601 item 4), so nothing reads it (it is still a tracked BMF measure).
   def display_rows
     @results.map do |r|
-      { "name" => r[:name], "rps" => r[:rps], "p50" => r[:p50], "p90" => r[:p90], "status" => r[:status] }
+      row = { "name" => r[:name], "rps" => r[:rps], "p50" => r[:p50], "p90" => r[:p90], "status" => r[:status] }
+      # Only multi-sample runs carry per-sample values; the key is absent otherwise so
+      # single-sample consumers (and the sample-confirmation join) can treat "no key"
+      # as "no repeated samples".
+      row["samples"] = r[:samples] if r[:samples]
+      row
     end
   end
 

--- a/benchmarks/lib/track_benchmarks/bencher_run.rb
+++ b/benchmarks/lib/track_benchmarks/bencher_run.rb
@@ -23,23 +23,5 @@ module TrackBenchmarks
       Github.notice("Bencher reported only stale active alert(s); no current boundary-backed regression remains.")
       0
     end
-
-    # A missing start-point baseline (operational, not a regression): retrying without
-    # the start-point hash falls back to the latest baseline. The no-regression guard is
-    # load-bearing — a real regression must not be silently re-run against a different
-    # baseline. The stderr match detects the operational error, not an alert.
-    def retry_without_start_point_hash?(stderr, exit_code, report)
-      exit_code != 0 &&
-        stderr.match?(/Head Version.*not found/) &&
-        !Summary.regression?(report)
-    end
-
-    def without_start_point_hash(start_point_args)
-      retry_args = start_point_args.dup
-      if (hash_arg_index = retry_args.index("--start-point-hash"))
-        retry_args.slice!(hash_arg_index, 2)
-      end
-      retry_args
-    end
   end
 end

--- a/benchmarks/lib/track_benchmarks/bencher_run.rb
+++ b/benchmarks/lib/track_benchmarks/bencher_run.rb
@@ -18,9 +18,13 @@ module TrackBenchmarks
     end
 
     def normalized_exit_code(exit_code, report)
-      return exit_code unless exit_code != 0 && report&.filtered_alert? && !Summary.regression?(report)
+      return exit_code if exit_code.zero? || report.nil? || Summary.regression?(report)
+      return exit_code unless report.filtered_alert? || report.unconfirmed_alert?
 
-      Github.notice("Bencher reported only stale active alert(s); no current boundary-backed regression remains.")
+      Github.notice(
+        "Bencher alert(s) were all stale or unconfirmed across samples; " \
+        "no current boundary-backed regression remains."
+      )
       0
     end
   end

--- a/benchmarks/lib/track_benchmarks/branch_args.rb
+++ b/benchmarks/lib/track_benchmarks/branch_args.rb
@@ -1,13 +1,27 @@
 # frozen_string_literal: true
 
 module TrackBenchmarks
-  # Resolves the Bencher branch and start-point arguments for each GitHub event.
+  # Resolves the Bencher branches for relative continuous benchmarking (#3492,
+  # https://bencher.dev/docs/how-to/track-benchmarks/#relative-continuous-benchmarking).
+  #
+  # Every tracking run submits TWO reports measured on the SAME runner:
+  #   1. the base ref's results to a throwaway per-run baseline branch
+  #      (--start-point-reset: a fresh series, nothing from other runners), then
+  #   2. the head ref's results to the event's branch, compared against that baseline
+  #      via --start-point <baseline> --start-point-reset and percentage thresholds
+  #      (BencherRunner mode :relative_head).
+  # The side-by-side comparison replaces the old statistical baseline built from
+  # main's history across runners, whose cross-runner variance drowned the signal on
+  # shared GitHub-hosted runners (#4071).
   module BranchArgs
+    RunPlan = Struct.new(:baseline_branch, :head_branch, keyword_init: true)
+
     module_function
 
-    # A confirmation rerun (BENCHMARK_MODE=confirm) re-tests a main-push regression candidate
-    # on a fresh runner before the issue is filed. It must NOT pollute main's Bencher series,
-    # so it submits to a throwaway per-run branch and re-tests against main's cloned baseline.
+    # A confirmation rerun (BENCHMARK_MODE=confirm) re-runs a main-push regression
+    # candidate's relative comparison on a fresh runner before the issue is filed. It
+    # must NOT pollute main's Bencher series, so its head report goes to a throwaway
+    # per-run branch.
     def confirmation_mode?(env: ENV)
       env.fetch("BENCHMARK_MODE", "initial") == "confirm"
     end
@@ -18,73 +32,63 @@ module TrackBenchmarks
       value.to_s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
     end
 
-    # A unique synthetic Bencher branch for the confirmation rerun, e.g.
+    # A unique synthetic Bencher branch for the confirmation rerun's head report, e.g.
     # "confirm-main-123456-pro-shard-1-2". Unique per run AND suite/shard so concurrent
-    # confirmation reruns never share a series, and never "main" so the confirmation sample
-    # is not appended to main's history.
+    # confirmation reruns never share a series, and never "main" so the confirmation
+    # sample is not appended to main's history.
     def confirmation_branch(run_id, suite_name)
       "confirm-main-#{run_id}-#{slugify(suite_name)}"
     end
 
-    # Re-test against main's baseline without writing into main's series: clone main's
-    # thresholds onto the throwaway branch and reset it to a fresh copy of main's head each
-    # run. This is the same anchoring the PR path uses (branch_and_start_point_args).
-    def confirmation_start_point_args
-      ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
+    # The throwaway branch holding this run's same-runner baseline. Unique per run AND
+    # suite/shard: --start-point <branch> clones the branch's CURRENT head, so a name
+    # shared between concurrently-running shards could compare one shard's head results
+    # against another shard's baseline data (whose benchmark names don't even overlap,
+    # silently disabling detection). The confirmation rerun gets its own prefix so it
+    # can never collide with the initial run's baseline within the same workflow run.
+    def baseline_branch(env: ENV)
+      prefix = confirmation_mode?(env:) ? "confirm-base" : "base"
+      "#{prefix}-#{env.fetch('GITHUB_RUN_ID')}-#{slugify(env.fetch('BENCHMARK_SUITE_NAME'))}"
     end
 
-    def branch_and_start_point_args(env: ENV)
+    def run_plan(env: ENV)
+      RunPlan.new(baseline_branch: baseline_branch(env:), head_branch: head_branch(env:))
+    end
+
+    # Where the head ref's results are reported: the event's real branch ("main" for
+    # pushes, the PR branch, the dispatched ref), or the throwaway confirmation branch.
+    # Note the relative flow resets that branch to the per-run baseline every run, so
+    # dashboard series no longer accumulate history on GitHub-hosted runners — the
+    # long-term trend lives on the dedicated local-runner testbed instead (#4073).
+    def head_branch(env: ENV)
       if confirmation_mode?(env:)
-        return [
-          confirmation_branch(env.fetch("GITHUB_RUN_ID"), env.fetch("BENCHMARK_SUITE_NAME")),
-          confirmation_start_point_args
-        ]
+        return confirmation_branch(env.fetch("GITHUB_RUN_ID"), env.fetch("BENCHMARK_SUITE_NAME"))
       end
 
       case env.fetch("GITHUB_EVENT_NAME")
       when "push"
-        ["main", []]
+        "main"
       when "pull_request"
-        [
-          env.fetch("GITHUB_HEAD_REF"),
-          [
-            "--start-point", env.fetch("GITHUB_BASE_REF"),
-            "--start-point-hash", env.fetch("GITHUB_BASE_SHA"),
-            "--start-point-clone-thresholds",
-            "--start-point-reset"
-          ]
-        ]
+        env.fetch("GITHUB_HEAD_REF")
       when "workflow_dispatch"
-        workflow_dispatch_args(env)
+        env.fetch("GITHUB_REF_NAME")
       else
         warn "Unexpected event type: #{env.fetch('GITHUB_EVENT_NAME')}"
         exit 1
       end
     end
 
-    def workflow_dispatch_args(env)
-      branch = env.fetch("GITHUB_REF_NAME")
-      return [branch, []] if branch == "main"
-
-      stdout, status = GithubCli.capture(
-        "gh", "api", "repos/#{env.fetch('GITHUB_REPOSITORY')}/compare/main...#{branch}",
-        "--jq", ".merge_base_commit.sha",
-        error_message: "Failed to resolve merge-base with main for #{branch}"
-      )
-      start_point_args = ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
-      # On API failure GithubCli already emits ::error::; fall back to the latest
-      # baseline rather than conflating a failed call with "no merge-base found".
-      merge_base = status.success? ? stdout.strip : ""
-
-      if merge_base.empty?
-        puts "Could not find merge-base with main via GitHub API, continuing without hash"
-      else
-        puts "Found merge-base via API: #{merge_base}"
-        start_point_args.insert(2, "--start-point-hash", merge_base)
-      end
-
-      [branch, start_point_args]
+    # The baseline run starts a fresh series even when a rerun reuses the branch name.
+    def baseline_start_point_args
+      ["--start-point-reset"]
     end
-    private_class_method :workflow_dispatch_args
+
+    # The head run is anchored to the just-recorded baseline. No
+    # --start-point-clone-thresholds: relative thresholds are (re)stated on every run
+    # by BencherRunner mode :relative_head, and no --start-point-hash: the baseline
+    # branch's head IS the exact data this runner just measured.
+    def head_start_point_args(baseline_branch)
+      ["--start-point", baseline_branch, "--start-point-reset"]
+    end
   end
 end

--- a/benchmarks/lib/track_benchmarks/cli.rb
+++ b/benchmarks/lib/track_benchmarks/cli.rb
@@ -10,10 +10,13 @@ module TrackBenchmarks
     end
 
     def run
-      branch, start_point_args = BranchArgs.branch_and_start_point_args(env:)
-      bencher_result = BencherRun.run_bencher!(bencher_runner, branch, start_point_args)
-      bencher_exit_code, report = retry_without_start_point_hash(branch, start_point_args, bencher_result)
-      bencher_exit_code = BencherRun.normalized_exit_code(bencher_exit_code, report)
+      plan = BranchArgs.run_plan(env:)
+      run_baseline(plan)
+      head_result = BencherRun.run_bencher!(
+        head_runner, plan.head_branch, BranchArgs.head_start_point_args(plan.baseline_branch)
+      )
+      report = head_result.report
+      bencher_exit_code = BencherRun.normalized_exit_code(head_result.exit_code, report)
 
       # Build the Markdown summary table once; the same body feeds the job summary, the
       # PR comment, and the candidate/confirmation hand-offs.
@@ -37,32 +40,41 @@ module TrackBenchmarks
 
     attr_reader :suite_name, :report_marker, :env
 
-    def bencher_runner
-      @bencher_runner ||= BencherRunner.new(benchmark_json: Config::BENCHMARK_JSON, report_json: Config::REPORT_JSON)
+    # Records the base ref's results (measured moments ago on THIS runner) as the
+    # comparison baseline: a fresh series on a throwaway per-run branch. The baseline
+    # run configures no thresholds, so it can never alert — any non-zero exit is an
+    # operational failure (auth/API/network/CLI) and aborts before the head run could
+    # submit a comparison against a baseline that was never recorded.
+    def run_baseline(plan)
+      result = BencherRun.run_bencher!(
+        baseline_runner, plan.baseline_branch, BranchArgs.baseline_start_point_args
+      )
+      return if result.exit_code.zero?
+
+      warn "::error::Bencher baseline upload for #{suite_name} failed (exit #{result.exit_code}); " \
+           "cannot run the relative comparison without a same-runner baseline. Check the logs above."
+      exit result.exit_code
+    end
+
+    def baseline_runner
+      @baseline_runner ||= BencherRunner.new(
+        benchmark_json: Config::BASELINE_BENCHMARK_JSON,
+        report_json: Config::BASELINE_REPORT_JSON,
+        mode: :relative_baseline
+      )
+    end
+
+    def head_runner
+      @head_runner ||= BencherRunner.new(
+        benchmark_json: Config::BENCHMARK_JSON,
+        report_json: Config::REPORT_JSON,
+        mode: :relative_head
+      )
     end
 
     def pr_report_poster
       # Keep this behind replace_pr_comments so non-PR runs never require PR env vars.
       @pr_report_poster ||= PrReportPoster.from_env(suite_name:, marker: report_marker)
-    end
-
-    def retry_without_start_point_hash(branch, start_point_args, bencher_result)
-      stderr = bencher_result.stderr
-      bencher_exit_code = bencher_result.exit_code
-      report = bencher_result.report
-      unless BencherRun.retry_without_start_point_hash?(stderr, bencher_exit_code, report)
-        return [bencher_exit_code, report]
-      end
-
-      retry_args = BencherRun.without_start_point_hash(start_point_args)
-      puts "Start-point hash not found in Bencher; retrying without --start-point-hash"
-      Github.warning("Start-point hash not found in Bencher; falling back to latest baseline for comparison")
-      # The retry's stderr is unused: regression classification reads the JSON report,
-      # and this path only triggers when the first run had no regression.
-      retry_result = BencherRun.run_bencher!(bencher_runner, branch, retry_args)
-      # Intentionally leave retry_result.stderr unused here. BencherRunner#run has
-      # already emitted it; only the exit code and parsed report affect the outcome.
-      [retry_result.exit_code, retry_result.report]
     end
 
     def post_pull_request_report(report, report_markdown)

--- a/benchmarks/lib/track_benchmarks/cli.rb
+++ b/benchmarks/lib/track_benchmarks/cli.rb
@@ -16,6 +16,10 @@ module TrackBenchmarks
         head_runner, plan.head_branch, BranchArgs.head_start_point_args(plan.baseline_branch)
       )
       report = head_result.report
+      # Sample confirmation must run before anything consumes the report: it can
+      # downgrade alerts, which changes the summary highlighting, regression
+      # detection, the candidate hand-off, and the normalized exit code below.
+      apply_sample_confirmation(report)
       bencher_exit_code = BencherRun.normalized_exit_code(head_result.exit_code, report)
 
       # Build the Markdown summary table once; the same body feeds the job summary, the
@@ -39,6 +43,28 @@ module TrackBenchmarks
     private
 
     attr_reader :suite_name, :report_marker, :env
+
+    # Join both phases' per-sample values (display sidecars) and let the report
+    # downgrade boundary crossings that did not reproduce across samples (#4580).
+    # Either sidecar missing sample data (single-sample runs, failed routes, older
+    # base refs whose bench scripts predate sampling) skips confirmation entirely —
+    # fail open to single-sample behavior.
+    def apply_sample_confirmation(report)
+      return unless report
+
+      head_samples = Summary.samples_by_name(Config::DISPLAY_JSON)
+      base_samples = Summary.samples_by_name(Config::BASELINE_DISPLAY_JSON)
+      return if head_samples.empty? || base_samples.empty?
+
+      report.apply_sample_confirmation!(head_samples:, base_samples:)
+      return unless report.unconfirmed_alert?
+
+      names = report.unconfirmed_alerts.map { |alert| "#{alert.benchmark} (#{alert.measure})" }.uniq
+      Github.notice(
+        "Sample confirmation downgraded #{report.unconfirmed_alerts.length} Bencher alert(s) whose " \
+        "base/head samples overlap: #{names.join(', ')}"
+      )
+    end
 
     # Records the base ref's results (measured moments ago on THIS runner) as the
     # comparison baseline: a fresh series on a throwaway per-run branch. The baseline

--- a/benchmarks/lib/track_benchmarks/config.rb
+++ b/benchmarks/lib/track_benchmarks/config.rb
@@ -7,6 +7,11 @@ module TrackBenchmarks
 
     BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
     REPORT_JSON = ENV.fetch("BENCHER_REPORT_JSON", "bench_results/bencher_report.json")
+    # The base ref's results from this runner's base benchmark phase — the comparison
+    # baseline for relative continuous benchmarking. The workflow stashes them outside
+    # the workspace (the head phase git-cleans it) and points this env var there.
+    BASELINE_BENCHMARK_JSON = ENV.fetch("BENCHMARK_BASELINE_JSON", "bench_results_base/benchmark.json")
+    BASELINE_REPORT_JSON = ENV.fetch("BENCHER_BASELINE_REPORT_JSON", "bench_results_base/bencher_report.json")
     # Written by the bench scripts (BmfCollector#write_display_json); carries the
     # summary-table columns Bencher never sees (p90, raw Status), keyed by the same
     # canonical name as the report so the join is exact.

--- a/benchmarks/lib/track_benchmarks/config.rb
+++ b/benchmarks/lib/track_benchmarks/config.rb
@@ -12,6 +12,9 @@ module TrackBenchmarks
     # the workspace (the head phase git-cleans it) and points this env var there.
     BASELINE_BENCHMARK_JSON = ENV.fetch("BENCHMARK_BASELINE_JSON", "bench_results_base/benchmark.json")
     BASELINE_REPORT_JSON = ENV.fetch("BENCHER_BASELINE_REPORT_JSON", "bench_results_base/bencher_report.json")
+    # The base phase's display sidecar. Its per-sample raw values pair with the head
+    # sidecar's for sample confirmation (BencherReport#apply_sample_confirmation!).
+    BASELINE_DISPLAY_JSON = ENV.fetch("BENCHMARK_BASELINE_DISPLAY_JSON", "bench_results_base/benchmark_display.json")
     # Written by the bench scripts (BmfCollector#write_display_json); carries the
     # summary-table columns Bencher never sees (p90, raw Status), keyed by the same
     # canonical name as the report so the join is exact.

--- a/benchmarks/lib/track_benchmarks/confirmation.rb
+++ b/benchmarks/lib/track_benchmarks/confirmation.rb
@@ -83,8 +83,8 @@ module TrackBenchmarks
         when :confirmed
           lines = confirmed_alerts.map { |alert| "- #{describe_alert(alert)}" }.join("\n")
           "## #{suite_name} confirmation: ✅ CONFIRMED\n\n" \
-            "These first-run alerts re-alerted on a fresh runner (re-tested against main's " \
-            "baseline) and will be reported:\n\n#{lines}\n\n"
+            "These first-run alerts re-alerted on a fresh runner (base and head re-benchmarked " \
+            "side by side) and will be reported:\n\n#{lines}\n\n"
         when :cleared
           "## #{suite_name} confirmation: 🟢 CLEARED (noise)\n\n" \
           "The first-run alert(s) did not re-alert on a fresh runner. No issue will be filed.\n\n"

--- a/benchmarks/lib/track_benchmarks/summary.rb
+++ b/benchmarks/lib/track_benchmarks/summary.rb
@@ -48,6 +48,18 @@ module TrackBenchmarks
       BenchmarkTable.new(title: "#{suite_name} Benchmark Summary", rows:, report:).to_markdown
     end
 
+    # Per-sample raw values from a display sidecar, keyed by benchmark name — the
+    # shape BencherReport#apply_sample_confirmation! consumes. Rows without a
+    # "samples" key (single-sample runs, failed routes) are skipped; a missing or
+    # invalid sidecar yields {} (the caller then skips confirmation, failing open).
+    def samples_by_name(display_json)
+      display_rows(display_json).each_with_object({}) do |row, samples|
+        next unless row.is_a?(Hash) && row["samples"].is_a?(Hash) && row["name"]
+
+        samples[row["name"]] = row["samples"]
+      end
+    end
+
     # Body for regression hand-offs. Normally the rendered table; but if the display
     # sidecar was missing/corrupt rendered_report returned "" — don't hand off empty
     # evidence. Substitute a run-URL pointer and shout via ::error::.

--- a/benchmarks/spec/bench_spec.rb
+++ b/benchmarks/spec/bench_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "bench" do
           @added = []
         end
 
-        def add(name:, rps:, p50:, status:, p90: nil)
-          @added << { name:, rps:, p50:, p90:, status: }
+        def add(name:, rps:, p50:, status:, p90: nil, samples: nil)
+          @added << { name:, rps:, p50:, p90:, status:, samples: }
         end
       end.new
     end
@@ -39,7 +39,7 @@ RSpec.describe "bench" do
     end
 
     it "returns no failures and records every route when all succeed" do
-      runner = ->(_route) { [100.0, 1.0, 2.0, "200=10"] }
+      runner = ->(_route) { { rps: 100.0, p50: 1.0, p90: 2.0, status: "200=10", samples: nil } }
 
       failed = run_benchmark_suite(%w[/a /b], collector, runner:)
 
@@ -47,11 +47,20 @@ RSpec.describe "bench" do
       expect(collector.added.map { |m| m[:name] }).to eq(%w[/a /b])
     end
 
+    it "passes per-sample values through to the collector" do
+      samples = { "rps" => [99.0, 100.0, 101.0] }
+      runner = ->(_route) { { rps: 100.0, p50: 1.0, p90: 2.0, status: "200=10", samples: } }
+
+      run_benchmark_suite(%w[/a], collector, runner:)
+
+      expect(collector.added.first).to include(samples:)
+    end
+
     it "continues past a failing route and returns every route that failed" do
       runner = lambda do |route|
         raise "k6 benchmark failed" if route == "/bad"
 
-        [100.0, 1.0, 2.0, "200=10"]
+        { rps: 100.0, p50: 1.0, p90: 2.0, status: "200=10", samples: nil }
       end
 
       failed = nil
@@ -80,6 +89,63 @@ RSpec.describe "bench" do
 
       expect(failed).to eq(%w[/x /y])
       expect(collector.added).to be_empty
+    end
+  end
+
+  # Sampling aggregation (#4580): repeated k6 samples per route are reduced to
+  # medians (robust to a one-off noisy sample), summed status counts, and a raw
+  # per-sample payload keyed by Bencher measure for sample confirmation.
+  describe "#aggregate_samples" do
+    it "reports the median per metric and keeps per-sample values by measure" do
+      result = aggregate_samples(
+        [
+          [100.0, 10.0, 20.0, "200=100"],
+          [130.0, 8.0, 26.0, "200=130"],
+          [90.0, 11.0, 22.0, "200=90,3xx=1"]
+        ]
+      )
+
+      expect(result).to eq(
+        rps: 100.0, p50: 10.0, p90: 22.0, status: "200=320,3xx=1",
+        samples: {
+          "rps" => [100.0, 130.0, 90.0],
+          "p50_latency" => [10.0, 8.0, 11.0],
+          "p90_latency" => [20.0, 26.0, 22.0]
+        }
+      )
+    end
+
+    it "averages the middle two samples for even sample counts" do
+      result = aggregate_samples([[100.0, 10.0, 20.0, "200=1"], [110.0, 12.0, 24.0, "200=1"]])
+
+      expect(result[:rps]).to eq(105.0)
+      expect(result[:p50]).to eq(11.0)
+    end
+
+    it "keeps the single-sample result unchanged with no samples payload" do
+      result = aggregate_samples([[100.0, 10.0, 20.0, "200=100"]])
+
+      expect(result).to eq(rps: 100.0, p50: 10.0, p90: 20.0, status: "200=100", samples: nil)
+    end
+
+    it "propagates MISSING for a metric any sample failed to produce, and drops it from samples" do
+      result = aggregate_samples(
+        [
+          [100.0, 10.0, "MISSING", "200=100"],
+          [110.0, 12.0, 24.0, "200=110"]
+        ]
+      )
+
+      expect(result[:p90]).to eq("MISSING")
+      expect(result[:rps]).to eq(105.0)
+      expect(result[:samples]).to eq("rps" => [100.0, 110.0], "p50_latency" => [10.0, 12.0])
+    end
+
+    it "skips MISSING statuses when merging and stays MISSING when all are" do
+      expect(aggregate_samples([[1.0, 1.0, 1.0, "MISSING"], [1.0, 1.0, 1.0, "200=5"]])[:status])
+        .to eq("200=5")
+      expect(aggregate_samples([[1.0, 1.0, 1.0, "MISSING"], [1.0, 1.0, 1.0, "MISSING"]])[:status])
+        .to eq("MISSING")
     end
   end
 

--- a/benchmarks/spec/bencher_report_spec.rb
+++ b/benchmarks/spec/bencher_report_spec.rb
@@ -404,6 +404,94 @@ RSpec.describe BencherReport do
   # measures comma-lists, then report=). These fields are NOT part of the documented
   # contract, so extraction is lenient: any missing piece yields nil and the caller
   # renders the benchmark name unlinked rather than failing the job.
+  # Sample confirmation (#4580): repeated per-route samples act as built-in reruns.
+  # Overlapping base/head sample ranges downgrade a boundary crossing (alerts move
+  # out of #alerts; #significance reports :unconfirmed); disjoint ranges confirm it.
+  describe "#apply_sample_confirmation!" do
+    def alerting_report
+      described_class.parse(
+        report_json(
+          results: [[rps_regression_result]],
+          alerts: [alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")]
+        )
+      )
+    end
+
+    def confirmed(report, head:, base:)
+      report.apply_sample_confirmation!(
+        head_samples: { "/foo: Core" => { "rps" => head } },
+        base_samples: { "/foo: Core" => { "rps" => base } }
+      )
+    end
+
+    it "keeps a change whose sample ranges are disjoint (reproduced in every sample)" do
+      report = confirmed(alerting_report, head: [80.0, 82.0, 79.0], base: [100.0, 98.0, 101.0])
+
+      expect(report.regression?).to be(true)
+      expect(report.unconfirmed_alert?).to be(false)
+      expect(report.significance("/foo: Core", "rps", :lower)).to eq(:regression)
+    end
+
+    it "downgrades a change whose sample ranges overlap (did not reproduce)" do
+      report = confirmed(alerting_report, head: [80.0, 99.5, 79.0], base: [99.0, 98.0, 101.0])
+
+      expect(report.regression?).to be(false)
+      expect(report.unconfirmed_alert?).to be(true)
+      expect(report.unconfirmed_alerts.first.benchmark).to eq("/foo: Core")
+      expect(report.significance("/foo: Core", "rps", :lower)).to eq(:unconfirmed)
+    end
+
+    it "downgrades an unreproduced improvement flag too" do
+      report = described_class.parse(
+        report_json(results: [[rps_regression_result(value: 115.0)]])
+      )
+      confirmed(report, head: [115.0, 99.0, 116.0], base: [100.0, 98.0, 101.0])
+
+      expect(report.significance("/foo: Core", "rps", :lower)).to eq(:unconfirmed)
+    end
+
+    it "matches sample measure keys across slug/name normalization" do
+      report = alerting_report
+      report.apply_sample_confirmation!(
+        head_samples: { "/foo: Core" => { "RPS" => [80.0, 99.5] } },
+        base_samples: { "/foo: Core" => { "rps" => [99.0, 101.0] } }
+      )
+
+      expect(report.unconfirmed_alert?).to be(true)
+    end
+
+    it "fails open when either side lacks two numeric samples" do
+      [
+        { head: [80.0], base: [100.0, 101.0] },              # too few head samples
+        { head: [80.0, "x"], base: [100.0, 101.0] },         # non-numeric head sample
+        { head: [80.0, 99.5], base: nil },                   # base measure missing
+        {}                                                   # no sample data at all
+      ].each do |scenario|
+        report = alerting_report
+        if scenario.any?
+          report.apply_sample_confirmation!(
+            head_samples: { "/foo: Core" => { "rps" => scenario[:head] }.compact },
+            base_samples: { "/foo: Core" => { "rps" => scenario[:base] }.compact }
+          )
+        else
+          report.apply_sample_confirmation!(head_samples: {}, base_samples: {})
+        end
+
+        expect(report.regression?).to be(true), "expected fail-open for #{scenario.inspect}"
+        expect(report.significance("/foo: Core", "rps", :lower)).to eq(:regression)
+      end
+    end
+
+    it "leaves boundary-only significance untouched for pairs without an alert" do
+      # p90 has no alert (boundary-less in production) — confirmation only consults
+      # sample data for flags that fire; a non-flagged measure stays nil/unchanged.
+      report = described_class.parse(report_json(results: [[rps_regression_result(value: 95.0)]]))
+      confirmed(report, head: [95.0, 96.0], base: [100.0, 99.0])
+
+      expect(report.significance("/foo: Core", "rps", :lower)).to be_nil
+    end
+  end
+
   describe "#perf_url" do
     def bench(name:, uuid:, measure_uuids:)
       measures = measure_uuids.each_with_index.map do |muuid, i|

--- a/benchmarks/spec/bencher_report_spec.rb
+++ b/benchmarks/spec/bencher_report_spec.rb
@@ -483,8 +483,9 @@ RSpec.describe BencherReport do
     end
 
     it "leaves boundary-only significance untouched for pairs without an alert" do
-      # p90 has no alert (boundary-less in production) — confirmation only consults
-      # sample data for flags that fire; a non-flagged measure stays nil/unchanged.
+      # rps at 95.0 sits inside its 90–110 interval, so no flag fires — confirmation
+      # only downgrades measures whose boundary crossing fired; a non-flagged measure
+      # stays nil/unchanged even when its sample ranges overlap.
       report = described_class.parse(report_json(results: [[rps_regression_result(value: 95.0)]]))
       confirmed(report, head: [95.0, 96.0], base: [100.0, 99.0])
 

--- a/benchmarks/spec/bencher_runner_spec.rb
+++ b/benchmarks/spec/bencher_runner_spec.rb
@@ -8,7 +8,11 @@ require_relative "../lib/bencher_runner"
 RSpec.describe BencherRunner do
   subject(:runner) { described_class.new(benchmark_json: "bench.json", report_json: "report.json") }
 
-  def capture_run_command(branch: "my-branch", start_point_args: [])
+  def runner_for(mode)
+    described_class.new(benchmark_json: "bench.json", report_json: "report.json", mode:)
+  end
+
+  def capture_run_command(branch: "my-branch", start_point_args: [], runner: self.runner)
     status = instance_double(Process::Status, exitstatus: 0)
     report_json = JSON.generate("results" => [], "alerts" => [])
     captured_args = nil
@@ -81,8 +85,44 @@ RSpec.describe BencherRunner do
       )
     end
 
-    it "passes the tuned maximum sample size to Bencher thresholds" do
-      expect(capture_run_command.each_cons(2)).to include(["--threshold-max-sample-size", "64"])
+    it "uses the t-test with the tuned maximum sample size by default (statistical trend mode)" do
+      args = capture_run_command
+
+      expect(args.each_cons(2)).to include(["--threshold-test", "t_test"])
+      expect(args.each_cons(2)).to include(["--threshold-max-sample-size", "64"])
+      expect(args).to include("--err")
+    end
+
+    it "omits thresholds and --err for a relative baseline run (it must never gate the job)" do
+      args = capture_run_command(runner: runner_for(:relative_baseline), start_point_args: ["--start-point-reset"])
+
+      expect(args).not_to include("--err")
+      expect(args).not_to include("--threshold-measure")
+      expect(args).not_to include("--thresholds-reset")
+      expect(args).to include("--start-point-reset")
+    end
+
+    it "compares a relative head run with percentage thresholds and resets stale threshold models" do
+      args = capture_run_command(runner: runner_for(:relative_head))
+
+      expect(args).to include("--err", "--thresholds-reset")
+      expect(args.each_cons(2)).to include(["--threshold-test", "percentage"])
+      expect(args.each_cons(2)).not_to include(["--threshold-test", "t_test"])
+      # A percentage boundary is computed from the baseline directly; the sample-size
+      # cap only applies to the t-test's history window.
+      expect(args).not_to include("--threshold-max-sample-size")
+      expect(parse_thresholds(args)).to eq(
+        [
+          { measure: "rps", lower: "0.25", upper: "_" },
+          { measure: "p50_latency", lower: "_", upper: "0.25" },
+          { measure: "failed_pct", lower: "_", upper: "0.25" }
+        ]
+      )
+    end
+
+    it "rejects unknown modes at construction time" do
+      expect { described_class.new(benchmark_json: "b.json", report_json: "r.json", mode: :nope) }
+        .to raise_error(ArgumentError, /unknown mode :nope/)
     end
   end
 

--- a/benchmarks/spec/benchmark_table_spec.rb
+++ b/benchmarks/spec/benchmark_table_spec.rb
@@ -98,6 +98,20 @@ RSpec.describe BenchmarkTable do
     expect(markdown).to include("| /foo | **80.0** 🔴 20.0% (100.0) | **4.0** 🟢 20.0% (5.0) | 6.0 | 200=100 |")
   end
 
+  it "renders an unconfirmed crossing with ⚠️ plus the plain arrow, unbolded" do
+    report = fake_report(
+      verdicts: { ["/foo", "rps"] => :unconfirmed, ["/foo", "p50_latency"] => :unconfirmed },
+      baselines: { ["/foo", "rps"] => 100.0, ["/foo", "p50_latency"] => 5.0 }
+    )
+    markdown = render(
+      rows: [row(name: "/foo", rps: 80.0, p50: 7.0, p90: 6.0, status: "200=100")],
+      report:
+    )
+
+    expect(markdown).to include("| /foo | 80.0 ⚠️ ▼20.0% (100.0) | 7.0 ⚠️ ▲40.0% (5.0) | 6.0 | 200=100 |")
+    expect(markdown).to include("⚠️ crossed threshold but base/head samples overlap (unconfirmed)")
+  end
+
   it "shows a p90 delta when a baseline exists but never marks it significant (p90 is untracked)" do
     # Even if the report somehow returned a verdict for p90, the p90 column has no
     # direction, so the renderer must not consult significance for it — only the baseline.

--- a/benchmarks/spec/bmf_collector_spec.rb
+++ b/benchmarks/spec/bmf_collector_spec.rb
@@ -115,6 +115,24 @@ RSpec.describe BmfCollector do
         expect(collector.display_rows.map { |row| row["name"] }).to eq(["/broken"])
         expect(collector.to_bmf).to be_empty
       end
+
+      it "carries per-sample values in the row (and never in the BMF payload)" do
+        samples = { "rps" => [99.0, 100.0, 101.0], "p50_latency" => [4.9, 5.0, 5.2] }
+        collector = described_class.new
+        collector.add(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100", samples:)
+
+        expect(collector.display_rows.first["samples"]).to eq(samples)
+        expect(collector.to_bmf.dig("/foo", "rps")).to eq("value" => 100.0)
+        expect(collector.to_bmf["/foo"].keys).not_to include("samples")
+      end
+
+      it "omits the samples key for single-sample rows (nil or empty samples)" do
+        collector = described_class.new
+        collector.add(name: "/single", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100", samples: nil)
+        collector.add(name: "/empty", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100", samples: {})
+
+        expect(collector.display_rows).to(be_none { |row| row.key?("samples") })
+      end
     end
 
     describe "#write_display_json" do

--- a/benchmarks/spec/track_benchmarks/branch_args_spec.rb
+++ b/benchmarks/spec/track_benchmarks/branch_args_spec.rb
@@ -4,88 +4,63 @@ require_relative "../spec_helper"
 require_relative "../../lib/track_benchmarks"
 
 RSpec.describe TrackBenchmarks::BranchArgs do
-  describe ".branch_and_start_point_args" do
-    it "uses main with no start point for push events" do
-      branch, start_point_args = described_class.branch_and_start_point_args(
-        env: { "GITHUB_EVENT_NAME" => "push" }
-      )
-
-      expect(branch).to eq("main")
-      expect(start_point_args).to eq([])
-    end
-
-    it "uses the pull request head branch and base SHA as the start point" do
-      branch, start_point_args = described_class.branch_and_start_point_args(
+  describe ".run_plan" do
+    it "targets main and a per-run baseline branch for push events" do
+      plan = described_class.run_plan(
         env: {
-          "GITHUB_EVENT_NAME" => "pull_request",
-          "GITHUB_HEAD_REF" => "feature/benchmarks",
-          "GITHUB_BASE_REF" => "main",
-          "GITHUB_BASE_SHA" => "abc123"
+          "GITHUB_EVENT_NAME" => "push",
+          "GITHUB_RUN_ID" => "12345",
+          "BENCHMARK_SUITE_NAME" => "Core"
         }
       )
 
-      expect(branch).to eq("feature/benchmarks")
-      expect(start_point_args).to eq(
-        %w[
-          --start-point main
-          --start-point-hash abc123
-          --start-point-clone-thresholds
-          --start-point-reset
-        ]
-      )
+      expect(plan.head_branch).to eq("main")
+      expect(plan.baseline_branch).to eq("base-12345-core")
     end
 
-    it "adds a workflow_dispatch merge-base hash when the GitHub API resolves one" do
-      status = instance_double(Process::Status, success?: true)
-      allow(GithubCli).to receive(:capture).with(
-        "gh", "api", "repos/shakacode/react_on_rails/compare/main...feature/benchmarks",
-        "--jq", ".merge_base_commit.sha",
-        error_message: "Failed to resolve merge-base with main for feature/benchmarks"
-      ).and_return(["merge-base-sha\n", status])
-
-      branch = nil
-      start_point_args = nil
-      expect do
-        branch, start_point_args = described_class.branch_and_start_point_args(
-          env: {
-            "GITHUB_EVENT_NAME" => "workflow_dispatch",
-            "GITHUB_REF_NAME" => "feature/benchmarks",
-            "GITHUB_REPOSITORY" => "shakacode/react_on_rails"
-          }
-        )
-      end.to output(/Found merge-base via API: merge-base-sha/).to_stdout
-
-      expect(branch).to eq("feature/benchmarks")
-      expect(start_point_args).to eq(
-        %w[
-          --start-point main
-          --start-point-hash merge-base-sha
-          --start-point-clone-thresholds
-          --start-point-reset
-        ]
+    it "targets the pull request head branch and a per-run baseline branch" do
+      plan = described_class.run_plan(
+        env: {
+          "GITHUB_EVENT_NAME" => "pull_request",
+          "GITHUB_HEAD_REF" => "feature/benchmarks",
+          "GITHUB_RUN_ID" => "12345",
+          "BENCHMARK_SUITE_NAME" => "Pro (shard 1/2)"
+        }
       )
+
+      expect(plan.head_branch).to eq("feature/benchmarks")
+      expect(plan.baseline_branch).to eq("base-12345-pro-shard-1-2")
     end
 
-    it "falls back to the latest main baseline when workflow_dispatch merge-base lookup fails" do
-      status = instance_double(Process::Status, success?: false)
-      allow(GithubCli).to receive(:capture).and_return(["", status])
+    it "targets the dispatched ref for workflow_dispatch events" do
+      plan = described_class.run_plan(
+        env: {
+          "GITHUB_EVENT_NAME" => "workflow_dispatch",
+          "GITHUB_REF_NAME" => "feature/benchmarks",
+          "GITHUB_RUN_ID" => "12345",
+          "BENCHMARK_SUITE_NAME" => "Core"
+        }
+      )
 
-      branch = nil
-      start_point_args = nil
-      expect do
-        branch, start_point_args = described_class.branch_and_start_point_args(
+      expect(plan.head_branch).to eq("feature/benchmarks")
+      expect(plan.baseline_branch).to eq("base-12345-core")
+    end
+
+    # Concurrent shards must never share a baseline branch: --start-point <branch>
+    # clones the branch's CURRENT head, so a shared name could anchor one shard's
+    # comparison to another shard's baseline data.
+    it "gives concurrently-running shards distinct baseline branches" do
+      plans = ["Pro (shard 1/2)", "Pro (shard 2/2)"].map do |suite_name|
+        described_class.run_plan(
           env: {
-            "GITHUB_EVENT_NAME" => "workflow_dispatch",
-            "GITHUB_REF_NAME" => "feature/benchmarks",
-            "GITHUB_REPOSITORY" => "shakacode/react_on_rails"
+            "GITHUB_EVENT_NAME" => "push",
+            "GITHUB_RUN_ID" => "12345",
+            "BENCHMARK_SUITE_NAME" => suite_name
           }
         )
-      end.to output(/Could not find merge-base with main via GitHub API/).to_stdout
+      end
 
-      expect(branch).to eq("feature/benchmarks")
-      expect(start_point_args).to eq(
-        %w[--start-point main --start-point-clone-thresholds --start-point-reset]
-      )
+      expect(plans.map(&:baseline_branch).uniq.length).to eq(2)
     end
 
     it "fails loudly for unexpected event types" do
@@ -93,10 +68,29 @@ RSpec.describe TrackBenchmarks::BranchArgs do
       expected_exit = raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
 
       expect do
-        described_class.branch_and_start_point_args(
-          env: { "GITHUB_EVENT_NAME" => "schedule" }
+        described_class.run_plan(
+          env: {
+            "GITHUB_EVENT_NAME" => "schedule",
+            "GITHUB_RUN_ID" => "12345",
+            "BENCHMARK_SUITE_NAME" => "Core"
+          }
         )
       end.to expected_output.and(expected_exit)
+    end
+  end
+
+  describe ".baseline_start_point_args / .head_start_point_args" do
+    it "starts the baseline as a fresh series" do
+      expect(described_class.baseline_start_point_args).to eq(["--start-point-reset"])
+    end
+
+    it "anchors the head run to the just-recorded baseline branch, without cloned thresholds" do
+      args = described_class.head_start_point_args("base-12345-core")
+
+      expect(args).to eq(%w[--start-point base-12345-core --start-point-reset])
+      # Relative thresholds are (re)stated per run by BencherRunner mode :relative_head,
+      # so nothing may be cloned from the start point.
+      expect(args).not_to include("--start-point-clone-thresholds")
     end
   end
 end

--- a/benchmarks/spec/track_benchmarks/cli_spec.rb
+++ b/benchmarks/spec/track_benchmarks/cli_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe TrackBenchmarks::Cli do
         .with(head_runner, "main", %w[--start-point base-42-core --start-point-reset])
         .and_return(head_result)
       allow(TrackBenchmarks::BencherRun).to receive(:normalized_exit_code).with(1, report).and_return(1)
+      allow(TrackBenchmarks::Summary).to receive(:samples_by_name).and_return({})
       allow(TrackBenchmarks::Summary).to receive(:rendered_report)
         .with(report, "Core", TrackBenchmarks::Config::DISPLAY_JSON)
         .and_return("summary")
@@ -56,6 +57,44 @@ RSpec.describe TrackBenchmarks::Cli do
 
       expect(TrackBenchmarks::BencherRun).to have_received(:run_bencher!).twice
       expect(TrackBenchmarks::RegressionPayloads).to have_received(:main_push?).with(env:)
+    end
+
+    it "applies sample confirmation from both sidecars before normalizing the exit code" do
+      env = {
+        "GITHUB_EVENT_NAME" => "push",
+        "GITHUB_REF" => "refs/heads/main",
+        "GITHUB_RUN_ID" => "42",
+        "BENCHMARK_SUITE_NAME" => "Core"
+      }
+      cli = described_class.new(suite_name: "Core", report_marker: "core", env:)
+      baseline_runner = instance_double(BencherRunner)
+      head_runner = instance_double(BencherRunner)
+      report = instance_double(BencherReport)
+      head_samples = { "/x: Core" => { "rps" => [80.0, 99.0] } }
+      base_samples = { "/x: Core" => { "rps" => [100.0, 98.0] } }
+      unconfirmed = BencherReport::Alert.new(benchmark: "/x: Core", measure: "rps", limit: "lower")
+
+      stub_runners(baseline_runner, head_runner)
+      allow(TrackBenchmarks::BencherRun).to receive(:run_bencher!)
+        .and_return(result_type.new(stderr: "", exit_code: 0, report: nil),
+                    result_type.new(stderr: "", exit_code: 1, report:))
+      allow(TrackBenchmarks::Summary).to receive(:samples_by_name)
+        .with(TrackBenchmarks::Config::DISPLAY_JSON).and_return(head_samples)
+      allow(TrackBenchmarks::Summary).to receive(:samples_by_name)
+        .with(TrackBenchmarks::Config::BASELINE_DISPLAY_JSON).and_return(base_samples)
+      allow(report).to receive_messages(unconfirmed_alert?: true, unconfirmed_alerts: [unconfirmed])
+      allow(TrackBenchmarks::Summary).to receive(:rendered_report).and_return("summary")
+      allow(TrackBenchmarks::Summary).to receive(:post_report_to_summary)
+      allow(TrackBenchmarks::RegressionPayloads).to receive(:main_push?).and_return(false)
+
+      # Confirmation must be applied to the report BEFORE the exit code is normalized:
+      # normalization reads the post-confirmation alert state.
+      expect(report).to receive(:apply_sample_confirmation!)
+        .with(head_samples:, base_samples:).ordered
+      expect(TrackBenchmarks::BencherRun).to receive(:normalized_exit_code).with(1, report).ordered.and_return(0)
+
+      expect { cli.run }
+        .to output(%r{::notice::Sample confirmation downgraded 1 Bencher alert\(s\).*/x: Core \(rps\)}).to_stdout
     end
 
     it "aborts before the head comparison when the baseline upload fails" do

--- a/benchmarks/spec/track_benchmarks/cli_spec.rb
+++ b/benchmarks/spec/track_benchmarks/cli_spec.rb
@@ -7,38 +7,79 @@ RSpec.describe TrackBenchmarks::Cli do
   include BenchmarkEnvHelper
 
   describe "#run" do
-    it "passes injected env through benchmark orchestration gates" do
-      env = { "GITHUB_EVENT_NAME" => "push", "GITHUB_REF" => "refs/heads/main" }
-      cli = described_class.new(suite_name: "Core", report_marker: "core", env:)
-      runner = instance_double(BencherRunner)
-      report = instance_double(BencherReport)
-      result_type = Struct.new(:stderr, :exit_code, :report, keyword_init: true)
-      result = result_type.new(stderr: "", exit_code: 1, report:)
+    let(:result_type) { Struct.new(:stderr, :exit_code, :report, keyword_init: true) }
 
+    def stub_runners(baseline_runner, head_runner)
+      allow(BencherRunner).to receive(:new).with(
+        benchmark_json: TrackBenchmarks::Config::BASELINE_BENCHMARK_JSON,
+        report_json: TrackBenchmarks::Config::BASELINE_REPORT_JSON,
+        mode: :relative_baseline
+      ).and_return(baseline_runner)
       allow(BencherRunner).to receive(:new).with(
         benchmark_json: TrackBenchmarks::Config::BENCHMARK_JSON,
-        report_json: TrackBenchmarks::Config::REPORT_JSON
-      ).and_return(runner)
-      allow(TrackBenchmarks::BranchArgs).to receive(:branch_and_start_point_args).with(env:).and_return(["main", []])
-      allow(TrackBenchmarks::BencherRun).to receive(:run_bencher!).with(runner, "main", []).and_return(result)
-      allow(TrackBenchmarks::BencherRun).to receive(:retry_without_start_point_hash?)
-        .with("", 1, report)
-        .and_return(false)
+        report_json: TrackBenchmarks::Config::REPORT_JSON,
+        mode: :relative_head
+      ).and_return(head_runner)
+    end
+
+    it "submits the baseline then the head comparison and passes env through orchestration gates" do
+      env = {
+        "GITHUB_EVENT_NAME" => "push",
+        "GITHUB_REF" => "refs/heads/main",
+        "GITHUB_RUN_ID" => "42",
+        "BENCHMARK_SUITE_NAME" => "Core"
+      }
+      cli = described_class.new(suite_name: "Core", report_marker: "core", env:)
+      baseline_runner = instance_double(BencherRunner)
+      head_runner = instance_double(BencherRunner)
+      report = instance_double(BencherReport)
+      baseline_result = result_type.new(stderr: "", exit_code: 0, report: nil)
+      head_result = result_type.new(stderr: "", exit_code: 1, report:)
+
+      stub_runners(baseline_runner, head_runner)
+      allow(TrackBenchmarks::BencherRun).to receive(:run_bencher!)
+        .with(baseline_runner, "base-42-core", ["--start-point-reset"])
+        .and_return(baseline_result)
+      allow(TrackBenchmarks::BencherRun).to receive(:run_bencher!)
+        .with(head_runner, "main", %w[--start-point base-42-core --start-point-reset])
+        .and_return(head_result)
       allow(TrackBenchmarks::BencherRun).to receive(:normalized_exit_code).with(1, report).and_return(1)
       allow(TrackBenchmarks::Summary).to receive(:rendered_report)
         .with(report, "Core", TrackBenchmarks::Config::DISPLAY_JSON)
         .and_return("summary")
       expect(TrackBenchmarks::Summary).to receive(:post_report_to_summary).with("summary", "Core")
-      allow(TrackBenchmarks::BranchArgs).to receive(:confirmation_mode?).with(env:).and_return(false)
       allow(TrackBenchmarks::RegressionPayloads).to receive(:main_push?).with(env:).and_return(true)
       expect(TrackBenchmarks::RegressionPayloads).to receive(:report_main_push_candidate)
         .with(report, "summary", 1, "Core")
 
       cli.run
 
-      expect(TrackBenchmarks::BranchArgs).to have_received(:branch_and_start_point_args).with(env:)
-      expect(TrackBenchmarks::BranchArgs).to have_received(:confirmation_mode?).with(env:)
+      expect(TrackBenchmarks::BencherRun).to have_received(:run_bencher!).twice
       expect(TrackBenchmarks::RegressionPayloads).to have_received(:main_push?).with(env:)
+    end
+
+    it "aborts before the head comparison when the baseline upload fails" do
+      env = {
+        "GITHUB_EVENT_NAME" => "push",
+        "GITHUB_REF" => "refs/heads/main",
+        "GITHUB_RUN_ID" => "42",
+        "BENCHMARK_SUITE_NAME" => "Core"
+      }
+      cli = described_class.new(suite_name: "Core", report_marker: "core", env:)
+      baseline_runner = instance_double(BencherRunner)
+      head_runner = instance_double(BencherRunner)
+      baseline_result = result_type.new(stderr: "auth failed", exit_code: 2, report: nil)
+
+      stub_runners(baseline_runner, head_runner)
+      allow(TrackBenchmarks::BencherRun).to receive(:run_bencher!)
+        .with(baseline_runner, "base-42-core", ["--start-point-reset"])
+        .and_return(baseline_result)
+
+      expected_output = output(/::error::Bencher baseline upload for Core failed \(exit 2\)/).to_stderr
+      expected_exit = raise_error(SystemExit) { |error| expect(error.status).to eq(2) }
+      expect { cli.run }.to expected_output.and(expected_exit)
+
+      expect(TrackBenchmarks::BencherRun).to have_received(:run_bencher!).once
     end
   end
 

--- a/benchmarks/spec/track_benchmarks/summary_spec.rb
+++ b/benchmarks/spec/track_benchmarks/summary_spec.rb
@@ -77,6 +77,32 @@ RSpec.describe TrackBenchmarks::Summary do
     end
   end
 
+  describe ".samples_by_name" do
+    it "keys each row's per-sample values by benchmark name, skipping sample-less rows" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "benchmark_display.json")
+        File.write(path, JSON.generate(
+                           [
+                             { "name" => "/a", "rps" => 10.0, "samples" => { "rps" => [9.0, 10.0, 11.0] } },
+                             { "name" => "/single", "rps" => 10.0 },
+                             { "name" => "/bad-samples", "rps" => 10.0, "samples" => "oops" },
+                             { "rps" => 10.0, "samples" => { "rps" => [1.0, 2.0] } }
+                           ]
+                         ))
+
+        expect(described_class.samples_by_name(path)).to eq(
+          "/a" => { "rps" => [9.0, 10.0, 11.0] }
+        )
+      end
+    end
+
+    it "returns an empty hash for a missing sidecar" do
+      Dir.mktmpdir do |dir|
+        expect(described_class.samples_by_name(File.join(dir, "missing.json"))).to eq({})
+      end
+    end
+  end
+
   describe ".regressed_alert_pairs" do
     it "deduplicates active alert benchmark and measure pairs" do
       report = BencherReport.parse(

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -8,10 +8,9 @@ require_relative "../lib/bmf_helpers"
 
 # track_benchmarks.rb runs its tracking flow only under `if __FILE__ == $PROGRAM_NAME`,
 # so requiring it just loads the helpers. These pin the classification that decides
-# whether a Bencher run is a real regression vs a missing-baseline retry — now read
-# from the JSON report's alerts[] rather than by grepping stderr. The two are
-# mutually exclusive by design: an alert must never trigger a start-point-hash retry,
-# or a real regression would be silently re-measured against the wrong baseline.
+# whether a Bencher run is a real regression — read from the JSON report's alerts[]
+# rather than by grepping stderr — and the branch targeting of the relative
+# continuous benchmarking runs.
 RSpec.describe "track_benchmarks" do
   include BenchmarkEnvHelper
 
@@ -109,27 +108,6 @@ RSpec.describe "track_benchmarks" do
     end
   end
 
-  describe "#retry_without_start_point_hash?" do
-    it "is true when the start-point head version is missing and there is no regression" do
-      expect(retry_without_start_point_hash?("Head Version abc123 not found", 1, report_without_alert)).to be(true)
-    end
-
-    it "is true when the head version is missing and no report was produced" do
-      expect(retry_without_start_point_hash?("Head Version abc123 not found", 1, nil)).to be(true)
-    end
-
-    it "is false when the report has an active alert (must not retry a real regression)" do
-      report = report_with_alert
-      expect(retry_without_start_point_hash?("Head Version abc123 not found", 1, report)).to be(false)
-      expect(regression?(report)).to be(true)
-    end
-
-    it "is false on success and for unrelated non-zero failures" do
-      expect(retry_without_start_point_hash?("Head Version abc123 not found", 0, report_without_alert)).to be(false)
-      expect(retry_without_start_point_hash?("some other error", 1, report_without_alert)).to be(false)
-    end
-  end
-
   describe "#replace_pr_comments" do
     it "does not require CI event env outside pull requests" do
       with_env("GITHUB_EVENT_NAME" => nil) do
@@ -205,18 +183,18 @@ RSpec.describe "track_benchmarks" do
       end
     end
 
-    describe "#branch_and_start_point_args" do
-      it "targets a throwaway branch and re-tests against main without polluting its series" do
+    describe "#run_plan" do
+      it "targets throwaway branches for both runs so main's series is never polluted" do
         ENV["BENCHMARK_MODE"] = "confirm"
         ENV["GITHUB_RUN_ID"] = "777"
         ENV["BENCHMARK_SUITE_NAME"] = "Core"
 
-        branch, start_point_args = branch_and_start_point_args
-        expect(branch).to eq("confirm-main-777-core")
-        expect(branch).not_to eq("main")
-        expect(start_point_args).to eq(
-          %w[--start-point main --start-point-clone-thresholds --start-point-reset]
-        )
+        plan = run_plan
+        expect(plan.head_branch).to eq("confirm-main-777-core")
+        expect(plan.head_branch).not_to eq("main")
+        # The confirmation's baseline must also never collide with the initial run's
+        # baseline branch within the same workflow run.
+        expect(plan.baseline_branch).to eq("confirm-base-777-core")
       end
     end
 
@@ -457,6 +435,17 @@ RSpec.describe "track_benchmarks" do
 
     it "are all emitted by BmfCollector (so no threshold is a silent no-op)" do
       expect(emitted).to include(*BencherRunner::THRESHOLDS.map(&:first))
+    end
+
+    # The CI relative comparison (RELATIVE_THRESHOLDS, percentage) and the local
+    # statistical trend runs (THRESHOLDS, t-test) must track the same measures with the
+    # same regression directions — only the boundary math differs. This keeps every
+    # THRESHOLDS-based invariant below (BmfCollector emission, summary-table columns)
+    # authoritative for the relative set too.
+    it "use the same measures and directions for relative (CI) and statistical (local) tracking" do
+      pairs = ->(thresholds) { thresholds.map { |measure, direction, _boundary| [measure, direction] } }
+
+      expect(pairs.call(BencherRunner::RELATIVE_THRESHOLDS)).to eq(pairs.call(BencherRunner::THRESHOLDS))
     end
 
     it "exclude p90_latency, which BmfCollector emits boundary-less (recorded but never alerted)" do

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -376,9 +376,46 @@ RSpec.describe "track_benchmarks" do
 
       exit_code = nil
       expect { exit_code = normalized_bencher_exit_code(1, report) }
-        .to output(/::notice::Bencher reported only stale active alert/).to_stdout
+        .to output(/::notice::Bencher alert\(s\) were all stale or unconfirmed across samples/).to_stdout
 
       expect(exit_code).to eq(0)
+    end
+
+    it "normalizes an alert exit to success when every active alert is unconfirmed across samples" do
+      report = BencherReport.parse(
+        JSON.generate(
+          "results" => [[result("/x", [rps_measure(value: 80.0)])]],
+          "alerts" => [active_alert]
+        )
+      )
+      # Overlapping base/head sample ranges: the median crossed the boundary but the
+      # change did not reproduce, so sample confirmation downgrades the alert.
+      report.apply_sample_confirmation!(
+        head_samples: { "/x" => { "rps" => [80.0, 99.0, 78.0] } },
+        base_samples: { "/x" => { "rps" => [100.0, 98.0, 102.0] } }
+      )
+
+      exit_code = nil
+      expect { exit_code = normalized_bencher_exit_code(1, report) }
+        .to output(/::notice::Bencher alert\(s\) were all stale or unconfirmed across samples/).to_stdout
+
+      expect(exit_code).to eq(0)
+    end
+
+    it "keeps the alert exit when a confirmed regression remains" do
+      report = BencherReport.parse(
+        JSON.generate(
+          "results" => [[result("/x", [rps_measure(value: 80.0)])]],
+          "alerts" => [active_alert]
+        )
+      )
+      # Disjoint ranges (every head sample below every base sample): confirmed.
+      report.apply_sample_confirmation!(
+        head_samples: { "/x" => { "rps" => [80.0, 82.0, 78.0] } },
+        base_samples: { "/x" => { "rps" => [100.0, 98.0, 102.0] } }
+      )
+
+      expect(normalized_bencher_exit_code(1, report)).to eq(1)
     end
   end
 

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -5,6 +5,7 @@ require_relative "lib/track_benchmarks"
 require_relative "lib/bencher_token"
 
 BENCHMARK_JSON = TrackBenchmarks::Config::BENCHMARK_JSON
+BASELINE_BENCHMARK_JSON = TrackBenchmarks::Config::BASELINE_BENCHMARK_JSON
 REPORT_JSON = TrackBenchmarks::Config::REPORT_JSON
 DISPLAY_JSON = TrackBenchmarks::Config::DISPLAY_JSON
 CANDIDATE_REPORT_JSON = TrackBenchmarks::Config::CANDIDATE_REPORT_JSON
@@ -27,12 +28,8 @@ def confirmation_branch(run_id, suite_name)
   TrackBenchmarks::BranchArgs.confirmation_branch(run_id, suite_name)
 end
 
-def confirmation_start_point_args
-  TrackBenchmarks::BranchArgs.confirmation_start_point_args
-end
-
-def branch_and_start_point_args
-  TrackBenchmarks::BranchArgs.branch_and_start_point_args
+def run_plan
+  TrackBenchmarks::BranchArgs.run_plan
 end
 
 def run_bencher!(branch, start_point_args)
@@ -103,10 +100,6 @@ def describe_alert(alert)
   TrackBenchmarks::Confirmation.describe_alert(alert)
 end
 
-def retry_without_start_point_hash?(stderr, exit_code, report)
-  TrackBenchmarks::BencherRun.retry_without_start_point_hash?(stderr, exit_code, report)
-end
-
 def main_push?
   TrackBenchmarks::RegressionPayloads.main_push?
 end
@@ -143,11 +136,18 @@ end
 # Only run the benchmark tracking when invoked as a script; `require`-ing the file
 # (e.g. from specs) just loads the compatibility helpers above.
 if __FILE__ == $PROGRAM_NAME
-  # Check the input file before validating env vars — a missing benchmark.json is the more
-  # actionable failure (almost always upstream `bench.rb` didn't produce results).
-  unless File.exist?(BENCHMARK_JSON)
-    warn "Benchmark JSON file not found: #{BENCHMARK_JSON}"
-    exit 1
+  # Check the input files before validating env vars — a missing benchmark.json is the
+  # more actionable failure (almost always an upstream bench phase didn't produce
+  # results). Relative continuous benchmarking needs BOTH this runner's runs: the base
+  # phase's baseline and the head phase's results.
+  {
+    "head benchmark JSON" => BENCHMARK_JSON,
+    "baseline (base-phase) benchmark JSON" => BASELINE_BENCHMARK_JSON
+  }.each do |label, path|
+    unless File.exist?(path)
+      warn "#{label} file not found: #{path}"
+      exit 1
+    end
   end
 
   SUITE_NAME = env!("BENCHMARK_SUITE_NAME")


### PR DESCRIPTION
## Summary

Closes #3492.

Switches the benchmark workflow from statistical continuous benchmarking (t-test thresholds against main's cross-runner history) to [relative continuous benchmarking](https://bencher.dev/docs/how-to/track-benchmarks/#relative-continuous-benchmarking): each suite job now builds and benchmarks **both the comparison base ref and the head ref on the same runner**, then compares them directly. This removes the cross-runner variance that made shared-runner alerts noise-dominated (#4071, false positives #4038–#4044).

- New `benchmark-suite-phase` composite action runs one ref end to end (checkout + clean → install/build → assets → DB seed → server → bench → stop server); `benchmark-suite.yml` invokes it twice per job. Servers start under `setsid` so each phase can kill its whole process tree and free the port for the next phase.
- `track_benchmarks.rb` now makes two Bencher runs: base results to a throwaway per-run baseline branch (`base-<run_id>-<suite-slug>`, `--start-point-reset`; unique per suite/shard so concurrent shards can't anchor to each other's data), then head results anchored to it (`--start-point <baseline> --start-point-reset --thresholds-reset`) with **percentage thresholds** (25% one-sided per measure) instead of the t-test. The `--start-point-hash` retry fallback is gone with the hash itself.
- Post-#4485 rebase: hosted suites are **manual-dispatch-only** (main's direction; the trusted trend lives on the dedicated local runner). The comparison base is resolved once in `prepare-benchmark-matrix`: merge-base with `main` for branch dispatches, `HEAD^` when dispatched on `main` itself — fail-loud, no API dependency.
- The old CI confirmation/regression-issue pipeline was deleted on main by #4485; this PR carries none of that plumbing. Rerun-to-confirm now lives at the report layer (sample confirmation below), which works identically for dispatched hosted runs.
- The local dedicated-hardware runner keeps statistical t-test trend tracking (`BencherRunner`'s default mode). Long-term dashboards now live on its testbed — relative runs reset the shared-runner series each run.

## Stability (round 2 — response to the initial run)

The initial run flagged 15 routes 🔴/🟢 on an infra-only diff with swings up to +149% p50 — pure noise. Root cause was found, reproduced off-CI, and fixed; detected changes now also have to survive built-in reruns before they flag.

1. **k6 `noConnectionReuse: true`** — the dominant noise source. A keep-alive connection is pinned to whichever Puma worker process accepted it, and Linux's LIFO accept-queue wakeup skews reconnect placement, so the 10 VUs' per-worker split drifts randomly within a run (splits as bad as 9/1/0 observed — a whole worker idle for the sample). Each 30s sample landed in a random queueing "mode": stable-RPS/wild-p50 on saturated SSR routes, coupled RPS/p50 swings on fast routes, and the one suite with no Puma in front (node renderer, vegeta) rock-stable — all three initial-run patterns explained. Reproduced in a CI-topology Linux container (4 cores; k6 pinned to core 0; Puma 3 workers × 3 threads on cores 1–3; puma 6.6.1; k6 v2.0.0):

   | mode | RPS spread (max/min−1) | RPS CV | p50 spread | p50 CV |
   | --- | --- | --- | --- | --- |
   | keep-alive (initial run) | 38.2% | 10.0% | 36.0% | 8.5% |
   | `noConnectionReuse` | **9.3%** | **3.3%** | **9.2%** | **3.4%** |

   Connect cost is excluded from `http_req_duration`, and `tcp_tw_reuse=2` recycles loopback TIME_WAIT ports (verified clean at 7.7k conn/s — 12× the busiest route).
2. **Median-of-3 sampling** — each route runs `BENCHMARK_SAMPLES` (CI: 3) k6 samples of 12s instead of a single 30s run; the median per measure ships to Bencher, so one disturbed sample can no longer set a route's number. Per-sample values ride in the display sidecar.
3. **Sample confirmation (rerun-to-confirm)** — a Bencher boundary crossing only stands if it reproduced across **every** sample (base and head sample ranges disjoint). Otherwise the summary table shows an unbolded ⚠️ instead of 🔴/🟢, the alert leaves the regression/candidate path, and the exit code normalizes. Pairs without ≥2 numeric samples on both sides fail open to single-sample behavior. The fresh-runner confirmation pipeline for main pushes is unchanged and now consumes only sample-confirmed alerts.
4. **One instrument for both phases** — both phases now execute the HEAD ref's stashed `benchmarks/` tree (a new "Stash head benchmark harness" step + `harness-dir` action input), not each phase's checkout. The harness is the measuring instrument; running two different copies would turn any harness change (like this PR) into a phantom base-vs-head delta. App-side inputs (`bin/prod*`, gems, packs, renderer config, node-renderer protocol version) still come from each phase's own checkout — `bench-node-renderer.rb` resolves those through `GITHUB_WORKSPACE`.

**Acceptance for this PR:** a dispatched benchmark run on this branch is an A/A test (base = merge-base with main; app code identical), so the summary tables should show no 🔴/🟢 flags (at most ⚠️ downgrades) and small deltas. Do not merge on a run that still looks like the initial one.

## Trade-offs

- Roughly doubles job wall-clock (two builds + two benchmark passes), plus ~10 min/job for sampling (3×12s + two extra k6 startups per route vs one 30s run).
- A PR adding a brand-new suite/app can't benchmark it (the base ref can't build it); drop the benchmark label for such PRs.
- Absolute numbers step once with the connection change (throughput now includes per-request connects). Irrelevant for the relative comparison; the local statistical trend series (`run-local-benchmark.rb`, unchanged single-sample 30s defaults) re-baselines within a few runs — noted in `LOCAL_BENCHMARK.md`.
- Interleaved/randomized base-head ordering from the issue is not implemented; sequential base-then-head matches the Bencher docs, and the container A/A runs bound within-job drift well under the 25% thresholds once connection stickiness is gone.

## Workflow Change Audit

- **Secrets**: no new secrets; `GITHUB_BASE_SHA` env removed from the tracking step; `GH_TOKEN` added to the detect-changes base-resolution step (existing `GITHUB_TOKEN`).
- **Permissions**: unchanged.
- **Triggers**: unchanged.
- **Third-party actions**: none added; still `bencherdev/bencher@v0.6.2`, `actions/*`, `grafana/setup-k6-action@v1`, `pnpm/action-setup@v6`.
- New steps/inputs are literal-only: the harness stash copies `benchmarks/` to `runner.temp`; `harness-dir`/`BENCHMARK_SAMPLES`/`BENCHMARK_BASELINE_DISPLAY_JSON` are constants. Untrusted inputs are still passed via `env:`/action inputs, never interpolated into scripts.

## Verification

- All 348 benchmark specs pass (`bundle exec rspec benchmarks/spec`) — 20 new for sampling aggregation, sample-confirmation semantics (disjoint vs overlapping ranges, fail-open), ⚠️ rendering, exit-code normalization, and CLI wiring.
- RuboCop clean on `benchmarks/`; `actionlint` clean; Prettier clean on changed files.
- Mechanism validation in a CI-topology Linux container (table above): keep-alive vs `noConnectionReuse` A/B, 8×10s runs each; concurrent- and sequential-connect worker-split probes; port-churn stress at 7.7k conn/s with 0 failed requests.
- End-to-end `bench.rb` run (real k6, local server, `BENCHMARK_SAMPLES=3`): per-sample suffixed artifacts written, medians correctly selected, samples sidecar populated, statuses summed.
- End-to-end smoke test with a stub `bencher` binary produced exactly the two-command sequence from the Bencher docs (baseline `--start-point-reset` upload, then percentage-threshold comparison run).
- Evidence runs: two clean A/A runs on the pre-rebase heads (details in comments), plus a dispatched A/A run on the reconciled head exercising the dispatch-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relative base-vs-head continuous benchmarking with an explicit base reference, including two-phase runs in the same workflow and extra base-phase artifacts.
  * Enabled multi-sample k6 benchmarking with per-sample outputs and aggregated median metrics.
  * Improved “unconfirmed” (⚠️) benchmark alert handling when base/head samples overlap, including updated confirmation and tracking behavior.
* **Documentation**
  * Updated local benchmark docs to clarify repeated-sample behavior and connection/alert interpretation.
* **Tests**
  * Expanded coverage for multi-sample aggregation, unconfirmed alert logic, and new workflow/suite wiring expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Confidence note

- Validated: 348 benchmark specs (`bundle exec rspec benchmarks/spec`, re-run green on the rebased head 9e430a435); RuboCop / actionlint / Prettier clean; A/A benchmark run [29187847192](https://github.com/shakacode/react_on_rails/actions/runs/29187847192) on 75543d47d — 0 flagged rows across all 4 suites (initial run: 36), max |Δ| 18.5% (was 202%), 0 cells ≥ 25%; all 9 optimized hosted CI workflows green on 75543d47d (Generator, Playwright E2E, Integration, Pro Integration, Pro Package, RSpec gem, JS unit, Assets Precompile, Lint); `required-pr-gate` green; `script/pr-merge-ledger 4580 --strict` → `complete_allowed: true` (changelog: `not_user_visible`; codex P1 dispositioned `not_applicable` with evidence).
- Evidence: [stability before/after comparison](https://github.com/shakacode/react_on_rails/pull/4580#issuecomment-4950888593); CodeRabbit APPROVED, claude-review clean (non-blocking notes), greptile 4/5, 0 unresolved review threads on 75543d47d.
- UNKNOWN: none — final head 41dcba6a6: all branch CI green, strict merge ledger complete_allowed, dispatch run 29992479059 green on all three k6 suites through the fixed full-history base resolution (node-renderer failure = pre-existing #4779, unchanged by this PR). Earlier: a second independent A/A benchmark run ([29190965437](https://github.com/shakacode/react_on_rails/actions/runs/29190965437)): again 0 flagged rows across all 4 suites, max |Δ| 20.1%, 0 cells ≥ 25%. Final-cycle review threads (6) triaged: 2 rebutted with evidence, 4 deferred to #4613 with rationale; 0 unresolved.
- Residual risk: multi-minute CPU-steal windows on shared runners can still shift a stretch of adjacent routes in one phase (observed +13–18% on four adjacent Core routes, well under thresholds); fully cancelling that would need interleaved base/head phases — documented trade-off, revisit only if real runs show it crossing thresholds.



