### PR TITLE
Docs: fix npm README JavaScript API link

### DIFF
--- a/packages/react-on-rails/README.md
+++ b/packages/react-on-rails/README.md
@@ -107,7 +107,7 @@ rails generate react_on_rails:install
 
 - [Getting Started](https://reactonrails.com/docs/getting-started/quick-start/)
 - [Installation Guide](https://reactonrails.com/docs/getting-started/existing-rails-app/)
-- [API Reference](https://reactonrails.com/docs/api-reference/)
+- [JavaScript API](https://reactonrails.com/docs/api-reference/javascript-api/)
 - [Configuration](https://reactonrails.com/docs/configuration/)
 
 ## License


### PR DESCRIPTION
## Why

The `react-on-rails` npm README links “API Reference” to `/docs/api-reference/`, but that category has no landing page and returns 404. This leaves npm visitors without a working API destination.

## What changed

Replace the dead category link with the JavaScript API page, which documents `ReactOnRails.register` and the npm package's public API.

## Validation

- `.agents/bin/ci-detect origin/main` — classified as documentation-only; no hosted CI jobs recommended
- `pnpm exec prettier --check packages/react-on-rails/README.md` — passed
- Pre-commit Markdown link and formatting hooks — passed
- `curl` against `https://reactonrails.com/docs/api-reference/javascript-api/` — HTTP 200
- Local test suite not run: documentation-only change, per repository policy

## Review notes

- Changelog: not required for a link correction
- Pre-push review: manual self-review; additional AI review and simplify passes skipped because this is a one-line, low-risk documentation fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation links to point directly to the JavaScript API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->