### PR TITLE
Update RSC package pin to 19.2.1-rc.1

### DIFF
--- a/docs/oss/building-features/react-19-activity.md
+++ b/docs/oss/building-features/react-19-activity.md
@@ -25,7 +25,7 @@ This is the React-blessed replacement for the classic "keep the inactive tab ali
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `react` / `react-dom` in your app  | **19.2.0 or later** (`Activity` does not exist in earlier versions, including 19.0/19.1)                                                                                                                                            |
 | `react_on_rails` gem + npm package | Any current version — the package's peer dependency is `react >= 16`, so React on Rails does not constrain you; just upgrade `react`/`react-dom` in **your app's** bundle                                                           |
-| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and the supported `react-on-rails-rsc` 19.2.x line (`>= 19.2.1`; `19.2.1-rc.0` during the RC soak), so `<Activity>` is available on that coordinated set |
+| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and the supported `react-on-rails-rsc` 19.2.x line (`>= 19.2.1`; `19.2.1-rc.1` during the RC soak), so `<Activity>` is available on that coordinated set |
 
 `<Activity>` is a regular React feature inside your components. React on Rails needs no configuration for it — it works with the standard `react_component` helper in both client-side rendering and server-side rendering with hydration.
 

--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -190,7 +190,7 @@ Before starting any component migration, verify these items. Skipping them is th
 
 - [ ] **React 19.2 installed** -- both `react` and `react-dom` on 19.2.x with patch `>= 19.2.7`, with matching versions (`yarn why react` shows no duplicates)
 - [ ] **Node renderer configured** -- RSC requires `NodeRenderer`, not ExecJS. If `config.server_renderer` is not set to `"NodeRenderer"`, migrate first
-- [ ] **`react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- during the React on Rails Pro 17 RC soak, use `19.2.1-rc.0`; check with `yarn why react-on-rails-rsc`
+- [ ] **`react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- during the React on Rails Pro 17 RC soak, use `19.2.1-rc.1`; check with `yarn why react-on-rails-rsc`
 - [ ] **Three webpack bundles building** -- client, server, and RSC bundles all compile without errors
 - [ ] **RSC manifests generated** -- `react-client-manifest.json` and `react-server-client-manifest.json` exist in your webpack output directory
 - [ ] **RSC payload route mounted** -- `rsc_payload_route` in `config/routes.rb`

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -49,7 +49,7 @@ yarn why react-on-rails-rsc
 
 If you're on React 18 or earlier, upgrade first -- RSC requires React 19.
 
-> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. During the 17.0 release-candidate soak, use `react-on-rails-rsc@19.2.1-rc.0` until the stable package is published. Older 19.0.x RSC packages no longer satisfy the Pro 17 runtime floor.
+> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. During the 17.0 release-candidate soak, use `react-on-rails-rsc@19.2.1-rc.1` until the stable package is published. Older 19.0.x RSC packages no longer satisfy the Pro 17 runtime floor.
 
 ## Step 2: Configure Rails for RSC
 
@@ -619,7 +619,7 @@ React on Rails Pro 17 RSC requires the coordinated React 19.2.x / `react-on-rail
 **Fix:** Upgrade React, React DOM, and `react-on-rails-rsc` together:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
 ```
 
 ### Mistake 2: Forgetting the RSC bundle watcher in development

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -436,7 +436,7 @@ React on Rails Pro 17 RSC release set. Key constraints:
 - The fix landed in `react-on-rails-rsc` 19.2.0-rc.3 and is included in the 19.2.1 package line. Check the
   [react_on_rails_rsc releases](https://github.com/shakacode/react_on_rails_rsc/releases)
   and the Pro release notes for the exact package to install. React on Rails Pro 17 RC packages use
-  `react-on-rails-rsc@19.2.1-rc.0`; the 17.0 final release requires `react-on-rails-rsc >= 19.2.1`
+  `react-on-rails-rsc@19.2.1-rc.1`; the 17.0 final release requires `react-on-rails-rsc >= 19.2.1`
   on the supported RSC 19.2.x package line.
 - **Do not** bump `react-on-rails-rsc` on its own; it must be upgraded together with a compatible
   React, React DOM, and React on Rails Pro set, or the Pro node renderer's peer-compatibility check

--- a/docs/pro/react-server-components/create-without-ssr.md
+++ b/docs/pro/react-server-components/create-without-ssr.md
@@ -26,16 +26,16 @@ bundle add react_on_rails_pro --version="= VERSION"
 Also, install React 19.2.x, React DOM 19.2.x, and the `react-on-rails-rsc` release currently used by the generator:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
 ```
 
 > [!NOTE]
 > React on Rails Pro 17 RSC requires React 19.2.x with patch >= 19.2.7. React 19.0.x is no longer a supported Pro RSC runtime line in v17. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
 >
-> During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
+> During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.1` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
 
 2. Enable support for Server Components in React on Rails Pro configuration:
 

--- a/docs/pro/react-server-components/critical-resource-hints.md
+++ b/docs/pro/react-server-components/critical-resource-hints.md
@@ -48,7 +48,7 @@ The useful React DOM APIs for RSC resource hints are:
 
 > [!NOTE]
 > The generator currently installs the tested React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
-> line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak). Newer published
+> line (`19.2.1-rc.1` during the React on Rails Pro 17 RC soak). Newer published
 > `react-on-rails-rsc` releases may add automatic package-level hinting, but app-authored resource
 > hints should still use React DOM's public APIs rather than package-private helpers.
 

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -12,7 +12,7 @@ The generator supports Rspack — when `assets_bundler: rspack` is detected in `
 The RSC implementation depends on the `react-on-rails-rsc` npm package, which provides bundler-specific manifest plugins plus a shared loader:
 
 - **WebpackPlugin** (`react-on-rails-rsc/WebpackPlugin`) — generates client/server component manifest files under webpack.
-- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the `react-on-rails-rsc` 19.2.1 package line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak).
+- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the `react-on-rails-rsc` 19.2.1 package line (`19.2.1-rc.1` during the React on Rails Pro 17 RC soak).
 - **WebpackLoader** (`react-on-rails-rsc/WebpackLoader`) — transforms `'use client'` files into client reference proxies in the RSC bundle. Works under both webpack and rspack.
 
 ## React and Package Version Policy
@@ -24,7 +24,7 @@ now target the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
 line.
 
 During the React on Rails Pro 17 release-candidate soak, the generator pins
-`react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not
+`react-on-rails-rsc@19.2.1-rc.1` because the stable `19.2.1` package is not
 published yet. For the 17.0 final release, use a stable `react-on-rails-rsc`
 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and
 `react-on-rails-rsc` upgraded as a coordinated set.

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -23,15 +23,15 @@ Before running the generator, verify your environment:
 If React is outside the supported 19.2.x range or below 19.2.7, upgrade it first:
 
 ```bash
-pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
 ```
 
 > **React 19.2.x with patch >= 19.2.7** is required for the React on Rails Pro 17 RSC path. React 19.0.x is no longer a supported Pro RSC runtime line in v17.
 
 > [!NOTE]
-> The RSC generator uses the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.x package line with patch >= 19.2.1. During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1.
+> The RSC generator uses the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.x package line with patch >= 19.2.1. During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.1` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1.
 
 > [!NOTE]
 > Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set. The RSC bundler APIs are version-coupled, so do not bump `react-on-rails-rsc` by itself.
@@ -39,7 +39,7 @@ pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
 The generator-managed RSC version is what goes in your app's `package.json`. Separately, the Pro package itself declares an optional peer range, which is broader on purpose:
 
 > [!NOTE]
-> The Pro package's optional `react-on-rails-rsc` peer range for the 17.0 final release is `>= 19.2.1 < 20.0.0`. Release candidates temporarily admit the matching prerelease tuple (`>= 19.2.1-rc.0 < 20.0.0`) so the RC package can be tested before the stable `19.2.1` package is published. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
+> The Pro package's optional `react-on-rails-rsc` peer range for the 17.0 final release is `>= 19.2.1 < 20.0.0`. Release candidates temporarily admit the matching prerelease tuple (`>= 19.2.1-rc.1 < 20.0.0`) so the RC package can be tested before the stable `19.2.1` package is published. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
 
 ## Pre-Migration: Audit Components for Client API Usage
 
@@ -268,7 +268,7 @@ Then run `bundle install` before retrying the generator.
 
 If the RSC bundle build fails but server and client builds succeed, the issue is likely in `rscWebpackConfig.js`. Common causes:
 
-- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1-rc.0` / `yarn add react-on-rails-rsc@19.2.1-rc.0` / `pnpm add react-on-rails-rsc@19.2.1-rc.0` during the 17.0 RC soak, or install a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1 once it is published.
+- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1-rc.1` / `yarn add react-on-rails-rsc@19.2.1-rc.1` / `pnpm add react-on-rails-rsc@19.2.1-rc.1` during the 17.0 RC soak, or install a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1 once it is published.
 - **React or `react-on-rails-rsc` version mismatch**: RSC currently requires React 19.2.x with patch >= 19.2.7 and `react-on-rails-rsc` 19.2.x with patch >= 19.2.1. Check with `npm ls react react-dom react-on-rails-rsc`, `yarn why react` / `yarn why react-dom` / `yarn why react-on-rails-rsc`, or `pnpm list react react-dom react-on-rails-rsc`
 - **Custom webpack config incompatibility**: If your `serverWebpackConfig.js` was heavily customized, the generator's transforms may not apply cleanly. See [Preparing Your App: Step 4](../../oss/migrating/rsc-preparing-app.md#step-4-set-up-the-rsc-webpack-bundle) for the underlying intent of each webpack change
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -95,7 +95,7 @@ Ensure you're using the coordinated React 19.2.x line in your `package.json`:
 }
 ```
 
-> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1` (or `19.2.1-rc.0` during the 17.0 RC soak).
+> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1` (or `19.2.1-rc.1` during the 17.0 RC soak).
 
 ### 2. Prepare Your React Components
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1956,7 +1956,7 @@ Ensure you're using the coordinated React 19.2.x line in your `package.json`:
 }
 ```
 
-> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1` (or `19.2.1-rc.0` during the 17.0 RC soak).
+> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1` (or `19.2.1-rc.1` during the 17.0 RC soak).
 
 ### 2. Prepare Your React Components
 
@@ -5617,7 +5617,7 @@ The useful React DOM APIs for RSC resource hints are:
 
 > [!NOTE]
 > The generator currently installs the tested React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
-> line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak). Newer published
+> line (`19.2.1-rc.1` during the React on Rails Pro 17 RC soak). Newer published
 > `react-on-rails-rsc` releases may add automatic package-level hinting, but app-authored resource
 > hints should still use React DOM's public APIs rather than package-private helpers.
 
@@ -7066,16 +7066,16 @@ bundle add react_on_rails_pro --version="= VERSION"
 Also, install React 19.2.x, React DOM 19.2.x, and the `react-on-rails-rsc` release currently used by the generator:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
 ```
 
 > [!NOTE]
 > React on Rails Pro 17 RSC requires React 19.2.x with patch >= 19.2.7. React 19.0.x is no longer a supported Pro RSC runtime line in v17. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
 >
-> During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
+> During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.1` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
 
 2. Enable support for Server Components in React on Rails Pro configuration:
 
@@ -8933,15 +8933,15 @@ Before running the generator, verify your environment:
 If React is outside the supported 19.2.x range or below 19.2.7, upgrade it first:
 
 ```bash
-pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
+# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
 ```
 
 > **React 19.2.x with patch >= 19.2.7** is required for the React on Rails Pro 17 RSC path. React 19.0.x is no longer a supported Pro RSC runtime line in v17.
 
 > [!NOTE]
-> The RSC generator uses the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.x package line with patch >= 19.2.1. During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1.
+> The RSC generator uses the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.x package line with patch >= 19.2.1. During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.1` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1.
 
 > [!NOTE]
 > Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set. The RSC bundler APIs are version-coupled, so do not bump `react-on-rails-rsc` by itself.
@@ -8949,7 +8949,7 @@ pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
 The generator-managed RSC version is what goes in your app's `package.json`. Separately, the Pro package itself declares an optional peer range, which is broader on purpose:
 
 > [!NOTE]
-> The Pro package's optional `react-on-rails-rsc` peer range for the 17.0 final release is `>= 19.2.1 < 20.0.0`. Release candidates temporarily admit the matching prerelease tuple (`>= 19.2.1-rc.0 < 20.0.0`) so the RC package can be tested before the stable `19.2.1` package is published. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
+> The Pro package's optional `react-on-rails-rsc` peer range for the 17.0 final release is `>= 19.2.1 < 20.0.0`. Release candidates temporarily admit the matching prerelease tuple (`>= 19.2.1-rc.1 < 20.0.0`) so the RC package can be tested before the stable `19.2.1` package is published. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
 
 ## Pre-Migration: Audit Components for Client API Usage
 
@@ -9178,7 +9178,7 @@ Then run `bundle install` before retrying the generator.
 
 If the RSC bundle build fails but server and client builds succeed, the issue is likely in `rscWebpackConfig.js`. Common causes:
 
-- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1-rc.0` / `yarn add react-on-rails-rsc@19.2.1-rc.0` / `pnpm add react-on-rails-rsc@19.2.1-rc.0` during the 17.0 RC soak, or install a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1 once it is published.
+- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1-rc.1` / `yarn add react-on-rails-rsc@19.2.1-rc.1` / `pnpm add react-on-rails-rsc@19.2.1-rc.1` during the 17.0 RC soak, or install a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1 once it is published.
 - **React or `react-on-rails-rsc` version mismatch**: RSC currently requires React 19.2.x with patch >= 19.2.7 and `react-on-rails-rsc` 19.2.x with patch >= 19.2.1. Check with `npm ls react react-dom react-on-rails-rsc`, `yarn why react` / `yarn why react-dom` / `yarn why react-on-rails-rsc`, or `pnpm list react react-dom react-on-rails-rsc`
 - **Custom webpack config incompatibility**: If your `serverWebpackConfig.js` was heavily customized, the generator's transforms may not apply cleanly. See [Preparing Your App: Step 4](../../oss/migrating/rsc-preparing-app.md#step-4-set-up-the-rsc-webpack-bundle) for the underlying intent of each webpack change
 
@@ -10038,7 +10038,7 @@ The generator supports Rspack — when `assets_bundler: rspack` is detected in `
 The RSC implementation depends on the `react-on-rails-rsc` npm package, which provides bundler-specific manifest plugins plus a shared loader:
 
 - **WebpackPlugin** (`react-on-rails-rsc/WebpackPlugin`) — generates client/server component manifest files under webpack.
-- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the `react-on-rails-rsc` 19.2.1 package line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak).
+- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the `react-on-rails-rsc` 19.2.1 package line (`19.2.1-rc.1` during the React on Rails Pro 17 RC soak).
 - **WebpackLoader** (`react-on-rails-rsc/WebpackLoader`) — transforms `'use client'` files into client reference proxies in the RSC bundle. Works under both webpack and rspack.
 
 ## React and Package Version Policy
@@ -10050,7 +10050,7 @@ now target the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
 line.
 
 During the React on Rails Pro 17 release-candidate soak, the generator pins
-`react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not
+`react-on-rails-rsc@19.2.1-rc.1` because the stable `19.2.1` package is not
 published yet. For the 17.0 final release, use a stable `react-on-rails-rsc`
 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and
 `react-on-rails-rsc` upgraded as a coordinated set.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6754,7 +6754,7 @@ This is the React-blessed replacement for the classic "keep the inactive tab ali
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `react` / `react-dom` in your app  | **19.2.0 or later** (`Activity` does not exist in earlier versions, including 19.0/19.1)                                                                                                                                            |
 | `react_on_rails` gem + npm package | Any current version — the package's peer dependency is `react >= 16`, so React on Rails does not constrain you; just upgrade `react`/`react-dom` in **your app's** bundle                                                           |
-| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and the supported `react-on-rails-rsc` 19.2.x line (`>= 19.2.1`; `19.2.1-rc.0` during the RC soak), so `<Activity>` is available on that coordinated set |
+| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and the supported `react-on-rails-rsc` 19.2.x line (`>= 19.2.1`; `19.2.1-rc.1` during the RC soak), so `<Activity>` is available on that coordinated set |
 
 `<Activity>` is a regular React feature inside your components. React on Rails needs no configuration for it — it works with the standard `react_component` helper in both client-side rendering and server-side rendering with hydration.
 
@@ -25266,7 +25266,7 @@ Before starting any component migration, verify these items. Skipping them is th
 
 - [ ] **React 19.2 installed** -- both `react` and `react-dom` on 19.2.x with patch `>= 19.2.7`, with matching versions (`yarn why react` shows no duplicates)
 - [ ] **Node renderer configured** -- RSC requires `NodeRenderer`, not ExecJS. If `config.server_renderer` is not set to `"NodeRenderer"`, migrate first
-- [ ] **`react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- during the React on Rails Pro 17 RC soak, use `19.2.1-rc.0`; check with `yarn why react-on-rails-rsc`
+- [ ] **`react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- during the React on Rails Pro 17 RC soak, use `19.2.1-rc.1`; check with `yarn why react-on-rails-rsc`
 - [ ] **Three webpack bundles building** -- client, server, and RSC bundles all compile without errors
 - [ ] **RSC manifests generated** -- `react-client-manifest.json` and `react-server-client-manifest.json` exist in your webpack output directory
 - [ ] **RSC payload route mounted** -- `rsc_payload_route` in `config/routes.rb`
@@ -25367,7 +25367,7 @@ yarn why react-on-rails-rsc
 
 If you're on React 18 or earlier, upgrade first -- RSC requires React 19.
 
-> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. During the 17.0 release-candidate soak, use `react-on-rails-rsc@19.2.1-rc.0` until the stable package is published. Older 19.0.x RSC packages no longer satisfy the Pro 17 runtime floor.
+> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. During the 17.0 release-candidate soak, use `react-on-rails-rsc@19.2.1-rc.1` until the stable package is published. Older 19.0.x RSC packages no longer satisfy the Pro 17 runtime floor.
 
 ## Step 2: Configure Rails for RSC
 
@@ -25935,7 +25935,7 @@ React on Rails Pro 17 RSC requires the coordinated React 19.2.x / `react-on-rail
 **Fix:** Upgrade React, React DOM, and `react-on-rails-rsc` together:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.1
 ```
 
 ### Mistake 2: Forgetting the RSC bundle watcher in development
@@ -29587,7 +29587,7 @@ React on Rails Pro 17 RSC release set. Key constraints:
 - The fix landed in `react-on-rails-rsc` 19.2.0-rc.3 and is included in the 19.2.1 package line. Check the
   [react_on_rails_rsc releases](https://github.com/shakacode/react_on_rails_rsc/releases)
   and the Pro release notes for the exact package to install. React on Rails Pro 17 RC packages use
-  `react-on-rails-rsc@19.2.1-rc.0`; the 17.0 final release requires `react-on-rails-rsc >= 19.2.1`
+  `react-on-rails-rsc@19.2.1-rc.1`; the 17.0 final release requires `react-on-rails-rsc >= 19.2.1`
   on the supported RSC 19.2.x package line.
 - **Do not** bump `react-on-rails-rsc` on its own; it must be upgraded together with a compatible
   React, React DOM, and React on Rails Pro set, or the Pro node renderer's peer-compatibility check

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       "These force patched versions of transitive dev dependencies. Remove when upstream packages update.",
       "ajv overrides were intentionally excluded: ajv v8 breaks webpack's schema-utils/ajv-keywords.",
       "The 2 moderate ajv alerts (ReDoS in $data option) are tolerable — ajv only validates our own config files.",
-      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react-on-rails-pro-node-renderer>react(-dom)/react-on-rails-rsc, react-on-rails-pro>react(-dom)/react-on-rails-rsc, and react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scope Pro RSC package tests and dummy validation to the React 19.2.7 + react-on-rails-rsc 19.2.1-rc.0 pair, the React on Rails 17 RSC floor (#3865; gate landed in #4026). The root workspace pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 only for legacy non-Pro fixture coverage."
+      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react-on-rails-pro-node-renderer>react(-dom)/react-on-rails-rsc, react-on-rails-pro>react(-dom)/react-on-rails-rsc, and react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scope Pro RSC package tests and dummy validation to the React 19.2.7 + react-on-rails-rsc 19.2.1-rc.1 pair, the React on Rails 17 RSC floor (#3865; gate landed in #4026). The root workspace pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 only for legacy non-Pro fixture coverage."
     ],
     "overrides": {
       "react": "$react",
@@ -141,13 +141,13 @@
       "react_on_rails>react-dom": "^19.2.0",
       "react-on-rails-pro-node-renderer>react": "~19.2.7",
       "react-on-rails-pro-node-renderer>react-dom": "~19.2.7",
-      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1-rc.1",
       "react-on-rails-pro>react": "~19.2.7",
       "react-on-rails-pro>react-dom": "~19.2.7",
-      "react-on-rails-pro>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro>react-on-rails-rsc": "19.2.1-rc.1",
       "react_on_rails_pro_dummy>react": "~19.2.7",
       "react_on_rails_pro_dummy>react-dom": "~19.2.7",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1-rc.0",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1-rc.1",
       "sentry-testkit>body-parser": "npm:empty-npm-package@1.0.0",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0",
       "lodash@>=4.0.0 <=4.17.22": ">=4.17.23 <5",

--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -72,7 +72,7 @@
     "react": "~19.2.7",
     "react-dom": "~19.2.7",
     "react-on-rails": "workspace:*",
-    "react-on-rails-rsc": "19.2.1-rc.0",
+    "react-on-rails-rsc": "19.2.1-rc.1",
     "redis": "^5.0.1",
     "sentry-testkit": "^5.0.6",
     "touch": "^3.1.0",

--- a/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
@@ -24,7 +24,7 @@
 // 19.2.1 package is published without accepting older prereleases on the same
 // tuple. When it is set, keep its core tuple equal to `minimumVersion`.
 export const RSC_PEER_SUPPORT = {
-  reactOnRailsRsc: { minimumVersion: '19.2.1', minimumPrereleaseVersion: '19.2.1-rc.0', supportedMajor: 19 },
+  reactOnRailsRsc: { minimumVersion: '19.2.1', minimumPrereleaseVersion: '19.2.1-rc.1', supportedMajor: 19 },
   react: {
     supportedMajor: 19,
     supportedRanges: [

--- a/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
@@ -16,7 +16,7 @@
 import { checkRscPeerCompatibility } from '../src/shared/checkRscPeerCompatibility';
 import { RSC_PEER_SUPPORT } from '../src/shared/rscPeerSupport';
 
-const { minimumVersion } = RSC_PEER_SUPPORT.reactOnRailsRsc;
+const { minimumPrereleaseVersion, minimumVersion } = RSC_PEER_SUPPORT.reactOnRailsRsc;
 type MutableRscSupport = {
   minimumVersion: string;
   minimumPrereleaseVersion?: string;
@@ -85,11 +85,13 @@ describe('checkRscPeerCompatibility', () => {
   });
 
   it('returns ok for the coordinated RC floor prerelease', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: '19.2.1-rc.0', reactVersion: '19.2.7' }).level).toBe('ok');
+    expect(
+      checkRscPeerCompatibility({ rscVersion: minimumPrereleaseVersion, reactVersion: '19.2.7' }).level,
+    ).toBe('ok');
   });
 
   it('returns ok for a prerelease newer than the coordinated RC floor', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: '19.2.1-rc.1', reactVersion: '19.2.7' }).level).toBe('ok');
+    expect(checkRscPeerCompatibility({ rscVersion: '19.2.1-rc.2', reactVersion: '19.2.7' }).level).toBe('ok');
   });
 
   it('returns ok for a hyphenated prerelease newer than the coordinated RC floor', () => {
@@ -100,14 +102,14 @@ describe('checkRscPeerCompatibility', () => {
     const r = checkRscPeerCompatibility({ rscVersion: '19.2.1-beta.0', reactVersion: '19.2.7' });
     expect(r.level).toBe('error');
     expect(r.message).toContain('19.2.1-beta.0');
-    expect(r.message).toContain('19.2.1-rc.0');
+    expect(r.message).toContain(minimumPrereleaseVersion);
   });
 
   it('errors for future prereleases outside the coordinated RC floor tuple', () => {
     const r = checkRscPeerCompatibility({ rscVersion: '19.2.2-alpha.0', reactVersion: '19.2.7' });
     expect(r.level).toBe('error');
     expect(r.message).toContain('19.2.2-alpha.0');
-    expect(r.message).toContain('19.2.1-rc.0');
+    expect(r.message).toContain(minimumPrereleaseVersion);
   });
 
   it('returns ok for a version with a leading v (prefix stripped for comparison)', () => {
@@ -161,7 +163,7 @@ describe('checkRscPeerCompatibility', () => {
   });
 
   it('errors when React 19.0 is paired with the React 19.2 RSC package line', () => {
-    const r = checkRscPeerCompatibility({ rscVersion: '19.2.1-rc.0', reactVersion: '19.0.4' });
+    const r = checkRscPeerCompatibility({ rscVersion: minimumPrereleaseVersion, reactVersion: '19.0.4' });
     expect(r.level).toBe('error');
     expect(r.message).toContain('react');
     expect(r.message).toContain('19.0.4');

--- a/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
@@ -27,6 +27,7 @@ const versionBelowMinimumVersion = (version: string) => {
 describe('runRscPeerCompatibilityCheck', () => {
   let warnSpy: jest.SpyInstance;
   let runRscPeerCompatibilityCheck: typeof import('../src/shared/runRscPeerCompatibilityCheck').runRscPeerCompatibilityCheck;
+  let minimumPrereleaseVersion: string | undefined;
   let minimumVersion: string;
   let belowMinimumVersion: string;
 
@@ -46,6 +47,7 @@ describe('runRscPeerCompatibilityCheck', () => {
     const { RSC_PEER_SUPPORT } = jest.requireActual(
       '../src/shared/rscPeerSupport',
     ) as typeof import('../src/shared/rscPeerSupport');
+    minimumPrereleaseVersion = RSC_PEER_SUPPORT.reactOnRailsRsc.minimumPrereleaseVersion;
     minimumVersion = RSC_PEER_SUPPORT.reactOnRailsRsc.minimumVersion;
     belowMinimumVersion = versionBelowMinimumVersion(minimumVersion);
 
@@ -137,7 +139,7 @@ describe('runRscPeerCompatibilityCheck', () => {
   it('does not warn for the coordinated RC package line', () => {
     expect(() =>
       runRscPeerCompatibilityCheck({
-        resolveVersion: resolveVersions('19.2.1-rc.0'),
+        resolveVersion: resolveVersions(minimumPrereleaseVersion ?? minimumVersion),
       }),
     ).not.toThrow();
     expect(warnSpy).not.toHaveBeenCalled();
@@ -176,7 +178,7 @@ describe('runRscPeerCompatibilityCheck', () => {
   it('throws when React 19.0 is paired with the React 19.2 RSC package line', () => {
     expect(() =>
       runRscPeerCompatibilityCheck({
-        resolveVersion: resolveVersions('19.2.1-rc.0', '19.0.4'),
+        resolveVersion: resolveVersions(minimumPrereleaseVersion ?? minimumVersion, '19.0.4'),
       }),
     ).toThrow(/Incompatible react/);
     expect(warnSpy).not.toHaveBeenCalled();

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -84,7 +84,7 @@
   "peerDependencies": {
     "react": ">= 16",
     "react-dom": ">= 16",
-    "react-on-rails-rsc": ">=19.2.1-rc.0 <20.0.0",
+    "react-on-rails-rsc": ">=19.2.1-rc.1 <20.0.0",
     "@tanstack/react-router": ">=1.139.0 <2.0.0",
     "ioredis": ">= 5"
   },
@@ -115,7 +115,7 @@
     "mock-fs": "^5.5.0",
     "react": "~19.2.7",
     "react-dom": "~19.2.7",
-    "react-on-rails-rsc": "19.2.1-rc.0",
+    "react-on-rails-rsc": "19.2.1-rc.1",
     "ioredis": "5.11.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ overrides:
   react_on_rails>react-dom: ^19.2.0
   react-on-rails-pro-node-renderer>react: ~19.2.7
   react-on-rails-pro-node-renderer>react-dom: ~19.2.7
-  react-on-rails-pro-node-renderer>react-on-rails-rsc: 19.2.1-rc.0
+  react-on-rails-pro-node-renderer>react-on-rails-rsc: 19.2.1-rc.1
   react-on-rails-pro>react: ~19.2.7
   react-on-rails-pro>react-dom: ~19.2.7
-  react-on-rails-pro>react-on-rails-rsc: 19.2.1-rc.0
+  react-on-rails-pro>react-on-rails-rsc: 19.2.1-rc.1
   react_on_rails_pro_dummy>react: ~19.2.7
   react_on_rails_pro_dummy>react-dom: ~19.2.7
-  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.1-rc.0
+  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.1-rc.1
   sentry-testkit>body-parser: npm:empty-npm-package@1.0.0
   sentry-testkit>express: npm:empty-npm-package@1.0.0
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23 <5'
@@ -286,8 +286,8 @@ importers:
         specifier: ~19.2.7
         version: 19.2.7(react@19.2.7)
       react-on-rails-rsc:
-        specifier: 19.2.1-rc.0
-        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.2.1-rc.1
+        version: 19.2.1-rc.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
 
   packages/react-on-rails-pro-node-renderer:
     dependencies:
@@ -401,8 +401,8 @@ importers:
         specifier: workspace:*
         version: link:../react-on-rails
       react-on-rails-rsc:
-        specifier: 19.2.1-rc.0
-        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.2.1-rc.1
+        version: 19.2.1-rc.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
       redis:
         specifier: ^5.0.1
         version: 5.10.0
@@ -765,8 +765,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.2.1-rc.0
-        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
+        specifier: 19.2.1-rc.1
+        version: 19.2.1-rc.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8514,7 +8514,7 @@ packages:
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.2.7
+      react: ~19.0.4
 
   react-error-boundary@4.1.2:
     resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
@@ -8543,12 +8543,16 @@ packages:
       react-dom: ~19.0.4
       webpack: ^5.59.0
 
-  react-on-rails-rsc@19.2.1-rc.0:
-    resolution: {integrity: sha512-lWUQloOMYS2/Jio7M9pKaY84+gNJ1ZD2pMTj37HDZtf6GsJjb0CJfJlizvxbquUdMQawX+1h59c63syFZ7AWmQ==}
+  react-on-rails-rsc@19.2.1-rc.1:
+    resolution: {integrity: sha512-ZwfZ2THm95Oo6a9cihkpK6SCEnEuZk298+q0DYACHImRXGlMXOzS5xwWl7jrB4FOYRWY576HC9sF7yRwO5wTrA==}
     peerDependencies:
-      react: ^19.2.7
-      react-dom: ^19.2.7
+      '@rspack/core': ^1.0.0 || ^2.0.0
+      react: ~19.0.4
+      react-dom: ~19.0.4
       webpack: ^5.59.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
 
   react-proptypes@1.0.0:
     resolution: {integrity: sha512-rIAUscBmSfPVEUkOc9wR66sMJolmCC6Bi88I7oNegkwoFkUFcqU2UhpBt8/AyFtSFxnk9zNMZ9cSZ9BQA433uA==}
@@ -8596,8 +8600,8 @@ packages:
     resolution: {integrity: sha512-bYfuvqPJnHB4CHo2Ze7fQyJAO77TUu1W/aKFt81ICXbLiOTg5jHaO/NPDlpvGWUALoEGaGb7Oi1uXAaO+Bw6jw==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: ^19.2.7
-      react-dom: ^19.2.7
+      react: ~19.0.4
+      react-dom: ~19.0.4
       webpack: ^5.59.0
 
   react@18.3.1:
@@ -19251,7 +19255,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
+  react-on-rails-rsc@19.2.1-rc.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -19260,8 +19264,10 @@ snapshots:
       react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
       webpack: 5.104.1(@swc/core@1.15.3)(esbuild@0.28.0)(webpack-cli@7.0.3)
       webpack-sources: 3.3.3
+    optionalDependencies:
+      '@rspack/core': 2.0.5
 
-  react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3)):
+  react-on-rails-rsc@19.2.1-rc.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -19270,6 +19276,8 @@ snapshots:
       react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
+    optionalDependencies:
+      '@rspack/core': 2.0.5
 
   react-proptypes@1.0.0:
     dependencies:

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -162,7 +162,7 @@ module ReactOnRails
       RSC_REACT_VERSION_RANGE = "~19.2.7"
       # Pinned to the 19.2.1 release candidate, which carries the coordinated React 19.2.7 RSC
       # peer floor required by the React on Rails Pro 17 runtime check.
-      RSC_PACKAGE_VERSION_PIN = "19.2.1-rc.0"
+      RSC_PACKAGE_VERSION_PIN = "19.2.1-rc.1"
 
       private
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5112,7 +5112,15 @@ RSpec.describe ReactOnRails::Doctor do
             FileUtils.mkdir_p("config/webpack")
             File.write("config/routes.rb", "Rails.application.routes.draw do\n  rsc_payload_route\nend")
             File.write("config/webpack/rscWebpackConfig.js", "module.exports = {}")
-            File.write("package.json", '{"dependencies":{"react":"~19.2.7","react-on-rails-rsc":"19.2.1-rc.0"}}')
+            File.write(
+              "package.json",
+              JSON.generate(
+                "dependencies" => {
+                  "react" => "~19.2.7",
+                  "react-on-rails-rsc" => described_class::RSC_PACKAGE_INSTALL_VERSION
+                }
+              )
+            )
             File.write("Procfile.dev", "rsc-bundle: RSC_BUNDLE_ONLY=true bin/shakapacker --watch")
             example.run
           end
@@ -5153,7 +5161,15 @@ RSpec.describe ReactOnRails::Doctor do
             FileUtils.mkdir_p("config/webpack")
             File.write("config/routes.rb", "rsc_payload_route")
             File.write("config/webpack/rscWebpackConfig.js", "{}")
-            File.write("package.json", '{"dependencies":{"react":"~19.2.7","react-on-rails-rsc":"19.2.1-rc.0"}}')
+            File.write(
+              "package.json",
+              JSON.generate(
+                "dependencies" => {
+                  "react" => "~19.2.7",
+                  "react-on-rails-rsc" => described_class::RSC_PACKAGE_INSTALL_VERSION
+                }
+              )
+            )
             File.write("Procfile.dev", "rsc-bundle: RSC_BUNDLE_ONLY=true bin/shakapacker --watch")
             example.run
           end
@@ -5648,6 +5664,8 @@ RSpec.describe ReactOnRails::Doctor do
   end
 
   describe "check_rsc_react_version" do
+    let(:rsc_package_version) { described_class::RSC_PACKAGE_INSTALL_VERSION }
+
     let(:doctor) { described_class.new(verbose: false, fix: false) }
     let(:checker) { doctor.instance_variable_get(:@checker) }
 
@@ -5864,7 +5882,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.0.7",
                   "react-dom" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -5872,7 +5890,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.0.7")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => rsc_package_version,
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             example.run
@@ -5889,7 +5907,7 @@ RSpec.describe ReactOnRails::Doctor do
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(error_msgs).to include(
           a_string_including(
-            "react-on-rails-rsc 19.2.1-rc.0 requires react ^19.2.7",
+            "react-on-rails-rsc #{rsc_package_version} requires react ^19.2.7",
             "installed react is 19.0.7"
           )
         )
@@ -5899,7 +5917,7 @@ RSpec.describe ReactOnRails::Doctor do
 
       it "does not report peer compatibility success when peer checks are unexpectedly empty" do
         rsc_package = {
-          "version" => "19.2.1-rc.0",
+          "version" => rsc_package_version,
           "peerDependencies" => { "react" => "^19.0.4" }
         }
         allow(doctor).to receive(:rsc_peer_check_results).and_return([])
@@ -5977,7 +5995,7 @@ RSpec.describe ReactOnRails::Doctor do
             expect(error_msgs).to include(
               a_string_including(
                 "react-on-rails-rsc 19.2.1-beta.0 is not supported by React on Rails Pro 17 RSC",
-                "or 19.2.1-rc.0 during the 17.0 RC soak"
+                "or #{rsc_package_version} during the 17.0 RC soak"
               )
             )
             expect(doctor).not_to have_received(:capture_rsc_dist_tags)
@@ -6014,7 +6032,7 @@ RSpec.describe ReactOnRails::Doctor do
             expect(error_msgs).to include(
               a_string_including(
                 "react-on-rails-rsc 19.2.2-alpha.0 is not supported by React on Rails Pro 17 RSC",
-                "or 19.2.1-rc.0 during the 17.0 RC soak"
+                "or #{rsc_package_version} during the 17.0 RC soak"
               )
             )
             expect(doctor).not_to have_received(:capture_rsc_dist_tags)
@@ -6067,7 +6085,7 @@ RSpec.describe ReactOnRails::Doctor do
               JSON.generate(
                 "dependencies" => {
                   "react" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -6099,7 +6117,7 @@ RSpec.describe ReactOnRails::Doctor do
                   "react-dom" => "19.0.7"
                 },
                 "optionalDependencies" => {
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -6124,7 +6142,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.0.7",
                   "react-dom" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -6132,7 +6150,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.0.7")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => rsc_package_version,
               "peerDependencies" => { "react" => "^19.0.0", "react-dom" => "^19.0.0" }
             )
             stub_package_root(Dir.pwd)
@@ -6144,7 +6162,7 @@ RSpec.describe ReactOnRails::Doctor do
             warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with unsupported React 19.0.7",
+                "react-on-rails-rsc #{rsc_package_version} is installed with unsupported React 19.0.7",
                 "React/React DOM 19.2.x with patch >= 19.2.7"
               )
             )
@@ -6162,7 +6180,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.3.0",
                   "react-dom" => "19.3.0",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -6170,7 +6188,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.3.0")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => rsc_package_version,
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             stub_package_root(Dir.pwd)
@@ -6182,7 +6200,7 @@ RSpec.describe ReactOnRails::Doctor do
             warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with unsupported React 19.3.0",
+                "react-on-rails-rsc #{rsc_package_version} is installed with unsupported React 19.3.0",
                 "React/React DOM 19.2.x with patch >= 19.2.7"
               )
             )
@@ -6200,7 +6218,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.2.7",
                   "react-dom" => "19.3.0",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -6208,7 +6226,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.3.0")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => rsc_package_version,
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             stub_package_root(Dir.pwd)
@@ -6219,7 +6237,7 @@ RSpec.describe ReactOnRails::Doctor do
             error_msgs = checker.messages.select { |m| m[:type] == :error }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with unsupported React DOM 19.3.0",
+                "react-on-rails-rsc #{rsc_package_version} is installed with unsupported React DOM 19.3.0",
                 "React/React DOM 19.2.x with patch >= 19.2.7"
               )
             )
@@ -6236,7 +6254,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.2.7",
                   "react-dom" => "19.2.8",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -6244,7 +6262,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.2.8")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => rsc_package_version,
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             stub_package_root(Dir.pwd)
@@ -6255,7 +6273,7 @@ RSpec.describe ReactOnRails::Doctor do
             error_msgs = checker.messages.select { |m| m[:type] == :error }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with React 19.2.7 but React DOM 19.2.8",
+                "react-on-rails-rsc #{rsc_package_version} is installed with React 19.2.7 but React DOM 19.2.8",
                 "react and react-dom to resolve to the same version"
               )
             )
@@ -6274,7 +6292,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.2.7",
                   "react-dom" => "19.2.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => rsc_package_version
                 }
               )
             )
@@ -6282,7 +6300,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.2.7")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => rsc_package_version,
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             example.run
@@ -6295,7 +6313,7 @@ RSpec.describe ReactOnRails::Doctor do
           .with(Dir.pwd)
           .and_return(
             [
-              JSON.generate("latest" => "19.0.5", "next" => "19.2.1-rc.1"),
+              JSON.generate("latest" => "19.0.5", "next" => "19.2.1-rc.2"),
               instance_double(Process::Status, success?: true)
             ]
           )
@@ -6305,7 +6323,7 @@ RSpec.describe ReactOnRails::Doctor do
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(warning_msgs).to include(
           a_string_including(
-            "react-on-rails-rsc 19.2.1-rc.0 is behind the npm next dist-tag 19.2.1-rc.1",
+            "react-on-rails-rsc #{rsc_package_version} is behind the npm next dist-tag 19.2.1-rc.2",
             "React Server Components track React minor versions"
           )
         )
@@ -6565,6 +6583,7 @@ RSpec.describe ReactOnRails::Doctor do
   end
 
   describe "JSON output for RSC compatibility" do
+    let(:rsc_package_version) { described_class::RSC_PACKAGE_INSTALL_VERSION }
     let(:json_doctor) { described_class.new(format: :json) }
     let(:checker) { json_doctor.instance_variable_get(:@checker) }
     let(:pro_config) do
@@ -6594,7 +6613,7 @@ RSpec.describe ReactOnRails::Doctor do
               "dependencies" => {
                 "react" => "19.0.7",
                 "react-dom" => "19.0.7",
-                "react-on-rails-rsc" => "19.2.1-rc.0"
+                "react-on-rails-rsc" => rsc_package_version
               }
             )
           )
@@ -6602,7 +6621,7 @@ RSpec.describe ReactOnRails::Doctor do
           install_package("react-dom", "version" => "19.0.7")
           install_package(
             "react-on-rails-rsc",
-            "version" => "19.2.1-rc.0",
+            "version" => rsc_package_version,
             "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
           )
           example.run
@@ -6637,7 +6656,7 @@ RSpec.describe ReactOnRails::Doctor do
       report = JSON.parse(output.join("\n"))
       rsc_check = report["checks"].find { |check| check["id"] == "react_server_components" }
       expect(rsc_check["status"]).to eq("fail")
-      expect(rsc_check["message"]).to include("react-on-rails-rsc 19.2.1-rc.0 requires react ^19.2.7")
+      expect(rsc_check["message"]).to include("react-on-rails-rsc #{rsc_package_version} requires react ^19.2.7")
       expect(report["status"]).to eq("fail")
     end
   end

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -289,10 +289,10 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
       instance.add_npm_dependencies_result = false
       allow(instance).to receive(:existing_package_names).and_return(%w[react-on-rails-rsc])
 
-      result = instance.send(:add_packages, ["react-on-rails-rsc@19.2.1-rc.0"])
+      result = instance.send(:add_packages, ["react-on-rails-rsc@19.2.1-rc.1"])
 
       expect(result).to be(true)
-      expect(instance.system_calls).to include(%w[npm install --save-exact react-on-rails-rsc@19.2.1-rc.0])
+      expect(instance.system_calls).to include(%w[npm install --save-exact react-on-rails-rsc@19.2.1-rc.1])
     end
   end
 
@@ -803,7 +803,7 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
   describe "#rsc_packages_with_version" do
     it "defines an explicit RSC package version pin independent from the React semver range prefix" do
       expect(ReactOnRails::Generators::JsDependencyManager::RSC_REACT_VERSION_RANGE).to eq("~19.2.7")
-      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.2.1-rc.0")
+      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.2.1-rc.1")
     end
 
     it "keeps the generated RSC React policy on the 19.2.x patch track" do
@@ -883,11 +883,11 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1-rc.0")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1-rc.1")
       expect(warning_text).to include("left the version pin in package.json")
       expect(warning_text).to include("react-on-rails-rsc/WebpackPlugin")
       expect(warning_text).to include("react-on-rails-rsc/RspackPlugin")
-      manual_command = "npm install --save-exact react-on-rails-rsc@19.2.1-rc.0"
+      manual_command = "npm install --save-exact react-on-rails-rsc@19.2.1-rc.1"
       expect(warning_text).to include(manual_command)
       expect(warning_text.scan(manual_command).size).to eq(1)
     end
@@ -895,9 +895,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
     it "keeps the pinned manual install instruction when the pinned install raises" do
       allow(instance)
         .to receive(:rsc_packages_with_version)
-        .and_return([["react-on-rails-rsc@19.2.1-rc.0"], true])
+        .and_return([["react-on-rails-rsc@19.2.1-rc.1"], true])
 
-      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.2.1-rc.0"]).and_raise("network down")
+      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.2.1-rc.1"]).and_raise("network down")
       allow(instance).to receive(:add_packages).with(["react-on-rails-rsc"]).and_return(true)
 
       instance.send(:add_rsc_dependencies)
@@ -906,9 +906,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1-rc.0")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1-rc.1")
       expect(warning_text).to include("Error adding React Server Components dependencies: network down")
-      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.2.1-rc.0")
+      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.2.1-rc.1")
     end
 
     it "uses computed rsc packages for manual recovery when installation raises" do

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -56,7 +56,7 @@
     "react-intl": "^10",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "19.2.1-rc.0",
+    "react-on-rails-rsc": "19.2.1-rc.1",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",

--- a/script/convert-test.bash
+++ b/script/convert-test.bash
@@ -105,13 +105,13 @@ write_fixture() {
       "react_on_rails>react-dom": "^19.2.0",
       "react-on-rails-pro>react": "~19.2.7",
       "react-on-rails-pro>react-dom": "~19.2.7",
-      "react-on-rails-pro>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro>react-on-rails-rsc": "19.2.1-rc.1",
       "react-on-rails-pro-node-renderer>react": "~19.2.7",
       "react-on-rails-pro-node-renderer>react-dom": "~19.2.7",
-      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1-rc.1",
       "react_on_rails_pro_dummy>react": "~19.2.7",
       "react_on_rails_pro_dummy>react-dom": "~19.2.7",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1-rc.0",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1-rc.1",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0"
     }
   }


### PR DESCRIPTION
## Summary

Pro RSC apps generated from the 17.0 release line will now install the published `react-on-rails-rsc@19.2.1-rc.1` package rather than the superseded RC.0 build. The generator, Doctor, Node renderer, workspace overrides, dummy app, and documentation now enforce the same compatibility floor, so generated and existing apps receive one consistent recommendation.

Related: #3823

## Validation

- npm registry confirms `react-on-rails-rsc@19.2.1-rc.1`, with React and React DOM peers `^19.2.7`.
- A clean `pnpm install --lockfile-only --force --registry=https://registry.npmjs.org` using the declared pnpm 10.33.4 reproduces `pnpm-lock.yaml` without a diff. pnpm records the root-wide legacy `~19.0.4` React override in package peer metadata, while all three Pro-RSC importers resolve the published RC.1 package with React and React DOM 19.2.7.
- `bundle exec rspec spec/react_on_rails/generators/js_dependency_manager_spec.rb spec/lib/react_on_rails/doctor_spec.rb` — 457 examples, 0 failures.
- `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/checkRscPeerCompatibility.test.ts tests/runRscPeerCompatibilityCheck.test.ts --runInBand` — 39 tests passed.
- Node-renderer type check, workspace lint and format checks, OSS and Pro RuboCop, Pro license-header checks, and generated `llms-full` validation passed.
- `codex review --uncommitted` could not run because the installed CLI does not support the configured review model; manual diff review and the simplification pass found no remaining actionable issue.

## Changelog

`v17.0.0.rc.8` is already tagged and released. This user-visible release-line change is intentionally deferred to the next release candidate (`17.0.0.rc.9`) or final promotion after this PR merges.
