### PR TITLE
Guard store re-initialization to prevent divergent state in deferred hydration (#4572)

### DIFF
--- a/packages/react-on-rails/src/ClientRenderer.ts
+++ b/packages/react-on-rails/src/ClientRenderer.ts
@@ -114,6 +114,19 @@ function teardownErrorLabel(entry: RenderedEntry, domNodeId: string): string {
 
 function initializeStore(el: Element, railsContext: RailsContext): void {
   const name = el.getAttribute(REACT_ON_RAILS_STORE_ATTRIBUTE) || '';
+
+  // Guard: don't re-create an already-hydrated store.
+  // Before hydrate_on scheduling (#4037), all components hydrated in one synchronous pass, so every
+  // component read the same store instance created in that pass. Deferred hydration (visible/idle)
+  // breaks that invariant: forEachStore can run again (e.g. via reactOnRailsComponentLoaded for a
+  // Turbo Frame), re-creating the store while an already-hydrated :immediate sibling keeps the old
+  // instance and a not-yet-mounted :visible sibling will get the new one — divergent shared state.
+  // Skipping re-initialization restores the one-instance-per-name-per-page-lifetime invariant.
+  // See: https://github.com/shakacode/react_on_rails/issues/4572
+  if (StoreRegistry.getStore(name, false) !== undefined) {
+    return;
+  }
+
   const props = el.textContent !== null ? (JSON.parse(el.textContent) as Record<string, unknown>) : {};
   const storeGenerator = StoreRegistry.getStoreGenerator(name);
   const store = storeGenerator(props, railsContext);

--- a/packages/react-on-rails/src/ClientRenderer.ts
+++ b/packages/react-on-rails/src/ClientRenderer.ts
@@ -570,5 +570,16 @@ function unmountAllComponents(): void {
   renderedRoots.clear();
 }
 
+/**
+ * Clear all hydrated stores on page unload so navigation to a new page re-initializes stores
+ * with the new page's props. Without this, the initializeStore guard (which prevents duplicate
+ * store creation within a single page lifecycle) would skip re-initialization on navigation,
+ * leaving components bound to stale state from the previous page.
+ */
+function clearAllStores(): void {
+  StoreRegistry.clearHydratedStores();
+}
+
 // Register cleanup on page unload
 onPageUnloaded(unmountAllComponents);
+onPageUnloaded(clearAllStores);

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -1453,5 +1453,68 @@ describe('ClientRenderer', () => {
       const observerGlobal = globalThis as unknown as { IntersectionObserver?: unknown };
       delete observerGlobal.IntersectionObserver;
     });
+
+    it('clears stores on page unload so navigation re-initializes with new props', () => {
+      const storeGenerator = jest.fn((props: Record<string, unknown>) => ({
+        getState: () => ({ count: (props as { initialCount: number }).initialCount }),
+        dispatch: jest.fn(),
+        subscribe: jest.fn(),
+      }));
+      StoreRegistry.register({ NavigationStore: storeGenerator });
+      setupStoreElement('NavigationStore', { initialCount: 1 });
+
+      const TestComponent: React.FC = () => React.createElement('div', null, 'Test');
+      ComponentRegistry.register({ TestComponent });
+
+      const componentElement = document.createElement('div');
+      componentElement.className = 'js-react-on-rails-component';
+      componentElement.setAttribute('data-component-name', 'TestComponent');
+      componentElement.setAttribute('data-dom-id', 'nav-store-test');
+      componentElement.textContent = JSON.stringify({});
+      document.body.appendChild(componentElement);
+
+      const targetNode = document.createElement('div');
+      targetNode.id = 'nav-store-test';
+      document.body.appendChild(targetNode);
+
+      // First page load: creates the store
+      renderComponent('nav-store-test');
+      expect(storeGenerator).toHaveBeenCalledTimes(1);
+      const firstStore = StoreRegistry.getStore('NavigationStore');
+      expect(firstStore?.getState()).toEqual({ count: 1 });
+
+      // Simulate Turbo/Turbolinks page unload (this should clear stores)
+      runPageUnload();
+
+      // After page unload, the store should be cleared
+      expect(StoreRegistry.getStore('NavigationStore', false)).toBeUndefined();
+
+      // Simulate new page - clear DOM and set up fresh page content
+      // This mimics what Turbo does: replace the entire page content
+      document.body.innerHTML = '';
+      document.head.innerHTML = '';
+      setupRailsContext();
+      setupStoreElement('NavigationStore', { initialCount: 100 });
+
+      const newComponentElement = document.createElement('div');
+      newComponentElement.className = 'js-react-on-rails-component';
+      newComponentElement.setAttribute('data-component-name', 'TestComponent');
+      newComponentElement.setAttribute('data-dom-id', 'nav-store-test-2');
+      newComponentElement.textContent = JSON.stringify({});
+      document.body.appendChild(newComponentElement);
+
+      const newTargetNode = document.createElement('div');
+      newTargetNode.id = 'nav-store-test-2';
+      document.body.appendChild(newTargetNode);
+
+      // Second page load: should create a NEW store with new props
+      renderComponent('nav-store-test-2');
+      expect(storeGenerator).toHaveBeenCalledTimes(2);
+      const secondStore = StoreRegistry.getStore('NavigationStore');
+      expect(secondStore?.getState()).toEqual({ count: 100 });
+
+      // The stores should be different instances
+      expect(secondStore).not.toBe(firstStore);
+    });
   });
 });

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -1272,4 +1272,186 @@ describe('ClientRenderer', () => {
       expect(mockHydrateOrRender).toHaveBeenCalledTimes(2);
     });
   });
+
+  // Issue #4572: deferred hydration can bind a shared Redux store to a re-created instance
+  describe('store re-initialization guard (issue #4572)', () => {
+    beforeEach(() => {
+      runPageUnload();
+      setupRailsContext();
+      StoreRegistry.clearHydratedStores();
+      StoreRegistry.clearStoreGenerators();
+    });
+
+    afterEach(() => {
+      StoreRegistry.clearHydratedStores();
+      StoreRegistry.clearStoreGenerators();
+    });
+
+    const setupStoreElement = (storeName: string, props: Record<string, unknown>): void => {
+      // Use a div element with the store attribute, matching how forEachStore queries for stores
+      // (it queries by attribute, not by element type)
+      const storeElement = document.createElement('div');
+      storeElement.setAttribute('data-js-react-on-rails-store', storeName);
+      storeElement.textContent = JSON.stringify(props);
+      document.body.appendChild(storeElement);
+    };
+
+    it('does not re-create an already-hydrated store when forEachStore runs again', () => {
+      const storeGenerator = jest.fn((props: Record<string, unknown>) => ({
+        getState: () => ({ count: (props as { initialCount: number }).initialCount }),
+        dispatch: jest.fn(),
+        subscribe: jest.fn(),
+      }));
+      StoreRegistry.register({ SharedStore: storeGenerator });
+      setupStoreElement('SharedStore', { initialCount: 42 });
+
+      const TestComponent: React.FC = () => React.createElement('div', null, 'Test');
+      ComponentRegistry.register({ TestComponent });
+
+      // Setup a component that will trigger forEachStore
+      const componentElement = document.createElement('div');
+      componentElement.className = 'js-react-on-rails-component';
+      componentElement.setAttribute('data-component-name', 'TestComponent');
+      componentElement.setAttribute('data-dom-id', 'store-guard-test');
+      componentElement.textContent = JSON.stringify({});
+      document.body.appendChild(componentElement);
+
+      const targetNode = document.createElement('div');
+      targetNode.id = 'store-guard-test';
+      document.body.appendChild(targetNode);
+
+      // First render: creates the store
+      renderComponent('store-guard-test');
+      expect(storeGenerator).toHaveBeenCalledTimes(1);
+      const firstStore = StoreRegistry.getStore('SharedStore');
+
+      // Simulate a Turbo Frame or async content load that triggers another renderComponent
+      // This should NOT re-create the store
+      renderComponent('store-guard-test');
+      expect(storeGenerator).toHaveBeenCalledTimes(1);
+      const secondStore = StoreRegistry.getStore('SharedStore');
+
+      // The store instance should be the same
+      expect(firstStore).toBe(secondStore);
+    });
+
+    it('prevents store divergence between immediate and deferred components', () => {
+      type ObserverCallback = ConstructorParameters<typeof IntersectionObserver>[0];
+      const observerInstances: Array<{
+        callback: ObserverCallback;
+        disconnect: jest.Mock;
+        observe: jest.Mock;
+      }> = [];
+
+      class MockIntersectionObserver {
+        callback: ObserverCallback;
+
+        disconnect = jest.fn();
+
+        observe = jest.fn();
+
+        constructor(callback: ObserverCallback) {
+          this.callback = callback;
+          observerInstances.push(this);
+        }
+      }
+
+      Object.defineProperty(globalThis, 'IntersectionObserver', {
+        configurable: true,
+        value: MockIntersectionObserver,
+      });
+
+      let storeCallCount = 0;
+      const stores: Array<{ id: number }> = [];
+      const storeGenerator = jest.fn(() => {
+        storeCallCount += 1;
+        const store = {
+          id: storeCallCount,
+          getState: () => ({ storeId: storeCallCount }),
+          dispatch: jest.fn(),
+          subscribe: jest.fn(),
+        };
+        stores.push(store);
+        return store;
+      });
+      StoreRegistry.register({ SharedStore: storeGenerator });
+      setupStoreElement('SharedStore', {});
+
+      const TestComponent: React.FC = () => React.createElement('div', null, 'Test');
+      ComponentRegistry.register({ TestComponent });
+
+      // Setup immediate component
+      const immediateComponentEl = document.createElement('div');
+      immediateComponentEl.className = 'js-react-on-rails-component';
+      immediateComponentEl.setAttribute('data-component-name', 'TestComponent');
+      immediateComponentEl.setAttribute('data-dom-id', 'immediate-comp');
+      immediateComponentEl.setAttribute('data-hydrate-on', 'immediate');
+      immediateComponentEl.textContent = JSON.stringify({});
+      document.body.appendChild(immediateComponentEl);
+
+      const immediateTargetNode = document.createElement('div');
+      immediateTargetNode.id = 'immediate-comp';
+      immediateTargetNode.innerHTML = '<div>Server rendered</div>';
+      document.body.appendChild(immediateTargetNode);
+
+      // Setup visible (deferred) component
+      const visibleComponentEl = document.createElement('div');
+      visibleComponentEl.className = 'js-react-on-rails-component';
+      visibleComponentEl.setAttribute('data-component-name', 'TestComponent');
+      visibleComponentEl.setAttribute('data-dom-id', 'visible-comp');
+      visibleComponentEl.setAttribute('data-hydrate-on', 'visible');
+      visibleComponentEl.textContent = JSON.stringify({});
+      document.body.appendChild(visibleComponentEl);
+
+      const visibleTargetNode = document.createElement('div');
+      visibleTargetNode.id = 'visible-comp';
+      visibleTargetNode.innerHTML = '<div>Server rendered</div>';
+      document.body.appendChild(visibleTargetNode);
+
+      // First render: immediate component hydrates, visible is scheduled
+      renderComponent('immediate-comp');
+      renderComponent('visible-comp');
+
+      // Store should be created once
+      expect(storeGenerator).toHaveBeenCalledTimes(1);
+      const storeAfterFirstRender = StoreRegistry.getStore('SharedStore');
+
+      // Simulate async content load (e.g., Turbo Frame) triggering another forEachStore
+      // This happens when reactOnRailsComponentLoaded is called for a new component
+      const asyncComponentEl = document.createElement('div');
+      asyncComponentEl.className = 'js-react-on-rails-component';
+      asyncComponentEl.setAttribute('data-component-name', 'TestComponent');
+      asyncComponentEl.setAttribute('data-dom-id', 'async-comp');
+      asyncComponentEl.textContent = JSON.stringify({});
+      document.body.appendChild(asyncComponentEl);
+
+      const asyncTargetNode = document.createElement('div');
+      asyncTargetNode.id = 'async-comp';
+      document.body.appendChild(asyncTargetNode);
+
+      // This would previously re-create the store
+      renderComponent('async-comp');
+
+      // Store should still be the same instance
+      expect(storeGenerator).toHaveBeenCalledTimes(1);
+      const storeAfterAsyncLoad = StoreRegistry.getStore('SharedStore');
+      expect(storeAfterAsyncLoad).toBe(storeAfterFirstRender);
+
+      // Now the visible component becomes visible
+      observerInstances[0].callback(
+        [{ isIntersecting: true, intersectionRatio: 1 }] as IntersectionObserverEntry[],
+        observerInstances[0] as unknown as IntersectionObserver,
+      );
+
+      // The visible component should have gotten the same store instance
+      // (we can't directly test the component's store reference, but we verify
+      // the store wasn't re-created before the visible component mounted)
+      expect(storeGenerator).toHaveBeenCalledTimes(1);
+      expect(StoreRegistry.getStore('SharedStore')).toBe(storeAfterFirstRender);
+
+      // Cleanup
+      const observerGlobal = globalThis as unknown as { IntersectionObserver?: unknown };
+      delete observerGlobal.IntersectionObserver;
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a guard in `initializeStore` to skip re-creating a store that already exists in `hydratedStores`
- Restores the one-instance-per-name-per-page-lifetime invariant broken by deferred hydration

## Problem

Before `hydrate_on` scheduling (#4037), all components hydrated in one synchronous pass, so every component read the same store instance. Deferred hydration (`visible`/`idle`) breaks this invariant:

1. Initial `renderAllComponents()` creates store S1
2. Component A (`:immediate`) hydrates and gets S1
3. Component B (`:visible`) is scheduled but doesn't mount yet
4. A Turbo Frame or async fragment calls `reactOnRailsComponentLoaded()`, which re-runs `forEachStore` 
5. `initializeStore` unconditionally creates a new store S2, overwriting S1 in the registry
6. Component A is skipped by the `sameNode` guard, so it keeps S1
7. Component B scrolls into view and mounts with S2

Result: A dispatches to S1, B dispatches to S2 — divergent shared state with no error.

## Fix

Check if the store already exists in `hydratedStores` before creating a new one. This matches the Pro package's behavior which already guards via the `storeRenderers` map.

## Test plan

- [x] Added unit tests covering:
  - `forEachStore` running multiple times doesn't re-create stores
  - Store instance remains stable between immediate and deferred component hydration
- [x] All existing ClientRenderer tests pass (363 tests)
- [x] Type check passes
- [x] Lint passes

Fixes #4572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Redux store creation during repeated rendering passes within the same page lifecycle.
  * Ensured immediately hydrated and deferred/visible components consistently reuse the same store instance.
  * Added page-unload cleanup so hydrated stores are cleared on navigation, allowing correct re-initialization on the next page.
* **Tests**
  * Added coverage for the store re-initialization guard, deferred hydration timing, and page-unload store clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->