### PR TITLE
Docs: post-17.0.0 roadmap, product-strategy context, and Rspack-vs-Vite ADR

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -3,5 +3,6 @@
 ## Contexts
 
 - [React on Rails Pro (RSC)](./packages/react-on-rails-pro/CONTEXT.md) — React Server Components integration: payload generation, embedding, caching, and client-router prefetch
+- [Product Strategy & Roadmap](./internal/planning/CONTEXT.md) — release planning, backlog triage, and competitive positioning language (decision records: [internal/adr/](./internal/adr/))
 
 Other contexts (core gem, node renderer, generators) are not yet documented; add them here when their first term is resolved.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@ Performance claims ship with a public, reproducible artifact — or they don't s
 
 - **Current proof:** the [Gumroad RSC comparison](https://gumroad.reactonrails.com/rsc-demo) — React Server Components vs an Inertia control on real product pages: ~48%/43% faster browser navigation, ~44% less HTML+JS delivered.
 - **Structural position:** streaming SSR, React Server Components, partial hydration, and async server props with no API layer — on a persistent Node renderer wired to `Rails.cache`. The Inertia stack has none of these (synchronous `renderToString`, monolithic SSR bundle, no RSC); Next.js has them but demands its own runtime and data layer.
-- **Next:** Partial Pre-Rendering on React 19.2's now-stable `prerender`/`resume` APIs (prototype: ~36× warm TTFB). CSS-gated streamed reveals shipped in 17.0.0 — streamed pages no longer flash unstyled content; 17.1 adds the production CI gate that keeps it true.
+- **Next:** Partial Pre-Rendering on React 19.2's now-stable `prerender`/`resume` APIs. An internal prototype showed a ~36× warm-TTFB improvement; per this roadmap's own standard, that number graduates to a headline claim only when the 17.2 work ships its public, reproducible artifact ([#3571](https://github.com/shakacode/react_on_rails/issues/3571)). CSS-gated streamed reveals shipped in 17.0.0 — streamed pages no longer flash unstyled content; 17.1 adds the production CI gate that keeps it true.
 
 ### 2. Onboarding simplicity
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,80 @@
+# React on Rails Roadmap
+
+_Last updated: 2026-07-11 · Maintained by [ShakaCode](https://www.shakacode.com) · Live status: [GitHub milestones](https://github.com/shakacode/react_on_rails/milestones)_
+
+React on Rails 17.0.0 is shipping now. This document says where the project goes next and why, so evaluators and contributors can see the direction before committing.
+
+## North star
+
+Make **React on Rails Pro the obvious way to run modern React on a Rails backend** — for new apps, for teams migrating from Inertia or a separate Next.js frontend, and for existing React on Rails users upgrading. Pro is [trust-licensed](./REACT-ON-RAILS-PRO-LICENSE.md): freely installable, paid for production use, free for evaluation, education, and qualifying open source.
+
+## Three commitments
+
+Every release headlines one of these; nothing headlines anything else.
+
+### 1. Provable performance
+
+Performance claims ship with a public, reproducible artifact — or they don't ship.
+
+- **Current proof:** the [Gumroad RSC comparison](https://gumroad.reactonrails.com/rsc-demo) — React Server Components vs an Inertia control on real product pages: ~48%/43% faster browser navigation, ~44% less HTML+JS delivered.
+- **Structural position:** streaming SSR, React Server Components, partial hydration, and async server props with no API layer — on a persistent Node renderer wired to `Rails.cache`. The Inertia stack has none of these (synchronous `renderToString`, monolithic SSR bundle, no RSC); Next.js has them but demands its own runtime and data layer.
+- **Next:** Partial Pre-Rendering on React 19.2's now-stable `prerender`/`resume` APIs (prototype: ~36× warm TTFB), and CSS-gated streamed reveals so streamed pages never flash unstyled content.
+
+### 2. Onboarding simplicity
+
+The bar is Inertia's: one command and it works. `npx create-react-on-rails-app` (Pro-enabled by default) is that command; the roadmap tracks time-to-first-success and works-on-first-try as regressions, same as performance.
+
+### 3. Agent-native development
+
+AI coding agents increasingly choose the stack. React on Rails treats them as first-class developers: scaffolded `AGENTS.md` with the top runtime errors and fixes (shipped), `bin/rails react_on_rails:doctor`, `llms.txt`/`llms-full.txt`, and agent-legible error output. The 17.x cycle extends this with generated-from-docs `llms-full.txt` freshness guarantees and an agent toolchain informed by where the ecosystem landed (Next.js 16.3's bundled version-matched docs + Skills; TanStack's and Inertia's agent Skills).
+
+## Release plan
+
+### 17.1 — onboarding + agent content _(target: ~6–8 weeks after 17.0.0 final)_
+
+The "instant to start" release. Non-breaking.
+
+- CSS-gated streamed reveal — eliminate FOUC on streamed RSC/SSR pages ([#4557](https://github.com/shakacode/react_on_rails/issues/4557))
+- `llms-full.txt` generated from docs with CI freshness guard ([#3896](https://github.com/shakacode/react_on_rails/issues/3896))
+- Agent-legible doctor and error output (structured, copy-promptable)
+- Onboarding quick wins from the 2026-07 backlog triage
+- React 19.2 security-hardened RSC baseline (react-on-rails-rsc ≥ 19.2.x line)
+
+### 17.2 — the numbers release
+
+The "prove it" release. Non-breaking.
+
+- **Partial Pre-Rendering productionized** ([#3245](https://github.com/shakacode/react_on_rails/issues/3245)) — static shell + streamed resume, on stable React 19.2 APIs, with a Gumroad-style public artifact
+- Benchmark CI re-enabled as a gate with published results ([#3169](https://github.com/shakacode/react_on_rails/issues/3169))
+- Rspack RSC production path ([#3488](https://github.com/shakacode/react_on_rails/issues/3488))
+- Agent toolchain v2: Skills shipped in-package; minimal MCP re-evaluated against ecosystem evidence
+- "Why Rspack (and not Vite)" positioning page — the decision is recorded in [internal/adr/0001](./internal/adr/0001-rspack-answers-vite.md)
+
+### 18.0 — the breaking batch _(unscheduled; ships when the batch justifies it)_
+
+Breaking changes are locked out of 17.x and accumulate here:
+
+- Redux phase-out from the new-app path ([#4271](https://github.com/shakacode/react_on_rails/issues/4271), [#4274](https://github.com/shakacode/react_on_rails/issues/4274), [#4279](https://github.com/shakacode/react_on_rails/issues/4279))
+- Bundler-neutral config file naming ([#2552](https://github.com/shakacode/react_on_rails/issues/2552))
+- Deferred breaking cleanups collected during 17.x
+
+### Continuous (every release)
+
+- React feature adoption tracking ([#3865](https://github.com/shakacode/react_on_rails/issues/3865)) — 19.2 shipped; ViewTransition and the Compiler's Rust port are the next watch items
+- DX parity with the Inertia stack where evaluator feedback demands it (forms, routing, image/RUM helpers)
+- Docs, comparisons, and the official demo fleet
+
+## Ecosystem watch _(2026-07 snapshot)_
+
+| Signal                          | State                                                                                    | Our position                                                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| React 19.2 `prerender`/`resume` | Stable                                                                                   | Foundation for PPR in 17.2                                                                              |
+| React `<ViewTransition>`        | Canary; 19.2 reveal-batching prepares it                                                 | Adopt when stable; streaming already aligned                                                            |
+| React Compiler                  | 1.0 stable; Rust port merged upstream                                                    | Recipe shipped; revisit default-on when frameworks do                                                   |
+| Next.js 16.3                    | Instant Navigations, agent DX (bundled docs, Skills, slim MCP)                           | Direction reference for agent-native + caching discipline                                               |
+| RSC on Vite / Rspack            | `@vitejs/plugin-rsc` consolidating; Rspack 2.x ships experimental native RSC             | Watch items for [ADR-0001](./internal/adr/0001-rspack-answers-vite.md); native Rspack RSC informs #3488 |
+| Inertia v3 + inertia_rails      | Fast-moving (Evil Martians maintainership); still no RSC/streaming SSR/partial hydration | Match their simplicity; extend the structural performance lead                                          |
+
+## How to influence this roadmap
+
+Open an issue with your use case — customer evidence outranks everything else in triage. Issues are labeled by theme (`theme:performance`, `theme:onboarding`, `theme:agent-native`, …) and scheduled via the [17.1 / 17.2 / 18.0 milestones](https://github.com/shakacode/react_on_rails/milestones). Commercial support and consulting: [react_on_rails@shakacode.com](mailto:react_on_rails@shakacode.com).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@ The "instant to start" release. Non-breaking.
 - Agent-legible doctor and error output — structured `--format=json`, copy-promptable fixes ([#4602](https://github.com/shakacode/react_on_rails/issues/4602))
 - "An agent builds a React on Rails Pro app" tutorial + scripted eval ([#4603](https://github.com/shakacode/react_on_rails/issues/4603))
 - Pro license token via Rails credentials — customer-requested onboarding fix ([#4553](https://github.com/shakacode/react_on_rails/issues/4553))
-- Onboarding quick wins from the 2026-07 backlog triage (`llms.txt`/`llms-full.txt` generation already shipped and verified live — [#3896](https://github.com/shakacode/react_on_rails/issues/3896))
+- Onboarding quick wins from the 2026-07 backlog triage ([umbrella #4607](https://github.com/shakacode/react_on_rails/issues/4607))
 - React 19.2 security-hardened RSC baseline (react-on-rails-rsc ≥ 19.2.x line)
 
 ### 17.2 — the numbers release

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # React on Rails Roadmap
 
-_Last updated: 2026-07-11 · Maintained by [ShakaCode](https://www.shakacode.com) · Live status: [GitHub milestones](https://github.com/shakacode/react_on_rails/milestones)_
+_Last updated: 2026-07-11 · Maintained by [ShakaCode](https://www.shakacode.com) · Live status: [roadmap umbrella #4607](https://github.com/shakacode/react_on_rails/issues/4607) and [GitHub milestones](https://github.com/shakacode/react_on_rails/milestones)_
 
 React on Rails 17.0.0 is shipping now. This document says where the project goes next and why, so evaluators and contributors can see the direction before committing.
 
@@ -18,7 +18,7 @@ Performance claims ship with a public, reproducible artifact — or they don't s
 
 - **Current proof:** the [Gumroad RSC comparison](https://gumroad.reactonrails.com/rsc-demo) — React Server Components vs an Inertia control on real product pages: ~48%/43% faster browser navigation, ~44% less HTML+JS delivered.
 - **Structural position:** streaming SSR, React Server Components, partial hydration, and async server props with no API layer — on a persistent Node renderer wired to `Rails.cache`. The Inertia stack has none of these (synchronous `renderToString`, monolithic SSR bundle, no RSC); Next.js has them but demands its own runtime and data layer.
-- **Next:** Partial Pre-Rendering on React 19.2's now-stable `prerender`/`resume` APIs (prototype: ~36× warm TTFB), and CSS-gated streamed reveals so streamed pages never flash unstyled content.
+- **Next:** Partial Pre-Rendering on React 19.2's now-stable `prerender`/`resume` APIs (prototype: ~36× warm TTFB). CSS-gated streamed reveals shipped in 17.0.0 — streamed pages no longer flash unstyled content; 17.1 adds the production CI gate that keeps it true.
 
 ### 2. Onboarding simplicity
 
@@ -26,7 +26,7 @@ The bar is Inertia's: one command and it works. `npx create-react-on-rails-app` 
 
 ### 3. Agent-native development
 
-AI coding agents increasingly choose the stack. React on Rails treats them as first-class developers: scaffolded `AGENTS.md` with the top runtime errors and fixes (shipped), `bin/rails react_on_rails:doctor`, `llms.txt`/`llms-full.txt`, and agent-legible error output. The 17.x cycle extends this with generated-from-docs `llms-full.txt` freshness guarantees and an agent toolchain informed by where the ecosystem landed (Next.js 16.3's bundled version-matched docs + Skills; TanStack's and Inertia's agent Skills).
+AI coding agents increasingly choose the stack. React on Rails treats them as first-class developers: scaffolded `AGENTS.md` with the top runtime errors and fixes (shipped), `bin/rails react_on_rails:doctor`, `llms.txt`/`llms-full.txt`, and agent-legible error output. `llms.txt`/`llms-full.txt` generation with a CI drift guard shipped and is verified live. The 17.x cycle extends this with an agent-legible doctor, an agent-builds-the-app tutorial + eval, and an agent toolchain informed by where the ecosystem landed (Next.js 16.3's bundled version-matched docs + Skills; TanStack's and Inertia's agent Skills).
 
 ## Release plan
 
@@ -34,17 +34,19 @@ AI coding agents increasingly choose the stack. React on Rails treats them as fi
 
 The "instant to start" release. Non-breaking.
 
-- CSS-gated streamed reveal — eliminate FOUC on streamed RSC/SSR pages ([#4557](https://github.com/shakacode/react_on_rails/issues/4557))
-- `llms-full.txt` generated from docs with CI freshness guard ([#3896](https://github.com/shakacode/react_on_rails/issues/3896))
-- Agent-legible doctor and error output (structured, copy-promptable)
-- Onboarding quick wins from the 2026-07 backlog triage
+- FOUC pipeline finished — production CI gate + simplification to the manifest-hint layer ([#4557](https://github.com/shakacode/react_on_rails/issues/4557); the reveal gating itself shipped in 17.0.0)
+- Security hardening cluster from the 2026-07 reviews — RSC payload endpoint authorization, node-renderer hardening, log hygiene ([#4595](https://github.com/shakacode/react_on_rails/issues/4595)–[#4597](https://github.com/shakacode/react_on_rails/issues/4597))
+- Agent-legible doctor and error output — structured `--format=json`, copy-promptable fixes ([#4602](https://github.com/shakacode/react_on_rails/issues/4602))
+- "An agent builds a React on Rails Pro app" tutorial + scripted eval ([#4603](https://github.com/shakacode/react_on_rails/issues/4603))
+- Pro license token via Rails credentials — customer-requested onboarding fix ([#4553](https://github.com/shakacode/react_on_rails/issues/4553))
+- Onboarding quick wins from the 2026-07 backlog triage (`llms.txt`/`llms-full.txt` generation already shipped and verified live — [#3896](https://github.com/shakacode/react_on_rails/issues/3896))
 - React 19.2 security-hardened RSC baseline (react-on-rails-rsc ≥ 19.2.x line)
 
 ### 17.2 — the numbers release
 
 The "prove it" release. Non-breaking.
 
-- **Partial Pre-Rendering productionized** ([#3245](https://github.com/shakacode/react_on_rails/issues/3245)) — static shell + streamed resume, on stable React 19.2 APIs, with a Gumroad-style public artifact
+- **Partial Pre-Rendering productionized** ([#3571](https://github.com/shakacode/react_on_rails/issues/3571)) — static shell + streamed resume, on stable React 19.2 APIs, with a Gumroad-style public artifact
 - Benchmark CI re-enabled as a gate with published results ([#3169](https://github.com/shakacode/react_on_rails/issues/3169))
 - Rspack RSC production path ([#3488](https://github.com/shakacode/react_on_rails/issues/3488))
 - Agent toolchain v2: Skills shipped in-package; minimal MCP re-evaluated against ecosystem evidence

--- a/internal/adr/0001-rspack-answers-vite.md
+++ b/internal/adr/0001-rspack-answers-vite.md
@@ -5,7 +5,7 @@ date: 2026-07-11
 
 # Rspack answers Vite — no Vite runtime support in the 17.x cycle
 
-The Rails ecosystem's default "modern React" stack is inertia*rails + vite_ruby, so evaluators keep asking why React on Rails runs on Shakapacker/Rspack instead of Vite. We decided **not** to build Vite runtime support in the 17.x cycle: the RSC pipeline (react-on-rails-rsc plugin, client/server manifests, flight chunk handling) is built on the webpack/rspack plugin contract, RSC-on-Vite is still experimental across the entire ecosystem, and Rspack already delivers Vite-class dev speed (~20× build improvements in our benchmarks) \_with* production RSC — which Vite cannot do. Instead we invest in Rspack DX parity (HMR speed, zero-config startup, error overlays) and publish a "Why Rspack (and not Vite)" positioning page, so the objection is answered in the open rather than dodged.
+The Rails ecosystem's default "modern React" stack is inertia_rails + vite_ruby, so evaluators keep asking why React on Rails runs on Shakapacker/Rspack instead of Vite. We decided **not** to build Vite runtime support in the 17.x cycle: the RSC pipeline (react-on-rails-rsc plugin, client/server manifests, flight chunk handling) is built on the webpack/rspack plugin contract, RSC-on-Vite is still experimental across the entire ecosystem, and Rspack already delivers Vite-class dev speed (~20× build improvements in our benchmarks) **with** production RSC — which Vite cannot do. Instead we invest in Rspack DX parity (HMR speed, zero-config startup, error overlays) and publish a "Why Rspack (and not Vite)" positioning page, so the objection is answered in the open rather than dodged.
 
 ## Considered options
 

--- a/internal/adr/0001-rspack-answers-vite.md
+++ b/internal/adr/0001-rspack-answers-vite.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+date: 2026-07-11
+---
+
+# Rspack answers Vite — no Vite runtime support in the 17.x cycle
+
+The Rails ecosystem's default "modern React" stack is inertia*rails + vite_ruby, so evaluators keep asking why React on Rails runs on Shakapacker/Rspack instead of Vite. We decided **not** to build Vite runtime support in the 17.x cycle: the RSC pipeline (react-on-rails-rsc plugin, client/server manifests, flight chunk handling) is built on the webpack/rspack plugin contract, RSC-on-Vite is still experimental across the entire ecosystem, and Rspack already delivers Vite-class dev speed (~20× build improvements in our benchmarks) \_with* production RSC — which Vite cannot do. Instead we invest in Rspack DX parity (HMR speed, zero-config startup, error overlays) and publish a "Why Rspack (and not Vite)" positioning page, so the objection is answered in the open rather than dodged.
+
+## Considered options
+
+- **Vite RFC for 18.0** (spike on the Vite Environment API, RSC excluded initially) — rejected for now: a large parallel investment while Rspack RSC productionization (#3488) is still in flight, and it would fork engineering attention during the window where onboarding + provable performance drive Pro installs.
+- **Vite for the standard (non-RSC) tier only** — rejected: permanently splits the bundler story and doubles the support/CI matrix for the tier that differentiates us least.
+- **Silent no** (no positioning content) — rejected: the question is asked constantly; leaving it unanswered costs evaluator trust.
+
+## Consequences
+
+- Bundler-neutral config naming (#2552) stays alive and lands in 18.0 so the door to Vite (or any bundler) stays open without another breaking cycle.
+- Revisit trigger: funnel evidence that bundler choice is a primary bounce reason for evaluators, or RSC-on-Vite reaching production maturity upstream. Watch items (2026-07): `@vitejs/plugin-rsc` (official under the vitejs org, pre-1.0, already the base for React Router's RSC framework mode) and Rspack 2.x's built-in experimental RSC (`react-server-dom-rspack` — a young fork of the wire packages; our webpack-package pipeline does not transfer 1:1, which informs the #3488 native-plugin pivot).
+- The "Why Rspack" page becomes part of the public positioning surface and must be kept honest — if Rspack DX parity claims stop being true, the page and this decision both come up for review.

--- a/internal/planning/CONTEXT.md
+++ b/internal/planning/CONTEXT.md
@@ -1,0 +1,52 @@
+# Product Strategy & Roadmap
+
+The language used when planning React on Rails releases, triaging the backlog, and positioning against competitors. Exists so roadmap issues, triage passes, and marketing claims all mean the same thing by the same words.
+
+## Language
+
+**Pro install**:
+A new Organization adopting React on Rails Pro in a real app — the roadmap's #1 goal metric, pursued through three funnels: new-app adoption, migration wins, and OSS→Pro upgrades.
+_Avoid_: download count, npm installs (raw download breadth was explicitly rejected as the metric)
+
+**Trust-based license**:
+The Pro distribution model — packages freely installable with no key enforcement; Production Use requires a paid per-Organization subscription on the honor system (EULA v2.2).
+_Avoid_: freemium, open core
+
+**Competitive frame**:
+The Inertia+Vite stack (`inertia_rails` + `vite_ruby`) — the default "modern Rails + React" recommendation the roadmap positions against. Next.js/TanStack Start/React roadmaps are direction references, not the battleground.
+_Avoid_: treating vite-rails alone as the competitor (it is a bundler layer; the rival is the full stack)
+
+**Headline theme**:
+One of the three roadmap pillars that get P0/P1 issues and the marketing narrative: Provable performance, Onboarding simplicity, Agent-native development.
+
+**Provable performance**:
+Performance claims backed by a public, reproducible artifact (e.g., the Gumroad RSC demo: ~48%/43% faster navigation, ~44% less HTML+JS vs the Inertia control).
+_Avoid_: unbenchmarked "fast" claims
+
+**Onboarding simplicity**:
+Neutralizing Inertia's "one command and it works" edge for the new-app funnel — generator quality, zero-config defaults, time-to-first-success.
+
+**Agent-native development**:
+Making React on Rails the stack AI coding agents can install, build with, and debug unaided — llms.txt, MCP, AGENTS.md scaffolding, agent-legible errors.
+
+**New-app path**:
+`npx create-react-on-rails-app` — defaults to Pro (opt out via `--standard`); the quick-start leads with it. Distinct from the existing-app installer (`rails g react_on_rails:install`), which still defaults Pro off.
+
+**Supporting theme**:
+Roadmap work that feeds the headliners but doesn't lead the narrative: DX-parity features (forms, routing, caching answers to Inertia's useForm/Link), modern React coverage, production-readiness/observability, docs/content, demo fleet.
+
+## Relationships
+
+- Each **Headline theme** serves at least one **Pro install** funnel: Provable performance → all three; Onboarding simplicity → new-app; Agent-native → new-app (agents increasingly choose the stack).
+- **Supporting themes** exist to remove objections within the **Competitive frame**, not to headline releases.
+- The **Trust-based license** makes **Pro install** an adoption metric first and a revenue metric second.
+
+## Example dialogue
+
+> **Dev:** "Inertia shipped a new `useForm` feature — do we headline a response in 17.1?"
+> **Maintainer:** "No — forms are a **supporting theme** (DX parity). It ships, but the release headline stays on a **headline theme**, like PPR numbers we can prove publicly."
+
+## Flagged ambiguities
+
+- "installs" was used to mean both raw package downloads and real adoptions — resolved: **Pro install** means an Organization adopting Pro in a real app; raw downloads rejected as a goal metric (2026-07-11).
+- "vite-rails as competitor" — resolved: the **Competitive frame** is the full Inertia+Vite stack; bundler-level Vite DX is a supporting concern, not the anchor (2026-07-11).

--- a/internal/planning/CONTEXT.md
+++ b/internal/planning/CONTEXT.md
@@ -9,7 +9,7 @@ A new Organization adopting React on Rails Pro in a real app — the roadmap's #
 _Avoid_: download count, npm installs (raw download breadth was explicitly rejected as the metric)
 
 **Trust-based license**:
-The Pro distribution model — packages freely installable with no key enforcement; Production Use requires a paid per-Organization subscription on the honor system (EULA v2.2).
+The Pro distribution model — packages freely installable with no key enforcement; Production Use requires a paid per-Organization subscription on the honor system, except where EULA v2.2 grants free use (evaluation, education, demos, and complimentary qualifying-open-source licenses under §4.1).
 _Avoid_: freemium, open core
 
 **Competitive frame**:


### PR DESCRIPTION
## Summary

Documentation companion to the 2026-07-11 backlog triage + roadmap session (umbrella #4607):

- **ROADMAP.md** (new, repo root) — public direction: north star (Pro adoption via new-app / migration / OSS→Pro funnels), the three headline themes (provable performance · onboarding simplicity · agent-native development), the 17.1 / 17.2 / 18.0 release plan wired to real issues and milestones, and a 2026-07 ecosystem-watch snapshot (React 19.2 prerender/resume stable, Next 16.3, TanStack Start RC, Inertia v3).
- **internal/planning/CONTEXT.md** (new) — the strategy language locked in the planning session (Pro install, trust-based license, competitive frame, headline vs supporting themes), so future triage and marketing mean the same things by the same words.
- **internal/adr/0001-rspack-answers-vite.md** (new) — records the decision to answer Vite with Rspack DX parity + positioning instead of building Vite runtime support in 17.x; includes revisit triggers (`@vitejs/plugin-rsc`, Rspack native RSC).
- **CONTEXT-MAP.md** — links the new strategy context.

## Related state (already executed on GitHub, not in this diff)

- Roadmap umbrella #4607 supersedes #3864 (closed with retrospective); milestones 17.0.x/17.1/17.2/18.0 created; 115 open issues dispositioned (11 evidence-closed, 46 milestone/theme-assigned, 25 parked, 20 close-candidates awaiting maintainer sign-off on #4607); gap issues #4600–#4605 filed.

## Verification

- Pre-commit hooks green on all touched files: prettier (3.6.2), Lychee link check, trailing newlines.
- Root/internal markdown only — no docs-site (docs/) pages touched, so no sidebars.ts or llms-full regeneration needed.
- All issue/milestone links in ROADMAP.md point at live GitHub objects created this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a product roadmap outlining release commitments, priorities, and ongoing focus areas.
  * Added guidance for contributing feedback through labeled issues and milestones.
  * Documented the project’s position on Rspack vs. Vite for the 17.x cycle, including revisit triggers.
  * Added a planning glossary defining roadmap terminology, themes, adoption metrics, and competitive framing.
  * Updated the context map to include Product Strategy & Roadmap documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Confidence note (merge-readiness, no merge authority granted this session)

- Validated: lefthook pre-commit (prettier 3.6.2, Lychee offline links, trailing newlines) green on both commits; first-head CI fully green (all checks passed or skipped); second head (c6a43d958, review fixes) re-running at time of writing.
- Review: all 4 CodeRabbit/claude threads fixed in c6a43d958 and resolved with evidence replies (ADR markup, EULA free-use exception precision, PPR ~36× claim labeled internal-prototype pending the #3571 public artifact).
- Remaining UNKNOWN facts: none affecting merge safety — docs-only diff (root + internal/), no docs-site pages, no code paths.
- Residual risk: none beyond wording; all issue/milestone links point at live objects.
- Merge authority: not granted for this session → leaving the merge to @justin808 (merge-queue enqueue per repo convention).
