### PR TITLE
Docs: add missing Pro close-hook warning changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   mismatches on streamed RSC apps such as the flagship demo. Fixes
   [Issue 4525](https://github.com/shakacode/react_on_rails/issues/4525). [PR 4532](https://github.com/shakacode/react_on_rails/pull/4532) by [justin808](https://github.com/justin808).
 
+- **[Pro]** **Healthy incremental streams no longer log premature close-hook timeout warnings**: The
+  Pro Node renderer now suppresses the short close-hook timeout warning while an incremental response
+  is still open and finishing normally, while preserving the diagnostic when the close hook remains
+  stalled after the response finishes. Fixes
+  [Issue 4524](https://github.com/shakacode/react_on_rails/issues/4524).
+  [PR 4531](https://github.com/shakacode/react_on_rails/pull/4531) by
+  [justin808](https://github.com/justin808).
+
 #### Added
 
 - **[Pro] Configurable license-token secret sources**: Rails applications can now provide a paid


### PR DESCRIPTION
## Why

PR #4531 changed a user-visible Pro Node renderer diagnostic but its changelog entry was missed. Documenting the behavior before 17.0.0 keeps the release notes accurate: healthy incremental streams no longer produce premature close-hook timeout warnings, while genuinely stalled post-response cleanup remains diagnosable.

Closes #4536.

## Implementation

- Add the missing Pro runtime fix under `Unreleased` → `Fixed`.
- Link the originating Issue #4524 and PR #4531.

## Verification

- `pnpm exec prettier --check CHANGELOG.md`
- `pnpm start format.listDifferent`
- `git diff --check origin/main...HEAD`
- Pre-commit trailing-newline and Prettier checks
- Offline Markdown link validation: 8 links checked, 0 errors

## Scope and CI

- Changed files: `CHANGELOG.md` only
- Labels: none; this is a focused changelog-only correction covered by the required PR gate and local formatting/link checks.
- Churn: one commit, no generated or runtime files changed.

## Confidence note

High. The entry matches the merged #4531 behavior and the linked #4524 issue; no release metadata or runtime source changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed premature close-hook timeout warnings for healthy incremental streams.
  * Diagnostic warnings are now retained when a close hook stalls after the response has completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->