### PR TITLE
Installer: offer Pro during existing-app setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Added
 
+- **Existing-app Pro choice**: Interactive `react_on_rails:install` runs now ask whether to enable
+  React on Rails Pro when no Pro, RSC, or standard-only choice is supplied. The bounded prompt defaults
+  to yes and explains trust-based evaluation and production licensing, while noninteractive runs retain
+  the open-source-only default. Explicit `--pro`, `--no-pro`, `--rsc`, `--no-rsc`, and `--standard-only`
+  choices skip the prompt. The doctor and post-install guidance now show the Pro upgrade path when Pro is
+  off. Fixes [Issue 4604](https://github.com/shakacode/react_on_rails/issues/4604) by
+  [justin808](https://github.com/justin808).
+
 - **Agent-legible doctor contract**: `bin/rails react_on_rails:doctor FORMAT=json` now includes stable
   check IDs, explicit severity and documentation fields, a nullable field reserved for diagnosis-specific
   safe mechanical fix commands,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   to yes and explains trust-based evaluation and production licensing, while noninteractive runs retain
   the open-source-only default. Explicit `--pro`, `--no-pro`, `--rsc`, `--no-rsc`, and `--standard-only`
   choices skip the prompt. The doctor and post-install guidance now show the Pro upgrade path when Pro is
-  off. Fixes [Issue 4604](https://github.com/shakacode/react_on_rails/issues/4604) by
+  off. Fixes [Issue 4604](https://github.com/shakacode/react_on_rails/issues/4604) in
+  [PR 4615](https://github.com/shakacode/react_on_rails/pull/4615) by
   [justin808](https://github.com/justin808).
 
 - **Agent-legible doctor contract**: `bin/rails react_on_rails:doctor FORMAT=json` now includes stable

--- a/docs/oss/getting-started/installation-into-an-existing-rails-app.md
+++ b/docs/oss/getting-started/installation-into-an-existing-rails-app.md
@@ -56,6 +56,7 @@ and React Server Components. Pro is free for evaluation; production use requires
 The prompt never appears in CI, redirected-input scripts, or other noninteractive sessions; those runs preserve the
 existing open-source-only default. Pass `--pro` or `--rsc` to select Pro without a prompt. Pass `--no-pro`,
 `--no-rsc`, or `--standard-only` to select the open-source setup explicitly and suppress the prompt.
+Because `--standard-only` is an explicit open-source choice, the generator rejects combining it with `--pro` or `--rsc`.
 
 For generator options such as `--rspack`, `--pro`, or `--rsc`, see the [generator details](../api-reference/generator-details.md).
 

--- a/docs/oss/getting-started/installation-into-an-existing-rails-app.md
+++ b/docs/oss/getting-started/installation-into-an-existing-rails-app.md
@@ -48,6 +48,15 @@ bundle exec rails generate react_on_rails:install --typescript
 
 TypeScript is the recommended default for new integrations. If you want JavaScript instead, omit `--typescript`.
 
+When you run the generator in an interactive terminal without choosing a product mode, it asks whether to enable
+React on Rails Pro. Press Enter or answer `y` to include the Node Renderer and the Pro foundation for streaming SSR
+and React Server Components. Pro is free for evaluation; production use requires a subscription. See the
+[Pro upgrade guide](../../pro/upgrading-to-pro.md) for licensing and setup details.
+
+The prompt never appears in CI, redirected-input scripts, or other noninteractive sessions; those runs preserve the
+existing open-source-only default. Pass `--pro` or `--rsc` to select Pro without a prompt. Pass `--no-pro`,
+`--no-rsc`, or `--standard-only` to select the open-source setup explicitly and suppress the prompt.
+
 For generator options such as `--rspack`, `--pro`, or `--rsc`, see the [generator details](../api-reference/generator-details.md).
 
 If the generator reports dependency-install warnings (for example, `JavaScript dependencies installation failed ...` followed by `Please run manually:`), run your package manager install and then compile once before starting the app:

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -101,7 +101,7 @@ module ReactOnRails
       class_option :standard_only,
                    type: :boolean,
                    default: false,
-                   desc: "Install only the open-source package and skip the interactive Pro prompt"
+                   desc: "Install only the open-source package; cannot be combined with --pro or --rsc"
 
       # Hidden option: allows tests (and advanced users) to signal that Shakapacker
       # was just installed, triggering force-overwrite of shakapacker.yml with RoR's template.
@@ -244,16 +244,17 @@ module ReactOnRails
       end
 
       def prompt_for_pro_features_if_applicable
+        validate_product_stack_choice!
         return if options.new_app? || explicit_product_stack_choice? || !interactive_install_session?
 
         say "React on Rails Pro is free for evaluation; production use requires a subscription."
         say "Learn more: https://reactonrails.com/docs/pro/upgrading-to-pro/"
         answer = ask(
-          "Enable React on Rails Pro features (Node Renderer, streaming SSR, and RSC)? [Y/n]",
-          :cyan,
-          default: "Y"
+          "Enable React on Rails Pro features (Node Renderer and streaming SSR; RSC available separately)? [Y/n]",
+          :cyan
         )
-        @interactive_pro_selection = answer.to_s.match?(/\A(?:y|yes)\z/i)
+        normalized_answer = answer.to_s.strip
+        @interactive_pro_selection = normalized_answer.empty? || normalized_answer.match?(/\A(?:y|yes)\z/i)
       end
 
       def explicit_product_stack_choice?
@@ -261,7 +262,13 @@ module ReactOnRails
       end
 
       def interactive_install_session?
-        $stdin.tty? && $stdout.tty?
+        !ReactOnRails::GitUtils.truthy_env?(ENV.fetch("CI", nil)) && $stdin.tty? && $stdout.tty?
+      end
+
+      def validate_product_stack_choice!
+        return unless options.standard_only? && (options.pro? || options.rsc?)
+
+        raise Thor::Error, "--standard-only cannot be combined with --pro or --rsc"
       end
 
       # Fresh-install context: default to Rspack (when Shakapacker supports it) unless the
@@ -900,8 +907,8 @@ module ReactOnRails
       end
 
       def product_stack_install_flag
-        return "--rsc" if options.rsc?
-        return "--pro" if options.pro?
+        return "--rsc" if use_rsc?
+        return "--pro" if use_pro?
 
         nil
       end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -909,6 +909,10 @@ module ReactOnRails
       def product_stack_install_flag
         return "--rsc" if use_rsc?
         return "--pro" if use_pro?
+        return "--standard-only" if options.standard_only?
+        return "--no-rsc" if options.key?(:rsc)
+        return "--no-pro" if options.key?(:pro)
+        return "--standard-only" if defined?(@interactive_pro_selection)
 
         nil
       end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -86,16 +86,22 @@ module ReactOnRails
                    desc: "Write AI-agent guidance files (AGENTS.md + editor pointers). Default: true"
 
       # --pro
+      # No static default: prompt suppression needs to distinguish an omitted flag from --no-pro.
       class_option :pro,
                    type: :boolean,
-                   default: false,
-                   desc: "Install React on Rails Pro with Node Renderer. Default: false"
+                   desc: "Install React on Rails Pro with Node Renderer"
 
       # --rsc
+      # No static default: prompt suppression needs to distinguish an omitted flag from --no-rsc.
       class_option :rsc,
                    type: :boolean,
+                   desc: "Install React Server Components support (includes Pro)"
+
+      # --standard-only
+      class_option :standard_only,
+                   type: :boolean,
                    default: false,
-                   desc: "Install React Server Components support (includes Pro). Default: false"
+                   desc: "Install only the open-source package and skip the interactive Pro prompt"
 
       # Hidden option: allows tests (and advanced users) to signal that Shakapacker
       # was just installed, triggering force-overwrite of shakapacker.yml with RoR's template.
@@ -196,6 +202,7 @@ module ReactOnRails
         # This is inherited by all invoked generators and persists through Rails initialization
         # See lib/react_on_rails/engine.rb for the validation skip logic
         ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
+        prompt_for_pro_features_if_applicable
 
         if installation_prerequisites_met? || options.ignore_warnings?
           invoke_generators
@@ -229,6 +236,33 @@ module ReactOnRails
       # Everything here is not run automatically b/c it's private
 
       private
+
+      def use_pro?
+        return @interactive_pro_selection if defined?(@interactive_pro_selection)
+
+        !!super
+      end
+
+      def prompt_for_pro_features_if_applicable
+        return if options.new_app? || explicit_product_stack_choice? || !interactive_install_session?
+
+        say "React on Rails Pro is free for evaluation; production use requires a subscription."
+        say "Learn more: https://reactonrails.com/docs/pro/upgrading-to-pro/"
+        answer = ask(
+          "Enable React on Rails Pro features (Node Renderer, streaming SSR, and RSC)? [Y/n]",
+          :cyan,
+          default: "Y"
+        )
+        @interactive_pro_selection = answer.to_s.match?(/\A(?:y|yes)\z/i)
+      end
+
+      def explicit_product_stack_choice?
+        options.key?(:pro) || options.key?(:rsc) || options.standard_only?
+      end
+
+      def interactive_install_session?
+        $stdin.tty? && $stdout.tty?
+      end
 
       # Fresh-install context: default to Rspack (when Shakapacker supports it) unless the
       # app already declares a bundler. See GeneratorHelper#fresh_install_rspack_default.

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3049,7 +3049,13 @@ module ReactOnRails
     # ── React on Rails Pro Setup ──────────────────────────────────────
 
     def check_pro_setup
-      return unless ReactOnRails::Utils.react_on_rails_pro?
+      unless ReactOnRails::Utils.react_on_rails_pro?
+        checker.add_info(<<~MSG.strip)
+          💎 React on Rails Pro adds the Node Renderer, streaming SSR, and RSC.
+          Upgrade guide: https://reactonrails.com/docs/pro/upgrading-to-pro/
+        MSG
+        return
+      end
 
       check_pro_initializer_existence
       ensure_rails_environment_loaded

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -3342,10 +3342,18 @@ RSpec.describe ReactOnRails::Doctor do
         allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
       end
 
-      it "does not add any Pro setup messages" do
-        initial_count = checker.messages.length
+      it "shows the Pro upgrade path without changing the existing check section" do
         doctor.send(:check_pro_setup)
-        expect(checker.messages.length).to eq(initial_count)
+        info_messages = checker.messages.select { |message| message[:type] == :info }
+
+        expect(info_messages).to include(
+          hash_including(
+            content: a_string_including(
+              "React on Rails Pro",
+              "https://reactonrails.com/docs/pro/upgrading-to-pro/"
+            )
+          )
+        )
       end
     end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4278,6 +4278,85 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  describe "interactive Pro selection" do
+    it "defaults to Pro when an existing-app user accepts the interactive prompt" do
+      install_generator = install_generator_fixture
+      allow(install_generator).to receive_messages(interactive_install_session?: true, ask: "Y")
+      allow(install_generator).to receive(:say)
+
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+
+      expect(install_generator.send(:use_pro?)).to be(true)
+      expect(install_generator).to have_received(:ask).with(
+        a_string_including("Enable React on Rails Pro features", "[Y/n]"),
+        :cyan,
+        hash_including(default: "Y")
+      )
+    end
+
+    it "keeps Pro off when an existing-app user answers no" do
+      install_generator = install_generator_fixture
+      allow(install_generator).to receive_messages(interactive_install_session?: true, ask: "n")
+      allow(install_generator).to receive(:say)
+
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+
+      expect(install_generator.send(:use_pro?)).to be(false)
+    end
+
+    it "prints the trust-license note and upgrade documentation before asking" do
+      install_generator = install_generator_fixture
+      allow(install_generator).to receive_messages(interactive_install_session?: true, ask: "Y")
+      allow(install_generator).to receive(:say)
+
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+
+      expect(install_generator).to have_received(:say)
+        .with(a_string_including("free for evaluation", "production use requires a subscription"))
+      expect(install_generator).to have_received(:say)
+        .with(a_string_including("https://reactonrails.com/docs/pro/upgrading-to-pro/"))
+    end
+
+    it "preserves the noninteractive Pro-off default without asking" do
+      install_generator = install_generator_fixture
+      allow(install_generator).to receive(:interactive_install_session?).and_return(false)
+
+      expect(install_generator).not_to receive(:ask)
+
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+
+      expect(install_generator.send(:use_pro?)).to be_falsey
+    end
+
+    it "does not prompt on the new-app path" do
+      install_generator = install_generator_fixture(["--new-app"])
+      allow(install_generator).to receive(:interactive_install_session?).and_return(true)
+
+      expect(install_generator).not_to receive(:ask)
+
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+    end
+
+    {
+      ["--pro"] => true,
+      ["--no-pro"] => false,
+      ["--rsc"] => true,
+      ["--no-rsc"] => false,
+      ["--standard-only"] => false
+    }.each do |flags, expected_pro|
+      it "does not prompt when #{flags.join(' ')} makes the product choice explicit" do
+        install_generator = install_generator_fixture(flags)
+        allow(install_generator).to receive(:interactive_install_session?).and_return(true)
+
+        expect(install_generator).not_to receive(:ask)
+
+        install_generator.send(:prompt_for_pro_features_if_applicable)
+
+        expect(install_generator.send(:use_pro?)).to eq(expected_pro)
+      end
+    end
+  end
+
   context "with helpful message" do
     before do
       # Clear any previous messages to ensure clean test state

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4281,16 +4281,16 @@ describe InstallGenerator, type: :generator do
   describe "interactive Pro selection" do
     it "defaults to Pro when an existing-app user accepts the interactive prompt" do
       install_generator = install_generator_fixture
-      allow(install_generator).to receive_messages(interactive_install_session?: true, ask: "Y")
+      allow(install_generator).to receive_messages(interactive_install_session?: true, ask: "")
       allow(install_generator).to receive(:say)
 
       install_generator.send(:prompt_for_pro_features_if_applicable)
 
       expect(install_generator.send(:use_pro?)).to be(true)
+      expect(install_generator.send(:use_rsc?)).to be_falsey
       expect(install_generator).to have_received(:ask).with(
-        a_string_including("Enable React on Rails Pro features", "[Y/n]"),
-        :cyan,
-        hash_including(default: "Y")
+        a_string_including("Enable React on Rails Pro features", "RSC available separately", "[Y/n]"),
+        :cyan
       )
     end
 
@@ -4329,7 +4329,7 @@ describe InstallGenerator, type: :generator do
     end
 
     it "does not prompt on the new-app path" do
-      install_generator = install_generator_fixture(["--new-app"])
+      install_generator = install_generator_fixture(new_app: true)
       allow(install_generator).to receive(:interactive_install_session?).and_return(true)
 
       expect(install_generator).not_to receive(:ask)
@@ -4337,15 +4337,31 @@ describe InstallGenerator, type: :generator do
       install_generator.send(:prompt_for_pro_features_if_applicable)
     end
 
+    it "does not prompt in CI even when stdin and stdout are TTYs" do
+      install_generator = install_generator_fixture
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stdout).to receive(:tty?).and_return(true)
+      allow(install_generator).to receive(:ask)
+
+      original_ci = ENV.fetch("CI", nil)
+      ENV["CI"] = "true"
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+
+      expect(install_generator).not_to have_received(:ask)
+      expect(install_generator.send(:use_pro?)).to be(false)
+    ensure
+      original_ci.nil? ? ENV.delete("CI") : ENV["CI"] = original_ci
+    end
+
     {
-      ["--pro"] => true,
-      ["--no-pro"] => false,
-      ["--rsc"] => true,
-      ["--no-rsc"] => false,
-      ["--standard-only"] => false
-    }.each do |flags, expected_pro|
-      it "does not prompt when #{flags.join(' ')} makes the product choice explicit" do
-        install_generator = install_generator_fixture(flags)
+      { pro: true } => true,
+      { pro: false } => false,
+      { rsc: true } => true,
+      { rsc: false } => false,
+      { standard_only: true } => false
+    }.each do |product_options, expected_pro|
+      it "does not prompt when #{product_options.inspect} makes the product choice explicit" do
+        install_generator = install_generator_fixture(product_options)
         allow(install_generator).to receive(:interactive_install_session?).and_return(true)
 
         expect(install_generator).not_to receive(:ask)
@@ -4353,6 +4369,17 @@ describe InstallGenerator, type: :generator do
         install_generator.send(:prompt_for_pro_features_if_applicable)
 
         expect(install_generator.send(:use_pro?)).to eq(expected_pro)
+      end
+    end
+
+    standard_only_options = { standard_only: true }
+    [{ pro: true }, { rsc: true }].each do |pro_option|
+      it "rejects --standard-only combined with #{pro_option.inspect}" do
+        install_generator = install_generator_fixture(standard_only_options.merge(pro_option))
+
+        expect do
+          install_generator.send(:prompt_for_pro_features_if_applicable)
+        end.to raise_error(Thor::Error, /--standard-only cannot be combined/)
       end
     end
   end
@@ -4513,6 +4540,17 @@ describe InstallGenerator, type: :generator do
       command = install_generator.send(:recovery_install_command)
 
       expect(command).to eq("rails generate react_on_rails:install --pro")
+    end
+
+    specify "recovery_install_command preserves an accepted interactive Pro selection" do
+      install_generator = install_generator_fixture
+      allow(install_generator).to receive_messages(interactive_install_session?: true, ask: "Y")
+      allow(install_generator).to receive(:say)
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+
+      expect(install_generator.send(:recovery_install_command)).to eq(
+        "rails generate react_on_rails:install --pro"
+      )
     end
 
     specify "recovery_install_command normalizes the --webpack alias to --no-rspack" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -4553,6 +4553,31 @@ describe InstallGenerator, type: :generator do
       )
     end
 
+    specify "recovery_install_command preserves a declined interactive Pro selection" do
+      install_generator = install_generator_fixture
+      allow(install_generator).to receive_messages(interactive_install_session?: true, ask: "n")
+      allow(install_generator).to receive(:say)
+      install_generator.send(:prompt_for_pro_features_if_applicable)
+
+      expect(install_generator.send(:recovery_install_command)).to eq(
+        "rails generate react_on_rails:install --standard-only"
+      )
+    end
+
+    {
+      { pro: false } => "--no-pro",
+      { rsc: false } => "--no-rsc",
+      { standard_only: true } => "--standard-only"
+    }.each do |product_options, expected_flag|
+      specify "recovery_install_command preserves #{product_options.inspect}" do
+        install_generator = install_generator_fixture(product_options)
+
+        expect(install_generator.send(:recovery_install_command)).to eq(
+          "rails generate react_on_rails:install #{expected_flag}"
+        )
+      end
+    end
+
     specify "recovery_install_command normalizes the --webpack alias to --no-rspack" do
       install_generator = install_generator_fixture(webpack: true)
 


### PR DESCRIPTION
## Why

Existing Rails apps silently defaulted to the open-source setup, so interactive users never saw the supported Pro path for the Node Renderer and streaming SSR. Automation must keep its existing dependency behavior.

## What changed

- prompts once in interactive existing-app installs when no Pro/RSC/standard-only choice was supplied
- defaults the prompt to Pro, explains that RSC is a separate flag, and shows the evaluation/production-license trust note plus upgrade documentation
- preserves Pro-off behavior for redirected/non-TTY and CI runs and suppresses the prompt for explicit positive and negative product flags
- adds a visible `--standard-only` opt-out and rejects conflicts with `--pro`/`--rsc`
- preserves resolved positive, negative, standard-only, and interactive choices in recovery commands
- adds the Pro upgrade path to the existing doctor section without changing doctor IDs or schema
- documents the matrix and adds the changelog entry

Fixes #4604.

## Verification

- focused prompt/recovery matrix — 21 examples, 0 failures
- `bundle exec rspec spec/lib/react_on_rails/doctor_spec.rb` — 371 examples, 0 failures
- TDD RED evidence: CI/conflict slice 13 examples / 3 intended failures; RSC/recovery slice 14 / 2; blank-default slice 1 / 1; OSS recovery slice 8 / 4
- manual PTY: Enter and `y` select Pro; `n` keeps Pro off and emits `--standard-only` recovery; `CI=true` suppresses the prompt and keeps Pro off
- redirected stdin: no prompt and Pro remains off
- scoped RuboCop, Prettier, docs sidebar, and `git diff --check` — pass
- `bin/check-links` — 3,324 checked, 0 errors
- pre-commit/pre-push hooks — pass, including online Markdown links
- final static independent review — clean; all eight review threads resolved

`.agents/bin/validate --changed --fast` passed dependency install, docs/sidebar, Ruby and benchmark lint, builds, ESLint, Prettier, typecheck, and OSS/Pro/CROI/Node Renderer JavaScript suites. Its broad Ruby stage is inconclusive: an independent review process accidentally ran the same non-concurrency-safe generator fixture simultaneously, causing 13 ENOENT/ENOTEMPTY fixture failures. The competing process was stopped, the ignored fixture reset, and the affected prompt/doctor suites passed serially as listed above.

## Review note

The local `codex review --base origin/main` gate could not run because the installed CLI rejects the configured `gpt-5.6-sol` model as requiring a newer Codex version. Independent static reviews caught and verified fixes for Thor option-presence coverage, standard-only conflicts, CI TTY suppression, RSC prompt wording, and complete recovery-command choice preservation.
