### PR TITLE
Pro: add an authorization hook for RSC payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   Existing behavior remains unchanged when the callback is unset, and the RSC security docs now explain
   the public endpoint boundary and app-controller authorization seam.
   Fixes [Issue 4595](https://github.com/shakacode/react_on_rails/issues/4595).
+  [PR 4621](https://github.com/shakacode/react_on_rails/pull/4621) by
+  [justin808](https://github.com/justin808).
 
 - **[Pro] Configurable license-token secret sources**: Rails applications can now provide a paid
   license through `config.license_token`, including from Rails credentials, while standalone Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,12 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4611](https://github.com/shakacode/react_on_rails/pull/4611) by
   [justin808](https://github.com/justin808).
 
+- **[Pro]** **Optional authorization callback for RSC payload routes**: Apps can configure
+  `rsc_payload_authorizer` to reject payload requests before component props are parsed or rendered.
+  Existing behavior remains unchanged when the callback is unset, and the RSC security docs now explain
+  the public endpoint boundary and app-controller authorization seam.
+  Fixes [Issue 4595](https://github.com/shakacode/react_on_rails/issues/4595).
+
 - **[Pro] Configurable license-token secret sources**: Rails applications can now provide a paid
   license through `config.license_token`, including from Rails credentials, while standalone Node
   renderers can use the `licenseToken` option. Explicit nonblank configuration takes precedence over

--- a/docs/oss/configuration/configuration-pro.md
+++ b/docs/oss/configuration/configuration-pro.md
@@ -150,6 +150,15 @@ ReactOnRailsPro.configure do |config|
   # Default is false
   config.enable_rsc_support = true
 
+  # Optional authorization callback for the mounted RSC payload endpoint.
+  # It receives the Rails controller and the requested component name before
+  # props are parsed or rendering begins. A false or nil result returns 403.
+  # Default is nil, which preserves the endpoint's existing allow-all behavior.
+  allowed_rsc_components = %w[AccountPage DashboardPage].freeze
+  config.rsc_payload_authorizer = lambda do |controller, component_name|
+    controller.session[:user_id].present? && allowed_rsc_components.include?(component_name)
+  end
+
   # Path to the RSC bundle file (relative to webpack output directory or absolute path)
   # The RSC bundle contains only server components and references to client components.
   # It's generated using the RSC Webpack Loader which transforms client components into

--- a/docs/oss/deployment/security-model-and-hardening.md
+++ b/docs/oss/deployment/security-model-and-hardening.md
@@ -222,6 +222,49 @@ Every item below maps to a configuration option or behavior verified in this rep
 
 ## React Server Components advisory posture (Pro)
 
+### Secure the RSC payload endpoint
+
+The endpoint is opt-in: React on Rails Pro does not mount it unless your routes call `rsc_payload_route`.
+The RSC generator adds that route when you opt into RSC. Once mounted, treat it as a public API: the URL
+contains a client-controlled component name and the `props` query parameter is also untrusted. Do not use
+either value as proof that a user may read a record, tenant, or internal component.
+
+Configure an authorizer to check the Rails session and restrict independently renderable components. The
+callback runs before props JSON is parsed or rendering starts. Returning `false` or `nil` responds with
+`403 Forbidden`; leaving the option unset preserves the existing allow-all behavior.
+
+```ruby
+# config/initializers/react_on_rails_pro.rb
+allowed_rsc_components = %w[AccountPage DashboardPage].freeze
+
+ReactOnRailsPro.configure do |config|
+  config.rsc_payload_authorizer = lambda do |controller, component_name|
+    controller.session[:user_id].present? && allowed_rsc_components.include?(component_name)
+  end
+end
+```
+
+For policy libraries or application-wide controller filters, route to an app-owned controller instead:
+
+```ruby
+# app/controllers/rsc_payload_controller.rb
+class RscPayloadController < ApplicationController
+  include ReactOnRailsPro::RSCPayloadRenderer
+
+  before_action :authenticate_user!
+end
+
+# config/routes.rb
+rsc_payload_route controller: "rsc_payload"
+```
+
+The shipped default payload controller inherits from `ActionController::Base`, not your
+`ApplicationController`, so your application's filters do not apply to it automatically. Whichever seam
+you use, derive identity and permissions from the session and database. Never authorize from RSC props;
+the browser can alter them before every payload request.
+
+### Track upstream RSC advisories
+
 RSC support in React on Rails Pro is built directly on React's Flight packages: the
 `react-on-rails-rsc` package wraps React's `react-server-dom-webpack`. Vulnerabilities in those upstream
 packages therefore apply to this stack, and the project's response is enforced in code:

--- a/docs/pro/react-server-components/how-react-server-components-work.md
+++ b/docs/pro/react-server-components/how-react-server-components-work.md
@@ -231,6 +231,14 @@ Rails.application.routes.draw do
 end
 ```
 
+> [!WARNING]
+> Once mounted, this endpoint is a public API. Both `:component_name` and `props` come from the client and
+> can be changed by an attacker. Configure `rsc_payload_authorizer` to check the Rails session and restrict
+> which components may be rendered, or route to an app-owned controller with your normal `before_action`
+> authentication. Never make authorization decisions from payload props. See
+> [Security Model and Hardening](../../oss/deployment/security-model-and-hardening.md#secure-the-rsc-payload-endpoint)
+> and [Pro configuration](../../oss/configuration/configuration-pro.md).
+
 You can change the path of the rsc route by passing the `path` option to the `rsc_payload_route` method.
 
 ```ruby

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/rsc_payload_renderer.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/rsc_payload_renderer.rb
@@ -24,6 +24,8 @@ module ReactOnRailsPro
 
     def rsc_payload
       @rsc_payload_component_name = rsc_payload_component_name
+      return head :forbidden unless rsc_payload_authorized?(@rsc_payload_component_name)
+
       @rsc_payload_component_props =
         begin
           rsc_payload_component_props
@@ -57,6 +59,11 @@ module ReactOnRailsPro
     end
 
     private
+
+    def rsc_payload_authorized?(component_name)
+      authorizer = ReactOnRailsPro.configuration.rsc_payload_authorizer
+      authorizer.nil? || authorizer.call(self, component_name)
+    end
 
     def rsc_payload_component_props
       return {} if params[:props].blank?

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -97,6 +97,7 @@ module ReactOnRailsPro
     DEFAULT_RSC_BUNDLE_JS_FILE = "rsc-bundle.js"
     DEFAULT_REACT_CLIENT_MANIFEST_FILE = "react-client-manifest.json"
     DEFAULT_REACT_SERVER_CLIENT_MANIFEST_FILE = "react-server-client-manifest.json"
+    RSC_PAYLOAD_AUTHORIZER_POSITIONAL_PARAMS = %i[req opt].freeze
     DEFAULT_CONCURRENT_COMPONENT_STREAMING_BUFFER_SIZE = 64
     # Ceiling TTL for a tag->cache-key index entry when the tagged cache entry
     # has no :expires_in of its own (see ReactOnRailsPro::Cache::TagIndex).
@@ -200,6 +201,11 @@ module ReactOnRailsPro
     def rsc_payload_authorizer=(value)
       unless value.nil? || value.respond_to?(:call)
         raise ReactOnRailsPro::Error, "config.rsc_payload_authorizer must be nil or respond to #call"
+      end
+
+      if value && !rsc_payload_authorizer_signature_valid?(value)
+        raise ReactOnRailsPro::Error,
+              "config.rsc_payload_authorizer must accept call(controller, component_name) without required keywords"
       end
 
       @rsc_payload_authorizer = value
@@ -331,6 +337,33 @@ module ReactOnRailsPro
     end
 
     private
+
+    def rsc_payload_authorizer_signature_valid?(authorizer)
+      parameters = rsc_payload_authorizer_parameters(authorizer)
+      return false if parameters.any? { |type, _name| type == :keyreq }
+
+      # A non-lambda Proc intentionally ignores surplus positional arguments,
+      # unlike lambdas, Methods, and callable service objects.
+      return true if authorizer.is_a?(Proc) && !authorizer.lambda?
+
+      strict_rsc_payload_authorizer_signature_valid?(parameters)
+    end
+
+    def rsc_payload_authorizer_parameters(authorizer)
+      return authorizer.parameters if authorizer.is_a?(Proc) || authorizer.is_a?(Method)
+
+      authorizer.method(:call).parameters
+    end
+
+    def strict_rsc_payload_authorizer_signature_valid?(parameters)
+      required_positionals = parameters.count { |type, _name| type == :req }
+      accepted_positionals = parameters.count do |type, _name|
+        RSC_PAYLOAD_AUTHORIZER_POSITIONAL_PARAMS.include?(type)
+      end
+      accepts_rest = parameters.any? { |type, _name| type == :rest }
+
+      required_positionals <= 2 && (accepted_positionals >= 2 || accepts_rest)
+    end
 
     def assign_initial_renderer_http_pool_size(value)
       validate_renderer_http_pool_size(value)

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -51,6 +51,7 @@ module ReactOnRailsPro
       raise_non_shell_server_rendering_errors: Configuration::DEFAULT_RAISE_NON_SHELL_SERVER_RENDERING_ERRORS,
       enable_rsc_support: Configuration::DEFAULT_ENABLE_RSC_SUPPORT,
       rsc_payload_generation_url_path: Configuration::DEFAULT_RSC_PAYLOAD_GENERATION_URL_PATH,
+      rsc_payload_authorizer: nil,
       rsc_bundle_js_file: Configuration::DEFAULT_RSC_BUNDLE_JS_FILE,
       react_client_manifest_file: Configuration::DEFAULT_REACT_CLIENT_MANIFEST_FILE,
       react_server_client_manifest_file: Configuration::DEFAULT_REACT_SERVER_CLIENT_MANIFEST_FILE,
@@ -121,7 +122,8 @@ module ReactOnRailsPro
                   :react_server_client_manifest_file
 
     attr_reader :concurrent_component_streaming_buffer_size, :renderer_http_keep_alive_timeout,
-                :renderer_http_pool_size, :cache_tag_index_expires_in, :cache_tag_index_max_keys
+                :renderer_http_pool_size, :cache_tag_index_expires_in, :cache_tag_index_max_keys,
+                :rsc_payload_authorizer
 
     # Sets how long tag->key index entries live (see Cache::TagIndex).
     #
@@ -195,6 +197,14 @@ module ReactOnRailsPro
       @renderer_http_keep_alive_timeout = value
     end
 
+    def rsc_payload_authorizer=(value)
+      unless value.nil? || value.respond_to?(:call)
+        raise ReactOnRailsPro::Error, "config.rsc_payload_authorizer must be nil or respond to #call"
+      end
+
+      @rsc_payload_authorizer = value
+    end
+
     def initialize(renderer_url: nil, renderer_password: nil, license_token: nil, # rubocop:disable Metrics/AbcSize
                    server_renderer: nil,
                    renderer_use_fallback_exec_js: nil, prerender_caching: nil,
@@ -208,7 +218,7 @@ module ReactOnRailsPro
                    ssr_pre_hook_js: nil, assets_to_copy: nil,
                    renderer_request_retry_limit: nil, throw_js_errors: nil, ssr_timeout: nil,
                    profile_server_rendering_js_code: nil, raise_non_shell_server_rendering_errors: nil,
-                   enable_rsc_support: nil, rsc_payload_generation_url_path: nil,
+                   enable_rsc_support: nil, rsc_payload_generation_url_path: nil, rsc_payload_authorizer: nil,
                    rsc_bundle_js_file: nil, react_client_manifest_file: nil,
                    react_server_client_manifest_file: nil,
                    concurrent_component_streaming_buffer_size: DEFAULT_CONCURRENT_COMPONENT_STREAMING_BUFFER_SIZE,
@@ -245,6 +255,7 @@ module ReactOnRailsPro
       self.raise_non_shell_server_rendering_errors = raise_non_shell_server_rendering_errors
       self.enable_rsc_support = enable_rsc_support
       self.rsc_payload_generation_url_path = rsc_payload_generation_url_path
+      self.rsc_payload_authorizer = rsc_payload_authorizer
       self.rsc_bundle_js_file = rsc_bundle_js_file
       self.react_client_manifest_file = react_client_manifest_file
       self.react_server_client_manifest_file = react_server_client_manifest_file

--- a/react_on_rails_pro/sig/react_on_rails_pro/configuration.rbs
+++ b/react_on_rails_pro/sig/react_on_rails_pro/configuration.rbs
@@ -82,6 +82,7 @@ module ReactOnRailsPro
     attr_accessor raise_non_shell_server_rendering_errors: bool?
     attr_accessor enable_rsc_support: bool?
     attr_accessor rsc_payload_generation_url_path: String?
+    attr_accessor rsc_payload_authorizer: untyped
     attr_accessor rsc_bundle_js_file: String?
     attr_accessor react_client_manifest_file: String?
     attr_accessor react_server_client_manifest_file: String?
@@ -119,6 +120,7 @@ module ReactOnRailsPro
       ?raise_non_shell_server_rendering_errors: bool?,
       ?enable_rsc_support: bool?,
       ?rsc_payload_generation_url_path: String?,
+      ?rsc_payload_authorizer: untyped,
       ?rsc_bundle_js_file: String?,
       ?react_client_manifest_file: String?,
       ?react_server_client_manifest_file: String?,

--- a/react_on_rails_pro/spec/dummy/spec/requests/rsc_payload_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/rsc_payload_spec.rb
@@ -16,6 +16,14 @@
 require "rails_helper"
 
 RSpec.describe "RSC payload endpoint" do
+  around do |example|
+    config = ReactOnRailsPro.configuration
+    original_authorizer = config.rsc_payload_authorizer if config.respond_to?(:rsc_payload_authorizer)
+    example.run
+  ensure
+    config.rsc_payload_authorizer = original_authorizer if config.respond_to?(:rsc_payload_authorizer=)
+  end
+
   def request_rsc_payload
     get "/rsc_payload/RscEchoProps", params: { props: { message: "hello" }.to_json }
   end
@@ -80,6 +88,36 @@ RSpec.describe "RSC payload endpoint" do
     expect(response).to have_http_status(:bad_request)
     expect(response.media_type).to eq("text/plain")
     expect(response.body).to eq("Invalid props JSON")
+  end
+
+  it "denies an unauthorized request before parsing malformed props" do
+    ReactOnRailsPro.configuration.rsc_payload_authorizer = ->(_controller, _component_name) { false }
+
+    get "/rsc_payload/RscEchoProps", params: { props: '{"message":' }
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "passes the controller and component name to the authorizer" do
+    authorization_context = nil
+    ReactOnRailsPro.configuration.rsc_payload_authorizer = lambda do |controller, component_name|
+      authorization_context = [controller, component_name]
+      true
+    end
+
+    request_rsc_payload
+
+    expect_valid_rsc_payload_response
+    expect(authorization_context.first).to be_a(PagesController)
+    expect(authorization_context.last).to eq("RscEchoProps")
+  end
+
+  it "denies the request when the configured authorizer returns nil" do
+    ReactOnRailsPro.configuration.rsc_payload_authorizer = ->(_controller, _component_name) {}
+
+    request_rsc_payload
+
+    expect(response).to have_http_status(:forbidden)
   end
 
   # Regression for https://github.com/shakacode/react_on_rails/issues/4550.

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -820,6 +820,33 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
     end
 
     describe "RSC configuration options" do
+      it "leaves the RSC payload authorizer unset by default" do
+        ReactOnRailsPro.configure {} # rubocop:disable Lint/EmptyBlock
+
+        expect(ReactOnRailsPro.configuration.rsc_payload_authorizer).to be_nil
+      end
+
+      it "accepts a callable RSC payload authorizer" do
+        authorizer = ->(_controller, _component_name) { true }
+
+        ReactOnRailsPro.configure do |config|
+          config.rsc_payload_authorizer = authorizer
+        end
+
+        expect(ReactOnRailsPro.configuration.rsc_payload_authorizer).to be(authorizer)
+      end
+
+      it "rejects a non-callable RSC payload authorizer" do
+        expect do
+          ReactOnRailsPro.configure do |config|
+            config.rsc_payload_authorizer = "authenticated"
+          end
+        end.to raise_error(
+          ReactOnRailsPro::Error,
+          /config\.rsc_payload_authorizer must be nil or respond to #call/
+        )
+      end
+
       it "has default values for RSC bundle and manifest files" do
         ReactOnRailsPro.configure {} # rubocop:disable Lint/EmptyBlock
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -826,14 +826,27 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
         expect(ReactOnRailsPro.configuration.rsc_payload_authorizer).to be_nil
       end
 
-      it "accepts a callable RSC payload authorizer" do
-        authorizer = ->(_controller, _component_name) { true }
-
-        ReactOnRailsPro.configure do |config|
-          config.rsc_payload_authorizer = authorizer
+      it "accepts authorizers compatible with the documented two-argument call" do
+        service_class = Class.new do
+          def call(_controller, _component_name = nil) = true
         end
+        service = service_class.new
+        authorizers = [
+          ->(_controller, _component_name) { true },
+          ->(_controller, _component_name = nil) { true },
+          ->(*_args) { true },
+          proc { |_controller| true },
+          service,
+          service.method(:call)
+        ]
 
-        expect(ReactOnRailsPro.configuration.rsc_payload_authorizer).to be(authorizer)
+        aggregate_failures do
+          authorizers.each do |authorizer|
+            expect do
+              ReactOnRailsPro.configuration.rsc_payload_authorizer = authorizer
+            end.not_to raise_error
+          end
+        end
       end
 
       it "rejects a non-callable RSC payload authorizer" do
@@ -845,6 +858,33 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
           ReactOnRailsPro::Error,
           /config\.rsc_payload_authorizer must be nil or respond to #call/
         )
+      end
+
+      it "rejects callables that cannot accept the documented two-argument call" do
+        one_argument_service = Class.new do
+          def call(_controller) = true
+        end
+        one_argument_method = one_argument_service.new.method(:call)
+        incompatible_authorizers = [
+          ->(_controller) { true },
+          one_argument_method,
+          one_argument_service.new,
+          ->(controller: nil, component_name: nil) { [controller, component_name] },
+          ->(_controller, _component_name, _account) { true },
+          ->(_controller, _component_name, account:) { account },
+          proc { |_controller, _component_name, account:| account }
+        ]
+
+        aggregate_failures do
+          incompatible_authorizers.each do |authorizer|
+            expect do
+              ReactOnRailsPro.configuration.rsc_payload_authorizer = authorizer
+            end.to raise_error(
+              ReactOnRailsPro::Error,
+              /must accept call\(controller, component_name\) without required keywords/
+            )
+          end
+        end
       end
 
       it "has default values for RSC bundle and manifest files" do


### PR DESCRIPTION
## Why

Enabling RSC mounts a payload endpoint that needs application-specific authorization in deployments where component props are sensitive. The endpoint remains opt-in, but generated and custom deployments need a narrow guard before request payloads are parsed.

Fixes #4595.

## What changed

- adds an optional `rsc_payload_authorizer` callable receiving the controller and component name
- denies false or nil authorization results with 403 before props parsing
- validates callable compatibility and publishes the API in Pro RBS signatures
- documents the endpoint exposure and authorization pattern

## Verification

- Pro configuration specs: 92 examples, 0 failures
- RSC payload request specs: 7 examples, 0 failures
- OSS and Pro RBS validation passed
- Pro RuboCop, formatting, diff checks, and 850 license headers passed
- QA-C verified deny-before-parse behavior at `2133ff5d1db658ae4d36dbf1c2aa875908630981`

## Review notes

The final local autoreview found no actionable issue. A prior RBS omission was independently confirmed and fixed before this candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `rsc_payload_authorizer` to optionally authorize mounted React Server Components payload endpoints.
  - Unauthorized requests are now rejected with 403 before payload props are parsed or rendered.
  - Leaving the authorizer unset preserves the existing allow-all behavior.

- **Documentation**
  - Added security guidance and examples for hardening the RSC payload endpoint, including recommended trusted-input practices and an app-owned controller pattern.

- **Tests**
  - Added and expanded authorization tests and configuration coverage for `rsc_payload_authorizer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->