### PR TITLE
Redact RSC rendering error details from client DOM in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,16 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4624](https://github.com/shakacode/react_on_rails/pull/4624) by
   [justin808](https://github.com/justin808).
 
+- **[Pro]** **RSC render errors no longer leak server details into client DOM**: In production, the
+  `REACT_ON_RAILS_RSC_ERRORS` inline script now emits only `{ hasErrors: true }` — the full error
+  message, stack trace, and file paths are redacted. Uses an allowlist (development/test show full
+  diagnostics) so custom envs like staging default to redacted. RSC rendering errors are now also
+  reported to error reporters (Sentry/Honeybadger) even with the default `throwJsErrors: false`
+  config, via a custom `'renderingError'` stream event. Fixes
+  [Issue 4629](https://github.com/shakacode/react_on_rails/issues/4629).
+  [PR 4631](https://github.com/shakacode/react_on_rails/pull/4631) by
+  [AbanoubGhadban](https://github.com/AbanoubGhadban).
+
 - **[Pro]** **Hardened Node renderer authentication and multipart uploads**: Authenticated multipart
   clients must now send the password field before file parts; the renderer rejects and discards leading file
   parts before creating upload storage. Uploads now enforce a 100 MB total request limit across files, fields,

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
@@ -612,14 +612,23 @@ export async function buildExecutionContext(
       });
 
       if (isReadableStream(result)) {
-        const newStreamAfterHandlingError = handleStreamError(result, (error) => {
-          const msg = formatExceptionMessage(
-            { renderingRequest },
-            error,
-            'Error in a rendering stream',
-            remapStackTraceForRequest,
-          );
+        const reportedErrors = new WeakSet<Error>();
+        const reportStreamError = (error: Error, label: string) => {
+          if (reportedErrors.has(error)) return;
+          reportedErrors.add(error);
+          const msg = formatExceptionMessage({ renderingRequest }, error, label, remapStackTraceForRequest);
           errorReporter.message(msg);
+        };
+
+        result.on('renderingError', (error: Error) => {
+          reportStreamError(error, 'Rendering error in stream');
+        });
+
+        const newStreamAfterHandlingError = handleStreamError(result, (error) => {
+          reportStreamError(
+            error instanceof Error ? error : new Error(String(error)),
+            'Error in a rendering stream',
+          );
         });
         return newStreamAfterHandlingError;
       }

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
@@ -25,7 +25,7 @@ import m from 'module';
 import cluster from 'cluster';
 import type { Readable } from 'stream';
 import { ReadableStream } from 'stream/web';
-import { promisify, TextEncoder } from 'util';
+import { promisify, TextEncoder, types as utilTypes } from 'util';
 import type { ReactOnRails as ROR } from 'react-on-rails' with { 'resolution-mode': 'import' };
 import type { Context } from 'vm';
 
@@ -612,23 +612,41 @@ export async function buildExecutionContext(
       });
 
       if (isReadableStream(result)) {
-        const reportedErrors = new WeakSet<Error>();
-        const reportStreamError = (error: Error, label: string) => {
-          if (reportedErrors.has(error)) return;
-          reportedErrors.add(error);
-          const msg = formatExceptionMessage({ renderingRequest }, error, label, remapStackTraceForRequest);
+        const reportedErrors = new WeakSet<object>();
+        // A stream error thrown inside the sandboxed VM realm is a genuine Error, but it
+        // fails the worker-realm `instanceof Error` check because it comes from a different
+        // realm's `Error.prototype`. Wrapping it in `new Error(String(error))` would discard
+        // its original message and stack (the whole point of reporting to Sentry/Honeybadger).
+        // Use a realm-agnostic check — `util.types.isNativeError` inspects the internal
+        // [[ErrorData]] slot, so it recognizes VM-realm Errors — plus a duck-type for
+        // error-like objects. Only truly non-Error throwables (strings, numbers, …) are
+        // wrapped, since those have no usable stack to preserve.
+        const isErrorLike = (value: unknown): value is { message?: string; stack?: string } => {
+          // eslint-disable-next-line @typescript-eslint/no-deprecated -- Error.isError (the suggested replacement) is not available until Node 23+; this package still supports Node 22, where util.types.isNativeError is the realm-agnostic native-Error check.
+          if (utilTypes.isNativeError(value)) return true;
+          if (typeof value !== 'object' || value === null) return false;
+          const { message, stack } = value as { message?: unknown; stack?: unknown };
+          return typeof stack === 'string' || typeof message === 'string';
+        };
+        const reportStreamError = (error: unknown, label: string) => {
+          const reportable: object = isErrorLike(error) ? error : new Error(String(error));
+          if (reportedErrors.has(reportable)) return;
+          reportedErrors.add(reportable);
+          const msg = formatExceptionMessage(
+            { renderingRequest },
+            reportable,
+            label,
+            remapStackTraceForRequest,
+          );
           errorReporter.message(msg);
         };
 
-        result.on('renderingError', (error: Error) => {
+        result.on('renderingError', (error: unknown) => {
           reportStreamError(error, 'Rendering error in stream');
         });
 
         const newStreamAfterHandlingError = handleStreamError(result, (error) => {
-          reportStreamError(
-            error instanceof Error ? error : new Error(String(error)),
-            'Error in a rendering stream',
-          );
+          reportStreamError(error, 'Error in a rendering stream');
         });
         return newStreamAfterHandlingError;
       }

--- a/packages/react-on-rails-pro-node-renderer/tests/htmlStreaming.test.js
+++ b/packages/react-on-rails-pro-node-renderer/tests/htmlStreaming.test.js
@@ -229,12 +229,20 @@ describe('html streaming', () => {
     10000,
   );
 
-  it("shouldn't notify error reporter when throwJsErrors is false and shell error happens", async () => {
+  it('notifies the error reporter with the genuine render error when throwJsErrors is false and a shell error happens', async () => {
+    // Behavior change (#4629 / PR #4631 observability fix): RSC rendering errors now reach the
+    // error reporter (Sentry/Honeybadger) even with the default throwJsErrors:false, via the
+    // custom 'renderingError' stream event. Previously the reporter was never called on this path
+    // (this test asserted `.not.toHaveBeenCalled()`), so genuine production render failures were
+    // invisible to monitoring. The reported error is the real render failure, not a benign path.
     await makeRequest({
       props: { throwSyncError: true },
       // throwJsErrors is false by default
     });
-    expect(errorReporter.message).not.toHaveBeenCalled();
+    expect(errorReporter.message).toHaveBeenCalled();
+    expect(errorReporter.message).toHaveBeenCalledWith(
+      expect.stringMatching(/Rendering error in stream[\s\S.]*Sync error from AsyncComponentsTreeForTesting/),
+    );
   }, 10000);
 
   it('should notify error reporter when throwJsErrors is true and shell error happens', async () => {
@@ -288,12 +296,19 @@ describe('html streaming', () => {
     10000,
   );
 
-  it('should not notify error reporter when throwJsErrors is false and async error happens', async () => {
+  it('notifies the error reporter with the genuine render error when throwJsErrors is false and an async error happens', async () => {
+    // Behavior change (#4629 / PR #4631 observability fix): async RSC rendering errors now reach
+    // the error reporter even with throwJsErrors:false, via the custom 'renderingError' stream
+    // event. Previously this asserted `.not.toHaveBeenCalled()`. The reported error is the real
+    // async render failure, not a benign path.
     await makeRequest({
       props: { throwAsyncError: true },
       throwJsErrors: false,
     });
-    expect(errorReporter.message).not.toHaveBeenCalled();
+    expect(errorReporter.message).toHaveBeenCalled();
+    expect(errorReporter.message).toHaveBeenCalledWith(
+      expect.stringMatching(/Rendering error in stream[\s\S.]*Async error from AsyncHelloWorldHooks/),
+    );
   }, 10000);
 
   it('should notify error reporter when throwJsErrors is true and async error happens', async () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
@@ -16,6 +16,8 @@
 import path from 'path';
 import fs from 'fs';
 import vm from 'vm';
+import { Readable } from 'stream';
+import { types as utilTypes } from 'util';
 import {
   uploadedBundlePath,
   createUploadedBundle,
@@ -30,6 +32,7 @@ import {
 import { buildExecutionContext, hasVMContextForBundle, resetVM } from '../src/worker/vm';
 import { getConfig } from '../src/shared/configBuilder';
 import { isErrorRenderResult } from '../src/shared/utils';
+import * as errorReporter from '../src/shared/errorReporter';
 
 const testName = 'vm';
 const uploadedBundlePathForTest = () => uploadedBundlePath(testName);
@@ -828,5 +831,116 @@ describe('buildVM and runInVM', () => {
       const result = await runInVM2('global.testVar', bundle);
       expect(result).toBe('test value');
     });
+  });
+});
+
+// Reception side of the RSC observability fix (#4629 PR #4631): when runInVM returns a
+// readable render stream, it attaches a custom 'renderingError' listener plus a WeakSet
+// dedup so rendering errors reach the error reporter (Sentry/Honeybadger) even with the
+// default throwJsErrors:false, and the same Error object is never reported twice across
+// the 'renderingError' and standard 'error' events. These tests drive that path through a
+// real VM whose rendering request returns a stream, then emit events on the original
+// stream (the one runInVM attaches its listeners to, before handleStreamError wraps it).
+describe('runInVM stream error reporting (renderingError listener + WeakSet dedup)', () => {
+  const streamTestName = 'vmStreamErrors';
+  const streamBundlePath = () => uploadedBundlePath(streamTestName);
+
+  let messageSpy: jest.SpyInstance;
+  const activeStreams: Readable[] = [];
+
+  beforeEach(async () => {
+    await resetForTest(streamTestName);
+    messageSpy = jest.spyOn(errorReporter, 'message').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    activeStreams.forEach((stream) => {
+      if (!stream.destroyed) stream.destroy();
+    });
+    activeStreams.length = 0;
+    messageSpy.mockRestore();
+  });
+
+  // Build a VM whose rendering request returns a Readable stream and hands the test both
+  // the ORIGINAL stream (the one runInVM attaches its listeners to) and a genuine VM-realm
+  // Error. A VM-realm Error is a real Error (`util.types.isNativeError` is true) but fails
+  // the worker-realm `instanceof Error` check because it comes from the VM realm's own
+  // `Error.prototype` — the exact case codex flagged where `new Error(String(error))` used
+  // to discard the original message and stack.
+  async function buildStreamReturningVM() {
+    const captured: { stream?: Readable; vmError?: unknown } = {};
+    const config = getConfig();
+    config.additionalContext = {
+      __TestReadable: Readable,
+      __captureStreamHandles: (stream: Readable, vmError: unknown) => {
+        captured.stream = stream;
+        captured.vmError = vmError;
+      },
+    };
+    await createUploadedBundle(streamTestName);
+    const { runInVM } = await buildExecutionContext([streamBundlePath()], /* buildVmsIfNeeded */ true);
+    const renderingRequest = [
+      '(function () {',
+      '  const stream = new __TestReadable({ read() {} });',
+      "  __captureStreamHandles(stream, new Error('VM realm stream failure'));",
+      '  return stream;',
+      '})()',
+    ].join('\n');
+    const wrapper = (await runInVM(renderingRequest, streamBundlePath())) as unknown as Readable;
+    activeStreams.push(wrapper);
+    if (captured.stream) activeStreams.push(captured.stream);
+    return { wrapper, stream: captured.stream as Readable, vmError: captured.vmError };
+  }
+
+  it('reports a renderingError stream event to the error reporter', async () => {
+    const { stream, vmError } = await buildStreamReturningVM();
+
+    stream.emit('renderingError', vmError);
+
+    expect(messageSpy).toHaveBeenCalledTimes(1);
+    expect(messageSpy.mock.calls[0][0]).toContain('VM realm stream failure');
+  });
+
+  it('preserves a genuine VM-realm Error message and stack instead of wrapping it', async () => {
+    const { stream, vmError } = await buildStreamReturningVM();
+
+    // Confirms the realm boundary: this is a real Error but not a worker-realm instance.
+    expect(utilTypes.isNativeError(vmError)).toBe(true);
+    expect(vmError instanceof Error).toBe(false);
+    const originalStack = (vmError as { stack: string }).stack;
+
+    stream.emit('renderingError', vmError);
+
+    const reported = messageSpy.mock.calls[0][0] as string;
+    // Message preserved verbatim (not a `String(error)` "Error: Error: ..." double-wrap).
+    expect(reported).toContain('VM realm stream failure');
+    // The reporter received the error's own stack frames, not a vm.ts wrapper frame.
+    const originalFrame = originalStack
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.startsWith('at '));
+    expect(originalFrame).toBeDefined();
+    expect(reported).toContain(originalFrame as string);
+  });
+
+  it('dedups the SAME Error instance across renderingError and error events (reported once)', async () => {
+    const { stream, vmError } = await buildStreamReturningVM();
+
+    stream.emit('renderingError', vmError);
+    stream.emit('error', vmError);
+
+    expect(messageSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports two DISTINCT Error instances separately', async () => {
+    const { stream } = await buildStreamReturningVM();
+
+    stream.emit('renderingError', new Error('first stream failure'));
+    stream.emit('renderingError', new Error('second stream failure'));
+
+    expect(messageSpy).toHaveBeenCalledTimes(2);
+    const messages = messageSpy.mock.calls.map((call) => call[0] as string).join('\n');
+    expect(messages).toContain('first stream failure');
+    expect(messages).toContain('second stream failure');
   });
 });

--- a/packages/react-on-rails-pro/src/capabilities/proRSC.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proRSC.ts
@@ -113,8 +113,14 @@ const streamRenderRSCComponent = (
     isShellReady: true,
   };
 
-  const { pipeToTransform, readableStream, emitError, isConsumerAborted, onConsumerAbort } =
-    transformRenderStreamChunksToResultObject(renderState);
+  const {
+    pipeToTransform,
+    readableStream,
+    emitError,
+    notifyRenderingError,
+    isConsumerAborted,
+    onConsumerAbort,
+  } = transformRenderStreamChunksToResultObject(renderState);
 
   // On client disconnect the RSC render stream is aborted by cancelUpstream; also release any RSC
   // payload streams this render fetched so their upstream Rails/API work stops, and run post-SSR
@@ -129,9 +135,10 @@ const streamRenderRSCComponent = (
 
   const reportError = (error: Error): Error => {
     const diagnosticError = addRSCClientHookDiagnostic(error, componentName);
-    console.error('Error in RSC stream', diagnosticError);
     if (throwJsErrors) {
       emitError(diagnosticError);
+    } else {
+      notifyRenderingError(diagnosticError);
     }
     renderState.hasErrors = true;
     renderState.error = diagnosticError;

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -100,13 +100,17 @@ function createRSCDiagnosticScript(
   metadata: Record<string, unknown>,
   cacheKey: string,
   sanitizedNonce?: string,
+  railsEnv?: string,
 ) {
   const { hasErrors, renderingError } = metadata;
   // `hasErrors` is a boolean per the server wire contract; renderingError only carries
   // a useful diagnostic when the server provided a non-blank message or stack.
   if (hasErrors !== true && !hasRenderingErrorSignal(renderingError)) return undefined;
+  // In production, emit only the hasErrors signal without the server error message or stack trace.
+  // Full diagnostics are still available server-side via onDiagnosticError (Sentry/Honeybadger).
+  const clientPayload = railsEnv === 'production' ? { hasErrors } : { hasErrors, renderingError };
   return createScriptTag(
-    `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify({ hasErrors, renderingError })}`,
+    `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify(clientPayload)}`,
     sanitizedNonce,
     true,
   );
@@ -1596,6 +1600,7 @@ type InjectRSCPayloadOptions = {
   rscClientManifestStylesheetHrefs?: ReadonlySet<string>;
   rscClientChunkStylesheetHrefsByChunkName?: RSCClientChunkStylesheetHrefsByChunkName;
   rscStreamObservability?: boolean;
+  railsEnv?: string;
 };
 
 /**
@@ -1635,6 +1640,7 @@ export default function injectRSCPayload(
     rscClientManifestStylesheetHrefs = new Set<string>(),
     rscClientChunkStylesheetHrefsByChunkName = loadRSCClientChunkStylesheetHrefsByChunkName(),
     rscStreamObservability = false,
+    railsEnv,
   } = options;
   const sanitizedNonce = sanitizeNonce(cspNonce);
   const htmlStream = new PassThrough();
@@ -2010,7 +2016,12 @@ export default function injectRSCPayload(
             const handleParsedChunk = (content: Uint8Array, metadata: Record<string, unknown>) => {
               const flightData = textDecoder.decode(content);
               if (!hasEmittedDiagnosticScript) {
-                const diagnosticScript = createRSCDiagnosticScript(metadata, rscPayloadKey, sanitizedNonce);
+                const diagnosticScript = createRSCDiagnosticScript(
+                  metadata,
+                  rscPayloadKey,
+                  sanitizedNonce,
+                  railsEnv,
+                );
                 if (diagnosticScript) {
                   rscPayloadBuffers.push(Buffer.from(diagnosticScript));
                   hasEmittedDiagnosticScript = true;

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -106,9 +106,13 @@ function createRSCDiagnosticScript(
   // `hasErrors` is a boolean per the server wire contract; renderingError only carries
   // a useful diagnostic when the server provided a non-blank message or stack.
   if (hasErrors !== true && !hasRenderingErrorSignal(renderingError)) return undefined;
-  // In production, emit only the hasErrors signal without the server error message or stack trace.
+  // Outside development/test, emit only the error signal without the server error message or stack.
   // Full diagnostics are reported server-side via the streaming error reporter (Sentry/Honeybadger).
-  const clientPayload = railsEnv === 'production' ? { hasErrors } : { hasErrors, renderingError };
+  // Allowlist (not denylist) so custom envs like staging/uat default to redacted.
+  // When railsEnv is undefined (direct callers not threading railsContext), preserve full diagnostics
+  // for backwards compatibility — the standard render path always provides railsEnv.
+  const showFullDiagnostics = railsEnv == null || railsEnv === 'development' || railsEnv === 'test';
+  const clientPayload = showFullDiagnostics ? { hasErrors, renderingError } : { hasErrors: true };
   return createScriptTag(
     `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify(clientPayload)}`,
     sanitizedNonce,

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -108,10 +108,8 @@ function createRSCDiagnosticScript(
   if (hasErrors !== true && !hasRenderingErrorSignal(renderingError)) return undefined;
   // Outside development/test, emit only the error signal without the server error message or stack.
   // Full diagnostics are reported server-side via the streaming error reporter (Sentry/Honeybadger).
-  // Allowlist (not denylist) so custom envs like staging/uat default to redacted.
-  // When railsEnv is undefined (direct callers not threading railsContext), preserve full diagnostics
-  // for backwards compatibility — the standard render path always provides railsEnv.
-  const showFullDiagnostics = railsEnv == null || railsEnv === 'development' || railsEnv === 'test';
+  // Fail-closed: unknown or missing railsEnv defaults to redacted (safe for a security gate).
+  const showFullDiagnostics = railsEnv === 'development' || railsEnv === 'test';
   const clientPayload = showFullDiagnostics ? { hasErrors, renderingError } : { hasErrors: true };
   return createScriptTag(
     `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify(clientPayload)}`,

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -107,7 +107,7 @@ function createRSCDiagnosticScript(
   // a useful diagnostic when the server provided a non-blank message or stack.
   if (hasErrors !== true && !hasRenderingErrorSignal(renderingError)) return undefined;
   // In production, emit only the hasErrors signal without the server error message or stack trace.
-  // Full diagnostics are still available server-side via onDiagnosticError (Sentry/Honeybadger).
+  // Full diagnostics are reported server-side via the streaming error reporter (Sentry/Honeybadger).
   const clientPayload = railsEnv === 'production' ? { hasErrors } : { hasErrors, renderingError };
   return createScriptTag(
     `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify(clientPayload)}`,

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -110,6 +110,11 @@ function createRSCDiagnosticScript(
   // Full diagnostics are reported server-side via the streaming error reporter (Sentry/Honeybadger).
   // Fail-closed: unknown or missing railsEnv defaults to redacted (safe for a security gate).
   const showFullDiagnostics = railsEnv === 'development' || railsEnv === 'test';
+  // The two branches normalize `hasErrors` differently on purpose. The redacted (production)
+  // branch forces `hasErrors: true` so a chunk that only tripped `hasRenderingErrorSignal`
+  // (server sent `hasErrors: false` but a non-blank message/stack) still emits a positive
+  // generic signal for error boundaries. The development/test branch instead passes the raw
+  // metadata through unchanged to preserve the exact historical dev payload shape for debugging.
   const clientPayload = showFullDiagnostics ? { hasErrors, renderingError } : { hasErrors: true };
   return createScriptTag(
     `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify(clientPayload)}`,

--- a/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
@@ -63,6 +63,7 @@ const streamRenderReactComponent = (
     pipeToTransform,
     writeChunk,
     emitError,
+    notifyRenderingError,
     endStream,
     onConsumerAbort,
     isConsumerAborted,
@@ -77,6 +78,8 @@ const streamRenderReactComponent = (
 
     if (throwJsErrors) {
       emitError(error);
+    } else {
+      notifyRenderingError(error);
     }
   };
 

--- a/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
@@ -236,6 +236,7 @@ const streamRenderReactComponent = (
                     ? {}
                     : { rscClientChunkStylesheetHrefsByChunkName: new Map() }),
                   rscStreamObservability: railsContext.rscStreamObservability,
+                  railsEnv: railsContext.railsEnv,
                 },
               ),
             );

--- a/packages/react-on-rails-pro/src/streamingUtils.ts
+++ b/packages/react-on-rails-pro/src/streamingUtils.ts
@@ -35,7 +35,7 @@ import RSCRequestTracker from './RSCRequestTracker.ts';
 import safePipe from './safePipe.ts';
 
 type BufferedEvent = {
-  event: 'data' | 'error' | 'end';
+  event: 'data' | 'error' | 'end' | 'renderingError';
   data: unknown;
 };
 
@@ -80,6 +80,8 @@ const bufferStream = (stream: Readable) => {
           this.push(data);
         } else if (event === 'error') {
           this.emit('error', data);
+        } else if (event === 'renderingError') {
+          this.emit('renderingError', data);
         } else {
           this.push(null);
         }
@@ -102,6 +104,13 @@ const bufferStream = (stream: Readable) => {
         bufferedStream.emit('error', error);
       } else {
         bufferedEvents.push({ event: 'error', data: error });
+      }
+    },
+    notifyRenderingError: (error: Error) => {
+      if (startedReading) {
+        bufferedStream.emit('renderingError', error);
+      } else {
+        bufferedEvents.push({ event: 'renderingError', data: error });
       }
     },
   };
@@ -145,7 +154,11 @@ export const transformRenderStreamChunksToResultObject = (renderState: StreamRen
   // 2. If an error is emitted into the transformStream, it would cause the render to fail
   // 3. By wrapping in Readable.from(), we can explicitly emit errors into the readableStream without affecting the transformStream
   // Note: Readable.from can merge multiple chunks into a single chunk, so we need to ensure that we can separate them later
-  const { stream: readableStream, emitError: emitRenderError } = bufferStream(transformStream);
+  const {
+    stream: readableStream,
+    emitError: emitRenderError,
+    notifyRenderingError: notifyRenderError,
+  } = bufferStream(transformStream);
 
   // Set once the consumer has abandoned the output stream before the render finished (issue #3885).
   const consumerAbortHandlers: Array<() => void> = [];
@@ -162,6 +175,13 @@ export const transformRenderStreamChunksToResultObject = (renderState: StreamRen
       return;
     }
     emitRenderError(error);
+  };
+
+  const notifyRenderingError = (error: Error) => {
+    if (consumerAborted) {
+      return;
+    }
+    notifyRenderError(error);
   };
 
   // Abort a render source if it can (ReactDOM `PipeableStream`), otherwise destroy it. Check that
@@ -275,6 +295,7 @@ export const transformRenderStreamChunksToResultObject = (renderState: StreamRen
     pipeToTransform,
     writeChunk,
     emitError,
+    notifyRenderingError,
     endStream,
     onConsumerAbort,
     isConsumerAborted,
@@ -375,16 +396,19 @@ export const streamServerRenderedComponent = <T, P extends RenderParams>(
 
     return renderStrategy(reactRenderingResult, optionsWithStreamingCapabilities, streamingTrackers);
   } catch (e) {
-    const { readableStream, pipeToTransform, emitError } = transformRenderStreamChunksToResultObject({
-      hasErrors: true,
-      isShellReady: false,
-      result: null,
-    });
+    const { readableStream, pipeToTransform, emitError, notifyRenderingError } =
+      transformRenderStreamChunksToResultObject({
+        hasErrors: true,
+        isShellReady: false,
+        result: null,
+      });
+    const error = convertToError(e);
     if (throwJsErrors) {
-      emitError(e);
+      emitError(error);
+    } else {
+      notifyRenderingError(error);
     }
 
-    const error = convertToError(e);
     const htmlResultStream = handleError({ e: error, name: componentName, serverSide: true });
     pipeToTransform(htmlResultStream);
     return readableStream as T;

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -544,6 +544,27 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('renderingError');
   });
 
+  it('redacts renderingError when railsEnv is not provided (undefined)', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: true,
+      renderingError: {
+        message: 'Database connection refused at 10.0.3.42:5432',
+        stack: 'Error: Database connection refused\n    at Pool (/app/lib/db.ts:18:11)',
+      },
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('"hasErrors":true');
+    expect(resultStr).not.toContain('Database connection refused');
+    expect(resultStr).not.toContain('10.0.3.42');
+    expect(resultStr).not.toContain('db.ts');
+    expect(resultStr).not.toContain('renderingError');
+  });
+
   it('forces hasErrors:true in production even when metadata has hasErrors:false with renderingError signal', async () => {
     const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
       hasErrors: false,

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -517,6 +517,51 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('renderingError');
   });
 
+  it('redacts renderingError in non-development/test environments like staging', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: true,
+      renderingError: {
+        message: 'Internal server failure',
+        stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
+      },
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'staging',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
+    expect(resultStr).toContain('"hasErrors":true');
+    expect(resultStr).not.toContain('Internal server failure');
+    expect(resultStr).not.toContain('server.ts');
+    expect(resultStr).not.toContain('renderingError');
+  });
+
+  it('forces hasErrors:true in production even when metadata has hasErrors:false with renderingError signal', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: false,
+      renderingError: {
+        message: 'Internal server failure',
+        stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
+      },
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'production',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('"hasErrors":true');
+    expect(resultStr).not.toContain('Internal server failure');
+    expect(resultStr).not.toContain('server.ts');
+    expect(resultStr).not.toContain('renderingError');
+  });
+
   it('includes full renderingError in diagnostic metadata in development', async () => {
     const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
       hasErrors: true,

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -423,7 +423,9 @@ describe('injectRSCPayload', () => {
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'test',
+    });
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain(
@@ -465,7 +467,9 @@ describe('injectRSCPayload', () => {
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'test',
+    });
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain('First error');

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -539,25 +539,6 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain('renderingError');
   });
 
-  it('includes full renderingError when railsEnv is not provided (backwards compatible)', async () => {
-    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
-      hasErrors: true,
-      renderingError: {
-        message: 'some server error',
-        stack: 'Error: some server error\n    at render (/app/components/Comp.tsx:5:1)',
-      },
-    });
-    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
-    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
-
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
-    const resultStr = await collectStreamData(result);
-
-    expect(resultStr).toContain('some server error');
-    expect(resultStr).toContain('Comp.tsx');
-    expect(resultStr).toContain('renderingError');
-  });
-
   it('promotes streamed RSC client chunk stylesheet preloads to gate reveal', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}']);
     const mockHTML = createMockHTMLStream([

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -493,6 +493,71 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain(expectedPayloadPushScript('{"test": "data"}'));
   });
 
+  it('redacts renderingError from diagnostic metadata in production', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: true,
+      renderingError: {
+        message: 'User 48213 not authorized for org 77',
+        stack: 'Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)',
+      },
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'production',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
+    expect(resultStr).toContain('"hasErrors":true');
+    expect(resultStr).not.toContain('User 48213');
+    expect(resultStr).not.toContain('not authorized');
+    expect(resultStr).not.toContain('Auth.server.tsx');
+    expect(resultStr).not.toContain('renderingError');
+  });
+
+  it('includes full renderingError in diagnostic metadata in development', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: true,
+      renderingError: {
+        message: 'useState is not a function',
+        stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
+      },
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'development',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
+    expect(resultStr).toContain('useState is not a function');
+    expect(resultStr).toContain('Broken.server.tsx');
+    expect(resultStr).toContain('renderingError');
+  });
+
+  it('includes full renderingError when railsEnv is not provided (backwards compatible)', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: true,
+      renderingError: {
+        message: 'some server error',
+        stack: 'Error: some server error\n    at render (/app/components/Comp.tsx:5:1)',
+      },
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('some server error');
+    expect(resultStr).toContain('Comp.tsx');
+    expect(resultStr).toContain('renderingError');
+  });
+
   it('promotes streamed RSC client chunk stylesheet preloads to gate reveal', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}']);
     const mockHTML = createMockHTMLStream([

--- a/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
@@ -1235,6 +1235,51 @@ describe('streamServerRenderedReactComponent', () => {
     expect(chunks[0].hasErrors && chunks[1].hasErrors).toBe(false);
   });
 
+  it('emits a renderingError event when shell errors with throwJsErrors false', async () => {
+    const { renderResult } = setupStreamTest({ throwSyncError: true, throwJsErrors: false });
+    const onRenderingError = jest.fn();
+    const onError = jest.fn();
+    renderResult.on('renderingError', onRenderingError);
+    renderResult.on('error', onError);
+    await new Promise((resolve) => {
+      renderResult.once('end', resolve);
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onRenderingError).toHaveBeenCalledTimes(1);
+    expect(onRenderingError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onRenderingError.mock.calls[0][0].message).toContain('Sync Error');
+  });
+
+  it('emits a renderingError event when async errors with throwJsErrors false', async () => {
+    const { renderResult } = setupStreamTest({ throwAsyncError: true, throwJsErrors: false });
+    const onRenderingError = jest.fn();
+    const onError = jest.fn();
+    renderResult.on('renderingError', onRenderingError);
+    renderResult.on('error', onError);
+    await new Promise((resolve) => {
+      renderResult.once('end', resolve);
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onRenderingError).toHaveBeenCalledTimes(1);
+    expect(onRenderingError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('does not emit renderingError when throwJsErrors is true (uses standard error event)', async () => {
+    const { renderResult } = setupStreamTest({ throwSyncError: true, throwJsErrors: true });
+    const onRenderingError = jest.fn();
+    const onError = jest.fn();
+    renderResult.on('renderingError', onRenderingError);
+    renderResult.on('error', onError);
+    await new Promise((resolve) => {
+      renderResult.once('end', resolve);
+    });
+
+    expect(onError).toHaveBeenCalled();
+    expect(onRenderingError).not.toHaveBeenCalled();
+  });
+
   it.each(['asyncRenderFunction', 'renderFunction'])(
     'streams a component from a %s that resolves to a React component',
     async (componentType) => {


### PR DESCRIPTION
## Summary

Fixes #4629 — Two issues with RSC render errors in production:

1. **Security**: RSC render errors leaked full server `message` and source-mapped `stack` into client DOM via `REACT_ON_RAILS_RSC_ERRORS` inline `<script>` tags
2. **Observability**: With default config (`throwJsErrors: false`), rendering errors never reached error reporters (Sentry/Honeybadger)

### Production error redaction

- **Gate at the DOM injection boundary** (`createRSCDiagnosticScript`): outside development/test, emit only `{ hasErrors: true }` — no `message`, no `stack`, no file paths
- **Fail-closed allowlist**: only explicit `development` or `test` envs show full diagnostics; all other envs (production, staging, uat, undefined) redact by default — safe for a security gate
- **Wire protocol unchanged**: `buildRenderMetadata` still sends the full `renderingError` to Ruby so `raise_prerender_error` and server-side error handling work as before

### Error reporting via custom stream event

- **Problem**: `emitError()` emits standard Node.js `'error'` events which `text()` from `stream/consumers` rejects on — can't just remove the `throwJsErrors` gate
- **Solution**: Custom `'renderingError'` stream event that standard consumers (`text()`, `pipe()`, async iterators) ignore, but the node renderer listens for
- **Deduplication**: `WeakSet<Error>` in vm.ts ensures same error is reported exactly once, even when `throwJsErrors: true` causes both events to fire
- **Consumer abort safety**: `notifyRenderingError` mirrors `emitError`'s abort guard — no reporting after client disconnect

## Changes

| File | What |
|------|------|
| `streamingUtils.ts` | Add `notifyRenderingError` to `bufferStream()` and `transformRenderStreamChunksToResultObject()` — buffers custom events before reading starts, wraps with consumer-abort guard |
| `streamServerRenderedReactComponent.ts` | Thread `railsContext.railsEnv` into `injectRSCPayload` options; call `notifyRenderingError` in `reportError` when `!throwJsErrors` |
| `proRSC.ts` | Call `notifyRenderingError` in `reportError` when `!throwJsErrors`; remove misleading `console.error` (Sentry doesn't capture console) |
| `vm.ts` (node renderer) | Listen for `'renderingError'` on raw stream; deduplicate with `WeakSet<Error>` against `handleStreamError`'s `'error'` handler |
| `injectRSCPayload.ts` | Add `railsEnv` param; fail-closed allowlist (development/test show full diagnostics, everything else redacts) |
| `injectRSCPayload.test.ts` | 4 tests: production redaction, development full diagnostics, staging redaction, `hasErrors:false` edge case |
| `streamServerRenderedReactComponent.test.jsx` | 3 tests: `renderingError` emission on shell/async errors with `throwJsErrors:false`, no emission when `throwJsErrors:true` |
| `CHANGELOG.md` | Entry under `[Unreleased] > Fixed` |

## Test plan

- [x] All 141 streaming tests pass (5 suites)
- [x] All 23 RSC tests pass (7 suites)
- [x] TypeScript clean on both packages
- [x] Prettier + ESLint clean
- [ ] CI passes

## Release / cherry-pick

This is a **security fix** (production RSC render errors leaking the server error
message and source-mapped stack — including file paths and potentially user data —
into the client DOM). **Candidate for cherry-pick into the `17.0.1` patch release.**
The behavior change is intentional security hardening: setups that never set
`railsEnv` now redact by default (fail-closed allowlist — full diagnostics only for
explicit `development`/`test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented RSC rendering error details (message/stack/file paths) from leaking into client output in production, staging, and when environment is unspecified.
  * Kept full rendering error diagnostics for development and test.
  * Improved rendering-error observability when JavaScript errors are not thrown, ensuring proper error notification via the streaming pipeline.
  * Avoided duplicate stream error reports and standardized error handling.
* **Documentation**
  * Updated the changelog to reflect the improved RSC error privacy and reporting behavior.
* **Tests**
  * Expanded coverage for environment-specific RSC error redaction and rendering-error event routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
