### PR TITLE
docs: correct OSS helper & API-reference examples (broken/stale snippets)

### DIFF
--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -1,6 +1,6 @@
 # Generator Details
 
-The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` (or its alias `--webpack`) if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
+The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off, with two exceptions: the bundler (**fresh installs now default to Rspack**, so pass `--no-rspack`, or its alias `--webpack`, if you want Webpack instead) and `--agent-files` (on by default — pass `--no-agent-files` to skip writing the AI-agent guidance files). Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
 
 Run `rails generate react_on_rails:install --help` for descriptions of all available options:
 

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -10,12 +10,14 @@ Usage:
 
 Options:
   -T, [--typescript], [--no-typescript]            # Generate TypeScript files and install TypeScript dependencies. Default: false
-      [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
-      [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack)
       [--tailwind], [--no-tailwind]                # Install Tailwind CSS v4 and style the generated SSR example. Default: false
-      [--pro], [--no-pro]                          # Install React on Rails Pro with Node Renderer. Default: false
-      [--rsc], [--no-rsc]                          # Install React Server Components support (includes Pro). Default: false
+      [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
+      [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack; --no-webpack is equivalent to --rspack)
       [--ignore-warnings], [--no-ignore-warnings]  # Skip warnings. Default: false
+      [--agent-files], [--no-agent-files]          # Write AI-agent guidance files (AGENTS.md + editor pointers). Default: true
+      [--pro], [--no-pro]                          # Install React on Rails Pro with Node Renderer
+      [--rsc], [--no-rsc]                          # Install React Server Components support (includes Pro)
+      [--standard-only], [--no-standard-only]      # Install only the open-source package; cannot be combined with --pro or --rsc
 
 Runtime options:
   -f, [--force]                    # Overwrite files that already exist

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -31,7 +31,7 @@ A good example of this would be something like a notifications counter in a head
 
 Suppose the Redux store is called `appStore`, and you have 3 React components that each needs to connect to a store: `NavbarApp`, `CommentsApp`, and `BlogsApp`. I named them with `App` to indicate that they are the registered components.
 
-You will need to make a function that can create the store you will be using for all components and register it via the `registerStore` method. Note: this is a **storeCreator**, meaning that it is a function that takes (props, location) and returns a store:
+You will need to make a function that can create the store you will be using for all components and register it via the `registerStoreGenerators` method. Note: this is a **store generator**, meaning that it is a function that takes `(props, railsContext)` and returns a store:
 
 ```js
 function appStore(props, railsContext) {
@@ -40,7 +40,7 @@ function appStore(props, railsContext) {
   return myAppStore;
 }
 
-ReactOnRails.registerStore({
+ReactOnRails.registerStoreGenerators({
   appStore,
 });
 ```
@@ -57,7 +57,7 @@ return (
 );
 ```
 
-From your Rails view, you can use the provided helper `redux_store(store_name, props)` to create a fresh version of the store (because it may already exist if you came from visiting a previous page). Note: for this example, since we're initializing this from the main layout, we're using a generic name of `@react_props`. In other words, the Rails controller would set `@react_props` to the properties to hydrate the Redux store.
+From your Rails view, you can use the provided helper `redux_store(store_name, props: {})` to create a fresh version of the store (because it may already exist if you came from visiting a previous page). Note: for this example, since we're initializing this from the main layout, we're using a generic name of `@react_props`. In other words, the Rails controller would set `@react_props` to the properties to hydrate the Redux store.
 
 **app/views/layouts/application.html.erb**
 
@@ -92,7 +92,7 @@ Include the module `ReactOnRails::Controller` in your controller, probably in Ap
 `redux_store(store_name, props: {})`
 
 - **store_name:** A name for the store. You'll refer to this name in 2 places in your JavaScript:
-  1. You'll call `ReactOnRails.registerStore({storeName})` in the same place that you register your components.
+  1. You'll call `ReactOnRails.registerStoreGenerators({storeName})` in the same place that you register your components.
   2. In your component definition, you'll call `ReactOnRails.getStore('storeName')` to get the hydrated Redux store to attach to your components.
 - **props:** Named parameter `props`. ReactOnRails takes care of setting up the hydration of your store with props from the view.
 
@@ -100,9 +100,9 @@ For an example, see [spec/dummy/app/controllers/pages_controller.rb](https://git
 
 ## View Helper
 
-`redux_store(store_name, props: {})`
+`redux_store(store_name, props: {}, defer: false, auto_load_bundle: nil)`
 
-This method has the same API as the controller extension. **HOWEVER**, we recommend the controller extension instead because the Rails executes the template code in the controller action's view file (`erb`, `haml`, `slim`, etc.) before the layout. So long as you call `redux_store` at the beginning of your action's view file, this will work. However, it's an easy mistake to put this call in the wrong place. Calling `redux_store` in the controller action ensures proper load order, regardless of where you call this in the controller action. Note: you won't know of this subtle ordering issue until you server render and you find that your store is not hydrated properly.
+The view helper accepts the controller extension arguments plus `defer:` and `auto_load_bundle:`. Use `defer: true` to render the store hydration data later through `redux_store_hydration_data`; use `auto_load_bundle:` to auto-load the generated store pack (defaults to `ReactOnRails.configuration.auto_load_bundle`). These two keywords are view-helper-only and are rejected by the controller extension. **HOWEVER**, we recommend the controller extension instead because the Rails executes the template code in the controller action's view file (`erb`, `haml`, `slim`, etc.) before the layout. So long as you call `redux_store` at the beginning of your action's view file, this will work. However, it's an easy mistake to put this call in the wrong place. Calling `redux_store` in the controller action ensures proper load order, regardless of where you call this in the controller action. Note: you won't know of this subtle ordering issue until you server render and you find that your store is not hydrated properly.
 
 `redux_store_hydration_data`
 

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -28,7 +28,7 @@ end %>
 
 ### `cached_react_component_hash(component_name, options = {}, &block)`
 
-Fragment-cached version of `react_component_hash`. Automatically sets `prerender: true` (required because the hash return value splits server-rendered HTML from the console replay script). Returns a hash with `"html"` and `"consoleReplayScript"` keys.
+Fragment-cached version of `react_component_hash`. Automatically sets `prerender: true` because the render function must return an object of HTML strings. Returns a hash whose `"componentHtml"` key holds the server-rendered HTML; when console replay is enabled, the replay script is embedded in that value. The hash also includes any additional keys your render function returns.
 
 Same caching options as `cached_react_component`.
 
@@ -37,8 +37,7 @@ Same caching options as `cached_react_component`.
               cache_key: [@user, @post]) do
   { user: @user.as_json }
 end %>
-<%= result["html"] %>
-<%= content_for :script_tags, result["consoleReplayScript"] %>
+<%= result["componentHtml"] %>
 ```
 
 ### `stream_react_component(component_name, options = {})`

--- a/docs/oss/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
+++ b/docs/oss/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
@@ -213,8 +213,8 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
    4. You no longer need to register the React components within the `ReactOnRails.configuration.components_subdirectory` nor directly add their bundles. For example, you can have a Rails view using three components:
 
       ```erb
-      <%= react_component("FooComponentOne", {}, auto_load_bundle: true) %>
-      <%= react_component("BarComponentOne", {}, auto_load_bundle: true) %>
+      <%= react_component("FooComponentOne", auto_load_bundle: true) %>
+      <%= react_component("BarComponentOne", auto_load_bundle: true) %>
 
       <% append_javascript_pack_tag('SpecialComponentNotToAutoLoadBundle') %>
       <%= react_component("SpecialComponentNotToAutoLoadBundle", {}) %>
@@ -262,7 +262,7 @@ When using `auto_load_bundle: true`, your Rails layout needs to include empty pa
 
 **How it works:**
 
-1. **Component calls automatically append bundles**: When you use `<%= react_component("ComponentName", props, auto_load_bundle: true) %>` in a view, React on Rails automatically calls `append_javascript_pack_tag "generated/ComponentName"` and `append_stylesheet_pack_tag "generated/ComponentName"` (in static/production modes).
+1. **Component calls automatically append bundles**: When you use `<%= react_component("ComponentName", props: props, auto_load_bundle: true) %>` in a view, React on Rails automatically calls `append_javascript_pack_tag "generated/ComponentName"` and `append_stylesheet_pack_tag "generated/ComponentName"` (in static/production modes).
 
 2. **Layout renders appended bundles**: The empty `<%= stylesheet_pack_tag %>` and `<%= javascript_pack_tag %>` calls in your layout are where the appended component bundles get rendered.
 
@@ -273,8 +273,8 @@ When using `auto_load_bundle: true`, your Rails layout needs to include empty pa
 If your view contains:
 
 ```erb
-<%= react_component("HelloWorld", @hello_world_props, auto_load_bundle: true) %>
-<%= react_component("HeavyMarkdownEditor", @editor_props, auto_load_bundle: true) %>
+<%= react_component("HelloWorld", props: @hello_world_props, auto_load_bundle: true) %>
+<%= react_component("HeavyMarkdownEditor", props: @editor_props, auto_load_bundle: true) %>
 ```
 
 React on Rails automatically generates HTML equivalent to:
@@ -453,13 +453,13 @@ end
 `app/views/hello_world/index.html.erb`:
 
 ```erb
-<%= react_component("HelloWorld", @hello_world_props, prerender: true) %>
+<%= react_component("HelloWorld", props: @hello_world_props, prerender: true) %>
 ```
 
 `app/views/hello_world/editor.html.erb`:
 
 ```erb
-<%= react_component("HeavyMarkdownEditor", @editor_props, prerender: true) %>
+<%= react_component("HeavyMarkdownEditor", props: @editor_props, prerender: true) %>
 ```
 
 ### 7. Generate Bundles

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -131,7 +131,6 @@ A cache-optimized landing page often looks like this:
 <% append_stylesheet_pack_tag("generated/WelcomePage") %>
 <%= preload_pack_asset("generated/WelcomePage.css") %>
 <%= rendered["componentHtml"] %>
-<%= content_for :script_tags, rendered["consoleReplayScript"] %>
 ```
 
 In this shape, `auto_load_bundle: false` keeps asset loading explicit so the page can preserve head ordering and preload

--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -139,7 +139,7 @@ With React on Rails auto-bundling, you don't need manual registration! Just add 
 
 <p>Here's a React component embedded in this Rails view:</p>
 
-<%= react_component("SimpleCounter", { initialCount: 5 }, { auto_load_bundle: true }) %>
+<%= react_component("SimpleCounter", props: { initialCount: 5 }, auto_load_bundle: true) %>
 ```
 
 The generated layouts already include these tags. If you add React on Rails to another layout, make sure the `<head>` section includes:

--- a/docs/oss/getting-started/using-react-on-rails.md
+++ b/docs/oss/getting-started/using-react-on-rails.md
@@ -88,7 +88,7 @@ You must configure bundler entry points and manually register each component.
 ### Modern Auto-Bundling (Recommended)
 
 ```erb
-<%= react_component("HelloWorld", { name: "World" }, { auto_load_bundle: true }) %>
+<%= react_component("HelloWorld", props: { name: "World" }, auto_load_bundle: true) %>
 ```
 
 With auto-bundling enabled:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -496,7 +496,7 @@ With React on Rails auto-bundling, you don't need manual registration! Just add 
 
 <p>Here's a React component embedded in this Rails view:</p>
 
-<%= react_component("SimpleCounter", { initialCount: 5 }, { auto_load_bundle: true }) %>
+<%= react_component("SimpleCounter", props: { initialCount: 5 }, auto_load_bundle: true) %>
 ```
 
 The generated layouts already include these tags. If you add React on Rails to another layout, make sure the `<head>` section includes:
@@ -1745,7 +1745,7 @@ You must configure bundler entry points and manually register each component.
 ### Modern Auto-Bundling (Recommended)
 
 ```erb
-<%= react_component("HelloWorld", { name: "World" }, { auto_load_bundle: true }) %>
+<%= react_component("HelloWorld", props: { name: "World" }, auto_load_bundle: true) %>
 ```
 
 With auto-bundling enabled:
@@ -3688,8 +3688,8 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
    4. You no longer need to register the React components within the `ReactOnRails.configuration.components_subdirectory` nor directly add their bundles. For example, you can have a Rails view using three components:
 
       ```erb
-      <%= react_component("FooComponentOne", {}, auto_load_bundle: true) %>
-      <%= react_component("BarComponentOne", {}, auto_load_bundle: true) %>
+      <%= react_component("FooComponentOne", auto_load_bundle: true) %>
+      <%= react_component("BarComponentOne", auto_load_bundle: true) %>
 
       <% append_javascript_pack_tag('SpecialComponentNotToAutoLoadBundle') %>
       <%= react_component("SpecialComponentNotToAutoLoadBundle", {}) %>
@@ -3737,7 +3737,7 @@ When using `auto_load_bundle: true`, your Rails layout needs to include empty pa
 
 **How it works:**
 
-1. **Component calls automatically append bundles**: When you use `<%= react_component("ComponentName", props, auto_load_bundle: true) %>` in a view, React on Rails automatically calls `append_javascript_pack_tag "generated/ComponentName"` and `append_stylesheet_pack_tag "generated/ComponentName"` (in static/production modes).
+1. **Component calls automatically append bundles**: When you use `<%= react_component("ComponentName", props: props, auto_load_bundle: true) %>` in a view, React on Rails automatically calls `append_javascript_pack_tag "generated/ComponentName"` and `append_stylesheet_pack_tag "generated/ComponentName"` (in static/production modes).
 
 2. **Layout renders appended bundles**: The empty `<%= stylesheet_pack_tag %>` and `<%= javascript_pack_tag %>` calls in your layout are where the appended component bundles get rendered.
 
@@ -3748,8 +3748,8 @@ When using `auto_load_bundle: true`, your Rails layout needs to include empty pa
 If your view contains:
 
 ```erb
-<%= react_component("HelloWorld", @hello_world_props, auto_load_bundle: true) %>
-<%= react_component("HeavyMarkdownEditor", @editor_props, auto_load_bundle: true) %>
+<%= react_component("HelloWorld", props: @hello_world_props, auto_load_bundle: true) %>
+<%= react_component("HeavyMarkdownEditor", props: @editor_props, auto_load_bundle: true) %>
 ```
 
 React on Rails automatically generates HTML equivalent to:
@@ -3928,13 +3928,13 @@ end
 `app/views/hello_world/index.html.erb`:
 
 ```erb
-<%= react_component("HelloWorld", @hello_world_props, prerender: true) %>
+<%= react_component("HelloWorld", props: @hello_world_props, prerender: true) %>
 ```
 
 `app/views/hello_world/editor.html.erb`:
 
 ```erb
-<%= react_component("HeavyMarkdownEditor", @editor_props, prerender: true) %>
+<%= react_component("HeavyMarkdownEditor", props: @editor_props, prerender: true) %>
 ```
 
 ### 7. Generate Bundles
@@ -4937,7 +4937,6 @@ A cache-optimized landing page often looks like this:
 <% append_stylesheet_pack_tag("generated/WelcomePage") %>
 <%= preload_pack_asset("generated/WelcomePage.css") %>
 <%= rendered["componentHtml"] %>
-<%= content_for :script_tags, rendered["consoleReplayScript"] %>
 ```
 
 In this shape, `auto_load_bundle: false` keeps asset loading explicit so the page can preserve head ordering and preload
@@ -19939,7 +19938,7 @@ A good example of this would be something like a notifications counter in a head
 
 Suppose the Redux store is called `appStore`, and you have 3 React components that each needs to connect to a store: `NavbarApp`, `CommentsApp`, and `BlogsApp`. I named them with `App` to indicate that they are the registered components.
 
-You will need to make a function that can create the store you will be using for all components and register it via the `registerStore` method. Note: this is a **storeCreator**, meaning that it is a function that takes (props, location) and returns a store:
+You will need to make a function that can create the store you will be using for all components and register it via the `registerStoreGenerators` method. Note: this is a **store generator**, meaning that it is a function that takes `(props, railsContext)` and returns a store:
 
 ```js
 function appStore(props, railsContext) {
@@ -19948,7 +19947,7 @@ function appStore(props, railsContext) {
   return myAppStore;
 }
 
-ReactOnRails.registerStore({
+ReactOnRails.registerStoreGenerators({
   appStore,
 });
 ```
@@ -19965,7 +19964,7 @@ return (
 );
 ```
 
-From your Rails view, you can use the provided helper `redux_store(store_name, props)` to create a fresh version of the store (because it may already exist if you came from visiting a previous page). Note: for this example, since we're initializing this from the main layout, we're using a generic name of `@react_props`. In other words, the Rails controller would set `@react_props` to the properties to hydrate the Redux store.
+From your Rails view, you can use the provided helper `redux_store(store_name, props: {})` to create a fresh version of the store (because it may already exist if you came from visiting a previous page). Note: for this example, since we're initializing this from the main layout, we're using a generic name of `@react_props`. In other words, the Rails controller would set `@react_props` to the properties to hydrate the Redux store.
 
 **app/views/layouts/application.html.erb**
 
@@ -20000,7 +19999,7 @@ Include the module `ReactOnRails::Controller` in your controller, probably in Ap
 `redux_store(store_name, props: {})`
 
 - **store_name:** A name for the store. You'll refer to this name in 2 places in your JavaScript:
-  1. You'll call `ReactOnRails.registerStore({storeName})` in the same place that you register your components.
+  1. You'll call `ReactOnRails.registerStoreGenerators({storeName})` in the same place that you register your components.
   2. In your component definition, you'll call `ReactOnRails.getStore('storeName')` to get the hydrated Redux store to attach to your components.
 - **props:** Named parameter `props`. ReactOnRails takes care of setting up the hydration of your store with props from the view.
 
@@ -20008,9 +20007,9 @@ For an example, see [spec/dummy/app/controllers/pages_controller.rb](https://git
 
 ## View Helper
 
-`redux_store(store_name, props: {})`
+`redux_store(store_name, props: {}, defer: false, auto_load_bundle: nil)`
 
-This method has the same API as the controller extension. **HOWEVER**, we recommend the controller extension instead because the Rails executes the template code in the controller action's view file (`erb`, `haml`, `slim`, etc.) before the layout. So long as you call `redux_store` at the beginning of your action's view file, this will work. However, it's an easy mistake to put this call in the wrong place. Calling `redux_store` in the controller action ensures proper load order, regardless of where you call this in the controller action. Note: you won't know of this subtle ordering issue until you server render and you find that your store is not hydrated properly.
+The view helper accepts the controller extension arguments plus `defer:` and `auto_load_bundle:`. Use `defer: true` to render the store hydration data later through `redux_store_hydration_data`; use `auto_load_bundle:` to auto-load the generated store pack (defaults to `ReactOnRails.configuration.auto_load_bundle`). These two keywords are view-helper-only and are rejected by the controller extension. **HOWEVER**, we recommend the controller extension instead because the Rails executes the template code in the controller action's view file (`erb`, `haml`, `slim`, etc.) before the layout. So long as you call `redux_store` at the beginning of your action's view file, this will work. However, it's an easy mistake to put this call in the wrong place. Calling `redux_store` in the controller action ensures proper load order, regardless of where you call this in the controller action. Note: you won't know of this subtle ordering issue until you server render and you find that your store is not hydrated properly.
 
 `redux_store_hydration_data`
 
@@ -20056,7 +20055,7 @@ end %>
 
 ### `cached_react_component_hash(component_name, options = {}, &block)`
 
-Fragment-cached version of `react_component_hash`. Automatically sets `prerender: true` (required because the hash return value splits server-rendered HTML from the console replay script). Returns a hash with `"html"` and `"consoleReplayScript"` keys.
+Fragment-cached version of `react_component_hash`. Automatically sets `prerender: true` because the render function must return an object of HTML strings. Returns a hash whose `"componentHtml"` key holds the server-rendered HTML; when console replay is enabled, the replay script is embedded in that value. The hash also includes any additional keys your render function returns.
 
 Same caching options as `cached_react_component`.
 
@@ -20065,8 +20064,7 @@ Same caching options as `cached_react_component`.
               cache_key: [@user, @post]) do
   { user: @user.as_json }
 end %>
-<%= result["html"] %>
-<%= content_for :script_tags, result["consoleReplayScript"] %>
+<%= result["componentHtml"] %>
 ```
 
 ### `stream_react_component(component_name, options = {})`
@@ -20254,7 +20252,7 @@ SOURCE: docs/oss/api-reference/generator-details.md
 
 # Generator Details
 
-The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` (or its alias `--webpack`) if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
+The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off, with two exceptions: the bundler (**fresh installs now default to Rspack**, so pass `--no-rspack`, or its alias `--webpack`, if you want Webpack instead) and `--agent-files` (on by default — pass `--no-agent-files` to skip writing the AI-agent guidance files). Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
 
 Run `rails generate react_on_rails:install --help` for descriptions of all available options:
 
@@ -20264,12 +20262,14 @@ Usage:
 
 Options:
   -T, [--typescript], [--no-typescript]            # Generate TypeScript files and install TypeScript dependencies. Default: false
-      [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
-      [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack)
       [--tailwind], [--no-tailwind]                # Install Tailwind CSS v4 and style the generated SSR example. Default: false
-      [--pro], [--no-pro]                          # Install React on Rails Pro with Node Renderer. Default: false
-      [--rsc], [--no-rsc]                          # Install React Server Components support (includes Pro). Default: false
+      [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
+      [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack; --no-webpack is equivalent to --rspack)
       [--ignore-warnings], [--no-ignore-warnings]  # Skip warnings. Default: false
+      [--agent-files], [--no-agent-files]          # Write AI-agent guidance files (AGENTS.md + editor pointers). Default: true
+      [--pro], [--no-pro]                          # Install React on Rails Pro with Node Renderer
+      [--rsc], [--no-rsc]                          # Install React Server Components support (includes Pro)
+      [--standard-only], [--no-standard-only]      # Install only the open-source package; cannot be combined with --pro or --rsc
 
 Runtime options:
   -f, [--force]                    # Overwrite files that already exist


### PR DESCRIPTION
Fixes #4634.

Every item was verified against current-`main` source (not just the issue's pinned commit) and, where it raises, reproduced empirically on Ruby 4.0.5. A second reviewer (Codex, gpt-5.5 xhigh) independently checked the investigation, plan, and final diff.

## Issue #4634 items

| # | File | Fix |
|---|------|-----|
| 1 | `getting-started/quick-start.md`, `getting-started/using-react-on-rails.md` | 3-positional-arg `react_component("N", {props}, {opts})` raised `ArgumentError: given 3, expected 1..2` → single options hash: `react_component("N", props: {...}, auto_load_bundle: true)` |
| 2 | `api-reference/ruby-api-pro.md` | `cached_react_component_hash` example used `result["html"]` → `result["componentHtml"]`; **removed** the bogus `result["consoleReplayScript"]` line (no such key — the replay script is embedded in `componentHtml`) and corrected the return-shape description |
| 3 | `api-reference/redux-store-api.md` | store generator signature `(props, location)` → `(props, railsContext)` (matches `StoreGenerator` type) |
| 4 | `api-reference/redux-store-api.md` | deprecated `ReactOnRails.registerStore` → `registerStoreGenerators` (3 spots; `getStore` is **not** deprecated, left as-is) |
| 5 | `api-reference/generator-details.md` | refreshed the `--help` options block to match the actual generator output: added `--agent-files` and `--standard-only`, fixed option order, corrected the `--webpack` description, and dropped the false "Default: false" on `--pro`/`--rsc` |
| 6 | `api-reference/redux-store-api.md` | documented `redux_store`'s `defer:` / `auto_load_bundle:` kwargs — in the **View Helper** section, **not** the Controller Extension line the issue's line number pointed to. The controller method routes extra kwargs through `validate_redux_store_options!`, which raises `unknown keyword: :defer`; only the view helper accepts them (reproduced empirically) |

## Additional same-class fixes found during the audit

The issue's stated goal is "examples that raise errors on copy-paste." The same two defect classes exist in sibling OSS docs, so they're fixed here too:

- **`core-concepts/auto-bundling-*.md`** — 7 more `react_component("X", props, opt: true)` examples (positional props before a keyword) that raise the same `ArgumentError` → `props:` keyword form.
- **`core-concepts/performance-benchmarks.md`** — removed the same bogus `rendered["consoleReplayScript"]` access (line above it already correctly uses `componentHtml`).

## Deliberately left unchanged (out of scope)

- The generated-pack example in `auto-bundling-*.md` ("### Generated Files") still shows `ReactOnRails.registerStore({...})` because `packs_generator.rb` literally emits that — the doc is faithful to generated output; changing it would make the doc wrong.
- Deprecated-but-working `registerStore` prose in `reference/error-reference.md` and `migrating/rsc-context-and-state.md` (broader cleanup; `error-reference.md` mirrors current `SmartError` output).
- Historical release notes and the migration before/after diffs in `migrating-from-react-rails.md` (which intentionally show the legacy form to convert away from).

## Verification

- Reproduced the failing calls and confirmed each corrected call parses/validates against the real method signatures (`react_component`, `react_component_hash`, view/controller `redux_store` + `validate_redux_store_options!`).
- Ran the real `rails generate react_on_rails:install --help` to make the options block faithful.
- `prettier --check` (v3.6.2) passes on all 7 files; `git diff --check` clean.
- No CHANGELOG entry (documentation-only, per changelog guidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and auto-bundling guides to use the current `react_component` keyword-argument format (`props:` / `auto_load_bundle:`).
  * Revised Redux store documentation to use store generators registration and clarified `redux_store` helper signatures/options (`defer`, `auto_load_bundle`).
  * Updated Pro documentation for `cached_react_component_hash` to reflect the new returned HTML/console replay key and adjusted ERB examples.
  * Expanded `react_on_rails:install` help/options details and removed outdated console replay script references from performance benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->