### PR TITLE
Docs: correct immediate_hydration removal details (#4638)

### DIFF
--- a/docs/oss/configuration/README.md
+++ b/docs/oss/configuration/README.md
@@ -305,20 +305,15 @@ ReactOnRails.configure do |config|
   ################################################################################
   # DEPRECATED CONFIGURATION
   ################################################################################
-  # 🚫 DEPRECATED: immediate_hydration is no longer used
+  # 🚫 REMOVED in v16.2.0: `config.immediate_hydration` now raises NoMethodError at boot.
+  # Immediate hydration is now automatically enabled for React on Rails Pro users and
+  # cannot be disabled. Remove this line from your initializer.
   #
-  # This configuration option has been removed. Immediate hydration is now
-  # automatically enabled for React on Rails Pro users and cannot be disabled.
+  # The helper parameter (`immediate_hydration:` key in `react_component`, `react_component_hash`,
+  # `redux_store`, and the streaming helpers) was removed later in v16.6.0. Passing it now logs a
+  # one-time deprecation warning and is ignored.
   #
-  # If you still have this in your config, it will log a deprecation warning:
-  # config.immediate_hydration = false  # ⚠️ Logs warning, has no effect
-  #
-  # Action Required: Remove this line from your config/initializers/react_on_rails.rb
-  # See CHANGELOG.md for migration instructions.
-  #
-  # Historical Context:
-  # Previously controlled whether Pro components hydrated immediately upon their
-  # server-rendered HTML reaching the client, vs waiting for full page load.
+  # See CHANGELOG.md for migration details.
 
   ################################################################################
   # I18N OPTIONS

--- a/docs/oss/configuration/README.md
+++ b/docs/oss/configuration/README.md
@@ -311,7 +311,7 @@ ReactOnRails.configure do |config|
   #
   # The helper parameter (`immediate_hydration:` key in `react_component`, `react_component_hash`,
   # `redux_store`, and the streaming helpers) was removed later in v16.6.0. Passing it now logs a
-  # one-time deprecation warning and is ignored.
+  # one-time warning and is ignored.
   #
   # The `data-immediate-hydration` HTML attribute is no longer rendered on component
   # elements as of v16.6.0. Remove any CSS/JS selectors or test assertions that target it.

--- a/docs/oss/configuration/README.md
+++ b/docs/oss/configuration/README.md
@@ -313,6 +313,9 @@ ReactOnRails.configure do |config|
   # `redux_store`, and the streaming helpers) was removed later in v16.6.0. Passing it now logs a
   # one-time deprecation warning and is ignored.
   #
+  # The `data-immediate-hydration` HTML attribute is no longer rendered on component
+  # elements as of v16.6.0. Remove any CSS/JS selectors or test assertions that target it.
+  #
   # See CHANGELOG.md for migration details.
 
   ################################################################################

--- a/docs/oss/configuration/configuration-deprecated.md
+++ b/docs/oss/configuration/configuration-deprecated.md
@@ -16,6 +16,10 @@ The `config.immediate_hydration` setting was removed in v16.2.0. Assigning it in
 
 The `immediate_hydration:` key passed to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` was removed in v16.6.0. Passing it now logs a one-time deprecation warning (once per helper per process) and the value is dropped. Delete the key from all helper calls.
 
+**Rendered HTML attribute:** ⚠️ REMOVED in v16.6.0
+
+The `data-immediate-hydration` attribute that was previously emitted on hydrated/streamed component elements is no longer rendered. If you have CSS/JS selectors (e.g. `[data-immediate-hydration]`) or test assertions targeting it, remove them.
+
 **Behavior:** React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro users are not affected.
 
 See [CHANGELOG.md](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md) for details.

--- a/docs/oss/configuration/configuration-deprecated.md
+++ b/docs/oss/configuration/configuration-deprecated.md
@@ -8,11 +8,15 @@ For current configuration options, see [Configuration](README.md).
 
 ### immediate_hydration
 
-**Status:** ⚠️ REMOVED in v16.6.0
+**Configuration option:** ⚠️ REMOVED in v16.2.0 — raises `NoMethodError` at boot
 
-This configuration option has been removed. React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro users are not affected.
+The `config.immediate_hydration` setting was removed in v16.2.0. Assigning it in your initializer now raises `NoMethodError` at boot (no `method_missing` fallback exists). Remove the line.
 
-**Migration:** Remove any `config.immediate_hydration` lines from your configuration and any `immediate_hydration:` keys passed to `react_component` / `stream_react_component` — both are no-ops and can be safely deleted.
+**Helper parameter:** ⚠️ REMOVED in v16.6.0 — logs a one-time warning, then ignored
+
+The `immediate_hydration:` key passed to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` was removed in v16.6.0. Passing it now logs a one-time deprecation warning (once per helper per process) and the value is dropped. Delete the key from all helper calls.
+
+**Behavior:** React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro users are not affected.
 
 See [CHANGELOG.md](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md) for details.
 

--- a/docs/oss/configuration/configuration-deprecated.md
+++ b/docs/oss/configuration/configuration-deprecated.md
@@ -14,13 +14,13 @@ The `config.immediate_hydration` setting was removed in v16.2.0. Assigning it in
 
 **Helper parameter:** ⚠️ REMOVED in v16.6.0 — logs a one-time warning, then ignored
 
-The `immediate_hydration:` key passed to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` was removed in v16.6.0. Passing it now logs a one-time deprecation warning (once per helper per process) and the value is dropped. Delete the key from all helper calls.
+The `immediate_hydration:` key passed to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` was removed in v16.6.0. Passing it now logs a one-time warning (once per helper per process) and the value is dropped. Delete the key from all helper calls.
 
 **Rendered HTML attribute:** ⚠️ REMOVED in v16.6.0
 
 The `data-immediate-hydration` attribute that was previously emitted on hydrated/streamed component elements is no longer rendered. If you have CSS/JS selectors (e.g. `[data-immediate-hydration]`) or test assertions targeting it, remove them.
 
-**Behavior:** React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro users are not affected.
+**Behavior:** React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro apps are still affected by the removals above (the config raises and the helper parameter is ignored), but their hydration behavior is otherwise unchanged — immediate hydration is disabled for non-Pro and was never a per-component option.
 
 See [CHANGELOG.md](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md) for details.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18451,7 +18451,7 @@ ReactOnRails.configure do |config|
   #
   # The helper parameter (`immediate_hydration:` key in `react_component`, `react_component_hash`,
   # `redux_store`, and the streaming helpers) was removed later in v16.6.0. Passing it now logs a
-  # one-time deprecation warning and is ignored.
+  # one-time warning and is ignored.
   #
   # The `data-immediate-hydration` HTML attribute is no longer rendered on component
   # elements as of v16.6.0. Remove any CSS/JS selectors or test assertions that target it.
@@ -19398,13 +19398,13 @@ The `config.immediate_hydration` setting was removed in v16.2.0. Assigning it in
 
 **Helper parameter:** ⚠️ REMOVED in v16.6.0 — logs a one-time warning, then ignored
 
-The `immediate_hydration:` key passed to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` was removed in v16.6.0. Passing it now logs a one-time deprecation warning (once per helper per process) and the value is dropped. Delete the key from all helper calls.
+The `immediate_hydration:` key passed to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` was removed in v16.6.0. Passing it now logs a one-time warning (once per helper per process) and the value is dropped. Delete the key from all helper calls.
 
 **Rendered HTML attribute:** ⚠️ REMOVED in v16.6.0
 
 The `data-immediate-hydration` attribute that was previously emitted on hydrated/streamed component elements is no longer rendered. If you have CSS/JS selectors (e.g. `[data-immediate-hydration]`) or test assertions targeting it, remove them.
 
-**Behavior:** React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro users are not affected.
+**Behavior:** React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro apps are still affected by the removals above (the config raises and the helper parameter is ignored), but their hydration behavior is otherwise unchanged — immediate hydration is disabled for non-Pro and was never a per-component option.
 
 See [CHANGELOG.md](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md) for details.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18445,20 +18445,18 @@ ReactOnRails.configure do |config|
   ################################################################################
   # DEPRECATED CONFIGURATION
   ################################################################################
-  # 🚫 DEPRECATED: immediate_hydration is no longer used
+  # 🚫 REMOVED in v16.2.0: `config.immediate_hydration` now raises NoMethodError at boot.
+  # Immediate hydration is now automatically enabled for React on Rails Pro users and
+  # cannot be disabled. Remove this line from your initializer.
   #
-  # This configuration option has been removed. Immediate hydration is now
-  # automatically enabled for React on Rails Pro users and cannot be disabled.
+  # The helper parameter (`immediate_hydration:` key in `react_component`, `react_component_hash`,
+  # `redux_store`, and the streaming helpers) was removed later in v16.6.0. Passing it now logs a
+  # one-time deprecation warning and is ignored.
   #
-  # If you still have this in your config, it will log a deprecation warning:
-  # config.immediate_hydration = false  # ⚠️ Logs warning, has no effect
+  # The `data-immediate-hydration` HTML attribute is no longer rendered on component
+  # elements as of v16.6.0. Remove any CSS/JS selectors or test assertions that target it.
   #
-  # Action Required: Remove this line from your config/initializers/react_on_rails.rb
-  # See CHANGELOG.md for migration instructions.
-  #
-  # Historical Context:
-  # Previously controlled whether Pro components hydrated immediately upon their
-  # server-rendered HTML reaching the client, vs waiting for full page load.
+  # See CHANGELOG.md for migration details.
 
   ################################################################################
   # I18N OPTIONS
@@ -19394,11 +19392,19 @@ For current configuration options, see [Configuration](README.md).
 
 ### immediate_hydration
 
-**Status:** ⚠️ REMOVED in v16.6.0
+**Configuration option:** ⚠️ REMOVED in v16.2.0 — raises `NoMethodError` at boot
 
-This configuration option has been removed. React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro users are not affected.
+The `config.immediate_hydration` setting was removed in v16.2.0. Assigning it in your initializer now raises `NoMethodError` at boot (no `method_missing` fallback exists). Remove the line.
 
-**Migration:** Remove any `config.immediate_hydration` lines from your configuration and any `immediate_hydration:` keys passed to `react_component` / `stream_react_component` — both are no-ops and can be safely deleted.
+**Helper parameter:** ⚠️ REMOVED in v16.6.0 — logs a one-time warning, then ignored
+
+The `immediate_hydration:` key passed to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` was removed in v16.6.0. Passing it now logs a one-time deprecation warning (once per helper per process) and the value is dropped. Delete the key from all helper calls.
+
+**Rendered HTML attribute:** ⚠️ REMOVED in v16.6.0
+
+The `data-immediate-hydration` attribute that was previously emitted on hydrated/streamed component elements is no longer rendered. If you have CSS/JS selectors (e.g. `[data-immediate-hydration]`) or test assertions targeting it, remove them.
+
+**Behavior:** React on Rails Pro now performs early hydration automatically for streamed components; there is no per-component toggle. Non-Pro users are not affected.
 
 See [CHANGELOG.md](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md) for details.
 


### PR DESCRIPTION
## Summary

Fixes #4638. The docs mis-stated when and how `immediate_hydration` was removed. This corrects both the config-vs-helper distinction and the removal versions/behavior, verified against source.

Two distinct removals, previously conflated:

- **`config.immediate_hydration` (setting)** — REMOVED in **v16.2.0**. No accessor and no `method_missing` fallback exist in `configuration.rb`, so assigning it now **raises `NoMethodError` at boot**. (The docs previously claimed it merely logs a warning and no-ops.)
- **`immediate_hydration:` (helper parameter)** — REMOVED later in **v16.6.0**. Passing it to `react_component`, `react_component_hash`, `redux_store`, `stream_react_component`, or `buffered_stream_react_component` now logs a **one-time deprecation warning (once per helper per process)** and the value is dropped.

## Files

- `docs/oss/configuration/README.md` — initializer comment now says REMOVED in v16.2.0 / raises `NoMethodError`, and notes the separate v16.6.0 helper-param removal.
- `docs/oss/configuration/configuration-deprecated.md` — split into a **Configuration option** section (16.2.0, raises) and a **Helper parameter** section (16.6.0, warns then ignores), all five helpers listed.

## Verification

- `lib/react_on_rails/configuration.rb` — no `immediate_hydration` accessor, no `method_missing` → `NoMethodError`.
- `lib/react_on_rails/helper.rb` — `warn_removed_immediate_hydration_option` (L29-62, 102-104, 163-165) guards on `@removed_immediate_hydration_warnings[helper_name]` (one-time per helper).
- `react_on_rails_pro/lib/.../react_on_rails_pro_helper.rb` — streaming helpers L148-150, 167-169.
- CHANGELOG.md — 16.2.0 and 16.6.0 entries.

Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for the removed `immediate_hydration` configuration option, including that assigning it raises a boot-time error (v16.2.0).
  * Clarified that the `immediate_hydration:` helper parameter is deprecated, logs a one-time warning, and is ignored (removed in v16.6.0).
  * Documented that the `data-immediate-hydration` attribute is no longer rendered (v16.6.0), and that related CSS/JS and test assertions should be removed.
  * Reconfirmed automatic early hydration for Pro streamed components with no per-component disable option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->