### PR TITLE
Docs: add reusable demo fleet RC update prompt

### DIFF
--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -24,11 +24,11 @@
 #   build          — command that must succeed before deploy (asset compile).
 #   review_app     — CPFlow review-app workflow file, the status check name the
 #                    orchestrator polls, and the CPFlow app name used to derive
-#                    the review-app base URL. Set the whole block to null (or
-#                    leave `cpflow_app_name: null`) for a demo with no review-app
-#                    pipeline yet; the orchestrator then skips smoke for that
-#                    repo. `cpflow_app_name` must be non-null before a repo's
-#                    `verify: true` flag can be cleared.
+#                    the review-app base URL. Set the whole block to null for a
+#                    demo with no review-app pipeline. If the block is present,
+#                    `cpflow_app_name` must be non-null before `verify: true` can
+#                    be cleared; a null name inside the block is an unverified
+#                    placeholder. The orchestrator skips smoke when no app is set.
 #   smoke          — list of paths the orchestrator hits against the
 #                    review-app URL after deploy. Each must return 2xx.
 #   headline       — short name of the per-repo appendix in the RC plan.

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -202,8 +202,9 @@ resume existing ownership or a fenced handoff; launch only when coordination say
 unclaimed and incomplete. Workers read target AGENTS.md, confirm
 verify-marked manifest metadata, update only consumed packages and lockfiles, then
 install/build/test/smoke. Open/update the PR, request and wait for all required hosted CI, and, where
-the manifest configures a review app, wait for deployment and run every declared smoke path. Both
-must pass when a review app is configured. Fix actionable reviews and finish each lane.
+the manifest has a non-null `review_app.cpflow_app_name`, wait for deployment and run every declared
+smoke path. Hosted CI and review-app smoke must both pass when that real app name is configured. Fix
+actionable reviews and finish each lane.
 
 Smoke is behavioral, not path-only. For each applicable app, verify the declared routes load,
 expected SSR content is present in the initial response, the manifest headline's RSC/client
@@ -263,8 +264,9 @@ handoff; launch only when coordination says the lane is unclaimed and incomplete
 target AGENTS.md, confirm
 verify-marked manifest metadata, update only consumed packages and lockfiles, then
 install/build/test/smoke. Open/update the PR, request and wait for all required hosted CI, and, where
-the manifest configures a review app, wait for deployment and run every declared smoke path. Both
-must pass when a review app is configured. Fix actionable reviews and finish each lane.
+the manifest has a non-null `review_app.cpflow_app_name`, wait for deployment and run every declared
+smoke path. Hosted CI and review-app smoke must both pass when that real app name is configured. Fix
+actionable reviews and finish each lane.
 
 Smoke is behavioral, not path-only. For each applicable app, verify the declared routes load,
 expected SSR content is present in the initial response, the manifest headline's RSC/client
@@ -369,8 +371,9 @@ Flagship, Hacker News RSC, Marketplace RSC, Gumroad RSC, Tutorial, and TanStack.
 reuse RC PRs unless a maintainer explicitly chooses one for unusual review history. One claimed
 worktree and worker per repo; read target AGENTS.md, verify manifest data, update only consumed
 packages/lockfiles, install/build/test/smoke, and open the PR. Request and wait for all required
-hosted CI; where the manifest configures a review app, also wait for deployment and run every
-declared smoke path. Both must pass when configured. Address actionable review.
+hosted CI; where the manifest has a non-null `review_app.cpflow_app_name`, also wait for deployment
+and run every declared smoke path. Hosted CI and review-app smoke must both pass when that real app
+name is configured. Address actionable review.
 
 Smoke is behavioral, not path-only. For each applicable app, verify the declared routes load,
 expected SSR content is present in the initial response, the manifest headline's RSC/client

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -137,12 +137,12 @@ Efficient execution:
    and RSC compatibility once. Workers reuse that evidence.
 2. Run the generator/install gate once in react_on_rails.
 3. Wave 1: one isolated worker per hard-gate repo, in parallel up to the lower of host capacity
-   and the manifest concurrency limit. Wave 2: process soft-track repos with the same bound after
-   hard-gate edits are stable. Soft-track failures never block the release decision.
-4. Each worker updates dependencies and lockfiles, runs install, build/tests, primary route/RSC
-   smoke, required hosted CI, and review-app smoke where available, then opens or updates its PR.
-   Address actionable reviews. Set merge_authority to auto_merge_when_gates_pass only when the
-   tracker's mode and go/no-go state authorize it; a freeze or phase conflict disables auto-merge.
+   and manifest concurrency. Wave 2 reports all soft-track repos; update only maintainer-selected
+   IDs with the same bound. Soft-track failures never block release.
+4. Each worker updates dependencies/lockfiles, runs local install/build/tests/smoke, then opens or
+   updates its PR. Request and wait for required hosted CI and review-app smoke where available;
+   address actionable reviews. Set merge_authority to auto_merge_when_gates_pass only when the
+   tracker mode/go-no-go state authorizes it; a freeze or phase conflict disables auto-merge.
 5. A fresh strongest-capability checker, distinct from every maker, independently audits every
    hard-gate diff and the combined release evidence before any final GO recommendation.
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -94,24 +94,28 @@ policy.
 
 Use these Codex launch settings:
 
-| Setting           | Value                                                                                 |
-| ----------------- | ------------------------------------------------------------------------------------- |
-| Project           | The regular `react_on_rails` project, opened at the repository root.                  |
-| Starting checkout | A clean checkout of the current default branch with `origin` fetched.                 |
-| Coordinator       | The strongest available coding model with `xhigh` reasoning.                          |
-| Access            | GitHub read/write plus authorized private Pro and HiChee access for their lanes.      |
-| Isolation         | One top-level task; let `$pr-batch` create a separate worktree for every target repo. |
+| Setting             | Value                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------- |
+| Project             | The regular `react_on_rails` project, opened at the repository root.                  |
+| Starting checkout   | A clean checkout of the current default branch with `origin` fetched.                 |
+| Orchestrator        | Sol with `xhigh` reasoning.                                                           |
+| Routine workers     | Terra with `high` reasoning for mechanical dependency and lockfile updates.           |
+| Uncertain workers   | Sol with `high` reasoning; escalate to Sol/`xhigh` only when required.                |
+| Routine QA          | Sol with `high` reasoning.                                                            |
+| Independent checker | A fresh Sol/`xhigh` instance, distinct from every worker.                             |
+| Access              | GitHub read/write plus authorized private Pro and HiChee access for their lanes.      |
+| Isolation           | One top-level task; let `$pr-batch` create a separate worktree for every target repo. |
+
+If those model names are unavailable on the active Codex host, bind equivalent exact routes before
+launch; never silently inherit the orchestrator route for every worker.
 
 Do not launch the batch from an individual demo app or the unpublished local
 `shakastack-demo-fleet` prototype.
 
 ```text
 /goal
-Use $pr-batch to update and validate the React on Rails demo fleet for [RC TAG], tracking the
-release gate in shakacode/react_on_rails#[TRACKER]. Finish the batch; do not stop after opening
-PRs.
-
-Confirm the workspace is the regular react_on_rails project root.
+Use $pr-batch to validate [RC TAG] across the complete React on Rails demo fleet; track it in
+shakacode/react_on_rails#[TRACKER]. Finish every lane, not just PR creation.
 
 Release artifacts:
 - react_on_rails and react_on_rails_pro gems: [RUBY RC]
@@ -120,14 +124,13 @@ Release artifacts:
 - react-on-rails-rsc: [RSC VERSION]
 
 Source of truth and scope:
-- Fetch [RC TAG], its release branch, and the default branch. Use the RC snapshot for package
-  coverage and the default branch for current policy/inventory. Stop for a maintainer decision if
-  a difference changes the gate.
-- Before editing each target, inspect its default branch, AGENTS.md, dependencies, package manager,
-  lockfiles, CI, and smoke commands. For every manifest entry marked verify, confirm its package
-  manager, smoke paths, and needs_pro value before accepting that metadata.
-- Update only packages actually consumed. Reuse a safe open RC PR; otherwise branch from the
-  current default branch. Do not stack on stale RC work merely to preserve it.
+- Fetch [RC TAG], its release branch, and the default branch. The RC snapshot controls package
+  coverage; the default branch controls current policy/inventory. Stop on gate-changing conflicts.
+- Each worker reads target AGENTS.md and verifies its default branch, dependencies, lockfiles,
+  package manager, CI, and smoke commands. For verify-marked entries, confirm package manager,
+  smoke paths, and needs_pro before accepting the metadata.
+- Update only consumed packages. Reuse a safe open RC PR; otherwise branch from current default.
+  Do not preserve stale RC work.
 
 Efficient execution:
 1. The coordinator verifies versions/dist-tags, release tag/commit, changelog, exact-commit CI,
@@ -146,10 +149,11 @@ Efficient execution:
 Coordination and safety:
 - Use a stable [RC TAG] batch id and one claim/worktree per repo. Respect live claims and report
   UNKNOWN coordination state rather than guessing.
-- Bind every route to a supported model/effort pair before launch. Use balanced/high for routine
-  bumps and strongest/xhigh for uncertain, private, escalated, and final QA work.
-- Never expose private HiChee or Pro logs, URLs, screenshots, app details, tokens, or secret names
-  in public PRs or the tracker. Post only public-safe pass/fail summaries.
+- Bind routes before launch: orchestrator and independent checker Sol/xhigh; routine workers
+  Terra/high; uncertain workers and routine QA Sol/high. Escalate workers to Sol/xhigh only after
+  MODEL_ESCALATION_REQUEST.
+- Never expose private HiChee/Pro logs, URLs, screenshots, app details, tokens, or secret names.
+  Post only public-safe pass/fail summaries.
 - Suspected RC regressions block their gates until fixed or waived by a maintainer. File focused
   follow-up issues for unrelated defects instead of expanding bump PRs.
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -92,25 +92,23 @@ After publishing an RC, replace the bracketed values and paste this prompt into 
 uses the manifest for discovery while preserving this document as the authority for release-gate
 policy.
 
-Use these Codex launch settings:
+#### Codex Task Settings
 
-| Setting             | Value                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------- |
-| Project             | The regular `react_on_rails` project, opened at the repository root.                  |
-| Starting checkout   | A clean checkout of the current default branch with `origin` fetched.                 |
-| Orchestrator        | Sol with `xhigh` reasoning.                                                           |
-| Routine workers     | Terra with `high` reasoning for mechanical dependency and lockfile updates.           |
-| Uncertain workers   | Sol with `high` reasoning; escalate to Sol/`xhigh` only when required.                |
-| Routine QA          | Sol with `high` reasoning.                                                            |
-| Independent checker | A fresh Sol/`xhigh` instance, distinct from every worker.                             |
-| Access              | GitHub read/write plus authorized private Pro and HiChee access for their lanes.      |
-| Isolation           | One top-level task; let `$pr-batch` create a separate worktree for every target repo. |
-
-If those model names are unavailable on the active Codex host, bind equivalent exact routes before
-launch; never silently inherit the orchestrator route for every worker.
+| Setting     | Value            |
+| ----------- | ---------------- |
+| Project     | `react_on_rails` |
+| Model       | 5.6 Sol          |
+| Reasoning   | Extra High       |
+| Permissions | Full access      |
 
 Do not launch the batch from an individual demo app or the unpublished local
 `shakastack-demo-fleet` prototype.
+
+#### Prompt
+
+Everything else—including worker-model routing, worktrees, concurrency, coordination, validation,
+review, privacy, and tracker evidence—is handled by the prompt. No additional Codex UI settings are
+required.
 
 ```text
 /goal
@@ -165,9 +163,9 @@ Evidence and closeout:
 - Re-read the tracker immediately before any update. Prefer append-only comments for concurrent
   batch evidence; preserve its current Agent Release Mode unless a maintainer explicitly changes
   it.
-- Final output must list every discovered repo and disposition, merged and open PRs, exact
-  validation evidence, follow-up issues, and a PASS/PARTIAL/BLOCKED verdict. Do not recommend
-  final promotion until every hard gate and the exact release commit are green.
+- Final output must list every repo/disposition, PR, validation result, follow-up, and an evidence
+  status of PASS/PARTIAL/BLOCKED. This is not the final go/no-go: request an explicit maintainer
+  decision and never recommend or perform final promotion automatically.
 ```
 
 ## Required Pass Criteria

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -86,6 +86,68 @@ The tracking issue is the single source of truth for:
    every behavioral lane is green or explicitly waived (Lane 4b artifact defects cannot be
    waived).
 
+### Efficient Demo-Fleet Update Prompt
+
+After publishing an RC, replace the bracketed values and paste this prompt into a Codex task. It
+uses the manifest for discovery while preserving this document as the authority for release-gate
+policy.
+
+```text
+/goal
+Use $pr-batch to update and validate the React on Rails demo fleet for [RC TAG], tracking the
+release gate in shakacode/react_on_rails#[TRACKER]. Finish the batch; do not stop after opening
+PRs.
+
+Release artifacts:
+- react_on_rails and react_on_rails_pro gems: [RUBY RC]
+- react-on-rails, react-on-rails-pro, react-on-rails-pro-node-renderer, and
+  create-react-on-rails-app: [NPM RC]
+- react-on-rails-rsc: [RSC VERSION]
+
+Source of truth and scope:
+- Read rc-testing-plan.md and demo-fleet.yml from the current default branch. The plan controls
+  policy; the manifest supplies the complete repo inventory.
+- Before editing each target, inspect its default branch, AGENTS.md, dependencies, package manager,
+  lockfiles, CI, and smoke commands. Treat manifest entries marked verify as hints.
+- Update only packages actually consumed. Reuse a safe open RC PR; otherwise branch from the
+  current default branch. Do not stack on stale RC work merely to preserve it.
+
+Efficient execution:
+1. The coordinator verifies published versions and dist-tags, release tag/commit, changelog,
+   exact-commit CI, and RSC compatibility once. Workers reuse that evidence.
+2. Run the generator/install gate once in react_on_rails.
+3. Wave 1: one isolated worker per hard-gate repo, in parallel up to the lower of host capacity
+   and the manifest concurrency limit. Wave 2: process all soft-track repos in parallel after the
+   hard-gate edits are stable. Soft-track failures never block the release decision.
+4. Each worker updates dependencies and lockfiles, runs install, build/tests, primary route/RSC
+   smoke, and required hosted CI or review app, then opens or updates its PR. Address actionable
+   reviews. Merge when all gates pass; merge_authority is auto_merge_when_gates_pass.
+5. A fresh strongest-capability checker, distinct from every maker, independently audits every
+   hard-gate diff and the combined release evidence before any final GO recommendation.
+
+Coordination and safety:
+- Use a stable batch id based on [RC TAG] and one claim/worktree per repo. Respect existing live
+  claims and report UNKNOWN coordination state rather than guessing. Do not run two workers in
+  one checkout.
+- Bind every route to a supported model/effort pair before launch. Use balanced/high for routine
+  bumps and strongest/xhigh for uncertain, private, escalated, and final QA work.
+- Never expose private HiChee or Pro logs, URLs, screenshots, app details, tokens, or secret names
+  in public PRs or the tracker. Post only public-safe pass/fail summaries.
+- Suspected RC regressions block their gates until fixed or waived by a maintainer. File focused
+  follow-up issues for unrelated defects instead of expanding bump PRs.
+
+Evidence and closeout:
+- Append current-head evidence to #[TRACKER]: artifacts, release commit/CI, one row per hard gate
+  with PR or merge SHA and install/build/smoke/CI/review state, public-safe HiChee status,
+  soft-track results, regressions or waivers, and blockers.
+- Re-read the tracker immediately before any update. Prefer append-only comments for concurrent
+  batch evidence; preserve its current Agent Release Mode unless a maintainer explicitly changes
+  it.
+- Final output must list every discovered repo and disposition, merged and open PRs, exact
+  validation evidence, follow-up issues, and a PASS/PARTIAL/BLOCKED verdict. Do not recommend
+  final promotion until every hard gate and the exact release commit are green.
+```
+
 ## Required Pass Criteria
 
 For each hard-gate app PR:

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -92,11 +92,26 @@ After publishing an RC, replace the bracketed values and paste this prompt into 
 uses the manifest for discovery while preserving this document as the authority for release-gate
 policy.
 
+Use these Codex launch settings:
+
+| Setting           | Value                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| Project           | The regular `react_on_rails` project, opened at the repository root.                  |
+| Starting checkout | A clean checkout of the current default branch with `origin` fetched.                 |
+| Coordinator       | The strongest available coding model with `xhigh` reasoning.                          |
+| Access            | GitHub read/write plus authorized private Pro and HiChee access for their lanes.      |
+| Isolation         | One top-level task; let `$pr-batch` create a separate worktree for every target repo. |
+
+Do not launch the batch from an individual demo app or the unpublished local
+`shakastack-demo-fleet` prototype.
+
 ```text
 /goal
 Use $pr-batch to update and validate the React on Rails demo fleet for [RC TAG], tracking the
 release gate in shakacode/react_on_rails#[TRACKER]. Finish the batch; do not stop after opening
 PRs.
+
+Confirm the workspace is the regular react_on_rails project root.
 
 Release artifacts:
 - react_on_rails and react_on_rails_pro gems: [RUBY RC]
@@ -105,30 +120,32 @@ Release artifacts:
 - react-on-rails-rsc: [RSC VERSION]
 
 Source of truth and scope:
-- Read rc-testing-plan.md and demo-fleet.yml from the current default branch. The plan controls
-  policy; the manifest supplies the complete repo inventory.
+- Fetch [RC TAG], its release branch, and the default branch. Use the RC snapshot for package
+  coverage and the default branch for current policy/inventory. Stop for a maintainer decision if
+  a difference changes the gate.
 - Before editing each target, inspect its default branch, AGENTS.md, dependencies, package manager,
-  lockfiles, CI, and smoke commands. Treat manifest entries marked verify as hints.
+  lockfiles, CI, and smoke commands. For every manifest entry marked verify, confirm its package
+  manager, smoke paths, and needs_pro value before accepting that metadata.
 - Update only packages actually consumed. Reuse a safe open RC PR; otherwise branch from the
   current default branch. Do not stack on stale RC work merely to preserve it.
 
 Efficient execution:
-1. The coordinator verifies published versions and dist-tags, release tag/commit, changelog,
-   exact-commit CI, and RSC compatibility once. Workers reuse that evidence.
+1. The coordinator verifies versions/dist-tags, release tag/commit, changelog, exact-commit CI,
+   and RSC compatibility once. Workers reuse that evidence.
 2. Run the generator/install gate once in react_on_rails.
 3. Wave 1: one isolated worker per hard-gate repo, in parallel up to the lower of host capacity
-   and the manifest concurrency limit. Wave 2: process all soft-track repos in parallel after the
+   and the manifest concurrency limit. Wave 2: process soft-track repos with the same bound after
    hard-gate edits are stable. Soft-track failures never block the release decision.
 4. Each worker updates dependencies and lockfiles, runs install, build/tests, primary route/RSC
-   smoke, and required hosted CI or review app, then opens or updates its PR. Address actionable
-   reviews. Merge when all gates pass; merge_authority is auto_merge_when_gates_pass.
+   smoke, required hosted CI, and review-app smoke where available, then opens or updates its PR.
+   Address actionable reviews. Set merge_authority to auto_merge_when_gates_pass only when the
+   tracker's mode and go/no-go state authorize it; a freeze or phase conflict disables auto-merge.
 5. A fresh strongest-capability checker, distinct from every maker, independently audits every
    hard-gate diff and the combined release evidence before any final GO recommendation.
 
 Coordination and safety:
-- Use a stable batch id based on [RC TAG] and one claim/worktree per repo. Respect existing live
-  claims and report UNKNOWN coordination state rather than guessing. Do not run two workers in
-  one checkout.
+- Use a stable [RC TAG] batch id and one claim/worktree per repo. Respect live claims and report
+  UNKNOWN coordination state rather than guessing.
 - Bind every route to a supported model/effort pair before launch. Use balanced/high for routine
   bumps and strongest/xhigh for uncertain, private, escalated, and final QA work.
 - Never expose private HiChee or Pro logs, URLs, screenshots, app details, tokens, or secret names
@@ -137,9 +154,10 @@ Coordination and safety:
   follow-up issues for unrelated defects instead of expanding bump PRs.
 
 Evidence and closeout:
-- Append current-head evidence to #[TRACKER]: artifacts, release commit/CI, one row per hard gate
-  with PR or merge SHA and install/build/smoke/CI/review state, public-safe HiChee status,
-  soft-track results, regressions or waivers, and blockers.
+- Before closeout, fetch each target's default branch; confirm evidence belongs to the exact PR
+  head and its base matches the fetched default head. After merge, confirm the merge commit is
+  reachable from the new default head. Record every compared SHA in #[TRACKER] with artifact,
+  build, smoke, CI/review, public-safe HiChee, soft-track, regression/waiver, and blocker evidence.
 - Re-read the tracker immediately before any update. Prefer append-only comments for concurrent
   batch evidence; preserve its current Agent Release Mode unless a maintainer explicitly changes
   it.

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -86,11 +86,11 @@ The tracking issue is the single source of truth for:
    every behavioral lane is green or explicitly waived (Lane 4b artifact defects cannot be
    waived).
 
-### Efficient Demo-Fleet Update Prompt
+### RC.10 Copy/Paste Demo-Fleet Prompts
 
-After publishing an RC, replace the bracketed values and paste this prompt into a Codex task. It
-uses the manifest for discovery while preserving this document as the authority for release-gate
-policy.
+These prompts are filled for the current release and can be pasted without replacing placeholders.
+They use the manifest for inventory while preserving this document as the authority for
+release-gate policy.
 
 #### Codex Task Settings
 
@@ -101,71 +101,324 @@ policy.
 | Reasoning   | Extra High       |
 | Permissions | Full access      |
 
-Do not launch the batch from an individual demo app or the unpublished local
-`shakastack-demo-fleet` prototype.
+These are the Codex task labels used by maintainers in July 2026. If the UI changes, choose the
+strongest available model and highest reasoning level. Open the regular `react_on_rails` project,
+not an individual demo app.
 
-#### Prompt
+Everything beyond this table—including worker-model routing, worktrees, concurrency, coordination,
+validation, review, privacy, and tracker evidence—is handled by the prompts.
+`Sol` and `Terra` are portable route classes defined by the installed `$pr-batch` workflow, not
+additional UI model names. `MODEL_ESCALATION_REQUEST` is that workflow's evidence-bearing request
+for coordinator-approved promotion from a cheaper worker route to Sol/xhigh.
 
-Everything else—including worker-model routing, worktrees, concurrency, coordination, validation,
-review, privacy, and tracker evidence—is handled by the prompt. No additional Codex UI settings are
-required.
+#### Published RC.10 Values
+
+| Release input     | Exact value                                                        |
+| ----------------- | ------------------------------------------------------------------ |
+| GitHub tag        | `v17.0.0.rc.10`                                                    |
+| Release commit    | `d09328988dd5caa7e358f262174141d0a84b7f94`                         |
+| Ruby gems         | `react_on_rails` and `react_on_rails_pro` `17.0.0.rc.10`           |
+| npm packages      | Four React on Rails packages at `17.0.0-rc.10`                     |
+| RSC package       | `react-on-rails-rsc` `19.2.1-rc.1`                                 |
+| Tracking issue    | `shakacode/react_on_rails#3823`                                    |
+| Public reused PRs | Flagship #25, HN #69, Marketplace #131, Gumroad #78, TanStack #192 |
+| Other hard gates  | Resume the private HiChee handoff; Tutorial is the only fresh PR   |
+
+The four npm packages are `react-on-rails`, `react-on-rails-pro`,
+`react-on-rails-pro-node-renderer`, and `create-react-on-rails-app`. The Ruby spelling uses
+`.rc.10`; npm uses `-rc.10`; RSC has its own React-aligned version.
+
+RC.10 is not promotable: its tagged generator, Pro peer/dev metadata, node-renderer/runtime floor,
+workspace overrides, lockfile, tests, and docs retain RSC rc.1. After stable 19.2.1 publishes,
+replace or clear every prerelease-specific RSC reference on `release/17.0.0`, regenerate locks/docs,
+cut and fully validate a new RC, then promote only it.
+
+For the next release, regenerate this entire copy/paste section rather than editing only the
+release blocks. Search for every RC-specific literal and update the section heading, values table,
+release versions and SHA, tracker, reuse/fresh PR plan, dates, batch titles, thread handles, batch
+IDs, generator gate target, combined-audit target, and post-final hard/soft targets. Re-measure every
+prompt before publishing the documentation. This prevents an apparently current prompt from
+retaining an RC.10 branch, PR, or commit.
+
+#### Recommended Launch Plan
+
+Run hard-gate Batches A and B concurrently in separate Codex tasks or on separate machines. Run the
+RC.10 behavioral verification beside them: Lane 0 first; then mandatory Lane 1, Lane 2 per debut
+feature, Lane 3, and Lane 4b in parallel; after findings are fixed or explicitly waived, run final
+Lane 4a. Start Batch C only after A/B hand off and current exact-RC.10 reports for Lanes 0, 1, 2, 3,
+4a, and 4b are posted to #3823. After the stable final packages are published, run one shared
+exact-final artifact preflight. Only after its Lane 4a result is COMPLETE and Lane 4b result is CLEAN
+may required hard-gate Batch D and optional shelved-app Batch E run concurrently. Batch D must
+finish before the tracker closes. Shelved apps do not justify
+repeated RC churn unless an RC changes a feature uniquely covered by one of them; Batch E failures
+create follow-up issues but do not block the release or tracker closeout.
+
+Before launching A or B, re-read the tracker and targeted private coordination state. If an RC.10
+batch already owns any hard-gate lane, resume or hand off through its existing batch ID, owner,
+claim, branch, and worktree; do not launch a second worker, take a second claim, infer cancellation
+from a stale/missing heartbeat, or cancel/release another lane. Use the A/B prompts as new launches
+only when targeted coordination confirms their lanes are both unclaimed and incomplete, or a
+maintainer explicitly cancels and relaunches the prior batch. A completed RC.10 handoff satisfies
+A/B and feeds Batch C instead of restarting the lane.
+
+Never copy live ownership from this file; the tracker and targeted coordination backend are the
+only authorities for current lane state. Reconcile terminal/report-complete soft handoffs, let live
+report-only owners finish, and open no RC soft PRs. Park only never-started mutation lanes. A
+stale/missing heartbeat alone never authorizes takeover. Dead-lane recovery requires backend TTL
+proof, an unrecoverable original session, inspected branch/PR state, no possible unpushed work, and
+a recorded fenced takeover before a fresh claim; otherwise keep the lane blocked. Shelved bumps
+remain final Batch E.
+
+Manifest closeout is separate from app bumps. Public lanes return field evidence/corrections for
+one `react_on_rails` metadata PR; clear `verify: true` only after repo inspection, dependency-review
+CI confirmation, and a real review-app name or `review_app: null`. HiChee evidence/corrections stay
+private: clear its flag only when a private maintainer confirms every published field is accurate
+and disclosure-approved, and publish no operational evidence. If an accurate required value cannot
+be public, leave the flag set and file a private-overlay design issue before automation treats the
+entry as authoritative. Leave other unconfirmed flags set and file follow-ups.
+
+#### Batch A: Core, HiChee, Flagship, and Tutorial
 
 ```text
 /goal
-Use $pr-batch to validate [RC TAG] across the complete React on Rails demo fleet; track it in
-shakacode/react_on_rails#[TRACKER]. Finish every lane, not just PR creation.
+Use $pr-batch to finish React on Rails 17 RC.10 Batch A.
+Batch title: ROR A 07-13 15:17 - RC10 core hard gates.
+Thread handle: ror-a-core-koa. Batch id: ror-17-rc10-a. merge_authority: ask.
 
-Release artifacts:
-- react_on_rails and react_on_rails_pro gems: [RUBY RC]
-- react-on-rails, react-on-rails-pro, react-on-rails-pro-node-renderer, and
-  create-react-on-rails-app: [NPM RC]
-- react-on-rails-rsc: [RSC VERSION]
+Release facts: tag v17.0.0.rc.10; commit d09328988dd5caa7e358f262174141d0a84b7f94;
+react_on_rails and react_on_rails_pro gems 17.0.0.rc.10; react-on-rails,
+react-on-rails-pro, react-on-rails-pro-node-renderer, and create-react-on-rails-app npm packages
+17.0.0-rc.10; react-on-rails-rsc 19.2.1-rc.1. Tracker: shakacode/react_on_rails#3823.
 
-Source of truth and scope:
-- Fetch [RC TAG], its release branch, and the default branch. The RC snapshot controls package
-  coverage; the default branch controls current policy/inventory. Stop on gate-changing conflicts.
-- Each worker reads target AGENTS.md and verifies its default branch, dependencies, lockfiles,
-  package manager, CI, and smoke commands. For verify-marked entries, confirm package manager,
-  smoke paths, and needs_pro before accepting the metadata.
-- Update only consumed packages. Reuse a safe open RC PR; otherwise branch from current default.
-  Do not preserve stale RC work.
+Lanes: exact-tag generator gate; resume the private HiChee RC.10 handoff; update Flagship #25;
+Tutorial is the only fresh PR.
 
-Efficient execution:
-1. The coordinator verifies versions/dist-tags, release tag/commit, changelog, exact-commit CI,
-   and RSC compatibility once. Workers reuse that evidence.
-2. Run the generator/install gate once in react_on_rails.
-3. Wave 1: one isolated worker per hard-gate repo, in parallel up to the lower of host capacity
-   and manifest concurrency. Wave 2 reports all soft-track repos; update only maintainer-selected
-   IDs with the same bound. Soft-track failures never block release.
-4. Each worker updates dependencies/lockfiles, runs local install/build/tests/smoke, then opens or
-   updates its PR. Request and wait for required hosted CI and review-app smoke where available;
-   address actionable reviews. Set merge_authority to auto_merge_when_gates_pass only when the
-   tracker mode/go-no-go state authorizes it; a freeze or phase conflict disables auto-merge.
-5. A fresh strongest-capability checker, distinct from every maker, independently audits every
-   hard-gate diff and the combined release evidence before any final GO recommendation.
+Fetch all refs and the tracker. Use v17.0.0.rc.10 for shipped code, package coverage, changelog, and
+generator behavior; use current defaults only for policy, fleet inventory, and target bases. If
+they conflict on what shipped or a repo consumes, stop that lane BLOCKED/UNKNOWN; never mix
+snapshots. Verify registry tags, release SHA/changelog/exact-commit CI once. One isolated claimed
+worktree per repo; respect remote claims. Reuse a completed RC.10 handoff for Batch C. Otherwise
+resume existing ownership or a fenced handoff; launch only when coordination says the lane is
+unclaimed and incomplete. Workers read target AGENTS.md, confirm
+verify-marked manifest metadata, update only consumed packages and lockfiles, then
+install/build/test/smoke. Open/update the PR, request and wait for all required hosted CI, and, where
+the manifest configures a review app, wait for deployment and run every declared smoke path. Both
+must pass when a review app is configured. Fix actionable reviews and finish each lane.
 
-Coordination and safety:
-- Use a stable [RC TAG] batch id and one claim/worktree per repo. Respect live claims and report
-  UNKNOWN coordination state rather than guessing.
-- Bind routes before launch: orchestrator and independent checker Sol/xhigh; routine workers
-  Terra/high; uncertain workers and routine QA Sol/high. Escalate workers to Sol/xhigh only after
-  MODEL_ESCALATION_REQUEST.
-- Never expose private HiChee/Pro logs, URLs, screenshots, app details, tokens, or secret names.
-  Post only public-safe pass/fail summaries.
-- Suspected RC regressions block their gates until fixed or waived by a maintainer. File focused
-  follow-up issues for unrelated defects instead of expanding bump PRs.
+Smoke is behavioral, not path-only. For each applicable app, verify the declared routes load,
+expected SSR content is present in the initial response, the manifest headline's RSC/client
+interaction works, and the browser console has no new red errors. A 2xx response alone does not
+pass. Record these results in the RC test report; keep private-app details out of the public tracker.
 
-Evidence and closeout:
-- Before closeout, fetch each target's default branch; confirm evidence belongs to the exact PR
-  head and its base matches the fetched default head. After merge, confirm the merge commit is
-  reachable from the new default head. Record every compared SHA in #[TRACKER] with artifact,
-  build, smoke, CI/review, public-safe HiChee, soft-track, regression/waiver, and blocker evidence.
-- Re-read the tracker immediately before any update. Prefer append-only comments for concurrent
-  batch evidence; preserve its current Agent Release Mode unless a maintainer explicitly changes
-  it.
-- Final output must list every repo/disposition, PR, validation result, follow-up, and an evidence
-  status of PASS/PARTIAL/BLOCKED. This is not the final go/no-go: request an explicit maintainer
-  decision and never recommend or perform final promotion automatically.
+Run the generator/install gate in a separate clean react_on_rails worktree at v17.0.0.rc.10. Verify
+HEAD is d09328988dd5caa7e358f262174141d0a84b7f94 before running the documented commands; never run
+this gate from main or the documentation worktree.
+
+Published mode matrix, in a scratch directory with no local overrides: `--standard` = core only,
+no Pro/RSC, `/hello_world`; no setup-mode flag = core+Pro, no RSC, working Pro SSR; `--rsc` =
+core+Pro+RSC, streamed and interactive HelloServer route. Generate all three through exact
+create-react-on-rails-app@17.0.0-rc.10 and assert exact 17.0.0.rc.10 gem, 17.0.0-rc.10 npm, and
+19.2.1-rc.1 RSC locks where applicable. Any extra/missing package, wrong route, or fallback is
+BLOCKED. Keep Pro/RSC logs private.
+
+Routes: coordinator/checker Sol/xhigh; mechanical Terra/high; uncertain/QA Sol/high; escalate only
+after evidenced MODEL_ESCALATION_REQUEST.
+
+Never expose private HiChee/Pro logs, URLs, screenshots, app details, tokens, secret names, or
+private repository SHAs. Keep HiChee evidence private; clear verify only for accurate public fields.
+Re-read #3823 before posting append-only, public-safe evidence. Include
+exact base/head/merge SHAs for public gates only; report only high-level pass/fail, tester, and date
+for HiChee. Do not change Agent Release Mode. Suspected RC regressions block their lane; unrelated
+defects get focused follow-up issues. Report PASS/PARTIAL/BLOCKED/UNKNOWN as evidence only;
+preserve UNKNOWN for unverifiable facts and treat it as non-passing. Hand the
+completed evidence to Batch C. Do not request, recommend, or perform final promotion.
+```
+
+#### Batch B: Public RSC Demos
+
+```text
+/goal
+Use $pr-batch to finish React on Rails 17 RC.10 Batch B.
+Batch title: ROR B 07-13 15:17 - RC10 public RSC hard gates.
+Thread handle: ror-b-rsc-nalu. Batch id: ror-17-rc10-b. merge_authority: ask.
+
+Release facts: tag v17.0.0.rc.10; commit d09328988dd5caa7e358f262174141d0a84b7f94;
+react_on_rails and react_on_rails_pro gems 17.0.0.rc.10; react-on-rails,
+react-on-rails-pro, react-on-rails-pro-node-renderer, and create-react-on-rails-app npm packages
+17.0.0-rc.10; react-on-rails-rsc 19.2.1-rc.1. Tracker: shakacode/react_on_rails#3823.
+
+Own only these lanes:
+1. shakacode/react-on-rails-demo-hacker-news-rsc: safely update PR #69.
+2. shakacode/react-on-rails-demo-marketplace-rsc: safely update PR #131.
+3. shakacode/react-on-rails-demo-gumroad-rsc: safely update PR #78.
+4. shakacode/react-on-rails-starter-tanstack: safely update PR #192.
+
+Fetch all refs and the tracker. Use v17.0.0.rc.10 for shipped code, package coverage, changelog, and
+generator behavior; use current defaults only for policy, fleet inventory, and target bases. If
+they conflict on what shipped or a repo consumes, stop that lane BLOCKED/UNKNOWN; never mix
+snapshots. Verify the release facts once and reuse the evidence. One isolated claimed worktree per
+repo; respect remote claims.
+Reuse a completed RC.10 handoff for Batch C. Otherwise resume existing ownership or a fenced
+handoff; launch only when coordination says the lane is unclaimed and incomplete. Workers read
+target AGENTS.md, confirm
+verify-marked manifest metadata, update only consumed packages and lockfiles, then
+install/build/test/smoke. Open/update the PR, request and wait for all required hosted CI, and, where
+the manifest configures a review app, wait for deployment and run every declared smoke path. Both
+must pass when a review app is configured. Fix actionable reviews and finish each lane.
+
+Smoke is behavioral, not path-only. For each applicable app, verify the declared routes load,
+expected SSR content is present in the initial response, the manifest headline's RSC/client
+interaction works, and the browser console has no new red errors. A 2xx response alone does not
+pass. Record these results in the RC test report.
+
+Routes: coordinator and fresh independent checker Sol/xhigh; mechanical workers Terra/high;
+uncertain workers and routine QA Sol/high. A worker may request stronger help by reporting
+MODEL_ESCALATION_REQUEST with evidence; only the coordinator may move it to Sol/xhigh.
+
+Do not expose private Pro data. Re-read #3823 before posting append-only evidence with exact
+base/head/merge SHAs; do not change Agent Release Mode. Suspected RC regressions block their lane;
+unrelated defects get focused follow-up issues. Report PASS/PARTIAL/BLOCKED/UNKNOWN as evidence
+only; preserve UNKNOWN for unverifiable facts and treat it as non-passing. Hand the completed
+evidence to Batch C. Do not request, recommend, or perform final promotion.
+```
+
+#### Batch C: Fresh Combined Evidence Audit
+
+Run this in a new Codex task after Batches A and B finish and all required exact-RC.10 behavioral
+lane reports are posted.
+
+```text
+/goal
+Independently audit React on Rails 17 RC.10 release evidence; make no repository changes or merges.
+Batch title: ROR C 07-13 15:17 - RC10 combined evidence audit.
+Thread handle: ror-c-audit-niu. Batch id: ror-17-rc10-audit. merge_authority: none.
+
+Use a fresh Sol/xhigh checker that made none of the changes. Verify tag v17.0.0.rc.10 and commit
+d09328988dd5caa7e358f262174141d0a84b7f94, exact-tag CI, changelog, registry artifacts (gems
+17.0.0.rc.10; four npm packages 17.0.0-rc.10; RSC 19.2.1-rc.1), the generator/install gate, and
+all seven hard-gate repos in internal/contributor-info/demo-fleet.yml.
+The tag controls shipped/package coverage; current defaults control policy/inventory/bases.
+Conflicts are BLOCKED/UNKNOWN; never mix snapshots.
+
+Audit the current RC.10 reports for Lane 0 and mandatory Lanes 1, 2, 3, 4a, and 4b in
+release-verification-runbook.md. Apply each lane's pass criteria, require Lane 4b CLEAN, and never
+accept a waiver for an artifact defect.
+
+RC.10 is BLOCKED from final: generator, Pro/node metadata/runtime ranges, overrides, locks, tests,
+and docs retain RSC rc.1. Replace/clear every prerelease RSC ref for stable 19.2.1, then cut and fully
+validate a new RC; never defer this to final-only work.
+
+Before auditing, require a current exact-RC.10 report for every listed behavioral lane. If one is
+missing, stale, or covers another RC, do not produce it from this read-only audit; return it to its
+owner and report UNKNOWN/PARTIAL rather than continuing toward final go/no-go.
+
+Re-fetch PRs/defaults. Require current-head install, lock, build, CI, smoke, and no untriaged RC
+regression. Open PR: record base/head; require base ancestry or an exact-parent hosted/synthetic
+merge with full checks and smoke on its merge SHA—head-only CI fails. Merged PR: require GitHub's
+merge OID reachable from current default and its tree containing the patch; squash heads need not
+be reachable. Missing current-base evidence or actionable review is BLOCKED and returned with exact
+remediation. This auditor never edits, pushes, reruns CI, or resolves threads.
+For every hard gate, require evidence matching each Smoke Evidence item in the RC test report:
+route load, expected SSR output, the repo's headline RSC/client interaction, and a browser console
+with no new red errors. Path-only or 2xx-only evidence is insufficient. A demonstrated failure is
+BLOCKED; missing or unverifiable behavioral evidence is UNKNOWN and non-passing. Mark an interaction
+not applicable only with a concrete repo-specific explanation.
+Re-read shakacode/react_on_rails#3823, then post one append-only public-safe audit comment without
+changing Agent Release Mode. Record exact SHAs only for public gates; keep HiChee repository
+metadata private and report only its high-level result. Report PASS/PARTIAL/BLOCKED/UNKNOWN
+evidence only. Preserve UNKNOWN for unverifiable facts; it is non-passing and cannot support final
+promotion. Aggregate as BLOCKED for a known blocker; otherwise UNKNOWN when any required fact is
+unknown; otherwise PARTIAL when known work remains incomplete; use PASS only when every required
+fact passes. Ask the maintainer for the final go/no-go. Never recommend or perform promotion.
+```
+
+#### Batch D: Hard-Gate Apps After Final Publication
+
+Paste this only after the registries contain the stable `17.0.0` packages and stable
+`react-on-rails-rsc` `19.2.1`. This batch is required before closing the tracker.
+
+```text
+/goal
+Use $pr-batch to finish the React on Rails 17.0.0 final hard-gate app bumps.
+Batch title: ROR D 07-13 15:17 - final hard-gate bumps.
+Thread handle: ror-d-final-moa. Batch id: ror-17-final-hard. merge_authority: ask.
+
+Preflight: require tag v17.0.0; stable react_on_rails and react_on_rails_pro gems 17.0.0; stable
+react-on-rails, react-on-rails-pro, react-on-rails-pro-node-renderer, and
+create-react-on-rails-app npm packages 17.0.0; and stable react-on-rails-rsc 19.2.1. Verify the tag,
+registry dist-tags, changelog, and exact-tag CI. Stop without changing apps if any artifact is
+missing, prerelease-tagged, or incoherent. Tracker: shakacode/react_on_rails#3823.
+
+Before changing any app, use a fresh independent checker and a clean checkout at v17.0.0 to run the
+final-promotion Lane 4a audit and Lane 4b version/coherence subset from
+release-verification-runbook.md against the final tag and actual published artifacts. Reuse existing
+reports only after verifying their exact-final scope, evidence, and freshness; otherwise produce
+them. Post both to #3823. Continue only when Lane 4a is COMPLETE and Lane 4b is CLEAN; on GAPS,
+DEFECTS, missing, or stale evidence, stop app changes and report BLOCKED. If runtime or packaging
+content differs from the accepted RC, stop for a broader release gate instead of treating the subset
+as sufficient.
+
+Repeat the published three-mode matrix through exact create-react-on-rails-app@17.0.0: `--standard`
+is core-only; no flag is core+Pro/no RSC with working Pro SSR; `--rsc` is core+Pro+RSC with a
+streamed, interactive HelloServer. Require exact stable 17.0.0 locks in every mode and
+react-on-rails-rsc 19.2.1 only for `--rsc`; any package missing or extra for its mode, wrong route,
+or fallback is BLOCKED.
+
+Open fresh final-version PRs in all seven hard-gate apps from current default branches: HiChee,
+Flagship, Hacker News RSC, Marketplace RSC, Gumroad RSC, Tutorial, and TanStack. Do not rename or
+reuse RC PRs unless a maintainer explicitly chooses one for unusual review history. One claimed
+worktree and worker per repo; read target AGENTS.md, verify manifest data, update only consumed
+packages/lockfiles, install/build/test/smoke, and open the PR. Request and wait for all required
+hosted CI; where the manifest configures a review app, also wait for deployment and run every
+declared smoke path. Both must pass when configured. Address actionable review.
+
+Smoke is behavioral, not path-only. For each applicable app, verify the declared routes load,
+expected SSR content is present in the initial response, the manifest headline's RSC/client
+interaction works, and the browser console has no new red errors. A 2xx response alone does not
+pass. Record these results in the RC test report; keep private-app details out of the public tracker.
+
+Use Terra/high for mechanical work, Sol/high for uncertain work/QA, and Sol/xhigh only after an
+evidenced MODEL_ESCALATION_REQUEST. A fresh Sol/xhigh checker audits current-head results. Re-read
+#3823 before appending evidence. Publish exact PR/CI/smoke SHAs only for public gates; for HiChee,
+publish only high-level pass/fail, tester, and date—never private URLs, logs, app details, or SHAs.
+Do not change Agent Release Mode. Finish only when every hard-gate final PR is merged or has an
+explicit focused follow-up issue accepted by a maintainer.
+```
+
+#### Batch E: Shelved Apps After Final Publication
+
+This optional batch may run beside Batch D after the same stable-artifact preflight.
+
+```text
+/goal
+Use $pr-batch to refresh the non-gating React on Rails demo fleet after final publication.
+Batch title: ROR E 07-13 15:17 - final shelved-app refresh.
+Thread handle: ror-e-shelved-mako. Batch id: ror-17-final-soft. merge_authority: ask.
+
+Preflight: independently verify, or reuse a current shared #3823 report proving, final tag v17.0.0;
+required 17.0.0 gem/npm artifacts and dist-tags; react-on-rails-rsc 19.2.1; changelog; exact-tag CI;
+Lane 4a COMPLETE; and Lane 4b CLEAN artifact coherence. Verify reused evidence's exact-final scope
+and freshness. On missing, prerelease, incoherent, stale, or UNKNOWN evidence, stop without changing
+repos. Tracker: shakacode/react_on_rails#3823.
+
+Own only the five soft-track repos in internal/contributor-info/demo-fleet.yml:
+- shakacode/react_on_rails-demo-octochangelog-on-rails-pro
+- shakacode/react-on-rails-demo-ssr-hmr
+- shakacode/react-on-rails-demo-v16-bundle-splitting (report-only while archived)
+- shakacode/react-on-rails-example-open-flights
+- shakacode/react-on-rails-example-migration
+
+Use one claimed worktree and worker per mutable repo. Workers read target AGENTS.md, verify manifest
+data, update only consumed packages/lockfiles, install/build/test/smoke, open or update PRs, request
+required hosted CI, and address actionable review. Treat the archived v16 bundle-splitting repo as
+read-only: inspect and report whether a refresh is useful, but create no claim/worktree/branch/PR or
+CI/review request unless a maintainer first unarchives it. Use Terra/high for mechanical work,
+Sol/high for uncertain work/QA, and Sol/xhigh only after an evidenced MODEL_ESCALATION_REQUEST. A
+fresh Sol/xhigh checker audits the results.
+
+These repos never block the final release or tracker closeout. Record exact PR/CI/smoke evidence
+and file focused follow-up issues for failures. Do not expose private Pro data or change tracker
+Agent Release Mode.
 ```
 
 ## Required Pass Criteria


### PR DESCRIPTION
## Summary

Release managers now get five exact, copy-ready prompts for the React on Rails 17 RC10/final demo-fleet workflow. Minimal Codex UI settings are separated from the operational behavior encoded in the prompts.

## What changed

- document the minimal Codex setup: project `react_on_rails`, model `5.6 Sol`, Extra High reasoning, Full access
- replace placeholders with the exact RC10 tag, commit, gem/npm/RSC versions, tracker, batch IDs, and current PR/handoff plan
- split work into concurrent hard-gate Batches A/B, a fresh read-only combined audit C, required post-final hard-gate Batch D, and optional final-only shelved Batch E
- require exact published-package generator coverage for standard, default Pro, and RSC modes, with mode-specific locks and behavioral smoke
- preserve current-base CI, review-app smoke, release-snapshot authority, private HiChee evidence, manifest verification closeout, claim recovery, and maintainer-controlled promotion
- clarify that shelved apps receive report-only RC coverage and version bumps only after final unless a maintainer opts into unique RC-only coverage
- align the manifest header with the intended `review_app: null` versus unresolved `cpflow_app_name: null` contract

## Release finding

RC10 cannot promote directly to final because its tagged generator, Pro/node metadata and runtime ranges, workspace overrides, locks, tests, and docs retain `react-on-rails-rsc@19.2.1-rc.1`. Stable RSC 19.2.1 requires replacing every prerelease-specific reference on `release/17.0.0`, regenerating locks/docs, cutting a new RC, and fully revalidating it.

Evidence: [promotion blocker](https://github.com/shakacode/react_on_rails/issues/3823#issuecomment-4964977558) and [completed fleet audit](https://github.com/shakacode/react_on_rails/issues/3823#issuecomment-4965503893).

## Validation

- Prettier passed for both changed documentation files
- offline and online Markdown link checks passed
- documentation/sidebar validation passed
- YAML parsing and `git diff --check` passed
- all five prompts satisfy the Codex goal limit with at least 300 characters of headroom
- independent closeout review is clean

Related: #3823

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **“RC.10 Copy/Paste Demo-Fleet Prompts”** subsection to the RC Validation Workflow, including a complete prompt package and guidance for coordinating batches, evidence re-verification, privacy-safe reporting, and standardized PASS/PARTIAL/BLOCKED outcomes.
  * Updated demo-fleet manifest documentation to clarify `review_app` behavior when unset (`null`), including when smoke steps are skipped and how verification flags relate to `cpflow_app_name`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->