### PR TITLE
docs: clarify release version ownership and RSC promotion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,11 +464,16 @@ non-semantic actionlint cleanup when local validation evidence documents that cl
 
 `bundle exec rake release[...]` owns the coordinated React on Rails product-version
 change. For ordinary RC and final preparation, agents prepare and stamp
-`CHANGELOG.md`, but must not manually bump the React on Rails gem/npm version
-fields, edit lockfile rows solely to mirror that product-version bump, or create
-the ordinary `Bump version to ...` commit. The release task updates the OSS and
-Pro gem versions, workspace package versions, internal cross-package dependency
-versions, and lockfiles in one generated release commit.
+`CHANGELOG.md`, but must not manually bump React on Rails' own gem/npm version
+fields or create the ordinary `Bump version to ...` commit. The release task
+updates the OSS and Pro gem version files, the `version` field in all five
+`package.json` files, and the Ruby `Gemfile.lock` files in that generated commit.
+It does not run `pnpm install` or regenerate `pnpm-lock.yaml`; workspace-protocol
+dependency conversion during npm publishing is temporary and is restored afterward.
+
+If a release-preparation or dependency-pin PR changes dependency ranges or pins,
+regenerate the affected npm/pnpm lockfiles in that PR. Do not defer those lockfile
+updates to the React on Rails product-version release task.
 
 Pins for independently released dependencies are separate changes. For example,
 promoting `react-on-rails-rsc` from an RC to a stable version still requires a
@@ -922,9 +927,10 @@ Stable/final releases must not use that global override or any accelerated
 asynchronous/deferred-gate bypass. Every unwaived final gate must pass. A
 narrowly scoped final waiver is allowed only where the existing final-release
 policy explicitly permits it, with the required evidence and maintainer sign-off;
-it does not waive any other gate. Pre-releases require only the
-GitHub-branch-protection-required checks and follow the active RC policy for any
-maintainer waiver.
+it does not waive any other gate. For the release command's CI-status gate,
+pre-releases require only the GitHub-branch-protection-required checks. That
+narrow rule does not replace the separate RC hard gates or behavioral validation,
+and any maintainer waiver must still follow the active RC policy.
 
 Claude Code sessions get `main`'s CI status injected at session start (and
 again before `gh pr create` / pushing to `main`) via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,22 @@ non-semantic actionlint cleanup when local validation evidence documents that cl
 
 **Process gap disposition**: When an audit, review, or batch closeout finds a recurring process miss, do not add a prose-only rule by default. The issue plan or PR evidence must choose one mechanism target: `script`, `schema`, `checklist+replay`, or `park`, and record the motivating miss, replay evidence or park reason, and non-goal. `park` means the miss is plausible but not worth mechanizing now.
 
+### Release Version Ownership
+
+`bundle exec rake release[...]` owns the coordinated React on Rails product-version
+change. For ordinary RC and final preparation, agents prepare and stamp
+`CHANGELOG.md`, but must not manually bump the React on Rails gem/npm version
+fields, edit lockfile rows solely to mirror that product-version bump, or create
+the ordinary `Bump version to ...` commit. The release task updates the OSS and
+Pro gem versions, workspace package versions, internal cross-package dependency
+versions, and lockfiles in one generated release commit.
+
+Pins for independently released dependencies are separate changes. For example,
+promoting `react-on-rails-rsc` from an RC to a stable version still requires a
+normal reviewed and tested PR that updates the generator pin, package metadata,
+and affected lockfiles before cutting the next React on Rails RC. Do not confuse
+that dependency update with manually bumping React on Rails' own version.
+
 ## Maintainer Attention Contract
 
 Maintainer attention is for judgment, not for routine progress pings or
@@ -679,7 +695,7 @@ Known residual risk: <none or concise risk>
 Finalized by: <different GitHub account or named check/app, with GitHub review/check or git-log source>
 ```
 
-Auto-merge threshold in accelerated RC is `8/10`. A score of `7/10` permits human merge after review, but not auto-merge. Final-release mode does not use confidence-only auto-merge: run the post-merge audit, update the changelog/release notes as needed, confirm required checks on `main`, and get an explicit maintainer release decision before publishing the final release.
+Auto-merge threshold in accelerated RC is `8/10`. A score of `7/10` permits human merge after review, but not auto-merge. Final-release mode does not use confidence-only auto-merge: run the post-merge audit, update the changelog/release notes as needed, confirm required checks on the exact release-branch SHA being promoted, and get an explicit maintainer release decision before publishing the final release.
 
 Score from a `10/10` baseline: all checks complete, expected skips explained, changed surfaces validated, no unresolved blocker threads, no known residual risk, and an independent finalizer. A non-trivial concern is any finding that, if correct, would be a correctness bug, security issue, behavioral regression, API contract break, data-loss risk, release-process break, or credible CI/test coverage gap. Deduct 1-2 points for incomplete validation or unknown residual risk, using the larger deduction when unsure, and at least 2 points for any failed or unexplained check. Missing required validation for a changed surface is at least a 2-point deduction. Any unresolved non-trivial concern disqualifies auto-merge regardless of score. A missing independent finalizer disqualifies auto-merge regardless of score.
 
@@ -902,8 +918,13 @@ source exists.
 The `main` branch must stay green. CI failures on `main` block releases:
 `rake release` refuses to publish over a red `main` unless you explicitly
 override (via `RELEASE_CI_STATUS_OVERRIDE=true` or the 4th positional arg).
-Stable releases require every check to pass; pre-releases require only the
-GitHub-branch-protection-required checks.
+Stable/final releases must not use that global override or any accelerated
+asynchronous/deferred-gate bypass. Every unwaived final gate must pass. A
+narrowly scoped final waiver is allowed only where the existing final-release
+policy explicitly permits it, with the required evidence and maintainer sign-off;
+it does not waive any other gate. Pre-releases require only the
+GitHub-branch-protection-required checks and follow the active RC policy for any
+maintainer waiver.
 
 Claude Code sessions get `main`'s CI status injected at session start (and
 again before `gh pr create` / pushing to `main`) via
@@ -918,9 +939,10 @@ If `main` is red:
 3. **If you're the one merging a PR**, check `main` post-merge within 30
    minutes (see `.claude/docs/main-health-monitoring.md`).
 
-**Never silently override the release CI gate.** If you set
-`RELEASE_CI_STATUS_OVERRIDE=true`, document in the PR / release notes why
-the red checks are unrelated to the release.
+**Never silently override the release CI gate.** If an RC policy permits
+`RELEASE_CI_STATUS_OVERRIDE=true`, document in the release tracker or release
+notes why the failed or missing checks are unrelated. Never use it for final
+promotion.
 
 ## Key Concept: File Suffixes vs. RSC Directive
 

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -214,6 +214,33 @@ fixed by republishing.
 > does **not** reach the release unless it is forward-ported in step 3 (run in reverse: cherry-pick
 > `main`→`release/X.Y.Z`). Prefer authoring stabilizing fixes against the release branch first.
 
+#### Promote prerelease dependencies before final
+
+Do not promote a React on Rails RC to final while it still pins a prerelease of a coordinated
+dependency. For `17.0.0` and `react-on-rails-rsc@19.2.1`, use this order:
+
+1. Follow the
+   [`react-on-rails-rsc` release guide](https://github.com/shakacode/react_on_rails_rsc/blob/main/internal/docs/releasing.md),
+   complete its downstream release gate, and accept the exact commit behind the tested
+   `19.2.1-rc.N`. If any code changes, publish and test another RSC RC instead of promoting an
+   untested commit.
+2. Publish that same accepted commit as stable `react-on-rails-rsc@19.2.1`, and verify the registry
+   package and `latest` dist-tag before changing React on Rails.
+3. Complete [#4357](https://github.com/shakacode/react_on_rails/issues/4357) on
+   `release/17.0.0`: update the Ruby generator's RSC pin and the Pro peer/dev dependency metadata,
+   node-renderer and dummy/override pins, and affected lockfiles. This is a dependency update, not a
+   manual bump of React on Rails' own gem/npm product version.
+4. Forward-port the dependency-pin fix to `main` with `git cherry-pick -x`, as for every other release
+   branch fix.
+5. Cut a new React on Rails RC that contains the stable RSC pin. Do not treat an earlier React on Rails
+   RC that still points at `19.2.1-rc.N` as the final candidate.
+6. Run the RC hard gates and demo-fleet QA against the newly published artifacts. Include a scratch
+   non-RSC smoke test that installs or copies the published `react-on-rails-pro@<rc>` tarball while
+   leaving `react-on-rails-rsc` absent; a monorepo/workspace symlink is not valid evidence because it
+   can mask package-resolution leaks.
+7. Only after that new RC is accepted should [#4569](https://github.com/shakacode/react_on_rails/issues/4569)
+   promote `17.0.0` final.
+
 ### 3. Forward-port stabilizing fixes back to `main`
 
 Every fix that lands on `release/X.Y.Z` must also reach `main`, or `main` regresses the moment the
@@ -297,8 +324,10 @@ git rev-parse HEAD            # confirm it equals the tag of the good RC
 git diff --stat v17.0.0.rc.3  # expect: empty (no drift since the good RC)
 ```
 
-Collapse the RC CHANGELOG sections into the final section and bump to the final version, then release —
-this is the only code change between the good RC and the final:
+Collapse the RC CHANGELOG sections into the final section, then release. Do not manually bump the
+React on Rails gem/npm product-version files; the release task owns that coordinated change. The
+CHANGELOG edit plus the task-generated version metadata is the only difference between the good RC
+and the final:
 
 ```bash
 # $react-on-rails-update-changelog release   (collapses rc sections into ### [17.0.0])
@@ -331,6 +360,13 @@ git diff --name-only v17.0.0.rc.3 v17.0.0
 be re-spun, and an explicit human sign-off on the promotion itself (see
 [Phase-tiered merge gating](#phase-tiered-merge-gating)). Set the mode to `final-release` on the tracker
 and publish phase `final` for the release line during the promotion freeze.
+
+Final promotion must fail closed. Do not set `RELEASE_CI_STATUS_OVERRIDE=true`, pass the fourth
+`override_ci_status` argument, or use an accelerated asynchronous/deferred-gate option when publishing
+the stable version. Successful gate evidence from the accepted RC may be reused only when the final
+release policy and release tooling validate that evidence. A narrowly scoped, documented final waiver
+remains possible only where the existing final-release policy explicitly permits it, with its required
+evidence and maintainer sign-off; it must not become a global skip of CI, ShakaPerf, or any other gate.
 
 ### 5. Close out the release line
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -19,9 +19,16 @@ See [Contributing](https://github.com/shakacode/react_on_rails/blob/main/CONTRIB
 ### Version ownership
 
 The release task owns React on Rails' coordinated product-version changes. Release-preparation PRs
-should update and stamp `CHANGELOG.md`, but should not manually edit the OSS/Pro gem versions,
-workspace package versions, related internal dependency versions, or lockfile rows solely for the next
-React on Rails version. `bundle exec rake release[...]` creates that `Bump version to ...` commit.
+should update and stamp `CHANGELOG.md`, but should not manually bump React on Rails' own OSS/Pro gem
+or npm version fields or create the ordinary `Bump version to ...` commit. `bundle exec rake
+release[...]` updates the OSS and Pro gem version files, the `version` field in all five `package.json`
+files, and the Ruby `Gemfile.lock` files in that generated commit. It does not run `pnpm install` or
+regenerate `pnpm-lock.yaml`; workspace-protocol dependency conversion during npm publishing is
+temporary and is restored afterward.
+
+If a release-preparation or dependency-pin PR changes dependency ranges or pins, regenerate the
+affected npm/pnpm lockfiles in that PR. Do not defer those lockfile updates to the React on Rails
+product-version release task.
 
 An independently published dependency pin is different: for example, moving from a
 `react-on-rails-rsc` RC to its accepted stable version must be reviewed and tested before the next

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -16,6 +16,18 @@ See [Contributing](https://github.com/shakacode/react_on_rails/blob/main/CONTRIB
 
 ## Release Process
 
+### Version ownership
+
+The release task owns React on Rails' coordinated product-version changes. Release-preparation PRs
+should update and stamp `CHANGELOG.md`, but should not manually edit the OSS/Pro gem versions,
+workspace package versions, related internal dependency versions, or lockfile rows solely for the next
+React on Rails version. `bundle exec rake release[...]` creates that `Bump version to ...` commit.
+
+An independently published dependency pin is different: for example, moving from a
+`react-on-rails-rsc` RC to its accepted stable version must be reviewed and tested before the next
+React on Rails RC. Follow the ordered dependency-promotion gate in the
+[Release-Train Runbook](release-train-runbook.md#promote-prerelease-dependencies-before-final).
+
 ### 1. Update the Changelog (BEFORE releasing)
 
 **Always update CHANGELOG.md before running the release task.** The release task reads the version from CHANGELOG.md and automatically creates a GitHub release from the changelog section.
@@ -95,7 +107,7 @@ Use override only when needed:
 **Full argument list:**
 
 ```bash
-bundle exec rake "release[version,dry_run,override_version_policy]"
+bundle exec rake "release[version,dry_run,override_version_policy,override_ci_status]"
 ```
 
 1. **`version`** (optional): Version bump type or explicit version
@@ -108,6 +120,15 @@ bundle exec rake "release[version,dry_run,override_version_policy]"
 
 3. **`override_version_policy`** (optional): `true` to override version policy checks (default: `false`)
 
+4. **`override_ci_status`** (optional): global release-gate override (default: `false`). It is only for
+   an explicitly approved prerelease waiver under the active RC policy; never use it for a stable/final
+   promotion.
+
+> Stable/final promotion must not set `RELEASE_CI_STATUS_OVERRIDE=true`, pass
+> `override_ci_status=true`, or use an accelerated asynchronous/deferred-gate bypass. Every unwaived
+> final gate must pass. A narrowly scoped final waiver remains subject to the existing final-release
+> policy, required evidence, and maintainer sign-off, and does not waive any other gate.
+
 **Environment variables:**
 
 ```bash
@@ -115,8 +136,14 @@ VERBOSE=1                    # Enable verbose logging (shows all output)
 NPM_OTP=<code>               # Provide NPM one-time password (reused for all NPM publishes)
 RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for both gems)
 RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
+RELEASE_CI_EVALUATE_HEAD=true # Evaluate the current release-source HEAD instead of walking back metadata-only commits
 GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
 ```
+
+`RELEASE_CI_EVALUATE_HEAD=true` is a strict diagnostic, not a waiver. Use it when the current HEAD
+itself is expected to have CI evidence and must be evaluated verbatim. It is usually not appropriate
+when HEAD contains only changelog/version/release-gate metadata and the runtime-bearing commit behind
+it is the candidate whose full suite must qualify the release.
 
 **Examples:**
 


### PR DESCRIPTION
## Summary

Release preparation now has an explicit ownership boundary: agents prepare the changelog and independently released dependency pins, while `bundle exec rake release[...]` creates React on Rails' coordinated gem/npm version commit. This prevents a release-preparation PR from pre-bumping product versions and leaving the release task to infer the wrong next version.

The release train now also documents the complete prerequisite chain for a stable RSC dependency: accept and publish the exact tested RSC candidate, update the Ruby generator and Pro/package pins, cut and validate another React on Rails RC from those published artifacts, and only then promote that accepted RC to final. Stable promotion explicitly forbids global CI, ShakaPerf, and deferred-gate bypasses; narrowly scoped waivers remain governed by the existing final-release evidence and sign-off policy.

The strict-HEAD environment variable is documented as a diagnostic rather than a waiver, including why metadata-only release commits normally should use the runtime-bearing walk-back.

## Validation

- `pnpm dlx prettier@3.6.2 --check AGENTS.md internal/contributor-info/release-train-runbook.md internal/contributor-info/releasing.md` — passed
- `bin/check-links` — passed online and offline through the repository hooks
- `.agents/bin/agent-workflow-seam-doctor` — passed
- `script/ci-changes-detector origin/main` — documentation-only; no hosted CI jobs recommended
- `codex review -c 'model="gpt-5.5"' -c 'model_reasoning_effort="xhigh"' --base origin/main` — no actionable findings on the committed PR diff
- Pre-commit and pre-push hooks — passed
- No product version fields or lockfiles changed

Labels: none — focused documentation and agent-instruction changes.

### QA Evidence

- QA lane: coordinator review in the isolated `react_on_rails-closeout` worktree after the implementation worker completed; coordination claim active during review and push
- Scope checked: the three changed instruction files, `rakelib/release.rake` version/CI/promotion behavior, the external RSC release guide, and the published-package isolation requirement
- Tested at: `802c95c3ee958b43a9087a5eafdb6bb0ce77a7d7`
- Automated checks: formatting, link validation, workflow seam validation, CI routing, repository hooks, and structured review listed above
- Manual checks: verified that the release task generates the coordinated version commit, selects the actual release source branch for CI, and permits metadata-only commits after an accepted RC without allowing runtime drift
- Findings: three implementation comments were fixed and resolved: lockfile ownership now matches the release task, duplicate wording was removed, and the prerelease required-check statement is scoped to the release command CI-status gate. Two later comments about mechanical final-bypass enforcement were verified, linked to existing issue #4648, and resolved as tracked follow-up; no unresolved current-head threads
- QA required: yes
- QA required rationale: canonical agent and release instructions affect the maintainer release workflow even though no runtime code changed
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: script — mechanical rejection of broad stable/final bypasses remains tracked separately; this PR supplies the operator and agent contract

## Confidence note

- Validated: version/lockfile ownership, prerelease CI-gate wording, final-promotion bypass restrictions, strict-HEAD diagnostics, formatting, links, workflow seams, CI routing, and repository hooks
- Evidence: current-head review-thread resolution plus an independent committed-diff review at `802c95c3ee958b43a9087a5eafdb6bb0ce77a7d7`
- Unknowns: none for this documentation-only scope
- Residual risk: mechanical enforcement of final-release bypass rules remains intentionally tracked in #4648; this PR documents the operator and agent contract

## Related

Related: #4357, #4569, #4641, #4647, #4648

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified release version ownership and automated coordination of product-version stamping across changelog and package/gem version files.
  * Added safeguards to ensure prerelease-to-final promotion follows the correct dependency prerelease verification sequence.
  * Strengthened “fail closed” guidance for stable/final publishing, including tighter CI gate handling and restrictions on CI status overrides.
  * Expanded release guidance with the `override_ci_status` option, clarified when lockfile regeneration is required, and added `RELEASE_CI_EVALUATE_HEAD=true` as a diagnostic.
  * Confirm required checks on the exact release-branch commit being promoted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

