### PR TITLE
Fix ambiguous prerelease retries

### DIFF
--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -88,12 +88,19 @@ RELEASE_VERSION_POLICY_OVERRIDE=true bundle exec rake "release[16.2.0]"
 bundle exec rake "release[16.2.0,false,true]"
 ```
 
+> **Retry safety:** Never drop the version argument when resuming an interrupted release. Retry the
+> exact prerelease version, for example `bundle exec rake "release[17.0.0.rc.10]"`. From a prerelease
+> checkout, an argument-less release fails closed unless the changelog advances the same release line
+> to a newer prerelease. Stable promotion must use an explicit stable version and a matching non-empty
+> changelog section.
+
 When called with no arguments, `rake release`:
 
 1. Reads the first versioned header from CHANGELOG.md (e.g., `### [16.5.0]`)
 2. Compares it to the current gem version
 3. If the changelog version is newer, prompts for confirmation and uses it
-4. If no new version is found, falls back to a patch bump
+4. If no new version is found from an already-stable checkout, falls back to a patch bump; from a
+   prerelease checkout, aborts with exact retry and stable-promotion guidance
 
 Dry runs use a temporary git worktree so version bumps and installs do not modify your current checkout.
 
@@ -121,7 +128,9 @@ bundle exec rake "release[version,dry_run,override_version_policy,override_ci_st
    - Bump types: `patch`, `minor`, `major`
    - Explicit: `16.2.0`
    - Pre-release: `16.2.0.beta.1` (rubygem format with dots, converted to `16.2.0-beta.1` for NPM)
-   - Empty (auto): use latest CHANGELOG.md version if newer, else patch bump
+   - Empty (auto): use a newer changelog prerelease on the same release line; from an already-stable
+     checkout, use a newer changelog version or fall back to a patch bump; otherwise abort with explicit
+     retry guidance
 
 2. **`dry_run`** (optional): `true` to preview changes without releasing (default: `false`)
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -54,14 +54,17 @@ React on Rails RC. Follow the ordered dependency-promotion gate in the
    - "Last reviewed" date and, when applicable, "Next review due"
 4. Review the PR, verify the computed version, and merge
 
-If you forget this step, the release task will print a warning and the GitHub release will need to be created manually afterward using `sync_github_release`.
+If a stable target lacks this section, the release task aborts before confirmation, tagging, or publication.
+For a prerelease, the task warns and skips the GitHub release; after adding the section, create it with
+`sync_github_release`.
 
 #### Why changelog comes BEFORE the release
 
 - `rake release` automatically creates a GitHub release if a changelog section exists -- no separate `sync_github_release` step needed
-- The release task warns if no changelog section is found for the target version
+- The release task aborts a stable target if no matching non-empty section exists; prereleases warn and
+  skip GitHub release creation
 - A premature version header (if release fails) is harmless -- you'll release eventually
-- A missing changelog after release means the GitHub release must be created manually
+- A prerelease or historical release missing its changelog requires manual GitHub release synchronization
 
 ### 2. Run the Release Task
 
@@ -99,7 +102,8 @@ When called with no arguments, `rake release`:
 1. Reads the first versioned header from CHANGELOG.md (e.g., `### [16.5.0]`)
 2. Compares it to the current gem version
 3. If the changelog version is newer, prompts for confirmation and uses it
-4. If no new version is found from an already-stable checkout, falls back to a patch bump; from a
+4. If no new version is found from an already-stable checkout, derives a patch candidate; the stable
+   changelog gate still blocks release until that version has a matching non-empty section. From a
    prerelease checkout, aborts with exact retry and stable-promotion guidance
 
 Dry runs use a temporary git worktree so version bumps and installs do not modify your current checkout.
@@ -129,8 +133,8 @@ bundle exec rake "release[version,dry_run,override_version_policy,override_ci_st
    - Explicit: `16.2.0`
    - Pre-release: `16.2.0.beta.1` (rubygem format with dots, converted to `16.2.0-beta.1` for NPM)
    - Empty (auto): use a newer changelog prerelease on the same release line; from an already-stable
-     checkout, use a newer changelog version or fall back to a patch bump; otherwise abort with explicit
-     retry guidance
+     checkout, use a newer changelog version or derive a patch candidate that the stable changelog gate
+     blocks until a matching non-empty section exists; otherwise abort with explicit retry guidance
 
 2. **`dry_run`** (optional): `true` to preview changes without releasing (default: `false`)
 
@@ -164,7 +168,7 @@ it is the candidate whose full suite must qualify the release.
 **Examples:**
 
 ```bash
-bundle exec rake release                                  # Use CHANGELOG.md version or patch bump
+bundle exec rake release                                  # Auto-detect version; stable targets require changelog
 bundle exec rake "release[patch]"                         # Bump patch version (16.1.1 → 16.1.2)
 bundle exec rake "release[minor]"                         # Bump minor version (16.1.1 → 16.2.0)
 bundle exec rake "release[major]"                         # Bump major version (16.1.1 → 17.0.0)
@@ -182,7 +186,8 @@ The `rake release` task automatically:
 1. **Validates release prerequisites**:
    - Checks for uncommitted changes (will abort if found)
    - Verifies NPM authentication (will run `npm login` if needed)
-   - Warns if CHANGELOG.md section is missing for the target version
+   - Requires a non-empty matching CHANGELOG.md section for stable targets; prereleases without one emit a warning,
+     including during dry runs
    - Validates version policy (monotonic + changelog/bump consistency)
 2. **Pulls latest changes** from the repository
 3. **Bumps version numbers** in:
@@ -264,7 +269,8 @@ The task automatically converts Ruby gem format to npm semver format:
 
 1. When prompted for **npm OTP**, enter your 2FA code from your authenticator app
 2. When prompted for **RubyGems OTP**, enter your 2FA code
-3. If using `rake release` with no version, confirm the version detected from CHANGELOG.md (or the computed patch version)
+3. If using `rake release` with no version, confirm the version detected from CHANGELOG.md. A stable checkout
+   may derive a patch candidate, but publication remains blocked until that version has a matching non-empty section.
 4. The script will automatically commit and push version bumps
 5. The script will automatically create a GitHub release (if CHANGELOG.md section exists)
 
@@ -277,7 +283,9 @@ The task automatically converts Ruby gem format to npm semver format:
 
 2. If the changelog was updated before release (recommended), verify the GitHub release was auto-created with the correct notes.
 
-3. If the changelog was NOT updated before release, update it now:
+3. For a prerelease or historical release that predates the stable changelog gate, if the changelog was NOT
+   updated before release, update it now. Current stable releases cannot reach this state because they abort
+   before publication:
 
    **Option A - Use Claude Code (recommended):**
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2251,7 +2251,7 @@ def extract_latest_changelog_version(monorepo_root:)
   nil
 end
 
-def confirm_release!(version:, monorepo_root:)
+def confirm_release!(version:, monorepo_root:, dry_run: false)
   changelog_path = File.join(monorepo_root, "CHANGELOG.md")
   has_changelog = extract_changelog_section(changelog_path:, version:)
 
@@ -2264,6 +2264,8 @@ def confirm_release!(version:, monorepo_root:)
         bundle exec rake "release[#{version}]"
     ERROR
   end
+
+  return if dry_run
 
   puts ""
   puts "################################################################################"
@@ -3100,7 +3102,7 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       )
     end
 
-    confirm_release!(version: resolved_target_gem_version, monorepo_root: release_root) unless is_dry_run
+    confirm_release!(version: resolved_target_gem_version, monorepo_root: release_root, dry_run: is_dry_run)
 
     # Having generated examples in-tree can interfere with publishing.
     sh_in_dir_for_release(release_root, "rm -rf gen-examples/examples")

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2251,6 +2251,13 @@ def extract_latest_changelog_version(monorepo_root:)
   nil
 end
 
+def report_release_dry_run_changelog(version:, has_changelog:)
+  return if has_changelog
+
+  puts "⚠️ Prerelease dry run for #{version}: no matching non-empty CHANGELOG.md section; " \
+       "no GitHub release would be created."
+end
+
 def confirm_release!(version:, monorepo_root:, dry_run: false)
   changelog_path = File.join(monorepo_root, "CHANGELOG.md")
   has_changelog = extract_changelog_section(changelog_path:, version:)
@@ -2265,7 +2272,7 @@ def confirm_release!(version:, monorepo_root:, dry_run: false)
     ERROR
   end
 
-  return if dry_run
+  return report_release_dry_run_changelog(version:, has_changelog:) if dry_run
 
   puts ""
   puts "################################################################################"
@@ -2905,7 +2912,9 @@ This will update and release:
   - patch/minor/major
   - explicit version like 16.2.0
   - explicit prerelease like 16.2.0.rc.1
-  - empty (auto): use latest CHANGELOG.md version if newer; refuse an equal prerelease; otherwise patch bump
+  - empty (auto): from a prerelease checkout, use only a newer same-line prerelease from CHANGELOG.md;
+    otherwise abort with explicit retry guidance. From a stable checkout, use a newer CHANGELOG.md version
+    or derive a patch candidate; the stable changelog gate still requires a matching non-empty section.
 2nd argument: Dry run (true/false, default: false)
 3rd argument: Override version policy checks (true/false, default: false)
 4th argument: Override release CI gates (true/false, default: false)
@@ -2939,7 +2948,7 @@ Environment variables:
   GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
 
 Examples:
-  rake release                                  # Use CHANGELOG.md version or patch bump
+  rake release                                  # Auto-detect version; stable targets require changelog
   rake release[patch]                           # Bump patch version (16.1.1 → 16.1.2)
   rake release[minor]                           # Bump minor version (16.1.1 → 16.2.0)
   rake release[major]                           # Bump major version (16.1.1 → 17.0.0)

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -534,6 +534,13 @@ def run_release_preflight_checks!(monorepo_root:, dry_run:)
   verify_gh_auth(monorepo_root:)
 end
 
+def resolve_release_version_before_auth!(version_input:, monorepo_root:, dry_run:, current_version: nil)
+  resolved_version_input = resolve_version_input(version_input, monorepo_root, current_version:)
+  validate_requested_version_input!(resolved_version_input)
+  run_release_preflight_checks!(monorepo_root:, dry_run:)
+  resolved_version_input
+end
+
 def current_gem_version(monorepo_root)
   version_file = File.join(monorepo_root, "react_on_rails", "lib", "react_on_rails", "version.rb")
   content = File.read(version_file)
@@ -2248,6 +2255,16 @@ def confirm_release!(version:, monorepo_root:)
   changelog_path = File.join(monorepo_root, "CHANGELOG.md")
   has_changelog = extract_changelog_section(changelog_path:, version:)
 
+  if !has_changelog && !release_prerelease_version?(version)
+    abort <<~ERROR
+      ❌ Stable release #{version} requires a non-empty CHANGELOG.md section.
+
+      Refusing to continue before confirmation, tagging, or publication.
+      Stamp the changelog for #{version}, complete the final-release gates, and retry explicitly:
+        bundle exec rake "release[#{version}]"
+    ERROR
+  end
+
   puts ""
   puts "################################################################################"
   puts "RELEASE CONFIRMATION"
@@ -2388,12 +2405,52 @@ def version_tagged?(monorepo_root, version)
   tagged_versions.include?(version)
 end
 
-def resolve_version_input(version_input, monorepo_root)
+def argumentless_prerelease_release_requires_explicit_version?(changelog_version:, current_version:)
+  return false unless release_prerelease_version?(current_version)
+  return true unless changelog_version
+  return true unless release_prerelease_version?(changelog_version)
+  return true unless same_release_base?(changelog_version, current_version)
+
+  Gem::Version.new(changelog_version) <= Gem::Version.new(current_version)
+end
+
+def argumentless_prerelease_release_message(changelog_version:, current_version:)
+  stable_version = release_base_version(current_version)
+
+  <<~ERROR
+    ❌ No explicit release version was supplied.
+
+    Current version: #{current_version}
+    Latest changelog version: #{changelog_version || 'none'}
+
+    Refusing to infer stable #{stable_version} from an argument-less prerelease retry.
+
+    To resume #{current_version} publication, run:
+      bundle exec rake "release[#{current_version}]"
+
+    To prepare the final #{stable_version} release, add a non-empty CHANGELOG.md section for #{stable_version},
+    complete the final-release gates, then run:
+      bundle exec rake "release[#{stable_version}]"
+  ERROR
+end
+
+def untagged_changelog_current_version?(monorepo_root:, changelog_version:, current_version:)
+  return false unless changelog_version
+  return false unless Gem::Version.new(changelog_version) == Gem::Version.new(current_version)
+
+  !version_tagged?(monorepo_root, changelog_version)
+end
+
+def resolve_version_input(version_input, monorepo_root, current_version: nil)
   stripped = version_input.to_s.strip
   return stripped unless stripped.empty?
 
   changelog_version = extract_latest_changelog_version(monorepo_root:)
-  current_version = current_gem_version(monorepo_root)
+  current_version ||= current_gem_version(monorepo_root)
+
+  if argumentless_prerelease_release_requires_explicit_version?(changelog_version:, current_version:)
+    abort argumentless_prerelease_release_message(changelog_version:, current_version:)
+  end
 
   if changelog_version && Gem::Version.new(changelog_version) > Gem::Version.new(current_version)
     puts "Found CHANGELOG.md version: #{changelog_version} (current: #{current_version})"
@@ -2403,9 +2460,7 @@ def resolve_version_input(version_input, monorepo_root)
   # If the latest changelog version matches the current version but hasn't been
   # tagged yet, use it. This handles the case where the changelog was updated
   # and the version bumped in a prior step (e.g., RC → stable promotion).
-  if changelog_version &&
-     Gem::Version.new(changelog_version) == Gem::Version.new(current_version) &&
-     !version_tagged?(monorepo_root, changelog_version)
+  if untagged_changelog_current_version?(monorepo_root:, changelog_version:, current_version:)
     puts "Found untagged CHANGELOG.md version: #{changelog_version} (current: #{current_version})"
     return changelog_version
   end
@@ -2831,6 +2886,10 @@ skip git branch checks, allowing releases from non-main branches. A stable relea
 `main` (standard) or from a matching `release/X.Y.Z` branch (release-train RC -> final promotion,
 see internal/contributor-info/release-train-runbook.md).
 
+Retry safety: Never drop the version argument when resuming an interrupted release. Always retry
+the exact version, for example `bundle exec rake \"release[16.2.0.rc.1]\"`. An argument-less command
+from a prerelease checkout fails closed instead of inferring promotion to the stable version.
+
 This will update and release:
   PUBLIC (npmjs.org + rubygems.org):
     - react-on-rails NPM package
@@ -2844,7 +2903,7 @@ This will update and release:
   - patch/minor/major
   - explicit version like 16.2.0
   - explicit prerelease like 16.2.0.rc.1
-  - empty (auto): use latest CHANGELOG.md version if newer, else patch bump
+  - empty (auto): use latest CHANGELOG.md version if newer; refuse an equal prerelease; otherwise patch bump
 2nd argument: Dry run (true/false, default: false)
 3rd argument: Override version policy checks (true/false, default: false)
 4th argument: Override release CI gates (true/false, default: false)
@@ -2911,17 +2970,23 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   # Configure output verbosity
   verbose(is_verbose)
 
-  run_release_preflight_checks!(monorepo_root:, dry_run: is_dry_run)
-
   released_gem_version = nil
   released_npm_version = nil
+  argumentless_starting_prerelease_version = if args_hash.fetch(:version, "").to_s.strip.empty?
+                                               starting_version = current_gem_version(monorepo_root)
+                                               starting_version if release_prerelease_version?(starting_version)
+                                             end
 
   with_release_checkout(monorepo_root:, dry_run: is_dry_run) do |release_root|
     release_paths_hash = release_paths(release_root)
     sh_in_dir_for_release(release_root, "git pull --rebase") unless is_dry_run
 
-    version_input = resolve_version_input(args_hash.fetch(:version, ""), release_root)
-    validate_requested_version_input!(version_input)
+    version_input = resolve_release_version_before_auth!(
+      version_input: args_hash.fetch(:version, ""),
+      monorepo_root: release_root,
+      dry_run: is_dry_run,
+      current_version: argumentless_starting_prerelease_version
+    )
 
     current_checkout_version = current_gem_version(release_root)
     resolved_target_gem_version = compute_target_gem_version(

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -260,6 +260,28 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /Stable release 17\.0\.0 requires a non-empty CHANGELOG\.md section/)
     end
 
+    it "refuses a stable dry run with no changelog content before reporting success" do
+      allow(self).to receive(:extract_changelog_section)
+        .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "17.0.0")
+        .and_return(nil)
+      expect($stdin).not_to receive(:gets)
+
+      expect do
+        confirm_release!(version: "17.0.0", monorepo_root: "/tmp/repo", dry_run: true)
+      end.to raise_error(SystemExit, /Stable release 17\.0\.0 requires a non-empty CHANGELOG\.md section/)
+    end
+
+    it "does not prompt during a prerelease dry run" do
+      allow(self).to receive(:extract_changelog_section)
+        .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "17.0.0.rc.10")
+        .and_return(nil)
+      expect($stdin).not_to receive(:gets)
+
+      expect do
+        confirm_release!(version: "17.0.0.rc.10", monorepo_root: "/tmp/repo", dry_run: true)
+      end.not_to raise_error
+    end
+
     it "allows confirmation when the stable release has non-empty changelog content" do
       allow(self).to receive(:extract_changelog_section)
         .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "17.0.0")

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -248,6 +248,30 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#confirm_release!" do
+    it "refuses a stable release with no changelog content before prompting even when input would confirm" do
+      allow(self).to receive(:extract_changelog_section)
+        .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "17.0.0")
+        .and_return(nil)
+      expect($stdin).not_to receive(:gets)
+
+      expect do
+        confirm_release!(version: "17.0.0", monorepo_root: "/tmp/repo")
+      end.to raise_error(SystemExit, /Stable release 17\.0\.0 requires a non-empty CHANGELOG\.md section/)
+    end
+
+    it "allows confirmation when the stable release has non-empty changelog content" do
+      allow(self).to receive(:extract_changelog_section)
+        .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "17.0.0")
+        .and_return("#### Breaking Changes\n\n- Final release notes")
+      allow($stdin).to receive(:gets).and_return("y\n")
+
+      expect do
+        confirm_release!(version: "17.0.0", monorepo_root: "/tmp/repo")
+      end.to output(/Changelog: ✓ section found.*Proceed with release\?/m).to_stdout
+    end
+  end
+
   describe "#run_release_preflight_checks!" do
     it "checks both npm and GitHub auth before a real release" do
       expect(self).to receive(:verify_npm_auth)
@@ -264,12 +288,126 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#resolve_release_version_before_auth!" do
+    it "aborts an argument-less prerelease retry before external authentication checks" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.10")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+      expect(self).not_to receive(:run_release_preflight_checks!)
+
+      expect do
+        resolve_release_version_before_auth!(version_input: "", monorepo_root: "/tmp/repo", dry_run: false)
+      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+    end
+
+    it "uses the pre-pull prerelease version when a pull advances the checkout to stable" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0")
+      expect(self).not_to receive(:current_gem_version)
+      expect(self).not_to receive(:run_release_preflight_checks!)
+
+      expect do
+        resolve_release_version_before_auth!(
+          version_input: "",
+          monorepo_root: "/tmp/repo",
+          dry_run: false,
+          current_version: "17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+    end
+  end
+
   describe "#resolve_version_input" do
+    it "preserves an explicit prerelease version without inferring from repository state" do
+      expect(self).not_to receive(:extract_latest_changelog_version)
+      expect(self).not_to receive(:current_gem_version)
+      expect(self).not_to receive(:version_tagged?)
+
+      expect(resolve_version_input("17.0.0.rc.10", "/tmp/repo")).to eq("17.0.0.rc.10")
+    end
+
     it "uses the latest changelog version when it is newer than the current gem version" do
       allow(self).to receive(:extract_latest_changelog_version).with(monorepo_root: "/tmp/repo").and_return("16.4.0")
       allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("16.3.0")
 
       expect(resolve_version_input("", "/tmp/repo")).to eq("16.4.0")
+    end
+
+    it "refuses an argument-less prerelease retry before tag lookup instead of inferring stable promotion" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.10")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+      expect(self).not_to receive(:version_tagged?)
+
+      expect do
+        resolve_version_input("", "/tmp/repo")
+      end.to raise_error(
+        SystemExit,
+        /Refusing to infer stable 17\.0\.0.*bundle exec rake "release\[17\.0\.0\.rc\.10\]"/m
+      )
+    end
+
+    it "refuses argument-less stable promotion from a prerelease checkout" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+      expect(self).not_to receive(:version_tagged?)
+
+      expect do
+        resolve_version_input("", "/tmp/repo")
+      end.to raise_error(
+        SystemExit,
+        /Refusing to infer stable 17\.0\.0.*bundle exec rake "release\[17\.0\.0\]"/m
+      )
+    end
+
+    it "refuses an argument-less prerelease retry when the changelog has no version" do
+      allow(self).to receive(:extract_latest_changelog_version).with(monorepo_root: "/tmp/repo").and_return(nil)
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+      expect(self).not_to receive(:version_tagged?)
+
+      expect do
+        resolve_version_input("", "/tmp/repo")
+      end.to raise_error(
+        SystemExit,
+        /bundle exec rake "release\[17\.0\.0\.rc\.10\]".*non-empty CHANGELOG\.md section for 17\.0\.0/m
+      )
+    end
+
+    it "refuses an argument-less prerelease retry when the changelog prerelease is stale" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.9")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+      expect(self).not_to receive(:version_tagged?)
+
+      expect do
+        resolve_version_input("", "/tmp/repo")
+      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+    end
+
+    it "derives stable-promotion guidance from the current prerelease when the changelog is stale" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("16.6.0")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+
+      expect do
+        resolve_version_input("", "/tmp/repo")
+      end.to raise_error(SystemExit, /stable 17\.0\.0.*bundle exec rake "release\[17\.0\.0\]"/m)
+    end
+
+    it "allows an argument-less advance to a newer prerelease from the changelog" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.11")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+
+      expect(resolve_version_input("", "/tmp/repo")).to eq("17.0.0.rc.11")
     end
 
     it "uses the current version when changelog version matches and is untagged" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /Stable release 17\.0\.0 requires a non-empty CHANGELOG\.md section/)
     end
 
-    it "does not prompt during a prerelease dry run" do
+    it "warns without prompting during a prerelease dry run with no changelog content" do
       allow(self).to receive(:extract_changelog_section)
         .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "17.0.0.rc.10")
         .and_return(nil)
@@ -279,7 +279,7 @@ RSpec.describe "release.rake helper methods" do
 
       expect do
         confirm_release!(version: "17.0.0.rc.10", monorepo_root: "/tmp/repo", dry_run: true)
-      end.not_to raise_error
+      end.to output(/Prerelease dry run.*no matching non-empty CHANGELOG\.md section/).to_stdout
     end
 
     it "allows confirmation when the stable release has non-empty changelog content" do
@@ -454,6 +454,21 @@ RSpec.describe "release.rake helper methods" do
       expect(self).not_to receive(:version_tagged?)
 
       expect(resolve_version_input("", "/tmp/repo")).to eq("patch")
+    end
+
+    it "blocks an inferred stable patch candidate until matching changelog evidence exists" do
+      allow(self).to receive(:extract_latest_changelog_version).with(monorepo_root: "/tmp/repo").and_return("16.2.9")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("16.3.0")
+      allow(self).to receive(:extract_changelog_section)
+        .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "16.3.1")
+        .and_return(nil)
+
+      version_input = resolve_version_input("", "/tmp/repo")
+      target_version = compute_target_gem_version(current_gem_version: "16.3.0", version_input:)
+
+      expect do
+        confirm_release!(version: target_version, monorepo_root: "/tmp/repo", dry_run: true)
+      end.to raise_error(SystemExit, /Stable release 16\.3\.1 requires a non-empty CHANGELOG\.md section/)
     end
   end
 


### PR DESCRIPTION
## Summary

Argument-less release retries now fail closed when the command starts from a prerelease checkout and the changelog is missing, stale, stable, on another release line, or still points at the same prerelease. The release task preserves the starting prerelease version across its pull, so an interrupted remote stable-version bump cannot erase that ambiguity before the safety check runs.

The abort happens before npm/GitHub authentication checks, release-tag lookup, or registry lookup and prints the exact explicit prerelease retry command. Stable releases and stable dry runs also require a non-empty matching changelog section before operator confirmation, tagging, or publication. A clearly newer prerelease on the same release line remains available. An already-stable argument-less checkout may still derive a patch candidate, but the stable changelog gate blocks publication until that candidate has matching non-empty evidence.

Prerelease dry runs now report missing changelog evidence without prompting. The release guide and task help distinguish stable aborts from prerelease warnings and scope post-release changelog repair to prereleases or historical releases.

## Decision log

- Preserve the version observed before `git pull --rebase` only when the invocation is argument-less and starts from a prerelease; stable checkouts continue resolving against the post-pull version.
- Permit argument-less automation only for a clearly newer prerelease on the same base version.
- Require explicit stable promotion plus a non-empty matching changelog section; release-gate overrides do not bypass this prerequisite.
- Keep explicit prerelease retries on their existing tag-at-HEAD and idempotent registry-publication paths.

## Validation

Validated at exact head `efe09eb6c71717b79217e1634455eb2c7f943a19`:

- `bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb` — 252 examples, 0 failures.
- `.agents/bin/validate --fast` — docs sidebar, full OSS and benchmark RuboCop, package build, ESLint, Prettier, and TypeScript passed; its long gem run had reached 847 examples with 0 failures when it was stopped because `main` advanced and invalidated that head.
- After rebasing onto current `origin/main`, the focused release suite, targeted RuboCop, docs sidebar, and diff checks passed again.
- Isolated configuration regression check on both untouched `origin/main` and the branch — 52 examples, 0 failures on each.
- Focused documentation sidebar/link checks and `git diff --check` — passed.
- Independent final-head GPT-5.6 Sol/xhigh review — no findings. Earlier findings about pull-time version advancement, dry-run gating, composed stable fallback behavior, and stale operator guidance were verified and fixed before this clean pass; one claimed clean-worktree ordering regression was rejected after direct code verification showed the guard still runs before pull.

## Release and workflow notes

- Release tracker mode: development; target phase: beta.
- Confidence: high, based on fail-closed regressions, full helper-path coverage, clean independent review, and current-head local validation.
- Churn: the operator documentation was based on current `main` after #4650 merged; no overlapping editor paths remain.
- GitHub Actions: no semantic workflow or action changes, so no post-merge exercise issue is required.
- Changelog: `not_user_visible`; this changes maintainer release tooling and its contributor documentation, so no product changelog entry is added.

## Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] ~Update CHANGELOG file~ — not user-visible release tooling

Fixes #4646.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol_%28xhigh%29-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Safety**
  * Safer `rake release` version resolution for interrupted prerelease retries, preventing unsafe stable promotion when no explicit version is provided.
  * Stable releases now require a matching, non-empty `CHANGELOG.md` section before confirmation/tagging/publishing (including in dry-run).
  * Refined “auto” version behavior to correctly handle newer/stale changelog entries for prereleases vs stable.
* **Documentation**
  * Updated retry-safety guidance and clarified how argument-less `rake release` behaves.
* **Tests**
  * Added/expanded coverage for changelog gating, dry-run prompting behavior, and revised version inference/retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->