### PR TITLE
CI: run Pro compatibility smokes in hosted tests

### DIFF
--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -393,6 +393,9 @@ jobs:
         run: pnpm run build
 
       - name: Run JS unit tests for Pro package
+        run: pnpm --filter react-on-rails-pro test
+
+      - name: Run JS unit tests for Pro Node Renderer package
         run: pnpm --filter react-on-rails-pro-node-renderer run ci
 
         env:

--- a/react_on_rails/spec/react_on_rails/hosted_ci_workflow_spec.rb
+++ b/react_on_rails/spec/react_on_rails/hosted_ci_workflow_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "json"
+require "yaml"
+require_relative "spec_helper"
+
+RSpec.describe "Pro hosted CI workflow" do
+  let(:repo_root) { File.expand_path("../../..", __dir__) }
+  let(:workflow) do
+    YAML.safe_load_file(
+      File.join(repo_root, ".github/workflows/pro-test-package-and-gem.yml"),
+      aliases: true
+    )
+  end
+  let(:pro_package) do
+    JSON.parse(File.read(File.join(repo_root, "packages/react-on-rails-pro/package.json")))
+  end
+
+  it "runs the packaged React compatibility smoke on the selected Pro hosted path" do
+    package_test_job = workflow.fetch("jobs").fetch("package-js-tests")
+    commands = package_test_job.fetch("steps").filter_map { |step| step["run"] }
+
+    expect(package_test_job.fetch("if")).to include("run_pro_tests == 'true'")
+    expect(commands).to include("pnpm --filter react-on-rails-pro test")
+    expect(pro_package.dig("scripts", "test")).to include("pnpm run test:packed-react-compatibility")
+    expect(commands).to include("pnpm --filter react-on-rails-pro-node-renderer run ci")
+  end
+end


### PR DESCRIPTION
## Summary

Relevant Pro package changes selected hosted Pro tests, but that workflow only executed the Node renderer test command. The packed React 16/17 compatibility smoke added in #4652 could therefore be skipped while the hosted run still appeared green.

The selected Pro package job now runs the full `react-on-rails-pro` test command, which includes the isolated packed React 16.14 and 17.0 webpack/SSR smokes, while preserving the dedicated Node renderer test step. A workflow contract spec ties the selected `run_pro_tests` route to both commands so this gap cannot silently recur.

Fixes #4644.

Related: #4652

## Validation

- TDD replay: `bundle exec rspec spec/react_on_rails/hosted_ci_workflow_spec.rb` failed before the workflow edit because the selected job lacked `pnpm --filter react-on-rails-pro test`; it now passes with 1 example and 0 failures.
- `actionlint .github/workflows/pro-test-package-and-gem.yml` — passed.
- `script/ci-changes-detector-test.bash` — passed all 77 detector cases; Pro changes select `run_pro_tests=true` and `run_js_tests=false`.
- `pnpm --filter react-on-rails-pro test` — passed 620 package tests plus packed React 16.14.0 and 17.0.2 install, webpack, and SSR runtime smokes.
- `pnpm --filter react-on-rails-pro-node-renderer run ci` — passed; the existing Node renderer path remains covered.
- `pnpm run lint`, `pnpm start format.listDifferent`, and `pnpm run nps check-typescript` — passed.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` — passed.
- `git diff --check origin/main...HEAD` and the pre-push branch lint hook — passed.
- `yamllint .github/` remains red on the repository's existing document-start and 80-column baseline; before/after comparison found no new finding from this diff.
- `.agents/bin/validate --changed` passed dependency setup, docs, lint, formatting, TypeScript, builds, Pro dummy bundles, all Pro package/packed compatibility tests, and Pro Node renderer tests. Its later broad OSS generator phase was stopped after unrelated existing `npm ERESOLVE` retries for `react-on-rails-rsc@19.2.1-rc.0` versus Pro's `^19.0.5` optional peer plus environment/config failures; focused changed-surface gates above are complete.

## Workflow and rollout evidence

- **Classification:** semantic CI-routing change in `.github/workflows/pro-test-package-and-gem.yml`; a post-merge exercise issue is required before merge.
- **Labels:** `ready-for-hosted-ci`, `force-full-hosted-ci`. Force-full is appropriate because the behavior being repaired is the hosted selector-to-Pro-job route itself; the final-head workflow log must explicitly show both packed React versions.
- **Mechanism target:** `checklist+replay`.
- **Motivating miss:** the post-merge audit of #4652 found that green hosted CI never invoked the new Pro compatibility smoke.
- **Replay evidence:** the new contract spec reproduced the missing command before the fix and passes after it. A sweep of 17 open PRs found four touching the newly enforced Pro surface: #4631, #4599, #4579, and #4575; all are behind current `main`. The stale-base race control is to require those affected heads to update to current `main` and rerun current hosted Pro CI before merge.
- **Non-goal:** no CI selector rewrite, trigger/permission change, runtime behavior change, or expansion of the React compatibility matrix.
- **Lockfiles/Dependabot:** not applicable; no dependency or lockfile changed.
- **Flagship demo:** not applicable; no product default, package pin, generator output, or recommended Pro/RSC path changed.
- **Changelog:** not user-visible; this corrects regression evidence routing without changing released behavior or support claims.

## Review receipt and churn

- App-bundled Codex `0.144.2` reviewed committed branch `origin/main...d5c4fcd0d` from immutable base `c74239fab`; result: clean, with no accepted or rejected findings.
- Included lenses: CI correctness, security/secret exposure, compatibility coverage, regression-test reachability, and release-process routing. Included paths are the workflow and its contract spec; no branch-diff paths were excluded.
- The Homebrew reviewer was unavailable because it was too old for the configured model; the app-bundled reviewer completed successfully. The additional Claude review and `/simplify` pass were unavailable because the local Claude CLI is not authenticated (`Not logged in`); no substitute engine weakened the primary clean review.
- Pre-push review churn: one focused corrective commit; no post-push fix rounds yet.

## Merge qualification

- Release gate: `main` beta phase with [release tracker #3823](https://github.com/shakacode/react_on_rails/issues/3823) in `development` mode; standard merge qualification applies.
- Merge authority: `auto_merge_when_gates_pass` from the active maintainer batch.
- Current head: `d5c4fcd0da526e924f54061d383627edc8c918d8`.
- Required gate: [attempt 2 passed](https://github.com/shakacode/react_on_rails/actions/runs/29305769038/job/87006566722) on the exact head.
- Force-full hosted CI: all 9 dispatched workflows completed successfully on the exact head, including the [gem/generator matrix](https://github.com/shakacode/react_on_rails/actions/runs/29307631477) and the [Pro package workflow](https://github.com/shakacode/react_on_rails/actions/runs/29307631512).
- Hosted compatibility evidence: the [Pro package job](https://github.com/shakacode/react_on_rails/actions/runs/29307631512/job/87004504031) ran the full Pro command, logged successful packed React 16.14.0 and 17.0.2 install/build/SSR smokes, and preserved the Node renderer suite.
- Independent QA: [qa-evidence v1](https://github.com/shakacode/react_on_rails/pull/4656#issuecomment-4965639607) is satisfied with no release-blocking findings.
- Reviews: Claude, Greptile, and CodeRabbit produced current-head artifacts; [triage](https://github.com/shakacode/react_on_rails/pull/4656#issuecomment-4965663441) found no `MUST-FIX` or `DISCUSS` items and zero unresolved threads.
- Strict merge ledger: generated at `2026-07-14T05:48:16Z` with `complete_allowed: true`, no violations, and no unknown fields.
- Base movement: `main` advanced only through unrelated #4654 release-rake/docs/spec files; there is no overlap with this PR's workflow and contract-spec paths.

Confidence note:

- Validated: TDD contract replay, actionlint, the full detector harness, full Pro package and Node renderer tests, packed React 16/17 runtime smokes, lint/format/type checks, OSS RuboCop, diff checks, independent QA, three configured review systems, the required PR gate, and all nine force-full hosted workflows.
- Evidence: the exact-head hosted runs, QA record, review-triage record, and strict merge-ledger result are linked or identified above.
- UNKNOWN: none.
- Residual risk: the broad local aggregate validator's unrelated generator phase did not finish locally, but the exact-head hosted gem/generator matrix completed successfully; no remaining merge-safety risk is identified.
- Decision points: 0.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that the Pro hosted CI workflow runs the expected JavaScript, React compatibility, and Node Renderer checks.
  * Confirmed the workflow is correctly gated and references the required packaged compatibility test command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

