### PR TITLE
Release: require strict HEAD evidence before retry guidance

### DIFF
--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -156,14 +156,45 @@ VERBOSE=1                    # Enable verbose logging (shows all output)
 NPM_OTP=<code>               # Provide NPM one-time password (reused for all NPM publishes)
 RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for both gems)
 RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
-RELEASE_CI_EVALUATE_HEAD=true # Evaluate the current release-source HEAD instead of walking back metadata-only commits
+RELEASE_CI_EVALUATE_HEAD=true # Strictly evaluate the fetched exact release-source HEAD; not a waiver
+RELEASE_CI_STATUS_OVERRIDE=true # DANGEROUS last-resort waiver for the release CI-status gate
 GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
 ```
 
-`RELEASE_CI_EVALUATE_HEAD=true` is a strict diagnostic, not a waiver. Use it when the current HEAD
-itself is expected to have CI evidence and must be evaluated verbatim. It is usually not appropriate
-when HEAD contains only changelog/version/release-gate metadata and the runtime-bearing commit behind
-it is the candidate whose full suite must qualify the release.
+#### Release CI evidence and strict HEAD evaluation
+
+For this gate, **HEAD** means the fetched exact tip of the release-source branch that would be
+tagged and published: `origin/main` for a mainline release or `origin/release/X.Y.Z` for a
+release-branch cut/promotion. It never means an unpushed local checkout tip.
+
+Normally, the gate walks back metadata-only commits (for example, a changelog/version commit) to
+the newest runtime-bearing commit. This is intentional: CI path filtering can attach no meaningful
+runtime suite to metadata-only commits, while the runtime-bearing commit is the one whose full
+suite establishes release health.
+
+`RELEASE_CI_EVALUATE_HEAD=true` disables only that walkback. It still queries and enforces the
+same CI gate at the exact fetched HEAD; it is a strict evaluation, not a waiver. It is appropriate
+only for the narrow topology where GitHub attached complete workflows to the final release tip,
+while the intermediate runtime SHA selected by normal walkback has zero usable runs.
+
+| Normal walkback / exact HEAD evidence                                                                                      | Required action                                                                                            |
+| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Walked-back SHA has usable CI evidence                                                                                     | Let the normal gate decide. Do not set either variable.                                                    |
+| Walked-back SHA has no usable runs; exact HEAD is pending                                                                  | Wait for the linked exact-HEAD checks. They remain blocking.                                               |
+| Walked-back SHA has no usable runs; exact HEAD has failed checks                                                           | Fix or otherwise resolve the failures. They remain blocking.                                               |
+| Walked-back SHA has no usable runs; exact HEAD is completely healthy under the same stable/prerelease required-check rules | Re-run with `RELEASE_CI_EVALUATE_HEAD=true`; it evaluates that exact HEAD and still blocks on any failure. |
+| Walked-back SHA has no usable runs; exact HEAD has no checks, unknown status, or an API failure                            | Fail closed. Wait for evidence or repair API/auth access; do not use strict HEAD without evidence.         |
+| Any case where a maintainer-approved waiver is truly required                                                              | `RELEASE_CI_STATUS_OVERRIDE=true` is the dangerous last resort, not a recovery default.                    |
+
+Examples:
+
+```bash
+# Only after the task reports complete healthy exact-HEAD evidence, retry the explicit target version:
+RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release[17.0.0.rc.10]"
+```
+
+Do not use `RELEASE_CI_STATUS_OVERRIDE=true` to substitute for pending, missing, failed, or
+unknown exact-HEAD evidence. It waives the release CI-status gate and does not make CI healthy.
 
 **Examples:**
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1949,25 +1949,34 @@ def gh_included_response_status(header_block, newline:)
   status_match[1].to_i
 end
 
-def known_unprotected_branch?(repo_slug:, branch_name:, encoded_branch:, required_status_checks_path:)
+def known_branch_without_required_checks?(repo_slug:, branch_name:, encoded_branch:, required_status_checks_path:)
   included_output, _included_error, included_status = capture_gh_stdout_and_stderr(
     "api", "--include", required_status_checks_path
   )
   return false if included_status.success?
-  return false unless branch_not_protected_response?(included_output)
+
+  expected_protected = required_status_checks_protection_state(included_output)
+  return false if expected_protected.nil?
 
   branch_output, branch_status = capture_gh_output("api", "repos/#{repo_slug}/branches/#{encoded_branch}")
   return false unless branch_status.success?
 
   branch = JSON.parse(branch_output)
-  branch.is_a?(Hash) && branch["name"] == branch_name && branch["protected"] == false
+  branch.is_a?(Hash) && branch["name"] == branch_name && branch["protected"] == expected_protected
 rescue JSON::ParserError
   false
 end
 
-def branch_not_protected_response?(output)
+def required_status_checks_protection_state(output)
   response = gh_included_json_response(output)
-  response&.dig(:status) == 404 && response.dig(:body, "message") == "Branch not protected"
+  return unless response&.dig(:status) == 404
+
+  case response.dig(:body, "message")
+  when "Branch not protected"
+    false
+  when "Required status checks not enabled"
+    true
+  end
 end
 
 def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "main")
@@ -1985,7 +1994,7 @@ def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "
   output, status = capture_gh_output("api", "--jq", jq_query, api_path)
   # Only a successful, structurally valid empty configuration means no required
   # checks. API errors and malformed payloads leave required gates unknown.
-  return nil if !status.success? && known_unprotected_branch?(
+  return nil if !status.success? && known_branch_without_required_checks?(
     repo_slug:,
     branch_name: ci_branch.to_s,
     encoded_branch:,

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1336,6 +1336,31 @@ CI_INCOMPLETE_STATUSES = %w[in_progress queued waiting requested pending].freeze
 # Conclusions considered acceptable. `skipped`/`neutral` are not failures (e.g. docs-only
 # paths-ignore skips, or workflows that intentionally short-circuit).
 CI_PASSING_CONCLUSIONS = %w[success skipped neutral].freeze
+CI_CHECK_RUN_STATUSES = (CI_INCOMPLETE_STATUSES + ["completed"]).freeze
+CI_COMPLETED_CONCLUSIONS = %w[
+  action_required cancelled failure neutral skipped stale success timed_out
+].freeze
+CI_LEGACY_STATUS_STATES = %w[error failure pending success].freeze
+CI_JSONL_FRAME_KEY = "_release_ci_jsonl_frame"
+CI_JSONL_ENVELOPE_FRAME = "envelope"
+CI_JSONL_ITEM_FRAME = "item"
+CI_CHECK_RUNS_JSONL_QUERY = [
+  'if type == "object" and (.check_runs | type == "array") then',
+  [
+    "[\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ENVELOPE_FRAME}\", \"check_runs\"], ",
+    "(.check_runs[] | [\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ITEM_FRAME}\", .])"
+  ].join,
+  'else error("expected check_runs array") end'
+].join(" ")
+CI_STATUSES_JSONL_QUERY = [
+  'if type == "array" then',
+  [
+    "[\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ENVELOPE_FRAME}\", \"statuses\"], ",
+    "(.[] | [\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ITEM_FRAME}\", .])"
+  ].join,
+  'else error("expected statuses array") end'
+].join(" ")
+REQUIRED_CHECK_DISCOVERY_UNKNOWN = Object.new.freeze
 
 # Upper bound on how many consecutive non-runtime-only commits the CI gate will
 # walk past when choosing which origin/main commit to evaluate. Bounds the git
@@ -1358,7 +1383,6 @@ def handle_release_branch_identity_violation!(message:, dry_run:)
   abort message
 end
 
-# rubocop:disable Metrics/MethodLength
 # Abort in strict mode when a release branch local HEAD differs from the remote.
 # In dry-run mode, warn and continue so the releaser still sees remote CI state.
 # The normal CI override must not bypass this: otherwise the release could tag a
@@ -1436,59 +1460,145 @@ def fetch_main_ci_checks(monorepo_root:, allow_override: false, dry_run: false, 
   sha = main_ci_evaluation_sha(monorepo_root:, head_sha: remote_sha, ref: "origin/#{ci_branch}")
 
   repo_slug = github_repo_slug(monorepo_root)
-  api_path = "repos/#{repo_slug}/commits/#{sha}/check-runs"
-
-  # `--paginate --jq '.check_runs[]'` flattens paginated responses into JSONL.
-  # Each non-empty line is one check_run object. We invoke `gh` directly here
-  # (rather than via `capture_gh_output`) so that a missing binary routes
-  # through `handle_main_ci_status_violation!` — same as a git fetch failure —
-  # instead of aborting unconditionally. This keeps `dry_run` / `allow_override`
-  # symmetric across every fetch step.
-  begin
-    output, status = Open3.capture2e(
-      "gh", "api", "--paginate", "--jq", ".check_runs[]", api_path
-    )
-  rescue Errno::ENOENT
-    # validate_main_ci_status! normally checks `gh` first, but keep this helper
-    # defensive for direct calls and focused tests.
-    handle_main_ci_status_violation!(
-      message: "❌ GitHub CLI (`gh`) is not installed. Install it from https://cli.github.com/ and retry.",
-      allow_override:,
-      dry_run:
-    )
-    # Only reached in override/dry-run mode; strict mode aborts above.
+  result = fetch_ci_check_runs_for_sha(repo_slug:, sha:)
+  if result[:error]
+    handle_main_ci_status_violation!(message: result[:error], allow_override:, dry_run:)
     return nil
   end
 
-  unless status.success?
-    handle_main_ci_status_violation!(
-      message: "❌ Unable to query GitHub Checks API for #{sha}.\n\n#{output}",
-      allow_override:,
-      dry_run:
-    )
-    # Only reached in override/dry-run mode; strict mode aborts above.
-    return nil
-  end
-
-  begin
-    check_runs = parse_gh_jsonl(output)
-  rescue JSON::ParserError => e
-    handle_main_ci_status_violation!(
-      message: "❌ Failed to parse check_runs response from gh: #{e.message}\n\nOutput:\n#{output}",
-      allow_override:,
-      dry_run:
-    )
-    return nil
-  end
-
-  { sha:, repo_slug:, check_runs: }
+  { sha:, head_sha: remote_sha, repo_slug:, check_runs: result[:check_runs] }
 end
-# rubocop:enable Metrics/MethodLength
+
+def fetch_ci_check_runs_for_sha(repo_slug:, sha:)
+  api_path = "repos/#{repo_slug}/commits/#{sha}/check-runs"
+  result = fetch_github_jsonl(
+    api_path:, jq_query: CI_CHECK_RUNS_JSONL_QUERY, api_name: "Checks", response_name: "check_runs", sha:,
+    envelope_name: "check_runs", item_validator: method(:valid_ci_check_run?)
+  )
+  return result if result[:error]
+
+  { check_runs: result[:items] }
+end
+
+def fetch_ci_statuses_for_sha(repo_slug:, sha:)
+  api_path = "repos/#{repo_slug}/commits/#{sha}/statuses"
+  result = fetch_github_jsonl(
+    api_path:, jq_query: CI_STATUSES_JSONL_QUERY, api_name: "Statuses", response_name: "statuses", sha:,
+    envelope_name: "statuses", item_validator: method(:valid_ci_status?)
+  )
+  return result if result[:error]
+
+  { statuses: result[:items] }
+end
+
+# Query a GitHub API endpoint as JSONL without deciding whether a failure can be
+# overridden. The normal release gate and exact-HEAD recovery diagnostic apply
+# different policy to the same evidence, so callers receive fail-closed errors.
+def fetch_github_jsonl(api_path:, jq_query:, api_name:, response_name:, sha:, envelope_name:, item_validator:)
+  output, status = Open3.capture2e("gh", "api", "--paginate", "--jq", jq_query, api_path)
+  return { error: "❌ Unable to query GitHub #{api_name} API for #{sha}.\n\n#{output}" } unless status.success?
+
+  items = validated_github_jsonl_items(output:, envelope_name:, item_validator:)
+  return { error: "❌ Received malformed GitHub #{api_name} evidence for #{sha}; release remains blocked." } unless items
+
+  { items: }
+rescue Errno::ENOENT
+  { error: "❌ GitHub CLI (`gh`) is not installed. Install it from https://cli.github.com/ and retry." }
+rescue JSON::ParserError => e
+  { error: "❌ Failed to parse #{response_name} response from gh: #{e.message}\n\nOutput:\n#{output}" }
+end
+
+def validated_github_jsonl_items(output:, envelope_name:, item_validator:)
+  parsed_items = parse_gh_jsonl(output)
+  return unless valid_github_jsonl_frames?(parsed_items, envelope_name:)
+
+  items = github_jsonl_frame_items(parsed_items, envelope_name:)
+  return unless items.all?(&item_validator)
+
+  items
+end
+
+def valid_github_jsonl_frames?(parsed_items, envelope_name:)
+  return false unless parsed_items.any? { |item| github_jsonl_envelope_frame?(item, envelope_name:) }
+
+  parsed_items.all? do |item|
+    github_jsonl_envelope_frame?(item, envelope_name:) || github_jsonl_item_frame?(item)
+  end
+end
+
+def github_jsonl_frame_items(parsed_items, envelope_name:)
+  parsed_items.reject { |item| github_jsonl_envelope_frame?(item, envelope_name:) }
+              .map { |item| item[2] }
+end
+
+def github_jsonl_envelope_frame?(item, envelope_name:)
+  item == [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, envelope_name]
+end
+
+def github_jsonl_item_frame?(item)
+  item.is_a?(Array) && item.length == 3 && item[0] == CI_JSONL_FRAME_KEY && item[1] == CI_JSONL_ITEM_FRAME
+end
 
 def parse_gh_jsonl(output)
   output.lines.reject { |line| line.strip.empty? }.map do |line|
     JSON.parse(line)
   end
+end
+
+def valid_ci_check_run_app?(run)
+  return true unless run.key?("app")
+
+  app = run["app"]
+  return false unless app.is_a?(Hash) && app.key?("id")
+
+  app["id"].is_a?(Integer)
+end
+
+def valid_ci_check_run_suite?(run)
+  return true unless run.key?("check_suite")
+
+  suite = run["check_suite"]
+  suite.is_a?(Hash) && suite["id"].is_a?(Integer)
+end
+
+def valid_ci_check_run_identity?(run)
+  return false unless run.is_a?(Hash) && run["id"].is_a?(Integer)
+  return false unless run["name"].is_a?(String) && !run["name"].empty?
+
+  valid_ci_check_run_app?(run) && valid_ci_check_run_suite?(run)
+end
+
+def valid_ci_check_run_state?(run)
+  return false unless CI_CHECK_RUN_STATUSES.include?(run["status"])
+
+  if run["status"] == "completed"
+    CI_COMPLETED_CONCLUSIONS.include?(run["conclusion"])
+  else
+    run["conclusion"].nil?
+  end
+end
+
+def valid_ci_check_run?(run)
+  valid_ci_check_run_identity?(run) && valid_ci_check_run_state?(run)
+end
+
+def valid_ci_status?(status)
+  status.is_a?(Hash) && status["id"].is_a?(Integer) &&
+    status["context"].is_a?(String) && !status["context"].empty? &&
+    CI_LEGACY_STATUS_STATES.include?(status["state"]) && valid_ci_status_created_at?(status)
+end
+
+def valid_ci_status_created_at?(status)
+  !parsed_ci_status_created_at(status).nil?
+end
+
+def parsed_ci_status_created_at(status)
+  created_at = status["created_at"]
+  return unless created_at.is_a?(String) && !created_at.strip.empty?
+
+  Time.iso8601(created_at)
+rescue ArgumentError
+  nil
 end
 
 # Choose which remote ref commit the CI gate should evaluate. Starting at
@@ -1650,41 +1760,12 @@ def git_parent_sha(monorepo_root:, sha:)
 end
 
 def fetch_main_commit_statuses(repo_slug:, sha:, allow_override:, dry_run:)
-  api_path = "repos/#{repo_slug}/commits/#{sha}/statuses"
+  result = fetch_ci_statuses_for_sha(repo_slug:, sha:)
+  return result[:statuses] unless result[:error]
 
-  begin
-    output, status = Open3.capture2e(
-      "gh", "api", "--paginate", "--jq", ".[]", api_path
-    )
-  rescue Errno::ENOENT
-    handle_main_ci_status_violation!(
-      message: "❌ GitHub CLI (`gh`) is not installed. Install it from https://cli.github.com/ and retry.",
-      allow_override:,
-      dry_run:
-    )
-    return nil
-  end
-
-  unless status.success?
-    handle_main_ci_status_violation!(
-      message: "❌ Unable to query GitHub Statuses API for #{sha}.\n\n#{output}",
-      allow_override:,
-      dry_run:
-    )
-    return nil
-  end
-
-  begin
-    parse_gh_jsonl(output)
-  rescue JSON::ParserError => e
-    handle_main_ci_status_violation!(
-      message: "❌ Failed to parse statuses response from gh: #{e.message}\n\nOutput:\n#{output}",
-      allow_override:,
-      dry_run:
-    )
-    # Only reached in override/dry-run mode; strict mode aborts above.
-    nil
-  end
+  handle_main_ci_status_violation!(message: result[:error], allow_override:, dry_run:)
+  # Only reached in override/dry-run mode; strict mode aborts above.
+  nil
 end
 
 def normalize_status_as_check_run(status)
@@ -1718,32 +1799,52 @@ def latest_commit_statuses(statuses)
   statuses
     .group_by { |status| status["context"] }
     .map do |_context, context_statuses|
-      # GitHub emits ISO 8601 UTC `created_at` values, which sort chronologically as strings.
-      context_statuses.max_by { |status| [status["created_at"].to_s, status["id"].to_i] }
+      context_statuses.max_by { |status| [parsed_ci_status_created_at(status), status["id"]] }
     end
 end
 
 def normalize_required_check_entries(checks)
-  Array(checks).filter_map do |check|
-    context = check["context"].to_s
-    next if context.empty?
+  checks.map { |check| { context: check["context"], app_id: check["app_id"] } }.uniq
+end
 
-    { context:, app_id: check["app_id"]&.to_i }
-  end.uniq
+def valid_required_check_entry?(check)
+  return false unless check.is_a?(Hash)
+  return false unless check.key?("app_id")
+
+  context = check["context"]
+  return false unless context.is_a?(String) && !context.empty?
+
+  check["app_id"].nil? || check["app_id"].is_a?(Integer)
+end
+
+def valid_required_check_contexts?(contexts)
+  contexts.is_a?(Array) && contexts.all? { |context| context.is_a?(String) && !context.empty? }
+end
+
+def valid_required_checks_payload?(parsed)
+  return false unless parsed.is_a?(Hash)
+  return false unless parsed.key?("contexts") && parsed.key?("checks")
+
+  contexts_payload = parsed["contexts"]
+  checks_payload = parsed["checks"]
+  return false unless valid_required_check_contexts?(contexts_payload)
+  return false unless checks_payload.is_a?(Array)
+
+  checks_payload.all? { |check| valid_required_check_entry?(check) }
 end
 
 def normalize_required_checks_payload(parsed)
-  return nil unless parsed.is_a?(Hash)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless valid_required_checks_payload?(parsed)
 
   checks = normalize_required_check_entries(parsed["checks"])
   check_contexts = checks.map { |check| check[:context] }
   # GitHub mirrors required status-check names into both `contexts` and `checks`.
   # Keep the modern `checks` entry when names overlap so one required gate is
   # evaluated once, with its app pin preserved.
-  contexts = Array(parsed["contexts"]).map(&:to_s).reject(&:empty?).uniq - check_contexts
+  contexts = parsed["contexts"].uniq - check_contexts
 
-  # No required names parseable is treated the same as "no branch protection
-  # visible" — fail-safe to evaluating every check run.
+  # A structurally valid empty configuration means no branch protection is
+  # configured. Malformed responses return the unknown sentinel above.
   contexts.empty? && checks.empty? ? nil : { contexts:, checks: }
 end
 
@@ -1754,29 +1855,27 @@ def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "
   # Keep legacy `contexts` separate from modern `checks` entries. Modern
   # required checks can be pinned to a GitHub App via `app_id`; legacy contexts
   # may be satisfied by either a Checks API run or a commit-status context.
-  jq_query = "{contexts: (.contexts // []), checks: (.checks // [] | map({context, app_id}))}"
+  jq_query = "{contexts, checks}"
   # Precondition: `fetch_main_ci_checks` already verified `gh` is installed
   # before `validate_main_ci_status!` calls this helper. The remaining failure
-  # mode here is "branch protection unknown", which returns nil so the caller
-  # fail-safes to evaluating every visible check_run.
+  # mode here is "branch protection unknown". Keep it distinct from a known
+  # unprotected branch so exact-HEAD recovery can fail closed.
   output, status = capture_gh_output("api", "--jq", jq_query, api_path)
-  # If branch protection isn't configured, isn't queryable with current token scope, or the
-  # endpoint returns 404, fall through to nil so the caller treats all checks as required
-  # (fail-safe).
-  return nil unless status.success?
+  # Only a successful, structurally valid empty configuration means no required
+  # checks. API errors and malformed payloads leave required gates unknown.
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless status.success?
 
   begin
     parsed = JSON.parse(output)
     normalize_required_checks_payload(parsed)
   rescue JSON::ParserError
-    nil
+    REQUIRED_CHECK_DISCOVERY_UNKNOWN
   end
 end
 
 def check_run_app_id(run)
-  app_id = run.dig("app", "id")
   # nil is the branch-protection wildcard; GitHub check-run app IDs are integers.
-  app_id&.to_i
+  run.dig("app", "id")
 end
 
 def required_check_app_wildcard?(app_id)
@@ -1906,10 +2005,22 @@ def format_main_ci_status_violation(kind:, short_sha:, runs:, ci_branch: "main")
   "#{header}\n\n#{lines.join("\n")}"
 end
 
+def main_ci_status_override_guidance(prefix: "")
+  <<~GUIDANCE.strip
+    #{prefix}DANGEROUS LAST RESORT — override only if the failures are known-unrelated to this release:
+    #{prefix}this waives the release CI-status gate and does not establish healthy CI evidence.
+    #{prefix}  RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake release[...]
+    #{prefix}  # or pass override_ci_status as the 4th positional argument:
+    #{prefix}  bundle exec rake "release[VERSION,false,false,true]"
+  GUIDANCE
+end
+
 def handle_main_ci_status_violation!(message:, allow_override:, dry_run:)
   if dry_run
-    puts message.lines.map { |line| "⚠️ DRY RUN: #{line}" }.join
-    puts "⚠️ DRY RUN: Real release would block. Use RELEASE_CI_STATUS_OVERRIDE=true to bypass."
+    puts "⚠️ DRY RUN: CI evidence below would block a real release:"
+    puts message
+    puts "⚠️ DRY RUN: Real release remains blocked."
+    puts main_ci_status_override_guidance(prefix: "⚠️ DRY RUN: ")
     return
   end
 
@@ -1919,97 +2030,23 @@ def handle_main_ci_status_violation!(message:, allow_override:, dry_run:)
     return
   end
 
-  abort <<~ERROR
-    #{message}
+  abort "#{message}\n\n#{main_ci_status_override_guidance}"
+end
 
-    To override (use only if the failures are known-unrelated to this release):
-      RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake release[...]
-      # or pass override_ci_status as the 4th positional argument:
-      bundle exec rake "release[VERSION,false,false,true]"
-  ERROR
+def deduplicate_ci_check_runs(check_runs)
+  check_runs
+    .group_by { |run| [run.dig("check_suite", "id") || run["id"], run["name"], check_run_app_id(run)] }
+    .map { |_key, runs| runs.max_by { |run| run["id"].to_i } }
 end
 
 # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dry_run:, ci_branch: "main")
-  puts "\nChecking CI status on origin/#{ci_branch}..."
-
-  data = fetch_main_ci_checks(monorepo_root:, allow_override:, dry_run:, ci_branch:)
-  # `fetch_main_ci_checks` returns nil when it surfaced a violation through
-  # `handle_main_ci_status_violation!` (dry-run or override path). In that case
-  # the warning has already been printed and we should not continue.
-  return if data.nil?
-
-  sha = data[:sha]
+def main_ci_status_evaluation(check_runs:, legacy_status_runs:, required_names:, is_prerelease:, sha:,
+                              ci_branch:)
+  check_runs = deduplicate_ci_check_runs(check_runs)
   short_sha = sha[0, 8]
-  repo_slug = data[:repo_slug]
-  check_runs = data[:check_runs]
-
-  # Collapse multiple runs per (check_suite_id, name) to the most recent
-  # attempt (highest check_run id). The key intentionally includes
-  # check_suite_id so we only collapse *true* reruns (same workflow run,
-  # same job name) and not unrelated workflows that happen to share a job
-  # name. For example, this repo has multiple workflows that each define a
-  # `detect-changes` job; without the suite_id in the key, a passing run
-  # from one workflow could mask a failing run from another. `id` is
-  # monotonically increasing per check run, so `max_by { id }` reliably
-  # selects the latest attempt within a suite.
-  # When `check_suite` is absent (rare — third-party integrations that don't
-  # attach to a suite), fall back to the run's own `id` for the group key so
-  # each nil-suite run sits in its own group and is never collapsed with
-  # another. The GitHub Actions Checks API always populates `check_suite`,
-  # so this only matters for external check integrations.
-  check_runs = check_runs
-               .group_by { |run| [run.dig("check_suite", "id") || run["id"], run["name"], check_run_app_id(run)] }
-               .map { |_key, runs| runs.max_by { |run| run["id"].to_i } }
-
-  # Always query branch-protection required checks (when configured) so the
-  # missing-required-check gate applies to both stable and prerelease.
-  # `evaluated` then differs by mode:
-  #   - prerelease: only the required subset (narrower filter; non-required failures are advisory)
-  #   - stable:     every check_run on the commit (broader filter; any failure blocks)
-  required_args = { monorepo_root: }
-  required_args[:repo_slug] = repo_slug if repo_slug
-  required_args[:ci_branch] = ci_branch
-  required_names = required_check_names_for_branch(**required_args)
-  required_status_contexts = required_names ? legacy_status_contexts_for_required_checks(required_names) : []
-  legacy_status_runs = []
-  legacy_status_fetch_unknown = false
-  if required_status_contexts.any?
-    statuses = fetch_main_commit_statuses(
-      repo_slug: repo_slug || github_repo_slug(monorepo_root),
-      sha:,
-      allow_override:,
-      dry_run:
-    )
-    if statuses.nil?
-      unless allow_override || dry_run
-        handle_main_ci_status_violation!(
-          message: "❌ Internal error: legacy status fetch returned nil unexpectedly in strict mode.",
-          allow_override:,
-          dry_run:
-        )
-        return
-      end
-
-      # Only dry-run/override mode reaches the fallback; strict mode aborts inside
-      # the fetch helper after surfacing the violation.
-      legacy_status_fetch_unknown = true
-      statuses = []
-    end
-
-    legacy_status_runs = legacy_status_runs_for_required_contexts(
-      required_checks: required_names,
-      statuses:
-    )
-  end
-
   if check_runs.empty? && legacy_status_runs.empty?
-    handle_main_ci_status_violation!(
-      message: format_main_ci_status_violation(kind: :no_checks, short_sha:, runs: nil, ci_branch:),
-      allow_override:,
-      dry_run:
-    )
-    return
+    message = format_main_ci_status_violation(kind: :no_checks, short_sha:, runs: nil, ci_branch:)
+    return { kind: :no_checks, message: }
   end
 
   evaluated = if is_prerelease && required_names
@@ -2021,30 +2058,14 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
                 check_runs + legacy_status_runs
               end
 
-  # Report visible failures before missing/in-progress runs. If both are
-  # present, the operator needs to know about the failure right away; this also
-  # prevents same-label legacy/modern required checks from hiding a failed
-  # legacy status behind a "missing required" message.
   failed = evaluated.select do |run|
     run["status"] == "completed" && !CI_PASSING_CONCLUSIONS.include?(run["conclusion"])
   end
   if failed.any?
-    handle_main_ci_status_violation!(
-      message: format_main_ci_status_violation(kind: :failed, short_sha:, runs: failed, ci_branch:),
-      allow_override:,
-      dry_run:
-    )
-    return
+    message = format_main_ci_status_violation(kind: :failed, short_sha:, runs: failed, ci_branch:)
+    return { kind: :failed, message: }
   end
 
-  # When branch protection lists required checks, treat any missing required
-  # check as blocking — for stable AND prerelease. Branch protection would
-  # refuse the merge in this state, so a release that ignored the gap would
-  # ship against a commit GitHub itself considers unverified.
-  # `:no_required_checks` covers the all-missing case (typically: CI hasn't
-  # started yet); `:missing_required_checks` covers the partial case (some
-  # required workflows ran, others never registered — usually a renamed or
-  # deleted workflow that branch protection still requires).
   unless required_names.nil?
     required_labels = required_check_labels(required_names)
     missing_required = missing_required_checks(
@@ -2052,66 +2073,250 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
       check_runs:,
       legacy_status_runs:
     )
-    missing_names = missing_required[:labels]
     if missing_required[:count] == required_check_count(required_names)
-      handle_main_ci_status_violation!(
-        message: format_main_ci_status_violation(kind: :no_required_checks, short_sha:, runs: nil, ci_branch:) +
-                 "\nRequired: #{required_labels.join(', ')}",
-        allow_override:,
-        dry_run:
-      )
-      return
-    elsif missing_names.any?
-      handle_main_ci_status_violation!(
-        message: format_main_ci_status_violation(kind: :missing_required_checks, short_sha:, runs: nil,
-                                                 ci_branch:) +
-                 "\nRequired: #{required_labels.join(', ')}\nMissing: #{missing_names.join(', ')}",
-        allow_override:,
-        dry_run:
-      )
-      return
+      message = format_main_ci_status_violation(kind: :no_required_checks, short_sha:, runs: nil, ci_branch:) +
+                "\nRequired: #{required_labels.join(', ')}"
+      return { kind: :no_required_checks, message: }
+    end
+    if missing_required[:labels].any?
+      message = format_main_ci_status_violation(kind: :missing_required_checks, short_sha:, runs: nil, ci_branch:) +
+                "\nRequired: #{required_labels.join(', ')}\nMissing: #{missing_required[:labels].join(', ')}"
+      return { kind: :missing_required_checks, message: }
     end
   end
 
   in_progress = evaluated.select { |run| CI_INCOMPLETE_STATUSES.include?(run["status"]) }
   if in_progress.any?
-    handle_main_ci_status_violation!(
-      message: format_main_ci_status_violation(kind: :in_progress, short_sha:, runs: in_progress, ci_branch:),
-      allow_override:,
-      dry_run:
-    )
-    return
+    message = format_main_ci_status_violation(kind: :in_progress, short_sha:, runs: in_progress, ci_branch:)
+    return { kind: :in_progress, message: }
   end
 
-  # Catch any run whose status falls outside both the "completed" and
-  # `CI_INCOMPLETE_STATUSES` buckets — e.g. a new GitHub status value we
-  # don't yet know about, or a `nil` from a malformed response. Treat the
-  # ambiguity as a failure rather than letting it slip through as green;
-  # the release gate is supposed to be the last-line check.
   unknown = evaluated.reject do |run|
     run["status"] == "completed" || CI_INCOMPLETE_STATUSES.include?(run["status"])
   end
   if unknown.any?
+    message = format_main_ci_status_violation(kind: :unknown_status, short_sha:, runs: unknown, ci_branch:)
+    return { kind: :unknown_status, message: }
+  end
+
+  healthy_count = required_names ? required_check_count(required_names) : evaluated.length
+  { kind: :healthy, healthy_count: }
+end
+
+def exact_head_unknown_guidance(error)
+  "❌ Exact HEAD evidence is unknown; release remains blocked.\n\n#{error}"
+end
+
+def recovery_ci_evidence_healthy?(check_runs:, statuses:)
+  check_runs.all? do |run|
+    valid_ci_check_run?(run) && run["status"] == "completed" && CI_PASSING_CONCLUSIONS.include?(run["conclusion"])
+  end && statuses.all? { |status| valid_ci_status?(status) && status["state"] == "success" }
+end
+
+def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required_names:, is_prerelease:, ci_branch:,
+                                 required_checks_known: true, target_gem_version: nil)
+  return nil if head_sha.nil? || head_sha == evaluated_sha
+  unless required_checks_known
+    return exact_head_unknown_guidance("❌ Required CI check discovery is unknown; release remains blocked.")
+  end
+
+  check_result = fetch_ci_check_runs_for_sha(repo_slug:, sha: head_sha)
+  return exact_head_unknown_guidance(check_result[:error]) if check_result[:error]
+
+  status_result = fetch_ci_statuses_for_sha(repo_slug:, sha: head_sha)
+  return exact_head_unknown_guidance(status_result[:error]) if status_result[:error]
+
+  unless recovery_ci_evidence_healthy?(check_runs: check_result[:check_runs], statuses: status_result[:statuses])
+    raw_status_runs = latest_commit_statuses(status_result[:statuses]).map do |status|
+      normalize_status_as_check_run(status)
+    end
+    raw_evaluation = main_ci_status_evaluation(
+      check_runs: check_result[:check_runs],
+      legacy_status_runs: raw_status_runs,
+      required_names: nil,
+      is_prerelease: false,
+      sha: head_sha,
+      ci_branch:
+    )
+    case raw_evaluation[:kind]
+    when :in_progress
+      return "⏳ Exact HEAD #{head_sha[0, 8]} still has pending CI evidence. " \
+             "Wait for it to complete; release remains blocked.\n\n#{raw_evaluation[:message]}"
+    when :failed
+      return [
+        "❌ Exact HEAD #{head_sha[0, 8]} has failing CI evidence. Release remains blocked.",
+        raw_evaluation[:message]
+      ].join("\n\n")
+    else
+      return "❌ Exact HEAD #{head_sha[0, 8]} does not provide complete healthy CI evidence; " \
+             "release remains blocked.\n\n#{raw_evaluation[:message]}"
+    end
+  end
+
+  legacy_status_runs = if required_names
+                         legacy_status_runs_for_required_contexts(
+                           required_checks: required_names,
+                           statuses: status_result[:statuses]
+                         )
+                       else
+                         []
+                       end
+
+  evaluation = main_ci_status_evaluation(
+    check_runs: check_result[:check_runs],
+    legacy_status_runs:,
+    required_names:,
+    is_prerelease:,
+    sha: head_sha,
+    ci_branch:
+  )
+
+  case evaluation[:kind]
+  when :healthy
+    if target_gem_version.to_s.empty?
+      return exact_head_unknown_guidance(
+        "❌ Exact HEAD is healthy, but the resolved release version is unavailable; release remains blocked."
+      )
+    end
+
+    <<~GUIDANCE.strip
+      ✓ Exact HEAD #{head_sha[0, 8]} has complete healthy CI evidence.
+      To re-evaluate and enforce that exact HEAD (strict evaluation, not a waiver):
+        RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release[#{target_gem_version}]"
+    GUIDANCE
+  when :in_progress
+    "⏳ Exact HEAD #{head_sha[0, 8]} still has pending CI evidence. " \
+    "Wait for it to complete; release remains blocked.\n\n#{evaluation[:message]}"
+  when :failed
+    "❌ Exact HEAD #{head_sha[0, 8]} has failing CI evidence. Release remains blocked.\n\n#{evaluation[:message]}"
+  else
+    "❌ Exact HEAD #{head_sha[0, 8]} does not provide complete healthy CI evidence; " \
+    "release remains blocked.\n\n#{evaluation[:message]}"
+  end
+end
+
+def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dry_run:, ci_branch: "main",
+                             target_gem_version: nil)
+  puts "\nChecking CI status on origin/#{ci_branch}..."
+
+  data = fetch_main_ci_checks(monorepo_root:, allow_override:, dry_run:, ci_branch:)
+  return if data.nil?
+
+  strict_exact_head_evaluation = ci_evaluate_head_only?
+  sha = data[:sha]
+  repo_slug = data[:repo_slug]
+  required_args = { monorepo_root:, ci_branch: }
+  required_args[:repo_slug] = repo_slug if repo_slug
+  required_names = required_check_names_for_branch(**required_args)
+  required_checks_known = !required_names.equal?(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+  unless required_checks_known
     handle_main_ci_status_violation!(
-      message: format_main_ci_status_violation(kind: :unknown_status, short_sha:, runs: unknown, ci_branch:),
+      message: "❌ Required CI check discovery is unknown for origin/#{ci_branch}; release remains blocked.",
       allow_override:,
       dry_run:
     )
     return
   end
 
-  # The fetch helper already warned in dry-run/override mode. Do not print a
-  # green status when required legacy status data was unavailable.
+  statuses = []
+  legacy_status_runs = []
+  legacy_status_fetch_unknown = false
+  has_legacy_status_requirements = required_names && legacy_status_contexts_for_required_checks(required_names).any?
+  if has_legacy_status_requirements || strict_exact_head_evaluation
+    statuses = fetch_main_commit_statuses(
+      repo_slug: repo_slug || github_repo_slug(monorepo_root), sha:, allow_override:, dry_run:
+    )
+    if statuses.nil?
+      unless allow_override || dry_run
+        handle_main_ci_status_violation!(
+          message: "❌ Internal error: legacy status fetch returned nil unexpectedly in strict mode.",
+          allow_override:,
+          dry_run:
+        )
+        return
+      end
+      legacy_status_fetch_unknown = true
+      statuses = []
+    end
+    return if strict_exact_head_evaluation && legacy_status_fetch_unknown
+  end
+
+  if strict_exact_head_evaluation
+    strict_evidence_valid = data[:check_runs].all? { |run| valid_ci_check_run?(run) } &&
+                            statuses.all? { |status| valid_ci_status?(status) }
+    unless strict_evidence_valid
+      handle_main_ci_status_violation!(
+        message: "❌ Strict exact-HEAD CI evidence is malformed or unknown; release remains blocked.",
+        allow_override:,
+        dry_run:
+      )
+      return
+    end
+
+    unless recovery_ci_evidence_healthy?(check_runs: data[:check_runs], statuses:)
+      raw_status_runs = latest_commit_statuses(statuses).map { |status| normalize_status_as_check_run(status) }
+      raw_evaluation = main_ci_status_evaluation(
+        check_runs: data[:check_runs],
+        legacy_status_runs: raw_status_runs,
+        required_names: nil,
+        is_prerelease: false,
+        sha:,
+        ci_branch:
+      )
+      handle_main_ci_status_violation!(message: raw_evaluation[:message], allow_override:, dry_run:)
+      return
+    end
+  end
+
+  if has_legacy_status_requirements
+    legacy_status_runs = legacy_status_runs_for_required_contexts(required_checks: required_names, statuses:)
+  end
+
+  evaluation = main_ci_status_evaluation(
+    check_runs: data[:check_runs],
+    legacy_status_runs:,
+    required_names:,
+    is_prerelease:,
+    sha:,
+    ci_branch:
+  )
+  if evaluation[:kind] != :healthy
+    message = evaluation[:message]
+    if %i[no_checks no_required_checks].include?(evaluation[:kind]) && !has_legacy_status_requirements
+      statuses = fetch_main_commit_statuses(
+        repo_slug: repo_slug || github_repo_slug(monorepo_root), sha:, allow_override:, dry_run:
+      )
+      if statuses.nil?
+        legacy_status_fetch_unknown = true
+        statuses = []
+      end
+    end
+    recovery_eligible = !legacy_status_fetch_unknown && recovery_ci_evidence_healthy?(
+      check_runs: data[:check_runs], statuses:
+    )
+    if recovery_eligible && %i[no_checks no_required_checks].include?(evaluation[:kind])
+      guidance = exact_head_recovery_guidance(
+        repo_slug:,
+        head_sha: data[:head_sha],
+        evaluated_sha: sha,
+        required_names:,
+        is_prerelease:,
+        ci_branch:,
+        required_checks_known:,
+        target_gem_version:
+      )
+      message += "\n\n#{guidance}" if guidance
+    end
+    handle_main_ci_status_violation!(message:, allow_override:, dry_run:)
+    return
+  end
+
   return if legacy_status_fetch_unknown
 
-  # Stable releases still evaluated every visible run above for failures, but
-  # when branch protection is visible the success count should report required
-  # gates so mirrored Checks/Statuses API entries are not counted twice.
   qualifier = is_prerelease && required_names ? "required " : ""
-  healthy_count = required_names ? required_check_count(required_names) : evaluated.length
-  noun = healthy_count == 1 ? "check" : "checks"
+  noun = evaluation[:healthy_count] == 1 ? "check" : "checks"
   ci_label = ci_branch == "main" ? "Main CI" : "CI on origin/#{ci_branch}"
-  puts "✓ #{ci_label} is healthy on #{short_sha} (#{healthy_count} #{qualifier}#{noun})"
+  puts "✓ #{ci_label} is healthy on #{sha[0, 8]} (#{evaluation[:healthy_count]} #{qualifier}#{noun})"
 end
 # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
@@ -3089,7 +3294,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       is_prerelease:,
       allow_override: allow_ci_status_override,
       dry_run: is_dry_run,
-      ci_branch:
+      ci_branch:,
+      target_gem_version: resolved_target_gem_version
     )
 
     release_branch_final_promotion = !is_prerelease && current_branch == "release/#{resolved_target_gem_version}"

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -209,6 +209,12 @@ rescue Errno::ENOENT
   abort "❌ GitHub CLI (`gh`) is not installed. Install it from https://cli.github.com/ and retry."
 end
 
+def capture_gh_stdout_and_stderr(*)
+  Open3.capture3("gh", *)
+rescue Errno::ENOENT
+  abort "❌ GitHub CLI (`gh`) is not installed. Install it from https://cli.github.com/ and retry."
+end
+
 def read_output_from_io(reader)
   Thread.new do
     reader.read
@@ -308,7 +314,7 @@ def handle_shakaperf_release_gate_violation!(message:)
     For a transient gate failure, retry the release from that same commit; the version bump is already present.
     If the gate should not be retried, push a revert commit before retrying the release.
 
-    To override this release gate (use only for an urgent release when ShakaPerf is known-unrelated):
+    For an explicitly approved prerelease override only (when ShakaPerf is known-unrelated):
       RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake release[...]
       # or pass override_ci_status as the 4th positional argument:
       bundle exec rake "release[VERSION,false,false,true]"
@@ -418,7 +424,7 @@ def print_shakaperf_release_gate_notice(ref:, head_sha:)
     Fresh dispatches can take up to #{start_timeout_minutes} minutes to appear before watching starts.
     Once a run is found, this release task will watch it for up to #{watch_timeout_minutes} minutes.
     A fresh dispatch can therefore block for up to about #{fresh_dispatch_timeout_minutes} minutes total.
-    To skip only for an urgent release where ShakaPerf is known-unrelated:
+    To skip only for an explicitly approved prerelease where ShakaPerf is known-unrelated:
       RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake release[...]
       # or pass override_ci_status as the 4th positional argument:
       bundle exec rake "release[VERSION,false,false,true]"
@@ -1325,6 +1331,19 @@ def ci_status_override_enabled?(override_flag)
   release_truthy?(override_flag) || release_truthy?(ENV.fetch("RELEASE_CI_STATUS_OVERRIDE", nil))
 end
 
+def ensure_ci_status_override_is_prerelease!(allow_override:, is_prerelease:)
+  return unless allow_override && !is_prerelease
+
+  abort "❌ CI status override is allowed only for prerelease releases; " \
+        "stable/final releases require healthy CI evidence."
+end
+
+def ci_status_override_allowed_for_release!(override_flag:, is_prerelease:)
+  allow_override = ci_status_override_enabled?(override_flag)
+  ensure_ci_status_override_is_prerelease!(allow_override:, is_prerelease:)
+  allow_override
+end
+
 # Escape hatch: force the CI gate to evaluate origin/main HEAD verbatim instead
 # of walking back over non-runtime-only commits (see `main_ci_evaluation_sha`).
 def ci_evaluate_head_only?
@@ -1353,12 +1372,13 @@ CI_CHECK_RUNS_JSONL_QUERY = [
   'else error("expected check_runs array") end'
 ].join(" ")
 CI_STATUSES_JSONL_QUERY = [
-  'if type == "array" then',
+  'if type == "object" and (.sha | type == "string" and test("[^[:space:]]")) and ' \
+  '(.statuses | type == "array") then',
   [
-    "[\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ENVELOPE_FRAME}\", \"statuses\"], ",
-    "(.[] | [\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ITEM_FRAME}\", .])"
+    "[\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ENVELOPE_FRAME}\", {\"name\": \"statuses\", \"sha\": .sha}], ",
+    "(.statuses[] | [\"#{CI_JSONL_FRAME_KEY}\", \"#{CI_JSONL_ITEM_FRAME}\", .])"
   ].join,
-  'else error("expected statuses array") end'
+  'else error("expected status object with sha and statuses array") end'
 ].join(" ")
 REQUIRED_CHECK_DISCOVERY_UNKNOWN = Object.new.freeze
 
@@ -1473,7 +1493,7 @@ def fetch_ci_check_runs_for_sha(repo_slug:, sha:)
   api_path = "repos/#{repo_slug}/commits/#{sha}/check-runs"
   result = fetch_github_jsonl(
     api_path:, jq_query: CI_CHECK_RUNS_JSONL_QUERY, api_name: "Checks", response_name: "check_runs", sha:,
-    envelope_name: "check_runs", item_validator: method(:valid_ci_check_run?)
+    envelope_name: "check_runs", item_validator: ->(run) { valid_ci_check_run?(run, sha:) }
   )
   return result if result[:error]
 
@@ -1481,10 +1501,11 @@ def fetch_ci_check_runs_for_sha(repo_slug:, sha:)
 end
 
 def fetch_ci_statuses_for_sha(repo_slug:, sha:)
-  api_path = "repos/#{repo_slug}/commits/#{sha}/statuses"
+  api_path = "repos/#{repo_slug}/commits/#{sha}/status"
   result = fetch_github_jsonl(
     api_path:, jq_query: CI_STATUSES_JSONL_QUERY, api_name: "Statuses", response_name: "statuses", sha:,
-    envelope_name: "statuses", item_validator: method(:valid_ci_status?)
+    envelope_name: "statuses", envelope_validator: ->(envelope) { valid_ci_statuses_envelope?(envelope, sha:) },
+    item_validator: method(:valid_ci_status?)
   )
   return result if result[:error]
 
@@ -1494,11 +1515,12 @@ end
 # Query a GitHub API endpoint as JSONL without deciding whether a failure can be
 # overridden. The normal release gate and exact-HEAD recovery diagnostic apply
 # different policy to the same evidence, so callers receive fail-closed errors.
-def fetch_github_jsonl(api_path:, jq_query:, api_name:, response_name:, sha:, envelope_name:, item_validator:)
+def fetch_github_jsonl(api_path:, jq_query:, api_name:, response_name:, sha:, envelope_name:, item_validator:,
+                       envelope_validator: nil)
   output, status = Open3.capture2e("gh", "api", "--paginate", "--jq", jq_query, api_path)
   return { error: "❌ Unable to query GitHub #{api_name} API for #{sha}.\n\n#{output}" } unless status.success?
 
-  items = validated_github_jsonl_items(output:, envelope_name:, item_validator:)
+  items = validated_github_jsonl_items(output:, envelope_name:, item_validator:, envelope_validator:)
   return { error: "❌ Received malformed GitHub #{api_name} evidence for #{sha}; release remains blocked." } unless items
 
   { items: }
@@ -1508,31 +1530,35 @@ rescue JSON::ParserError => e
   { error: "❌ Failed to parse #{response_name} response from gh: #{e.message}\n\nOutput:\n#{output}" }
 end
 
-def validated_github_jsonl_items(output:, envelope_name:, item_validator:)
+def validated_github_jsonl_items(output:, envelope_name:, item_validator:, envelope_validator: nil)
   parsed_items = parse_gh_jsonl(output)
-  return unless valid_github_jsonl_frames?(parsed_items, envelope_name:)
+  return unless parsed_items
+  return unless valid_github_jsonl_frames?(parsed_items, envelope_name:, envelope_validator:)
 
-  items = github_jsonl_frame_items(parsed_items, envelope_name:)
+  items = github_jsonl_frame_items(parsed_items, envelope_name:, envelope_validator:)
   return unless items.all?(&item_validator)
 
   items
 end
 
-def valid_github_jsonl_frames?(parsed_items, envelope_name:)
-  return false unless parsed_items.any? { |item| github_jsonl_envelope_frame?(item, envelope_name:) }
+def valid_github_jsonl_frames?(parsed_items, envelope_name:, envelope_validator:)
+  return false unless github_jsonl_envelope_frame?(parsed_items.first, envelope_name:, envelope_validator:)
 
   parsed_items.all? do |item|
-    github_jsonl_envelope_frame?(item, envelope_name:) || github_jsonl_item_frame?(item)
+    github_jsonl_envelope_frame?(item, envelope_name:, envelope_validator:) || github_jsonl_item_frame?(item)
   end
 end
 
-def github_jsonl_frame_items(parsed_items, envelope_name:)
-  parsed_items.reject { |item| github_jsonl_envelope_frame?(item, envelope_name:) }
+def github_jsonl_frame_items(parsed_items, envelope_name:, envelope_validator:)
+  parsed_items.reject { |item| github_jsonl_envelope_frame?(item, envelope_name:, envelope_validator:) }
               .map { |item| item[2] }
 end
 
-def github_jsonl_envelope_frame?(item, envelope_name:)
-  item == [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, envelope_name]
+def github_jsonl_envelope_frame?(item, envelope_name:, envelope_validator:)
+  return false unless item.is_a?(Array) && item.length == 3
+  return false unless item[0] == CI_JSONL_FRAME_KEY && item[1] == CI_JSONL_ENVELOPE_FRAME
+
+  envelope_validator ? envelope_validator.call(item[2]) : item[2] == envelope_name
 end
 
 def github_jsonl_item_frame?(item)
@@ -1540,9 +1566,25 @@ def github_jsonl_item_frame?(item)
 end
 
 def parse_gh_jsonl(output)
+  output = normalized_utf8_output(output)
+  return unless output
+
   output.lines.reject { |line| line.strip.empty? }.map do |line|
     JSON.parse(line)
   end
+end
+
+def normalized_utf8_output(output)
+  return unless output.is_a?(String)
+
+  output = output.dup
+  output.force_encoding(Encoding::UTF_8) if output.encoding == Encoding::BINARY
+  return unless output.valid_encoding? && output.encoding.ascii_compatible?
+
+  output.encode(Encoding::UTF_8)
+rescue ArgumentError, Encoding::CompatibilityError, Encoding::InvalidByteSequenceError,
+       Encoding::UndefinedConversionError
+  nil
 end
 
 def valid_ci_check_run_app?(run)
@@ -1551,18 +1593,18 @@ def valid_ci_check_run_app?(run)
   app = run["app"]
   return false unless app.is_a?(Hash) && app.key?("id")
 
-  app["id"].is_a?(Integer)
+  positive_github_id?(app["id"])
 end
 
 def valid_ci_check_run_suite?(run)
   return true unless run.key?("check_suite")
 
   suite = run["check_suite"]
-  suite.is_a?(Hash) && suite["id"].is_a?(Integer)
+  suite.is_a?(Hash) && positive_github_id?(suite["id"])
 end
 
 def valid_ci_check_run_identity?(run)
-  return false unless run.is_a?(Hash) && run["id"].is_a?(Integer)
+  return false unless run.is_a?(Hash) && positive_github_id?(run["id"])
   return false unless run["name"].is_a?(String) && !run["name"].empty?
 
   valid_ci_check_run_app?(run) && valid_ci_check_run_suite?(run)
@@ -1578,12 +1620,21 @@ def valid_ci_check_run_state?(run)
   end
 end
 
-def valid_ci_check_run?(run)
-  valid_ci_check_run_identity?(run) && valid_ci_check_run_state?(run)
+def positive_github_id?(id)
+  id.is_a?(Integer) && id.positive?
+end
+
+def valid_ci_check_run?(run, sha: nil)
+  valid_ci_check_run_identity?(run) && valid_ci_check_run_state?(run) && (sha.nil? || run["head_sha"] == sha)
+end
+
+def valid_ci_statuses_envelope?(envelope, sha:)
+  sha.is_a?(String) && !sha.empty? && envelope.is_a?(Hash) &&
+    envelope["name"] == "statuses" && envelope["sha"] == sha
 end
 
 def valid_ci_status?(status)
-  status.is_a?(Hash) && status["id"].is_a?(Integer) &&
+  status.is_a?(Hash) && positive_github_id?(status["id"]) &&
     status["context"].is_a?(String) && !status["context"].empty? &&
     CI_LEGACY_STATUS_STATES.include?(status["state"]) && valid_ci_status_created_at?(status)
 end
@@ -1631,7 +1682,7 @@ def log_main_ci_walkback(head_sha:, evaluated_sha:, skipped:, ref:)
        "CI can skip the full runtime suite on such commits."
   puts "   Skipped #{skipped.length} release-gate commit(s): #{skipped.map { |s| s[0, 8] }.join(', ')}"
   puts "   Evaluating CI on #{evaluated_sha[0, 8]} — the most recent commit that ran the full suite."
-  puts "   (Set RELEASE_CI_EVALUATE_HEAD=true to force strict HEAD evaluation.)"
+  puts "   Strict exact-HEAD recovery is offered only after exact-HEAD CI evidence is complete and healthy."
 end
 
 def main_ci_walkback_commit?(monorepo_root:, sha:, ref:)
@@ -1814,7 +1865,7 @@ def valid_required_check_entry?(check)
   context = check["context"]
   return false unless context.is_a?(String) && !context.empty?
 
-  check["app_id"].nil? || check["app_id"].is_a?(Integer)
+  check["app_id"].nil? || check["app_id"] == -1 || positive_github_id?(check["app_id"])
 end
 
 def valid_required_check_contexts?(contexts)
@@ -1848,6 +1899,77 @@ def normalize_required_checks_payload(parsed)
   contexts.empty? && checks.empty? ? nil : { contexts:, checks: }
 end
 
+def gh_included_json_response(output)
+  header_block, body, newline = gh_included_response_parts(output)
+  status = gh_included_response_status(header_block, newline:)
+  return nil unless status
+
+  body = JSON.parse(body)
+  return nil unless body.is_a?(Hash)
+
+  { status:, body: }
+rescue JSON::ParserError
+  nil
+end
+
+def gh_included_response_parts(output)
+  output = normalized_utf8_output(output)
+  return [nil, nil, nil] unless output
+
+  newline = gh_included_response_newline(output)
+  return [nil, nil, nil] unless newline && valid_gh_included_response_bytes?(output)
+
+  header_block, body, *trailing_sections = output.split("#{newline}#{newline}", -1)
+  return [nil, nil, nil] unless trailing_sections.empty? && header_block && body
+
+  [header_block, body, newline]
+end
+
+def gh_included_response_newline(output)
+  return unless output.is_a?(String)
+  return "\n" unless output.include?("\r")
+  return unless output.include?("\r\n") && !output.match?(/\r(?!\n)|(?<!\r)\n/)
+
+  "\r\n"
+end
+
+def valid_gh_included_response_bytes?(output)
+  !output.match?(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/)
+end
+
+def gh_included_response_status(header_block, newline:)
+  return nil unless header_block
+
+  header_lines = header_block.split(newline, -1)
+  status_match = header_lines.shift&.match(%r{\AHTTP/\d\.\d (\d{3})(?: [^\r\n]+)?\z})
+  return nil unless status_match
+  return nil unless header_lines.all? { |header| header.match?(/\A[!#$%&'*+\-.^_`|~0-9A-Za-z]+:[ \t]*[^\r\n]*\z/) }
+  return nil if header_lines.any? { |header| header.match?(/\Astatus:/i) }
+
+  status_match[1].to_i
+end
+
+def known_unprotected_branch?(repo_slug:, branch_name:, encoded_branch:, required_status_checks_path:)
+  included_output, _included_error, included_status = capture_gh_stdout_and_stderr(
+    "api", "--include", required_status_checks_path
+  )
+  return false if included_status.success?
+  return false unless branch_not_protected_response?(included_output)
+
+  branch_output, branch_status = capture_gh_output("api", "repos/#{repo_slug}/branches/#{encoded_branch}")
+  return false unless branch_status.success?
+
+  branch = JSON.parse(branch_output)
+  branch.is_a?(Hash) && branch["name"] == branch_name && branch["protected"] == false
+rescue JSON::ParserError
+  false
+end
+
+def branch_not_protected_response?(output)
+  response = gh_included_json_response(output)
+  response&.dig(:status) == 404 && response.dig(:body, "message") == "Branch not protected"
+end
+
 def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "main")
   repo_slug ||= github_repo_slug(monorepo_root)
   encoded_branch = URI.encode_www_form_component(ci_branch.to_s)
@@ -1863,6 +1985,12 @@ def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "
   output, status = capture_gh_output("api", "--jq", jq_query, api_path)
   # Only a successful, structurally valid empty configuration means no required
   # checks. API errors and malformed payloads leave required gates unknown.
+  return nil if !status.success? && known_unprotected_branch?(
+    repo_slug:,
+    branch_name: ci_branch.to_s,
+    encoded_branch:,
+    required_status_checks_path: api_path
+  )
   return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless status.success?
 
   begin
@@ -2007,7 +2135,7 @@ end
 
 def main_ci_status_override_guidance(prefix: "")
   <<~GUIDANCE.strip
-    #{prefix}DANGEROUS LAST RESORT — override only if the failures are known-unrelated to this release:
+    #{prefix}DANGEROUS PRERELEASE-ONLY LAST RESORT — override only if the failures are known-unrelated to this release:
     #{prefix}this waives the release CI-status gate and does not establish healthy CI evidence.
     #{prefix}  RELEASE_CI_STATUS_OVERRIDE=true bundle exec rake release[...]
     #{prefix}  # or pass override_ci_status as the 4th positional argument:
@@ -2036,7 +2164,7 @@ end
 def deduplicate_ci_check_runs(check_runs)
   check_runs
     .group_by { |run| [run.dig("check_suite", "id") || run["id"], run["name"], check_run_app_id(run)] }
-    .map { |_key, runs| runs.max_by { |run| run["id"].to_i } }
+    .map { |_key, runs| runs.max_by { |run| run["id"] } }
 end
 
 # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
@@ -2108,9 +2236,17 @@ def exact_head_unknown_guidance(error)
 end
 
 def recovery_ci_evidence_healthy?(check_runs:, statuses:)
-  check_runs.all? do |run|
-    valid_ci_check_run?(run) && run["status"] == "completed" && CI_PASSING_CONCLUSIONS.include?(run["conclusion"])
-  end && statuses.all? { |status| valid_ci_status?(status) && status["state"] == "success" }
+  return false unless check_runs.all? { |run| valid_ci_check_run?(run) }
+  return false unless statuses.all? { |status| valid_ci_status?(status) }
+
+  normalized = normalized_ci_evidence(check_runs:, statuses:)
+  normalized[:check_runs].all? do |run|
+    run["status"] == "completed" && CI_PASSING_CONCLUSIONS.include?(run["conclusion"])
+  end && normalized[:statuses].all? { |status| status["state"] == "success" }
+end
+
+def normalized_ci_evidence(check_runs:, statuses:)
+  { check_runs: deduplicate_ci_check_runs(check_runs), statuses: latest_commit_statuses(statuses) }
 end
 
 def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required_names:, is_prerelease:, ci_branch:,
@@ -2126,12 +2262,16 @@ def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required
   status_result = fetch_ci_statuses_for_sha(repo_slug:, sha: head_sha)
   return exact_head_unknown_guidance(status_result[:error]) if status_result[:error]
 
+  normalized_evidence = normalized_ci_evidence(
+    check_runs: check_result[:check_runs],
+    statuses: status_result[:statuses]
+  )
   unless recovery_ci_evidence_healthy?(check_runs: check_result[:check_runs], statuses: status_result[:statuses])
-    raw_status_runs = latest_commit_statuses(status_result[:statuses]).map do |status|
+    raw_status_runs = normalized_evidence[:statuses].map do |status|
       normalize_status_as_check_run(status)
     end
     raw_evaluation = main_ci_status_evaluation(
-      check_runs: check_result[:check_runs],
+      check_runs: normalized_evidence[:check_runs],
       legacy_status_runs: raw_status_runs,
       required_names: nil,
       is_prerelease: false,
@@ -2145,11 +2285,11 @@ def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required
     when :failed
       return [
         "❌ Exact HEAD #{head_sha[0, 8]} has failing CI evidence. Release remains blocked.",
-        raw_evaluation[:message]
+        raw_evaluation[:message] || "❌ Exact HEAD evidence is not healthy."
       ].join("\n\n")
     else
       return "❌ Exact HEAD #{head_sha[0, 8]} does not provide complete healthy CI evidence; " \
-             "release remains blocked.\n\n#{raw_evaluation[:message]}"
+             "release remains blocked.\n\n#{raw_evaluation[:message] || '❌ Exact HEAD evidence is not healthy.'}"
     end
   end
 
@@ -2197,6 +2337,7 @@ end
 
 def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dry_run:, ci_branch: "main",
                              target_gem_version: nil)
+  ensure_ci_status_override_is_prerelease!(allow_override:, is_prerelease:)
   puts "\nChecking CI status on origin/#{ci_branch}..."
 
   data = fetch_main_ci_checks(monorepo_root:, allow_override:, dry_run:, ci_branch:)
@@ -2219,10 +2360,12 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
   end
 
   statuses = []
+  statuses_fetched = false
   legacy_status_runs = []
   legacy_status_fetch_unknown = false
   has_legacy_status_requirements = required_names && legacy_status_contexts_for_required_checks(required_names).any?
   if has_legacy_status_requirements || strict_exact_head_evaluation
+    statuses_fetched = true
     statuses = fetch_main_commit_statuses(
       repo_slug: repo_slug || github_repo_slug(monorepo_root), sha:, allow_override:, dry_run:
     )
@@ -2253,17 +2396,22 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
       return
     end
 
+    normalized_evidence = normalized_ci_evidence(check_runs: data[:check_runs], statuses:)
     unless recovery_ci_evidence_healthy?(check_runs: data[:check_runs], statuses:)
-      raw_status_runs = latest_commit_statuses(statuses).map { |status| normalize_status_as_check_run(status) }
+      raw_status_runs = normalized_evidence[:statuses].map { |status| normalize_status_as_check_run(status) }
       raw_evaluation = main_ci_status_evaluation(
-        check_runs: data[:check_runs],
+        check_runs: normalized_evidence[:check_runs],
         legacy_status_runs: raw_status_runs,
         required_names: nil,
         is_prerelease: false,
         sha:,
         ci_branch:
       )
-      handle_main_ci_status_violation!(message: raw_evaluation[:message], allow_override:, dry_run:)
+      handle_main_ci_status_violation!(
+        message: raw_evaluation[:message] || "❌ Strict exact-HEAD CI evidence is not healthy; release remains blocked.",
+        allow_override:,
+        dry_run:
+      )
       return
     end
   end
@@ -2282,7 +2430,7 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
   )
   if evaluation[:kind] != :healthy
     message = evaluation[:message]
-    if %i[no_checks no_required_checks].include?(evaluation[:kind]) && !has_legacy_status_requirements
+    if %i[no_checks no_required_checks].include?(evaluation[:kind]) && !statuses_fetched
       statuses = fetch_main_commit_statuses(
         repo_slug: repo_slug || github_repo_slug(monorepo_root), sha:, allow_override:, dry_run:
       )
@@ -3122,7 +3270,7 @@ This will update and release:
     or derive a patch candidate; the stable changelog gate still requires a matching non-empty section.
 2nd argument: Dry run (true/false, default: false)
 3rd argument: Override version policy checks (true/false, default: false)
-4th argument: Override release CI gates (true/false, default: false)
+4th argument: Override prerelease CI gates only (true/false, default: false)
 
 Release CI policy:
   Before releasing, the script checks CI status on the tip of the branch being released:
@@ -3131,7 +3279,8 @@ Release CI policy:
     changelog/docs/comment-only (e.g. the pre-release `update-changelog`
     commit), CI path-skips the runtime suite there, so the gate walks back to
     the last runtime-bearing commit instead of waiting on meaningless checks.
-    Set RELEASE_CI_EVALUATE_HEAD=true to force strict HEAD evaluation.
+    The CI gate prints a strict exact-HEAD retry command only after it has found complete healthy
+    CI evidence on the fetched final tip.
   - Stable releases require every check run on the commit to have succeeded.
   - Pre-releases require only the GitHub-branch-protection-required checks
     to have succeeded.
@@ -3140,16 +3289,15 @@ Release CI policy:
   publishing npm packages or Ruby gems.
   If that gate fails, the remote branch has the version-bump commit but no release
   tag or published packages; retry from that commit or push a revert commit first.
-  In-progress checks and failing gates block the release until they pass, or until you
-  explicitly override via the 4th argument or RELEASE_CI_STATUS_OVERRIDE=true.
+  In-progress checks and failing gates block the release until they pass. An explicitly approved
+  prerelease-only waiver may use the 4th argument or RELEASE_CI_STATUS_OVERRIDE=true.
 
 Environment variables:
   VERBOSE=1                    # Enable verbose logging (shows all output)
   NPM_OTP=<code>               # Provide NPM one-time password (reused for all NPM publishes)
   RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for both gems)
   RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
-  RELEASE_CI_STATUS_OVERRIDE=true      # Override release CI gates
-  RELEASE_CI_EVALUATE_HEAD=true        # Evaluate origin/main HEAD verbatim (skip the non-runtime walk-back)
+  RELEASE_CI_STATUS_OVERRIDE=true      # DANGEROUS prerelease-only release CI waiver
   GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
 
 Examples:
@@ -3170,7 +3318,6 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   is_dry_run = release_truthy?(args_hash[:dry_run])
   is_verbose = ENV["VERBOSE"] == "1"
   allow_version_policy_override = version_policy_override_enabled?(args_hash[:override_version_policy])
-  allow_ci_status_override = ci_status_override_enabled?(args_hash[:override_ci_status])
   npm_otp = ENV.fetch("NPM_OTP", nil)
   rubygems_otp = ENV.fetch("RUBYGEMS_OTP", nil)
 
@@ -3212,6 +3359,10 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
     version_converter = ReactOnRails::VersionSyntaxConverter.new
     resolved_target_npm_version = version_converter.rubygem_to_npm(resolved_target_gem_version)
     is_prerelease = release_prerelease_version?(resolved_target_gem_version)
+    allow_ci_status_override = ci_status_override_allowed_for_release!(
+      override_flag: args_hash[:override_ci_status],
+      is_prerelease:
+    )
 
     # When cutting an rc from `main` and `release/X.Y.Z` does not yet exist, offer
     # to start the release line here instead of tagging the rc off `main`. If the

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -1454,6 +1454,37 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#ci_status_override_allowed_for_release!" do
+    it "rejects a positional CI override for a stable release before CI validation" do
+      expect do
+        ci_status_override_allowed_for_release!(override_flag: true, is_prerelease: false)
+      end.to raise_error(SystemExit, /CI status override is allowed only for prerelease releases/)
+    end
+
+    it "rejects RELEASE_CI_STATUS_OVERRIDE for a stable release" do
+      allow(ENV).to receive(:fetch).with("RELEASE_CI_STATUS_OVERRIDE", nil).and_return("true")
+
+      expect do
+        ci_status_override_allowed_for_release!(override_flag: nil, is_prerelease: false)
+      end.to raise_error(SystemExit, /CI status override is allowed only for prerelease releases/)
+    end
+
+    it "preserves the prerelease waiver" do
+      expect(ci_status_override_allowed_for_release!(override_flag: true, is_prerelease: true)).to be(true)
+    end
+  end
+
+  describe "release task help" do
+    it "does not advertise strict HEAD retry before the CI gate establishes healthy evidence" do
+      rakefile = File.read(File.expand_path("../../../rakelib/release.rake", __dir__))
+      help = rakefile.match(/desc\("(.*?)"\)\ntask :release/m)[1]
+
+      expect(help).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+      expect(help).to include("only after it has found complete healthy\n    CI evidence")
+      expect(help).to include("Override prerelease CI gates only")
+    end
+  end
+
   describe "#validate_main_ci_status!" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:sha) { "abc1234def5678abcdef" }
@@ -1479,6 +1510,10 @@ RSpec.describe "release.rake helper methods" do
 
     def required_check(context, app_id: nil)
       { context:, app_id: }
+    end
+
+    def statuses_envelope(sha)
+      { "name" => "statuses", "sha" => sha }
     end
 
     def next_check_run_id
@@ -1562,9 +1597,62 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    context "when the release branch is intentionally unprotected" do
+      it "evaluates every visible prerelease check instead of treating required checks as unknown" do
+        failure_status = instance_double(Process::Status, success?: false)
+        success_status = instance_double(Process::Status, success?: true)
+        api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+        branch_path = "repos/shakacode/react_on_rails/branches/main"
+        allow(self).to receive(:required_check_names_for_branch).and_call_original
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha:, repo_slug: "shakacode/react_on_rails", check_runs: [passing_run("Lint")])
+        allow(Open3).to receive(:capture2e)
+          .with("gh", "api", "--jq", "{contexts, checks}", api_path)
+          .and_return(["HTTP 404: Branch not protected", failure_status])
+        allow(Open3).to receive(:capture3)
+          .with("gh", "api", "--include", api_path)
+          .and_return([
+                        "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                        '{"message":"Branch not protected"}',
+                        "gh: branch protection is not enabled for this branch\n",
+                        failure_status
+                      ])
+        allow(Open3).to receive(:capture2e)
+          .with("gh", "api", branch_path)
+          .and_return(['{"name":"main","protected":false}', success_status])
+
+        output = nil
+        expect do
+          output = capture_stdout do
+            validate_main_ci_status!(
+              monorepo_root:,
+              is_prerelease: true,
+              allow_override: false,
+              dry_run: false
+            )
+          end
+        end.not_to raise_error
+        expect(output).to include("Main CI is healthy on #{short_sha} (1 check)")
+      end
+    end
+
     context "when strict exact-HEAD evaluation is enabled" do
       before do
         allow(self).to receive(:ci_evaluate_head_only?).and_return(true)
+      end
+
+      it "rejects a stable CI override before strict exact-HEAD evidence can be waived" do
+        expect(self).not_to receive(:fetch_main_ci_checks)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: true,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, /CI status override is allowed only for prerelease releases/)
       end
 
       it "blocks a prerelease when an unrelated exact-HEAD check fails" do
@@ -1611,6 +1699,92 @@ RSpec.describe "release.rake helper methods" do
             dry_run: false
           )
         end.to raise_error(SystemExit, /CI is still in progress.*Benchmark/m)
+      end
+
+      it "reuses initially fetched statuses when strict evaluation reaches the missing-required fallback" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: [passing_run("Advisory")]
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: false)
+          .and_return([], nil)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("No required CI check runs found")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+        expect(self).to have_received(:fetch_main_commit_statuses).once
+      end
+
+      it "accepts a successful strict exact-HEAD check rerun over an earlier failure" do
+        check_suite = { "id" => 77 }
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: [
+              failing_run("Lint", id: 1).merge("check_suite" => check_suite),
+              passing_run("Lint", id: 2).merge("check_suite" => check_suite)
+            ]
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint")]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: false)
+          .and_return([])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to output(/Main CI is healthy on #{short_sha} \(1 required check\)/).to_stdout
+      end
+
+      it "accepts a successful strict exact-HEAD legacy status over an earlier failure" do
+        statuses = [
+          { "id" => 1, "context" => "Legacy CI", "state" => "failure", "created_at" => "2026-07-13T00:00:00Z" },
+          { "id" => 2, "context" => "Legacy CI", "state" => "success", "created_at" => "2026-07-13T00:01:00Z" }
+        ]
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha:, head_sha: sha, repo_slug: "shakacode/react_on_rails", check_runs: [])
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: false)
+          .and_return(statuses)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to output(/Main CI is healthy on #{short_sha} \(1 required check\)/).to_stdout
       end
 
       it "fetches and blocks failed legacy status evidence for app-pinned-only protection" do
@@ -2079,6 +2253,55 @@ RSpec.describe "release.rake helper methods" do
           .and_return(walkback_without_ci_runs)
       end
 
+      it "keeps the complete walkback output free of strict guidance for incomplete exact-HEAD evidence" do
+        exact_head_cases = {
+          pending: { check_runs: [in_progress_run("Slow test")], statuses: [] },
+          failed: { check_runs: [failing_run("JS unit tests")], statuses: [] },
+          empty: { check_runs: [], statuses: [] },
+          malformed: {
+            check_runs: [{
+              "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success", "app" => {}
+            }],
+            statuses: []
+          },
+          unknown: { error: "❌ Unable to query GitHub Checks API for #{exact_head_sha}." }
+        }
+
+        exact_head_cases.each do |kind, result|
+          allow(self).to receive(:fetch_ci_check_runs_for_sha)
+            .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+            .and_return(result.slice(:check_runs, :error))
+          allow(self).to receive(:fetch_ci_statuses_for_sha)
+            .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+            .and_return(statuses: result.fetch(:statuses, []))
+
+          error = nil
+          output = capture_stdout do
+            log_main_ci_walkback(
+              head_sha: exact_head_sha,
+              evaluated_sha: walked_back_sha,
+              skipped: [exact_head_sha],
+              ref: "origin/main"
+            )
+            begin
+              validate_main_ci_status!(
+                monorepo_root:,
+                is_prerelease: false,
+                allow_override: false,
+                dry_run: false,
+                target_gem_version: "17.0.0.rc.10"
+              )
+            rescue SystemExit => exception
+              error = exception
+            end
+          end
+
+          expect(error).to be_a(SystemExit), "#{kind} exact-HEAD evidence should block the release"
+          expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true"),
+                                "#{kind} exact-HEAD evidence must not receive strict guidance"
+        end
+      end
+
       it "offers strict exact-HEAD evaluation only after exact HEAD is healthy" do
         strict_head_guidance = [
           "strict evaluation, not a waiver",
@@ -2107,6 +2330,60 @@ RSpec.describe "release.rake helper methods" do
           SystemExit,
           Regexp.new(strict_head_guidance, Regexp::MULTILINE)
         )
+      end
+
+      it "offers strict guidance when a successful exact-HEAD check rerun supersedes an earlier failure" do
+        check_suite = { "id" => 77 }
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(
+            check_runs: [
+              failing_run("Lint", id: 1).merge("check_suite" => check_suite),
+              passing_run("Lint", id: 2).merge("check_suite" => check_suite)
+            ]
+          )
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit, /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end
+
+      it "offers strict guidance when a successful exact-HEAD legacy status supersedes an earlier failure" do
+        successful_statuses = [
+          { "id" => 1, "context" => "Legacy CI", "state" => "failure", "created_at" => "2026-07-13T00:00:00Z" },
+          { "id" => 2, "context" => "Legacy CI", "state" => "success", "created_at" => "2026-07-13T00:01:00Z" }
+        ]
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: successful_statuses)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit, /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
       end
 
       it "withholds strict exact-HEAD guidance when walked-back unrelated evidence is pending" do
@@ -2319,7 +2596,7 @@ RSpec.describe "release.rake helper methods" do
         allow(Open3).to receive(:capture2e)
           .with(
             "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
-            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/status"
           )
           .and_return([malformed_status.to_json, success_status])
 
@@ -2356,10 +2633,10 @@ RSpec.describe "release.rake helper methods" do
         allow(Open3).to receive(:capture2e)
           .with(
             "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
-            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/status"
           )
           .and_return([[
-            [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"],
+            [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, statuses_envelope(exact_head_sha)],
             *statuses.map { |status| [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, status] }
           ].map(&:to_json).join("\n"), success_status])
 
@@ -2390,16 +2667,22 @@ RSpec.describe "release.rake helper methods" do
           .and_return(check_runs: [])
         success_status = instance_double(Process::Status, success?: true)
         statuses = [
-          { "id" => 1, "context" => "Legacy CI", "state" => "success", "created_at" => "2026-07-13T10:00:00+10:00" },
-          { "id" => 2, "context" => "Legacy CI", "state" => "failure", "created_at" => "2026-07-13T01:00:00Z" }
+          {
+            "id" => 1, "context" => "Legacy CI", "state" => "success",
+            "created_at" => "2026-07-13T10:00:00+10:00"
+          },
+          {
+            "id" => 2, "context" => "Legacy CI", "state" => "failure",
+            "created_at" => "2026-07-13T01:00:00Z"
+          }
         ]
         allow(Open3).to receive(:capture2e)
           .with(
             "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
-            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/status"
           )
           .and_return([[
-            [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"],
+            [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, statuses_envelope(exact_head_sha)],
             *statuses.map { |status| [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, status] }
           ].map(&:to_json).join("\n"), success_status])
 
@@ -2435,12 +2718,12 @@ RSpec.describe "release.rake helper methods" do
           when "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/check-runs"
             output = [
               [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
-              [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, passing_run("Legacy CI")]
+              [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, passing_run("Legacy CI").merge("head_sha" => exact_head_sha)]
             ].map(&:to_json).join("\n")
             [output, success_status]
-          when "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+          when "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/status"
             statuses_query = jq_query
-            jq_query == expected_statuses_query ? ["jq: expected statuses array", failure_status] : ["", success_status]
+            jq_query == expected_statuses_query ? ["jq: expected status object", failure_status] : ["", success_status]
           else
             raise "Unexpected GitHub API request: #{args.inspect}"
           end
@@ -2485,8 +2768,12 @@ RSpec.describe "release.rake helper methods" do
       it "keeps valid empty exact-HEAD API envelopes known empty" do
         success_status = instance_double(Process::Status, success?: true)
         allow(Open3).to receive(:capture2e) do |*args|
-          envelope_name = args.last.end_with?("/check-runs") ? "check_runs" : "statuses"
-          [[CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, envelope_name].to_json, success_status]
+          envelope = if args.last.end_with?("/check-runs")
+                       "check_runs"
+                     else
+                       statuses_envelope(exact_head_sha)
+                     end
+          [[CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, envelope].to_json, success_status]
         end
 
         expect(fetch_ci_check_runs_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha))
@@ -2501,8 +2788,71 @@ RSpec.describe "release.rake helper methods" do
         expect(Open3).to have_received(:capture2e)
           .with(
             "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
-            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/status"
           )
+      end
+
+      it "accepts documented legacy status items without an item SHA when the response envelope matches" do
+        success_status = instance_double(Process::Status, success?: true)
+        documented_status = {
+          "id" => 7,
+          "context" => "Legacy CI",
+          "state" => "success",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        output = [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, { "name" => "statuses", "sha" => exact_head_sha }],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, documented_status]
+        ].map(&:to_json).join("\n")
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/status"
+          )
+          .and_return([output, success_status])
+
+        expect(fetch_ci_statuses_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha))
+          .to eq(statuses: [documented_status])
+      end
+
+      it "fails closed when a combined-status response envelope is missing or mismatches the requested SHA" do
+        success_status = instance_double(Process::Status, success?: true)
+        documented_status = {
+          "id" => 7,
+          "context" => "Legacy CI",
+          "state" => "success",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+
+        [{ "name" => "statuses" }, statuses_envelope("different-sha")].each do |envelope|
+          output = [
+            [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, envelope],
+            [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, documented_status]
+          ].map(&:to_json).join("\n")
+          allow(Open3).to receive(:capture2e).and_return([output, success_status])
+
+          expect(fetch_ci_statuses_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)[:error])
+            .to include("malformed")
+        end
+      end
+
+      it "fails closed when a later combined-status page mismatches the requested SHA" do
+        success_status = instance_double(Process::Status, success?: true)
+        documented_status = {
+          "id" => 7,
+          "context" => "Legacy CI",
+          "state" => "success",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        output = [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, statuses_envelope(exact_head_sha)],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, documented_status],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, statuses_envelope("different-sha")]
+        ].map(&:to_json).join("\n")
+        allow(Open3).to receive(:capture2e).and_return([output, success_status])
+
+        expect(fetch_ci_statuses_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)[:error])
+          .to include("malformed")
       end
 
       it "treats successful blank JSONL output as unknown evidence" do
@@ -2572,7 +2922,7 @@ RSpec.describe "release.rake helper methods" do
           "⚠️ DRY RUN: CI evidence below would block a real release:",
           '^  RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\\[17\\.0\\.0\\.rc\\.10\\]"$',
           "⚠️ DRY RUN: Real release remains blocked.",
-          "⚠️ DRY RUN: DANGEROUS LAST RESORT",
+          "⚠️ DRY RUN: DANGEROUS PRERELEASE-ONLY LAST RESORT",
           "RELEASE_CI_STATUS_OVERRIDE=true"
         ].join(".*")
 
@@ -2888,7 +3238,7 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
-    context "when override is set on a failing main" do
+    context "when override is set on a failing prerelease" do
       it "warns and returns instead of aborting" do
         allow(self).to receive(:fetch_main_ci_checks)
           .with(monorepo_root:, allow_override: true, dry_run: false, ci_branch: "main")
@@ -2897,7 +3247,7 @@ RSpec.describe "release.rake helper methods" do
         expect do
           validate_main_ci_status!(
             monorepo_root:,
-            is_prerelease: false,
+            is_prerelease: true,
             allow_override: true,
             dry_run: false
           )
@@ -3671,18 +4021,22 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "frames every raw legacy status in page order, including pending statuses and empty pages" do
-      first_page = [
-        { "id" => 1, "context" => "Legacy CI", "state" => "success" },
-        { "id" => 2, "context" => "Advisory", "state" => "pending" }
-      ]
-      second_page = []
+      response_sha = "head5678"
+      first_page = {
+        "sha" => response_sha,
+        "statuses" => [
+          { "id" => 1, "context" => "Legacy CI", "state" => "success" },
+          { "id" => 2, "context" => "Advisory", "state" => "pending" }
+        ]
+      }
+      second_page = { "sha" => response_sha, "statuses" => [] }
 
       expect(run_ci_jsonl_query(CI_STATUSES_JSONL_QUERY, [first_page, second_page])).to eq(
         [
-          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"],
-          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page[0]],
-          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page[1]],
-          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"]
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, { "name" => "statuses", "sha" => response_sha }],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page["statuses"][0]],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page["statuses"][1]],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, { "name" => "statuses", "sha" => response_sha }]
         ]
       )
     end
@@ -3692,9 +4046,19 @@ RSpec.describe "release.rake helper methods" do
         run_ci_jsonl_query(CI_CHECK_RUNS_JSONL_QUERY, [{ "check_runs" => nil }])
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected check_runs array/)
 
-      expect do
-        run_ci_jsonl_query(CI_STATUSES_JSONL_QUERY, [{ "statuses" => [] }])
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected statuses array/)
+      malformed_status_pages = [
+        { "statuses" => [] },
+        { "sha" => " ", "statuses" => [] },
+        { "sha" => "head5678", "statuses" => {} }
+      ]
+      malformed_status_pages.each do |page|
+        expect do
+          run_ci_jsonl_query(CI_STATUSES_JSONL_QUERY, [page])
+        end.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          /expected status object with sha and statuses array/
+        )
+      end
     end
   end
 
@@ -3734,7 +4098,7 @@ RSpec.describe "release.rake helper methods" do
               "repos/shakacode/react_on_rails/commits/#{sha}/check-runs")
         .and_return([[
           [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
-          *check_runs.map { |run| [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, run] }
+          *check_runs.map { |run| [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, run.merge("head_sha" => sha)] }
         ].map(&:to_json).join("\n"), success_status])
     end
 
@@ -3859,11 +4223,11 @@ RSpec.describe "release.rake helper methods" do
       jsonl = [
         [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
         [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, {
-          "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success"
+          "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success", "head_sha" => "abc1234def"
         }],
         [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
         [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, {
-          "id" => 2, "name" => "Test", "status" => "completed", "conclusion" => "failure"
+          "id" => 2, "name" => "Test", "status" => "completed", "conclusion" => "failure", "head_sha" => "abc1234def"
         }]
       ].map(&:to_json).join("\n")
       allow(Open3).to receive(:capture2e)
@@ -3895,7 +4259,7 @@ RSpec.describe "release.rake helper methods" do
         .and_return([[
           [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
           [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, {
-            "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success"
+            "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success", "head_sha" => "rcsha123"
           }]
         ].map(&:to_json).join("\n"), success_status])
 
@@ -4024,6 +4388,26 @@ RSpec.describe "release.rake helper methods" do
       expect { result = main_ci_evaluation_sha(monorepo_root:, head_sha: "head") }
         .to output(/Evaluating CI on parent/).to_stdout
       expect(result).to eq("parent")
+    end
+
+    it "does not recommend strict HEAD evaluation before exact-HEAD evidence is inspected" do
+      allow(self).to receive(:commit_non_runtime_only?)
+        .with(monorepo_root:, sha: "head").and_return(true)
+      allow(self).to receive(:commit_non_runtime_only?)
+        .with(monorepo_root:, sha: "parent").and_return(false)
+      allow(self).to receive(:release_finalization_metadata_commit?)
+        .with(monorepo_root:, sha: "parent").and_return(false)
+      allow(self).to receive(:git_parent_sha)
+        .with(monorepo_root:, sha: "head").and_return("parent")
+
+      output = capture_stdout do
+        main_ci_evaluation_sha(monorepo_root:, head_sha: "head")
+      end
+
+      expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+      expect(output).to include(
+        "Strict exact-HEAD recovery is offered only after exact-HEAD CI evidence is complete and healthy."
+      )
     end
 
     it "labels release branch walkback output with the evaluated ref" do
@@ -4381,6 +4765,128 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#gh_included_json_response" do
+    it "rejects mixed newline framing and HTTP control bytes" do
+      mixed_newlines = "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\n\n" \
+                       '{"message":"Branch not protected"}'
+      nul_header = "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\u0000\r\n\r\n" \
+                   '{"message":"Branch not protected"}'
+
+      expect(gh_included_json_response(mixed_newlines)).to be_nil
+      expect(gh_included_json_response(nul_header)).to be_nil
+    end
+
+    it "returns nil instead of raising for invalid or incompatible response encodings" do
+      response = "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                 '{"message":"Branch not protected"}'
+      invalid_utf8 = "#{response}\xFF".b.force_encoding(Encoding::UTF_8)
+      incompatible_encoding = response.encode(Encoding::UTF_16LE)
+
+      [invalid_utf8, incompatible_encoding].each do |output|
+        parsed = nil
+        expect { parsed = gh_included_json_response(output) }.not_to raise_error
+        expect(parsed).to be_nil
+      end
+    end
+  end
+
+  describe "#validated_github_jsonl_items" do
+    it "returns nil instead of raising for invalid or incompatible evidence encodings" do
+      output = [
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, {
+          "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success"
+        }]
+      ].map(&:to_json).join("\n")
+      invalid_utf8 = "#{output}\xFF".b.force_encoding(Encoding::UTF_8)
+      incompatible_encoding = output.encode(Encoding::UTF_16LE)
+
+      [invalid_utf8, incompatible_encoding].each do |evidence|
+        items = nil
+        expect do
+          items = validated_github_jsonl_items(
+            output: evidence,
+            envelope_name: "check_runs",
+            item_validator: method(:valid_ci_check_run?)
+          )
+        end.not_to raise_error
+        expect(items).to be_nil
+      end
+    end
+
+    it "rejects item frames before the expected envelope" do
+      run = { "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success" }
+      output = [
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, run],
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, run.merge("id" => 2)]
+      ].map(&:to_json).join("\n")
+
+      expect(
+        validated_github_jsonl_items(
+          output:,
+          envelope_name: "check_runs",
+          item_validator: method(:valid_ci_check_run?)
+        )
+      ).to be_nil
+    end
+
+    it "requires exact SHA matches and positive GitHub identities for raw CI evidence" do
+      requested_sha = "head5678"
+      check_run = {
+        "id" => 1,
+        "name" => "Lint",
+        "status" => "completed",
+        "conclusion" => "success",
+        "head_sha" => requested_sha,
+        "app" => { "id" => 2 },
+        "check_suite" => { "id" => 3 }
+      }
+      status = {
+        "id" => 4,
+        "context" => "Legacy CI",
+        "state" => "success",
+        "created_at" => "2026-07-13T00:00:00Z"
+      }
+
+      [
+        check_run.merge("head_sha" => "other"),
+        check_run.merge("id" => 0),
+        check_run.merge("check_suite" => { "id" => 0 }),
+        check_run.merge("app" => { "id" => 0 })
+      ].each do |run|
+        output = [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, run]
+        ].map(&:to_json).join("\n")
+
+        expect(
+          validated_github_jsonl_items(
+            output:,
+            envelope_name: "check_runs",
+            item_validator: ->(item) { valid_ci_check_run?(item, sha: requested_sha) }
+          )
+        ).to be_nil
+      end
+
+      [status.merge("id" => 0)].each do |legacy_status|
+        output = [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, { "name" => "statuses", "sha" => requested_sha }],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, legacy_status]
+        ].map(&:to_json).join("\n")
+
+        expect(
+          validated_github_jsonl_items(
+            output:,
+            envelope_name: "statuses",
+            envelope_validator: ->(envelope) { valid_ci_statuses_envelope?(envelope, sha: requested_sha) },
+            item_validator: method(:valid_ci_status?)
+          )
+        ).to be_nil
+      end
+    end
+  end
+
   describe "#required_check_names_for_branch" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:success_status) { instance_double(Process::Status, success?: true) }
@@ -4451,11 +4957,197 @@ RSpec.describe "release.rake helper methods" do
       )
     end
 
-    it "returns an unknown discovery state when the branch protection endpoint returns an error" do
+    it "returns an unknown discovery state for an authentication or scope failure" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
       allow(Open3).to receive(:capture2e)
         .with("gh", "api", "--jq", expected_jq,
-              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+              api_path)
         .and_return(["HTTP 403: insufficient token scope", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 403 Forbidden\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Resource not accessible by integration"}',
+                      "gh: insufficient token scope\n",
+                      failure_status
+                    ])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns an unknown discovery state for an unrelated not-found response" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Not Found", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Not Found"}',
+                      "gh: Not Found\n",
+                      failure_status
+                    ])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+      expect(Open3).not_to have_received(:capture2e).with(
+        "gh", "api", "repos/shakacode/react_on_rails/branches/main"
+      )
+    end
+
+    it "returns unknown when the unprotected-branch corroboration names a different branch" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      branch_path = "repos/shakacode/react_on_rails/branches/main"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Branch not protected"}',
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", branch_path)
+        .and_return(['{"name":"release/17.0.0","protected":false}', success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns unknown when the unprotected-branch corroboration omits its name" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      branch_path = "repos/shakacode/react_on_rails/branches/main"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Branch not protected"}',
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", branch_path)
+        .and_return(['{"protected":false}', success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns an unknown discovery state when failed response evidence is malformed" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 500: upstream failure", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return(["HTTP/2.0 500 Internal Server Error\r\n\r\nnot JSON", "gh: upstream failure\n", failure_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns unknown instead of accepting a malformed included response header" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      branch_path = "repos/shakacode/react_on_rails/branches/main"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nnot-a-header\r\n\r\n" \
+                      '{"message":"Branch not protected"}',
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", branch_path)
+        .and_return(['{"protected":false}', success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+      expect(Open3).not_to have_received(:capture2e).with("gh", "api", branch_path)
+    end
+
+    it "returns unknown instead of accepting contradictory included response statuses" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      branch_path = "repos/shakacode/react_on_rails/branches/main"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 500 Internal Server Error\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Internal Server Error"}' \
+                      "\r\n\r\nHTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Branch not protected"}',
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", branch_path)
+        .and_return(['{"protected":false}', success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+      expect(Open3).not_to have_received(:capture2e).with("gh", "api", branch_path)
+    end
+
+    it "returns unknown instead of accepting a contradictory included status header" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      branch_path = "repos/shakacode/react_on_rails/branches/main"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\nStatus: 500\r\n\r\n" \
+                      '{"message":"Branch not protected"}',
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", branch_path)
+        .and_return(['{"protected":false}', success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+      expect(Open3).not_to have_received(:capture2e).with("gh", "api", branch_path)
+    end
+
+    it "returns unknown instead of raising for a non-object included response body" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n[]",
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
+
+      expect { required_check_names_for_branch(monorepo_root:) }
+        .not_to raise_error
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns unknown for trailing content after the included JSON response body" do
+      api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, api_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", api_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Branch not protected"}\ntrailing content',
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
 
       expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
     end
@@ -4514,6 +5206,17 @@ RSpec.describe "release.rake helper methods" do
         .and_return([{ contexts: [], checks: [{ context: "Lint" }] }.to_json, success_status])
 
       expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns an unknown discovery state when a modern check has a nonpositive app_id" do
+      [0, -2].each do |app_id|
+        allow(Open3).to receive(:capture2e)
+          .with("gh", "api", "--jq", expected_jq,
+                "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+          .and_return([{ contexts: [], checks: [{ context: "Lint", app_id: }] }.to_json, success_status])
+
+        expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+      end
     end
 
     it "returns nil for a structurally valid empty protection configuration" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -1637,6 +1637,46 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    context "when a protected branch has required status checks disabled" do
+      it "evaluates every visible prerelease check instead of treating required checks as unknown" do
+        failure_status = instance_double(Process::Status, success?: false)
+        success_status = instance_double(Process::Status, success?: true)
+        api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+        branch_path = "repos/shakacode/react_on_rails/branches/main"
+        allow(self).to receive(:required_check_names_for_branch).and_call_original
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha:, repo_slug: "shakacode/react_on_rails", check_runs: [passing_run("Lint")])
+        allow(Open3).to receive(:capture2e)
+          .with("gh", "api", "--jq", "{contexts, checks}", api_path)
+          .and_return(["HTTP 404: Required status checks not enabled", failure_status])
+        allow(Open3).to receive(:capture3)
+          .with("gh", "api", "--include", api_path)
+          .and_return([
+                        "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                        '{"message":"Required status checks not enabled"}',
+                        "gh: Required status checks not enabled\n",
+                        failure_status
+                      ])
+        allow(Open3).to receive(:capture2e)
+          .with("gh", "api", branch_path)
+          .and_return(['{"name":"main","protected":true}', success_status])
+
+        output = nil
+        expect do
+          output = capture_stdout do
+            validate_main_ci_status!(
+              monorepo_root:,
+              is_prerelease: true,
+              allow_override: false,
+              dry_run: false
+            )
+          end
+        end.not_to raise_error
+        expect(output).to include("Main CI is healthy on #{short_sha} (1 check)")
+      end
+    end
+
     context "when strict exact-HEAD evaluation is enabled" do
       before do
         allow(self).to receive(:ci_evaluate_head_only?).and_return(true)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -1562,6 +1562,233 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    context "when strict exact-HEAD evaluation is enabled" do
+      before do
+        allow(self).to receive(:ci_evaluate_head_only?).and_return(true)
+      end
+
+      it "blocks a prerelease when an unrelated exact-HEAD check fails" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: [passing_run("Lint", app_id: 123), failing_run("Benchmark")]
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, %r{CI on origin/main is not healthy.*Benchmark}m)
+      end
+
+      it "blocks a prerelease when an unrelated exact-HEAD check is pending" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: [passing_run("Lint", app_id: 123), in_progress_run("Benchmark")]
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, /CI is still in progress.*Benchmark/m)
+      end
+
+      it "fetches and blocks failed legacy status evidence for app-pinned-only protection" do
+        failed_status = {
+          "id" => 1,
+          "context" => "Advisory",
+          "state" => "failure",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: [passing_run("Lint", app_id: 123)]
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: false)
+          .and_return([failed_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, %r{CI on origin/main is not healthy.*Advisory}m)
+        expect(self).to have_received(:fetch_main_commit_statuses)
+      end
+
+      it "fails closed when strict exact-HEAD status evidence is unavailable" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: [passing_run("Lint", app_id: 123)]
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: false)
+          .and_return(nil)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, /legacy status fetch returned nil unexpectedly in strict mode/)
+      end
+
+      it "fails closed when strict exact-HEAD status evidence is malformed" do
+        malformed_status = {
+          "id" => 1,
+          "context" => nil,
+          "state" => "success",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: [passing_run("Lint", app_id: 123)]
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: false)
+          .and_return([malformed_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, /Strict exact-HEAD CI evidence is malformed or unknown/)
+      end
+
+      it "keeps explicitly empty strict exact-HEAD evidence blocked" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: []
+          )
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: false)
+          .and_return([])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, %r{No CI check runs visible on origin/main})
+      end
+    end
+
+    context "when required check discovery is unknown" do
+      it "fails closed for a stable release despite a healthy-looking visible subset" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha:, check_runs: [passing_run("Lint")])
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, ci_branch: "main")
+          .and_return(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, /Required CI check discovery is unknown/)
+      end
+
+      it "fails closed for a prerelease despite a healthy-looking visible subset" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha:, check_runs: [passing_run("Lint")])
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, ci_branch: "main")
+          .and_return(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit, /Required CI check discovery is unknown/)
+      end
+
+      it "fails closed when strict exact-HEAD evaluation has a healthy-looking subset" do
+        exact_head_sha = "head5678"
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha: exact_head_sha, head_sha: exact_head_sha, check_runs: [passing_run("Lint")])
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, ci_branch: "main")
+          .and_return(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Required CI check discovery is unknown")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+    end
+
     context "when releasing from a release branch (ci_branch override)" do
       it "evaluates the release branch tip and references it in violations" do
         allow(self).to receive(:fetch_main_ci_checks)
@@ -1834,6 +2061,833 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    context "when metadata walkback has no usable CI runs" do
+      let(:walked_back_sha) { "runtime123" }
+      let(:exact_head_sha) { "head5678" }
+      let(:walkback_without_ci_runs) do
+        {
+          sha: walked_back_sha,
+          head_sha: exact_head_sha,
+          repo_slug: "shakacode/react_on_rails",
+          check_runs: []
+        }
+      end
+
+      before do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(walkback_without_ci_runs)
+      end
+
+      it "offers strict exact-HEAD evaluation only after exact HEAD is healthy" do
+        strict_head_guidance = [
+          "strict evaluation, not a waiver",
+          'RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\\[17\\.0\\.0\\.rc\\.10\\]"',
+          "DANGEROUS",
+          "RELEASE_CI_STATUS_OVERRIDE=true"
+        ].join(".*")
+        define_singleton_method(:fetch_ci_check_runs_for_sha) do |repo_slug:, sha:|
+          expect(repo_slug).to eq("shakacode/react_on_rails")
+          expect(sha).to eq(exact_head_sha)
+          { check_runs: [passing_run("Lint")] }
+        end
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(
+          SystemExit,
+          Regexp.new(strict_head_guidance, Regexp::MULTILINE)
+        )
+      end
+
+      it "withholds strict exact-HEAD guidance when walked-back unrelated evidence is pending" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(walkback_without_ci_runs.merge(check_runs: [in_progress_run("Advisory")]))
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint")]))
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("No required CI check runs found")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+        expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
+      end
+
+      it "withholds strict exact-HEAD guidance when unrelated walked-back legacy status evidence is pending" do
+        pending_status = {
+          "id" => 1,
+          "context" => "Advisory",
+          "state" => "pending",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(walkback_without_ci_runs.merge(check_runs: [passing_run("Advisory")]))
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([pending_status])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Legacy CI")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("No required CI check runs found")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+        expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
+        expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
+      end
+
+      it "withholds strict exact-HEAD guidance when unrelated walked-back evidence has failed" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(walkback_without_ci_runs.merge(check_runs: [failing_run("Advisory")]))
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint")]))
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("No required CI check runs found")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+        expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
+        expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
+      end
+
+      it "fails closed when an app-pinned exact-HEAD check run has a malformed app ID" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+        success_status = instance_double(Process::Status, success?: true)
+        malformed_run = {
+          "id" => 1,
+          "name" => "Lint",
+          "status" => "completed",
+          "conclusion" => "success",
+          "app" => { "id" => "123-junk" }
+        }
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/check-runs"
+          )
+          .and_return([malformed_run.to_json, success_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Exact HEAD evidence is unknown")
+          expect(error.message).to include("malformed")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when an exact-HEAD check run has a partial app identity" do
+        success_status = instance_double(Process::Status, success?: true)
+        malformed_run = {
+          "id" => 1,
+          "name" => "Lint",
+          "status" => "completed",
+          "conclusion" => "success",
+          "app" => {}
+        }
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/check-runs"
+          )
+          .and_return([malformed_run.to_json, success_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Exact HEAD evidence is unknown")
+          expect(error.message).to include("malformed")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when malformed suite identity would hide an exact-HEAD failure" do
+        success_status = instance_double(Process::Status, success?: true)
+        earlier_failure = {
+          "id" => 1,
+          "name" => "Lint",
+          "status" => "completed",
+          "conclusion" => "failure",
+          "check_suite" => { "id" => "suite-junk" }
+        }
+        later_success = earlier_failure.merge("id" => 2, "conclusion" => "success")
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/check-runs"
+          )
+          .and_return([[earlier_failure, later_success].map(&:to_json).join("\n"), success_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Exact HEAD evidence is unknown")
+          expect(error.message).to include("malformed")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when exact-HEAD legacy status evidence has a malformed ID" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [])
+        success_status = instance_double(Process::Status, success?: true)
+        malformed_status = { "id" => "7-junk", "context" => "Legacy CI", "state" => "success" }
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+          )
+          .and_return([malformed_status.to_json, success_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Exact HEAD evidence is unknown")
+          expect(error.message).to include("malformed")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when a newer exact-HEAD legacy status lacks created_at" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [])
+        success_status = instance_double(Process::Status, success?: true)
+        statuses = [
+          { "id" => 1, "context" => "Legacy CI", "state" => "success", "created_at" => "2026-07-13T00:00:00Z" },
+          { "id" => 2, "context" => "Legacy CI", "state" => "failure" }
+        ]
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+          )
+          .and_return([[
+            [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"],
+            *statuses.map { |status| [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, status] }
+          ].map(&:to_json).join("\n"), success_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Exact HEAD evidence is unknown")
+          expect(error.message).to include("malformed")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "keeps the newer exact-HEAD legacy status failure when offsets differ" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [])
+        success_status = instance_double(Process::Status, success?: true)
+        statuses = [
+          { "id" => 1, "context" => "Legacy CI", "state" => "success", "created_at" => "2026-07-13T10:00:00+10:00" },
+          { "id" => 2, "context" => "Legacy CI", "state" => "failure", "created_at" => "2026-07-13T01:00:00Z" }
+        ]
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+          )
+          .and_return([[
+            [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"],
+            *statuses.map { |status| [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, status] }
+          ].map(&:to_json).join("\n"), success_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Exact HEAD #{exact_head_sha} has failing CI evidence")
+          expect(error.message).to include("Legacy CI")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when the exact-HEAD statuses envelope is malformed" do
+        expected_statuses_query = CI_STATUSES_JSONL_QUERY
+        statuses_query = nil
+        success_status = instance_double(Process::Status, success?: true)
+        failure_status = instance_double(Process::Status, success?: false)
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(Open3).to receive(:capture2e) do |*args|
+          jq_query = args[4]
+          case args[5]
+          when "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/check-runs"
+            output = [
+              [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+              [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, passing_run("Legacy CI")]
+            ].map(&:to_json).join("\n")
+            [output, success_status]
+          when "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+            statuses_query = jq_query
+            jq_query == expected_statuses_query ? ["jq: expected statuses array", failure_status] : ["", success_status]
+          else
+            raise "Unexpected GitHub API request: #{args.inspect}"
+          end
+        end
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Exact HEAD evidence is unknown")
+          expect(error.message).to include("Statuses API")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+        expect(statuses_query).to eq(expected_statuses_query)
+      end
+
+      it "rejects a malformed exact-HEAD check-runs envelope before flattening" do
+        expected_check_runs_query = CI_CHECK_RUNS_JSONL_QUERY
+        check_runs_query = nil
+        success_status = instance_double(Process::Status, success?: true)
+        failure_status = instance_double(Process::Status, success?: false)
+        allow(Open3).to receive(:capture2e) do |*args|
+          check_runs_query = args[4]
+          if check_runs_query == expected_check_runs_query
+            ["jq: expected check_runs array", failure_status]
+          else
+            ["", success_status]
+          end
+        end
+
+        result = fetch_ci_check_runs_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+
+        expect(result[:error]).to include("Checks API")
+        expect(check_runs_query).to eq(expected_check_runs_query)
+      end
+
+      it "keeps valid empty exact-HEAD API envelopes known empty" do
+        success_status = instance_double(Process::Status, success?: true)
+        allow(Open3).to receive(:capture2e) do |*args|
+          envelope_name = args.last.end_with?("/check-runs") ? "check_runs" : "statuses"
+          [[CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, envelope_name].to_json, success_status]
+        end
+
+        expect(fetch_ci_check_runs_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha))
+          .to eq(check_runs: [])
+        expect(fetch_ci_statuses_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha))
+          .to eq(statuses: [])
+        expect(Open3).to have_received(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/check-runs"
+          )
+        expect(Open3).to have_received(:capture2e)
+          .with(
+            "gh", "api", "--paginate", "--jq", CI_STATUSES_JSONL_QUERY,
+            "repos/shakacode/react_on_rails/commits/#{exact_head_sha}/statuses"
+          )
+      end
+
+      it "treats successful blank JSONL output as unknown evidence" do
+        success_status = instance_double(Process::Status, success?: true)
+        allow(Open3).to receive(:capture2e).and_return(["", success_status])
+
+        expect(fetch_ci_check_runs_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)[:error])
+          .to include("malformed")
+        expect(fetch_ci_statuses_for_sha(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)[:error])
+          .to include("malformed")
+      end
+
+      it "keeps current-marker-like exact-HEAD payloads as item data for schema validation" do
+        marker_like_failed_run = failing_run("Marker benchmark").merge(
+          CI_JSONL_FRAME_KEY => CI_JSONL_ENVELOPE_FRAME
+        )
+        output = [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, marker_like_failed_run]
+        ].map(&:to_json).join("\n")
+
+        items = validated_github_jsonl_items(
+          output:,
+          envelope_name: "check_runs",
+          item_validator: method(:valid_ci_check_run?)
+        )
+
+        expect(items).to eq([marker_like_failed_run])
+        expect(
+          main_ci_status_evaluation(
+            check_runs: items,
+            legacy_status_runs: [],
+            required_names: nil,
+            is_prerelease: false,
+            sha: exact_head_sha,
+            ci_branch: "main"
+          )[:kind]
+        ).to eq(:failed)
+
+        malformed_marker_like_run = { CI_JSONL_FRAME_KEY => CI_JSONL_ENVELOPE_FRAME }
+        malformed_output = [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, malformed_marker_like_run]
+        ].map(&:to_json).join("\n")
+
+        expect(
+          validated_github_jsonl_items(
+            output: malformed_output,
+            envelope_name: "check_runs",
+            item_validator: method(:valid_ci_check_run?)
+          )
+        ).to be_nil
+      end
+
+      it "keeps the strict exact-HEAD command copy-pasteable during a dry run" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: true, ci_branch: "main")
+          .and_return(walkback_without_ci_runs)
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expected_output = [
+          "⚠️ DRY RUN: CI evidence below would block a real release:",
+          '^  RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\\[17\\.0\\.0\\.rc\\.10\\]"$',
+          "⚠️ DRY RUN: Real release remains blocked.",
+          "⚠️ DRY RUN: DANGEROUS LAST RESORT",
+          "RELEASE_CI_STATUS_OVERRIDE=true"
+        ].join(".*")
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: true,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to output(Regexp.new(expected_output, Regexp::MULTILINE)).to_stdout
+      end
+
+      it "withholds strict exact-HEAD guidance without a resolved target version" do
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("resolved release version is unavailable")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when required-check discovery is unknown" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+        expect(self).not_to receive(:fetch_ci_check_runs_for_sha)
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("Required CI check discovery is unknown")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "inspects exact HEAD when a prerelease walked-back SHA has only advisory checks" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(walkback_without_ci_runs.merge(check_runs: [passing_run("Change detector")]))
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint")]))
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit, /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end
+
+      it "tells the operator to wait for pending exact-HEAD checks without recommending strict HEAD" do
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [in_progress_run("Slow test")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to match(%r{Exact HEAD.*pending.*Wait.*Slow test.*https://github\.com}m)
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "keeps failed exact-HEAD checks blocking without recommending strict HEAD" do
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [failing_run("JS unit tests")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to match(%r{Exact HEAD.*failing.*JS unit tests.*https://github\.com}m)
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when neither walked-back SHA nor exact HEAD has CI evidence" do
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to match(
+            /Exact HEAD.*does not provide complete healthy CI evidence.*No CI check runs visible/m
+          )
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fails closed when exact-HEAD CI evidence cannot be queried" do
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(error: "❌ Unable to query GitHub Checks API for #{exact_head_sha}.")
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to match(/Exact HEAD evidence is unknown.*Unable to query GitHub Checks API/m)
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "keeps unrelated failed exact-HEAD checks blocking for prerelease recovery" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint")]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint"), failing_run("Advisory benchmark")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to match(/Exact HEAD.*failing CI evidence.*Advisory benchmark/m)
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "keeps unrelated pending exact-HEAD checks blocking for prerelease recovery" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint")]))
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint"), in_progress_run("Benchmark")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to match(/Exact HEAD.*pending CI evidence.*Benchmark/m)
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+      end
+
+      it "fetches raw walked-back legacy statuses for app-pinned recovery evidence" do
+        pending_status = {
+          "id" => 1,
+          "context" => "Advisory",
+          "state" => "pending",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(walkback_without_ci_runs.merge(check_runs: [passing_run("Advisory")]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([pending_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("No required CI check runs found")
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+        expect(self).to have_received(:fetch_main_commit_statuses)
+      end
+
+      it "fetches raw exact-HEAD legacy statuses for app-pinned recovery evidence" do
+        failed_status = {
+          "id" => 1,
+          "context" => "Advisory",
+          "state" => "failure",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("Lint", app_id: 123)]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint", app_id: 123)])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [failed_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to match(/Exact HEAD.*failing CI evidence.*Advisory/m)
+          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        }
+        expect(self).to have_received(:fetch_ci_statuses_for_sha)
+      end
+
+      it "uses legacy required-status evidence for exact HEAD" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Legacy CI"]))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha: walked_back_sha, allow_override: false, dry_run: false)
+          .and_return([])
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [])
+        successful_status = {
+          "id" => 7,
+          "context" => "Legacy CI",
+          "state" => "success",
+          "created_at" => "2026-07-13T00:00:00Z"
+        }
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [successful_status])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit, /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end
+    end
+
     context "when override is set on a failing main" do
       it "warns and returns instead of aborting" do
         allow(self).to receive(:fetch_main_ci_checks)
@@ -1864,7 +2918,7 @@ RSpec.describe "release.rake helper methods" do
             allow_override: false,
             dry_run: true
           )
-        end.to output(%r{DRY RUN.*CI on origin/main is not healthy.*DRY RUN:.*Lint}m).to_stdout
+        end.to output(%r{DRY RUN: CI evidence below.*CI on origin/main is not healthy.*Lint}m).to_stdout
       end
     end
 
@@ -2223,7 +3277,7 @@ RSpec.describe "release.rake helper methods" do
             allow_override: false,
             dry_run: true
           )
-        end.to output(%r{DRY RUN: .*CI on origin/main is not healthy.*DRY RUN:.*Lint}m).to_stdout
+        end.to output(%r{DRY RUN: CI evidence below.*CI on origin/main is not healthy.*Lint}m).to_stdout
       end
 
       it "does not print green when required legacy status data is unavailable in dry-run" do
@@ -2249,6 +3303,44 @@ RSpec.describe "release.rake helper methods" do
 
         expect(output).to include("DRY RUN: Required legacy status fetch failed.")
         expect(output).not_to include("Main CI is healthy")
+      end
+
+      it "withholds strict exact-HEAD guidance when walked-back legacy status evidence is unknown in dry-run" do
+        exact_head_sha = "head5678"
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: true, ci_branch: "main")
+          .and_return(
+            sha:,
+            head_sha: exact_head_sha,
+            repo_slug: "shakacode/react_on_rails",
+            check_runs: []
+          )
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(contexts: ["Travis"], checks: []))
+        allow(self).to receive(:fetch_main_commit_statuses)
+          .with(repo_slug: "shakacode/react_on_rails", sha:, allow_override: false, dry_run: true)
+          .and_return(nil)
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [{ "id" => 1, "context" => "Travis", "state" => "success" }])
+
+        output = capture_stdout do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: true,
+            target_gem_version: "17.0.0.rc.10"
+          )
+        end
+
+        expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
+        expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
       end
 
       it "raises if strict legacy status fetch unexpectedly returns nil" do
@@ -2529,6 +3621,83 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "CI JSONL framing queries" do
+    def run_ci_jsonl_query(query, pages)
+      pages.flat_map do |page|
+        output, status = Open3.capture2e("jq", "-c", query, stdin_data: page.to_json)
+        expect(status.success?).to be(true), "jq framing query failed: #{output}"
+
+        output.lines.map { |line| JSON.parse(line) }
+      end
+    rescue Errno::ENOENT
+      raise "jq is required to verify the release CI JSONL framing boundary"
+    end
+
+    it "frames every raw check run in page order, including failures and empty pages" do
+      first_page = {
+        "check_runs" => [
+          { "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success" },
+          { "id" => 2, "name" => "Benchmark", "status" => "completed", "conclusion" => "failure" }
+        ]
+      }
+      second_page = { "check_runs" => [] }
+
+      expect(run_ci_jsonl_query(CI_CHECK_RUNS_JSONL_QUERY, [first_page, second_page])).to eq(
+        [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page["check_runs"][0]],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page["check_runs"][1]],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"]
+        ]
+      )
+    end
+
+    it "keeps current-marker-like raw check-run data inside exactly one item frame" do
+      marker_like_run = {
+        "id" => 3,
+        "name" => "Marker benchmark",
+        "status" => "completed",
+        "conclusion" => "failure",
+        CI_JSONL_FRAME_KEY => CI_JSONL_ENVELOPE_FRAME
+      }
+      raw_page = { "check_runs" => [marker_like_run] }
+
+      expect(run_ci_jsonl_query(CI_CHECK_RUNS_JSONL_QUERY, [raw_page])).to eq(
+        [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, marker_like_run]
+        ]
+      )
+    end
+
+    it "frames every raw legacy status in page order, including pending statuses and empty pages" do
+      first_page = [
+        { "id" => 1, "context" => "Legacy CI", "state" => "success" },
+        { "id" => 2, "context" => "Advisory", "state" => "pending" }
+      ]
+      second_page = []
+
+      expect(run_ci_jsonl_query(CI_STATUSES_JSONL_QUERY, [first_page, second_page])).to eq(
+        [
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page[0]],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, first_page[1]],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "statuses"]
+        ]
+      )
+    end
+
+    it "rejects malformed raw response envelopes" do
+      expect do
+        run_ci_jsonl_query(CI_CHECK_RUNS_JSONL_QUERY, [{ "check_runs" => nil }])
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected check_runs array/)
+
+      expect do
+        run_ci_jsonl_query(CI_STATUSES_JSONL_QUERY, [{ "statuses" => [] }])
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected statuses array/)
+    end
+  end
+
   describe "#fetch_main_ci_checks" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:success_status) { instance_double(Process::Status, success?: true) }
@@ -2561,9 +3730,12 @@ RSpec.describe "release.rake helper methods" do
     def stub_check_runs_for_sha(sha:, check_runs:)
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--paginate", "--jq", ".check_runs[]",
+        .with("gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
               "repos/shakacode/react_on_rails/commits/#{sha}/check-runs")
-        .and_return([check_runs.map(&:to_json).join("\n"), success_status])
+        .and_return([[
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+          *check_runs.map { |run| [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, run] }
+        ].map(&:to_json).join("\n"), success_status])
     end
 
     it "aborts if `git fetch origin main` fails" do
@@ -2609,7 +3781,7 @@ RSpec.describe "release.rake helper methods" do
         .and_return(["abc1234\n", success_status])
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--paginate", "--jq", ".check_runs[]",
+        .with("gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
               "repos/shakacode/react_on_rails/commits/abc1234/check-runs")
         .and_return(["HTTP 401: unauthorized", failure_status])
 
@@ -2627,7 +3799,7 @@ RSpec.describe "release.rake helper methods" do
         .and_return(["abc1234\n", success_status])
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--paginate", "--jq", ".check_runs[]",
+        .with("gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
               "repos/shakacode/react_on_rails/commits/abc1234/check-runs")
         .and_raise(Errno::ENOENT)
 
@@ -2645,7 +3817,7 @@ RSpec.describe "release.rake helper methods" do
         .and_return(["abc1234\n", success_status])
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--paginate", "--jq", ".check_runs[]",
+        .with("gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
               "repos/shakacode/react_on_rails/commits/abc1234/check-runs")
         .and_raise(Errno::ENOENT)
 
@@ -2665,7 +3837,7 @@ RSpec.describe "release.rake helper methods" do
         .and_return(["abc1234\n", success_status])
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--paginate", "--jq", ".check_runs[]",
+        .with("gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
               "repos/shakacode/react_on_rails/commits/abc1234/check-runs")
         .and_return(["this is not json", success_status])
 
@@ -2685,11 +3857,17 @@ RSpec.describe "release.rake helper methods" do
         .and_return(["abc1234def\n", success_status])
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
       jsonl = [
-        { "name" => "Lint", "status" => "completed", "conclusion" => "success" },
-        { "name" => "Test", "status" => "completed", "conclusion" => "failure" }
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, {
+          "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success"
+        }],
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+        [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, {
+          "id" => 2, "name" => "Test", "status" => "completed", "conclusion" => "failure"
+        }]
       ].map(&:to_json).join("\n")
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--paginate", "--jq", ".check_runs[]",
+        .with("gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
               "repos/shakacode/react_on_rails/commits/abc1234def/check-runs")
         .and_return([jsonl, success_status])
 
@@ -2712,10 +3890,14 @@ RSpec.describe "release.rake helper methods" do
         .and_return(["rcsha123\n", success_status])
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--paginate", "--jq", ".check_runs[]",
+        .with("gh", "api", "--paginate", "--jq", CI_CHECK_RUNS_JSONL_QUERY,
               "repos/shakacode/react_on_rails/commits/rcsha123/check-runs")
-        .and_return([{ "name" => "Lint", "status" => "completed", "conclusion" => "success" }.to_json,
-                     success_status])
+        .and_return([[
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ENVELOPE_FRAME, "check_runs"],
+          [CI_JSONL_FRAME_KEY, CI_JSONL_ITEM_FRAME, {
+            "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success"
+          }]
+        ].map(&:to_json).join("\n"), success_status])
 
       result = fetch_main_ci_checks(monorepo_root:, ci_branch: "release/17.0.0")
       expect(result[:sha]).to eq("rcsha123")
@@ -2766,7 +3948,7 @@ RSpec.describe "release.rake helper methods" do
       stub_release_branch_refs(remote_sha: "remote123", local_sha: "local456")
       stub_check_runs_for_sha(
         sha: "remote123",
-        check_runs: [{ "name" => "Lint", "status" => "completed", "conclusion" => "success" }]
+        check_runs: [{ "id" => 1, "name" => "Lint", "status" => "completed", "conclusion" => "success" }]
       )
 
       result = nil
@@ -3203,7 +4385,7 @@ RSpec.describe "release.rake helper methods" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:success_status) { instance_double(Process::Status, success?: true) }
     let(:failure_status) { instance_double(Process::Status, success?: false) }
-    let(:expected_jq) { "{contexts: (.contexts // []), checks: (.checks // [] | map({context, app_id}))}" }
+    let(:expected_jq) { "{contexts, checks}" }
 
     before do
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
@@ -3269,20 +4451,75 @@ RSpec.describe "release.rake helper methods" do
       )
     end
 
-    it "returns nil when the branch protection endpoint returns an error" do
+    it "returns an unknown discovery state when the branch protection endpoint returns an error" do
       allow(Open3).to receive(:capture2e)
         .with("gh", "api", "--jq", expected_jq,
               "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
-        .and_return(["HTTP 404: Branch not protected", failure_status])
+        .and_return(["HTTP 403: insufficient token scope", failure_status])
 
-      expect(required_check_names_for_branch(monorepo_root:)).to be_nil
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
     end
 
-    it "returns nil when the protection response yields an empty array (fail-safe)" do
+    it "returns an unknown discovery state when the branch protection response is malformed" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq,
+              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+        .and_return(["not valid JSON", success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "keeps nullable or missing branch protection fields visible to fail closed" do
+      # `{contexts, checks}` renders missing fields as null, which must remain
+      # distinguishable from a configured pair of empty arrays.
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", "{contexts, checks}",
+              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+        .and_return([{ contexts: nil, checks: nil }.to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns an unknown discovery state when the branch protection payload is not an object" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq,
+              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+        .and_return([[].to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns an unknown discovery state when branch protection fields are not arrays" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq,
+              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+        .and_return([{ contexts: [], checks: {} }.to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns an unknown discovery state when a required check entry is malformed" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq,
+              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+        .and_return([{ contexts: [], checks: [{ context: nil, app_id: 123 }] }.to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns an unknown discovery state when a modern check omits app_id" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq,
+              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+        .and_return([{ contexts: [], checks: [{ context: "Lint" }] }.to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "returns nil for a structurally valid empty protection configuration" do
       # Newer branch protection rules can return `contexts: []` with the real required
-      # names in `checks`. The combined jq query above returns `[]` only when neither
-      # field has names. Treat that as "no protection visible" and let the caller
-      # evaluate every check run rather than abort with :no_required_checks.
+      # names in `checks`. With both fields present and empty, treat this as "no
+      # protection visible" and let the caller evaluate every check run.
       allow(Open3).to receive(:capture2e)
         .with("gh", "api", "--jq", expected_jq,
               "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")


### PR DESCRIPTION
## Summary

Release retries can no longer be recommended from incomplete or malformed CI evidence. When normal metadata walkback finds no usable run, the task now offers strict exact-HEAD recovery only after both the walked-back and exact-tip evidence are structurally valid, finalized, and healthy; the suggested retry then enforces that same all-evidence boundary before applying ordinary required-check rules.

This keeps normal prerelease behavior unchanged—non-required checks remain advisory unless strict exact-HEAD mode is explicitly selected—while making unknown branch protection, malformed check identities, ambiguous pagination, pending statuses, and unrelated failures fail closed. Strict evaluation reuses its first validated legacy-status result instead of risking a contradictory second fetch. The CI override remains an explicitly dangerous prerelease-only waiver, is never implied by recovery guidance, and is rejected for stable/final promotion.

Protected branches that explicitly have required status checks disabled remain a known no-required-checks state after exact response and branch-name/protection corroboration, so the existing visible-check fallback still applies. Malformed, mismatched, and unrelated protection responses remain unknown and blocked.

No `.github` workflow files change. This is an internal release-safety correction, so the changelog classification is `not_user_visible`.

Fixes #4647

## Validation

- Post-repair release-helper suite: 332 examples, 0 failures.
- Targeted RuboCop on the release task and helper spec: 2 files, no offenses.
- Releasing guide: Prettier clean; pre-commit and pre-push hooks passed, including Markdown links.
- Full gem suite with runtime RBS checking disabled: 2,873 examples, 0 failures, 5 pending.
- The changed-file validator passed dependency checks, docs sidebar coverage, OSS and benchmark RuboCop, build, ESLint, Prettier, and type checking. Its gem-spec phase remains blocked by an unchanged runtime-RBS mismatch in `GitUtils`: the isolated nine-example baseline has four failures with runtime checking enabled and passes 9/9 with it disabled.
- Independent final review: fresh isolated Sol/xhigh checker reported `VERIFIED CLEAN` at `d4fef09df8b5da0f580563e4f5fb775f4fcb5f0f` after the current-head review repair.

## New concepts

### Authenticated JSONL pagination frames

Paginated command output needs to distinguish a valid empty API page from missing, truncated, or malformed output. The release gate now emits an explicit envelope for every raw page and wraps every API object in a separate item frame:

```text
raw page -> envelope frame
         -> item frame(check or status)
```

That boundary lets the parser fail closed when an envelope is absent while preserving every failed or pending item, even when ordinary item data resembles the frame marker. For legacy commit statuses, the envelope also binds every paginated response to the requested SHA through the combined-status response's documented `sha` field; status items themselves do not provide that field. It is preferable here to flattening raw JSON because an empty page is legitimate evidence but a blank stream is not. This pattern is unnecessary when a caller receives one already-validated JSON document with no pagination or empty-response ambiguity.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 (xhigh)](https://img.shields.io/badge/GPT--5_%28xhigh%29-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved release CI validation with stricter checks for exact commit evidence and malformed or incomplete results.
  * Added clearer retry guidance when CI evidence is missing or inconclusive.
  * Restricted CI override waivers to prerelease releases; stable releases can no longer bypass the gate.
  * Improved handling of GitHub Checks and legacy status results, including duplicate and unknown results.

* **Documentation**
  * Expanded release documentation with CI evidence decision guidance, override warnings, and exact-commit retry examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->