### PR TITLE
Release: reuse verified ShakaPerf pre-run evidence

### DIFF
--- a/.github/workflows/shakaperf-release-gates.yml
+++ b/.github/workflows/shakaperf-release-gates.yml
@@ -31,6 +31,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Read runtime versions
+        id: tool-versions
+        uses: ./.github/actions/read-tool-versions
+
+      - name: Setup Ruby
+        uses: ./.github/actions/setup-ruby
+        with:
+          ruby-version: ${{ steps.tool-versions.outputs.minimum-ruby-version }}
+          bundler-version: 2.5.4
+
       - name: Validate exact candidate
         id: candidate
         env:

--- a/.github/workflows/shakaperf-release-gates.yml
+++ b/.github/workflows/shakaperf-release-gates.yml
@@ -345,13 +345,15 @@ jobs:
           CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           CONCLUSION: ${{ needs.rsc-fouc.result }}
           RELEASE_BRANCH: ${{ github.ref_name }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           RUN_ID: ${{ github.run_id }}
           RUNTIME_TREE_FINGERPRINT: ${{ needs.candidate.outputs.runtime_tree_fingerprint }}
           TARGET_VERSION: ${{ inputs.target_version }}
         run: |
           ruby -rjson -rtime <<'RUBY'
           evidence = {
-            schema_version: 1,
+            schema_version: 2,
+            run_attempt: Integer(ENV.fetch("RUN_ATTEMPT"), 10),
             run_id: Integer(ENV.fetch("RUN_ID"), 10),
             run_url: "https://github.com/#{ENV.fetch('GITHUB_REPOSITORY')}/actions/runs/#{ENV.fetch('RUN_ID')}",
             branch: ENV.fetch("RELEASE_BRANCH"),

--- a/.github/workflows/shakaperf-release-gates.yml
+++ b/.github/workflows/shakaperf-release-gates.yml
@@ -1,25 +1,92 @@
 name: ShakaPerf Release Gates
+run-name: ShakaPerf Release Gates — ${{ inputs.target_version }} on ${{ github.ref_name }} @ ${{ inputs.candidate_sha }}
 
 permissions:
   contents: read
 
 on:
   workflow_dispatch:
+    inputs:
+      target_version:
+        description: RubyGems-format release version being tested
+        required: true
+        type: string
+      candidate_sha:
+        description: Exact release-branch commit being tested
+        required: true
+        type: string
 
 concurrency:
   group: shakaperf-release-gates-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
+  candidate:
+    name: Validate ${{ inputs.target_version }} on ${{ github.ref_name }} @ ${{ inputs.candidate_sha }}
+    runs-on: ubuntu-22.04
+    outputs:
+      runtime_tree_fingerprint: ${{ steps.candidate.outputs.runtime_tree_fingerprint }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Validate exact candidate
+        id: candidate
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          TARGET_VERSION: ${{ inputs.target_version }}
+        run: |
+          ruby -rrake <<'RUBY'
+          load "rakelib/release.rake"
+
+          candidate_sha = ENV.fetch("CANDIDATE_SHA")
+          current_sha = current_git_sha!(Dir.pwd, context: "validating ShakaPerf candidate")
+          abort "Candidate SHA #{candidate_sha} no longer matches workflow HEAD #{current_sha}." \
+            unless candidate_sha == current_sha
+
+          target_version = ENV.fetch("TARGET_VERSION")
+          validate_requested_version_input!(target_version)
+          ensure_release_branch_matches_target_base!(
+            current_branch: ENV.fetch("RELEASE_BRANCH"),
+            target_gem_version: target_version
+          )
+
+          current_version = current_gem_version(Dir.pwd)
+          prepared_candidate = shakaperf_prerun_candidate(
+            monorepo_root: Dir.pwd,
+            ref: ENV.fetch("RELEASE_BRANCH"),
+            head_sha: candidate_sha
+          )
+          prepared_version = prepared_candidate&.fetch(:target_version)
+          unless target_version == current_version || target_version == prepared_version
+            abort "Target version #{target_version} is neither the checked-in version " \
+                  "#{current_version} nor the prepared changelog version #{prepared_version || 'none'}."
+          end
+
+          fingerprint = shakaperf_runtime_tree_fingerprint(monorepo_root: Dir.pwd, sha: candidate_sha)
+          abort "Unable to fingerprint ShakaPerf candidate #{candidate_sha}." unless fingerprint
+
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |output|
+            output.puts "runtime_tree_fingerprint=#{fingerprint}"
+          end
+          File.open(ENV.fetch("GITHUB_STEP_SUMMARY"), "a") do |summary|
+            summary.puts "Testing #{target_version} on #{ENV.fetch('RELEASE_BRANCH')} at #{candidate_sha}."
+            summary.puts "Runtime tree fingerprint: `#{fingerprint}`"
+          end
+          RUBY
+
   rsc-fouc:
-    name: RSC FOUC ShakaPerf Gate
+    name: RSC FOUC gate for ${{ inputs.target_version }} @ ${{ inputs.candidate_sha }}
+    needs: candidate
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     env:
       RAILS_ENV: test
       NODE_ENV: test
       # Dummy value for RAILS_ENV=test; no real credentials are encrypted or persisted.
-      SECRET_KEY_BASE: dummy-secret-key-base-for-shakaperf-rsc-fouc # gitleaks:allow
+      SECRET_KEY_BASE: dummy-secret-key-base-for-shakaperf-rsc-fouc  # gitleaks:allow
       SHAKAPERF_CONTROL_URL: http://127.0.0.1:3000
       SHAKAPERF_EXPERIMENT_URL: http://127.0.0.1:3000
     steps:
@@ -252,3 +319,42 @@ jobs:
               kill "$(cat "$pidfile")" 2>/dev/null || true
             fi
           done
+
+  evidence:
+    name: Record gate evidence
+    if: always() && needs.candidate.result == 'success'
+    needs:
+      - candidate
+      - rsc-fouc
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Create machine-readable evidence
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          CONCLUSION: ${{ needs.rsc-fouc.result }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+          RUNTIME_TREE_FINGERPRINT: ${{ needs.candidate.outputs.runtime_tree_fingerprint }}
+          TARGET_VERSION: ${{ inputs.target_version }}
+        run: |
+          ruby -rjson -rtime <<'RUBY'
+          evidence = {
+            schema_version: 1,
+            run_id: Integer(ENV.fetch("RUN_ID"), 10),
+            run_url: "https://github.com/#{ENV.fetch('GITHUB_REPOSITORY')}/actions/runs/#{ENV.fetch('RUN_ID')}",
+            branch: ENV.fetch("RELEASE_BRANCH"),
+            candidate_sha: ENV.fetch("CANDIDATE_SHA"),
+            target_version: ENV.fetch("TARGET_VERSION"),
+            conclusion: ENV.fetch("CONCLUSION"),
+            runtime_tree_fingerprint: ENV.fetch("RUNTIME_TREE_FINGERPRINT"),
+            completed_at: Time.now.utc.iso8601
+          }
+          File.write("shakaperf-release-evidence.json", "#{JSON.pretty_generate(evidence)}\n")
+          RUBY
+
+      - name: Upload ShakaPerf release evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: shakaperf-release-evidence
+          path: shakaperf-release-evidence.json
+          retention-days: 30

--- a/.github/workflows/shakaperf-release-gates.yml
+++ b/.github/workflows/shakaperf-release-gates.yml
@@ -24,6 +24,7 @@ jobs:
   candidate:
     name: Validate ${{ inputs.target_version }} on ${{ github.ref_name }} @ ${{ inputs.candidate_sha }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     outputs:
       runtime_tree_fingerprint: ${{ steps.candidate.outputs.runtime_tree_fingerprint }}
     steps:
@@ -337,6 +338,7 @@ jobs:
       - candidate
       - rsc-fouc
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Create machine-readable evidence
         env:

--- a/.github/workflows/shakaperf-release-prerun.yml
+++ b/.github/workflows/shakaperf-release-prerun.yml
@@ -24,6 +24,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Read runtime versions
+        id: tool-versions
+        uses: ./.github/actions/read-tool-versions
+
+      - name: Setup Ruby
+        uses: ./.github/actions/setup-ruby
+        with:
+          ruby-version: ${{ steps.tool-versions.outputs.minimum-ruby-version }}
+          bundler-version: 2.5.4
+
       - name: Inspect changelog candidate
         id: candidate
         env:

--- a/.github/workflows/shakaperf-release-prerun.yml
+++ b/.github/workflows/shakaperf-release-prerun.yml
@@ -1,0 +1,70 @@
+name: Pre-run ShakaPerf Release Gates
+
+permissions:
+  actions: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'release/**'
+    paths:
+      - CHANGELOG.md
+
+concurrency:
+  group: shakaperf-release-prerun-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch prepared release candidate
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Inspect changelog candidate
+        id: candidate
+        env:
+          CANDIDATE_SHA: ${{ github.sha }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
+        run: |
+          ruby -rrake <<'RUBY'
+          load "rakelib/release.rake"
+
+          candidate = shakaperf_prerun_candidate(
+            monorepo_root: Dir.pwd,
+            ref: ENV.fetch("RELEASE_BRANCH"),
+            head_sha: ENV.fetch("CANDIDATE_SHA")
+          )
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |output|
+            output.puts "eligible=#{!candidate.nil?}"
+            next unless candidate
+
+            output.puts "target_version=#{candidate.fetch(:target_version)}"
+            output.puts "candidate_sha=#{candidate.fetch(:candidate_sha)}"
+          end
+
+          summary = if candidate
+                      "Prepared #{candidate.fetch(:target_version)} on #{candidate.fetch(:branch)} " \
+                        "at #{candidate.fetch(:candidate_sha)}; dispatching ShakaPerf."
+                    else
+                      "CHANGELOG.md does not prepare the next version for this release branch; no gate dispatched."
+                    end
+          File.open(ENV.fetch("GITHUB_STEP_SUMMARY"), "a") { |file| file.puts summary }
+          RUBY
+
+      - name: Dispatch ShakaPerf release gate
+        if: steps.candidate.outputs.eligible == 'true'
+        env:
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.candidate_sha }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          TARGET_VERSION: ${{ steps.candidate.outputs.target_version }}
+        run: |
+          gh workflow run shakaperf-release-gates.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_BRANCH" \
+            -f "target_version=$TARGET_VERSION" \
+            -f "candidate_sha=$CANDIDATE_SHA"

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -192,7 +192,8 @@ documentation edit or an unchanged/stale version therefore does not start the lo
 The dispatched Actions run names the target version, release branch, and exact candidate SHA. On
 completion it uploads `shakaperf-release-evidence.json` in the `shakaperf-release-evidence` artifact,
 containing the branch, target version, candidate SHA, conclusion, run URL, completion time, and runtime
-tree fingerprint. Open that run URL from the later `rake release` output to inspect the gate and its
+tree fingerprint, plus the workflow run attempt that produced the evidence. Open that run URL from the
+later `rake release` output to inspect the gate and its
 artifacts. The sequential validation, ShakaPerf, and evidence jobs are bounded to 60 minutes in total;
 the release task allows 65 minutes after finding a run so the workflow can reach that bound cleanly.
 Per-release-branch concurrency cancels an obsolete in-progress run when a newer prepared
@@ -204,11 +205,12 @@ prepared-candidate pre-run if that run is still active. A failed or otherwise no
 does not prevent the task from considering the latest pre-run. The task reuses completed pre-run evidence
 only when all of these checks succeed:
 
-- the run and artifact report success for the same branch, target version, candidate SHA, run ID, and
-  run URL;
+- the run and artifact report success for the same branch, target version, candidate SHA, run ID, run
+  attempt, and run URL;
 - the evidence is no more than seven days old, and both its recorded completion and the workflow's
   update occurred before this release command started, unless the task found that same pre-run already
-  active with a provable earlier start and watched it to successful completion itself;
+  active with a provable earlier current-attempt start and watched that same attempt to successful
+  completion itself;
 - the tested candidate is an ancestor of the version-bump commit;
 - the candidate and version-bump commits have the same exact Git-tree fingerprint after excluding only
   `CHANGELOG.md` and the existing release-finalization metadata paths; and

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -193,17 +193,22 @@ The dispatched Actions run names the target version, release branch, and exact c
 completion it uploads `shakaperf-release-evidence.json` in the `shakaperf-release-evidence` artifact,
 containing the branch, target version, candidate SHA, conclusion, run URL, completion time, and runtime
 tree fingerprint. Open that run URL from the later `rake release` output to inspect the gate and its
-artifacts. Per-release-branch concurrency cancels an obsolete in-progress run when a newer prepared
+artifacts. The sequential validation, ShakaPerf, and evidence jobs are bounded to 60 minutes in total;
+the release task allows 65 minutes after finding a run so the workflow can reach that bound cleanly.
+Per-release-branch concurrency cancels an obsolete in-progress run when a newer prepared
 candidate is dispatched; the newest branch candidate is authoritative, so a failed or cancelled newer
 run never causes fallback to an older success.
 
-When `bundle exec rake release[...]` later pushes the version-bump commit, it reuses the pre-run only
-when all of these checks succeed:
+When `bundle exec rake release[...]` later pushes the version-bump commit, it first watches the latest
+prepared-candidate pre-run if that run is still active. A failed or otherwise non-reusable exact-head run
+does not prevent the task from considering the latest pre-run. The task reuses completed pre-run evidence
+only when all of these checks succeed:
 
 - the run and artifact report success for the same branch, target version, candidate SHA, run ID, and
   run URL;
 - the evidence is no more than seven days old, and both its recorded completion and the workflow's
-  update occurred before this release command started;
+  update occurred before this release command started, unless the task found that same pre-run already
+  active with a provable earlier start and watched it to successful completion itself;
 - the tested candidate is an ancestor of the version-bump commit;
 - the candidate and version-bump commits have the same exact Git-tree fingerprint after excluding only
   `CHANGELOG.md` and the existing release-finalization metadata paths; and

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -181,6 +181,41 @@ stops before tagging. If `release/X.Y.Z` already exists, the task stops and tell
 > the current branch ref. If the release branch was just pushed, wait for at least one CI run on that
 > branch before cutting the first RC; otherwise the branch-tip gate can stop with a `no_checks` result.
 
+#### Automatic ShakaPerf pre-run after changelog preparation
+
+Pushing a prepared next-version `CHANGELOG.md` section to `release/X.Y.Z` automatically starts the
+ShakaPerf release gate for that branch tip. The lightweight dispatcher runs only for `CHANGELOG.md`
+pushes on `release/**`, then verifies that the first non-`Unreleased` changelog section is non-empty,
+newer than the checked-in gem version, and belongs to the branch's `X.Y.Z` release line. An arbitrary
+documentation edit or an unchanged/stale version therefore does not start the long-running gate.
+
+The dispatched Actions run names the target version, release branch, and exact candidate SHA. On
+completion it uploads `shakaperf-release-evidence.json` in the `shakaperf-release-evidence` artifact,
+containing the branch, target version, candidate SHA, conclusion, run URL, completion time, and runtime
+tree fingerprint. Open that run URL from the later `rake release` output to inspect the gate and its
+artifacts. Per-release-branch concurrency cancels an obsolete in-progress run when a newer prepared
+candidate is dispatched; the newest branch candidate is authoritative, so a failed or cancelled newer
+run never causes fallback to an older success.
+
+When `bundle exec rake release[...]` later pushes the version-bump commit, it reuses the pre-run only
+when all of these checks succeed:
+
+- the run and artifact report success for the same branch, target version, candidate SHA, run ID, and
+  run URL;
+- the evidence is no more than seven days old, and both its recorded completion and the workflow's
+  update occurred before this release command started;
+- the tested candidate is an ancestor of the version-bump commit;
+- the candidate and version-bump commits have the same exact Git-tree fingerprint after excluding only
+  `CHANGELOG.md` and the existing release-finalization metadata paths; and
+- every intervening commit is either an existing content-validated version-finalization metadata commit
+  or a canonical CI-detector-confirmed `CHANGELOG.md`-only commit.
+
+Missing, malformed, stale, wrong-version, wrong-branch, failed, cancelled, superseded, non-ancestor, or
+runtime-different evidence is never a waiver. The task falls back to dispatching the gate on the exact
+version-bump commit and waits for that run plus its verified evidence exactly as before. If the fresh
+gate or its evidence fails, tagging and package publication remain blocked. Final promotion keeps the
+same strict final-release gates and cannot use the prerelease-only CI override.
+
 A maintainer opens (or updates) the release tracker per [`rc-testing-plan.md`](rc-testing-plan.md) and
 sets the mode to `accelerated-rc` or `strict-rc`. Publish the phase as `rc` for this release line so
 agents pick up the RC gate automatically (see [Phase-tiered merge gating](#phase-tiered-merge-gating)).

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -45,9 +45,9 @@ SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE = "shakaperf-release-gates.yml"
 SHAKAPERF_RELEASE_GATE_START_TIMEOUT_SECONDS = 600
 SHAKAPERF_RELEASE_GATE_START_POLL_SECONDS = 5
 SHAKAPERF_RELEASE_GATE_RUN_LIST_LIMIT = 100
-SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS = 50 * 60
-# Keep in sync with timeout-minutes in .github/workflows/shakaperf-release-gates.yml.
-SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES = 45
+SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS = 65 * 60
+# Keep in sync with the sum of timeout-minutes in .github/workflows/shakaperf-release-gates.yml.
+SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES = 60
 SHAKAPERF_RELEASE_GATE_EVIDENCE_ARTIFACT = "shakaperf-release-evidence"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_FILE = "shakaperf-release-evidence.json"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
@@ -369,7 +369,8 @@ rescue ArgumentError
 end
 
 def shakaperf_release_gate_evidence_rejection(monorepo_root:, ref:, head_sha:, target_version:, run:, evidence:,
-                                              release_started_at:, validation_time:, require_prerun:)
+                                              release_started_at:, validation_time:, require_prerun:,
+                                              allow_prerun_completion_after_release_start: false)
   rejection = shakaperf_release_gate_evidence_schema_rejection(evidence)
   return rejection if rejection
 
@@ -380,7 +381,8 @@ def shakaperf_release_gate_evidence_rejection(monorepo_root:, ref:, head_sha:, t
   return rejection if rejection
 
   rejection = shakaperf_release_gate_evidence_time_rejection(
-    run:, evidence:, release_started_at:, validation_time:, require_prerun:
+    run:, evidence:, release_started_at:, validation_time:, require_prerun:,
+    allow_prerun_completion_after_release_start:
   )
   return rejection if rejection
 
@@ -437,7 +439,8 @@ def shakaperf_release_gate_evidence_candidate_rejection(ref:, target_version:, r
 end
 
 def shakaperf_release_gate_evidence_time_rejection(run:, evidence:, release_started_at:, validation_time:,
-                                                   require_prerun:)
+                                                   require_prerun:,
+                                                   allow_prerun_completion_after_release_start: false)
   times, rejection = shakaperf_release_gate_evidence_times(run:, evidence:)
   return rejection if rejection
 
@@ -445,11 +448,27 @@ def shakaperf_release_gate_evidence_time_rejection(run:, evidence:, release_star
   return "evidence completion time is after the workflow update" if completed_at > updated_at
   return "evidence completion time is in the future" if completed_at > validation_time
   return "evidence is stale" if validation_time - completed_at > SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS
+  return nil unless require_prerun
 
+  shakaperf_prerun_release_order_rejection(
+    run:, completed_at:, updated_at:, release_started_at:, allow_completion_after_release_start:
+      allow_prerun_completion_after_release_start
+  )
+end
+
+def shakaperf_prerun_release_order_rejection(run:, completed_at:, updated_at:, release_started_at:,
+                                             allow_completion_after_release_start:)
   release_start_second = Time.at(release_started_at.to_i).utc
-  if require_prerun && (completed_at >= release_start_second || updated_at >= release_start_second)
-    return "evidence was not complete before the release run started"
+  unless allow_completion_after_release_start
+    return "evidence was not complete before the release run started" if
+      completed_at >= release_start_second || updated_at >= release_start_second
+
+    return nil
   end
+
+  created_at = shakaperf_release_gate_time(run["createdAt"])
+  return "workflow start time is invalid" unless created_at
+  return "pre-run did not start before the release run" if created_at >= release_start_second
 
   nil
 end
@@ -777,6 +796,32 @@ def watch_shakaperf_release_gate_run!(repo_slug:, run:)
   )
 end
 
+def watch_existing_shakaperf_release_gate_run!(repo_slug:, run:)
+  run_id = run.fetch("databaseId").to_s
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  output, status, timed_out = capture_gh_output_with_timeout(
+    "run", "watch", run_id, "--repo", repo_slug, "--exit-status",
+    timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
+  )
+
+  if timed_out
+    handle_shakaperf_release_gate_violation!(
+      message: "❌ Timed out watching ShakaPerf release gate run #{run_id}.\n\nRun: #{run_url}"
+    )
+  end
+
+  refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
+  conclusion = refreshed_run["conclusion"].to_s
+  terminal_state_known = refreshed_run["status"].to_s == "completed" && !conclusion.empty?
+  watch_matches_conclusion = status.success? == (conclusion == "success")
+  return refreshed_run if terminal_state_known && watch_matches_conclusion
+
+  handle_shakaperf_release_gate_violation!(
+    message: "❌ Unable to establish the terminal result of existing ShakaPerf release gate run #{run_id}." \
+             "\n\nRun: #{run_url}\n\n#{output}"
+  )
+end
+
 def handle_existing_shakaperf_release_gate_run!(repo_slug:, monorepo_root:, ref:, run:, head_sha:, target_version:,
                                                 release_started_at:)
   return false unless run
@@ -821,8 +866,13 @@ def handle_active_shakaperf_release_gate_run(repo_slug:, monorepo_root:, ref:, r
                                              release_started_at:)
   run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
   puts "Found an existing ShakaPerf release gate run for #{head_sha[0, 8]}; watching it instead: #{run_url}"
-  watch_shakaperf_release_gate_run!(repo_slug:, run:)
-  refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
+  refreshed_run = watch_existing_shakaperf_release_gate_run!(repo_slug:, run:)
+  unless refreshed_run["conclusion"].to_s == "success"
+    return handle_completed_shakaperf_release_gate_run(
+      repo_slug:, monorepo_root:, ref:, run: refreshed_run, head_sha:, target_version:, release_started_at:
+    )
+  end
+
   rejection = shakaperf_release_gate_run_evidence_rejection(
     repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: refreshed_run, release_started_at:,
     require_prerun: false
@@ -842,12 +892,26 @@ def reuse_shakaperf_prerun?(repo_slug:, monorepo_root:, ref:, existing_runs:, he
   prerun = find_latest_shakaperf_prerun(existing_runs, head_sha)
   return false unless prerun
 
+  waited_for_active_prerun = active_shakaperf_release_gate_run?(prerun)
+  if waited_for_active_prerun
+    run_url = shakaperf_release_gate_run_url(repo_slug:, run: prerun)
+    puts "Found an in-progress ShakaPerf pre-run; watching it before deciding whether to dispatch: #{run_url}"
+    prerun = watch_existing_shakaperf_release_gate_run!(repo_slug:, run: prerun)
+    conclusion = prerun["conclusion"].to_s
+    unless conclusion == "success"
+      puts "Latest ShakaPerf pre-run completed with conclusion #{conclusion}; " \
+           "dispatching an exact-head gate: #{run_url}"
+      return false
+    end
+  end
+
   evidence = fetch_shakaperf_release_gate_evidence(repo_slug:, run: prerun)
   return false unless evidence
 
   rejection = shakaperf_release_gate_evidence_rejection(
     monorepo_root:, ref:, head_sha:, target_version:, run: prerun, evidence:, release_started_at:,
-    validation_time: Time.now.utc, require_prerun: true
+    validation_time: Time.now.utc, require_prerun: true,
+    allow_prerun_completion_after_release_start: waited_for_active_prerun
   )
   run_url = shakaperf_release_gate_run_url(repo_slug:, run: prerun)
   unless rejection
@@ -917,7 +981,7 @@ def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, target_version:
     release_started_at:
   )
 
-  return if !existing_run && reuse_shakaperf_prerun?(
+  return if reuse_shakaperf_prerun?(
     repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
   )
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -445,7 +445,9 @@ def shakaperf_release_gate_evidence_time_rejection(run:, evidence:, release_star
   return "evidence completion time is after the workflow update" if completed_at > updated_at
   return "evidence completion time is in the future" if completed_at > validation_time
   return "evidence is stale" if validation_time - completed_at > SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS
-  if require_prerun && (completed_at >= release_started_at || updated_at >= release_started_at)
+
+  release_start_second = Time.at(release_started_at.to_i).utc
+  if require_prerun && (completed_at >= release_start_second || updated_at >= release_start_second)
     return "evidence was not complete before the release run started"
   end
 
@@ -681,8 +683,21 @@ def find_latest_shakaperf_release_gate_run(runs, head_sha)
 end
 
 def find_latest_shakaperf_prerun(runs, head_sha)
-  runs.reject { |run| run["headSha"] == head_sha }
-      .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
+  candidates = runs.reject { |run| run["headSha"] == head_sha }
+  return nil unless candidates.all? { |run| valid_shakaperf_prerun_ordering_metadata?(run) }
+
+  candidates.max_by { |run| shakaperf_prerun_candidate_sort_key(run) }
+end
+
+def valid_shakaperf_prerun_ordering_metadata?(run)
+  positive_github_id?(run["databaseId"]) && !shakaperf_release_gate_time(run["createdAt"]).nil?
+end
+
+def shakaperf_prerun_candidate_sort_key(run)
+  created_at = shakaperf_release_gate_run_timestamp(run, "createdAt")
+  updated_at = shakaperf_release_gate_run_timestamp(run, "updatedAt")
+
+  [created_at, run["databaseId"].to_i, run["attempt"].to_i, updated_at]
 end
 
 def shakaperf_release_gate_run_sort_key(run)

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -937,11 +937,17 @@ def reuse_shakaperf_prerun?(repo_slug:, monorepo_root:, ref:, existing_runs:, he
   waited_for_active_prerun = active_shakaperf_release_gate_run?(prerun)
   if waited_for_active_prerun
     watched_attempt = prerun["attempt"]
+    watched_started_at = prerun["startedAt"]
     run_url = shakaperf_release_gate_run_url(repo_slug:, run: prerun)
     puts "Found an in-progress ShakaPerf pre-run; watching it before deciding whether to dispatch: #{run_url}"
     prerun = watch_existing_shakaperf_release_gate_run!(repo_slug:, run: prerun)
     unless prerun["attempt"] == watched_attempt
       puts "ShakaPerf pre-run attempt changed while the release task waited; " \
+           "dispatching an exact-head gate: #{run_url}"
+      return false
+    end
+    unless prerun["startedAt"] == watched_started_at
+      puts "ShakaPerf pre-run provenance changed while the release task waited; " \
            "dispatching an exact-head gate: #{run_url}"
       return false
     end
@@ -982,6 +988,14 @@ def dispatch_and_validate_shakaperf_release_gate!(repo_slug:, monorepo_root:, re
   watch_shakaperf_release_gate_run!(repo_slug:, run:)
 
   refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
+  unless trustworthy_terminal_shakaperf_release_gate_run?(original_run: run, refreshed_run:)
+    run_id = run.fetch("databaseId")
+    run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+    handle_shakaperf_release_gate_violation!(
+      message: "❌ Unable to establish the terminal result of freshly dispatched " \
+               "ShakaPerf release gate run #{run_id}.\n\nRun: #{run_url}"
+    )
+  end
   verify_fresh_shakaperf_release_gate_evidence!(
     repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: refreshed_run, release_started_at:
   )

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler"
+require "digest"
 require "English"
 require "json"
 require "net/http"
@@ -47,6 +48,21 @@ SHAKAPERF_RELEASE_GATE_RUN_LIST_LIMIT = 100
 SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS = 50 * 60
 # Keep in sync with timeout-minutes in .github/workflows/shakaperf-release-gates.yml.
 SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES = 45
+SHAKAPERF_RELEASE_GATE_EVIDENCE_ARTIFACT = "shakaperf-release-evidence"
+SHAKAPERF_RELEASE_GATE_EVIDENCE_FILE = "shakaperf-release-evidence.json"
+SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION = 1
+SHAKAPERF_RELEASE_GATE_EVIDENCE_KEYS = %w[
+  branch
+  candidate_sha
+  completed_at
+  conclusion
+  run_id
+  run_url
+  runtime_tree_fingerprint
+  schema_version
+  target_version
+].freeze
 # Keep in sync with every package.json, Gemfile.lock, and version file that the
 # release task rewrites while promoting an RC to a final release.
 # CHANGELOG.md is intentionally excluded. main_ci_walkback_commit? classifies
@@ -67,6 +83,7 @@ RELEASE_FINALIZATION_METADATA_PATHS = [
   "react_on_rails_pro/spec/dummy/Gemfile.lock",
   "react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock"
 ].freeze
+SHAKAPERF_RUNTIME_TREE_IGNORED_PATHS = (RELEASE_FINALIZATION_METADATA_PATHS + ["CHANGELOG.md"]).freeze
 
 # Helper methods for release-specific tasks
 # These are defined at the top level so they have access to Rake's sh method
@@ -306,6 +323,209 @@ def current_git_sha!(monorepo_root, context: nil)
   output.strip
 end
 
+def shakaperf_runtime_tree_fingerprint(monorepo_root:, sha:)
+  output, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "ls-tree", "-r", "-z", "--full-tree", sha
+  )
+  return nil unless status.success?
+
+  runtime_entries = output.split("\0").filter_map do |entry|
+    metadata, path = entry.split("\t", 2)
+    next if metadata.nil? || path.nil?
+    next if SHAKAPERF_RUNTIME_TREE_IGNORED_PATHS.include?(path)
+
+    "#{metadata}\t#{path}"
+  end
+  return nil if runtime_entries.empty?
+
+  Digest::SHA256.hexdigest(runtime_entries.sort.join("\0"))
+rescue StandardError
+  nil
+end
+
+def shakaperf_prerun_candidate(monorepo_root:, ref:, head_sha:)
+  target_version = extract_latest_changelog_version(monorepo_root:)
+  return nil unless target_version
+  return nil unless target_version.match?(/\A\d+\.\d+\.\d+(\.(test|beta|alpha|rc|pre)\.\d+)?\z/i)
+  return nil unless ref == "release/#{release_base_version(target_version)}"
+
+  current_version = current_gem_version(monorepo_root)
+  return nil unless Gem::Version.new(target_version) > Gem::Version.new(current_version)
+
+  changelog_path = File.join(monorepo_root, "CHANGELOG.md")
+  return nil unless extract_changelog_section(changelog_path:, version: target_version)
+
+  runtime_tree_fingerprint = shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: head_sha)
+  return nil unless runtime_tree_fingerprint
+
+  {
+    branch: ref,
+    candidate_sha: head_sha,
+    target_version:,
+    runtime_tree_fingerprint:
+  }
+rescue ArgumentError
+  nil
+end
+
+def shakaperf_release_gate_evidence_rejection(monorepo_root:, ref:, head_sha:, target_version:, run:, evidence:,
+                                              release_started_at:, validation_time:, require_prerun:)
+  rejection = shakaperf_release_gate_evidence_schema_rejection(evidence)
+  return rejection if rejection
+
+  rejection = shakaperf_release_gate_evidence_run_rejection(run:, evidence:)
+  return rejection if rejection
+
+  rejection = shakaperf_release_gate_evidence_candidate_rejection(ref:, target_version:, run:, evidence:)
+  return rejection if rejection
+
+  rejection = shakaperf_release_gate_evidence_time_rejection(
+    run:, evidence:, release_started_at:, validation_time:, require_prerun:
+  )
+  return rejection if rejection
+
+  shakaperf_release_gate_evidence_runtime_rejection(monorepo_root:, head_sha:, evidence:)
+rescue StandardError => e
+  "evidence verification failed: #{e.class}: #{e.message}"
+end
+
+def shakaperf_release_gate_evidence_schema_rejection(evidence)
+  return "evidence payload is not an object" unless evidence.is_a?(Hash)
+  unless evidence.keys.sort == SHAKAPERF_RELEASE_GATE_EVIDENCE_KEYS
+    return "evidence schema fields are incomplete or unknown"
+  end
+  unless evidence["schema_version"] == SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION
+    return "evidence schema version is unsupported"
+  end
+
+  nil
+end
+
+def shakaperf_release_gate_evidence_run_rejection(run:, evidence:)
+  unless run["status"] == "completed" && run["conclusion"] == "success"
+    return "workflow run did not complete successfully"
+  end
+  return "evidence conclusion is not success" unless evidence["conclusion"] == "success"
+
+  unless shakaperf_release_gate_run_id_matches?(run:, evidence:)
+    return "evidence run ID does not match the workflow run"
+  end
+
+  run_url = run["url"]
+  return "workflow run URL is missing" unless run_url.is_a?(String) && !run_url.empty?
+  return "evidence run URL does not match the workflow run" unless evidence["run_url"] == run_url
+
+  nil
+end
+
+def shakaperf_release_gate_run_id_matches?(run:, evidence:)
+  run_id = evidence["run_id"]
+  run_id.is_a?(Integer) && run_id.positive? && run_id == run["databaseId"]
+end
+
+def shakaperf_release_gate_evidence_candidate_rejection(ref:, target_version:, run:, evidence:)
+  return "evidence branch does not match the release branch" unless evidence["branch"] == ref
+  return "evidence target version does not match the release" unless evidence["target_version"] == target_version
+
+  candidate_sha = evidence["candidate_sha"]
+  return "evidence candidate SHA does not match the workflow run" unless candidate_sha == run["headSha"]
+
+  fingerprint = evidence["runtime_tree_fingerprint"]
+  return "evidence runtime fingerprint is malformed" unless fingerprint.to_s.match?(/\A[0-9a-f]{64}\z/)
+
+  nil
+end
+
+def shakaperf_release_gate_evidence_time_rejection(run:, evidence:, release_started_at:, validation_time:,
+                                                   require_prerun:)
+  times, rejection = shakaperf_release_gate_evidence_times(run:, evidence:)
+  return rejection if rejection
+
+  completed_at, updated_at = times
+  return "evidence completion time is after the workflow update" if completed_at > updated_at
+  return "evidence completion time is in the future" if completed_at > validation_time
+  return "evidence is stale" if validation_time - completed_at > SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS
+  if require_prerun && (completed_at >= release_started_at || updated_at >= release_started_at)
+    return "evidence was not complete before the release run started"
+  end
+
+  nil
+end
+
+def shakaperf_release_gate_evidence_times(run:, evidence:)
+  completed_at = shakaperf_release_gate_time(evidence["completed_at"])
+  return [nil, "evidence completion time is invalid"] unless completed_at
+
+  updated_at = shakaperf_release_gate_time(run["updatedAt"])
+  return [nil, "workflow completion time is invalid"] unless updated_at
+
+  [[completed_at, updated_at], nil]
+end
+
+def shakaperf_release_gate_evidence_runtime_rejection(monorepo_root:, head_sha:, evidence:)
+  candidate_sha = evidence["candidate_sha"]
+  fingerprint = evidence["runtime_tree_fingerprint"]
+  candidate_fingerprint = shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: candidate_sha)
+  return "candidate runtime tree cannot be verified" unless candidate_fingerprint == fingerprint
+
+  head_fingerprint = shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: head_sha)
+  return "release runtime tree differs from the tested candidate" unless head_fingerprint == fingerprint
+  return nil if candidate_sha == head_sha
+
+  commits = shakaperf_candidate_commit_shas(monorepo_root:, candidate_sha:, head_sha:)
+  return "tested candidate ancestry or intervening commits cannot be verified" unless commits
+  return "release commits after the tested candidate are not metadata-only" unless commits.all? do |sha|
+    shakaperf_prerun_metadata_commit?(monorepo_root:, sha:)
+  end
+
+  nil
+end
+
+def shakaperf_release_gate_time(value)
+  return value if value.is_a?(Time)
+  return nil unless value.is_a?(String) && !value.empty?
+
+  Time.iso8601(value)
+rescue ArgumentError
+  nil
+end
+
+def shakaperf_candidate_commit_shas(monorepo_root:, candidate_sha:, head_sha:)
+  _ancestor_output, ancestor_status = Open3.capture2e(
+    "git", "-C", monorepo_root, "merge-base", "--is-ancestor", candidate_sha, head_sha
+  )
+  return nil unless ancestor_status.success?
+
+  output, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "rev-list", "--reverse", "#{candidate_sha}..#{head_sha}"
+  )
+  return nil unless status.success?
+
+  commits = output.lines.map(&:strip).reject(&:empty?)
+  commits.empty? ? nil : commits
+rescue StandardError
+  nil
+end
+
+def shakaperf_prerun_metadata_commit?(monorepo_root:, sha:)
+  return true if release_finalization_metadata_commit?(monorepo_root:, sha:)
+  return false unless commit_non_runtime_only?(monorepo_root:, sha:)
+
+  shakaperf_changelog_only_commit?(monorepo_root:, sha:)
+end
+
+def shakaperf_changelog_only_commit?(monorepo_root:, sha:)
+  output, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "diff-tree", "--no-commit-id", "--name-status", "-r", "#{sha}^", sha
+  )
+  return false unless status.success?
+
+  changes = output.lines.map(&:chomp)
+  changes.any? && changes.all?("M\tCHANGELOG.md")
+rescue StandardError
+  false
+end
+
 def handle_shakaperf_release_gate_violation!(message:)
   abort <<~ERROR
     #{message}
@@ -342,6 +562,74 @@ def fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
 rescue JSON::ParserError => e
   handle_shakaperf_release_gate_violation!(
     message: "❌ Failed to parse ShakaPerf release gate workflow runs: #{e.message}\n\nOutput:\n#{output}"
+  )
+end
+
+def fetch_shakaperf_release_gate_evidence(repo_slug:, run:)
+  Dir.mktmpdir("shakaperf-release-evidence") do |dir|
+    output, status = capture_gh_output(
+      "run", "download", run.fetch("databaseId").to_s,
+      "--repo", repo_slug,
+      "--name", SHAKAPERF_RELEASE_GATE_EVIDENCE_ARTIFACT,
+      "--dir", dir
+    )
+    unless status.success?
+      warn "⚠️ Unable to download ShakaPerf pre-run evidence; dispatching an exact-head gate.\n#{output}"
+      return nil
+    end
+
+    evidence_paths = Dir.glob(File.join(dir, "**", SHAKAPERF_RELEASE_GATE_EVIDENCE_FILE))
+    unless evidence_paths.one?
+      warn "⚠️ ShakaPerf pre-run evidence artifact did not contain exactly one " \
+           "#{SHAKAPERF_RELEASE_GATE_EVIDENCE_FILE}; dispatching an exact-head gate."
+      return nil
+    end
+
+    JSON.parse(File.read(evidence_paths.first))
+  end
+rescue JSON::ParserError => e
+  warn "⚠️ Unable to parse ShakaPerf pre-run evidence: #{e.message}; dispatching an exact-head gate."
+  nil
+rescue StandardError => e
+  warn "⚠️ Unable to inspect ShakaPerf pre-run evidence: #{e.class}: #{e.message}; " \
+       "dispatching an exact-head gate."
+  nil
+end
+
+def refresh_shakaperf_release_gate_run!(repo_slug:, run:)
+  output, status = capture_gh_output(
+    "run", "view", run.fetch("databaseId").to_s,
+    "--repo", repo_slug,
+    "--json", "attempt,createdAt,databaseId,headSha,status,conclusion,updatedAt,url"
+  )
+  unless status.success?
+    handle_shakaperf_release_gate_violation!(
+      message: "❌ Unable to refresh ShakaPerf release gate workflow evidence.\n\n#{output}"
+    )
+  end
+
+  JSON.parse(output)
+rescue JSON::ParserError => e
+  handle_shakaperf_release_gate_violation!(
+    message: "❌ Failed to parse refreshed ShakaPerf release gate workflow evidence: #{e.message}"
+  )
+end
+
+def shakaperf_release_gate_run_evidence_rejection(repo_slug:, monorepo_root:, ref:, head_sha:, target_version:,
+                                                  run:, release_started_at:, require_prerun:)
+  evidence = fetch_shakaperf_release_gate_evidence(repo_slug:, run:)
+  return "evidence artifact is missing or unreadable" unless evidence
+
+  shakaperf_release_gate_evidence_rejection(
+    monorepo_root:,
+    ref:,
+    head_sha:,
+    target_version:,
+    run:,
+    evidence:,
+    release_started_at:,
+    validation_time: Time.now.utc,
+    require_prerun:
   )
 end
 
@@ -392,6 +680,11 @@ def find_latest_shakaperf_release_gate_run(runs, head_sha)
       .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
 end
 
+def find_latest_shakaperf_prerun(runs, head_sha)
+  runs.reject { |run| run["headSha"] == head_sha }
+      .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
+end
+
 def shakaperf_release_gate_run_sort_key(run)
   updated_at = shakaperf_release_gate_run_timestamp(run, "updatedAt")
   created_at = shakaperf_release_gate_run_timestamp(run, "createdAt")
@@ -417,8 +710,8 @@ def print_shakaperf_release_gate_notice(ref:, head_sha:)
   puts <<~NOTICE
 
     Running ShakaPerf release gate on #{ref} at #{head_sha[0, 8]} before tagging and publishing...
-    This checks for an existing matching GitHub Actions ShakaPerf Release Gates run.
-    If no reusable run exists, it dispatches a new workflow run and blocks until it passes.
+    This first checks for verified same-version pre-run evidence from this branch, then for an exact-head run.
+    If neither is reusable, it dispatches a new exact-head workflow run and blocks until verified evidence exists.
     Warm-cache waits usually take a few minutes.
     The workflow can run up to #{SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES} minutes.
     Fresh dispatches can take up to #{start_timeout_minutes} minutes to appear before watching starts.
@@ -431,9 +724,13 @@ def print_shakaperf_release_gate_notice(ref:, head_sha:)
   NOTICE
 end
 
-def dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:)
+def dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:, target_version:, candidate_sha:)
   output, status = capture_gh_output(
-    "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE, "--repo", repo_slug, "--ref", ref
+    "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
+    "--repo", repo_slug,
+    "--ref", ref,
+    "-f", "target_version=#{target_version}",
+    "-f", "candidate_sha=#{candidate_sha}"
   )
 
   return if status.success?
@@ -465,32 +762,121 @@ def watch_shakaperf_release_gate_run!(repo_slug:, run:)
   )
 end
 
-def handle_existing_shakaperf_release_gate_run!(repo_slug:, run:, head_sha:)
+def handle_existing_shakaperf_release_gate_run!(repo_slug:, monorepo_root:, ref:, run:, head_sha:, target_version:,
+                                                release_started_at:)
   return false unless run
 
+  if run["status"].to_s == "completed"
+    return handle_completed_shakaperf_release_gate_run(
+      repo_slug:, monorepo_root:, ref:, run:, head_sha:, target_version:, release_started_at:
+    )
+  end
+  return false unless active_shakaperf_release_gate_run?(run)
+
+  handle_active_shakaperf_release_gate_run(
+    repo_slug:, monorepo_root:, ref:, run:, head_sha:, target_version:, release_started_at:
+  )
+end
+
+def handle_completed_shakaperf_release_gate_run(repo_slug:, monorepo_root:, ref:, run:, head_sha:, target_version:,
+                                                release_started_at:)
   run_id = run.fetch("databaseId").to_s
   run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
-  if run["status"].to_s == "completed"
-    conclusion = run["conclusion"].to_s
-    if conclusion == "success"
-      puts "✓ ShakaPerf release gate already passed: #{run_url}"
-      return true
-    end
-
+  conclusion = run["conclusion"].to_s
+  unless conclusion == "success"
     puts "Latest ShakaPerf release gate run #{run_id} completed with conclusion " \
          "#{conclusion.empty? ? 'unknown' : conclusion}; dispatching a fresh gate run: #{run_url}"
     return false
   end
 
-  return false unless active_shakaperf_release_gate_run?(run)
+  rejection = shakaperf_release_gate_run_evidence_rejection(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run:, release_started_at:, require_prerun: false
+  )
+  unless rejection
+    puts "✓ ShakaPerf release gate already passed with verified evidence: #{run_url}"
+    return true
+  end
 
-  puts "Found an existing ShakaPerf release gate run for #{head_sha[0, 8]}; watching it instead: #{run_url}"
-  watch_shakaperf_release_gate_run!(repo_slug:, run:)
-  puts "✓ ShakaPerf release gate passed: #{run_url}"
-  true
+  puts "Successful ShakaPerf release gate evidence is not reusable (#{rejection}); " \
+       "dispatching a fresh exact-head gate: #{run_url}"
+  false
 end
 
-def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, allow_override:, dry_run:)
+def handle_active_shakaperf_release_gate_run(repo_slug:, monorepo_root:, ref:, run:, head_sha:, target_version:,
+                                             release_started_at:)
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  puts "Found an existing ShakaPerf release gate run for #{head_sha[0, 8]}; watching it instead: #{run_url}"
+  watch_shakaperf_release_gate_run!(repo_slug:, run:)
+  refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
+  rejection = shakaperf_release_gate_run_evidence_rejection(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: refreshed_run, release_started_at:,
+    require_prerun: false
+  )
+  unless rejection
+    puts "✓ ShakaPerf release gate passed with verified evidence: #{run_url}"
+    return true
+  end
+
+  puts "Completed ShakaPerf release gate evidence is not reusable (#{rejection}); " \
+       "dispatching a fresh exact-head gate: #{run_url}"
+  false
+end
+
+def reuse_shakaperf_prerun?(repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:,
+                            release_started_at:)
+  prerun = find_latest_shakaperf_prerun(existing_runs, head_sha)
+  return false unless prerun
+
+  evidence = fetch_shakaperf_release_gate_evidence(repo_slug:, run: prerun)
+  return false unless evidence
+
+  rejection = shakaperf_release_gate_evidence_rejection(
+    monorepo_root:, ref:, head_sha:, target_version:, run: prerun, evidence:, release_started_at:,
+    validation_time: Time.now.utc, require_prerun: true
+  )
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run: prerun)
+  unless rejection
+    puts "✓ Reusing successful ShakaPerf pre-run: #{run_url}"
+    return true
+  end
+
+  puts "Latest ShakaPerf pre-run is not reusable (#{rejection}); dispatching an exact-head gate: #{run_url}"
+  false
+end
+
+def dispatch_and_validate_shakaperf_release_gate!(repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:,
+                                                  target_version:, release_started_at:)
+  existing_run_ids = existing_runs.map { |run| run["databaseId"].to_s }
+  dispatch_started_at = shakaperf_release_gate_dispatch_started_at
+  dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:, target_version:, candidate_sha: head_sha)
+  run = wait_for_shakaperf_release_gate_run!(
+    repo_slug:, ref:, head_sha:, ignored_run_ids: existing_run_ids, earliest_created_at: dispatch_started_at
+  )
+  watch_shakaperf_release_gate_run!(repo_slug:, run:)
+
+  refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
+  verify_fresh_shakaperf_release_gate_evidence!(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: refreshed_run, release_started_at:
+  )
+end
+
+def verify_fresh_shakaperf_release_gate_evidence!(repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run:,
+                                                  release_started_at:)
+  rejection = shakaperf_release_gate_run_evidence_rejection(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run:, release_started_at:, require_prerun: false
+  )
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  if rejection
+    handle_shakaperf_release_gate_violation!(
+      message: "❌ Fresh ShakaPerf release gate evidence is invalid: #{rejection}.\n\nRun: #{run_url}"
+    )
+  end
+
+  puts "✓ ShakaPerf release gate passed with verified evidence: #{run_url}"
+end
+
+def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, target_version:, release_started_at:,
+                                allow_override:, dry_run:)
   if dry_run
     puts "⚠️ DRY RUN: Would run ShakaPerf release gate on #{ref} at #{head_sha[0, 8]} before publishing."
     return
@@ -506,24 +892,23 @@ def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, allow_override:
 
   existing_runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
   existing_run = find_latest_shakaperf_release_gate_run(existing_runs, head_sha)
-  return if handle_existing_shakaperf_release_gate_run!(repo_slug:, run: existing_run, head_sha:)
-
-  existing_run_ids = existing_runs.map do |run|
-    run["databaseId"].to_s
-  end
-  dispatch_started_at = shakaperf_release_gate_dispatch_started_at
-  dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:)
-
-  run = wait_for_shakaperf_release_gate_run!(
+  return if handle_existing_shakaperf_release_gate_run!(
     repo_slug:,
+    monorepo_root:,
     ref:,
+    run: existing_run,
     head_sha:,
-    ignored_run_ids: existing_run_ids,
-    earliest_created_at: dispatch_started_at
+    target_version:,
+    release_started_at:
   )
-  watch_shakaperf_release_gate_run!(repo_slug:, run:)
 
-  puts "✓ ShakaPerf release gate passed: #{run['url'] || "GitHub Actions run #{run.fetch('databaseId')}"}"
+  return if !existing_run && reuse_shakaperf_prerun?(
+    repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
+  )
+
+  dispatch_and_validate_shakaperf_release_gate!(
+    repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
+  )
 end
 
 def run_release_preflight_checks!(monorepo_root:, dry_run:)
@@ -3293,9 +3678,13 @@ Release CI policy:
   - Stable releases require every check run on the commit to have succeeded.
   - Pre-releases require only the GitHub-branch-protection-required checks
     to have succeeded.
-  After pushing the version bump commit, the script runs the ShakaPerf RSC FOUC
-  workflow_dispatch gate and waits for it before creating/pushing the tag and
-  publishing npm packages or Ruby gems.
+  A prepared next-version CHANGELOG.md push on release/** automatically starts
+  the ShakaPerf RSC FOUC gate. After pushing the version bump commit, the script
+  reuses that pre-run only when its artifact proves the same branch/version,
+  pre-release time ordering, freshness, and an identical runtime tree across
+  allowlisted release metadata changes. Otherwise it dispatches an exact-head
+  workflow_dispatch gate and waits for verified evidence before creating/pushing
+  the tag and publishing npm packages or Ruby gems.
   If that gate fails, the remote branch has the version-bump commit but no release
   tag or published packages; retry from that commit or push a revert commit first.
   In-progress checks and failing gates block the release until they pass. An explicitly approved
@@ -3321,6 +3710,7 @@ Examples:
   NPM_OTP=123456 RUBYGEMS_OTP=789012 rake release[patch]  # Skip OTP prompts")
 task :release, %i[version dry_run override_version_policy override_ci_status] do |_t, args|
   monorepo_root = current_monorepo_root
+  release_started_at = Time.now.utc
 
   args_hash = args.to_hash
 
@@ -3565,6 +3955,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
         monorepo_root: release_root,
         ref: current_branch,
         head_sha: current_git_sha!(release_root),
+        target_version: actual_gem_version,
+        release_started_at:,
         allow_override: allow_ci_status_override,
         dry_run: is_dry_run
       )

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -51,12 +51,13 @@ SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES = 60
 SHAKAPERF_RELEASE_GATE_EVIDENCE_ARTIFACT = "shakaperf-release-evidence"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_FILE = "shakaperf-release-evidence.json"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
-SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION = 1
+SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION = 2
 SHAKAPERF_RELEASE_GATE_EVIDENCE_KEYS = %w[
   branch
   candidate_sha
   completed_at
   conclusion
+  run_attempt
   run_id
   run_url
   runtime_tree_fingerprint
@@ -409,9 +410,8 @@ def shakaperf_release_gate_evidence_run_rejection(run:, evidence:)
   end
   return "evidence conclusion is not success" unless evidence["conclusion"] == "success"
 
-  unless shakaperf_release_gate_run_id_matches?(run:, evidence:)
-    return "evidence run ID does not match the workflow run"
-  end
+  identity_rejection = shakaperf_release_gate_evidence_run_identity_rejection(run:, evidence:)
+  return identity_rejection if identity_rejection
 
   run_url = run["url"]
   return "workflow run URL is missing" unless run_url.is_a?(String) && !run_url.empty?
@@ -420,9 +420,25 @@ def shakaperf_release_gate_evidence_run_rejection(run:, evidence:)
   nil
 end
 
+def shakaperf_release_gate_evidence_run_identity_rejection(run:, evidence:)
+  unless shakaperf_release_gate_run_id_matches?(run:, evidence:)
+    return "evidence run ID does not match the workflow run"
+  end
+  unless shakaperf_release_gate_run_attempt_matches?(run:, evidence:)
+    return "evidence run attempt does not match the workflow run"
+  end
+
+  nil
+end
+
 def shakaperf_release_gate_run_id_matches?(run:, evidence:)
   run_id = evidence["run_id"]
   run_id.is_a?(Integer) && run_id.positive? && run_id == run["databaseId"]
+end
+
+def shakaperf_release_gate_run_attempt_matches?(run:, evidence:)
+  run_attempt = evidence["run_attempt"]
+  run_attempt.is_a?(Integer) && run_attempt.positive? && run_attempt == run["attempt"]
 end
 
 def shakaperf_release_gate_evidence_candidate_rejection(ref:, target_version:, run:, evidence:)
@@ -466,9 +482,9 @@ def shakaperf_prerun_release_order_rejection(run:, completed_at:, updated_at:, r
     return nil
   end
 
-  created_at = shakaperf_release_gate_time(run["createdAt"])
-  return "workflow start time is invalid" unless created_at
-  return "pre-run did not start before the release run" if created_at >= release_start_second
+  started_at = shakaperf_release_gate_time(run["startedAt"])
+  return "workflow start time is invalid" unless started_at
+  return "pre-run did not start before the release run" if started_at >= release_start_second
 
   nil
 end
@@ -569,7 +585,7 @@ def fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
     "--workflow", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
     "--branch", ref,
     "--event", "workflow_dispatch",
-    "--json", "attempt,createdAt,databaseId,headSha,status,conclusion,updatedAt,url",
+    "--json", "attempt,createdAt,databaseId,headSha,startedAt,status,conclusion,updatedAt,url",
     "--limit", SHAKAPERF_RELEASE_GATE_RUN_LIST_LIMIT.to_s
   )
 
@@ -621,7 +637,7 @@ def refresh_shakaperf_release_gate_run!(repo_slug:, run:)
   output, status = capture_gh_output(
     "run", "view", run.fetch("databaseId").to_s,
     "--repo", repo_slug,
-    "--json", "attempt,createdAt,databaseId,headSha,status,conclusion,updatedAt,url"
+    "--json", "attempt,createdAt,databaseId,headSha,startedAt,status,conclusion,updatedAt,url"
   )
   unless status.success?
     handle_shakaperf_release_gate_violation!(
@@ -709,7 +725,10 @@ def find_latest_shakaperf_prerun(runs, head_sha)
 end
 
 def valid_shakaperf_prerun_ordering_metadata?(run)
-  positive_github_id?(run["databaseId"]) && !shakaperf_release_gate_time(run["createdAt"]).nil?
+  positive_github_id?(run["databaseId"]) &&
+    positive_github_id?(run["attempt"]) &&
+    !shakaperf_release_gate_time(run["createdAt"]).nil? &&
+    !shakaperf_release_gate_time(run["startedAt"]).nil?
 end
 
 def shakaperf_prerun_candidate_sort_key(run)
@@ -800,7 +819,7 @@ def watch_existing_shakaperf_release_gate_run!(repo_slug:, run:)
   run_id = run.fetch("databaseId").to_s
   run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
   output, status, timed_out = capture_gh_output_with_timeout(
-    "run", "watch", run_id, "--repo", repo_slug, "--exit-status",
+    "run", "watch", run_id, "--repo", repo_slug,
     timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
   )
 
@@ -810,11 +829,17 @@ def watch_existing_shakaperf_release_gate_run!(repo_slug:, run:)
     )
   end
 
+  unless status.success?
+    handle_shakaperf_release_gate_violation!(
+      message: "❌ Unable to watch existing ShakaPerf release gate run #{run_id}." \
+               "\n\nRun: #{run_url}\n\n#{output}"
+    )
+  end
+
   refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
   conclusion = refreshed_run["conclusion"].to_s
   terminal_state_known = refreshed_run["status"].to_s == "completed" && !conclusion.empty?
-  watch_matches_conclusion = status.success? == (conclusion == "success")
-  return refreshed_run if terminal_state_known && watch_matches_conclusion
+  return refreshed_run if terminal_state_known
 
   handle_shakaperf_release_gate_violation!(
     message: "❌ Unable to establish the terminal result of existing ShakaPerf release gate run #{run_id}." \
@@ -894,9 +919,15 @@ def reuse_shakaperf_prerun?(repo_slug:, monorepo_root:, ref:, existing_runs:, he
 
   waited_for_active_prerun = active_shakaperf_release_gate_run?(prerun)
   if waited_for_active_prerun
+    watched_attempt = prerun["attempt"]
     run_url = shakaperf_release_gate_run_url(repo_slug:, run: prerun)
     puts "Found an in-progress ShakaPerf pre-run; watching it before deciding whether to dispatch: #{run_url}"
     prerun = watch_existing_shakaperf_release_gate_run!(repo_slug:, run: prerun)
+    unless prerun["attempt"] == watched_attempt
+      puts "ShakaPerf pre-run attempt changed while the release task waited; " \
+           "dispatching an exact-head gate: #{run_url}"
+      return false
+    end
     conclusion = prerun["conclusion"].to_s
     unless conclusion == "success"
       puts "Latest ShakaPerf pre-run completed with conclusion #{conclusion}; " \

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -52,6 +52,9 @@ SHAKAPERF_RELEASE_GATE_EVIDENCE_ARTIFACT = "shakaperf-release-evidence"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_FILE = "shakaperf-release-evidence.json"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION = 2
+SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS = %w[
+  action_required cancelled failure neutral skipped stale startup_failure success timed_out
+].freeze
 SHAKAPERF_RELEASE_GATE_EVIDENCE_KEYS = %w[
   branch
   candidate_sha
@@ -712,6 +715,22 @@ def active_shakaperf_release_gate_run?(run)
   %w[queued in_progress requested waiting pending].include?(run["status"].to_s)
 end
 
+def same_shakaperf_release_gate_run_identity?(original_run:, refreshed_run:)
+  return false unless refreshed_run.is_a?(Hash)
+
+  head_sha = refreshed_run["headSha"]
+  positive_github_id?(refreshed_run["databaseId"]) &&
+    refreshed_run.values_at("databaseId", "headSha") == original_run.values_at("databaseId", "headSha") &&
+    head_sha.is_a?(String) && !head_sha.empty?
+end
+
+def trustworthy_terminal_shakaperf_release_gate_run?(original_run:, refreshed_run:)
+  same_shakaperf_release_gate_run_identity?(original_run:, refreshed_run:) &&
+    positive_github_id?(refreshed_run["attempt"]) &&
+    refreshed_run["status"] == "completed" &&
+    SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(refreshed_run["conclusion"])
+end
+
 def find_latest_shakaperf_release_gate_run(runs, head_sha)
   runs.select { |run| run["headSha"] == head_sha }
       .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
@@ -837,9 +856,7 @@ def watch_existing_shakaperf_release_gate_run!(repo_slug:, run:)
   end
 
   refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
-  conclusion = refreshed_run["conclusion"].to_s
-  terminal_state_known = refreshed_run["status"].to_s == "completed" && !conclusion.empty?
-  return refreshed_run if terminal_state_known
+  return refreshed_run if trustworthy_terminal_shakaperf_release_gate_run?(original_run: run, refreshed_run:)
 
   handle_shakaperf_release_gate_violation!(
     message: "❌ Unable to establish the terminal result of existing ShakaPerf release gate run #{run_id}." \

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -577,6 +577,16 @@ RSpec.describe "release.rake helper methods" do
         expect(ruby_setup).to be < release_helper_load
       end
     end
+
+    it "bounds every gate job and leaves the release watcher enough time for the full workflow" do
+      gate_workflow = File.read(File.join(repo_root, ".github/workflows/shakaperf-release-gates.yml"))
+      job_timeouts = gate_workflow.scan(/^    timeout-minutes: (\d+)$/).flatten.map(&:to_i)
+
+      expect(job_timeouts).to contain_exactly(10, 45, 5)
+      expect(job_timeouts.sum).to eq(SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES)
+      expect(SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS / 60)
+        .to be > SHAKAPERF_RELEASE_GATE_WORKFLOW_TIMEOUT_MINUTES
+    end
   end
 
   describe "#shakaperf_release_gate_evidence_rejection" do
@@ -591,6 +601,7 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => candidate_sha,
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T11:30:00Z",
         "updatedAt" => "2026-07-14T12:00:30Z",
         "url" => run_url
       }
@@ -623,7 +634,8 @@ RSpec.describe "release.rake helper methods" do
     end
 
     def evidence_rejection(run: self.run, evidence: self.evidence, target_version: "17.0.0.rc.8",
-                           release_started_at: self.release_started_at)
+                           release_started_at: self.release_started_at,
+                           allow_prerun_completion_after_release_start: false)
       shakaperf_release_gate_evidence_rejection(
         monorepo_root:,
         ref: "release/17.0.0",
@@ -633,7 +645,8 @@ RSpec.describe "release.rake helper methods" do
         evidence:,
         release_started_at:,
         validation_time:,
-        require_prerun: true
+        require_prerun: true,
+        allow_prerun_completion_after_release_start:
       )
     end
 
@@ -682,6 +695,48 @@ RSpec.describe "release.rake helper methods" do
 
       expect(evidence_rejection(run: late_run, evidence: late_evidence))
         .to eq("evidence was not complete before the release run started")
+    end
+
+    it "accepts a pre-run that started before release and completed while the release waited for it" do
+      late_evidence = evidence.merge("completed_at" => "2026-07-14T13:01:00Z")
+      late_run = run.merge("updatedAt" => "2026-07-14T13:01:30Z")
+
+      expect(
+        evidence_rejection(
+          run: late_run,
+          evidence: late_evidence,
+          allow_prerun_completion_after_release_start: true
+        )
+      ).to be_nil
+    end
+
+    it "rejects an active pre-run whose start time cannot be proven to precede release" do
+      late_evidence = evidence.merge("completed_at" => "2026-07-14T13:01:00Z")
+      same_second_run = run.merge(
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "updatedAt" => "2026-07-14T13:01:30Z"
+      )
+
+      expect(
+        evidence_rejection(
+          run: same_second_run,
+          evidence: late_evidence,
+          allow_prerun_completion_after_release_start: true
+        )
+      ).to eq("pre-run did not start before the release run")
+    end
+
+    it "rejects an active pre-run when refreshed start metadata is missing" do
+      late_evidence = evidence.merge("completed_at" => "2026-07-14T13:01:00Z")
+      missing_start_run = run.merge("createdAt" => nil, "updatedAt" => "2026-07-14T13:01:30Z")
+
+      expect(
+        evidence_rejection(
+          run: missing_start_run,
+          evidence: late_evidence,
+          allow_prerun_completion_after_release_start: true
+        )
+      ).to eq("workflow start time is invalid")
     end
 
     it "rejects second-precision evidence from the same second as a fractional release start" do
@@ -854,7 +909,7 @@ RSpec.describe "release.rake helper methods" do
 
       expected_notice = Regexp.new(
         [
-          "fresh dispatch can therefore block for up to about 60 minutes total",
+          "fresh dispatch can therefore block for up to about 75 minutes total",
           "RELEASE_CI_STATUS_OVERRIDE=true",
           "ShakaPerf release gate passed"
         ].join(".*"),
@@ -1000,6 +1055,156 @@ RSpec.describe "release.rake helper methods" do
       end.to output(%r{Reusing successful ShakaPerf pre-run.*actions/runs/123456}m).to_stdout
     end
 
+    it "waits for an in-progress pre-run before reusing its evidence" do
+      candidate_sha = "feedface" * 5
+      in_progress_prerun = run.merge(
+        "headSha" => candidate_sha,
+        "status" => "in_progress",
+        "conclusion" => "",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      completed_prerun = in_progress_prerun.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_prerun])
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .with(
+          "run", "watch", "123456", "--repo", repo_slug, "--exit-status",
+          timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
+        )
+        .and_return(["", success_status, false])
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: in_progress_prerun).and_return(completed_prerun)
+      expect(self).not_to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: in_progress_prerun)
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: completed_prerun).and_return({ "candidate_sha" => candidate_sha })
+      allow(self).to receive(:shakaperf_release_gate_evidence_rejection).with(
+        monorepo_root:,
+        ref: "release-branch",
+        head_sha:,
+        target_version:,
+        run: completed_prerun,
+        evidence: { "candidate_sha" => candidate_sha },
+        release_started_at:,
+        validation_time: kind_of(Time),
+        require_prerun: true,
+        allow_prerun_completion_after_release_start: true
+      ).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/watching it before deciding whether to dispatch.*Reusing successful ShakaPerf pre-run/m)
+        .to_stdout
+      expect(self).to have_received(:shakaperf_release_gate_evidence_rejection).with(
+        monorepo_root:,
+        ref: "release-branch",
+        head_sha:,
+        target_version:,
+        run: completed_prerun,
+        evidence: { "candidate_sha" => candidate_sha },
+        release_started_at:,
+        validation_time: kind_of(Time),
+        require_prerun: true,
+        allow_prerun_completion_after_release_start: true
+      )
+    end
+
+    it "dispatches an exact-head gate when an in-progress pre-run finishes unsuccessfully" do
+      candidate_sha = "feedface" * 5
+      in_progress_prerun = run.merge(
+        "headSha" => candidate_sha,
+        "status" => "in_progress",
+        "conclusion" => ""
+      )
+      failed_prerun = in_progress_prerun.merge(
+        "status" => "completed",
+        "conclusion" => "failure",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      fresh_run = run.merge("databaseId" => 654_321)
+      completed_fresh_run = fresh_run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T14:30:00Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_prerun])
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .and_return(["Tests failed", failure_status, false], ["", success_status, false])
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: in_progress_prerun).and_return(failed_prerun)
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: fresh_run).and_return(completed_fresh_run)
+      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(fresh_run)
+      expect(self).to receive(:dispatch_shakaperf_release_gate_workflow!).with(
+        repo_slug:,
+        ref: "release-branch",
+        target_version:,
+        candidate_sha: head_sha
+      )
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/pre-run.*conclusion failure.*dispatching an exact-head gate.*gate passed/m).to_stdout
+    end
+
+    it "reuses valid pre-run evidence after a non-reusable exact-head run" do
+      candidate_sha = "feedface" * 5
+      failed_exact_head_run = run.merge(
+        "databaseId" => 654_321,
+        "status" => "completed",
+        "conclusion" => "failure",
+        "updatedAt" => "2026-07-14T12:30:00Z"
+      )
+      successful_prerun = run.merge(
+        "headSha" => candidate_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([failed_exact_head_run, successful_prerun])
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: successful_prerun).and_return({ "candidate_sha" => candidate_sha })
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/completed with conclusion failure.*Reusing successful ShakaPerf pre-run/m).to_stdout
+    end
+
     it "watches an in-progress gate run for the same head SHA without dispatching another run" do
       in_progress_run = run.merge(
         "databaseId" => 321_654,
@@ -1028,6 +1233,76 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false
         )
       end.to output(/watching it instead.*ShakaPerf release gate passed/m).to_stdout
+    end
+
+    it "considers reusable pre-run evidence when an in-progress exact-head run finishes unsuccessfully" do
+      candidate_sha = "feedface" * 5
+      in_progress_exact_head_run = run.merge(
+        "databaseId" => 654_321,
+        "status" => "in_progress",
+        "conclusion" => ""
+      )
+      failed_exact_head_run = in_progress_exact_head_run.merge(
+        "status" => "completed",
+        "conclusion" => "failure",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      successful_prerun = run.merge(
+        "headSha" => candidate_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_exact_head_run, successful_prerun])
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .and_return(["Tests failed", failure_status, false])
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: in_progress_exact_head_run).and_return(failed_exact_head_run)
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: successful_prerun).and_return({ "candidate_sha" => candidate_sha })
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/completed with conclusion failure.*Reusing successful ShakaPerf pre-run/m).to_stdout
+    end
+
+    it "fails closed when a watched existing run has no trustworthy terminal result" do
+      in_progress_run = run.merge(
+        "databaseId" => 654_321,
+        "status" => "in_progress",
+        "conclusion" => ""
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_run])
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .and_return(["GitHub API unavailable", failure_status, false])
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: in_progress_run).and_return(in_progress_run)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to raise_error(SystemExit, /Unable to establish the terminal result.*GitHub API unavailable/m)
     end
 
     it "does not reuse a successful run when a rerun updated a same-SHA failure more recently" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -564,6 +564,10 @@ RSpec.describe "release.rake helper methods" do
       )
       expect(gate_workflow).to include("target_version:", "candidate_sha:", "cancel-in-progress: true")
       expect(gate_workflow).to include("name: shakaperf-release-evidence", "shakaperf-release-evidence.json")
+      expect(gate_workflow).to include(
+        "RUN_ATTEMPT: ${{ github.run_attempt }}",
+        'run_attempt: Integer(ENV.fetch("RUN_ATTEMPT"), 10)'
+      )
     end
 
     it "sets up a supported Ruby before either workflow loads the release helpers" do
@@ -598,17 +602,20 @@ RSpec.describe "release.rake helper methods" do
     let(:run) do
       {
         "databaseId" => 123_456,
+        "attempt" => 1,
         "headSha" => candidate_sha,
         "status" => "completed",
         "conclusion" => "success",
         "createdAt" => "2026-07-14T11:30:00Z",
+        "startedAt" => "2026-07-14T11:30:05Z",
         "updatedAt" => "2026-07-14T12:00:30Z",
         "url" => run_url
       }
     end
     let(:evidence) do
       {
-        "schema_version" => 1,
+        "schema_version" => 2,
+        "run_attempt" => 1,
         "run_id" => 123_456,
         "run_url" => run_url,
         "branch" => "release/17.0.0",
@@ -674,6 +681,11 @@ RSpec.describe "release.rake helper methods" do
         .to eq("evidence run ID does not match the workflow run")
     end
 
+    it "rejects evidence from another workflow run attempt" do
+      expect(evidence_rejection(evidence: evidence.merge("run_attempt" => 2)))
+        .to eq("evidence run attempt does not match the workflow run")
+    end
+
     %w[failure cancelled].each do |conclusion|
       it "rejects a #{conclusion} workflow run" do
         rejected_run = run.merge("conclusion" => conclusion)
@@ -710,10 +722,27 @@ RSpec.describe "release.rake helper methods" do
       ).to be_nil
     end
 
+    it "rejects a rerun attempt that started after the release even when the workflow was created earlier" do
+      late_evidence = evidence.merge("run_attempt" => 2, "completed_at" => "2026-07-14T13:02:00Z")
+      rerun = run.merge(
+        "attempt" => 2,
+        "startedAt" => "2026-07-14T13:01:00Z",
+        "updatedAt" => "2026-07-14T13:02:30Z"
+      )
+
+      expect(
+        evidence_rejection(
+          run: rerun,
+          evidence: late_evidence,
+          allow_prerun_completion_after_release_start: true
+        )
+      ).to eq("pre-run did not start before the release run")
+    end
+
     it "rejects an active pre-run whose start time cannot be proven to precede release" do
       late_evidence = evidence.merge("completed_at" => "2026-07-14T13:01:00Z")
       same_second_run = run.merge(
-        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:00Z",
         "updatedAt" => "2026-07-14T13:01:30Z"
       )
 
@@ -728,7 +757,7 @@ RSpec.describe "release.rake helper methods" do
 
     it "rejects an active pre-run when refreshed start metadata is missing" do
       late_evidence = evidence.merge("completed_at" => "2026-07-14T13:01:00Z")
-      missing_start_run = run.merge("createdAt" => nil, "updatedAt" => "2026-07-14T13:01:30Z")
+      missing_start_run = run.merge("startedAt" => nil, "updatedAt" => "2026-07-14T13:01:30Z")
 
       expect(
         evidence_rejection(
@@ -765,18 +794,22 @@ RSpec.describe "release.rake helper methods" do
     it "treats the newest branch candidate as authoritative even when it was cancelled" do
       old_success = {
         "databaseId" => 1,
+        "attempt" => 1,
         "headSha" => "old",
         "status" => "completed",
         "conclusion" => "success",
         "createdAt" => "2026-07-14T11:00:00Z",
+        "startedAt" => "2026-07-14T11:00:05Z",
         "updatedAt" => "2026-07-14T11:00:00Z"
       }
       newer_cancelled = {
         "databaseId" => 2,
+        "attempt" => 1,
         "headSha" => "new",
         "status" => "completed",
         "conclusion" => "cancelled",
         "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
         "updatedAt" => "2026-07-14T12:00:00Z"
       }
 
@@ -792,6 +825,7 @@ RSpec.describe "release.rake helper methods" do
         "conclusion" => "success",
         "attempt" => 2,
         "createdAt" => "2026-07-14T11:00:00Z",
+        "startedAt" => "2026-07-14T12:59:00Z",
         "updatedAt" => "2026-07-14T13:00:00Z"
       }
       newer_cancelled = {
@@ -801,6 +835,7 @@ RSpec.describe "release.rake helper methods" do
         "conclusion" => "cancelled",
         "attempt" => 1,
         "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
         "updatedAt" => "2026-07-14T12:00:30Z"
       }
 
@@ -811,18 +846,22 @@ RSpec.describe "release.rake helper methods" do
     it "refuses reuse when candidate ordering metadata is incomplete" do
       old_success = {
         "databaseId" => 1,
+        "attempt" => 1,
         "headSha" => "old",
         "status" => "completed",
         "conclusion" => "success",
         "createdAt" => "2026-07-14T11:00:00Z",
+        "startedAt" => "2026-07-14T11:00:05Z",
         "updatedAt" => "2026-07-14T11:30:00Z"
       }
       malformed_newer_cancelled = {
         "databaseId" => 2,
+        "attempt" => 1,
         "headSha" => "new",
         "status" => "completed",
         "conclusion" => "cancelled",
         "createdAt" => nil,
+        "startedAt" => "2026-07-14T12:00:05Z",
         "updatedAt" => "2026-07-14T12:30:00Z"
       }
 
@@ -857,8 +896,10 @@ RSpec.describe "release.rake helper methods" do
     let(:run) do
       {
         "databaseId" => 123_456,
+        "attempt" => 1,
         "headSha" => head_sha,
         "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       }
     end
@@ -1073,7 +1114,7 @@ RSpec.describe "release.rake helper methods" do
         .and_return([in_progress_prerun])
       allow(self).to receive(:capture_gh_output_with_timeout)
         .with(
-          "run", "watch", "123456", "--repo", repo_slug, "--exit-status",
+          "run", "watch", "123456", "--repo", repo_slug,
           timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
         )
         .and_return(["", success_status, false])
@@ -1123,6 +1164,57 @@ RSpec.describe "release.rake helper methods" do
       )
     end
 
+    it "dispatches an exact-head gate when the active pre-run attempt changes while waiting" do
+      candidate_sha = "feedface" * 5
+      in_progress_prerun = run.merge(
+        "headSha" => candidate_sha,
+        "status" => "in_progress",
+        "conclusion" => "",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      rerun_prerun = in_progress_prerun.merge(
+        "attempt" => 2,
+        "startedAt" => "2026-07-14T13:01:00Z",
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      fresh_run = run.merge("databaseId" => 654_321)
+      completed_fresh_run = fresh_run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T14:30:00Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_prerun])
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .and_return(["", success_status, false], ["", success_status, false])
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: in_progress_prerun).and_return(rerun_prerun)
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: fresh_run).and_return(completed_fresh_run)
+      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(fresh_run)
+      expect(self).to receive(:dispatch_shakaperf_release_gate_workflow!).with(
+        repo_slug:,
+        ref: "release-branch",
+        target_version:,
+        candidate_sha: head_sha
+      )
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/attempt changed.*dispatching an exact-head gate.*gate passed/m).to_stdout
+    end
+
     it "dispatches an exact-head gate when an in-progress pre-run finishes unsuccessfully" do
       candidate_sha = "feedface" * 5
       in_progress_prerun = run.merge(
@@ -1145,7 +1237,7 @@ RSpec.describe "release.rake helper methods" do
         .with(repo_slug:, ref: "release-branch")
         .and_return([in_progress_prerun])
       allow(self).to receive(:capture_gh_output_with_timeout)
-        .and_return(["Tests failed", failure_status, false], ["", success_status, false])
+        .and_return(["", success_status, false], ["", success_status, false])
       allow(self).to receive(:refresh_shakaperf_release_gate_run!)
         .with(repo_slug:, run: in_progress_prerun).and_return(failed_prerun)
       allow(self).to receive(:refresh_shakaperf_release_gate_run!)
@@ -1217,7 +1309,7 @@ RSpec.describe "release.rake helper methods" do
       expect(self).not_to receive(:capture_gh_output)
       allow(self).to receive(:capture_gh_output_with_timeout)
         .with(
-          "run", "watch", "321654", "--repo", repo_slug, "--exit-status",
+          "run", "watch", "321654", "--repo", repo_slug,
           timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
         )
         .and_return(["", success_status, false])
@@ -1257,7 +1349,7 @@ RSpec.describe "release.rake helper methods" do
         .with(repo_slug:, ref: "release-branch")
         .and_return([in_progress_exact_head_run, successful_prerun])
       allow(self).to receive(:capture_gh_output_with_timeout)
-        .and_return(["Tests failed", failure_status, false])
+        .and_return(["", success_status, false])
       allow(self).to receive(:refresh_shakaperf_release_gate_run!)
         .with(repo_slug:, run: in_progress_exact_head_run).and_return(failed_exact_head_run)
       allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
@@ -1287,7 +1379,7 @@ RSpec.describe "release.rake helper methods" do
         .with(repo_slug:, ref: "release-branch")
         .and_return([in_progress_run])
       allow(self).to receive(:capture_gh_output_with_timeout)
-        .and_return(["GitHub API unavailable", failure_status, false])
+        .and_return(["", success_status, false])
       allow(self).to receive(:refresh_shakaperf_release_gate_run!)
         .with(repo_slug:, run: in_progress_run).and_return(in_progress_run)
       expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
@@ -1302,7 +1394,34 @@ RSpec.describe "release.rake helper methods" do
           allow_override: false,
           dry_run: false
         )
-      end.to raise_error(SystemExit, /Unable to establish the terminal result.*GitHub API unavailable/m)
+      end.to raise_error(SystemExit, /Unable to establish the terminal result/m)
+    end
+
+    it "fails closed on a watcher API error even when refresh reports a terminal workflow failure" do
+      in_progress_run = run.merge(
+        "databaseId" => 654_321,
+        "status" => "in_progress",
+        "conclusion" => ""
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_run])
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .and_return(["GitHub API unavailable", failure_status, false])
+      expect(self).not_to receive(:refresh_shakaperf_release_gate_run!)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to raise_error(SystemExit, /Unable to watch existing ShakaPerf release gate.*GitHub API unavailable/m)
     end
 
     it "does not reuse a successful run when a rerun updated a same-SHA failure more recently" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -885,6 +885,47 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#trustworthy_terminal_shakaperf_release_gate_run?" do
+    let(:original_run) do
+      {
+        "databaseId" => 654_321,
+        "attempt" => 1,
+        "headSha" => "abc123",
+        "status" => "in_progress",
+        "conclusion" => ""
+      }
+    end
+    let(:terminal_run) { original_run.merge("status" => "completed", "conclusion" => "failure") }
+
+    it "accepts a known terminal result for the watched run" do
+      expect(trustworthy_terminal_shakaperf_release_gate_run?(original_run:, refreshed_run: terminal_run)).to be true
+    end
+
+    it "rejects another run ID" do
+      refreshed_run = terminal_run.merge("databaseId" => 654_322)
+
+      expect(trustworthy_terminal_shakaperf_release_gate_run?(original_run:, refreshed_run:)).to be false
+    end
+
+    it "rejects another head SHA" do
+      refreshed_run = terminal_run.merge("headSha" => "different-head")
+
+      expect(trustworthy_terminal_shakaperf_release_gate_run?(original_run:, refreshed_run:)).to be false
+    end
+
+    it "rejects an invalid attempt" do
+      refreshed_run = terminal_run.merge("attempt" => 0)
+
+      expect(trustworthy_terminal_shakaperf_release_gate_run?(original_run:, refreshed_run:)).to be false
+    end
+
+    it "rejects an unknown terminal conclusion" do
+      refreshed_run = terminal_run.merge("conclusion" => "future_conclusion")
+
+      expect(trustworthy_terminal_shakaperf_release_gate_run?(original_run:, refreshed_run:)).to be false
+    end
+  end
+
   describe "#run_shakaperf_release_gate!" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:repo_slug) { "shakacode/react_on_rails" }

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -565,6 +565,18 @@ RSpec.describe "release.rake helper methods" do
       expect(gate_workflow).to include("target_version:", "candidate_sha:", "cancel-in-progress: true")
       expect(gate_workflow).to include("name: shakaperf-release-evidence", "shakaperf-release-evidence.json")
     end
+
+    it "sets up a supported Ruby before either workflow loads the release helpers" do
+      %w[shakaperf-release-gates.yml shakaperf-release-prerun.yml].each do |workflow_name|
+        workflow = File.read(File.join(repo_root, ".github/workflows", workflow_name))
+        version_reader = workflow.index("uses: ./.github/actions/read-tool-versions")
+        ruby_setup = workflow.index("uses: ./.github/actions/setup-ruby")
+        release_helper_load = workflow.index("ruby -rrake")
+
+        expect(version_reader).to be < ruby_setup
+        expect(ruby_setup).to be < release_helper_load
+      end
+    end
   end
 
   describe "#shakaperf_release_gate_evidence_rejection" do
@@ -672,6 +684,13 @@ RSpec.describe "release.rake helper methods" do
         .to eq("evidence was not complete before the release run started")
     end
 
+    it "rejects second-precision evidence from the same second as a fractional release start" do
+      fractional_start = Time.iso8601("2026-07-14T12:00:30.900Z")
+
+      expect(evidence_rejection(release_started_at: fractional_start))
+        .to eq("evidence was not complete before the release run started")
+    end
+
     it "rejects evidence from another release branch" do
       wrong_branch_evidence = evidence.merge("branch" => "release/17.0.1")
 
@@ -694,6 +713,7 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "old",
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T11:00:00Z",
         "updatedAt" => "2026-07-14T11:00:00Z"
       }
       newer_cancelled = {
@@ -701,11 +721,58 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "new",
         "status" => "completed",
         "conclusion" => "cancelled",
+        "createdAt" => "2026-07-14T12:00:00Z",
         "updatedAt" => "2026-07-14T12:00:00Z"
       }
 
       expect(find_latest_shakaperf_prerun([old_success, newer_cancelled], "release-head"))
         .to eq(newer_cancelled)
+    end
+
+    it "does not let a rerun of an older candidate supersede a newer candidate" do
+      old_rerun = {
+        "databaseId" => 1,
+        "headSha" => "old",
+        "status" => "completed",
+        "conclusion" => "success",
+        "attempt" => 2,
+        "createdAt" => "2026-07-14T11:00:00Z",
+        "updatedAt" => "2026-07-14T13:00:00Z"
+      }
+      newer_cancelled = {
+        "databaseId" => 2,
+        "headSha" => "new",
+        "status" => "completed",
+        "conclusion" => "cancelled",
+        "attempt" => 1,
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      }
+
+      expect(find_latest_shakaperf_prerun([old_rerun, newer_cancelled], "release-head"))
+        .to eq(newer_cancelled)
+    end
+
+    it "refuses reuse when candidate ordering metadata is incomplete" do
+      old_success = {
+        "databaseId" => 1,
+        "headSha" => "old",
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T11:00:00Z",
+        "updatedAt" => "2026-07-14T11:30:00Z"
+      }
+      malformed_newer_cancelled = {
+        "databaseId" => 2,
+        "headSha" => "new",
+        "status" => "completed",
+        "conclusion" => "cancelled",
+        "createdAt" => nil,
+        "updatedAt" => "2026-07-14T12:30:00Z"
+      }
+
+      expect(find_latest_shakaperf_prerun([old_success, malformed_newer_cancelled], "release-head"))
+        .to be_nil
     end
   end
 
@@ -736,6 +803,7 @@ RSpec.describe "release.rake helper methods" do
       {
         "databaseId" => 123_456,
         "headSha" => head_sha,
+        "createdAt" => "2026-07-14T12:00:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       }
     end

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -1105,6 +1105,38 @@ RSpec.describe "release.rake helper methods" do
         .to_stdout
     end
 
+    it "fails closed when a freshly dispatched gate refresh changes run identity" do
+      fresh_run = run.merge("databaseId" => 654_321)
+      mismatched_run = fresh_run.merge(
+        "databaseId" => 654_322,
+        "headSha" => "different-head",
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      allow(self).to receive(:dispatch_shakaperf_release_gate_workflow!)
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: release_started_at,
+        wait_for_shakaperf_release_gate_run!: fresh_run
+      )
+      allow(self).to receive(:watch_shakaperf_release_gate_run!).with(repo_slug:, run: fresh_run)
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: fresh_run).and_return(mismatched_run)
+      expect(self).not_to receive(:verify_fresh_shakaperf_release_gate_evidence!)
+
+      expect do
+        dispatch_and_validate_shakaperf_release_gate!(
+          repo_slug:,
+          monorepo_root:,
+          ref: "release-branch",
+          existing_runs: [],
+          head_sha:,
+          target_version:,
+          release_started_at:
+        )
+      end.to raise_error(SystemExit, /Unable to establish the terminal result of freshly dispatched.*654321/m)
+    end
+
     it "reuses successful pre-run evidence for a runtime-equivalent metadata bump" do
       candidate_sha = "feedface" * 5
       successful_prerun = run.merge(
@@ -1254,6 +1286,58 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false
         )
       end.to output(/attempt changed.*dispatching an exact-head gate.*gate passed/m).to_stdout
+    end
+
+    it "dispatches an exact-head gate when the active pre-run start time changes while waiting" do
+      candidate_sha = "feedface" * 5
+      in_progress_prerun = run.merge(
+        "headSha" => candidate_sha,
+        "startedAt" => "2026-07-14T13:01:00Z",
+        "status" => "in_progress",
+        "conclusion" => "",
+        "updatedAt" => "2026-07-14T13:01:30Z"
+      )
+      changed_prerun = in_progress_prerun.merge(
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      fresh_run = run.merge("databaseId" => 654_321)
+      completed_fresh_run = fresh_run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T14:30:00Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([in_progress_prerun])
+      allow(self).to receive(:capture_gh_output_with_timeout)
+        .and_return(["", success_status, false], ["", success_status, false])
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: in_progress_prerun).and_return(changed_prerun)
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: fresh_run).and_return(completed_fresh_run)
+      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(fresh_run)
+      expect(self).not_to receive(:fetch_shakaperf_release_gate_evidence).with(repo_slug:, run: changed_prerun)
+      expect(self).to receive(:dispatch_shakaperf_release_gate_workflow!).with(
+        repo_slug:,
+        ref: "release-branch",
+        target_version:,
+        candidate_sha: head_sha
+      )
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/provenance changed.*dispatching an exact-head gate.*gate passed/m).to_stdout
     end
 
     it "dispatches an exact-head gate when an in-progress pre-run finishes unsuccessfully" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -485,10 +485,251 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#shakaperf_prerun_candidate" do
+    let(:monorepo_root) { "/tmp/repo" }
+    let(:head_sha) { "candidate123" }
+
+    it "identifies a prepared next release on the matching release branch" do
+      allow(self).to receive(:current_gem_version).with(monorepo_root).and_return("17.0.0.rc.7")
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root:).and_return("17.0.0.rc.8")
+      allow(self).to receive(:extract_changelog_section)
+        .with(changelog_path: "/tmp/repo/CHANGELOG.md", version: "17.0.0.rc.8")
+        .and_return("#### Fixed\n\n- Release fix")
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root:, sha: head_sha).and_return("a" * 64)
+
+      expect(
+        shakaperf_prerun_candidate(
+          monorepo_root:,
+          ref: "release/17.0.0",
+          head_sha:
+        )
+      ).to eq(
+        branch: "release/17.0.0",
+        candidate_sha: head_sha,
+        target_version: "17.0.0.rc.8",
+        runtime_tree_fingerprint: "a" * 64
+      )
+    end
+
+    it "ignores a changelog push that does not prepare a newer matching release" do
+      allow(self).to receive(:current_gem_version).with(monorepo_root).and_return("17.0.0.rc.8")
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root:).and_return("17.0.0.rc.8")
+
+      expect(
+        shakaperf_prerun_candidate(
+          monorepo_root:,
+          ref: "release/17.0.0",
+          head_sha:
+        )
+      ).to be_nil
+    end
+  end
+
+  describe "#shakaperf_runtime_tree_fingerprint" do
+    let(:success_status) { instance_double(Process::Status, success?: true) }
+
+    it "hashes the exact non-release-metadata tree" do
+      entries = [
+        "100644 blob changelog\tCHANGELOG.md",
+        "100644 blob version\treact_on_rails/lib/react_on_rails/version.rb",
+        "100644 blob runtime\treact_on_rails/lib/react_on_rails/engine.rb",
+        ""
+      ].join("\0")
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "ls-tree", "-r", "-z", "--full-tree", "candidate")
+        .and_return([entries, success_status])
+
+      expected = Digest::SHA256.hexdigest(
+        "100644 blob runtime\treact_on_rails/lib/react_on_rails/engine.rb"
+      )
+      expect(shakaperf_runtime_tree_fingerprint(monorepo_root: "/tmp/repo", sha: "candidate")).to eq(expected)
+    end
+  end
+
+  describe "ShakaPerf pre-run workflow contract" do
+    let(:repo_root) { File.expand_path("../../..", __dir__) }
+
+    it "dispatches an identified changelog candidate and records reusable gate evidence" do
+      prerun_workflow = File.read(File.join(repo_root, ".github/workflows/shakaperf-release-prerun.yml"))
+      gate_workflow = File.read(File.join(repo_root, ".github/workflows/shakaperf-release-gates.yml"))
+
+      expect(prerun_workflow).to include("branches:\n      - 'release/**'", "paths:\n      - CHANGELOG.md")
+      expect(prerun_workflow).to include(
+        "workflow run shakaperf-release-gates.yml",
+        "target_version=",
+        "candidate_sha="
+      )
+      expect(gate_workflow).to include("target_version:", "candidate_sha:", "cancel-in-progress: true")
+      expect(gate_workflow).to include("name: shakaperf-release-evidence", "shakaperf-release-evidence.json")
+    end
+  end
+
+  describe "#shakaperf_release_gate_evidence_rejection" do
+    let(:monorepo_root) { "/tmp/repo" }
+    let(:candidate_sha) { "a" * 40 }
+    let(:head_sha) { "b" * 40 }
+    let(:fingerprint) { "c" * 64 }
+    let(:run_url) { "https://github.com/shakacode/react_on_rails/actions/runs/123456" }
+    let(:run) do
+      {
+        "databaseId" => 123_456,
+        "headSha" => candidate_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T12:00:30Z",
+        "url" => run_url
+      }
+    end
+    let(:evidence) do
+      {
+        "schema_version" => 1,
+        "run_id" => 123_456,
+        "run_url" => run_url,
+        "branch" => "release/17.0.0",
+        "candidate_sha" => candidate_sha,
+        "target_version" => "17.0.0.rc.8",
+        "conclusion" => "success",
+        "runtime_tree_fingerprint" => fingerprint,
+        "completed_at" => "2026-07-14T12:00:00Z"
+      }
+    end
+    let(:release_started_at) { Time.iso8601("2026-07-14T13:00:00Z") }
+    let(:validation_time) { Time.iso8601("2026-07-14T13:05:00Z") }
+
+    before do
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root:, sha: candidate_sha).and_return(fingerprint)
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root:, sha: head_sha).and_return(fingerprint)
+      allow(self).to receive(:shakaperf_candidate_commit_shas)
+        .with(monorepo_root:, candidate_sha:, head_sha:).and_return([head_sha])
+      allow(self).to receive(:release_finalization_metadata_commit?)
+        .with(monorepo_root:, sha: head_sha).and_return(true)
+    end
+
+    def evidence_rejection(run: self.run, evidence: self.evidence, target_version: "17.0.0.rc.8",
+                           release_started_at: self.release_started_at)
+      shakaperf_release_gate_evidence_rejection(
+        monorepo_root:,
+        ref: "release/17.0.0",
+        head_sha:,
+        target_version:,
+        run:,
+        evidence:,
+        release_started_at:,
+        validation_time:,
+        require_prerun: true
+      )
+    end
+
+    it "accepts a successful pre-run followed only by a version-metadata bump" do
+      expect(evidence_rejection).to be_nil
+    end
+
+    it "rejects a runtime tree change after the tested candidate" do
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root:, sha: head_sha).and_return("d" * 64)
+
+      expect(evidence_rejection).to eq("release runtime tree differs from the tested candidate")
+    end
+
+    it "rejects evidence for another target version" do
+      expect(
+        evidence_rejection(evidence: evidence.merge("target_version" => "17.0.0.rc.9"))
+      ).to eq("evidence target version does not match the release")
+    end
+
+    it "rejects a run ID that only coerces to the workflow run ID" do
+      coerced_id_evidence = evidence.merge("run_id" => "123456junk")
+
+      expect(evidence_rejection(evidence: coerced_id_evidence))
+        .to eq("evidence run ID does not match the workflow run")
+    end
+
+    %w[failure cancelled].each do |conclusion|
+      it "rejects a #{conclusion} workflow run" do
+        rejected_run = run.merge("conclusion" => conclusion)
+
+        expect(evidence_rejection(run: rejected_run)).to eq("workflow run did not complete successfully")
+      end
+    end
+
+    it "rejects stale evidence" do
+      stale_evidence = evidence.merge("completed_at" => "2026-07-01T12:00:00Z")
+      stale_run = run.merge("updatedAt" => "2026-07-01T12:00:30Z")
+
+      expect(evidence_rejection(run: stale_run, evidence: stale_evidence)).to eq("evidence is stale")
+    end
+
+    it "rejects a gate that did not finish before the release run started" do
+      late_evidence = evidence.merge("completed_at" => "2026-07-14T13:00:00Z")
+      late_run = run.merge("updatedAt" => "2026-07-14T13:00:30Z")
+
+      expect(evidence_rejection(run: late_run, evidence: late_evidence))
+        .to eq("evidence was not complete before the release run started")
+    end
+
+    it "rejects evidence from another release branch" do
+      wrong_branch_evidence = evidence.merge("branch" => "release/17.0.1")
+
+      expect(evidence_rejection(evidence: wrong_branch_evidence))
+        .to eq("evidence branch does not match the release branch")
+    end
+
+    it "rejects unverifiable candidate ancestry instead of accepting unknown state" do
+      allow(self).to receive(:shakaperf_candidate_commit_shas)
+        .with(monorepo_root:, candidate_sha:, head_sha:).and_return(nil)
+
+      expect(evidence_rejection).to eq("tested candidate ancestry or intervening commits cannot be verified")
+    end
+  end
+
+  describe "#find_latest_shakaperf_prerun" do
+    it "treats the newest branch candidate as authoritative even when it was cancelled" do
+      old_success = {
+        "databaseId" => 1,
+        "headSha" => "old",
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T11:00:00Z"
+      }
+      newer_cancelled = {
+        "databaseId" => 2,
+        "headSha" => "new",
+        "status" => "completed",
+        "conclusion" => "cancelled",
+        "updatedAt" => "2026-07-14T12:00:00Z"
+      }
+
+      expect(find_latest_shakaperf_prerun([old_success, newer_cancelled], "release-head"))
+        .to eq(newer_cancelled)
+    end
+  end
+
+  describe "#shakaperf_prerun_metadata_commit?" do
+    let(:monorepo_root) { "/tmp/repo" }
+
+    it "does not accept an arbitrary detector-classified non-runtime commit" do
+      allow(self).to receive(:release_finalization_metadata_commit?)
+        .with(monorepo_root:, sha: "docs").and_return(false)
+      allow(self).to receive(:commit_non_runtime_only?)
+        .with(monorepo_root:, sha: "docs").and_return(true)
+      allow(self).to receive(:shakaperf_changelog_only_commit?)
+        .with(monorepo_root:, sha: "docs").and_return(false)
+
+      expect(shakaperf_prerun_metadata_commit?(monorepo_root:, sha: "docs")).to be false
+    end
+  end
+
   describe "#run_shakaperf_release_gate!" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:repo_slug) { "shakacode/react_on_rails" }
     let(:head_sha) { "abc1234def5678abcdef" }
+    let(:target_version) { "17.0.0.rc.8" }
+    let(:release_started_at) { Time.iso8601("2026-07-14T13:00:00Z") }
     let(:success_status) { instance_double(Process::Status, success?: true) }
     let(:failure_status) { instance_double(Process::Status, success?: false) }
     let(:run) do
@@ -501,6 +742,17 @@ RSpec.describe "release.rake helper methods" do
 
     before do
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return(repo_slug)
+      allow(self).to receive_messages(
+        fetch_shakaperf_release_gate_evidence: { "verified" => true },
+        shakaperf_release_gate_evidence_rejection: nil
+      )
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!) do |run:, **|
+        run.merge(
+          "status" => "completed",
+          "conclusion" => "success",
+          "updatedAt" => "2026-07-14T13:30:00Z"
+        )
+      end
     end
 
     it "dispatches the workflow on the release ref and watches the matching run" do
@@ -511,7 +763,9 @@ RSpec.describe "release.rake helper methods" do
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
           "--repo", repo_slug,
-          "--ref", "release-branch"
+          "--ref", "release-branch",
+          "-f", "target_version=#{target_version}",
+          "-f", "candidate_sha=#{head_sha}"
         )
         .and_return(["", success_status])
       allow(self).to receive(:wait_for_shakaperf_release_gate_run!)
@@ -544,6 +798,8 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: false
         )
@@ -552,7 +808,9 @@ RSpec.describe "release.rake helper methods" do
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
           "--repo", repo_slug,
-          "--ref", "release-branch"
+          "--ref", "release-branch",
+          "-f", "target_version=#{target_version}",
+          "-f", "candidate_sha=#{head_sha}"
         )
       expect(self).to have_received(:wait_for_shakaperf_release_gate_run!)
         .with(
@@ -585,10 +843,93 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: false
         )
       end.to output(%r{ShakaPerf release gate already passed.*actions/runs/123456}m).to_stdout
+    end
+
+    it "dispatches a fresh exact-head gate when a successful run has no verifiable evidence" do
+      successful_run = run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      fresh_run = run.merge("databaseId" => 654_321)
+      refreshed_fresh_run = fresh_run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      release_started_at = Time.iso8601("2026-07-14T13:00:00Z")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([successful_run])
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: successful_run).and_return(nil)
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: refreshed_fresh_run).and_return({ "fresh" => true })
+      expect(self).to receive(:dispatch_shakaperf_release_gate_workflow!).with(
+        repo_slug:,
+        ref: "release-branch",
+        target_version: "17.0.0.rc.8",
+        candidate_sha: head_sha
+      )
+      allow(self).to receive_messages(
+        shakaperf_release_gate_evidence_rejection: nil,
+        shakaperf_release_gate_dispatch_started_at: release_started_at,
+        wait_for_shakaperf_release_gate_run!: fresh_run,
+        capture_gh_output_with_timeout: ["", success_status, false]
+      )
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: fresh_run).and_return(refreshed_fresh_run)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version: "17.0.0.rc.8",
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(/dispatching a fresh exact-head gate.*ShakaPerf release gate passed with verified evidence/m)
+        .to_stdout
+    end
+
+    it "reuses successful pre-run evidence for a runtime-equivalent metadata bump" do
+      candidate_sha = "feedface" * 5
+      successful_prerun = run.merge(
+        "headSha" => candidate_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      evidence = { "candidate_sha" => candidate_sha }
+      release_started_at = Time.iso8601("2026-07-14T13:00:00Z")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch")
+        .and_return([successful_prerun])
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: successful_prerun).and_return(evidence)
+      allow(self).to receive(:shakaperf_release_gate_evidence_rejection).and_return(nil)
+      expect(self).not_to receive(:capture_gh_output_with_timeout)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version: "17.0.0.rc.8",
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to output(%r{Reusing successful ShakaPerf pre-run.*actions/runs/123456}m).to_stdout
     end
 
     it "watches an in-progress gate run for the same head SHA without dispatching another run" do
@@ -613,6 +954,8 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: false
         )
@@ -643,7 +986,9 @@ RSpec.describe "release.rake helper methods" do
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
           "--repo", repo_slug,
-          "--ref", "release-branch"
+          "--ref", "release-branch",
+          "-f", "target_version=#{target_version}",
+          "-f", "candidate_sha=#{head_sha}"
         )
         .and_return(["", success_status])
       allow(self).to receive(:wait_for_shakaperf_release_gate_run!)
@@ -667,6 +1012,8 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: false
         )
@@ -675,7 +1022,9 @@ RSpec.describe "release.rake helper methods" do
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
           "--repo", repo_slug,
-          "--ref", "release-branch"
+          "--ref", "release-branch",
+          "-f", "target_version=#{target_version}",
+          "-f", "candidate_sha=#{head_sha}"
         )
     end
 
@@ -687,6 +1036,8 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: true,
           dry_run: false
         )
@@ -701,6 +1052,8 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: true
         )
@@ -715,7 +1068,9 @@ RSpec.describe "release.rake helper methods" do
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
           "--repo", repo_slug,
-          "--ref", "release-branch"
+          "--ref", "release-branch",
+          "-f", "target_version=#{target_version}",
+          "-f", "candidate_sha=#{head_sha}"
         )
         .and_return(["HTTP 404", failure_status])
 
@@ -724,6 +1079,8 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: false
         )
@@ -738,7 +1095,9 @@ RSpec.describe "release.rake helper methods" do
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
           "--repo", repo_slug,
-          "--ref", "release-branch"
+          "--ref", "release-branch",
+          "-f", "target_version=#{target_version}",
+          "-f", "candidate_sha=#{head_sha}"
         )
         .and_return(["", success_status])
       allow(self).to receive(:wait_for_shakaperf_release_gate_run!)
@@ -762,10 +1121,47 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: false
         )
       end.to raise_error(SystemExit, %r{ShakaPerf release gate failed.*actions/runs/123456.*Tests failed}m)
+    end
+
+    it "aborts after a successful fresh gate when its evidence is invalid" do
+      refreshed_run = run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T13:30:00Z"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch").and_return([])
+      allow(self).to receive(:dispatch_shakaperf_release_gate_workflow!)
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run:).and_return(refreshed_run)
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: refreshed_run).and_return({ "invalid" => true })
+      allow(self).to receive_messages(
+        wait_for_shakaperf_release_gate_run!: run,
+        capture_gh_output_with_timeout: ["", success_status, false],
+        shakaperf_release_gate_evidence_rejection: "evidence target version does not match the release"
+      )
+
+      expect do
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      end.to raise_error(
+        SystemExit,
+        /Fresh ShakaPerf release gate evidence is invalid: evidence target version does not match the release/
+      )
     end
 
     it "aborts when watching the matching gate run times out" do
@@ -776,7 +1172,9 @@ RSpec.describe "release.rake helper methods" do
         .with(
           "workflow", "run", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
           "--repo", repo_slug,
-          "--ref", "release-branch"
+          "--ref", "release-branch",
+          "-f", "target_version=#{target_version}",
+          "-f", "candidate_sha=#{head_sha}"
         )
         .and_return(["", success_status])
       allow(self).to receive(:wait_for_shakaperf_release_gate_run!)
@@ -800,6 +1198,8 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
+          release_started_at:,
           allow_override: false,
           dry_run: false
         )


### PR DESCRIPTION
## Why

ShakaPerf currently starts only after the release command has already prepared and pushed a candidate, so a release can spend its critical path waiting for a long-running gate that could have run earlier. Retrying also needs strict, auditable proof that prior evidence belongs to the same release candidate and runtime tree.

## What changed

- Add an automatic pre-run dispatcher for prepared changelog candidates on `release/**` branches.
- Require the ShakaPerf gate to identify the exact target version and candidate SHA, then publish versioned evidence containing the run ID, workflow attempt, branch, candidate, conclusion, runtime fingerprint, and completion time.
- Reuse evidence only when its schema, run identity, branch, version, SHA, freshness, ancestry, and runtime-equivalent tree all verify. Ambiguous or invalid state fails closed.
- Keep the newest candidate authoritative even when it was cancelled or failed; rerunning an older candidate cannot supersede it.
- Preserve exact-head dispatch as the fallback and leave final-promotion override policy unchanged.
- Document the pre-run, reuse, retry, and fail-closed operator flow.

Closes #4645.

## Verification

- `bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb` — 375 examples, 0 failures
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` — 237 files, no offenses
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `actionlint` on both changed workflows
- Ruby YAML parsing on both changed workflows
- `script/check-docs-sidebar`
- `script/ci-changes-detector origin/main` — full hosted suite recommended

The broad changed-file validator was also exercised but did not complete cleanly because existing generated-example dev-server and peer-resolution failures are unrelated to this diff. The release-helper, lint, formatting, workflow-syntax, YAML, and docs checks above are green; full hosted CI is required for the candidate head.

## Review notes

- Independent exact-route review prompted fixes for runner Ruby bootstrap, timestamp boundaries, candidate ordering, active-run fallback, attempt/start-time provenance, watcher/API failures, and refreshed-run identity validation. The final exact-head review is clean.
- Added a coordinator regression for older-candidate rerun supersession.
- No executable overlap was found with other open PRs during the pre-push sweep; one docs-only PR also touches the release runbook and will be rechecked before merge.
- Semantic GitHub Actions changes require a linked post-merge exercise issue before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated pre-run that dispatches release gates when a prepared changelog change is pushed to a release branch.
  * Release gates now generate and attach machine-readable evidence (including version/commit outcome and runtime fingerprint) as an artifact.
  * Verified pre-run evidence may be reused during publication when it precisely matches the expected inputs.
* **Bug Fixes**
  * Prevents reuse of stale, mismatched, incomplete, or terminally-failed gate evidence.
  * Cancels in-progress checks when a newer candidate run starts.
* **Documentation**
  * Added a runbook covering pre-run triggers, evidence reuse rules, and fallback behavior.
* **Tests**
  * Added contract and helper behavior tests for the new evidence and dispatch sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->