### PR TITLE
Fix Hacker News demo-fleet smoke path

### DIFF
--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -138,7 +138,7 @@ repos:
     needs_pro: true
     ruby_test: bin/rails test && bin/rails test:system
     build: bin/rails react_on_rails:generate_packs && bin/shakapacker
-    smoke: [/, /news]
+    smoke: [/, /news/1]
     verify: true
 
   - name: shakacode/react-on-rails-demo-marketplace-rsc


### PR DESCRIPTION
## Summary

- Replace the Hacker News demo-fleet smoke path `/news` with the concrete paginated route `/news/1`.
- Keep the demo application and its `/news/:page` routing unchanged.

## Why

The fleet manifest currently asks smoke verification to visit `/news`, but the Hacker News demo exposes `GET /news/:page`. Using page `1` gives the fleet a deterministic route that the unchanged demo can serve.

Closes #4653.

## Validation

- RED/GREEN YAML assertion: before the change the smoke list was `["/", "/news"]`; after the change it is `["/", "/news/1"]`.
- `git diff --check`
- `.agents/bin/validate --changed`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` — 237 files inspected, no offenses.
- Pre-commit and pre-push hooks, including Prettier and branch/Markdown checks.
- Independent demo-route QA passed on both exact demo revisions named by the issue.

The CI detector classified this as a documentation/data-only change with no runtime CI jobs. Hosted checks and configured review agents remain merge gates.

## Test strategy

No permanent literal-value test was added. The manifest entry itself is declarative data, and a second assertion that repeats `/news/1` would only duplicate that value. The meaningful regression proof is to parse the manifest and replay its path against the demo's real route table; that independent QA is being completed for both the demo default revision and dependency-update PR #69.

## Release and changelog

- Release mode: `development` (target branch `main`, beta qualification rules).
- Changelog: not user-visible; no changelog entry needed.
- Labels: none; the repository CI detector found no package/runtime lane to select.

## Confidence note

The change is a single manifest value, is scoped to issue #4653, and matches the demo's existing `/news/:page` contract. Local validation, pre-push review, independent Rails route replay on both demo revisions, hosted checks, and all configured current-head review systems are clean. No unresolved implementation risk is known.

## Codex Decision Log

- **Non-blocking:** Whether to add a permanent regression test for this literal manifest value.
  - **Decision:** Do not add a duplicate-value unit test; use manifest parsing plus independent route replay instead.
  - **Why:** The fleet smoke orchestrator that would make a durable behavioral test meaningful is tracked separately, while a second copy of `/news/1` would not verify routing behavior.
  - **Review later:** Add orchestrator-level coverage when fleet smoke automation is implemented.

## Review churn

- Pre-push review gate: bundled Codex `review --uncommitted` against `origin/main`; no actionable findings.
- Follow-up commits after first push: 0.
- Review-thread fix rounds: 0 so far.
- CI reruns caused by fix churn: 0 so far.
- Current-head hosted review coverage: Claude review passed with no blocker, CodeRabbit approved, and Greptile reported 5/5 confidence with no blocking issues.
- Follow-up review findings: none; unresolved review threads: 0.
- Outcome: ready without an extra review-fix cycle.

## QA Evidence

Independent QA booted Rails in `RAILS_ENV=test` on both the demo default revision `3e94379cf4965906d62e2d17c44534d17dd0da66` and PR #69 head `c46a939fb8bf0067989214188f357d07ad7b52bf`. On each revision, route recognition returned `{controller: "stories", action: "index", page: "1"}` for `GET /news/1`, while `GET /news` raised `ActionController::RoutingError`.

This exercises the live Rails route set but does not render a full HTTP/RSC response through the external Node renderer. That downstream rendering path is unchanged; route recognition directly verifies the contract corrected by this manifest-only change.

<!-- qa-evidence v1
required: yes
status: satisfied
head_sha: c47ef3e973af0f082d90e3aa9897cb8aab22a4c9
tested_at: PR #4664 head c47ef3e973af0f082d90e3aa9897cb8aab22a4c9
scope: demo-fleet manifest plus Rails route sets at demo default 3e94379cf4965906d62e2d17c44534d17dd0da66 and PR 69 head c46a939fb8bf0067989214188f357d07ad7b52bf
automated_checks: YAML parse and exact smoke-list assertion; git diff check; validate changed; RuboCop; repository hooks
manual_checks: Rails test-environment route recognition for GET /news/1 and negative GET /news on both exact demo revisions
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->
