### PR TITLE
Test: exercise Rspack/Vite benchmark workflow path filter

### DIFF
--- a/benchmarks/rspack-vite-dx/README.md
+++ b/benchmarks/rspack-vite-dx/README.md
@@ -53,3 +53,5 @@ This is an isolation benchmark, not the final Rails onboarding comparison reques
 Overlay attachment is a useful smoke check, not an overlay-quality score. Click-to-editor remains explicitly unverified because it depends on local editor protocol setup. Configuration line counts are descriptive and should not be treated as equal to concepts a new user must understand without a separate user study or generated-app audit.
 
 Therefore, use this artifact to refine a future full Rails-vs-Rails benchmark and to catch large local regressions. Do not use it alone to publish “parity,” “faster,” “near-instant,” “sub-second,” or onboarding-superiority claims.
+
+<!-- Verification-only change for the post-merge workflow exercise in #4627. -->


### PR DESCRIPTION
## Why

This is a verification-only pull request for #4627. It exercises the positive path of the `Rspack/Vite DX benchmark replay` workflow after #4626 landed by changing an inert comment under `benchmarks/rspack-vite-dx/**`.

This PR must be closed without merging after its workflow evidence is recorded.

## Change

- Add one inert HTML comment to `benchmarks/rspack-vite-dx/README.md`.
- Do not change benchmark behavior, workflow configuration, or published documentation.

## Local verification

- Isolated frozen install passed.
- `pnpm run check` passed, including formatting, 18 tests, and report replay.
- `git diff --check` passed.
- Repository pre-commit and pre-push checks passed.

## Expected hosted evidence

- The PR event starts `Rspack/Vite DX benchmark replay`.
- Its `rspack-vite-dx-check` job performs the isolated frozen install and passes `pnpm run check` at `c08b2259941287d7e2059f9057cf54825f637c5e`.

Tracking: #4627
