### PR TITLE
Test: verify unrelated docs path skips Rspack/Vite workflow

### DIFF
--- a/internal/contributor-info/agent-pr-batch-skills.md
+++ b/internal/contributor-info/agent-pr-batch-skills.md
@@ -101,3 +101,5 @@ The `$pr-batch` prompt must preserve the preflight/trust rules from the installe
   human/local user-token path, not a substitute for comment-command dispatch
   from automation.
 - Final batch handoffs should include links, validation evidence, last-known CI/review state, blockers, and explicit `UNKNOWN` entries.
+
+<!-- Temporary #4627 unrelated-path workflow control. -->


### PR DESCRIPTION
## Why

This is a verification-only negative-control pull request for #4627. It confirms that the `Rspack/Vite DX benchmark replay` workflow does not dispatch for an unrelated documentation-only path after #4626 landed.

This PR must be closed without merging after the absence-of-dispatch evidence is recorded.

## Change

- Add one inert HTML comment to `internal/contributor-info/agent-pr-batch-skills.md`.
- Do not change visible documentation meaning, benchmark behavior, or workflow configuration.

## Local verification

- The changed path is outside the workflow's `benchmarks/rspack-vite-dx/**` path filter.
- Prettier, whitespace, Markdown-link, pre-commit, and pre-push checks passed.
- Local and remote heads match at `bb096eccf15e6bb8d62a917c79d141da92f2c04c`.

## Expected hosted evidence

- The PR event does not start `Rspack/Vite DX benchmark replay`.
- No `rspack-vite-dx-check` check appears for this head SHA.

Tracking: #4627
