### PR TITLE
Release: add auditable accelerated RC async gates

### DIFF
--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -240,9 +240,12 @@ authorization provenance; retries load and reuse that persisted authorization in
 it into a conflicting record. Persisted authorization is not permission to reuse stale pending evidence:
 before retrying any tag or immutable publication, the task refreshes exact-candidate CI and the exact
 recorded ShakaPerf run. Current success remains usable, and only a live in-progress state with no
-conclusion may remain deferred; an active status paired with any non-null conclusion is contradictory
-evidence and blocks. Failed, missing, malformed, stale, API-unknown, or otherwise non-deferable evidence
-also blocks the retry. Every same-version-and-SHA retry discovers durable repository history first,
+conclusion that is bound to the immutable RC candidate may remain deferred. A different-SHA pre-run must
+already be completed successfully and pass the live artifact, runtime-tree, ancestry, and metadata-only
+commit proof; an active different-SHA run cannot be authorized, persisted, reused, or carried across a
+publication boundary. An active status paired with any non-null conclusion is contradictory evidence and
+blocks. Failed, missing, malformed, stale, API-unknown, or otherwise non-deferable evidence also blocks the
+retry. Every same-version-and-SHA retry discovers durable repository history first,
 whether or not it explicitly supplies `RELEASE_ACCELERATED_RC`. If history exists, the unique tracker and
 canonical authorization chain control the retry; explicit tracker, reason, and options must match that
 authorization exactly, and a rejected or conflicting chain remains blocking. The task never refreshes or
@@ -263,7 +266,8 @@ repository-wide proof after posting and immediately before tag handling, so an a
 that appears concurrently on another tracker blocks immutable publication. Before tag handling, immediately
 before tag push, and again after tag push before package publication, accelerated RCs also refresh exact-head
 CI and the recorded ShakaPerf run. A newly failed, missing, malformed, or unknown gate blocks; pending evidence
-must still exactly match the confirmed authorization, while a transition to success is allowed. A material
+must still exactly match the confirmed authorization, and pending ShakaPerf must name the immutable RC candidate,
+while a transition to success is allowed. A material
 pending-state change is untriaged at these boundaries and requires a new authorization rather than silent reuse.
 Omission never downgrades an interrupted accelerated attempt to an ordinary lightweight-tag release and
 never permits the broad prerelease CI override. A genuinely ordinary RC with no accelerated history keeps
@@ -283,7 +287,8 @@ and every later refresh. During accelerated post-dispatch polling, the complete 
 validated before target, ignored-run, or dispatch-time filtering; conflicting duplicates, ambiguous multiple fresh runs,
 and any malformed or unknown sibling block independent of API order. Only a fully valid canonical unrelated run is
 ignored. Accelerated evidence never synthesizes a missing run URL. A valid active exact-head run may remain pending and
-a valid active pre-run may trigger an exact-head dispatch, but malformed or contradictory evidence blocks before either
+a valid active pre-run may trigger an exact-head dispatch during fresh selection, but that active different-SHA run is
+never itself persisted or reused as deferred evidence. Malformed or contradictory evidence blocks before either
 disposition. The selected exact-head or pre-run state is classified before a dispatch request can take effect, so any
 selected known failure or unknown state outranks pending dispatch independent of API order. This accelerated-only polling
 seam does not change the ordinary blocking ShakaPerf waiter or its historical display-URL fallback.
@@ -324,7 +329,8 @@ comments through the issues APIs.
 ShakaPerf evidence is bound to the requested version, workflow run, run attempt, and candidate SHA
 through reconciliation and every publication boundary. Reused accepted-RC evidence remains bound to
 the accepted record's exact stored snapshot. That snapshot can identify a verified runtime-equivalent pre-run whose
-candidate differs from the immutable RC candidate; the pre-run policy is rechecked live, while accepted-RC and final-tip
+candidate differs from the immutable RC candidate only after the run completed successfully and passed mechanical
+verification; the pre-run policy is rechecked live, while accepted-RC and final-tip
 runtime equivalence remain separate required gates. A newly run strict final gate is instead bound directly to the final
 candidate. Every authorization record must have the
 same canonical digest; canonical-digest-identical duplicates are idempotent, but any distinct

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -269,7 +269,13 @@ Omission never downgrades an interrupted accelerated attempt to an ordinary ligh
 never permits the broad prerelease CI override. A genuinely ordinary RC with no accelerated history keeps
 its lightweight-tag path. Same-version retry discovery must complete successfully before the task can
 prove that accelerated history is absent; API, pagination, permission, or parse failure therefore blocks
-that retry as unknown. A marker comment is ignored before author permission checks only when it contains
+that retry as unknown. Repository and selected-tracker discovery read chronological 100-comment pages
+incrementally, validate string bodies, positive unique comment IDs, canonical repository issue URLs, and
+nondecreasing creation times, and retain only marker-bearing comments. Exactly 1,000 retained marker comments
+are allowed, and a short 250th page completes discovery; exceeding 1,000 markers or requiring a 251st page blocks
+as unknown instead of ignoring history or exhausting unbounded memory/API work. Markerless ordinary comments may
+have a deleted author when their safe structural fields remain valid; marker records still require an attributable
+trusted author. A marker comment is ignored before author permission checks only when it contains
 exactly one canonical marker whose payload is the byte-for-byte lowercase hexadecimal encoding of key-sorted
 canonical JSON for a complete, structurally valid tracker record and proves it targets another
 version-and-SHA pair. Reordered or whitespace-varied JSON, uppercase hexadecimal, incomplete records,
@@ -277,8 +283,10 @@ unknown fields, noncanonical state, odd-length or partially decoded payloads, es
 malformed boundaries, duplicated markers, and
 spoofed summaries cannot prove irrelevance and therefore reach strict parsing and block. Discovery comments
 must name the canonical API issue URL in the exact requested repository; wrong hosts, repositories, paths,
-queries, fragments, and pull-request URLs are rejected before their issue number is used. Pull requests
-cannot serve as release trackers even though GitHub exposes their comments through the issues APIs.
+queries, and fragments are rejected before their issue number is used. Every tracker referenced by a plausible
+exact-candidate marker is fetched once and must pass the same open release-tracker eligibility check used by
+selected-tracker publication. Pull requests cannot serve as release trackers even though GitHub exposes their
+comments through the issues APIs.
 
 ShakaPerf evidence is bound to the requested version, workflow run, run attempt, and candidate SHA
 through reconciliation and final reuse. Every authorization record for the candidate must have the
@@ -353,8 +361,13 @@ that block final promotion. Stable CI, version policy, and every other final gat
 remote tag names that normalize to the same RC version are ambiguous and block every first-promotion and
 retry source-selection route, regardless of alias ordering or which alias carries accelerated provenance.
 After existing-tag validation or explicit-SHA tag creation, the task revalidates both local `HEAD` and the
-tag against the carried candidate SHA immediately before `git push --tags`, then repeats that validation
-after the push immediately before package publication. For accelerated RC publication and accelerated-RC
+tag against the carried candidate SHA immediately before `git push --tags`. After the push it repeats the local
+validation and resolves the live remote stable tag's peeled SHA immediately before package publication. Accelerated
+final promotion additionally carries the canonical source RC tag, its candidate SHA, and its exact annotated-tag
+authorization provenance. It force-fetches and revalidates that live source tag at final tag handling, immediately
+before stable-tag push, and after stable-tag push before packages; deletion, movement, lost provenance, or an
+unclassifiable tag blocks. This source-tag check is additional to the live stable-tag peeled-SHA validation. For
+accelerated RC publication and accelerated-RC
 final promotion, both boundaries also re-fetch all trusted repository history for the exact RC candidate
 and require the same unique tracker and canonical, retry-equivalent authorization/terminal chain. A new
 rejection, tracker conflict, chain mutation, missing record, or unknown repository read aborts before the

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -328,13 +328,13 @@ idempotent only when every field except `recorded_at` is identical, and any othe
 variation is conflicting. `candidate-rejected` is absorbing; append-time revalidation prevents a
 concurrent reconciliation from adding acceptance or any other later transition. Every posted transition
 is re-fetched and proven present in the complete canonical chain before the task proceeds toward immutable
-publication or reports reconciliation success. Selected-tracker markers with malformed or unsupported schemas,
-markers authored by accounts without repository write permission, or records whose named approver does not match
-the trusted comment author fail closed. Repository-wide discovery ignores an exact-candidate marker only after
-GitHub successfully proves its author lacks maintainer permission; an unknown permission/API result and every
-malformed record from a trusted author still fail closed. Only the explicit `none`, `read`, or `triage` permission
-results count as a known non-maintainer classification; blank, missing, malformed, unsupported, or future permission
-values are unknown and block even when the API call itself succeeded. Status-specific
+publication or reports reconciliation success. Aside from the canonical unrelated-marker cheap skip above,
+selected-tracker and repository-wide scans ignore a marker comment based on its author only after GitHub successfully
+proves that author lacks maintainer permission. An unknown permission/API result, every malformed or unsupported
+record from a trusted author, and any trusted record whose named approver does not match its comment author still fail
+closed. Only the explicit `none`, `read`, or `triage` permission results count as a known non-maintainer classification;
+blank, missing, malformed, unsupported, or future permission values are unknown and block even when the API call
+itself succeeded. Status-specific
 contradictions also fail closed: accepted records require every success and evidence URL, while
 rejected records require a known failed gate.
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -289,7 +289,11 @@ selected-tracker publication. Pull requests cannot serve as release trackers eve
 comments through the issues APIs.
 
 ShakaPerf evidence is bound to the requested version, workflow run, run attempt, and candidate SHA
-through reconciliation and final reuse. Every authorization record for the candidate must have the
+through reconciliation and every publication boundary. Reused accepted-RC evidence remains bound to
+the accepted record's exact stored snapshot. That snapshot can identify a verified runtime-equivalent pre-run whose
+candidate differs from the immutable RC candidate; the pre-run policy is rechecked live, while accepted-RC and final-tip
+runtime equivalence remain separate required gates. A newly run strict final gate is instead bound directly to the final
+candidate. Every authorization record must have the
 same canonical digest; canonical-digest-identical duplicates are idempotent, but any distinct
 authorization blocks append, retry, reconciliation, and final promotion. Every
 `published-awaiting-gates` record for the candidate must be the complete canonical transition from
@@ -300,6 +304,9 @@ final promotion require at least one canonical `published-awaiting-gates` transi
 be ordered authorization, publication completion, then terminal state, with parseable monotonic timestamps.
 Exact authorization duplicates and the narrowly permitted publication/terminal retry variants remain
 idempotent only within their phase; pending transitions after terminal state are invalid.
+Reconciliation performs bounded repository-wide exact-version-and-SHA validation against the selected
+tracker and canonical authorization before reporting existing terminal state or appending a new terminal
+transition, then repeats that validation after the append helper re-fetches the selected tracker.
 
 Reconcile the record after the deferred gates and all downstream RC testing finish:
 
@@ -321,9 +328,13 @@ idempotent only when every field except `recorded_at` is identical, and any othe
 variation is conflicting. `candidate-rejected` is absorbing; append-time revalidation prevents a
 concurrent reconciliation from adding acceptance or any other later transition. Every posted transition
 is re-fetched and proven present in the complete canonical chain before the task proceeds toward immutable
-publication or reports reconciliation success. Tracker markers with
-malformed or unsupported schemas, markers authored by accounts without repository write permission,
-or records whose named approver does not match the trusted comment author fail closed. Status-specific
+publication or reports reconciliation success. Selected-tracker markers with malformed or unsupported schemas,
+markers authored by accounts without repository write permission, or records whose named approver does not match
+the trusted comment author fail closed. Repository-wide discovery ignores an exact-candidate marker only after
+GitHub successfully proves its author lacks maintainer permission; an unknown permission/API result and every
+malformed record from a trusted author still fail closed. Only the explicit `none`, `read`, or `triage` permission
+results count as a known non-maintainer classification; blank, missing, malformed, unsupported, or future permission
+values are unknown and block even when the API call itself succeeded. Status-specific
 contradictions also fail closed: accepted records require every success and evidence URL, while
 rejected records require a known failed gate.
 
@@ -373,9 +384,18 @@ and require the same unique tracker and canonical, retry-equivalent authorizatio
 rejection, tracker conflict, chain mutation, missing record, or unknown repository read aborts before the
 next irreversible step. Accelerated final promotion also carries the exact refreshed RC CI snapshot and the
 exact ShakaPerf identity that passed the final gate, whether reused from the accepted RC or produced by a new
-strict final run. It refreshes and compares both at tag handling, immediately before stable-tag push, and again
-after the push before npm or gem publication; failed, missing, malformed, stale, unknown, or materially changed
-evidence blocks. All of those exact-RC CI refreshes use the carried final-promotion branch, even when the accepted
+strict final run. The carried boundary context names that mode explicitly: reused evidence must exactly match the
+accepted record's stored candidate, target, run, and attempt, including a validated pre-run candidate when applicable;
+live refreshes compare that stored candidate with the accepted RC candidate so the pre-run policy remains required.
+Strict-final evidence must match the validated final candidate and stable target. A strict-final run is also captured as
+a frozen canonical identity anchor containing its
+branch/ref, run ID, attempt, URL, candidate, target, and release-start identity. At publication-operation entry, the
+task copies that validated anchor outside the mutable carried context; replacing both the live record and its context
+anchor therefore cannot redefine the evidence that passed the gate. The complete context identity, including that mode
+and candidate/target binding, is revalidated at tag handling, immediately before stable-tag push, and after the push
+before packages. The task also
+refreshes and compares the live gate evidence at each boundary; failed, missing, malformed, stale, unknown, or materially
+changed evidence blocks. All of those exact-RC CI refreshes use the carried final-promotion branch, even when the accepted
 RC record originated on a different source branch. A `candidate-accepted` stable-tag boundary without this complete,
 internally consistent final-promotion context aborts before tag handling; nil context remains valid only for ordinary
 releases and accelerated RC publication authorization, which use their separate live boundaries. Accelerated or broad

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -356,7 +356,11 @@ limited to ordinary RCs for which complete discovery proves there is no accelera
 Final promotion repeats repository-wide exact-version-and-SHA discovery and rejects any record on a tracker
 other than the one selected by the canonical tag provenance. The final tip must be that SHA or
 mechanically runtime-equivalent through the existing metadata-only promotion rules. Runtime
-equivalence is checked again after the final version-bump commit. Every intervening commit is inspected:
+equivalence is checked again after the final version-bump commit. The task first proves that the immutable
+accepted RC still exactly matches its recorded runtime fingerprint. When the final SHA differs, the canonical
+positive-only commit classifier then decides the RC-to-final delta and must return canonical lowercase 40-hex commit
+identities; a coarse final-tip fingerprint cannot override that classification or reject a positively classified
+docs/comment-only delta. Every intervening commit is inspected:
 package manifests, version files, and `Gemfile.lock` files may differ only by their normalized product-version
 metadata, while dependency, lockfile, or any other runtime-bearing content change requires a new accepted RC
 and cannot fall back to a fresh final ShakaPerf run. Accepted ShakaPerf evidence is

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -213,6 +213,15 @@ RELEASE_ACCELERATED_RC_REASON="Start published-artifact fleet testing while the 
 bundle exec rake "release[17.0.0.rc.10]"
 ```
 
+Accelerated publication and same-candidate durable retries must run from the exact matching
+`release/X.Y.Z` branch for the RC target. Before accelerated mode is known, the generic prerelease retry check may
+inspect or fetch exact-target tag state. Same-candidate durable retry resolution may also perform bounded, read-only
+repository-history discovery, author-permission checks, and tracker-eligibility reads before it can establish that
+accelerated options exist. Once options resolve, the branch guard runs before explicit accelerated target-tag
+preflight, post-resolution selected-tracker and approver access, CI confirmation, version mutation, push, workflow
+dispatch, tracker mutation, tag handling, or publication. Ordinary non-accelerated prereleases may still be cut from
+non-release feature branches.
+
 The task rejects the accelerated path when the version is implicit, the target is not a canonical
 lowercase `.rc.` version, the tracker is closed or ineligible, the reason is missing, or
 `RELEASE_CI_STATUS_OVERRIDE` is also set. Case-varied spellings such as `.RC.` are rejected before

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -249,6 +249,14 @@ At that completion boundary, the task first proves that the tracker is still eli
 repository-wide history has one canonical tracker and authorization with no absorbing rejection. It repeats
 that repository-wide proof after append or idempotent reuse, so a concurrent cross-tracker or terminal conflict
 cannot be reported as a successful completion.
+If all six artifacts became public but that completion append was interrupted, the reconciliation task can
+recover the missing transition before it evaluates the deferred gates. Recovery requires the canonical
+authorization-only repository history, the exact remote annotated RC tag object, its peeled candidate SHA and
+authorization provenance, and exact registry metadata for all four npm packages and both RubyGems. It
+revalidates the complete remote tag-object/candidate identity after the registry reads and then uses the normal
+repository-wide completion append. Partial, mismatched, malformed, ambiguous,
+or unavailable registry/tag/history evidence blocks, and a GitHub outage still blocks durable recovery; there
+is no offline or unaudited completion bypass.
 Retries reuse the same candidate without appending duplicate status records. Accelerated RCs use an annotated
 tag containing canonical tracker and
 authorization provenance; retries load and reuse that persisted authorization instead of refreshing
@@ -433,10 +441,12 @@ retry source-selection route, regardless of alias ordering or which alias carrie
 After existing-tag validation or explicit-SHA tag creation, the task revalidates both local `HEAD` and the
 tag against the carried candidate SHA immediately before `git push --tags`. After the push it repeats the local
 validation and resolves the live remote stable tag's peeled SHA immediately before package publication. Accelerated
-final promotion additionally carries the canonical source RC tag, its candidate SHA, and its exact annotated-tag
-authorization provenance. It force-fetches and revalidates that live source tag at final tag handling, immediately
-before stable-tag push, and after stable-tag push before packages; deletion, movement, lost provenance, or an
-unclassifiable tag blocks. This source-tag check is additional to the live stable-tag peeled-SHA validation. For
+final promotion additionally carries the canonical source RC tag, its exact annotated tag-object SHA, its peeled
+candidate SHA, and its authorization provenance. At final tag handling, immediately before stable-tag push, and
+after stable-tag push before packages, it requires the local ref and one live remote direct/peeled snapshot to match
+that same captured object and candidate; deletion, movement, replacement by another same-candidate tag object or a
+lightweight tag, lost provenance, or an unclassifiable tag blocks. This source-tag check is additional to the live
+stable-tag peeled-SHA validation. For
 accelerated RC publication and accelerated-RC
 final promotion, both boundaries also re-fetch all trusted repository history for the exact RC candidate
 and require the same unique tracker and canonical, retry-equivalent authorization/terminal chain. A new

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -267,17 +267,45 @@ must still exactly match the confirmed authorization, while a transition to succ
 pending-state change is untriaged at these boundaries and requires a new authorization rather than silent reuse.
 Omission never downgrades an interrupted accelerated attempt to an ordinary lightweight-tag release and
 never permits the broad prerelease CI override. A genuinely ordinary RC with no accelerated history keeps
-its lightweight-tag path. Same-version retry discovery must complete successfully before the task can
+its lightweight-tag path. Before a fresh exact-head asynchronous ShakaPerf dispatch, a latest structurally valid
+same-target pre-run with a completed known failure or unknown terminal conclusion blocks publication instead of being
+superseded by new pending evidence. Accelerated selection first classifies every fetched run as the exact target, a
+canonically self-consistent unrelated target, or unknown; only proven unrelated evidence is ignored. Missing, malformed,
+or mismatched title, head, run, attempt, URL, status, conclusion, or timestamp identity remains visible and cannot
+authorize reuse. Before target filtering, duplicate collapse, ordering, reuse, or dispatch, every fetched accelerated
+run—including a canonically unrelated target—must have positive integer run and attempt IDs and the literal URL
+`https://github.com/<bound-repository>/actions/runs/<same-run-id>` with no alternate host, repository, path, port, query,
+fragment, or normalization. The API state is also total: active states permit only a null conclusion, completed runs
+require a recognized terminal conclusion, `createdAt` and `updatedAt` must be present and ordered parseable timestamps,
+and every state except queued requires a present `startedAt` ordered between them. A queued run may have a null
+`startedAt`; a non-null value must still be parseable and ordered. The same contract applies to a freshly dispatched run
+and every later refresh. During accelerated post-dispatch polling, the complete fetched array and every member are
+validated before target, ignored-run, or dispatch-time filtering; conflicting duplicates, ambiguous multiple fresh runs,
+and any malformed or unknown sibling block independent of API order. Only a fully valid canonical unrelated run is
+ignored. Accelerated evidence never synthesizes a missing run URL. A valid active exact-head run may remain pending and
+a valid active pre-run may trigger an exact-head dispatch, but malformed or contradictory evidence blocks before either
+disposition. The selected exact-head or pre-run state is classified before a dispatch request can take effect, so any
+selected known failure or unknown state outranks pending dispatch independent of API order. This accelerated-only polling
+seam does not change the ordinary blocking ShakaPerf waiter or its historical display-URL fallback.
+Conflicting duplicate run identities or equal ordering keys block independent of API order; only canonically identical
+duplicates collapse. A deterministically newer ordered success may supersede older ordered failures after normal
+runtime-equivalent evidence verification, while a newer ordered failure remains blocking. Reusable successful pre-runs
+remain valid, and only fully formed canonically unrelated targets are ignored without poisoning the lane. Same-version
+retry discovery must complete successfully before the task can
 prove that accelerated history is absent; API, pagination, permission, or parse failure therefore blocks
 that retry as unknown. Repository and selected-tracker discovery read chronological 100-comment pages
-incrementally, validate string bodies, positive unique comment IDs, canonical repository issue URLs, and
-nondecreasing creation times, and retain only comments containing the explicit hidden machine-marker opener
+incrementally, validate string bodies, positive unique comment IDs, canonical repository issue URLs, parseable string
+creation and update timestamps, and nondecreasing creation times, and retain only comments containing the explicit hidden
+machine-marker opener
 with the literal ASCII opener `<!-- react-on-rails-accelerated-rc `, including its single trailing space. A plain-text
 mention, suffix lookalike, alternate whitespace, or escaped opener is ordinary discussion: it is not parsed, attributed,
 or counted toward the marker bound. Exactly 1,000 retained machine-marker comments are allowed, and a short 250th page
 completes discovery; exceeding 1,000 markers or requiring a 251st page blocks as unknown instead of ignoring history or
-exhausting unbounded memory/API work. Comments whose authors were deleted may remain when their safe structural fields
-are valid. Only an exactly present `user: nil` author is known deleted and contributes no durable record; a missing or
+exhausting unbounded memory/API work. Missing, malformed, or unparseable creation or update timestamps block even on
+markerless API comments. Durable marker comments must remain unedited: their parsed creation and update instants must be
+equal, so an in-place rewrite of acceptance, rejection, conflict, approval, or evidence fields blocks before trust or
+state use. Comments whose authors were deleted may remain when their safe structural fields are valid. Only an exactly
+present `user: nil` author is known deleted and contributes no durable record; a missing or
 malformed author envelope is unknown and blocks. Unattributable machine-marker comments cannot authorize, satisfy,
 mutate, or conflict with trusted history. A marker comment is ignored before author permission checks only when it contains
 exactly one canonical marker whose payload is the byte-for-byte lowercase hexadecimal encoding of key-sorted

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -161,7 +161,7 @@ RELEASE_CI_STATUS_OVERRIDE=true # DANGEROUS last-resort waiver for the release C
 RELEASE_ACCELERATED_RC=true # Explicit RC only: publish while named pending gates finish
 RELEASE_TRACKER=<issue> # Active release tracker for accelerated RC records and final promotion
 RELEASE_ACCELERATED_RC_REASON=<reason> # Single-line maintainer reason for accelerated publication
-GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
+GEM_RELEASE_MAX_RETRIES=<n>  # Positive base-10 integer max retry attempts (default: 3)
 ```
 
 #### Release CI evidence and strict HEAD evaluation
@@ -241,10 +241,16 @@ state aborts before authorization is recorded. If refreshed evidence is still de
 differs from what the prompt displayed, the task displays the new snapshot and requires confirmation again;
 continually changing evidence eventually aborts rather than authorizing an unstable snapshot. It then
 appends the refreshed machine-readable `publication-authorized` record before
-creating the tag or publishing any package. After immutable artifacts and the GitHub release are
-available, it appends `published-awaiting-gates`. An interrupted attempt therefore remains visibly
-blocking even if publication partly succeeds, and retries reuse the same candidate without appending
-duplicate status records. Accelerated RCs use an annotated tag containing canonical tracker and
+creating the tag or publishing any package. After all six immutable npm and RubyGem artifacts are
+confirmed, it immediately appends `published-awaiting-gates` before fallible GitHub-release synchronization
+or other post-publish work. Partial package publication never appends that transition; once every package
+is published, a later GitHub-release sync failure still leaves the candidate durably awaiting reconciliation.
+At that completion boundary, the task first proves that the tracker is still eligible and that bounded
+repository-wide history has one canonical tracker and authorization with no absorbing rejection. It repeats
+that repository-wide proof after append or idempotent reuse, so a concurrent cross-tracker or terminal conflict
+cannot be reported as a successful completion.
+Retries reuse the same candidate without appending duplicate status records. Accelerated RCs use an annotated
+tag containing canonical tracker and
 authorization provenance; retries load and reuse that persisted authorization instead of refreshing
 it into a conflicting record. Persisted authorization is not permission to reuse stale pending evidence:
 before retrying any tag or immutable publication, the task refreshes exact-candidate CI and the exact

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -304,10 +304,11 @@ completes discovery; exceeding 1,000 markers or requiring a 251st page blocks as
 exhausting unbounded memory/API work. Missing, malformed, or unparseable creation or update timestamps block even on
 markerless API comments. Durable marker comments must remain unedited: their parsed creation and update instants must be
 equal, so an in-place rewrite of acceptance, rejection, conflict, approval, or evidence fields blocks before trust or
-state use. Comments whose authors were deleted may remain when their safe structural fields are valid. Only an exactly
-present `user: nil` author is known deleted and contributes no durable record; a missing or
-malformed author envelope is unknown and blocks. Unattributable machine-marker comments cannot authorize, satisfy,
-mutate, or conflict with trusted history. A marker comment is ignored before author permission checks only when it contains
+state use. A safely structured markerless ordinary comment may remain ignorable when its author envelope is exactly
+`user: nil`. An explicit machine-marker comment with `user: nil` instead blocks replay as unattributable history, because
+silently dropping it could erase an absorbing rejection or another durable transition. A missing or malformed author
+envelope is likewise unknown and blocks. Unattributable machine-marker comments cannot authorize, satisfy, mutate,
+conflict with, or be omitted from trusted history. A marker comment is ignored before author permission checks only when it contains
 exactly one canonical marker whose payload is the byte-for-byte lowercase hexadecimal encoding of key-sorted
 canonical JSON for a complete, structurally valid tracker record and proves it targets another
 version-and-SHA pair. Reordered or whitespace-varied JSON, uppercase hexadecimal, incomplete records,

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -271,11 +271,15 @@ its lightweight-tag path. Same-version retry discovery must complete successfull
 prove that accelerated history is absent; API, pagination, permission, or parse failure therefore blocks
 that retry as unknown. Repository and selected-tracker discovery read chronological 100-comment pages
 incrementally, validate string bodies, positive unique comment IDs, canonical repository issue URLs, and
-nondecreasing creation times, and retain only marker-bearing comments. Exactly 1,000 retained marker comments
-are allowed, and a short 250th page completes discovery; exceeding 1,000 markers or requiring a 251st page blocks
-as unknown instead of ignoring history or exhausting unbounded memory/API work. Markerless ordinary comments may
-have a deleted author when their safe structural fields remain valid; marker records still require an attributable
-trusted author. A marker comment is ignored before author permission checks only when it contains
+nondecreasing creation times, and retain only comments containing the explicit hidden machine-marker opener
+with the literal ASCII opener `<!-- react-on-rails-accelerated-rc `, including its single trailing space. A plain-text
+mention, suffix lookalike, alternate whitespace, or escaped opener is ordinary discussion: it is not parsed, attributed,
+or counted toward the marker bound. Exactly 1,000 retained machine-marker comments are allowed, and a short 250th page
+completes discovery; exceeding 1,000 markers or requiring a 251st page blocks as unknown instead of ignoring history or
+exhausting unbounded memory/API work. Comments whose authors were deleted may remain when their safe structural fields
+are valid. Only an exactly present `user: nil` author is known deleted and contributes no durable record; a missing or
+malformed author envelope is unknown and blocks. Unattributable machine-marker comments cannot authorize, satisfy,
+mutate, or conflict with trusted history. A marker comment is ignored before author permission checks only when it contains
 exactly one canonical marker whose payload is the byte-for-byte lowercase hexadecimal encoding of key-sorted
 canonical JSON for a complete, structurally valid tracker record and proves it targets another
 version-and-SHA pair. Reordered or whitespace-varied JSON, uppercase hexadecimal, incomplete records,
@@ -329,10 +333,11 @@ variation is conflicting. `candidate-rejected` is absorbing; append-time revalid
 concurrent reconciliation from adding acceptance or any other later transition. Every posted transition
 is re-fetched and proven present in the complete canonical chain before the task proceeds toward immutable
 publication or reports reconciliation success. Aside from the canonical unrelated-marker cheap skip above,
-selected-tracker and repository-wide scans ignore a marker comment based on its author only after GitHub successfully
-proves that author lacks maintainer permission. An unknown permission/API result, every malformed or unsupported
-record from a trusted author, and any trusted record whose named approver does not match its comment author still fail
-closed. Only the explicit `none`, `read`, or `triage` permission results count as a known non-maintainer classification;
+selected-tracker and repository-wide scans ignore an attributable marker comment based on its author only after GitHub
+successfully proves that author lacks maintainer permission. Unattributable comments are never trusted evidence; an
+unknown permission/API result for an attributable author, every malformed or unsupported record from a trusted author,
+and any trusted record whose named approver does not match its comment author still fail closed. Only the explicit
+`none`, `read`, or `triage` permission results count as a known non-maintainer classification;
 blank, missing, malformed, unsupported, or future permission values are unknown and block even when the API call
 itself succeeded. Status-specific
 contradictions also fail closed: accepted records require every success and evidence URL, while

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -158,6 +158,9 @@ RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for bo
 RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
 RELEASE_CI_EVALUATE_HEAD=true # Strictly evaluate the fetched exact release-source HEAD; not a waiver
 RELEASE_CI_STATUS_OVERRIDE=true # DANGEROUS last-resort waiver for the release CI-status gate
+RELEASE_ACCELERATED_RC=true # Explicit RC only: publish while named pending gates finish
+RELEASE_TRACKER=<issue> # Active release tracker for accelerated RC records and final promotion
+RELEASE_ACCELERATED_RC_REASON=<reason> # Single-line maintainer reason for accelerated publication
 GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
 ```
 
@@ -195,6 +198,175 @@ RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release[17.0.0.rc.10]"
 
 Do not use `RELEASE_CI_STATUS_OVERRIDE=true` to substitute for pending, missing, failed, or
 unknown exact-HEAD evidence. It waives the release CI-status gate and does not make CI healthy.
+
+#### Audited accelerated RC publication
+
+The accelerated path exists only to start published-artifact testing of an explicit RC while
+otherwise healthy exact-head CI or ShakaPerf is still pending. It is not a waiver and does not
+apply to beta/alpha versions or stable/final releases. Use it only with an active release tracker
+and a GitHub account that has write, maintain, or admin permission:
+
+```bash
+RELEASE_ACCELERATED_RC=true \
+RELEASE_TRACKER=4821 \
+RELEASE_ACCELERATED_RC_REASON="Start published-artifact fleet testing while the named gates finish" \
+bundle exec rake "release[17.0.0.rc.10]"
+```
+
+The task rejects the accelerated path when the version is implicit, the target is not a canonical
+lowercase `.rc.` version, the tracker is closed or ineligible, the reason is missing, or
+`RELEASE_CI_STATUS_OVERRIDE` is also set. Case-varied spellings such as `.RC.` are rejected before
+tracker records or tag provenance can be created. Every numeric core component and the numeric `rc`
+identifier must also use canonical npm-semver spelling: zero itself is valid, but leading zeroes are not.
+It still fails closed on failed, missing, malformed,
+ambiguous, stale, or API-unknown evidence. The only release-source CI state it may defer is a visible
+in-progress state.
+
+After pushing the version-bump commit, the task binds all evidence to that exact SHA. It reuses a
+verified ShakaPerf run or dispatches one and records its URL without waiting for completion, then
+queries exact-head CI and displays every non-success check and URL. A second confirmation names the
+RC, exact SHA, tracker, ShakaPerf run, pending CI checks, and maintainer reason before any tag or
+package is published. Immediately after that answer, the task refreshes both exact-candidate CI and the
+recorded ShakaPerf run. Failure, missing or malformed evidence, an unknown API result, or an unrecognized
+state aborts before authorization is recorded. If refreshed evidence is still deferable but materially
+differs from what the prompt displayed, the task displays the new snapshot and requires confirmation again;
+continually changing evidence eventually aborts rather than authorizing an unstable snapshot. It then
+appends the refreshed machine-readable `publication-authorized` record before
+creating the tag or publishing any package. After immutable artifacts and the GitHub release are
+available, it appends `published-awaiting-gates`. An interrupted attempt therefore remains visibly
+blocking even if publication partly succeeds, and retries reuse the same candidate without appending
+duplicate status records. Accelerated RCs use an annotated tag containing canonical tracker and
+authorization provenance; retries load and reuse that persisted authorization instead of refreshing
+it into a conflicting record. Persisted authorization is not permission to reuse stale pending evidence:
+before retrying any tag or immutable publication, the task refreshes exact-candidate CI and the exact
+recorded ShakaPerf run. Current success remains usable, and only a live in-progress state with no
+conclusion may remain deferred; an active status paired with any non-null conclusion is contradictory
+evidence and blocks. Failed, missing, malformed, stale, API-unknown, or otherwise non-deferable evidence
+also blocks the retry. Every same-version-and-SHA retry discovers durable repository history first,
+whether or not it explicitly supplies `RELEASE_ACCELERATED_RC`. If history exists, the unique tracker and
+canonical authorization chain control the retry; explicit tracker, reason, and options must match that
+authorization exactly, and a rejected or conflicting chain remains blocking. The task never refreshes or
+creates a conflicting authorization. A history-free explicit attempt may create its first authorization only
+when the exact RC tag does not exist. An existing ordinary lightweight RC tag can be retried unflagged through
+the ordinary path, but `RELEASE_ACCELERATED_RC=true` cannot convert it or append accelerated history that lacks
+matching annotated-tag provenance. Every explicit accelerated cut checks both the local and `origin` exact-target
+tag and force-fetches a remote-only tag for provenance classification, regardless of the starting checkout
+version. An unavailable remote read or unclassifiable tag blocks. This runs before live gates, confirmation,
+version mutation, tracker append, or push; only an exact canonical annotated retry from its tagged candidate
+may continue.
+Exact-head CI snapshots sort non-success checks canonically by name, state, and URL before persistence and
+comparison. API enumeration-order changes therefore do not require another confirmation or block a publication
+boundary, while any real check identity, state, URL, duplicate, or conflicting-entry change remains material.
+Before accepting, reusing, or appending that authorization, the task loads every trusted repository issue
+comment for the exact version and SHA and requires one tracker with one canonical chain. It repeats that
+repository-wide proof after posting and immediately before tag handling, so an authorization or rejection
+that appears concurrently on another tracker blocks immutable publication. Before tag handling, immediately
+before tag push, and again after tag push before package publication, accelerated RCs also refresh exact-head
+CI and the recorded ShakaPerf run. A newly failed, missing, malformed, or unknown gate blocks; pending evidence
+must still exactly match the confirmed authorization, while a transition to success is allowed. A material
+pending-state change is untriaged at these boundaries and requires a new authorization rather than silent reuse.
+Omission never downgrades an interrupted accelerated attempt to an ordinary lightweight-tag release and
+never permits the broad prerelease CI override. A genuinely ordinary RC with no accelerated history keeps
+its lightweight-tag path. Same-version retry discovery must complete successfully before the task can
+prove that accelerated history is absent; API, pagination, permission, or parse failure therefore blocks
+that retry as unknown. A marker comment is ignored before author permission checks only when it contains
+exactly one canonical marker whose payload is the byte-for-byte lowercase hexadecimal encoding of key-sorted
+canonical JSON for a complete, structurally valid tracker record and proves it targets another
+version-and-SHA pair. Reordered or whitespace-varied JSON, uppercase hexadecimal, incomplete records,
+unknown fields, noncanonical state, odd-length or partially decoded payloads, escaped or corrupt identities,
+malformed boundaries, duplicated markers, and
+spoofed summaries cannot prove irrelevance and therefore reach strict parsing and block. Discovery comments
+must name the canonical API issue URL in the exact requested repository; wrong hosts, repositories, paths,
+queries, fragments, and pull-request URLs are rejected before their issue number is used. Pull requests
+cannot serve as release trackers even though GitHub exposes their comments through the issues APIs.
+
+ShakaPerf evidence is bound to the requested version, workflow run, run attempt, and candidate SHA
+through reconciliation and final reuse. Every authorization record for the candidate must have the
+same canonical digest; canonical-digest-identical duplicates are idempotent, but any distinct
+authorization blocks append, retry, reconciliation, and final promotion. Every
+`published-awaiting-gates` record for the candidate must be the complete canonical transition from
+that authorization. Only `approved_by` and `recorded_at` may differ across idempotent publication
+completion retries; any other contradiction blocks append, retry, reconciliation, and final
+promotion. An empty publication set is valid only before immutable publication. Reconciliation and
+final promotion require at least one canonical `published-awaiting-gates` transition. Durable records must
+be ordered authorization, publication completion, then terminal state, with parseable monotonic timestamps.
+Exact authorization duplicates and the narrowly permitted publication/terminal retry variants remain
+idempotent only within their phase; pending transitions after terminal state are invalid.
+
+Reconcile the record after the deferred gates and all downstream RC testing finish:
+
+```bash
+RELEASE_TRACKER=4821 \
+RELEASE_ACCELERATED_RC_RECONCILIATION_REASON="All deferred gates and published-artifact checks passed" \
+RELEASE_DEMO_FLEET_EVIDENCE_URL=https://github.com/example/demo-evidence \
+RELEASE_BEHAVIORAL_EVIDENCE_URL=https://github.com/example/behavioral-evidence \
+RELEASE_ARTIFACT_EVIDENCE_URL=https://github.com/example/artifact-evidence \
+bundle exec rake "release:reconcile_accelerated_rc[17.0.0.rc.10]"
+```
+
+Reconciliation refreshes exact-candidate CI and the recorded ShakaPerf run. A known failure writes
+`candidate-rejected` with do-not-promote guidance; fix the cause and cut the next immutable RC.
+Pending or unknown evidence remains unresolved and cannot be accepted. Success requires HTTPS links
+for demo-fleet, behavioral, and published-artifact verification before the task writes
+`candidate-accepted`. Terminal state is validated as a complete set: accepted duplicates are
+idempotent only when every field except `recorded_at` is identical, and any other accepted-record
+variation is conflicting. `candidate-rejected` is absorbing; append-time revalidation prevents a
+concurrent reconciliation from adding acceptance or any other later transition. Every posted transition
+is re-fetched and proven present in the complete canonical chain before the task proceeds toward immutable
+publication or reports reconciliation success. Tracker markers with
+malformed or unsupported schemas, markers authored by accounts without repository write permission,
+or records whose named approver does not match the trusted comment author fail closed. Status-specific
+contradictions also fail closed: accepted records require every success and evidence URL, while
+rejected records require a known failed gate.
+
+Final promotion of an accelerated RC from `release/X.Y.Z` requires `RELEASE_TRACKER=<issue>`;
+ordinary strictly gated lightweight RC tags keep the standard promotion path only when no tracker is
+supplied and complete repository-wide exact-version-and-SHA discovery proves that no durable accelerated
+history exists. Supplying `RELEASE_TRACKER` while the RC tag lacks canonical accelerated provenance, or
+finding accelerated history behind a lightweight tag, blocks promotion instead of falling back to the
+ordinary path. A markerless annotated RC
+tag is never treated as ordinary, and inability to determine the tag object type blocks promotion as
+unknown. For an accelerated RC, `RELEASE_TRACKER` must match the tracker encoded in the annotated RC
+tag, the tag's authorization digest must match the canonical `publication-authorized` record, and the
+candidate's latest state must be `candidate-accepted`. Missing or deleted authorization or publication
+transition, mismatched trackers, and any `candidate-rejected` state block permanently. The accepted
+record must bind to the exact remote RC tag SHA and be complete. A provenance-bearing accelerated tag must
+also use the literal canonical ref `v<target_version>` with lowercase dotted `.rc.` spelling; a dashed or
+case-varied alias is rejected even when it points at the same annotated object. Dashed-tag compatibility is
+limited to ordinary RCs for which complete discovery proves there is no accelerated provenance or history.
+Final promotion repeats repository-wide exact-version-and-SHA discovery and rejects any record on a tracker
+other than the one selected by the canonical tag provenance. The final tip must be that SHA or
+mechanically runtime-equivalent through the existing metadata-only promotion rules. Runtime
+equivalence is checked again after the final version-bump commit. Every intervening commit is inspected:
+package manifests, version files, and `Gemfile.lock` files may differ only by their normalized product-version
+metadata, while dependency, lockfile, or any other runtime-bearing content change requires a new accepted RC
+and cannot fall back to a fresh final ShakaPerf run. Accepted ShakaPerf evidence is
+refreshed and re-verified against the final tip; otherwise the normal strict final ShakaPerf gate runs
+only for a still-runtime-equivalent finalization. After that gate completes, the task re-fetches the live
+remote RC tag, repository-wide canonical tracker chain, and exact accepted-RC CI immediately before stable
+tagging and publication. The re-fetched accepted record must differ from the originally gated record only by its
+permitted retry timestamp. Local `HEAD` must still equal the validated final candidate, and the stable tag
+is created and verified against that explicit SHA rather than implicit moving `HEAD`. Deletion, mutation,
+newly appended rejection or conflict, or pending, failed, missing, stale, or unknown current evidence
+blocks the boundary. Both `publication-authorized` and `published-awaiting-gates` are unresolved states
+that block final promotion. Stable CI, version policy, and every other final gate remain strict. Multiple
+remote tag names that normalize to the same RC version are ambiguous and block every first-promotion and
+retry source-selection route, regardless of alias ordering or which alias carries accelerated provenance.
+After existing-tag validation or explicit-SHA tag creation, the task revalidates both local `HEAD` and the
+tag against the carried candidate SHA immediately before `git push --tags`, then repeats that validation
+after the push immediately before package publication. For accelerated RC publication and accelerated-RC
+final promotion, both boundaries also re-fetch all trusted repository history for the exact RC candidate
+and require the same unique tracker and canonical, retry-equivalent authorization/terminal chain. A new
+rejection, tracker conflict, chain mutation, missing record, or unknown repository read aborts before the
+next irreversible step. Accelerated final promotion also carries the exact refreshed RC CI snapshot and the
+exact ShakaPerf identity that passed the final gate, whether reused from the accepted RC or produced by a new
+strict final run. It refreshes and compares both at tag handling, immediately before stable-tag push, and again
+after the push before npm or gem publication; failed, missing, malformed, stale, unknown, or materially changed
+evidence blocks. All of those exact-RC CI refreshes use the carried final-promotion branch, even when the accepted
+RC record originated on a different source branch. A `candidate-accepted` stable-tag boundary without this complete,
+internally consistent final-promotion context aborts before tag handling; nil context remains valid only for ordinary
+releases and accelerated RC publication authorization, which use their separate live boundaries. Accelerated or broad
+CI override flags cannot weaken final promotion.
 
 **Examples:**
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -52,9 +52,42 @@ SHAKAPERF_RELEASE_GATE_EVIDENCE_ARTIFACT = "shakaperf-release-evidence"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_FILE = "shakaperf-release-evidence.json"
 SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION = 2
+ACCELERATED_RC_RECORD_SCHEMA_VERSION = 1
+ACCELERATED_RC_RECORD_MARKER = "react-on-rails-accelerated-rc"
+ACCELERATED_RC_TAG_PROVENANCE_MARKER = "react-on-rails-accelerated-rc-provenance"
+ACCELERATED_RC_CANONICAL_TARGET_PATTERN =
+  /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.rc\.(?:0|[1-9]\d*)\z/
+ACCELERATED_RC_CANONICAL_TARGET_CASE_INSENSITIVE_PATTERN =
+  /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.rc\.(?:0|[1-9]\d*)\z/i
+ACCELERATED_RC_LOOSE_TARGET_PATTERN = /\A\d+\.\d+\.\d+\.rc\.\d+\z/i
+ACCELERATED_RC_RECORD_IDENTITY_FIELDS = %w[status target_version candidate_sha].freeze
+ACCELERATED_RC_PENDING_STATUSES = %w[publication-authorized published-awaiting-gates].freeze
+ACCELERATED_RC_TERMINAL_STATUSES = %w[candidate-accepted candidate-rejected].freeze
+ACCELERATED_RC_RECORD_STATUSES = (ACCELERATED_RC_PENDING_STATUSES + ACCELERATED_RC_TERMINAL_STATUSES).freeze
+ACCELERATED_RC_REQUIRED_EVIDENCE = %w[demo_fleet behavioral artifacts].freeze
+ACCELERATED_RC_RECORD_FIELDS = %w[
+  schema_version status target_version candidate_sha runtime_tree_fingerprint release_branch release_tracker ci
+  shakaperf reason approved_by recorded_at required_follow_up evidence
+].freeze
+ACCELERATED_RC_CI_FIELDS = %w[status sha checks_url non_success].freeze
+ACCELERATED_RC_CI_CHECK_FIELDS = %w[name state url].freeze
+ACCELERATED_RC_SHAKAPERF_FIELDS = %w[
+  status run_id attempt run_url candidate_sha target_version release_started_at
+].freeze
+ACCELERATED_RC_TAG_PROVENANCE_FIELDS = %w[
+  schema_version target_version candidate_sha release_tracker authorization_digest
+].freeze
+ACCELERATED_RC_AUTHORIZATION_BOUND_FIELDS = %w[
+  schema_version target_version candidate_sha runtime_tree_fingerprint release_branch release_tracker
+].freeze
+ACCELERATED_RC_CI_BOUND_FIELDS = %w[sha checks_url].freeze
+ACCELERATED_RC_SHAKAPERF_BOUND_FIELDS = %w[
+  run_id attempt candidate_sha target_version release_started_at
+].freeze
 SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS = %w[
   action_required cancelled failure neutral skipped stale startup_failure success timed_out
 ].freeze
+SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES = %w[queued in_progress requested waiting pending].freeze
 SHAKAPERF_RELEASE_GATE_EVIDENCE_KEYS = %w[
   branch
   candidate_sha
@@ -588,7 +621,7 @@ def fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
     "--workflow", SHAKAPERF_RELEASE_GATE_WORKFLOW_FILE,
     "--branch", ref,
     "--event", "workflow_dispatch",
-    "--json", "attempt,createdAt,databaseId,headSha,startedAt,status,conclusion,updatedAt,url",
+    "--json", "attempt,createdAt,databaseId,displayTitle,headSha,startedAt,status,conclusion,updatedAt,url",
     "--limit", SHAKAPERF_RELEASE_GATE_RUN_LIST_LIMIT.to_s
   )
 
@@ -640,7 +673,7 @@ def refresh_shakaperf_release_gate_run!(repo_slug:, run:)
   output, status = capture_gh_output(
     "run", "view", run.fetch("databaseId").to_s,
     "--repo", repo_slug,
-    "--json", "attempt,createdAt,databaseId,headSha,startedAt,status,conclusion,updatedAt,url"
+    "--json", "attempt,createdAt,databaseId,displayTitle,headSha,startedAt,status,conclusion,updatedAt,url"
   )
   unless status.success?
     handle_shakaperf_release_gate_violation!(
@@ -688,14 +721,15 @@ rescue ArgumentError
   false
 end
 
-def wait_for_shakaperf_release_gate_run!(repo_slug:, ref:, head_sha:, ignored_run_ids: [], earliest_created_at: nil)
+def wait_for_shakaperf_release_gate_run!(repo_slug:, ref:, head_sha:, target_version:, ignored_run_ids: [],
+                                         earliest_created_at: nil)
   deadline = Time.now + SHAKAPERF_RELEASE_GATE_START_TIMEOUT_SECONDS
   ignored_run_ids = ignored_run_ids.map(&:to_s)
 
   loop do
     runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
     matching_run = runs.find do |run|
-      run["headSha"] == head_sha &&
+      shakaperf_release_gate_run_matches_target?(run:, ref:, head_sha:, target_version:) &&
         !ignored_run_ids.include?(run["databaseId"].to_s) &&
         shakaperf_release_gate_run_created_after?(run, earliest_created_at)
     end
@@ -711,8 +745,23 @@ def wait_for_shakaperf_release_gate_run!(repo_slug:, ref:, head_sha:, ignored_ru
   )
 end
 
+def shakaperf_release_gate_display_title(ref:, head_sha:, target_version:)
+  "ShakaPerf Release Gates — #{target_version} on #{ref} @ #{head_sha}"
+end
+
+def shakaperf_release_gate_run_matches_target?(run:, ref:, head_sha:, target_version:)
+  run["headSha"] == head_sha && positive_github_id?(run["attempt"]) &&
+    run["displayTitle"] == shakaperf_release_gate_display_title(ref:, head_sha:, target_version:)
+end
+
 def active_shakaperf_release_gate_run?(run)
-  %w[queued in_progress requested waiting pending].include?(run["status"].to_s)
+  return false unless SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES.include?(run["status"].to_s)
+
+  unless run["conclusion"].nil?
+    abort "❌ Active ShakaPerf run has a terminal conclusion; refusing contradictory gate evidence."
+  end
+
+  true
 end
 
 def same_shakaperf_release_gate_run_identity?(original_run:, refreshed_run:)
@@ -720,7 +769,8 @@ def same_shakaperf_release_gate_run_identity?(original_run:, refreshed_run:)
 
   head_sha = refreshed_run["headSha"]
   positive_github_id?(refreshed_run["databaseId"]) &&
-    refreshed_run.values_at("databaseId", "headSha") == original_run.values_at("databaseId", "headSha") &&
+    refreshed_run.values_at("databaseId", "headSha", "attempt", "displayTitle") ==
+      original_run.values_at("databaseId", "headSha", "attempt", "displayTitle") &&
     head_sha.is_a?(String) && !head_sha.empty?
 end
 
@@ -731,13 +781,33 @@ def trustworthy_terminal_shakaperf_release_gate_run?(original_run:, refreshed_ru
     SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(refreshed_run["conclusion"])
 end
 
-def find_latest_shakaperf_release_gate_run(runs, head_sha)
-  runs.select { |run| run["headSha"] == head_sha }
-      .max_by { |run| shakaperf_release_gate_run_sort_key(run) }
+def trustworthy_terminal_shakaperf_workflow_run?(original_run:, refreshed_run:)
+  return false unless refreshed_run.is_a?(Hash)
+
+  refreshed_run.values_at("databaseId", "headSha", "displayTitle") ==
+    original_run.values_at("databaseId", "headSha", "displayTitle") &&
+    positive_github_id?(refreshed_run["attempt"]) &&
+    refreshed_run["status"] == "completed" &&
+    SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(refreshed_run["conclusion"])
 end
 
-def find_latest_shakaperf_prerun(runs, head_sha)
+def find_latest_shakaperf_release_gate_run(runs, head_sha, ref: nil, target_version: nil)
+  matching_runs = runs.select do |run|
+    run["headSha"] == head_sha &&
+      (!target_version || shakaperf_release_gate_run_matches_target?(run:, ref:, head_sha:, target_version:))
+  end
+  matching_runs.max_by { |run| shakaperf_release_gate_run_sort_key(run) }
+end
+
+def find_latest_shakaperf_prerun(runs, head_sha, ref: nil, target_version: nil)
   candidates = runs.reject { |run| run["headSha"] == head_sha }
+  if target_version
+    candidates = candidates.select do |run|
+      shakaperf_release_gate_run_matches_target?(
+        run:, ref:, head_sha: run["headSha"], target_version:
+      )
+    end
+  end
   return nil unless candidates.all? { |run| valid_shakaperf_prerun_ordering_metadata?(run) }
 
   candidates.max_by { |run| shakaperf_prerun_candidate_sort_key(run) }
@@ -856,7 +926,7 @@ def watch_existing_shakaperf_release_gate_run!(repo_slug:, run:)
   end
 
   refreshed_run = refresh_shakaperf_release_gate_run!(repo_slug:, run:)
-  return refreshed_run if trustworthy_terminal_shakaperf_release_gate_run?(original_run: run, refreshed_run:)
+  return refreshed_run if trustworthy_terminal_shakaperf_workflow_run?(original_run: run, refreshed_run:)
 
   handle_shakaperf_release_gate_violation!(
     message: "❌ Unable to establish the terminal result of existing ShakaPerf release gate run #{run_id}." \
@@ -896,7 +966,7 @@ def handle_completed_shakaperf_release_gate_run(repo_slug:, monorepo_root:, ref:
   )
   unless rejection
     puts "✓ ShakaPerf release gate already passed with verified evidence: #{run_url}"
-    return true
+    return run
   end
 
   puts "Successful ShakaPerf release gate evidence is not reusable (#{rejection}); " \
@@ -921,7 +991,7 @@ def handle_active_shakaperf_release_gate_run(repo_slug:, monorepo_root:, ref:, r
   )
   unless rejection
     puts "✓ ShakaPerf release gate passed with verified evidence: #{run_url}"
-    return true
+    return refreshed_run
   end
 
   puts "Completed ShakaPerf release gate evidence is not reusable (#{rejection}); " \
@@ -970,7 +1040,7 @@ def reuse_shakaperf_prerun?(repo_slug:, monorepo_root:, ref:, existing_runs:, he
   run_url = shakaperf_release_gate_run_url(repo_slug:, run: prerun)
   unless rejection
     puts "✓ Reusing successful ShakaPerf pre-run: #{run_url}"
-    return true
+    return prerun
   end
 
   puts "Latest ShakaPerf pre-run is not reusable (#{rejection}); dispatching an exact-head gate: #{run_url}"
@@ -983,7 +1053,8 @@ def dispatch_and_validate_shakaperf_release_gate!(repo_slug:, monorepo_root:, re
   dispatch_started_at = shakaperf_release_gate_dispatch_started_at
   dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:, target_version:, candidate_sha: head_sha)
   run = wait_for_shakaperf_release_gate_run!(
-    repo_slug:, ref:, head_sha:, ignored_run_ids: existing_run_ids, earliest_created_at: dispatch_started_at
+    repo_slug:, ref:, head_sha:, target_version:, ignored_run_ids: existing_run_ids,
+    earliest_created_at: dispatch_started_at
   )
   watch_shakaperf_release_gate_run!(repo_slug:, run:)
 
@@ -999,6 +1070,7 @@ def dispatch_and_validate_shakaperf_release_gate!(repo_slug:, monorepo_root:, re
   verify_fresh_shakaperf_release_gate_evidence!(
     repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: refreshed_run, release_started_at:
   )
+  refreshed_run
 end
 
 def verify_fresh_shakaperf_release_gate_evidence!(repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run:,
@@ -1033,7 +1105,7 @@ def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, target_version:
 
   existing_runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
   existing_run = find_latest_shakaperf_release_gate_run(existing_runs, head_sha)
-  return if handle_existing_shakaperf_release_gate_run!(
+  validated_run = handle_existing_shakaperf_release_gate_run!(
     repo_slug:,
     monorepo_root:,
     ref:,
@@ -1042,14 +1114,121 @@ def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, target_version:
     target_version:,
     release_started_at:
   )
+  return validated_run if validated_run
 
-  return if reuse_shakaperf_prerun?(
+  validated_run = reuse_shakaperf_prerun?(
     repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
   )
+  return validated_run if validated_run
 
   dispatch_and_validate_shakaperf_release_gate!(
     repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
   )
+end
+
+def run_accelerated_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, target_version:, release_started_at:)
+  repo_slug = github_repo_slug(monorepo_root)
+  existing_runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
+  existing_run = find_latest_shakaperf_release_gate_run(existing_runs, head_sha, ref:, target_version:)
+  if existing_run && active_shakaperf_release_gate_run?(existing_run)
+    return accelerated_shakaperf_snapshot(
+      repo_slug:, run: existing_run, ref:, candidate_sha: head_sha, target_version:, release_started_at:,
+      status: "pending"
+    )
+  end
+  exact_snapshot = verified_accelerated_shakaperf_snapshot(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: existing_run,
+    release_started_at:, require_prerun: false, candidate_sha: head_sha
+  )
+  return exact_snapshot if exact_snapshot
+
+  reject_known_accelerated_shakaperf_failure!(repo_slug:, run: existing_run)
+  prerun = find_latest_shakaperf_prerun(existing_runs, head_sha, ref:, target_version:)
+  prerun_snapshot = verified_accelerated_shakaperf_snapshot(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: prerun,
+    release_started_at:, require_prerun: true, candidate_sha: prerun&.fetch("headSha", nil)
+  )
+  return prerun_snapshot if prerun_snapshot
+
+  dispatch_accelerated_shakaperf_release_gate!(
+    repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
+  )
+end
+
+def dispatch_accelerated_shakaperf_release_gate!(repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:,
+                                                 target_version:, release_started_at:)
+  existing_run_ids = existing_runs.map { |run| run["databaseId"].to_s }
+  dispatch_started_at = shakaperf_release_gate_dispatch_started_at
+  dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:, target_version:, candidate_sha: head_sha)
+  run = wait_for_shakaperf_release_gate_run!(
+    repo_slug:,
+    ref:,
+    head_sha:,
+    target_version:,
+    ignored_run_ids: existing_run_ids,
+    earliest_created_at: dispatch_started_at
+  )
+
+  if run["status"] == "completed"
+    reject_known_accelerated_shakaperf_failure!(repo_slug:, run:)
+    snapshot = verified_accelerated_shakaperf_snapshot(
+      repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run:,
+      release_started_at:, require_prerun: false, candidate_sha: head_sha
+    )
+    return snapshot if snapshot
+
+    abort "❌ Freshly dispatched ShakaPerf run completed without trustworthy evidence; " \
+          "refusing unaudited publication."
+  end
+  unless active_shakaperf_release_gate_run?(run)
+    abort "❌ Freshly dispatched ShakaPerf run state is unknown; refusing unaudited publication."
+  end
+
+  accelerated_shakaperf_snapshot(
+    repo_slug:, run:, ref:, candidate_sha: head_sha, target_version:, release_started_at:, status: "pending"
+  )
+end
+
+def verified_accelerated_shakaperf_snapshot(repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run:,
+                                            release_started_at:, require_prerun:, candidate_sha:)
+  return nil unless run&.fetch("status", nil) == "completed" && run["conclusion"] == "success"
+
+  rejection = shakaperf_release_gate_run_evidence_rejection(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run:, release_started_at:, require_prerun:
+  )
+  return nil if rejection
+
+  accelerated_shakaperf_snapshot(
+    repo_slug:, run:, ref:, candidate_sha:, target_version:, release_started_at:, status: "success"
+  )
+end
+
+def accelerated_shakaperf_snapshot(repo_slug:, run:, ref:, candidate_sha:, target_version:, release_started_at:,
+                                   status:)
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  started_at = shakaperf_release_gate_time(release_started_at)
+  unless positive_github_id?(run["databaseId"]) && run["headSha"] == candidate_sha &&
+         shakaperf_release_gate_run_matches_target?(run:, ref:, head_sha: candidate_sha, target_version:) &&
+         %w[pending success].include?(status) && valid_accelerated_rc_https_url?(run_url) && started_at
+    abort "❌ Accelerated RC ShakaPerf run identity is unknown or malformed; refusing unaudited publication."
+  end
+
+  {
+    status:,
+    run_id: run.fetch("databaseId"),
+    attempt: run.fetch("attempt"),
+    run_url:,
+    candidate_sha:,
+    target_version:,
+    release_started_at: started_at.iso8601
+  }
+end
+
+def reject_known_accelerated_shakaperf_failure!(repo_slug:, run:)
+  return unless run&.fetch("status", nil) == "completed" && run["conclusion"] != "success"
+
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  abort "❌ Accelerated RC publication found a known ShakaPerf failure (#{run['conclusion']}): #{run_url}"
 end
 
 def run_release_preflight_checks!(monorepo_root:, dry_run:)
@@ -1341,17 +1520,50 @@ def remote_release_tags(monorepo_root:, pattern:)
 end
 
 def latest_remote_rc_tag_for_version(monorepo_root:, target_gem_version:)
-  candidates = remote_release_tags(monorepo_root:, pattern: "v#{target_gem_version}*").filter_map do |tag|
-    gem_version = parse_release_tag_to_gem_version(tag)
-    next unless gem_version
+  candidates = remote_rc_tag_candidates_for_version(monorepo_root:, target_gem_version:)
+  validate_unambiguous_remote_rc_tag_candidates!(candidates)
+  candidates.max_by { |_tag, version| version }&.first
+end
 
-    version = parse_gem_version_components(gem_version)
-    next unless release_base_version(gem_version) == target_gem_version && version[:prerelease_type] == "rc"
+def remote_rc_tag_candidates_for_version(monorepo_root:, target_gem_version:)
+  remote_release_tags(monorepo_root:, pattern: "v#{target_gem_version}*").filter_map do |tag|
+    remote_rc_tag_candidate(tag:, target_gem_version:)
+  end
+end
 
-    [tag, Gem::Version.new(gem_version)]
+def validate_unambiguous_remote_rc_tag_candidates!(candidates)
+  ambiguous = ambiguous_remote_rc_tag_candidates(candidates)
+  if ambiguous
+    tags = ambiguous.map(&:first).uniq.sort.join(", ")
+    abort "❌ Stable promotion is blocked by ambiguous remote RC tags for the same normalized version: #{tags}."
   end
 
-  candidates.max_by { |_tag, version| version }&.first
+  candidates
+end
+
+def remote_rc_tag_for_exact_version!(monorepo_root:, rc_gem_version:)
+  target_gem_version = release_base_version(rc_gem_version)
+  expected_version = Gem::Version.new(rc_gem_version)
+  candidates = remote_rc_tag_candidates_for_version(monorepo_root:, target_gem_version:).select do |_tag, version|
+    version == expected_version
+  end
+  validate_unambiguous_remote_rc_tag_candidates!(candidates)
+  candidates.first&.first
+end
+
+def remote_rc_tag_candidate(tag:, target_gem_version:)
+  gem_version = parse_release_tag_to_gem_version(tag)
+  return nil unless gem_version
+
+  version = parse_gem_version_components(gem_version)
+  return nil unless release_base_version(gem_version) == target_gem_version
+  return nil unless version[:prerelease_type] == "rc"
+
+  [tag, Gem::Version.new(gem_version)]
+end
+
+def ambiguous_remote_rc_tag_candidates(candidates)
+  candidates.group_by(&:last).values.find { |entries| entries.map(&:first).uniq.length > 1 }
 end
 
 def rc_tag_ancestor?(monorepo_root:, tag_sha:, head_sha:)
@@ -1385,12 +1597,33 @@ def release_branch_commits_after_rc_tag(monorepo_root:, tag_sha:, head_sha:)
 
   commits = commit_shas_after_rc_tag!(monorepo_root:, tag_sha:, head_sha:)
   metadata_only = commits.all? do |sha|
-    commit_non_runtime_only?(monorepo_root:, sha:) ||
-      release_finalization_metadata_commit?(monorepo_root:, sha:)
+    release_branch_non_runtime_commit?(monorepo_root:, sha:)
   end
   return { status: :runtime_bearing, commits: } unless metadata_only
 
   { status: :non_runtime_only, commits: }
+end
+
+def release_branch_non_runtime_commit?(monorepo_root:, sha:)
+  metadata_touched = release_finalization_metadata_touched(monorepo_root:, sha:)
+  return false if metadata_touched.nil?
+  return release_finalization_metadata_commit?(monorepo_root:, sha:) if metadata_touched
+
+  commit_non_runtime_only?(monorepo_root:, sha:)
+end
+
+def release_finalization_metadata_touched(monorepo_root:, sha:)
+  output, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "diff-tree", "--no-commit-id", "--name-only", "-r", "#{sha}^", sha
+  )
+  return nil unless status.success?
+
+  paths = output.lines.map(&:strip).reject(&:empty?)
+  return nil if paths.empty?
+
+  paths.any? { |path| RELEASE_FINALIZATION_METADATA_PATHS.include?(path) }
+rescue StandardError
+  nil
 end
 
 def ensure_release_branch_current_version_is_rc!(current_branch:, current_checkout_version:, target_gem_version:)
@@ -1512,6 +1745,32 @@ def release_tag_retry_state_for_current_head(monorepo_root:, current_branch:, cu
   tag_retry_state
 end
 
+def preflight_explicit_accelerated_rc_target_tag!(monorepo_root:, target_gem_version:, current_checkout_version:)
+  tag = "v#{target_gem_version}"
+  local_tag_exists = local_release_tag_exists?(monorepo_root:, tag:)
+  remote_tag_exists = remote_git_tag_exists?(monorepo_root:, tag:)
+  if remote_tag_exists
+    fetch_remote_release_tag!(monorepo_root:, tag:, tag_type: "accelerated RC")
+    local_tag_exists = true
+  end
+  return unless local_tag_exists
+
+  provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag:)
+  unless provenance
+    abort "❌ Existing ordinary lightweight RC tag #{tag} cannot be converted to accelerated publication."
+  end
+
+  tagged_sha = peeled_git_tag_sha(monorepo_root:, tag:)
+  current_sha = current_git_sha!(monorepo_root, context: "accelerated RC target-tag preflight")
+  matching_retry = current_checkout_version == target_gem_version &&
+                   provenance["target_version"] == target_gem_version &&
+                   provenance["candidate_sha"] == tagged_sha &&
+                   tagged_sha == current_sha
+  return provenance if matching_retry
+
+  abort "❌ Existing accelerated RC tag #{tag} may be retried only from its exact canonical tagged candidate."
+end
+
 def remote_release_tag_retry?(retry_state)
   retry_state == :remote
 end
@@ -1547,7 +1806,9 @@ end
 def release_branch_promotion_rc_tag!(monorepo_root:, current_branch:, current_checkout_version:, target_gem_version:)
   if release_prerelease_version?(current_checkout_version)
     ensure_release_branch_current_version_is_rc!(current_branch:, current_checkout_version:, target_gem_version:)
-    return { rc_tag: "v#{current_checkout_version}", stable_tag_retry: false, stable_tag_at_head: false }
+    rc_tag = remote_rc_tag_for_exact_version!(monorepo_root:, rc_gem_version: current_checkout_version)
+    rc_tag ||= "v#{current_checkout_version}"
+    return { rc_tag:, stable_tag_retry: false, stable_tag_at_head: false }
   end
 
   if current_checkout_version != target_gem_version
@@ -1868,6 +2129,2096 @@ def ci_status_override_allowed_for_release!(override_flag:, is_prerelease:)
   allow_override = ci_status_override_enabled?(override_flag)
   ensure_ci_status_override_is_prerelease!(allow_override:, is_prerelease:)
   allow_override
+end
+
+def validate_canonical_accelerated_rc_target!(target_gem_version)
+  target_version = target_gem_version.to_s
+  return if target_version.match?(ACCELERATED_RC_CANONICAL_TARGET_PATTERN)
+
+  if target_version.match?(ACCELERATED_RC_CANONICAL_TARGET_CASE_INSENSITIVE_PATTERN)
+    abort "❌ Accelerated RC publication requires canonical lowercase `.rc.` version casing."
+  end
+  if target_version.match?(ACCELERATED_RC_LOOSE_TARGET_PATTERN)
+    abort "❌ Accelerated RC publication requires canonical npm semver numeric identifiers without leading zeroes."
+  end
+
+  abort "❌ Accelerated publication is available for explicit RC targets only."
+end
+
+def resolve_accelerated_rc_options!(requested:, explicit_version_input:, target_gem_version:, tracker:, reason:,
+                                    allow_ci_override:)
+  return nil unless requested
+
+  normalized_version_input = explicit_version_input.to_s.strip
+  abort "❌ Accelerated RC publication requires an explicit RC version." if normalized_version_input.empty?
+  validate_canonical_accelerated_rc_target!(target_gem_version)
+  unless normalized_version_input == target_gem_version
+    abort "❌ Accelerated RC publication's explicit version must exactly match the resolved RC target."
+  end
+  unless tracker.to_s.match?(/\A[1-9]\d*\z/)
+    abort "❌ Accelerated RC publication requires a release tracker issue number."
+  end
+  normalized_reason = normalized_accelerated_rc_reason!(reason, action: "publication")
+  abort "❌ Accelerated RC publication cannot be combined with the broad CI status override." if allow_ci_override
+
+  {
+    target_gem_version:,
+    tracker: tracker.to_i,
+    reason: normalized_reason,
+    allow_ci_override:
+  }
+end
+
+def resolve_accelerated_rc_options_for_release!(requested:, explicit_version_input:, target_gem_version:, tracker:,
+                                                reason:, allow_ci_override:, repo_slug:, monorepo_root:,
+                                                current_checkout_version:, candidate_sha:)
+  requested_options = resolve_accelerated_rc_options!(
+    requested:, explicit_version_input:, target_gem_version:, tracker:, reason:, allow_ci_override:
+  )
+  same_candidate_retry = rc_prerelease_version?(target_gem_version) &&
+                         current_checkout_version == target_gem_version
+  return requested_options unless same_candidate_retry
+
+  unless candidate_sha.to_s.match?(/\A[0-9a-f]{40}\z/)
+    abort "❌ Accelerated RC same-candidate retry discovery requires the exact current candidate SHA."
+  end
+
+  authorization = accelerated_rc_authorization_for_same_candidate_retry!(
+    repo_slug:, monorepo_root:, target_version: target_gem_version, candidate_sha:,
+    accelerated_requested: !requested_options.nil?
+  )
+  return requested_options unless authorization
+
+  validate_explicit_accelerated_rc_retry_options!(requested_options, authorization) if requested_options
+
+  if allow_ci_override
+    abort "❌ Accelerated RC retry cannot be combined with the broad CI status override, even when " \
+          "RELEASE_ACCELERATED_RC was omitted."
+  end
+
+  {
+    target_gem_version:,
+    tracker: authorization.fetch("release_tracker"),
+    reason: authorization.fetch("reason"),
+    allow_ci_override: false
+  }
+end
+
+def validate_explicit_accelerated_rc_retry_options!(requested_options, authorization)
+  canonical_options = {
+    target_gem_version: authorization.fetch("target_version"),
+    tracker: authorization.fetch("release_tracker"),
+    reason: authorization.fetch("reason"),
+    allow_ci_override: false
+  }
+  return canonical_options if requested_options == canonical_options
+
+  abort "❌ Explicit accelerated RC retry options must match the durable canonical authorization."
+end
+
+def normalized_accelerated_rc_reason!(reason, action:)
+  normalized_reason = reason.to_s.strip
+  abort "❌ Accelerated RC #{action} requires a maintainer reason." if normalized_reason.empty?
+  if normalized_reason.match?(/[\r\n\0]/) || normalized_reason.include?("<!--") ||
+     normalized_reason.include?("-->") || normalized_reason.length > 500
+    abort "❌ Accelerated RC #{action}'s maintainer reason must be single-line plain text."
+  end
+
+  normalized_reason
+end
+
+def accelerated_rc_tracker_comment(record)
+  marker = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v#{ACCELERATED_RC_RECORD_SCHEMA_VERSION} " \
+           "#{canonical_accelerated_rc_encoded_payload(record)} -->"
+  ci = record.fetch("ci")
+  shakaperf = record.fetch("shakaperf")
+
+  <<~MARKDOWN
+    #{marker}
+    ### Accelerated RC gate record — `#{record.fetch('status')}`
+
+    - RC: `#{record.fetch('target_version')}` at `#{record.fetch('candidate_sha')}`
+    - Exact-head CI: `#{ci.fetch('status')}` — #{ci.fetch('checks_url')}
+    - ShakaPerf: `#{shakaperf.fetch('status')}` — #{shakaperf.fetch('run_url')}
+    - Maintainer: `#{record.fetch('approved_by')}` at `#{record.fetch('recorded_at')}`
+    - Reason: #{record.fetch('reason')}
+  MARKDOWN
+end
+
+def accelerated_rc_records_from_comments(comments)
+  comments.flat_map { |comment| accelerated_rc_records_from_comment(comment) }
+end
+
+def accelerated_rc_records_from_comment(comment)
+  marker = Regexp.escape(ACCELERATED_RC_RECORD_MARKER)
+  body = comment.fetch("body", "")
+  return [] unless body.include?(ACCELERATED_RC_RECORD_MARKER)
+
+  marker_count = body.scan(/<!-- #{marker}\b/).length
+  abort "❌ Release tracker contains a malformed accelerated RC record." unless marker_count == 1
+
+  matches = body.scan(/<!-- #{marker} v(\d+) ([0-9a-fA-F]+) -->/)
+  abort "❌ Release tracker contains a malformed accelerated RC record." unless matches.one?
+
+  matches.map do |schema_version, encoded_payload|
+    unless schema_version.to_i == ACCELERATED_RC_RECORD_SCHEMA_VERSION
+      abort "❌ Release tracker contains an unsupported accelerated RC record schema."
+    end
+
+    abort "❌ Release tracker contains a malformed accelerated RC record." unless encoded_payload.length.even?
+
+    record = JSON.parse([encoded_payload].pack("H*"))
+    validate_accelerated_rc_tracker_record!(record)
+    validate_canonical_accelerated_rc_encoded_payload!(record:, encoded_payload:)
+  rescue ArgumentError, JSON::ParserError
+    abort "❌ Release tracker contains a malformed accelerated RC record."
+  end
+end
+
+def validate_accelerated_rc_tracker_record!(record)
+  abort "❌ Release tracker contains a malformed accelerated RC record." unless
+    valid_accelerated_rc_tracker_record?(record)
+
+  record
+end
+
+def valid_accelerated_rc_tracker_record?(record)
+  valid_accelerated_rc_identity?(record) && valid_accelerated_rc_audit_metadata?(record) &&
+    valid_accelerated_rc_ci_record?(record["ci"], record["candidate_sha"]) &&
+    valid_accelerated_rc_shakaperf_record?(record["shakaperf"], record["target_version"]) &&
+    valid_accelerated_rc_state?(record)
+end
+
+def accelerated_rc_exact_keys?(value, expected_keys)
+  value.is_a?(Hash) && value.keys.sort == expected_keys.sort
+end
+
+def valid_accelerated_rc_state?(record)
+  gate_statuses = [record.dig("ci", "status"), record.dig("shakaperf", "status")]
+  case record["status"]
+  when *ACCELERATED_RC_PENDING_STATUSES
+    record["evidence"].empty? && gate_statuses.none?("failed")
+  when "candidate-accepted"
+    accelerated_rc_gate_evidence_complete?(record)
+  when "candidate-rejected"
+    record["evidence"].empty? && gate_statuses.include?("failed")
+  else
+    false
+  end
+end
+
+def valid_accelerated_rc_identity?(record)
+  accelerated_rc_exact_keys?(record, ACCELERATED_RC_RECORD_FIELDS) &&
+    record["schema_version"] == ACCELERATED_RC_RECORD_SCHEMA_VERSION &&
+    ACCELERATED_RC_RECORD_STATUSES.include?(record["status"]) &&
+    record["target_version"].to_s.match?(ACCELERATED_RC_CANONICAL_TARGET_PATTERN) &&
+    record["candidate_sha"].to_s.match?(/\A[0-9a-f]{40}\z/) &&
+    record["runtime_tree_fingerprint"].to_s.match?(/\A[0-9a-f]{64}\z/)
+end
+
+def valid_accelerated_rc_audit_metadata?(record)
+  valid_accelerated_rc_nonempty_string?(record["release_branch"]) &&
+    valid_accelerated_rc_tracker_number?(record["release_tracker"]) && record["evidence"].is_a?(Hash) &&
+    valid_accelerated_rc_nonempty_string?(record["approved_by"]) &&
+    valid_accelerated_rc_reason?(record["reason"]) &&
+    valid_accelerated_rc_nonempty_string?(record["required_follow_up"]) &&
+    !shakaperf_release_gate_time(record["recorded_at"]).nil?
+end
+
+def valid_accelerated_rc_nonempty_string?(value)
+  value.is_a?(String) && !value.empty?
+end
+
+def valid_accelerated_rc_tracker_number?(value)
+  value.is_a?(Integer) && value.positive?
+end
+
+def valid_accelerated_rc_reason?(reason)
+  reason.is_a?(String) && !reason.strip.empty? && reason.length <= 500 && !reason.match?(/[\r\n\0]/) &&
+    !reason.include?("<!--") && !reason.include?("-->")
+end
+
+def valid_accelerated_rc_ci_record?(ci_snapshot, candidate_sha)
+  return false unless ci_snapshot.is_a?(Hash)
+
+  checks = ci_snapshot["non_success"]
+  valid_accelerated_rc_ci_identity?(ci_snapshot, candidate_sha) &&
+    checks.is_a?(Array) && checks.all? { |check| valid_accelerated_rc_ci_check?(check) } &&
+    valid_accelerated_rc_ci_status?(ci_snapshot["status"], checks)
+end
+
+def valid_accelerated_rc_ci_identity?(ci_snapshot, candidate_sha)
+  accelerated_rc_exact_keys?(ci_snapshot, ACCELERATED_RC_CI_FIELDS) &&
+    %w[pending success failed].include?(ci_snapshot["status"]) &&
+    ci_snapshot["sha"] == candidate_sha && valid_accelerated_rc_https_url?(ci_snapshot["checks_url"])
+end
+
+def valid_accelerated_rc_ci_status?(status, checks)
+  failed, pending = accelerated_rc_ci_state_flags(checks)
+  case status
+  when "success" then !failed && !pending
+  when "pending" then pending && !failed
+  when "failed" then failed
+  else false
+  end
+end
+
+def accelerated_rc_ci_state_flags(checks)
+  states = checks.map { |check| check["state"] }
+  [
+    states.any? { |state| accelerated_rc_failed_ci_state?(state) },
+    states.any? { |state| CI_INCOMPLETE_STATUSES.include?(state) }
+  ]
+end
+
+def accelerated_rc_failed_ci_state?(state)
+  !CI_INCOMPLETE_STATUSES.include?(state) && !CI_PASSING_CONCLUSIONS.include?(state)
+end
+
+def valid_accelerated_rc_ci_check?(check)
+  accelerated_rc_exact_keys?(check, ACCELERATED_RC_CI_CHECK_FIELDS) &&
+    valid_accelerated_rc_nonempty_string?(check["name"]) &&
+    valid_accelerated_rc_nonempty_string?(check["state"]) &&
+    valid_accelerated_rc_https_url?(check["url"])
+end
+
+def valid_accelerated_rc_shakaperf_record?(shakaperf, target_version)
+  return false unless shakaperf.is_a?(Hash) && %w[pending success failed].include?(shakaperf["status"])
+
+  expected_fields = ACCELERATED_RC_SHAKAPERF_FIELDS + (shakaperf["status"] == "failed" ? ["conclusion"] : [])
+  accelerated_rc_exact_keys?(shakaperf, expected_fields) && valid_accelerated_rc_shakaperf_identity?(shakaperf) &&
+    shakaperf["target_version"] == target_version && valid_accelerated_rc_shakaperf_conclusion?(shakaperf)
+end
+
+def valid_accelerated_rc_shakaperf_identity?(shakaperf)
+  shakaperf["run_id"].is_a?(Integer) && shakaperf["run_id"].positive? &&
+    shakaperf["attempt"].is_a?(Integer) && shakaperf["attempt"].positive? &&
+    valid_accelerated_rc_https_url?(shakaperf["run_url"]) &&
+    shakaperf["candidate_sha"].to_s.match?(/\A[0-9a-f]{40}\z/) &&
+    shakaperf["target_version"].to_s.match?(ACCELERATED_RC_CANONICAL_TARGET_PATTERN) &&
+    !shakaperf_release_gate_time(shakaperf["release_started_at"]).nil?
+end
+
+def valid_accelerated_rc_shakaperf_conclusion?(shakaperf)
+  shakaperf["status"] != "failed" ||
+    (SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(shakaperf["conclusion"]) &&
+      shakaperf["conclusion"] != "success")
+end
+
+def valid_accelerated_rc_https_url?(value)
+  uri = URI.parse(value.to_s)
+  uri.is_a?(URI::HTTPS) && !uri.host.to_s.empty? && uri.userinfo.nil?
+rescue URI::InvalidURIError
+  false
+end
+
+def fetch_release_tracker_comments(repo_slug:, tracker:)
+  output, status = capture_gh_output(
+    "api", "--paginate", "--slurp", "repos/#{repo_slug}/issues/#{tracker}/comments"
+  )
+  abort "❌ Unable to read release tracker ##{tracker}.\n\n#{output}" unless status.success?
+
+  pages = JSON.parse(output)
+  unless pages.is_a?(Array) && pages.all?(Array)
+    abort "❌ Release tracker ##{tracker} comments returned an unexpected JSON structure."
+  end
+
+  comments = pages.flatten(1)
+  abort "❌ Release tracker ##{tracker} comments returned an unexpected JSON structure." unless comments.all?(Hash)
+
+  comments
+rescue JSON::ParserError => e
+  abort "❌ Release tracker ##{tracker} comments returned invalid JSON: #{e.message}"
+end
+
+def fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  comments = fetch_release_tracker_comments(repo_slug:, tracker:)
+  marker_comments = comments.select { |comment| comment.fetch("body", "").include?(ACCELERATED_RC_RECORD_MARKER) }
+  permissions = {}
+  records = marker_comments.flat_map do |comment|
+    login = comment.dig("user", "login").to_s
+    abort "❌ Accelerated RC tracker record has no attributable GitHub author." if login.empty?
+
+    permission = permissions.fetch(login) do
+      output, status = capture_gh_output(
+        "api", "repos/#{repo_slug}/collaborators/#{login}/permission", "--jq", ".permission"
+      )
+      unless status.success?
+        abort "❌ Unable to verify the repository permission of accelerated RC record author #{login}.\n\n#{output}"
+      end
+      permissions[login] = output.strip
+    end
+    validate_release_approver!(login:, permission:)
+    accelerated_rc_records_from_trusted_comment!(comment:, login:)
+  end
+
+  unless records.all? { |record| record["release_tracker"] == tracker }
+    abort "❌ Accelerated RC record is bound to a different release tracker."
+  end
+
+  records
+end
+
+def fetch_repository_accelerated_rc_records_for_candidate!(repo_slug:, target_version:, candidate_sha:)
+  comments = fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug:)
+  marker_comments = comments.select do |comment|
+    repository_accelerated_rc_comment_plausibly_targets_candidate?(
+      comment:, target_version:, candidate_sha:
+    )
+  end
+  permissions = {}
+  records = marker_comments.flat_map do |comment|
+    trusted_accelerated_rc_records_from_repository_comment!(comment:, repo_slug:, permissions:)
+  end
+
+  accelerated_rc_records_for_candidate(records, target_version:, candidate_sha:)
+end
+
+def validated_repository_accelerated_rc_candidate_history!(
+  repo_slug:, target_version:, candidate_sha:, expected_tracker: nil,
+  selected_authorization: nil, allow_empty: false
+)
+  records = fetch_repository_accelerated_rc_records_for_candidate!(repo_slug:, target_version:, candidate_sha:)
+  if records.empty?
+    return { records:, tracker: nil, chain: nil } if allow_empty
+
+    abort "❌ Repository-wide accelerated RC history is missing for the exact candidate."
+  end
+
+  trackers = records.map { |record| record["release_tracker"] }.uniq
+  abort "❌ Repository-wide accelerated RC history contains conflicting release trackers." unless trackers.one?
+
+  tracker = trackers.first
+  if expected_tracker && tracker != expected_tracker
+    abort "❌ Repository-wide accelerated RC history is bound to a different release tracker."
+  end
+
+  chain = validated_accelerated_rc_candidate_chain!(records, selected_authorization:)
+  { records:, tracker:, chain: }
+end
+
+def repository_accelerated_rc_comment_plausibly_targets_candidate?(comment:, target_version:, candidate_sha:)
+  body = comment.fetch("body", "")
+  return false unless body.include?(ACCELERATED_RC_RECORD_MARKER)
+  return true if body.include?("- RC: `#{target_version}` at `#{candidate_sha}`")
+
+  marker = Regexp.escape(ACCELERATED_RC_RECORD_MARKER)
+  marker_count = body.scan(/<!-- #{marker}\b/).length
+  matches = body.scan(/<!-- #{marker} v(\d+) ([0-9a-fA-F]+) -->/)
+  return true unless marker_count == 1 && matches.one?
+
+  identities = matches.map do |schema_version, encoded_payload|
+    repository_accelerated_rc_marker_candidate_identity(schema_version:, encoded_payload:)
+  end
+  return true if identities.any?(&:nil?)
+
+  identities.include?([target_version, candidate_sha])
+end
+
+def repository_accelerated_rc_marker_candidate_identity(schema_version:, encoded_payload:)
+  return nil unless schema_version.to_i == ACCELERATED_RC_RECORD_SCHEMA_VERSION
+  return nil unless encoded_payload.length.even?
+
+  decoded_payload = [encoded_payload].pack("H*")
+  record = JSON.parse(decoded_payload)
+  return nil unless valid_accelerated_rc_tracker_record?(record)
+  return nil unless encoded_payload == canonical_accelerated_rc_encoded_payload(record)
+
+  target_version, candidate_sha = record.values_at("target_version", "candidate_sha")
+  [target_version, candidate_sha]
+rescue ArgumentError, JSON::ParserError
+  nil
+end
+
+def fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug:)
+  output, status = capture_gh_output(
+    "api", "--paginate", "--slurp", "repos/#{repo_slug}/issues/comments?per_page=100"
+  )
+  abort "❌ Unable to discover durable accelerated RC retry history.\n\n#{output}" unless status.success?
+
+  pages = JSON.parse(output)
+  unless pages.is_a?(Array) && pages.all?(Array)
+    abort "❌ Repository issue comments returned an unexpected JSON structure during accelerated RC retry discovery."
+  end
+
+  comments = pages.flatten(1)
+  unless comments.all?(Hash)
+    abort "❌ Repository issue comments returned an unexpected JSON structure during accelerated RC retry discovery."
+  end
+
+  comments
+rescue JSON::ParserError => e
+  abort "❌ Repository issue comments returned invalid JSON during accelerated RC retry discovery: #{e.message}"
+end
+
+def trusted_accelerated_rc_records_from_repository_comment!(comment:, repo_slug:, permissions:)
+  tracker = release_tracker_number_from_repository_comment_issue_url!(
+    issue_url: comment.fetch("issue_url", nil), repo_slug:
+  )
+
+  login = comment.dig("user", "login").to_s
+  abort "❌ Accelerated RC tracker record has no attributable GitHub author." if login.empty?
+
+  permission = accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
+  validate_release_approver!(login:, permission:)
+  records = accelerated_rc_records_from_trusted_comment!(comment:, login:)
+  unless records.all? { |record| record["release_tracker"] == tracker }
+    abort "❌ Accelerated RC retry history is bound to a different release tracker."
+  end
+
+  records
+end
+
+def release_tracker_number_from_repository_comment_issue_url!(issue_url:, repo_slug:)
+  canonical_issue_url = %r{\Ahttps://api\.github\.com/repos/#{Regexp.escape(repo_slug)}/issues/([1-9]\d*)\z}
+  tracker = issue_url.match(canonical_issue_url)&.captures&.first&.to_i if issue_url.is_a?(String)
+  return tracker if tracker
+
+  abort "❌ Accelerated RC retry history must name an exact requested repository issue URL."
+end
+
+def accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
+  return permissions.fetch(login) if permissions.key?(login)
+
+  output, status = capture_gh_output(
+    "api", "repos/#{repo_slug}/collaborators/#{login}/permission", "--jq", ".permission"
+  )
+  unless status.success?
+    abort "❌ Unable to verify the repository permission of accelerated RC record author #{login}.\n\n#{output}"
+  end
+
+  permissions[login] = output.strip
+end
+
+def accelerated_rc_records_from_trusted_comment!(comment:, login:)
+  records = accelerated_rc_records_from_comment(comment)
+  unless records.all? { |record| record["approved_by"] == login }
+    abort "❌ Accelerated RC record approver does not match its trusted comment author."
+  end
+
+  records
+end
+
+def validate_release_tracker_issue!(issue, tracker:)
+  labels = Array(issue["labels"]).map { |label| label.is_a?(Hash) ? label["name"] : label }
+  release_tracker = issue["title"].to_s.start_with?("Release gate:") ||
+                    (%w[release TRACKING] - labels).empty?
+  unless issue["number"] == tracker && issue["state"] == "open" && issue["pull_request"].nil? && release_tracker
+    abort "❌ Accelerated RC publication requires an active open release tracker; ##{tracker} is not eligible."
+  end
+
+  issue
+end
+
+def fetch_release_tracker_issue!(repo_slug:, tracker:)
+  output, status = capture_gh_output("api", "repos/#{repo_slug}/issues/#{tracker}")
+  abort "❌ Unable to read release tracker ##{tracker}.\n\n#{output}" unless status.success?
+
+  validate_release_tracker_issue!(JSON.parse(output), tracker:)
+rescue JSON::ParserError => e
+  abort "❌ Release tracker ##{tracker} returned invalid JSON: #{e.message}"
+end
+
+def validate_release_approver!(login:, permission:)
+  unless %w[write maintain admin].include?(permission)
+    abort "❌ Accelerated RC approval requires write, maintain, or admin repository permission for #{login}."
+  end
+
+  login
+end
+
+def current_release_approver!(repo_slug:)
+  login_output, login_status = capture_gh_output("api", "user", "--jq", ".login")
+  abort "❌ Unable to identify the GitHub account approving accelerated RC publication.\n\n#{login_output}" unless
+    login_status.success?
+
+  login = login_output.strip
+  permission_output, permission_status = capture_gh_output(
+    "api", "repos/#{repo_slug}/collaborators/#{login}/permission", "--jq", ".permission"
+  )
+  unless permission_status.success?
+    abort "❌ Unable to verify repository permission for accelerated RC approver #{login}.\n\n#{permission_output}"
+  end
+
+  validate_release_approver!(login:, permission: permission_output.strip)
+end
+
+def post_release_tracker_comment!(repo_slug:, tracker:, body:)
+  Tempfile.create(["accelerated-rc-record", ".md"]) do |file|
+    file.write(body)
+    file.flush
+    output, status = capture_gh_output(
+      "issue", "comment", tracker.to_s, "--repo", repo_slug, "--body-file", file.path
+    )
+    abort "❌ Unable to append accelerated RC evidence to release tracker ##{tracker}.\n\n#{output}" unless
+      status.success?
+  end
+end
+
+def validate_repository_accelerated_rc_authorization_append!(repo_slug:, tracker:, record:, allow_empty:)
+  return unless record["status"] == "publication-authorized"
+
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:,
+    target_version: record.fetch("target_version"),
+    candidate_sha: record.fetch("candidate_sha"),
+    expected_tracker: tracker,
+    selected_authorization: record,
+    allow_empty:
+  )
+  abort_if_accelerated_rc_retry_rejected!(history.fetch(:records)) unless history.fetch(:records).empty?
+  history
+end
+
+def append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record:)
+  validate_accelerated_rc_tracker_record!(record)
+  validate_repository_accelerated_rc_authorization_append!(repo_slug:, tracker:, record:, allow_empty: true)
+  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  validate_accelerated_rc_candidate_state_before_append!(records, record)
+
+  same_identity = records.select do |existing|
+    ACCELERATED_RC_RECORD_IDENTITY_FIELDS.all? { |field| existing[field] == record[field] }
+  end
+  duplicate = same_identity.find { |existing| accelerated_rc_same_identity_retry_equivalent?(existing, record) }
+  return duplicate if duplicate
+
+  unless same_identity.empty?
+    abort "❌ Conflicting accelerated RC tracker record already exists for this status, version, and candidate."
+  end
+
+  post_release_tracker_comment!(repo_slug:, tracker:, body: accelerated_rc_tracker_comment(record))
+  refreshed_records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  validate_accelerated_rc_candidate_state_before_append!(refreshed_records, record)
+  posted_digest = accelerated_rc_record_digest(record)
+  persisted = refreshed_records.find { |existing| accelerated_rc_record_digest(existing) == posted_digest }
+  abort "❌ Accelerated RC tracker append could not be verified after posting; refusing to continue." unless persisted
+
+  validate_repository_accelerated_rc_authorization_append!(repo_slug:, tracker:, record:, allow_empty: false)
+
+  persisted
+end
+
+def validate_accelerated_rc_candidate_state_before_append!(records, record)
+  candidate_records = accelerated_rc_records_for_candidate(
+    records,
+    target_version: record.fetch("target_version"),
+    candidate_sha: record.fetch("candidate_sha")
+  )
+  validate_accelerated_rc_terminal_before_append!(candidate_records, record)
+
+  proposed_state = candidate_records + [record]
+  validated_accelerated_rc_candidate_chain!(
+    proposed_state,
+    require_publication: ACCELERATED_RC_TERMINAL_STATUSES.include?(record["status"])
+  )
+end
+
+def validate_accelerated_rc_terminal_before_append!(candidate_records, record)
+  terminal = validated_accelerated_rc_terminal_set!(candidate_records)
+  return unless terminal && !accelerated_rc_retry_equivalent?(terminal, record)
+
+  if terminal["status"] == "candidate-rejected"
+    abort "❌ Accelerated RC candidate was permanently rejected; candidate-rejected is absorbing and no later " \
+          "state transition may be appended."
+  end
+
+  abort "❌ Accelerated RC candidate is already terminal; only a retry-equivalent terminal record is idempotent."
+end
+
+def accelerated_rc_same_identity_retry_equivalent?(left, right)
+  if left["status"] == "published-awaiting-gates" && right["status"] == "published-awaiting-gates"
+    accelerated_rc_publication_completion_equivalent?(left, right)
+  else
+    accelerated_rc_retry_equivalent?(left, right)
+  end
+end
+
+def accelerated_rc_retry_equivalent?(left, right)
+  canonical_accelerated_rc_value(left.except("recorded_at")) ==
+    canonical_accelerated_rc_value(right.except("recorded_at"))
+end
+
+def accelerated_rc_record_bound_to_authorization?(record, authorization)
+  ACCELERATED_RC_AUTHORIZATION_BOUND_FIELDS.all? { |field| record[field] == authorization[field] } &&
+    ACCELERATED_RC_CI_BOUND_FIELDS.all? { |field| record.dig("ci", field) == authorization.dig("ci", field) } &&
+    ACCELERATED_RC_SHAKAPERF_BOUND_FIELDS.all? do |field|
+      record.dig("shakaperf", field) == authorization.dig("shakaperf", field)
+    end
+end
+
+def canonical_accelerated_rc_value(value)
+  case value
+  when Hash
+    value.keys.sort.to_h { |key| [key, canonical_accelerated_rc_value(value.fetch(key))] }
+  when Array
+    value.map { |item| canonical_accelerated_rc_value(item) }
+  else
+    value
+  end
+end
+
+def canonical_accelerated_rc_json(value)
+  JSON.generate(canonical_accelerated_rc_value(value))
+end
+
+def canonical_accelerated_rc_encoded_payload(record)
+  canonical_accelerated_rc_json(record).unpack1("H*")
+end
+
+def validate_canonical_accelerated_rc_encoded_payload!(record:, encoded_payload:)
+  return record if encoded_payload == canonical_accelerated_rc_encoded_payload(record)
+
+  abort "❌ Release tracker contains a malformed accelerated RC record."
+end
+
+def accelerated_rc_record_digest(record)
+  Digest::SHA256.hexdigest(canonical_accelerated_rc_json(record))
+end
+
+def accelerated_rc_tag_provenance(record)
+  validate_accelerated_rc_tracker_record!(record)
+  {
+    "schema_version" => ACCELERATED_RC_RECORD_SCHEMA_VERSION,
+    "target_version" => record.fetch("target_version"),
+    "candidate_sha" => record.fetch("candidate_sha"),
+    "release_tracker" => record.fetch("release_tracker"),
+    "authorization_digest" => accelerated_rc_record_digest(record)
+  }
+end
+
+def valid_accelerated_rc_tag_provenance?(provenance)
+  accelerated_rc_exact_keys?(provenance, ACCELERATED_RC_TAG_PROVENANCE_FIELDS) &&
+    provenance["schema_version"] == ACCELERATED_RC_RECORD_SCHEMA_VERSION &&
+    provenance["target_version"].to_s.match?(ACCELERATED_RC_CANONICAL_TARGET_PATTERN) &&
+    provenance["candidate_sha"].to_s.match?(/\A[0-9a-f]{40}\z/) &&
+    valid_accelerated_rc_tracker_number?(provenance["release_tracker"]) &&
+    provenance["authorization_digest"].to_s.match?(/\A[0-9a-f]{64}\z/)
+end
+
+def accelerated_rc_tag_message(record)
+  provenance = accelerated_rc_tag_provenance(record)
+  "#{ACCELERATED_RC_TAG_PROVENANCE_MARKER} v#{ACCELERATED_RC_RECORD_SCHEMA_VERSION} " \
+    "#{JSON.generate(provenance).unpack1('H*')}"
+end
+
+def accelerated_rc_tag_provenance_from_message(message)
+  marker = Regexp.escape(ACCELERATED_RC_TAG_PROVENANCE_MARKER)
+  marker_count = message.to_s.scan(/#{marker}\b/).length
+  return nil if marker_count.zero?
+
+  matches = message.to_s.scan(/#{marker} v(\d+) ([0-9a-f]+)/)
+  abort "❌ Accelerated RC tag contains malformed provenance." unless marker_count == 1 && matches.length == 1
+
+  schema_version, encoded_payload = matches.first
+  unless schema_version.to_i == ACCELERATED_RC_RECORD_SCHEMA_VERSION && encoded_payload.length.even?
+    abort "❌ Accelerated RC tag contains unsupported or malformed provenance."
+  end
+  provenance = JSON.parse([encoded_payload].pack("H*"))
+  abort "❌ Accelerated RC tag contains malformed provenance." unless valid_accelerated_rc_tag_provenance?(provenance)
+
+  provenance
+rescue ArgumentError, JSON::ParserError
+  abort "❌ Accelerated RC tag contains malformed provenance."
+end
+
+def accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag:)
+  type, type_status = Open3.capture2e("git", "-C", monorepo_root, "cat-file", "-t", "refs/tags/#{tag}")
+  abort "❌ Unable to inspect RC tag provenance for #{tag}: #{type}" unless type_status.success?
+  return nil if type.strip == "commit"
+
+  abort "❌ RC tag #{tag} has an unexpected git object type." unless type.strip == "tag"
+
+  message, message_status = Open3.capture2e(
+    "git", "-C", monorepo_root, "for-each-ref", "--format=%(contents)", "refs/tags/#{tag}"
+  )
+  abort "❌ Unable to inspect RC tag provenance for #{tag}: #{message}" unless message_status.success?
+
+  provenance = accelerated_rc_tag_provenance_from_message(message)
+  abort "❌ Annotated RC tag #{tag} lacks canonical accelerated provenance." unless provenance
+
+  provenance
+end
+
+def create_accelerated_rc_tag!(monorepo_root:, tag:, record:)
+  candidate_sha = record.fetch("candidate_sha")
+  head_sha = current_git_sha!(monorepo_root)
+  unless head_sha == candidate_sha
+    abort "❌ Current HEAD moved after accelerated RC authorization; refusing to tag an unauthorized candidate."
+  end
+
+  sh_args_in_dir_for_release(
+    monorepo_root, "git", "tag", "-a", tag, candidate_sha, "-m", accelerated_rc_tag_message(record)
+  )
+end
+
+def validate_release_tag_candidate_sha!(monorepo_root:, tag:, candidate_sha:)
+  tag_sha = peeled_git_tag_sha(monorepo_root:, tag:)
+  unless tag_sha == candidate_sha
+    abort "❌ Release tag #{tag} is not bound to the explicitly validated release candidate SHA."
+  end
+
+  tag_sha
+end
+
+def create_release_tag_at_candidate_sha!(monorepo_root:, tag:, candidate_sha:)
+  head_sha = current_git_sha!(monorepo_root, context: "release tag creation")
+  unless head_sha == candidate_sha
+    abort "❌ Local HEAD moved before release tag creation; refusing to tag an unvalidated commit."
+  end
+
+  sh_args_in_dir_for_release(monorepo_root, "git", "tag", tag, candidate_sha)
+  validate_release_tag_candidate_sha!(monorepo_root:, tag:, candidate_sha:)
+end
+
+def validate_release_candidate_publication_boundary!(monorepo_root:, tag:, candidate_sha:, phase:)
+  head_sha = current_git_sha!(monorepo_root, context: "release #{phase}")
+  unless head_sha == candidate_sha
+    abort "❌ Local HEAD moved away from the validated release candidate before #{phase}; " \
+          "refusing to continue."
+  end
+
+  validate_release_tag_candidate_sha!(monorepo_root:, tag:, candidate_sha:)
+end
+
+def validate_repository_accelerated_rc_authorization_boundary!(monorepo_root:, record:, phase:)
+  repo_slug = github_repo_slug(monorepo_root)
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:,
+    target_version: record.fetch("target_version"),
+    candidate_sha: record.fetch("candidate_sha"),
+    expected_tracker: record.fetch("release_tracker"),
+    selected_authorization: record
+  )
+  abort_if_accelerated_rc_retry_rejected!(history.fetch(:records))
+  validate_accelerated_rc_authorization_live_evidence_boundary!(
+    repo_slug:, monorepo_root:, authorization: record, phase:
+  )
+  history
+end
+
+def validate_repository_accelerated_rc_boundary_record!(monorepo_root:, record:, phase:)
+  return validate_repository_accelerated_rc_authorization_boundary!(monorepo_root:, record:, phase:) if
+    record["status"] == "publication-authorized"
+
+  unless record["status"] == "candidate-accepted"
+    abort "❌ Accelerated release boundary requires canonical authorization or accepted-candidate state."
+  end
+
+  repo_slug = github_repo_slug(monorepo_root)
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:,
+    target_version: record.fetch("target_version"),
+    candidate_sha: record.fetch("candidate_sha"),
+    expected_tracker: record.fetch("release_tracker")
+  )
+  abort_if_accelerated_rc_retry_rejected!(history.fetch(:records))
+  terminal = history.dig(:chain, :terminal)
+  unless terminal && terminal["status"] == "candidate-accepted" &&
+         accelerated_rc_retry_equivalent?(terminal, record)
+    abort "❌ Accelerated final-promotion evidence changed at the repository-wide publication boundary."
+  end
+
+  history
+end
+
+def validate_accelerated_repository_publication_boundary!(monorepo_root:, record:, phase:)
+  return unless record
+
+  validate_repository_accelerated_rc_boundary_record!(monorepo_root:, record:, phase:)
+end
+
+def accelerated_repository_boundary_context!(accelerated_publication_record:, accelerated_boundary_record:)
+  if accelerated_publication_record && accelerated_boundary_record
+    abort "❌ Release tag handling received ambiguous accelerated boundary evidence."
+  end
+
+  record = accelerated_boundary_record || accelerated_publication_record
+  tag_authorization = accelerated_publication_record
+  tag_authorization ||= record if record&.fetch("status", nil) == "publication-authorized"
+  { record:, tag_authorization: }
+end
+
+def valid_final_promotion_context_identity?(context:, candidate_sha:)
+  context_record = context.fetch(:record)
+  ci_branch = context.fetch(:ci_branch)
+  ci_snapshot = context.fetch(:ci_snapshot)
+  shakaperf_record = context.fetch(:shakaperf_record)
+  ci_branch.is_a?(String) && !ci_branch.empty? &&
+    context.fetch(:candidate_sha) == candidate_sha &&
+    ci_snapshot.fetch("sha") == context_record.fetch("candidate_sha") &&
+    shakaperf_record.fetch("release_branch") == ci_branch &&
+    shakaperf_record.fetch("candidate_sha") == candidate_sha
+end
+
+def validate_final_promotion_context!(boundary_record:, context:, candidate_sha:)
+  unless context
+    if boundary_record&.fetch("status", nil) == "candidate-accepted"
+      abort "❌ Release tag handling is missing accelerated final-promotion context."
+    end
+
+    return
+  end
+
+  context_record = context.fetch(:record)
+  valid = boundary_record&.fetch("status", nil) == "candidate-accepted" &&
+          accelerated_rc_retry_equivalent?(boundary_record, context_record) &&
+          valid_final_promotion_context_identity?(context:, candidate_sha:)
+  return if valid
+
+  abort "❌ Release tag handling received inconsistent accelerated final-promotion boundary evidence."
+rescue KeyError
+  abort "❌ Release tag handling received incomplete accelerated final-promotion boundary evidence."
+end
+
+def validate_accelerated_tag_publication_boundary!(monorepo_root:, record:, final_promotion_context:, phase:)
+  validate_accelerated_repository_publication_boundary!(monorepo_root:, record:, phase:)
+  validate_final_promotion_ci_publication_boundary!(
+    monorepo_root:, context: final_promotion_context, phase:
+  )
+  validate_final_promotion_shakaperf_publication_boundary!(
+    monorepo_root:, context: final_promotion_context, phase:
+  )
+end
+
+def ensure_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, tag_authorization:)
+  tag_exists = system(
+    "git", "-C", monorepo_root, "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}",
+    out: File::NULL, err: File::NULL
+  )
+  if tag_exists
+    if tag_authorization
+      validate_existing_accelerated_rc_tag!(monorepo_root:, tag:, record: tag_authorization)
+    else
+      validate_release_tag_candidate_sha!(monorepo_root:, tag:, candidate_sha:)
+    end
+    puts "Git tag #{tag} already exists, skipping tag creation"
+  elsif tag_authorization
+    create_accelerated_rc_tag!(monorepo_root:, tag:, record: tag_authorization)
+  else
+    create_release_tag_at_candidate_sha!(monorepo_root:, tag:, candidate_sha:)
+  end
+end
+
+def push_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, accelerated_publication_record: nil,
+                                    accelerated_boundary_record: nil, accelerated_final_promotion_context: nil)
+  boundary_context = accelerated_repository_boundary_context!(
+    accelerated_publication_record:, accelerated_boundary_record:
+  )
+  boundary_record = boundary_context.fetch(:record)
+  tag_authorization = boundary_context.fetch(:tag_authorization)
+  validate_final_promotion_context!(
+    boundary_record:, context: accelerated_final_promotion_context, candidate_sha:
+  )
+  validate_accelerated_tag_publication_boundary!(
+    monorepo_root:, record: boundary_record,
+    final_promotion_context: accelerated_final_promotion_context, phase: "tag handling"
+  )
+  ensure_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, tag_authorization:)
+  validate_accelerated_tag_publication_boundary!(
+    monorepo_root:, record: boundary_record,
+    final_promotion_context: accelerated_final_promotion_context, phase: "git tag push"
+  )
+  validate_release_candidate_publication_boundary!(
+    monorepo_root:, tag:, candidate_sha:, phase: "git tag push"
+  )
+  sh_in_dir_for_release(monorepo_root, "LEFTHOOK=0 git push --tags")
+  validate_accelerated_tag_publication_boundary!(
+    monorepo_root:, record: boundary_record,
+    final_promotion_context: accelerated_final_promotion_context, phase: "package publication"
+  )
+  validate_release_candidate_publication_boundary!(
+    monorepo_root:, tag:, candidate_sha:, phase: "package publication"
+  )
+end
+
+def validate_existing_accelerated_rc_tag!(monorepo_root:, tag:, record:)
+  actual = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag:)
+  expected = accelerated_rc_tag_provenance(record)
+  target_sha = peeled_git_tag_sha(monorepo_root:, tag:)
+  abort "❌ Existing RC tag #{tag} does not match the persisted accelerated publication authorization." unless
+    actual == expected && target_sha == expected["candidate_sha"]
+
+  actual
+end
+
+def local_release_tag_exists?(monorepo_root:, tag:)
+  _output, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "show-ref", "--verify", "--quiet", "refs/tags/#{tag}"
+  )
+  return true if status.success?
+  return false if status.exitstatus == 1
+
+  abort "❌ Unable to inspect existing release tag #{tag} before accelerated RC retry."
+end
+
+def accelerated_rc_records_for_candidate(records, target_version:, candidate_sha:)
+  records.select do |record|
+    record["target_version"] == target_version && record["candidate_sha"] == candidate_sha
+  end
+end
+
+def accelerated_rc_authorization_for_same_candidate_retry!(
+  repo_slug:, monorepo_root:, target_version:, candidate_sha:, accelerated_requested:
+)
+  tag = "v#{target_version}"
+  tag_exists = local_release_tag_exists?(monorepo_root:, tag:)
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:, target_version:, candidate_sha:, allow_empty: true
+  )
+  candidate_records = history.fetch(:records)
+  if candidate_records.empty?
+    return accelerated_rc_authorization_without_history!(
+      monorepo_root:, tag:, tag_exists:, accelerated_requested:
+    )
+  end
+
+  tracker = history.fetch(:tracker)
+  fetch_release_tracker_issue!(repo_slug:, tracker:)
+  chain = history.fetch(:chain)
+  terminal = chain.fetch(:terminal)
+  if terminal && terminal["status"] == "candidate-rejected"
+    abort "❌ Accelerated RC retry is blocked because this immutable candidate was permanently rejected."
+  end
+
+  authorization = chain.fetch(:authorization)
+  validate_accelerated_rc_retry_tag_authorization!(
+    candidate_records:, authorization:, tag_exists:, tracker:, target_version:, candidate_sha:, monorepo_root:, tag:
+  )
+
+  authorization
+end
+
+def accelerated_rc_authorization_without_history!(monorepo_root:, tag:, tag_exists:, accelerated_requested:)
+  return nil unless tag_exists
+
+  provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag:)
+  unless provenance
+    if accelerated_requested
+      abort "❌ Existing ordinary lightweight RC tag #{tag} cannot be converted to accelerated publication."
+    end
+
+    return nil
+  end
+
+  abort "❌ Accelerated RC retry is blocked because its annotated tag has provenance but the durable " \
+        "repository tracker chain is missing."
+end
+
+def accelerated_rc_single_retry_tracker!(candidate_records)
+  trackers = candidate_records.map { |record| record["release_tracker"] }.uniq
+  abort "❌ Accelerated RC retry history is bound to conflicting release trackers." unless trackers.one?
+
+  trackers.first
+end
+
+def validate_accelerated_rc_retry_tag_authorization!(candidate_records:, authorization:, tag_exists:, tracker:,
+                                                     target_version:, candidate_sha:, monorepo_root:, tag:)
+  return unless tag_exists
+
+  tagged_authorization = accelerated_rc_tagged_authorization_for_retry!(
+    authorizations: candidate_records.select { |record| record["status"] == "publication-authorized" },
+    tracker:, target_version:, candidate_sha:, monorepo_root:, tag:
+  )
+  return if accelerated_rc_record_digest(tagged_authorization) == accelerated_rc_record_digest(authorization)
+
+  abort "❌ Existing RC tag references a noncanonical accelerated publication authorization."
+end
+
+def accelerated_rc_publication_authorization_for_retry!(repo_slug:, tracker:, target_version:, candidate_sha:,
+                                                        monorepo_root:, tag:)
+  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  candidate_records = accelerated_rc_records_for_candidate(records, target_version:, candidate_sha:)
+  abort_if_accelerated_rc_retry_rejected!(candidate_records)
+  authorizations = candidate_records.select { |record| record["status"] == "publication-authorized" }
+  authorization = if local_release_tag_exists?(monorepo_root:, tag:)
+                    accelerated_rc_tagged_authorization_for_retry!(
+                      authorizations:, tracker:, target_version:, candidate_sha:, monorepo_root:, tag:
+                    )
+                  elsif candidate_records.any?
+                    canonical_accelerated_rc_authorization_for_retry!(authorizations)
+                  end
+  return nil unless authorization
+
+  validate_accelerated_rc_retry_chain!(candidate_records, authorization)
+end
+
+def abort_if_accelerated_rc_retry_rejected!(candidate_records)
+  terminal = validated_accelerated_rc_terminal_set!(candidate_records)
+  return unless terminal && terminal["status"] == "candidate-rejected"
+
+  abort "❌ Accelerated RC retry is blocked because this immutable candidate was permanently rejected."
+end
+
+def canonical_accelerated_rc_authorization_for_retry!(authorizations)
+  validated_accelerated_rc_authorization_set!(authorizations)
+end
+
+def validated_accelerated_rc_authorization_set!(candidate_records, selected_authorization: nil)
+  authorizations = candidate_records.select { |record| record["status"] == "publication-authorized" }
+  abort "❌ Accelerated RC state is missing its canonical publication authorization." if authorizations.empty?
+
+  digests = authorizations.map { |record| accelerated_rc_record_digest(record) }.uniq
+  abort "❌ Accelerated RC state contains conflicting canonical publication authorizations." unless digests.one?
+
+  if selected_authorization && accelerated_rc_record_digest(selected_authorization) != digests.first
+    abort "❌ Selected accelerated RC publication authorization is not canonical for this candidate."
+  end
+
+  selected_authorization || authorizations.first
+end
+
+def validate_accelerated_rc_retry_chain!(candidate_records, authorization)
+  validated_accelerated_rc_candidate_chain!(
+    candidate_records, selected_authorization: authorization
+  ).fetch(:authorization)
+end
+
+def accelerated_rc_tagged_authorization_for_retry!(authorizations:, tracker:, target_version:, candidate_sha:,
+                                                   monorepo_root:, tag:)
+  provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag:)
+  expected_identity = [target_version, candidate_sha, tracker]
+  unless provenance && provenance.values_at("target_version", "candidate_sha", "release_tracker") == expected_identity
+    abort "❌ Existing RC tag #{tag} lacks matching canonical accelerated publication provenance."
+  end
+
+  authorization = authorizations.find do |record|
+    accelerated_rc_record_digest(record) == provenance["authorization_digest"]
+  end
+  abort "❌ Existing RC tag #{tag} references a missing canonical publication authorization." unless authorization
+
+  authorization
+end
+
+def json_compatible_release_value(value)
+  JSON.parse(JSON.generate(value))
+end
+
+def accelerated_rc_ci_check_sort_key(check)
+  %w[name state url].map { |field| check[field] || check[field.to_sym] }.map(&:to_s)
+end
+
+def canonical_accelerated_rc_ci_snapshot_for_comparison(snapshot)
+  normalized = json_compatible_release_value(snapshot)
+  checks = normalized["non_success"]
+  return normalized unless checks.is_a?(Array) && checks.all?(Hash)
+
+  normalized["non_success"] = checks.sort_by { |check| accelerated_rc_ci_check_sort_key(check) }
+  normalized
+end
+
+def build_accelerated_rc_publication_record(options:, candidate_sha:, runtime_tree_fingerprint:, release_branch:,
+                                            ci_snapshot:, shakaperf:, approved_by:, recorded_at:)
+  {
+    "schema_version" => ACCELERATED_RC_RECORD_SCHEMA_VERSION,
+    "status" => "publication-authorized",
+    "target_version" => options.fetch(:target_gem_version),
+    "candidate_sha" => candidate_sha,
+    "runtime_tree_fingerprint" => runtime_tree_fingerprint,
+    "release_branch" => release_branch,
+    "release_tracker" => options.fetch(:tracker),
+    "ci" => json_compatible_release_value(ci_snapshot),
+    "shakaperf" => json_compatible_release_value(shakaperf),
+    "reason" => options.fetch(:reason),
+    "approved_by" => approved_by,
+    "recorded_at" => recorded_at.iso8601,
+    "required_follow_up" => "Complete immutable publication, then run release:reconcile_accelerated_rc before final.",
+    "evidence" => {}
+  }
+end
+
+def valid_accelerated_rc_retry_ci_check?(check)
+  check.is_a?(Hash) && !check[:name].to_s.empty? && !check[:state].to_s.empty? &&
+    valid_accelerated_rc_https_url?(check[:url])
+end
+
+def valid_accelerated_rc_retry_ci_snapshot_shape?(snapshot)
+  return false unless snapshot.is_a?(Hash)
+  return false unless snapshot[:non_success].is_a?(Array)
+  return false unless valid_accelerated_rc_https_url?(snapshot[:checks_url])
+
+  snapshot[:non_success].all? { |check| valid_accelerated_rc_retry_ci_check?(check) }
+end
+
+def current_accelerated_rc_retry_ci_snapshot?(snapshot, candidate_sha:)
+  status = snapshot[:status]
+  non_success_states = snapshot.fetch(:non_success).map { |check| check.fetch(:state) }
+  incomplete = non_success_states.any? { |state| CI_INCOMPLETE_STATUSES.include?(state) }
+  allowed_states = CI_INCOMPLETE_STATUSES + CI_PASSING_CONCLUSIONS
+  return false unless snapshot[:sha] == candidate_sha
+  return false unless non_success_states.all? { |state| allowed_states.include?(state) }
+  return incomplete if status == "pending"
+  return !incomplete if status == "success"
+
+  false
+end
+
+def validate_accelerated_rc_retry_ci_snapshot!(snapshot, candidate_sha:)
+  valid = valid_accelerated_rc_retry_ci_snapshot_shape?(snapshot) &&
+          current_accelerated_rc_retry_ci_snapshot?(snapshot, candidate_sha:)
+  return snapshot if valid
+
+  abort "❌ Persisted accelerated RC authorization cannot be reused because current exact-candidate CI " \
+        "evidence is failed, stale, malformed, or unknown."
+end
+
+def accelerated_rc_live_shakaperf_record(release_branch:, candidate_sha:, target_version:, shakaperf:)
+  {
+    "release_branch" => release_branch,
+    "candidate_sha" => candidate_sha,
+    "target_version" => target_version,
+    "shakaperf" => json_compatible_release_value(shakaperf)
+  }
+end
+
+def refresh_accelerated_rc_live_evidence!(repo_slug:, monorepo_root:, release_branch:, candidate_sha:,
+                                          target_version:, shakaperf:, context:)
+  refresh_record = accelerated_rc_live_shakaperf_record(
+    release_branch:, candidate_sha:, target_version:, shakaperf:
+  )
+  refreshed_shakaperf = accelerated_rc_shakaperf_snapshot!(
+    repo_slug:, monorepo_root:, record: refresh_record
+  )
+  unless refreshed_shakaperf.is_a?(Hash) && %w[pending success].include?(refreshed_shakaperf["status"])
+    abort "❌ Accelerated RC #{context} live ShakaPerf evidence is failed or unknown."
+  end
+
+  refreshed_ci = fetch_accelerated_rc_ci_snapshot!(
+    repo_slug:, sha: candidate_sha, monorepo_root:, ci_branch: release_branch
+  )
+  valid_ci = valid_accelerated_rc_retry_ci_snapshot_shape?(refreshed_ci) &&
+             current_accelerated_rc_retry_ci_snapshot?(refreshed_ci, candidate_sha:)
+  unless valid_ci
+    abort "❌ Accelerated RC #{context} live exact-candidate CI evidence is failed, missing, stale, " \
+          "malformed, or unknown."
+  end
+
+  { ci: refreshed_ci, shakaperf: refreshed_shakaperf }
+end
+
+def accelerated_rc_deferred_evidence_changed?(previous:, refreshed:)
+  %i[ci shakaperf].any? do |gate|
+    current = if gate == :ci
+                canonical_accelerated_rc_ci_snapshot_for_comparison(refreshed.fetch(gate))
+              else
+                json_compatible_release_value(refreshed.fetch(gate))
+              end
+    prior = if gate == :ci
+              canonical_accelerated_rc_ci_snapshot_for_comparison(previous.fetch(gate))
+            else
+              json_compatible_release_value(previous.fetch(gate))
+            end
+    current["status"] == "pending" && current != prior
+  end
+end
+
+def confirmed_fresh_accelerated_rc_evidence!(repo_slug:, monorepo_root:, release_branch:, candidate_sha:,
+                                             target_version:, tracker:, reason:, ci_snapshot:, shakaperf:)
+  evidence = { ci: ci_snapshot, shakaperf: }
+  confirmations = 0
+
+  loop do
+    confirm_accelerated_rc_publication!(
+      version: target_version,
+      candidate_sha:,
+      tracker:,
+      reason:,
+      ci_snapshot: evidence.fetch(:ci),
+      shakaperf: evidence.fetch(:shakaperf)
+    )
+    refreshed = refresh_accelerated_rc_live_evidence!(
+      repo_slug:,
+      monorepo_root:,
+      release_branch:,
+      candidate_sha:,
+      target_version:,
+      shakaperf: evidence.fetch(:shakaperf),
+      context: "refreshed authorization"
+    )
+    return refreshed unless accelerated_rc_deferred_evidence_changed?(previous: evidence, refreshed:)
+
+    confirmations += 1
+    if confirmations >= 3
+      abort "❌ Accelerated RC pending evidence did not stabilize across confirmation; refusing authorization."
+    end
+    puts "⚠️ Accelerated RC pending evidence changed during confirmation; review and confirm the refreshed snapshot."
+    evidence = refreshed
+  end
+end
+
+def fresh_accelerated_rc_authorization_evidence!(repo_slug:, monorepo_root:, release_branch:, candidate_sha:,
+                                                 target_version:, tracker:, reason:, release_started_at:)
+  shakaperf = run_accelerated_shakaperf_release_gate!(
+    monorepo_root:, ref: release_branch, head_sha: candidate_sha, target_version:, release_started_at:
+  )
+  ci_snapshot = fetch_accelerated_rc_ci_snapshot!(
+    repo_slug:, sha: candidate_sha, monorepo_root:, ci_branch: release_branch
+  )
+  confirmed_fresh_accelerated_rc_evidence!(
+    repo_slug:,
+    monorepo_root:,
+    release_branch:,
+    candidate_sha:,
+    target_version:,
+    tracker:,
+    reason:,
+    ci_snapshot:,
+    shakaperf:
+  )
+end
+
+def validate_accelerated_rc_authorization_live_evidence_boundary!(repo_slug:, monorepo_root:, authorization:, phase:)
+  refreshed = refresh_accelerated_rc_live_evidence!(
+    repo_slug:,
+    monorepo_root:,
+    release_branch: authorization.fetch("release_branch"),
+    candidate_sha: authorization.fetch("candidate_sha"),
+    target_version: authorization.fetch("target_version"),
+    shakaperf: authorization.fetch("shakaperf"),
+    context: "#{phase} boundary"
+  )
+  stored = { ci: authorization.fetch("ci"), shakaperf: authorization.fetch("shakaperf") }
+  return refreshed unless accelerated_rc_deferred_evidence_changed?(previous: stored, refreshed:)
+
+  abort "❌ Accelerated RC #{phase} boundary found materially changed pending evidence that was not confirmed."
+end
+
+def validate_persisted_accelerated_rc_authorization_evidence!(repo_slug:, monorepo_root:, authorization:)
+  candidate_sha = authorization.fetch("candidate_sha")
+  ci = fetch_accelerated_rc_ci_snapshot!(
+    repo_slug:,
+    sha: candidate_sha,
+    monorepo_root:,
+    ci_branch: authorization.fetch("release_branch")
+  )
+  validate_accelerated_rc_retry_ci_snapshot!(ci, candidate_sha:)
+
+  shakaperf = accelerated_rc_shakaperf_snapshot!(repo_slug:, monorepo_root:, record: authorization)
+  return authorization if %w[pending success].include?(shakaperf["status"])
+
+  abort "❌ Persisted accelerated RC authorization cannot be reused because current ShakaPerf evidence failed."
+end
+
+def reuse_accelerated_rc_publication_authorization!(
+  repo_slug:, monorepo_root:, history:, authorization:, tracker:, target_version:, candidate_sha:, tag:
+)
+  validate_accelerated_rc_retry_tag_authorization!(
+    candidate_records: history.fetch(:records),
+    authorization:,
+    tag_exists: local_release_tag_exists?(monorepo_root:, tag:),
+    tracker:,
+    target_version:,
+    candidate_sha:,
+    monorepo_root:,
+    tag:
+  )
+  validate_persisted_accelerated_rc_authorization_evidence!(repo_slug:, monorepo_root:, authorization:)
+  puts "✓ Reusing canonical accelerated RC publication authorization from tracker ##{tracker}."
+  authorization
+end
+
+def authorize_accelerated_rc_publication!(repo_slug:, monorepo_root:, release_branch:, candidate_sha:, options:,
+                                          approver:, release_started_at:, tag:)
+  tracker = options.fetch(:tracker)
+  target_version = options.fetch(:target_gem_version)
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:, target_version:, candidate_sha:, expected_tracker: tracker, allow_empty: true
+  )
+  abort_if_accelerated_rc_retry_rejected!(history.fetch(:records)) unless history.fetch(:records).empty?
+  persisted = history.dig(:chain, :authorization)
+  if persisted
+    return reuse_accelerated_rc_publication_authorization!(
+      repo_slug:, monorepo_root:, history:, authorization: persisted, tracker:, target_version:, candidate_sha:, tag:
+    )
+  end
+
+  accelerated_rc_authorization_without_history!(
+    monorepo_root:,
+    tag:,
+    tag_exists: local_release_tag_exists?(monorepo_root:, tag:),
+    accelerated_requested: true
+  )
+
+  refreshed_evidence = fresh_accelerated_rc_authorization_evidence!(
+    repo_slug:,
+    monorepo_root:,
+    release_branch:,
+    candidate_sha:,
+    target_version:,
+    tracker:,
+    reason: options.fetch(:reason),
+    release_started_at:
+  )
+  ci = refreshed_evidence.fetch(:ci)
+  shakaperf = refreshed_evidence.fetch(:shakaperf)
+  runtime_tree_fingerprint = shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: candidate_sha)
+  abort "❌ Unable to fingerprint the accelerated RC runtime tree; refusing unaudited publication." unless
+    runtime_tree_fingerprint
+
+  record = build_accelerated_rc_publication_record(
+    options:, candidate_sha:, runtime_tree_fingerprint:, release_branch:, ci_snapshot: ci, shakaperf:,
+    approved_by: approver, recorded_at: Time.now.utc
+  )
+  fetch_release_tracker_issue!(repo_slug:, tracker:)
+  append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record:)
+end
+
+def accelerated_rc_published_record(authorized_record:, recorded_at:, approved_by: authorized_record["approved_by"])
+  authorized_record.merge(
+    "status" => "published-awaiting-gates",
+    "approved_by" => approved_by,
+    "recorded_at" => recorded_at.iso8601,
+    "required_follow_up" => "Run release:reconcile_accelerated_rc before promoting this RC to final."
+  )
+end
+
+def record_accelerated_rc_publication_complete!(repo_slug:, tracker:, authorized_record:, approved_by:, recorded_at:)
+  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  candidate_records = accelerated_rc_records_for_candidate(
+    records,
+    target_version: authorized_record.fetch("target_version"),
+    candidate_sha: authorized_record.fetch("candidate_sha")
+  )
+  chain = validated_accelerated_rc_candidate_chain!(
+    candidate_records, selected_authorization: authorized_record
+  )
+  terminal = chain.fetch(:terminal)
+  if terminal && terminal["status"] == "candidate-rejected"
+    abort "❌ Accelerated RC publication completion is blocked because this candidate was permanently rejected."
+  end
+  canonical_authorization = chain.fetch(:authorization)
+  publications = chain.fetch(:publications)
+  return publications.first unless publications.empty?
+
+  published_record = accelerated_rc_published_record(
+    authorized_record: canonical_authorization, recorded_at:, approved_by:
+  )
+  append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record: published_record)
+end
+
+def accelerated_rc_publication_completion_equivalent?(existing, expected)
+  retry_variant_fields = %w[approved_by recorded_at]
+  canonical_accelerated_rc_value(existing.except(*retry_variant_fields)) ==
+    canonical_accelerated_rc_value(expected.except(*retry_variant_fields))
+end
+
+def validated_accelerated_rc_publication_set!(candidate_records, authorization, require_publication: false)
+  publications = candidate_records.select { |record| record["status"] == "published-awaiting-gates" }
+  if publications.empty?
+    abort "❌ Canonical published-awaiting-gates transition is missing." if require_publication
+
+    return publications
+  end
+
+  expected = accelerated_rc_published_record(
+    authorized_record: authorization,
+    approved_by: authorization["approved_by"],
+    recorded_at: Time.at(0).utc
+  )
+  unless publications.all? { |record| accelerated_rc_publication_completion_equivalent?(record, expected) }
+    abort "❌ Accelerated RC publication set contains state that is not the canonical authorized transition."
+  end
+
+  publications
+end
+
+def validated_accelerated_rc_terminal_set!(candidate_records)
+  terminal_records = candidate_records.select do |record|
+    ACCELERATED_RC_TERMINAL_STATUSES.include?(record["status"])
+  end
+  return nil if terminal_records.empty?
+
+  rejected = terminal_records.select { |record| record["status"] == "candidate-rejected" }
+  if rejected.any? && rejected.length != terminal_records.length
+    abort "❌ Accelerated RC candidate was permanently rejected; candidate-rejected is absorbing and " \
+          "contradictory terminal history is invalid."
+  end
+
+  canonical = terminal_records.first
+  unless terminal_records.all? { |record| accelerated_rc_retry_equivalent?(record, canonical) }
+    abort "❌ Accelerated RC state contains conflicting #{canonical.fetch('status')} terminal records."
+  end
+
+  canonical
+end
+
+def validated_accelerated_rc_candidate_chain!(
+  candidate_records,
+  selected_authorization: nil,
+  require_publication: false
+)
+  authorization = validated_accelerated_rc_authorization_set!(
+    candidate_records, selected_authorization:
+  )
+  unless accelerated_rc_authorization_chain_valid?(candidate_records, authorization)
+    abort "❌ Accelerated RC tracker state is not bound to the canonical publication authorization."
+  end
+
+  terminal = validated_accelerated_rc_terminal_set!(candidate_records)
+  publications = validated_accelerated_rc_publication_set!(
+    candidate_records,
+    authorization,
+    require_publication: require_publication || !terminal.nil?
+  )
+  validate_accelerated_rc_transition_order!(candidate_records)
+
+  { authorization:, publications:, terminal: }
+end
+
+def validate_accelerated_rc_transition_order!(candidate_records)
+  current_phase = -1
+  previous_time = nil
+
+  candidate_records.each do |record|
+    phase = accelerated_rc_transition_phase!(record["status"])
+    if phase < current_phase || (phase.positive? && current_phase < phase - 1)
+      abort "❌ Accelerated RC tracker transition order is invalid; expected authorization, publication, terminal."
+    end
+
+    recorded_at = accelerated_rc_transition_recorded_at!(record)
+    if previous_time && recorded_at < previous_time
+      abort "❌ Accelerated RC tracker transition timestamps must be parseable and monotonic."
+    end
+
+    current_phase = phase
+    previous_time = recorded_at
+  end
+
+  candidate_records
+end
+
+def accelerated_rc_transition_phase!(status)
+  phase = {
+    "publication-authorized" => 0,
+    "published-awaiting-gates" => 1,
+    "candidate-accepted" => 2,
+    "candidate-rejected" => 2
+  }[status]
+  abort "❌ Accelerated RC tracker transition order contains an unknown state." unless phase
+
+  phase
+end
+
+def accelerated_rc_transition_recorded_at!(record)
+  recorded_at = shakaperf_release_gate_time(record["recorded_at"])
+  abort "❌ Accelerated RC tracker transition timestamps must be parseable and monotonic." unless recorded_at
+
+  recorded_at
+end
+
+def accelerated_rc_terminal_record(records:, target_version:, candidate_sha:)
+  candidate_records = records.select do |record|
+    record["target_version"] == target_version && record["candidate_sha"] == candidate_sha &&
+      ACCELERATED_RC_RECORD_STATUSES.include?(record["status"])
+  end
+  validated_accelerated_rc_terminal_set!(candidate_records)
+end
+
+def accelerated_rc_published_record!(records:, target_version:)
+  matching = accelerated_rc_records_for_target(records, target_version)
+  abort "❌ No accelerated RC tracker record exists for #{target_version}." if matching.empty?
+
+  latest_publication = accelerated_rc_latest_record_with_status(matching, "published-awaiting-gates")
+  abort "❌ No published-awaiting-gates record exists for #{target_version}." unless latest_publication
+
+  candidate_sha = latest_publication.fetch("candidate_sha")
+  candidate_records = accelerated_rc_records_for_candidate(matching, target_version:, candidate_sha:)
+  chain = validated_accelerated_rc_candidate_chain!(candidate_records, require_publication: true)
+  chain.fetch(:terminal) || latest_publication
+end
+
+def accelerated_rc_records_for_target(records, target_version)
+  records.select { |record| record["target_version"] == target_version }
+end
+
+def accelerated_rc_record_with_status(records, status)
+  records.find { |record| record["status"] == status }
+end
+
+def accelerated_rc_latest_record_with_status(records, status)
+  records.reverse.find { |record| record["status"] == status }
+end
+
+def accelerated_rc_authorization_chain_valid?(records, authorization)
+  authorization && records.all? { |record| accelerated_rc_record_bound_to_authorization?(record, authorization) }
+end
+
+def accelerated_rc_shakaperf_snapshot!(repo_slug:, monorepo_root:, record:)
+  stored = record.fetch("shakaperf")
+  run = refresh_shakaperf_release_gate_run!(repo_slug:, run: { "databaseId" => stored.fetch("run_id") })
+  run_url = validated_accelerated_rc_shakaperf_run_url!(
+    repo_slug:, run:, stored:, ref: record.fetch("release_branch")
+  )
+  if active_shakaperf_release_gate_run?(run)
+    return stored.merge("status" => "pending", "run_id" => run.fetch("databaseId"), "run_url" => run_url)
+  end
+
+  unless run["status"] == "completed"
+    abort "❌ ShakaPerf reconciliation is unknown for #{run_url}; refusing to accept or reject the RC."
+  end
+  unless SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(run["conclusion"])
+    abort "❌ ShakaPerf reconciliation is unknown for #{run_url}; refusing to accept or reject the RC."
+  end
+  if run["conclusion"] != "success"
+    return stored.merge(
+      "status" => "failed",
+      "conclusion" => run["conclusion"],
+      "run_id" => run.fetch("databaseId"),
+      "run_url" => run_url
+    )
+  end
+
+  verified_accelerated_rc_shakaperf_success_snapshot!(
+    repo_slug:, monorepo_root:, record:, stored:, run:, run_url:
+  )
+end
+
+def verified_accelerated_rc_shakaperf_success_snapshot!(repo_slug:, monorepo_root:, record:, stored:, run:, run_url:)
+  release_started_at = shakaperf_release_gate_time(stored["release_started_at"])
+  abort "❌ Stored ShakaPerf release start time is invalid; reconciliation remains unknown." unless release_started_at
+
+  rejection = shakaperf_release_gate_run_evidence_rejection(
+    repo_slug:,
+    monorepo_root:,
+    ref: record.fetch("release_branch"),
+    head_sha: record.fetch("candidate_sha"),
+    target_version: record.fetch("target_version"),
+    run:,
+    release_started_at:,
+    require_prerun: accelerated_rc_shakaperf_requires_prerun?(record)
+  )
+  abort "❌ ShakaPerf reconciliation evidence is unknown or invalid: #{rejection}" if rejection
+
+  stored.merge("status" => "success", "run_id" => run.fetch("databaseId"), "run_url" => run_url)
+end
+
+def validated_accelerated_rc_shakaperf_run_url!(repo_slug:, run:, stored:, ref:)
+  unless valid_accelerated_rc_shakaperf_run_identity?(repo_slug:, run:, stored:, ref:)
+    abort "❌ Refreshed ShakaPerf run identity is unknown or malformed; reconciliation remains blocked."
+  end
+
+  shakaperf_release_gate_run_url(repo_slug:, run:)
+end
+
+def valid_accelerated_rc_shakaperf_run_identity?(repo_slug:, run:, stored:, ref:)
+  return false unless run.is_a?(Hash) && positive_github_id?(run["databaseId"])
+
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  run["databaseId"] == stored["run_id"] && run["attempt"] == stored["attempt"] &&
+    shakaperf_release_gate_run_matches_target?(
+      run:, ref:, head_sha: stored["candidate_sha"], target_version: stored["target_version"]
+    ) && valid_accelerated_rc_https_url?(run_url)
+end
+
+def accelerated_rc_shakaperf_requires_prerun?(record)
+  record.fetch("shakaperf").fetch("candidate_sha") != record.fetch("candidate_sha")
+end
+
+def confirm_accelerated_rc_publication!(version:, candidate_sha:, tracker:, reason:, ci_snapshot:, shakaperf:)
+  print_accelerated_rc_publication_summary(
+    version:, candidate_sha:, tracker:, reason:, ci_snapshot:, shakaperf:
+  )
+  print "Publish this RC while the named gates finish? [y/N] "
+  $stdout.flush
+  answer = $stdin.gets&.strip&.downcase
+  abort "Accelerated RC publication aborted." unless answer == "y"
+end
+
+def print_accelerated_rc_publication_summary(version:, candidate_sha:, tracker:, reason:, ci_snapshot:, shakaperf:)
+  puts "\n#{'#' * 80}"
+  puts "ACCELERATED RC PUBLICATION CONFIRMATION"
+  puts "#" * 80
+  puts "  RC version: #{version}"
+  puts "  Candidate SHA: #{candidate_sha}"
+  puts "  Release tracker: ##{tracker}"
+  puts "  Exact-head CI: #{ci_snapshot.fetch(:status)} (#{ci_snapshot.fetch(:checks_url)})"
+  print_accelerated_rc_non_success_checks(ci_snapshot)
+  puts "  ShakaPerf: #{shakaperf.fetch(:status)} (#{shakaperf.fetch(:run_url)})"
+  puts "  Maintainer reason: #{reason}"
+  puts "#" * 80
+end
+
+def print_accelerated_rc_non_success_checks(ci_snapshot)
+  ci_snapshot.fetch(:non_success).each do |check|
+    puts "    - #{check.fetch(:name)}: #{check.fetch(:state)}"
+    puts "      #{check.fetch(:url)}"
+  end
+end
+
+def reconcile_accelerated_rc_record(published_record:, ci_snapshot:, shakaperf:, evidence:, approved_by:, reason:,
+                                    recorded_at:)
+  if [ci_snapshot["status"], shakaperf["status"]].include?("failed")
+    return published_record.merge(
+      "status" => "candidate-rejected",
+      "ci" => ci_snapshot,
+      "shakaperf" => shakaperf,
+      "evidence" => {},
+      "approved_by" => approved_by,
+      "reason" => reason,
+      "recorded_at" => recorded_at,
+      "required_follow_up" => "Do not promote this immutable RC; fix the failure and cut the next RC."
+    )
+  end
+
+  missing = ACCELERATED_RC_REQUIRED_EVIDENCE.reject do |name|
+    valid_accelerated_rc_https_url?(evidence[name])
+  end
+  unless ci_snapshot["status"] == "success" && shakaperf["status"] == "success" && missing.empty?
+    abort "❌ Accelerated RC candidate cannot be accepted while required gate evidence is incomplete."
+  end
+
+  published_record.merge(
+    "status" => "candidate-accepted",
+    "ci" => ci_snapshot,
+    "shakaperf" => shakaperf,
+    "evidence" => evidence,
+    "approved_by" => approved_by,
+    "reason" => reason,
+    "recorded_at" => recorded_at,
+    "required_follow_up" => "Proceed only through the strict final promotion gates."
+  )
+end
+
+def run_accelerated_rc_reconciliation!(repo_slug:, monorepo_root:, tracker:, target_version:, reason:, evidence:)
+  fetch_release_tracker_issue!(repo_slug:, tracker:)
+  approved_by = current_release_approver!(repo_slug:)
+  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  published_record = accelerated_rc_published_record!(records:, target_version:)
+  terminal_record = terminal_accelerated_rc_reconciliation_record!(published_record)
+  return terminal_record if terminal_record
+
+  candidate_sha = published_record.fetch("candidate_sha")
+  ci = json_compatible_release_value(
+    fetch_accelerated_rc_ci_snapshot!(
+      repo_slug:,
+      sha: candidate_sha,
+      monorepo_root:,
+      ci_branch: published_record.fetch("release_branch"),
+      fail_on_failure: false
+    )
+  )
+  shakaperf = if ci["status"] == "failed"
+                published_record.fetch("shakaperf")
+              else
+                accelerated_rc_shakaperf_snapshot!(repo_slug:, monorepo_root:, record: published_record)
+              end
+  reconciled_record = reconcile_accelerated_rc_record(
+    published_record:,
+    ci_snapshot: ci,
+    shakaperf:,
+    evidence:,
+    approved_by:,
+    reason: normalized_accelerated_rc_reason!(reason, action: "reconciliation"),
+    recorded_at: Time.now.utc.iso8601
+  )
+  append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record: reconciled_record)
+  if reconciled_record["status"] == "candidate-rejected"
+    abort "❌ Accelerated RC candidate was rejected. Do not promote this immutable RC; " \
+          "fix the failure and cut the next RC."
+  end
+
+  puts "✓ Accelerated RC candidate accepted with complete deferred and downstream evidence."
+  reconciled_record
+end
+
+def terminal_accelerated_rc_reconciliation_record!(record)
+  return nil unless ACCELERATED_RC_TERMINAL_STATUSES.include?(record["status"])
+
+  if record["status"] == "candidate-rejected"
+    abort "❌ Accelerated RC candidate was already rejected and can never be promoted; cut the next RC."
+  end
+
+  puts "Accelerated RC reconciliation is already terminal: #{record.fetch('status')}."
+  record
+end
+
+def accepted_accelerated_rc_record_for_release_branch_promotion!(monorepo_root:, rc_tag:, final_head_sha:,
+                                                                 tracker_input:)
+  tag_provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag: rc_tag)
+  unless tag_provenance
+    if tracker_input
+      abort "❌ Final promotion is blocked: explicit RELEASE_TRACKER was supplied, but the RC tag lacks " \
+            "canonical accelerated provenance."
+    end
+
+    repo_slug = github_repo_slug(monorepo_root)
+    rc_version = parse_release_tag_to_gem_version(rc_tag)
+    rc_sha = peeled_git_tag_sha(monorepo_root:, tag: rc_tag)
+    history = fetch_repository_accelerated_rc_records_for_candidate!(
+      repo_slug:, target_version: rc_version, candidate_sha: rc_sha
+    )
+    return nil if history.empty?
+
+    abort "❌ Final promotion is blocked: lightweight RC tag #{rc_tag} has durable accelerated history " \
+          "but lacks canonical accelerated provenance."
+  end
+
+  validate_literal_accelerated_rc_tag_name!(rc_tag:, tag_provenance:)
+
+  tracker = tag_provenance.fetch("release_tracker")
+  unless tracker_input.to_s.match?(/\A[1-9]\d*\z/) && tracker_input.to_i == tracker
+    abort "❌ Final promotion is blocked: RELEASE_TRACKER must match the canonical tracker recorded " \
+          "in the accelerated RC tag."
+  end
+
+  repo_slug = github_repo_slug(monorepo_root)
+  fetch_release_tracker_issue!(repo_slug:, tracker:)
+  rc_version = tag_provenance.fetch("target_version")
+  rc_sha = peeled_git_tag_sha(monorepo_root:, tag: rc_tag)
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:, target_version: rc_version, candidate_sha: rc_sha, expected_tracker: tracker
+  )
+  accepted_accelerated_rc_record_for_promotion!(
+    records: history.fetch(:records),
+    rc_version:,
+    rc_sha:,
+    final_head_sha:,
+    monorepo_root:,
+    tag_provenance:
+  )
+end
+
+def validate_literal_accelerated_rc_tag_name!(rc_tag:, tag_provenance:)
+  expected_tag = "v#{tag_provenance.fetch('target_version')}"
+  return if rc_tag == expected_tag
+
+  abort "❌ Final promotion requires the literal canonical accelerated RC tag #{expected_tag}; " \
+        "aliases are not accepted for provenance-bearing candidates."
+end
+
+def accepted_accelerated_rc_record_for_promotion!(records:, rc_version:, rc_sha:, final_head_sha:, monorepo_root:,
+                                                  tag_provenance:)
+  matching_records = records.select { |record| record["target_version"] == rc_version }
+  candidate_records = accelerated_rc_promotion_candidate_records!(
+    matching_records:, rc_version:, rc_sha:, tag_provenance:
+  )
+  return nil unless candidate_records
+
+  abort_if_accelerated_rc_candidate_rejected!(candidate_records:, rc_version:)
+  validate_accepted_accelerated_rc_record_for_promotion!(
+    record: candidate_records.last, rc_version:, rc_sha:, final_head_sha:, monorepo_root:
+  )
+end
+
+def accelerated_rc_promotion_candidate_records!(matching_records:, rc_version:, rc_sha:, tag_provenance:)
+  return nil unless accelerated_rc_tag_provenance_required!(matching_records:, tag_provenance:)
+
+  validate_accelerated_rc_promotion_tag_identity!(tag_provenance:, rc_version:, rc_sha:)
+
+  candidate_records = accelerated_rc_records_for_candidate(
+    matching_records, target_version: rc_version, candidate_sha: rc_sha
+  )
+  authorization = accelerated_rc_authorization_for_provenance(candidate_records, tag_provenance)
+  unless authorization
+    abort "❌ Final promotion is blocked: canonical accelerated RC publication authorization is missing " \
+          "or does not match the RC tag provenance."
+  end
+  validated_accelerated_rc_candidate_chain!(
+    candidate_records, selected_authorization: authorization, require_publication: true
+  )
+
+  candidate_records
+end
+
+def accelerated_rc_tag_provenance_required!(matching_records:, tag_provenance:)
+  return true if tag_provenance
+  return false if matching_records.empty?
+
+  abort "❌ Final promotion is blocked: accelerated RC tracker records exist, but the RC tag lacks " \
+        "canonical accelerated-publication provenance."
+end
+
+def validate_accelerated_rc_promotion_tag_identity!(tag_provenance:, rc_version:, rc_sha:)
+  return if tag_provenance["target_version"] == rc_version && tag_provenance["candidate_sha"] == rc_sha
+
+  abort "❌ Final promotion is blocked: RC tag provenance does not match the selected RC version and SHA."
+end
+
+def accelerated_rc_authorization_for_provenance(candidate_records, tag_provenance)
+  candidate_records.find do |record|
+    record["status"] == "publication-authorized" &&
+      accelerated_rc_record_digest(record) == tag_provenance["authorization_digest"]
+  end
+end
+
+def abort_if_accelerated_rc_candidate_rejected!(candidate_records:, rc_version:)
+  terminal = validated_accelerated_rc_terminal_set!(candidate_records)
+  return unless terminal && terminal["status"] == "candidate-rejected"
+
+  abort "❌ Final promotion is blocked: #{rc_version} was permanently rejected. Cut the next immutable RC."
+end
+
+def validate_accepted_accelerated_rc_record_for_promotion!(record:, rc_version:, rc_sha:, final_head_sha:,
+                                                           monorepo_root:)
+  unless record["status"] == "candidate-accepted"
+    abort "❌ Final promotion is blocked: #{rc_version} has deferred RC gates in state " \
+          "#{record['status'].inspect}. Do not promote pending, rejected, or unreconciled evidence."
+  end
+  abort "❌ Final promotion is blocked: accepted evidence is not bound to the RC tag SHA." unless
+    record["candidate_sha"] == rc_sha
+  abort "❌ Final promotion is blocked: accepted RC evidence is incomplete." unless
+    accelerated_rc_gate_evidence_complete?(record)
+  unless accelerated_rc_runtime_equivalent?(
+    record:, rc_sha:, final_head_sha:, monorepo_root:
+  )
+    abort "❌ Final promotion is blocked: the final tip is not runtime-equivalent to the accepted RC candidate."
+  end
+
+  record
+end
+
+def accelerated_rc_gate_evidence_complete?(record)
+  evidence = record.fetch("evidence", {})
+  record.dig("ci", "status") == "success" && record.dig("shakaperf", "status") == "success" &&
+    evidence.keys.sort == ACCELERATED_RC_REQUIRED_EVIDENCE.sort &&
+    ACCELERATED_RC_REQUIRED_EVIDENCE.all? { |name| valid_accelerated_rc_https_url?(evidence[name]) }
+end
+
+def refresh_accepted_rc_ci_evidence_for_promotion!(repo_slug:, monorepo_root:, ci_branch:, record:)
+  candidate_sha = record.fetch("candidate_sha")
+  snapshot = fetch_accelerated_rc_ci_snapshot!(
+    repo_slug:,
+    sha: candidate_sha,
+    monorepo_root:,
+    ci_branch:
+  )
+  valid_snapshot = valid_accelerated_rc_retry_ci_snapshot_shape?(snapshot) &&
+                   current_accelerated_rc_retry_ci_snapshot?(snapshot, candidate_sha:) &&
+                   snapshot[:status] == "success"
+  unless valid_snapshot
+    abort "❌ Final promotion is blocked: refreshed exact-RC CI is failed, pending, missing, malformed, " \
+          "stale, unknown, or not candidate-bound."
+  end
+
+  snapshot
+end
+
+def validate_final_promotion_ci_publication_boundary!(monorepo_root:, context:, phase:)
+  return unless context
+
+  record = context.fetch(:record)
+  expected_snapshot = context.fetch(:ci_snapshot)
+  refreshed_snapshot = refresh_accepted_rc_ci_evidence_for_promotion!(
+    repo_slug: github_repo_slug(monorepo_root),
+    monorepo_root:,
+    ci_branch: context.fetch(:ci_branch),
+    record:
+  )
+  return refreshed_snapshot if
+    canonical_accelerated_rc_ci_snapshot_for_comparison(refreshed_snapshot) ==
+    canonical_accelerated_rc_ci_snapshot_for_comparison(expected_snapshot)
+
+  abort "❌ Final promotion #{phase} boundary found materially changed exact-candidate CI evidence."
+end
+
+def validate_final_promotion_shakaperf_publication_boundary!(monorepo_root:, context:, phase:)
+  return unless context
+
+  record = context.fetch(:shakaperf_record)
+  expected_snapshot = record.fetch("shakaperf")
+  refreshed_snapshot = accelerated_rc_shakaperf_snapshot!(
+    repo_slug: github_repo_slug(monorepo_root), monorepo_root:, record:
+  )
+  unless refreshed_snapshot.is_a?(Hash) && refreshed_snapshot["status"] == "success"
+    abort "❌ Final promotion #{phase} boundary ShakaPerf evidence is failed, missing, malformed, or unknown."
+  end
+  return refreshed_snapshot if canonical_accelerated_rc_value(refreshed_snapshot) ==
+                               canonical_accelerated_rc_value(expected_snapshot)
+
+  abort "❌ Final promotion #{phase} boundary found materially changed ShakaPerf evidence."
+end
+
+def accepted_rc_record_at_publication_boundary!(monorepo_root:, rc_tag:, final_head_sha:, tracker_input:, record:)
+  unless remote_git_tag_exists?(monorepo_root:, tag: rc_tag)
+    abort "❌ Final promotion is blocked: the live remote RC tag disappeared at the publication boundary."
+  end
+  fetch_remote_rc_tag!(monorepo_root:, rc_tag:)
+
+  boundary_record = accepted_accelerated_rc_record_for_release_branch_promotion!(
+    monorepo_root:, rc_tag:, final_head_sha:, tracker_input:
+  )
+  abort "❌ Final promotion is blocked: accelerated RC evidence disappeared at the publication boundary." unless
+    boundary_record
+  unless accelerated_rc_retry_equivalent?(boundary_record, record)
+    abort "❌ Final promotion is blocked: the accepted RC record changed at the publication boundary."
+  end
+
+  boundary_record
+end
+
+def validate_final_promotion_boundary_head!(monorepo_root:, final_head_sha:)
+  boundary_head_sha = current_git_sha!(monorepo_root, context: "final promotion publication boundary")
+  return if boundary_head_sha == final_head_sha
+
+  abort "❌ Final promotion is blocked: local HEAD moved after validation at the publication boundary."
+end
+
+def strict_final_promotion_shakaperf_snapshot!(monorepo_root:, current_branch:, final_head_sha:, target_version:,
+                                               release_started_at:, allow_ci_override:, dry_run:)
+  run = run_shakaperf_release_gate!(
+    monorepo_root:,
+    ref: current_branch,
+    head_sha: final_head_sha,
+    target_version:,
+    release_started_at:,
+    allow_override: allow_ci_override,
+    dry_run:
+  )
+  unless run.is_a?(Hash) && run["status"] == "completed" && run["conclusion"] == "success"
+    abort "❌ Final promotion is blocked: strict ShakaPerf gate identity is missing, malformed, or unknown."
+  end
+
+  accelerated_shakaperf_snapshot(
+    repo_slug: github_repo_slug(monorepo_root),
+    run:,
+    ref: current_branch,
+    candidate_sha: run.fetch("headSha"),
+    target_version:,
+    release_started_at:,
+    status: "success"
+  )
+end
+
+def final_promotion_boundary_context(final_head_sha:, current_branch:, record:, ci_snapshot:, shakaperf:)
+  normalized_shakaperf = json_compatible_release_value(shakaperf)
+  {
+    candidate_sha: final_head_sha,
+    ci_branch: current_branch,
+    record:,
+    ci_snapshot: json_compatible_release_value(ci_snapshot),
+    shakaperf_record: {
+      "release_branch" => current_branch,
+      "candidate_sha" => final_head_sha,
+      "target_version" => normalized_shakaperf.fetch("target_version"),
+      "shakaperf" => normalized_shakaperf
+    }
+  }
+end
+
+def final_promotion_shakaperf_snapshot!(repo_slug:, monorepo_root:, current_branch:, final_head_sha:, record:,
+                                        target_version:, release_started_at:, allow_ci_override:, dry_run:)
+  reused = reuse_accepted_rc_shakaperf_evidence!(
+    repo_slug:, monorepo_root:, ref: current_branch, head_sha: final_head_sha, record:
+  )
+  return record.fetch("shakaperf") if reused
+
+  strict_final_promotion_shakaperf_snapshot!(
+    monorepo_root:,
+    current_branch:,
+    final_head_sha:,
+    target_version:,
+    release_started_at:,
+    allow_ci_override:,
+    dry_run:
+  )
+end
+
+def run_accepted_rc_final_promotion_gates!(repo_slug:, monorepo_root:, current_branch:, rc_tag:, tracker_input:,
+                                           final_head_sha:, record:, target_version:, release_started_at:,
+                                           allow_ci_override:, dry_run:)
+  unless accelerated_rc_runtime_equivalent?(
+    record:, rc_sha: record.fetch("candidate_sha"), final_head_sha:, monorepo_root:
+  )
+    abort "❌ Final promotion is blocked: post-bump runtime drift requires a new accepted RC; " \
+          "a fresh final ShakaPerf run cannot replace accepted candidate evidence."
+  end
+
+  ci_snapshot = refresh_accepted_rc_ci_evidence_for_promotion!(
+    repo_slug:, monorepo_root:, ci_branch: current_branch, record:
+  )
+  shakaperf = final_promotion_shakaperf_snapshot!(
+    repo_slug:,
+    monorepo_root:,
+    current_branch:,
+    final_head_sha:,
+    record:,
+    target_version:,
+    release_started_at:,
+    allow_ci_override:,
+    dry_run:
+  )
+
+  boundary_record = accepted_rc_record_at_publication_boundary!(
+    monorepo_root:, rc_tag:, final_head_sha:, tracker_input:, record:
+  )
+
+  boundary_ci_snapshot = refresh_accepted_rc_ci_evidence_for_promotion!(
+    repo_slug:, monorepo_root:, ci_branch: current_branch, record: boundary_record
+  )
+  unless canonical_accelerated_rc_ci_snapshot_for_comparison(boundary_ci_snapshot) ==
+         canonical_accelerated_rc_ci_snapshot_for_comparison(ci_snapshot)
+    abort "❌ Final promotion is blocked: exact-candidate CI evidence changed at the publication boundary."
+  end
+  validate_final_promotion_boundary_head!(monorepo_root:, final_head_sha:)
+
+  final_promotion_boundary_context(
+    final_head_sha:,
+    current_branch:,
+    record: boundary_record,
+    ci_snapshot: boundary_ci_snapshot,
+    shakaperf:
+  )
+end
+
+def accelerated_rc_runtime_equivalent?(record:, rc_sha:, final_head_sha:, monorepo_root:)
+  fingerprint = record["runtime_tree_fingerprint"]
+  return false unless fingerprint.to_s.match?(/\A[0-9a-f]{64}\z/)
+
+  candidate_fingerprint = shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: rc_sha)
+  return false unless candidate_fingerprint == fingerprint
+
+  final_fingerprint = if final_head_sha == rc_sha
+                        candidate_fingerprint
+                      else
+                        shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: final_head_sha)
+                      end
+  return false unless final_fingerprint == fingerprint
+  return true if final_head_sha == rc_sha
+
+  commits_after_rc = release_branch_commits_after_rc_tag(
+    monorepo_root:, tag_sha: rc_sha, head_sha: final_head_sha
+  )
+  commits_after_rc[:status] == :non_runtime_only
+end
+
+def reuse_accepted_rc_shakaperf_evidence!(repo_slug:, monorepo_root:, ref:, head_sha:, record:)
+  stored = record.fetch("shakaperf")
+  run = refresh_shakaperf_release_gate_run!(repo_slug:, run: { "databaseId" => stored.fetch("run_id") })
+  unless valid_accelerated_rc_shakaperf_run_identity?(repo_slug:, run:, stored:, ref:)
+    puts "Accepted RC ShakaPerf evidence is not reusable (run identity changed); running the strict final gate."
+    return false
+  end
+  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  unless run["status"] == "completed" && run["conclusion"] == "success"
+    puts "Accepted RC ShakaPerf evidence is not reusable (workflow is no longer a successful terminal run): #{run_url}"
+    return false
+  end
+
+  release_started_at = shakaperf_release_gate_time(stored["release_started_at"])
+  unless release_started_at
+    puts "Accepted RC ShakaPerf evidence is not reusable (stored release start time is invalid): #{run_url}"
+    return false
+  end
+
+  rejection = shakaperf_release_gate_run_evidence_rejection(
+    repo_slug:,
+    monorepo_root:,
+    ref:,
+    head_sha:,
+    target_version: record.fetch("target_version"),
+    run:,
+    release_started_at:,
+    require_prerun: accelerated_rc_shakaperf_requires_prerun?(record)
+  )
+  if rejection
+    puts "Accepted RC ShakaPerf evidence is not reusable (#{rejection}): #{run_url}"
+    return false
+  end
+
+  puts "✓ Reusing accepted RC ShakaPerf evidence for runtime-equivalent final promotion: #{run_url}"
+  true
+rescue KeyError => e
+  puts "Accepted RC ShakaPerf evidence is not reusable (missing #{e.key.inspect}); running the strict final gate."
+  false
 end
 
 # Escape hatch: force the CI gate to evaluate origin/main HEAD verbatim instead
@@ -2784,6 +5135,90 @@ def normalized_ci_evidence(check_runs:, statuses:)
   { check_runs: deduplicate_ci_check_runs(check_runs), statuses: latest_commit_statuses(statuses) }
 end
 
+def accelerated_rc_ci_snapshot(sha:, repo_slug:, check_runs:, statuses:, required_names: nil, fail_on_failure: true)
+  checks_url = "https://github.com/#{repo_slug}/commit/#{sha}/checks"
+  runs = deduplicate_ci_check_runs(check_runs) +
+         latest_commit_statuses(statuses).map { |status| normalize_status_as_check_run(status) }
+  if runs.empty?
+    abort "❌ Accelerated RC publication's exact-head CI evidence is unknown (no checks or statuses returned)."
+  end
+  failed = runs.select do |run|
+    run["status"] == "completed" && !CI_PASSING_CONCLUSIONS.include?(run["conclusion"])
+  end
+  if failed.any? && fail_on_failure
+    lines = failed.map do |run|
+      run_url = run["html_url"].to_s.empty? ? checks_url : run["html_url"]
+      "- #{run['name']}: #{run['conclusion']}\n  #{run_url}"
+    end
+    abort "❌ Accelerated RC publication found known failed exact-head CI evidence:\n#{lines.join("\n")}"
+  end
+  validate_accelerated_rc_required_checks!(required_names:, check_runs:, statuses:) if failed.empty?
+
+  non_success = runs.filter_map do |run|
+    next if run["status"] == "completed" && run["conclusion"] == "success"
+
+    state = run["status"] == "completed" ? run["conclusion"] : run["status"]
+    {
+      name: run["name"],
+      state:,
+      url: run["html_url"].to_s.empty? ? checks_url : run["html_url"].to_s
+    }
+  end
+  non_success.sort_by! { |check| accelerated_rc_ci_check_sort_key(check) }
+  status = if failed.any?
+             "failed"
+           elsif runs.any? { |run| CI_INCOMPLETE_STATUSES.include?(run["status"]) }
+             "pending"
+           else
+             "success"
+           end
+
+  {
+    status:,
+    sha:,
+    checks_url:,
+    non_success:
+  }
+end
+
+def validate_accelerated_rc_required_checks!(required_names:, check_runs:, statuses:)
+  return unless required_names
+
+  legacy_status_runs = legacy_status_runs_for_required_contexts(required_checks: required_names, statuses:)
+  missing = missing_required_checks(required_checks: required_names, check_runs:, legacy_status_runs:)
+  return if missing[:count].zero?
+
+  abort "❌ Required exact-head CI checks have not appeared: #{missing[:labels].join(', ')}. " \
+        "Accelerated RC evidence remains incomplete."
+end
+
+def accelerated_rc_required_checks!(repo_slug:, monorepo_root:, ci_branch:)
+  required_names = required_check_names_for_branch(monorepo_root:, repo_slug:, ci_branch:)
+  return required_names unless required_names.equal?(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+  abort "❌ Required exact-head CI check discovery is unknown; accelerated RC publication remains blocked."
+end
+
+def fetch_accelerated_rc_ci_snapshot!(repo_slug:, sha:, monorepo_root: nil, ci_branch: nil, fail_on_failure: true)
+  check_result = fetch_ci_check_runs_for_sha(repo_slug:, sha:)
+  abort "#{check_result[:error]}\n\n❌ Accelerated RC exact-head CI evidence is unknown." if check_result[:error]
+
+  status_result = fetch_ci_statuses_for_sha(repo_slug:, sha:)
+  abort "#{status_result[:error]}\n\n❌ Accelerated RC exact-head CI evidence is unknown." if status_result[:error]
+
+  required_names = if monorepo_root && ci_branch
+                     accelerated_rc_required_checks!(repo_slug:, monorepo_root:, ci_branch:)
+                   end
+  accelerated_rc_ci_snapshot(
+    sha:,
+    repo_slug:,
+    check_runs: check_result.fetch(:check_runs),
+    statuses: status_result.fetch(:statuses),
+    required_names:,
+    fail_on_failure:
+  )
+end
+
 def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required_names:, is_prerelease:, ci_branch:,
                                  required_checks_known: true, target_gem_version: nil)
   return nil if head_sha.nil? || head_sha == evaluated_sha
@@ -2871,7 +5306,7 @@ def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required
 end
 
 def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dry_run:, ci_branch: "main",
-                             target_gem_version: nil)
+                             target_gem_version: nil, defer_pending: false)
   ensure_ci_status_override_is_prerelease!(allow_override:, is_prerelease:)
   puts "\nChecking CI status on origin/#{ci_branch}..."
 
@@ -2963,6 +5398,11 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
     sha:,
     ci_branch:
   )
+  if evaluation[:kind] == :in_progress && defer_pending && is_prerelease
+    puts "⚠️ ACCELERATED RC: deferring pending CI until post-publication reconciliation."
+    puts evaluation.fetch(:message)
+    return evaluation.merge(sha:)
+  end
   if evaluation[:kind] != :healthy
     message = evaluation[:message]
     if %i[no_checks no_required_checks].include?(evaluation[:kind]) && !statuses_fetched
@@ -3830,6 +6270,10 @@ Release CI policy:
   tag or published packages; retry from that commit or push a revert commit first.
   In-progress checks and failing gates block the release until they pass. An explicitly approved
   prerelease-only waiver may use the 4th argument or RELEASE_CI_STATUS_OVERRIDE=true.
+  An explicit RC may instead use the audited accelerated path to publish while only pending
+  exact-head CI and ShakaPerf gates finish. That path rejects known failures and unknown evidence,
+  records immutable candidate evidence on a maintainer-controlled release tracker, and must be
+  reconciled before final promotion. It never applies to stable/final releases.
 
 Environment variables:
   VERBOSE=1                    # Enable verbose logging (shows all output)
@@ -3837,6 +6281,9 @@ Environment variables:
   RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for both gems)
   RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
   RELEASE_CI_STATUS_OVERRIDE=true      # DANGEROUS prerelease-only release CI waiver
+  RELEASE_ACCELERATED_RC=true           # Enable audited pending-gate publication for an explicit RC
+  RELEASE_TRACKER=<issue>               # Active release tracker (required for accelerated RC/final promotion)
+  RELEASE_ACCELERATED_RC_REASON=<reason> # Single-line maintainer rationale for accelerated publication
   GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
 
 Examples:
@@ -3846,6 +6293,8 @@ Examples:
   rake release[major]                           # Bump major version (16.1.1 → 17.0.0)
   rake release[16.2.0]                          # Set explicit version
   rake release[16.2.0.beta.1]                   # Set pre-release version (→ 16.2.0-beta.1 for NPM)
+  RELEASE_ACCELERATED_RC=true RELEASE_TRACKER=<issue> RELEASE_ACCELERATED_RC_REASON=<reason> \
+    rake release[16.2.0.rc.1]                   # Publish an RC while named pending gates finish
   rake release[patch,true]                      # Dry run
   VERBOSE=1 rake release[patch]                 # Release with verbose logging
   NPM_OTP=123456 RUBYGEMS_OTP=789012 rake release[patch]  # Skip OTP prompts")
@@ -3875,6 +6324,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
 
   released_gem_version = nil
   released_npm_version = nil
+  accelerated_publication_record = nil
+  final_promotion_context = nil
   argumentless_starting_prerelease_version = if args_hash.fetch(:version, "").to_s.strip.empty?
                                                starting_version = current_gem_version(monorepo_root)
                                                starting_version if release_prerelease_version?(starting_version)
@@ -3899,10 +6350,50 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
     version_converter = ReactOnRails::VersionSyntaxConverter.new
     resolved_target_npm_version = version_converter.rubygem_to_npm(resolved_target_gem_version)
     is_prerelease = release_prerelease_version?(resolved_target_gem_version)
+    prerelease_tag_retry_state = :none
+    if is_prerelease
+      prerelease_tag_retry_state = release_tag_retry_state_for_current_head(
+        monorepo_root: release_root,
+        current_branch:,
+        current_checkout_version:,
+        target_gem_version: resolved_target_gem_version,
+        tag_type: "prerelease"
+      )
+    end
     allow_ci_status_override = ci_status_override_allowed_for_release!(
       override_flag: args_hash[:override_ci_status],
       is_prerelease:
     )
+    accelerated_rc_requested = release_truthy?(ENV.fetch("RELEASE_ACCELERATED_RC", nil))
+    accelerated_rc_same_candidate_retry = rc_prerelease_version?(resolved_target_gem_version) &&
+                                          current_checkout_version == resolved_target_gem_version
+    accelerated_rc_retry_probe = !accelerated_rc_requested && accelerated_rc_same_candidate_retry
+    repo_slug = github_repo_slug(release_root) if accelerated_rc_requested || accelerated_rc_retry_probe
+    accelerated_rc_options = resolve_accelerated_rc_options_for_release!(
+      requested: accelerated_rc_requested,
+      explicit_version_input: args_hash.fetch(:version, ""),
+      target_gem_version: resolved_target_gem_version,
+      tracker: ENV.fetch("RELEASE_TRACKER", nil),
+      reason: ENV.fetch("RELEASE_ACCELERATED_RC_REASON", nil),
+      allow_ci_override: allow_ci_status_override,
+      repo_slug:,
+      monorepo_root: release_root,
+      current_checkout_version:,
+      candidate_sha: accelerated_rc_same_candidate_retry ? current_git_sha!(release_root) : nil
+    )
+    if accelerated_rc_options && accelerated_rc_requested
+      preflight_explicit_accelerated_rc_target_tag!(
+        monorepo_root: release_root,
+        target_gem_version: resolved_target_gem_version,
+        current_checkout_version:
+      )
+    end
+    accelerated_approver = nil
+    if accelerated_rc_options
+      repo_slug ||= github_repo_slug(release_root)
+      fetch_release_tracker_issue!(repo_slug:, tracker: accelerated_rc_options.fetch(:tracker))
+      accelerated_approver = current_release_approver!(repo_slug:)
+    end
 
     # When cutting an rc from `main` and `release/X.Y.Z` does not yet exist, offer
     # to start the release line here instead of tagging the rc off `main`. If the
@@ -3949,6 +6440,17 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
         target_gem_version: resolved_target_gem_version
       )
     end
+    release_branch_final_promotion = !is_prerelease && current_branch == "release/#{resolved_target_gem_version}"
+    accepted_rc_record = nil
+    if release_branch_final_promotion
+      rc_tag = release_branch_promotion.fetch(:rc_tag)
+      accepted_rc_record = accepted_accelerated_rc_record_for_release_branch_promotion!(
+        monorepo_root: release_root,
+        rc_tag:,
+        final_head_sha: current_git_sha!(release_root),
+        tracker_input: ENV.fetch("RELEASE_TRACKER", nil)
+      )
+    end
 
     # Validate the tip of the branch we are actually releasing from: the
     # release/X.Y.Z tip for an RC cut or final promotion, otherwise origin/main.
@@ -3961,16 +6463,6 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
         current_branch:,
         current_checkout_version:,
         target_gem_version: resolved_target_gem_version
-      )
-    end
-    prerelease_tag_retry_state = :none
-    if is_prerelease
-      prerelease_tag_retry_state = release_tag_retry_state_for_current_head(
-        monorepo_root: release_root,
-        current_branch:,
-        current_checkout_version:,
-        target_gem_version: resolved_target_gem_version,
-        tag_type: "prerelease"
       )
     end
     idempotent_publish_retry = release_branch_promotion.fetch(:stable_tag_retry) ||
@@ -3986,10 +6478,10 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       allow_override: allow_ci_status_override,
       dry_run: is_dry_run,
       ci_branch:,
-      target_gem_version: resolved_target_gem_version
+      target_gem_version: resolved_target_gem_version,
+      defer_pending: !accelerated_rc_options.nil?
     )
 
-    release_branch_final_promotion = !is_prerelease && current_branch == "release/#{resolved_target_gem_version}"
     validate_release_version_policy!(
       monorepo_root: release_root,
       target_gem_version: resolved_target_gem_version,
@@ -4092,26 +6584,55 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
 
       # Push the version-bump commit first so the workflow_dispatch run can be matched by headSha.
       sh_in_dir_for_release(release_root, "LEFTHOOK=0 git push")
-      run_shakaperf_release_gate!(
-        monorepo_root: release_root,
-        ref: current_branch,
-        head_sha: current_git_sha!(release_root),
-        target_version: actual_gem_version,
-        release_started_at:,
-        allow_override: allow_ci_status_override,
-        dry_run: is_dry_run
-      )
-
+      release_candidate_sha = current_git_sha!(release_root)
+      validated_release_candidate_sha = release_candidate_sha
       tag_name = "v#{actual_gem_version}"
-      tag_exists = system("git", "-C", release_root, "rev-parse", "--verify", "--quiet", "refs/tags/#{tag_name}",
-                          out: File::NULL, err: File::NULL)
-      if tag_exists
-        puts "Git tag #{tag_name} already exists, skipping tag creation"
+      if accelerated_rc_options
+        accelerated_publication_record = authorize_accelerated_rc_publication!(
+          repo_slug:,
+          monorepo_root: release_root,
+          release_branch: current_branch,
+          candidate_sha: release_candidate_sha,
+          options: accelerated_rc_options,
+          approver: accelerated_approver,
+          release_started_at:,
+          tag: tag_name
+        )
+      elsif accepted_rc_record
+        final_promotion_context = run_accepted_rc_final_promotion_gates!(
+          repo_slug: github_repo_slug(release_root),
+          monorepo_root: release_root,
+          current_branch:,
+          rc_tag:,
+          tracker_input: ENV.fetch("RELEASE_TRACKER", nil),
+          final_head_sha: release_candidate_sha,
+          record: accepted_rc_record,
+          target_version: actual_gem_version,
+          release_started_at:,
+          allow_ci_override: allow_ci_status_override,
+          dry_run: is_dry_run
+        )
+        validated_release_candidate_sha = final_promotion_context.fetch(:candidate_sha)
+        accepted_rc_record = final_promotion_context.fetch(:record)
       else
-        sh_in_dir_for_release(release_root, "git tag #{tag_name}")
+        run_shakaperf_release_gate!(
+          monorepo_root: release_root,
+          ref: current_branch,
+          head_sha: release_candidate_sha,
+          target_version: actual_gem_version,
+          release_started_at:,
+          allow_override: allow_ci_status_override,
+          dry_run: is_dry_run
+        )
       end
 
-      sh_in_dir_for_release(release_root, "LEFTHOOK=0 git push --tags")
+      push_release_tag_for_candidate!(
+        monorepo_root: release_root,
+        tag: tag_name,
+        candidate_sha: validated_release_candidate_sha,
+        accelerated_boundary_record: accelerated_publication_record || accepted_rc_record,
+        accelerated_final_promotion_context: final_promotion_context
+      )
 
       puts "\n#{'=' * 80}"
       puts "Publishing PUBLIC packages to npmjs.org..."
@@ -4219,6 +6740,21 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
     puts "\nTo actually release, run: rake release[#{released_gem_version}]"
   else
     sync_github_release_after_publish(monorepo_root:, gem_version: released_gem_version, dry_run: false)
+    if accelerated_publication_record
+      repo_slug = github_repo_slug(monorepo_root)
+      tracker = accelerated_publication_record.fetch("release_tracker")
+      fetch_release_tracker_issue!(repo_slug:, tracker:)
+      record_accelerated_rc_publication_complete!(
+        repo_slug:,
+        tracker:,
+        authorized_record: accelerated_publication_record,
+        recorded_at: Time.now.utc,
+        approved_by: accelerated_approver
+      )
+      puts "⚠️ RC published with gates still reconciling. Before final promotion, run:"
+      puts "  RELEASE_TRACKER=#{tracker} bundle exec rake " \
+           "\"release:reconcile_accelerated_rc[#{released_gem_version}]\""
+    end
 
     changelog_path = File.join(monorepo_root, "CHANGELOG.md")
     has_changelog_section = extract_changelog_section(changelog_path:, version: released_gem_version)
@@ -4330,6 +6866,35 @@ end
 
 # rubocop:disable Metrics/BlockLength
 namespace :release do
+  desc("Reconcile an accelerated RC's deferred gates and record an accepted or rejected tracker state.")
+  task :reconcile_accelerated_rc, [:version] do |_t, args|
+    monorepo_root = current_monorepo_root
+    target_version = args[:version].to_s.strip
+    abort "❌ Accelerated RC reconciliation requires an explicit RC version." if target_version.empty?
+    validate_canonical_accelerated_rc_target!(target_version)
+
+    tracker_input = ENV.fetch("RELEASE_TRACKER", nil)
+    unless tracker_input.to_s.match?(/\A[1-9]\d*\z/)
+      abort "❌ Accelerated RC reconciliation requires RELEASE_TRACKER=<active issue number>."
+    end
+
+    reason = ENV.fetch("RELEASE_ACCELERATED_RC_RECONCILIATION_REASON", nil)
+    evidence = {
+      "demo_fleet" => ENV.fetch("RELEASE_DEMO_FLEET_EVIDENCE_URL", nil),
+      "behavioral" => ENV.fetch("RELEASE_BEHAVIORAL_EVIDENCE_URL", nil),
+      "artifacts" => ENV.fetch("RELEASE_ARTIFACT_EVIDENCE_URL", nil)
+    }
+    verify_gh_auth(monorepo_root:)
+    run_accelerated_rc_reconciliation!(
+      repo_slug: github_repo_slug(monorepo_root),
+      monorepo_root:,
+      tracker: tracker_input.to_i,
+      target_version:,
+      reason:,
+      evidence:
+    )
+  end
+
   desc("Start a release line: create + push release/X.Y.Z from origin/main, then stop for CI.
 
 Cuts the ephemeral release branch the release train stabilizes on. It does NOT tag rc.0 — the

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2435,16 +2435,10 @@ def fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
     login = comment.dig("user", "login").to_s
     abort "❌ Accelerated RC tracker record has no attributable GitHub author." if login.empty?
 
-    permission = permissions.fetch(login) do
-      output, status = capture_gh_output(
-        "api", "repos/#{repo_slug}/collaborators/#{login}/permission", "--jq", ".permission"
-      )
-      unless status.success?
-        abort "❌ Unable to verify the repository permission of accelerated RC record author #{login}.\n\n#{output}"
-      end
-      permissions[login] = output.strip
-    end
-    validate_release_approver!(login:, permission:)
+    permission = accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
+    permission_class = accelerated_rc_repository_permission_class!(permission:, login:)
+    next [] if permission_class == :non_maintainer
+
     accelerated_rc_records_from_trusted_comment!(comment:, login:)
   end
 
@@ -3394,13 +3388,6 @@ def accelerated_rc_authorization_without_history!(monorepo_root:, tag:, tag_exis
         "repository tracker chain is missing."
 end
 
-def accelerated_rc_single_retry_tracker!(candidate_records)
-  trackers = candidate_records.map { |record| record["release_tracker"] }.uniq
-  abort "❌ Accelerated RC retry history is bound to conflicting release trackers." unless trackers.one?
-
-  trackers.first
-end
-
 def validate_accelerated_rc_retry_tag_authorization!(candidate_records:, authorization:, tag_exists:, tracker:,
                                                      target_version:, candidate_sha:, monorepo_root:, tag:)
   return unless tag_exists
@@ -3414,33 +3401,11 @@ def validate_accelerated_rc_retry_tag_authorization!(candidate_records:, authori
   abort "❌ Existing RC tag references a noncanonical accelerated publication authorization."
 end
 
-def accelerated_rc_publication_authorization_for_retry!(repo_slug:, tracker:, target_version:, candidate_sha:,
-                                                        monorepo_root:, tag:)
-  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
-  candidate_records = accelerated_rc_records_for_candidate(records, target_version:, candidate_sha:)
-  abort_if_accelerated_rc_retry_rejected!(candidate_records)
-  authorizations = candidate_records.select { |record| record["status"] == "publication-authorized" }
-  authorization = if local_release_tag_exists?(monorepo_root:, tag:)
-                    accelerated_rc_tagged_authorization_for_retry!(
-                      authorizations:, tracker:, target_version:, candidate_sha:, monorepo_root:, tag:
-                    )
-                  elsif candidate_records.any?
-                    canonical_accelerated_rc_authorization_for_retry!(authorizations)
-                  end
-  return nil unless authorization
-
-  validate_accelerated_rc_retry_chain!(candidate_records, authorization)
-end
-
 def abort_if_accelerated_rc_retry_rejected!(candidate_records)
   terminal = validated_accelerated_rc_terminal_set!(candidate_records)
   return unless terminal && terminal["status"] == "candidate-rejected"
 
   abort "❌ Accelerated RC retry is blocked because this immutable candidate was permanently rejected."
-end
-
-def canonical_accelerated_rc_authorization_for_retry!(authorizations)
-  validated_accelerated_rc_authorization_set!(authorizations)
 end
 
 def validated_accelerated_rc_authorization_set!(candidate_records, selected_authorization: nil)
@@ -3455,12 +3420,6 @@ def validated_accelerated_rc_authorization_set!(candidate_records, selected_auth
   end
 
   selected_authorization || authorizations.first
-end
-
-def validate_accelerated_rc_retry_chain!(candidate_records, authorization)
-  validated_accelerated_rc_candidate_chain!(
-    candidate_records, selected_authorization: authorization
-  ).fetch(:authorization)
 end
 
 def accelerated_rc_tagged_authorization_for_retry!(authorizations:, tracker:, target_version:, candidate_sha:,

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2584,7 +2584,13 @@ def valid_accelerated_rc_tracker_record?(record)
   valid_accelerated_rc_identity?(record) && valid_accelerated_rc_audit_metadata?(record) &&
     valid_accelerated_rc_ci_record?(record["ci"], record["candidate_sha"]) &&
     valid_accelerated_rc_shakaperf_record?(record["shakaperf"], record["target_version"]) &&
+    valid_accelerated_rc_deferred_shakaperf_candidate?(record) &&
     valid_accelerated_rc_state?(record)
+end
+
+def valid_accelerated_rc_deferred_shakaperf_candidate?(record)
+  shakaperf = record.fetch("shakaperf")
+  shakaperf["status"] != "pending" || shakaperf["candidate_sha"] == record.fetch("candidate_sha")
 end
 
 def accelerated_rc_exact_keys?(value, expected_keys)
@@ -4216,6 +4222,11 @@ def accelerated_rc_shakaperf_snapshot!(repo_slug:, monorepo_root:, record:)
     repo_slug:, run:, stored:, ref: record.fetch("release_branch")
   )
   if active_shakaperf_release_gate_run?(run)
+    if accelerated_rc_shakaperf_requires_prerun?(record)
+      abort "❌ Pending ShakaPerf evidence must match the exact RC candidate; " \
+            "a different-SHA pre-run must complete and pass live mechanical verification."
+    end
+
     return stored.merge("status" => "pending", "run_id" => run.fetch("databaseId"), "run_url" => run_url)
   end
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -96,6 +96,10 @@ SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS = %w[
   action_required cancelled failure neutral skipped stale startup_failure success timed_out
 ].freeze
 SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES = %w[queued in_progress requested waiting pending].freeze
+SHAKAPERF_RELEASE_GATE_CANONICAL_VERSION_PATTERN =
+  /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.rc\.(?:0|[1-9]\d*))?\z/
+SHAKAPERF_RELEASE_GATE_DISPLAY_TITLE_PATTERN =
+  /\AShakaPerf Release Gates — (?<target_version>.+) on (?<ref>.+) @ (?<head_sha>[0-9a-f]{40})\z/
 SHAKAPERF_RELEASE_GATE_EVIDENCE_KEYS = %w[
   branch
   candidate_sha
@@ -753,6 +757,65 @@ def wait_for_shakaperf_release_gate_run!(repo_slug:, ref:, head_sha:, target_ver
   )
 end
 
+def accelerated_shakaperf_polling_target_runs!(runs:, ref:, target_version:)
+  collapse_accelerated_shakaperf_run_duplicates!(runs).filter_map do |run|
+    case accelerated_shakaperf_run_target_classification(run:, ref:, target_version:)
+    when :target
+      run
+    when :unrelated
+      nil
+    else
+      abort "❌ Accelerated RC ShakaPerf polling target identity is unknown or malformed; " \
+            "refusing unaudited publication."
+    end
+  end
+end
+
+def accelerated_shakaperf_fresh_polling_run!(
+  runs:, repo_slug:, ref:, head_sha:, target_version:, ignored_run_ids:, earliest_created_at:
+)
+  unless runs.is_a?(Array)
+    abort "❌ Accelerated RC ShakaPerf polling collection is unknown or malformed; " \
+          "refusing unaudited publication."
+  end
+
+  runs.each { |run| validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:) }
+  target_runs = accelerated_shakaperf_polling_target_runs!(runs:, ref:, target_version:)
+  fresh_runs = target_runs.select do |run|
+    shakaperf_release_gate_run_matches_target?(run:, ref:, head_sha:, target_version:) &&
+      !ignored_run_ids.include?(run["databaseId"].to_s) &&
+      shakaperf_release_gate_run_created_after?(run, earliest_created_at)
+  end
+  if fresh_runs.length > 1
+    abort "❌ Accelerated RC ShakaPerf polling returned ambiguous concurrent fresh runs; " \
+          "refusing unaudited publication."
+  end
+
+  fresh_runs.first
+end
+
+def wait_for_accelerated_shakaperf_release_gate_run!(repo_slug:, ref:, head_sha:, target_version:,
+                                                     ignored_run_ids: [], earliest_created_at: nil)
+  deadline = Time.now + SHAKAPERF_RELEASE_GATE_START_TIMEOUT_SECONDS
+  ignored_run_ids = ignored_run_ids.map(&:to_s)
+
+  loop do
+    runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
+    fresh_run = accelerated_shakaperf_fresh_polling_run!(
+      runs:, repo_slug:, ref:, head_sha:, target_version:, ignored_run_ids:, earliest_created_at:
+    )
+    return fresh_run if fresh_run
+
+    break if Time.now >= deadline
+
+    sleep SHAKAPERF_RELEASE_GATE_START_POLL_SECONDS
+  end
+
+  handle_shakaperf_release_gate_violation!(
+    message: "❌ Timed out waiting for accelerated ShakaPerf release gate workflow to start for #{head_sha[0, 8]}."
+  )
+end
+
 def shakaperf_release_gate_display_title(ref:, head_sha:, target_version:)
   "ShakaPerf Release Gates — #{target_version} on #{ref} @ #{head_sha}"
 end
@@ -760,6 +823,33 @@ end
 def shakaperf_release_gate_run_matches_target?(run:, ref:, head_sha:, target_version:)
   run["headSha"] == head_sha && positive_github_id?(run["attempt"]) &&
     run["displayTitle"] == shakaperf_release_gate_display_title(ref:, head_sha:, target_version:)
+end
+
+def shakaperf_release_gate_canonical_title_identity(run)
+  return nil unless run.is_a?(Hash) && run["headSha"].is_a?(String)
+
+  match = SHAKAPERF_RELEASE_GATE_DISPLAY_TITLE_PATTERN.match(run["displayTitle"].to_s)
+  return nil unless match && match[:head_sha] == run["headSha"]
+
+  title_target = match[:target_version]
+  title_ref = match[:ref]
+  return nil unless title_target.match?(SHAKAPERF_RELEASE_GATE_CANONICAL_VERSION_PATTERN)
+
+  target_base = title_target.split(".").first(3).join(".")
+  return nil unless title_ref == "release/#{target_base}"
+
+  { target_version: title_target, ref: title_ref, head_sha: match[:head_sha] }
+end
+
+def accelerated_shakaperf_run_target_classification(run:, ref:, target_version:)
+  identity = shakaperf_release_gate_canonical_title_identity(run)
+  return :unknown unless identity
+
+  if identity.fetch(:ref) == ref && identity.fetch(:target_version) == target_version
+    :target
+  else
+    :unrelated
+  end
 end
 
 def active_shakaperf_release_gate_run?(run)
@@ -807,7 +897,7 @@ def find_latest_shakaperf_release_gate_run(runs, head_sha, ref: nil, target_vers
   matching_runs.max_by { |run| shakaperf_release_gate_run_sort_key(run) }
 end
 
-def find_latest_shakaperf_prerun(runs, head_sha, ref: nil, target_version: nil)
+def shakaperf_prerun_candidates(runs, head_sha, ref: nil, target_version: nil)
   candidates = runs.reject { |run| run["headSha"] == head_sha }
   if target_version
     candidates = candidates.select do |run|
@@ -816,9 +906,98 @@ def find_latest_shakaperf_prerun(runs, head_sha, ref: nil, target_version: nil)
       )
     end
   end
+
+  candidates
+end
+
+def find_latest_shakaperf_prerun(runs, head_sha, ref: nil, target_version: nil)
+  candidates = shakaperf_prerun_candidates(runs, head_sha, ref:, target_version:)
   return nil unless candidates.all? { |run| valid_shakaperf_prerun_ordering_metadata?(run) }
 
   candidates.max_by { |run| shakaperf_prerun_candidate_sort_key(run) }
+end
+
+def collapse_accelerated_shakaperf_run_duplicates!(runs)
+  identities = {}
+  runs.each_with_object([]) do |run, unique_runs|
+    abort "❌ Accelerated RC ShakaPerf run identity is unknown or malformed." unless run.is_a?(Hash)
+
+    identity = [run["databaseId"], run["attempt"]]
+    unless identity.all? { |value| positive_github_id?(value) }
+      unique_runs << run
+      next
+    end
+
+    existing = identities[identity]
+    if existing
+      unless existing == run
+        abort "❌ Accelerated RC ShakaPerf duplicate run identity is conflicting; refusing unaudited publication."
+      end
+      next
+    end
+
+    identities[identity] = run
+    unique_runs << run
+  end
+end
+
+def valid_shakaperf_release_gate_ordering_metadata?(run)
+  valid_identity_and_times = positive_github_id?(run["databaseId"]) &&
+                             positive_github_id?(run["attempt"]) &&
+                             !shakaperf_release_gate_time(run["createdAt"]).nil? &&
+                             !shakaperf_release_gate_time(run["updatedAt"]).nil?
+  return false unless valid_identity_and_times
+
+  if SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES.include?(run["status"])
+    run["startedAt"].nil? || !shakaperf_release_gate_time(run["startedAt"]).nil?
+  else
+    !shakaperf_release_gate_time(run["startedAt"]).nil?
+  end
+end
+
+def accelerated_shakaperf_candidate_selection!(runs, exact_head:)
+  if exact_head
+    ordering_validator = method(:valid_shakaperf_release_gate_ordering_metadata?)
+    sort_key = method(:shakaperf_release_gate_run_sort_key)
+  else
+    ordering_validator = method(:valid_accelerated_shakaperf_prerun_ordering_metadata?)
+    sort_key = method(:shakaperf_prerun_candidate_sort_key)
+  end
+  ordered, unordered = runs.partition { |run| ordering_validator.call(run) }
+  ordered.group_by { |run| sort_key.call(run) }.each_value do |same_key_runs|
+    next if same_key_runs.one?
+
+    abort "❌ Accelerated RC ShakaPerf equal ordering keys are conflicting; refusing unaudited publication."
+  end
+
+  { run: ordered.max_by { |run| sort_key.call(run) }, unordered_runs: unordered }
+end
+
+def accelerated_shakaperf_run_selection!(runs, head_sha, repo_slug:, ref:, target_version:)
+  unless runs.is_a?(Array)
+    abort "❌ Accelerated RC ShakaPerf run collection is unknown or malformed; refusing unaudited publication."
+  end
+
+  runs.each { |run| validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:) }
+  unique_runs = collapse_accelerated_shakaperf_run_duplicates!(runs)
+  relevant_runs = unique_runs.filter_map do |run|
+    case accelerated_shakaperf_run_target_classification(run:, ref:, target_version:)
+    when :target
+      run
+    when :unrelated
+      nil
+    else
+      abort "❌ Accelerated RC ShakaPerf target identity is unknown or malformed; refusing unaudited publication."
+    end
+  end
+  exact_runs, preruns = relevant_runs.partition { |run| run["headSha"] == head_sha }
+  exact_selection = accelerated_shakaperf_candidate_selection!(exact_runs, exact_head: true)
+  prerun_selection = accelerated_shakaperf_candidate_selection!(preruns, exact_head: false)
+  {
+    exact_run: exact_selection.fetch(:run),
+    prerun: prerun_selection.fetch(:run),
+    unordered_runs: exact_selection.fetch(:unordered_runs) + prerun_selection.fetch(:unordered_runs)
+  }
 end
 
 def valid_shakaperf_prerun_ordering_metadata?(run)
@@ -826,6 +1005,11 @@ def valid_shakaperf_prerun_ordering_metadata?(run)
     positive_github_id?(run["attempt"]) &&
     !shakaperf_release_gate_time(run["createdAt"]).nil? &&
     !shakaperf_release_gate_time(run["startedAt"]).nil?
+end
+
+def valid_accelerated_shakaperf_prerun_ordering_metadata?(run)
+  valid_shakaperf_prerun_ordering_metadata?(run) &&
+    !shakaperf_release_gate_time(run["updatedAt"]).nil?
 end
 
 def shakaperf_prerun_candidate_sort_key(run)
@@ -1137,29 +1321,50 @@ end
 def run_accelerated_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, target_version:, release_started_at:)
   repo_slug = github_repo_slug(monorepo_root)
   existing_runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
-  existing_run = find_latest_shakaperf_release_gate_run(existing_runs, head_sha, ref:, target_version:)
-  if existing_run && active_shakaperf_release_gate_run?(existing_run)
+  selection = accelerated_shakaperf_run_selection!(existing_runs, head_sha, repo_slug:, ref:, target_version:)
+  unordered_states = selection.fetch(:unordered_runs).map do |unordered_run|
+    accelerated_shakaperf_run_state!(repo_slug:, run: unordered_run, unordered: true)
+  end
+  force_exact_head_dispatch = unordered_states.include?(:dispatch)
+  existing_snapshot = selected_accelerated_shakaperf_snapshot(
+    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, release_started_at:, selection:,
+    force_exact_head_dispatch:
+  )
+  return existing_snapshot if existing_snapshot.is_a?(Hash)
+
+  dispatch_accelerated_shakaperf_release_gate!(
+    repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
+  )
+end
+
+def selected_accelerated_shakaperf_snapshot(repo_slug:, monorepo_root:, ref:, head_sha:, target_version:,
+                                            release_started_at:, selection:, force_exact_head_dispatch:)
+  existing_run = selection.fetch(:exact_run)
+  exact_state = accelerated_shakaperf_run_state!(repo_slug:, run: existing_run, unordered: false)
+  return nil if force_exact_head_dispatch && exact_state != :none
+
+  if exact_state == :active
     return accelerated_shakaperf_snapshot(
       repo_slug:, run: existing_run, ref:, candidate_sha: head_sha, target_version:, release_started_at:,
       status: "pending"
     )
   end
-  exact_snapshot = verified_accelerated_shakaperf_snapshot(
-    repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: existing_run,
-    release_started_at:, require_prerun: false, candidate_sha: head_sha
-  )
-  return exact_snapshot if exact_snapshot
+  if exact_state == :success
+    exact_snapshot = verified_accelerated_shakaperf_snapshot(
+      repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: existing_run,
+      release_started_at:, require_prerun: false, candidate_sha: head_sha
+    )
+    return exact_snapshot if exact_snapshot
+  end
 
-  reject_known_accelerated_shakaperf_failure!(repo_slug:, run: existing_run)
-  prerun = find_latest_shakaperf_prerun(existing_runs, head_sha, ref:, target_version:)
-  prerun_snapshot = verified_accelerated_shakaperf_snapshot(
+  prerun = selection.fetch(:prerun)
+  prerun_state = accelerated_shakaperf_run_state!(repo_slug:, run: prerun, unordered: false)
+  return nil if force_exact_head_dispatch
+  return unless prerun_state == :success
+
+  verified_accelerated_shakaperf_snapshot(
     repo_slug:, monorepo_root:, ref:, head_sha:, target_version:, run: prerun,
-    release_started_at:, require_prerun: true, candidate_sha: prerun&.fetch("headSha", nil)
-  )
-  return prerun_snapshot if prerun_snapshot
-
-  dispatch_accelerated_shakaperf_release_gate!(
-    repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:, release_started_at:
+    release_started_at:, require_prerun: true, candidate_sha: prerun.fetch("headSha")
   )
 end
 
@@ -1168,7 +1373,7 @@ def dispatch_accelerated_shakaperf_release_gate!(repo_slug:, monorepo_root:, ref
   existing_run_ids = existing_runs.map { |run| run["databaseId"].to_s }
   dispatch_started_at = shakaperf_release_gate_dispatch_started_at
   dispatch_shakaperf_release_gate_workflow!(repo_slug:, ref:, target_version:, candidate_sha: head_sha)
-  run = wait_for_shakaperf_release_gate_run!(
+  run = wait_for_accelerated_shakaperf_release_gate_run!(
     repo_slug:,
     ref:,
     head_sha:,
@@ -1176,6 +1381,7 @@ def dispatch_accelerated_shakaperf_release_gate!(repo_slug:, monorepo_root:, ref
     ignored_run_ids: existing_run_ids,
     earliest_created_at: dispatch_started_at
   )
+  validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:)
 
   if run["status"] == "completed"
     reject_known_accelerated_shakaperf_failure!(repo_slug:, run:)
@@ -1213,11 +1419,12 @@ end
 
 def accelerated_shakaperf_snapshot(repo_slug:, run:, ref:, candidate_sha:, target_version:, release_started_at:,
                                    status:)
-  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:)
+  run_url = run.fetch("url")
   started_at = shakaperf_release_gate_time(release_started_at)
-  unless positive_github_id?(run["databaseId"]) && run["headSha"] == candidate_sha &&
+  unless run["headSha"] == candidate_sha &&
          shakaperf_release_gate_run_matches_target?(run:, ref:, head_sha: candidate_sha, target_version:) &&
-         %w[pending success].include?(status) && valid_accelerated_rc_https_url?(run_url) && started_at
+         %w[pending success].include?(status) && started_at
     abort "❌ Accelerated RC ShakaPerf run identity is unknown or malformed; refusing unaudited publication."
   end
 
@@ -1233,14 +1440,87 @@ def accelerated_shakaperf_snapshot(repo_slug:, run:, ref:, candidate_sha:, targe
 end
 
 def reject_known_accelerated_shakaperf_failure!(repo_slug:, run:)
-  return unless run&.fetch("status", nil) == "completed" && run["conclusion"] != "success"
+  return unless run.is_a?(Hash) && run["status"] == "completed" && run["conclusion"] != "success"
 
-  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:)
+  run_url = run.fetch("url")
   unless SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(run["conclusion"])
     abort "❌ Accelerated RC ShakaPerf result is unknown; refusing unaudited publication: #{run_url}"
   end
 
   abort "❌ Accelerated RC publication found a known ShakaPerf failure (#{run['conclusion']}): #{run_url}"
+end
+
+def accelerated_shakaperf_run_state!(repo_slug:, run:, unordered:)
+  return :none unless run
+
+  validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:)
+
+  status = run["status"]
+  conclusion = run["conclusion"]
+  if status == "completed"
+    return unordered ? :ignore : :success if conclusion == "success"
+
+    reject_known_accelerated_shakaperf_failure!(repo_slug:, run:)
+  elsif SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES.include?(status)
+    active_shakaperf_release_gate_run?(run)
+    return unordered ? :dispatch : :active
+  end
+
+  abort "❌ Accelerated RC ShakaPerf run state is unknown or malformed; refusing unaudited publication."
+end
+
+def validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:)
+  return run if valid_accelerated_shakaperf_run_metadata?(repo_slug:, run:)
+
+  abort "❌ Accelerated RC ShakaPerf run identity, URL, state, or timestamp metadata is malformed; " \
+        "refusing unaudited publication."
+end
+
+def valid_accelerated_shakaperf_run_metadata?(repo_slug:, run:)
+  return false unless run.is_a?(Hash)
+
+  valid_accelerated_shakaperf_run_identity_metadata?(repo_slug:, run:) &&
+    valid_accelerated_shakaperf_run_state_metadata?(run) &&
+    valid_accelerated_shakaperf_run_timestamp_metadata?(run)
+end
+
+def valid_accelerated_shakaperf_run_identity_metadata?(repo_slug:, run:)
+  run_id = run["databaseId"]
+  positive_github_id?(run_id) && positive_github_id?(run["attempt"]) &&
+    valid_accelerated_shakaperf_run_url?(repo_slug:, run_id:, url: run["url"])
+end
+
+def valid_accelerated_shakaperf_run_state_metadata?(run)
+  status = run["status"]
+  conclusion = run["conclusion"]
+  return SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(conclusion) if status == "completed"
+
+  SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES.include?(status) && conclusion.nil?
+end
+
+def valid_accelerated_shakaperf_run_timestamp_metadata?(run)
+  created_at = accelerated_shakaperf_api_timestamp(run["createdAt"])
+  updated_at = accelerated_shakaperf_api_timestamp(run["updatedAt"])
+  return false unless created_at && updated_at && created_at <= updated_at
+
+  started_at_value = run["startedAt"]
+  return run["status"] == "queued" if started_at_value.nil?
+
+  started_at = accelerated_shakaperf_api_timestamp(started_at_value)
+  started_at && created_at <= started_at && started_at <= updated_at
+end
+
+def accelerated_shakaperf_api_timestamp(value)
+  return nil unless value.is_a?(String)
+
+  shakaperf_release_gate_time(value)
+end
+
+def valid_accelerated_shakaperf_run_url?(repo_slug:, run_id:, url:)
+  repo_slug.is_a?(String) && repo_slug.match?(%r{\A[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\z}) &&
+    positive_github_id?(run_id) &&
+    url == "https://github.com/#{repo_slug}/actions/runs/#{run_id}"
 end
 
 def run_release_preflight_checks!(monorepo_root:, dry_run:)
@@ -2534,21 +2814,37 @@ rescue ArgumentError, JSON::ParserError
   nil
 end
 
+def valid_accelerated_rc_comment_schema_shape?(comment)
+  comment.is_a?(Hash) &&
+    comment["id"].is_a?(Integer) && comment["id"].positive? &&
+    comment["body"].is_a?(String) &&
+    comment["created_at"].is_a?(String) &&
+    comment["updated_at"].is_a?(String)
+end
+
+def accelerated_rc_comment_timestamps!(comment)
+  created_at = Time.iso8601(comment.fetch("created_at"))
+  updated_at = Time.iso8601(comment.fetch("updated_at"))
+  if accelerated_rc_machine_marker_comment?(comment) && updated_at != created_at
+    abort "❌ Edited accelerated RC marker comment detected; durable history must remain append-only."
+  end
+
+  [created_at, updated_at]
+end
+
 def validate_accelerated_rc_comment_schema!(comment:, repo_slug:)
-  valid = comment.is_a?(Hash) &&
-          comment["id"].is_a?(Integer) && comment["id"].positive? &&
-          comment["body"].is_a?(String) &&
-          comment["created_at"].is_a?(String)
-  abort "❌ Accelerated RC comment page contains an invalid comment schema." unless valid
+  unless valid_accelerated_rc_comment_schema_shape?(comment)
+    abort "❌ Accelerated RC comment page contains an invalid comment schema."
+  end
 
   tracker = release_tracker_number_from_repository_comment_issue_url!(
     issue_url: comment["issue_url"], repo_slug:
   )
-  created_at = Time.iso8601(comment.fetch("created_at"))
+  created_at, updated_at = accelerated_rc_comment_timestamps!(comment)
 
-  # GitHub can retain an ordinary comment after its author is deleted. Marker records still require
-  # an attributable trusted author later, but markerless comments need only this safe structural schema.
-  { id: comment.fetch("id"), tracker:, created_at: }
+  # Every API comment needs trustworthy chronology. GitHub can retain an ordinary comment after its author is deleted;
+  # marker records additionally must be unedited and require an attributable trusted author later.
+  { id: comment.fetch("id"), tracker:, created_at:, updated_at: }
 rescue ArgumentError
   abort "❌ Accelerated RC comment page contains an invalid comment schema."
 end
@@ -3966,21 +4262,24 @@ def verified_accelerated_rc_shakaperf_success_snapshot!(repo_slug:, monorepo_roo
 end
 
 def validated_accelerated_rc_shakaperf_run_url!(repo_slug:, run:, stored:, ref:)
+  validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:)
   unless valid_accelerated_rc_shakaperf_run_identity?(repo_slug:, run:, stored:, ref:)
     abort "❌ Refreshed ShakaPerf run identity is unknown or malformed; reconciliation remains blocked."
   end
 
-  shakaperf_release_gate_run_url(repo_slug:, run:)
+  run.fetch("url")
 end
 
 def valid_accelerated_rc_shakaperf_run_identity?(repo_slug:, run:, stored:, ref:)
-  return false unless run.is_a?(Hash) && positive_github_id?(run["databaseId"])
+  return false unless stored.is_a?(Hash) && valid_accelerated_shakaperf_run_metadata?(repo_slug:, run:)
+  return false unless valid_accelerated_shakaperf_run_url?(
+    repo_slug:, run_id: stored["run_id"], url: stored["run_url"]
+  )
 
-  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
   run["databaseId"] == stored["run_id"] && run["attempt"] == stored["attempt"] &&
     shakaperf_release_gate_run_matches_target?(
       run:, ref:, head_sha: stored["candidate_sha"], target_version: stored["target_version"]
-    ) && valid_accelerated_rc_https_url?(run_url)
+    )
 end
 
 def accelerated_rc_shakaperf_requires_prerun?(record)
@@ -4571,11 +4870,12 @@ end
 def reuse_accepted_rc_shakaperf_evidence!(repo_slug:, monorepo_root:, ref:, head_sha:, record:)
   stored = record.fetch("shakaperf")
   run = refresh_shakaperf_release_gate_run!(repo_slug:, run: { "databaseId" => stored.fetch("run_id") })
+  validate_accelerated_shakaperf_run_metadata!(repo_slug:, run:)
   unless valid_accelerated_rc_shakaperf_run_identity?(repo_slug:, run:, stored:, ref:)
     puts "Accepted RC ShakaPerf evidence is not reusable (run identity changed); running the strict final gate."
     return false
   end
-  run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  run_url = run.fetch("url")
   unless run["status"] == "completed" && run["conclusion"] == "success"
     puts "Accepted RC ShakaPerf evidence is not reusable (workflow is no longer a successful terminal run): #{run_url}"
     return false

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1597,6 +1597,22 @@ def ensure_release_branch_matches_target_base!(current_branch:, target_gem_versi
   ERROR
 end
 
+def ensure_accelerated_rc_release_branch!(current_branch:, target_gem_version:)
+  expected_release_branch = "release/#{release_base_version(target_gem_version)}"
+  return if current_branch == expected_release_branch
+
+  abort <<~ERROR
+    ❌ Accelerated RC publication must run from the matching release branch.
+
+    Current branch: #{current_branch}
+    Target version: #{target_gem_version}
+    Expected branch: #{expected_release_branch}
+
+    Switch to the matching release branch before requesting or retrying accelerated RC publication.
+    Ordinary non-accelerated prereleases may still run from non-release branches.
+  ERROR
+end
+
 def same_release_base?(first_version, second_version)
   first_components = parse_gem_version_components(first_version)
   second_components = parse_gem_version_components(second_version)
@@ -7029,7 +7045,7 @@ Environment variables:
   RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for both gems)
   RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
   RELEASE_CI_STATUS_OVERRIDE=true      # DANGEROUS prerelease-only release CI waiver
-  RELEASE_ACCELERATED_RC=true           # Enable audited pending-gate publication for an explicit RC
+  RELEASE_ACCELERATED_RC=true           # Enable audited pending-gate publication from matching release/X.Y.Z
   RELEASE_TRACKER=<issue>               # Active release tracker (required for accelerated RC/final promotion)
   RELEASE_ACCELERATED_RC_REASON=<reason> # Single-line maintainer rationale for accelerated publication
   GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
@@ -7129,6 +7145,12 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       current_checkout_version:,
       candidate_sha: accelerated_rc_same_candidate_retry ? current_git_sha!(release_root) : nil
     )
+    if accelerated_rc_options
+      ensure_accelerated_rc_release_branch!(
+        current_branch:,
+        target_gem_version: resolved_target_gem_version
+      )
+    end
     if accelerated_rc_options && accelerated_rc_requested
       preflight_explicit_accelerated_rc_target_tag!(
         monorepo_root: release_root,

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1340,7 +1340,9 @@ end
 def selected_accelerated_shakaperf_snapshot(repo_slug:, monorepo_root:, ref:, head_sha:, target_version:,
                                             release_started_at:, selection:, force_exact_head_dispatch:)
   existing_run = selection.fetch(:exact_run)
+  prerun = selection.fetch(:prerun)
   exact_state = accelerated_shakaperf_run_state!(repo_slug:, run: existing_run, unordered: false)
+  prerun_state = accelerated_shakaperf_run_state!(repo_slug:, run: prerun, unordered: false)
   return nil if force_exact_head_dispatch && exact_state != :none
 
   if exact_state == :active
@@ -1357,8 +1359,6 @@ def selected_accelerated_shakaperf_snapshot(repo_slug:, monorepo_root:, ref:, he
     return exact_snapshot if exact_snapshot
   end
 
-  prerun = selection.fetch(:prerun)
-  prerun_state = accelerated_shakaperf_run_state!(repo_slug:, run: prerun, unordered: false)
   return nil if force_exact_head_dispatch
   return unless prerun_state == :success
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -4293,24 +4293,76 @@ def confirm_accelerated_rc_publication!(version:, candidate_sha:, tracker:, reas
   abort "Accelerated RC publication aborted." unless answer == "y"
 end
 
+def abort_invalid_accelerated_rc_confirmation_evidence!
+  abort "❌ Accelerated RC confirmation evidence is malformed or incomplete; refusing publication."
+end
+
+def normalized_accelerated_rc_confirmation_hash!(value)
+  abort_invalid_accelerated_rc_confirmation_evidence! unless value.is_a?(Hash)
+
+  value.each_with_object({}) do |(key, nested_value), normalized|
+    valid_key = key.is_a?(String) || key.is_a?(Symbol)
+    abort_invalid_accelerated_rc_confirmation_evidence! unless valid_key
+    normalized_key = key.to_s
+    abort_invalid_accelerated_rc_confirmation_evidence! if normalized.key?(normalized_key)
+    normalized[normalized_key] = nested_value
+  end
+end
+
+def valid_accelerated_rc_confirmation_check?(check)
+  valid_accelerated_rc_nonempty_string?(check["name"]) &&
+    valid_accelerated_rc_nonempty_string?(check["state"]) &&
+    check["url"].is_a?(String) && valid_accelerated_rc_https_url?(check["url"])
+end
+
+def normalized_accelerated_rc_confirmation_checks!(checks)
+  abort_invalid_accelerated_rc_confirmation_evidence! unless checks.is_a?(Array)
+
+  checks.map { |check| normalized_accelerated_rc_confirmation_hash!(check) }
+end
+
+def valid_accelerated_rc_confirmation_ci?(snapshot)
+  %w[pending success].include?(snapshot["status"]) &&
+    snapshot["checks_url"].is_a?(String) && valid_accelerated_rc_https_url?(snapshot["checks_url"]) &&
+    snapshot["non_success"].all? { |check| valid_accelerated_rc_confirmation_check?(check) } &&
+    valid_accelerated_rc_ci_status?(snapshot["status"], snapshot["non_success"])
+end
+
+def valid_accelerated_rc_confirmation_shakaperf?(shakaperf)
+  %w[pending success].include?(shakaperf["status"]) &&
+    shakaperf["run_url"].is_a?(String) && valid_accelerated_rc_https_url?(shakaperf["run_url"])
+end
+
+def normalized_accelerated_rc_confirmation_evidence!(ci_snapshot:, shakaperf:)
+  ci = normalized_accelerated_rc_confirmation_hash!(ci_snapshot)
+  shakaperf_snapshot = normalized_accelerated_rc_confirmation_hash!(shakaperf)
+  ci["non_success"] = normalized_accelerated_rc_confirmation_checks!(ci["non_success"])
+  valid = valid_accelerated_rc_confirmation_ci?(ci) &&
+          valid_accelerated_rc_confirmation_shakaperf?(shakaperf_snapshot)
+  abort_invalid_accelerated_rc_confirmation_evidence! unless valid
+
+  [ci, shakaperf_snapshot]
+end
+
 def print_accelerated_rc_publication_summary(version:, candidate_sha:, tracker:, reason:, ci_snapshot:, shakaperf:)
+  ci_snapshot, shakaperf = normalized_accelerated_rc_confirmation_evidence!(ci_snapshot:, shakaperf:)
   puts "\n#{'#' * 80}"
   puts "ACCELERATED RC PUBLICATION CONFIRMATION"
   puts "#" * 80
   puts "  RC version: #{version}"
   puts "  Candidate SHA: #{candidate_sha}"
   puts "  Release tracker: ##{tracker}"
-  puts "  Exact-head CI: #{ci_snapshot.fetch(:status)} (#{ci_snapshot.fetch(:checks_url)})"
+  puts "  Exact-head CI: #{ci_snapshot.fetch('status')} (#{ci_snapshot.fetch('checks_url')})"
   print_accelerated_rc_non_success_checks(ci_snapshot)
-  puts "  ShakaPerf: #{shakaperf.fetch(:status)} (#{shakaperf.fetch(:run_url)})"
+  puts "  ShakaPerf: #{shakaperf.fetch('status')} (#{shakaperf.fetch('run_url')})"
   puts "  Maintainer reason: #{reason}"
   puts "#" * 80
 end
 
 def print_accelerated_rc_non_success_checks(ci_snapshot)
-  ci_snapshot.fetch(:non_success).each do |check|
-    puts "    - #{check.fetch(:name)}: #{check.fetch(:state)}"
-    puts "      #{check.fetch(:url)}"
+  ci_snapshot.fetch("non_success").each do |check|
+    puts "    - #{check.fetch('name')}: #{check.fetch('state')}"
+    puts "      #{check.fetch('url')}"
   end
 end
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -87,6 +87,10 @@ ACCELERATED_RC_CI_BOUND_FIELDS = %w[sha checks_url].freeze
 ACCELERATED_RC_SHAKAPERF_BOUND_FIELDS = %w[
   run_id attempt candidate_sha target_version release_started_at
 ].freeze
+ACCELERATED_RC_MAINTAINER_PERMISSIONS = %w[write maintain admin].freeze
+ACCELERATED_RC_NON_MAINTAINER_PERMISSIONS = %w[none read triage].freeze
+FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE = "accepted-rc-reuse"
+FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE = "strict-final"
 SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS = %w[
   action_required cancelled failure neutral skipped stale startup_failure success timed_out
 ].freeze
@@ -1004,7 +1008,7 @@ end
 
 def reuse_shakaperf_prerun?(repo_slug:, monorepo_root:, ref:, existing_runs:, head_sha:, target_version:,
                             release_started_at:)
-  prerun = find_latest_shakaperf_prerun(existing_runs, head_sha)
+  prerun = find_latest_shakaperf_prerun(existing_runs, head_sha, ref:, target_version:)
   return false unless prerun
 
   waited_for_active_prerun = active_shakaperf_release_gate_run?(prerun)
@@ -1107,7 +1111,7 @@ def run_shakaperf_release_gate!(monorepo_root:, ref:, head_sha:, target_version:
   print_shakaperf_release_gate_notice(ref:, head_sha:)
 
   existing_runs = fetch_shakaperf_release_gate_runs(repo_slug:, ref:)
-  existing_run = find_latest_shakaperf_release_gate_run(existing_runs, head_sha)
+  existing_run = find_latest_shakaperf_release_gate_run(existing_runs, head_sha, ref:, target_version:)
   validated_run = handle_existing_shakaperf_release_gate_run!(
     repo_slug:,
     monorepo_root:,
@@ -1231,6 +1235,10 @@ def reject_known_accelerated_shakaperf_failure!(repo_slug:, run:)
   return unless run&.fetch("status", nil) == "completed" && run["conclusion"] != "success"
 
   run_url = shakaperf_release_gate_run_url(repo_slug:, run:)
+  unless SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS.include?(run["conclusion"])
+    abort "❌ Accelerated RC ShakaPerf result is unknown; refusing unaudited publication: #{run_url}"
+  end
+
   abort "❌ Accelerated RC publication found a known ShakaPerf failure (#{run['conclusion']}): #{run_url}"
 end
 
@@ -2630,7 +2638,9 @@ def trusted_accelerated_rc_records_from_repository_comment!(
   abort "❌ Accelerated RC tracker record has no attributable GitHub author." if login.empty?
 
   permission = accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
-  validate_release_approver!(login:, permission:)
+  permission_class = accelerated_rc_repository_permission_class!(permission:, login:)
+  return [] if permission_class == :non_maintainer
+
   records = accelerated_rc_records_from_trusted_comment!(comment:, login:)
   unless records.all? { |record| record["release_tracker"] == tracker }
     abort "❌ Accelerated RC retry history is bound to a different release tracker."
@@ -2649,16 +2659,28 @@ def release_tracker_number_from_repository_comment_issue_url!(issue_url:, repo_s
 end
 
 def accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
-  return permissions.fetch(login) if permissions.key?(login)
+  if permissions.key?(login)
+    permission = permissions.fetch(login)
+  else
+    output, status = capture_gh_output(
+      "api", "repos/#{repo_slug}/collaborators/#{login}/permission", "--jq", ".permission"
+    )
+    unless status.success?
+      abort "❌ Unable to verify the repository permission of accelerated RC record author #{login}.\n\n#{output}"
+    end
 
-  output, status = capture_gh_output(
-    "api", "repos/#{repo_slug}/collaborators/#{login}/permission", "--jq", ".permission"
-  )
-  unless status.success?
-    abort "❌ Unable to verify the repository permission of accelerated RC record author #{login}.\n\n#{output}"
+    permission = output.strip
   end
 
-  permissions[login] = output.strip
+  accelerated_rc_repository_permission_class!(permission:, login:)
+  permissions[login] = permission
+end
+
+def accelerated_rc_repository_permission_class!(permission:, login:)
+  return :maintainer if ACCELERATED_RC_MAINTAINER_PERMISSIONS.include?(permission)
+  return :non_maintainer if ACCELERATED_RC_NON_MAINTAINER_PERMISSIONS.include?(permission)
+
+  abort "❌ Accelerated RC repository permission for #{login} is unknown; durable history cannot be ignored or trusted."
 end
 
 def accelerated_rc_records_from_trusted_comment!(comment:, login:)
@@ -2691,11 +2713,15 @@ rescue JSON::ParserError => e
 end
 
 def validate_release_approver!(login:, permission:)
-  unless %w[write maintain admin].include?(permission)
+  unless valid_release_approver_permission?(permission)
     abort "❌ Accelerated RC approval requires write, maintain, or admin repository permission for #{login}."
   end
 
   login
+end
+
+def valid_release_approver_permission?(permission)
+  ACCELERATED_RC_MAINTAINER_PERMISSIONS.include?(permission)
 end
 
 def current_release_approver!(repo_slug:)
@@ -3055,17 +3081,100 @@ def accelerated_repository_boundary_context!(accelerated_publication_record:, ac
   { record:, tag_authorization: }
 end
 
-def valid_final_promotion_context_identity?(context:, candidate_sha:)
+def valid_final_promotion_context_identity?(context:, candidate_sha:,
+                                            expected_strict_final_shakaperf_identity_anchor:)
   context_record = context.fetch(:record)
   ci_branch = context.fetch(:ci_branch)
   ci_snapshot = context.fetch(:ci_snapshot)
   shakaperf_record = context.fetch(:shakaperf_record)
+  final_target_version = context.fetch(:final_target_version)
+  shakaperf_evidence_mode = context.fetch(:shakaperf_evidence_mode)
+  strict_final_shakaperf_identity_anchor = context.fetch(:strict_final_shakaperf_identity_anchor, nil)
   ci_branch.is_a?(String) && !ci_branch.empty? &&
+    strict_final_shakaperf_identity_anchor == expected_strict_final_shakaperf_identity_anchor &&
     context.fetch(:candidate_sha) == candidate_sha &&
     ci_snapshot.fetch("sha") == context_record.fetch("candidate_sha") &&
-    shakaperf_record.fetch("release_branch") == ci_branch &&
-    shakaperf_record.fetch("candidate_sha") == candidate_sha &&
+    final_target_version == Gem::Version.new(context_record.fetch("target_version")).release.to_s &&
+    valid_final_promotion_shakaperf_context_identity?(
+      shakaperf_record:, ci_branch:, context_record:, candidate_sha:, final_target_version:, shakaperf_evidence_mode:,
+      strict_final_shakaperf_identity_anchor:
+    ) &&
     valid_final_promotion_source_rc_context_identity?(context:, context_record:)
+end
+
+def valid_final_promotion_shakaperf_context_identity?(shakaperf_record:, ci_branch:, context_record:, candidate_sha:,
+                                                      final_target_version:, shakaperf_evidence_mode:,
+                                                      strict_final_shakaperf_identity_anchor:)
+  shakaperf_candidate_sha = shakaperf_record.fetch("candidate_sha")
+  return false unless valid_final_promotion_shakaperf_common_identity?(
+    shakaperf_record:, ci_branch:, shakaperf_candidate_sha:
+  )
+
+  case shakaperf_evidence_mode
+  when FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE
+    valid_accepted_rc_final_promotion_shakaperf_identity?(
+      shakaperf_record:, context_record:, shakaperf_candidate_sha:, strict_final_shakaperf_identity_anchor:
+    )
+  when FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE
+    valid_strict_final_promotion_shakaperf_identity?(
+      shakaperf_record:, shakaperf_candidate_sha:, candidate_sha:, final_target_version:,
+      identity_anchor: strict_final_shakaperf_identity_anchor
+    )
+  else
+    false
+  end
+end
+
+def valid_final_promotion_shakaperf_common_identity?(shakaperf_record:, ci_branch:, shakaperf_candidate_sha:)
+  shakaperf_record.fetch("release_branch") == ci_branch &&
+    shakaperf_record.dig("shakaperf", "candidate_sha") == shakaperf_candidate_sha &&
+    shakaperf_record.dig("shakaperf", "target_version") == shakaperf_record.fetch("target_version")
+end
+
+def valid_accepted_rc_final_promotion_shakaperf_identity?(shakaperf_record:, context_record:,
+                                                          shakaperf_candidate_sha:,
+                                                          strict_final_shakaperf_identity_anchor:)
+  strict_final_shakaperf_identity_anchor.nil? &&
+    canonical_accelerated_rc_value(shakaperf_record.fetch("shakaperf")) ==
+      canonical_accelerated_rc_value(context_record.fetch("shakaperf")) &&
+    shakaperf_candidate_sha == context_record.dig("shakaperf", "candidate_sha")
+end
+
+def valid_strict_final_promotion_shakaperf_identity?(shakaperf_record:, shakaperf_candidate_sha:, candidate_sha:,
+                                                     final_target_version:, identity_anchor:)
+  shakaperf_candidate_sha == candidate_sha && shakaperf_record.fetch("target_version") == final_target_version &&
+    valid_strict_final_promotion_shakaperf_identity_anchor?(shakaperf_record:, identity_anchor:)
+end
+
+def valid_strict_final_promotion_shakaperf_identity_anchor?(shakaperf_record:, identity_anchor:)
+  return false unless identity_anchor.is_a?(String) && identity_anchor.frozen?
+  return false unless valid_strict_final_promotion_shakaperf_record?(shakaperf_record)
+
+  identity_anchor == final_promotion_shakaperf_identity_anchor(shakaperf_record)
+end
+
+def valid_strict_final_promotion_shakaperf_record?(record)
+  return false unless accelerated_rc_exact_keys?(
+    record, %w[release_branch candidate_sha target_version shakaperf]
+  )
+
+  valid_strict_final_promotion_shakaperf_snapshot?(record.fetch("shakaperf"))
+end
+
+def valid_strict_final_promotion_shakaperf_snapshot?(snapshot)
+  accelerated_rc_exact_keys?(snapshot, ACCELERATED_RC_SHAKAPERF_FIELDS) && snapshot["status"] == "success" &&
+    valid_strict_final_promotion_shakaperf_snapshot_identity?(snapshot)
+end
+
+def valid_strict_final_promotion_shakaperf_snapshot_identity?(snapshot)
+  positive_github_id?(snapshot["run_id"]) && positive_github_id?(snapshot["attempt"]) &&
+    valid_accelerated_rc_https_url?(snapshot["run_url"]) &&
+    snapshot["candidate_sha"].to_s.match?(/\A[0-9a-f]{40}\z/) &&
+    !shakaperf_release_gate_time(snapshot["release_started_at"]).nil?
+end
+
+def final_promotion_shakaperf_identity_anchor(shakaperf_record)
+  canonical_accelerated_rc_json(shakaperf_record).freeze
 end
 
 def valid_final_promotion_source_rc_context_identity?(context:, context_record:)
@@ -3077,7 +3186,8 @@ def valid_final_promotion_source_rc_context_identity?(context:, context_record:)
       context_record.values_at("target_version", "candidate_sha", "release_tracker")
 end
 
-def validate_final_promotion_context!(boundary_record:, context:, candidate_sha:)
+def validate_final_promotion_context!(boundary_record:, context:, candidate_sha:,
+                                      expected_strict_final_shakaperf_identity_anchor: nil)
   unless context
     if boundary_record&.fetch("status", nil) == "candidate-accepted"
       abort "❌ Release tag handling is missing accelerated final-promotion context."
@@ -3089,7 +3199,9 @@ def validate_final_promotion_context!(boundary_record:, context:, candidate_sha:
   context_record = context.fetch(:record)
   valid = boundary_record&.fetch("status", nil) == "candidate-accepted" &&
           accelerated_rc_retry_equivalent?(boundary_record, context_record) &&
-          valid_final_promotion_context_identity?(context:, candidate_sha:)
+          valid_final_promotion_context_identity?(
+            context:, candidate_sha:, expected_strict_final_shakaperf_identity_anchor:
+          )
   return if valid
 
   abort "❌ Release tag handling received inconsistent accelerated final-promotion boundary evidence."
@@ -3097,7 +3209,14 @@ rescue KeyError
   abort "❌ Release tag handling received incomplete accelerated final-promotion boundary evidence."
 end
 
-def validate_accelerated_tag_publication_boundary!(monorepo_root:, record:, final_promotion_context:, phase:)
+def validate_accelerated_tag_publication_boundary!(
+  monorepo_root:, record:, final_promotion_context:, candidate_sha:,
+  expected_strict_final_shakaperf_identity_anchor:, phase:
+)
+  validate_final_promotion_context!(
+    boundary_record: record, context: final_promotion_context, candidate_sha:,
+    expected_strict_final_shakaperf_identity_anchor:
+  )
   validate_accelerated_repository_publication_boundary!(monorepo_root:, record:, phase:)
   validate_final_promotion_ci_publication_boundary!(
     monorepo_root:, context: final_promotion_context, phase:
@@ -3108,6 +3227,11 @@ def validate_accelerated_tag_publication_boundary!(monorepo_root:, record:, fina
   validate_final_promotion_source_rc_tag_boundary!(
     monorepo_root:, context: final_promotion_context, phase:
   )
+end
+
+def retain_final_promotion_shakaperf_identity_anchor(context)
+  identity_anchor = context&.fetch(:strict_final_shakaperf_identity_anchor, nil)
+  identity_anchor.is_a?(String) ? identity_anchor.dup.freeze : identity_anchor
 end
 
 def validate_final_promotion_source_rc_tag_boundary!(monorepo_root:, context:, phase:)
@@ -3159,17 +3283,25 @@ def push_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, accele
   )
   boundary_record = boundary_context.fetch(:record)
   tag_authorization = boundary_context.fetch(:tag_authorization)
+  strict_final_shakaperf_identity_anchor = retain_final_promotion_shakaperf_identity_anchor(
+    accelerated_final_promotion_context
+  )
   validate_final_promotion_context!(
-    boundary_record:, context: accelerated_final_promotion_context, candidate_sha:
+    boundary_record:, context: accelerated_final_promotion_context, candidate_sha:,
+    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor
   )
   validate_accelerated_tag_publication_boundary!(
     monorepo_root:, record: boundary_record,
-    final_promotion_context: accelerated_final_promotion_context, phase: "tag handling"
+    final_promotion_context: accelerated_final_promotion_context, candidate_sha:,
+    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor,
+    phase: "tag handling"
   )
   ensure_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, tag_authorization:)
   validate_accelerated_tag_publication_boundary!(
     monorepo_root:, record: boundary_record,
-    final_promotion_context: accelerated_final_promotion_context, phase: "git tag push"
+    final_promotion_context: accelerated_final_promotion_context, candidate_sha:,
+    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor,
+    phase: "git tag push"
   )
   validate_release_candidate_publication_boundary!(
     monorepo_root:, tag:, candidate_sha:, phase: "git tag push"
@@ -3177,7 +3309,9 @@ def push_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, accele
   sh_in_dir_for_release(monorepo_root, "LEFTHOOK=0 git push --tags")
   validate_accelerated_tag_publication_boundary!(
     monorepo_root:, record: boundary_record,
-    final_promotion_context: accelerated_final_promotion_context, phase: "package publication"
+    final_promotion_context: accelerated_final_promotion_context, candidate_sha:,
+    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor,
+    phase: "package publication"
   )
   validate_release_candidate_publication_boundary!(
     monorepo_root:, tag:, candidate_sha:, phase: "package publication"
@@ -3934,14 +4068,50 @@ def reconcile_accelerated_rc_record(published_record:, ci_snapshot:, shakaperf:,
   )
 end
 
-def run_accelerated_rc_reconciliation!(repo_slug:, monorepo_root:, tracker:, target_version:, reason:, evidence:)
-  fetch_release_tracker_issue!(repo_slug:, tracker:)
-  approved_by = current_release_approver!(repo_slug:)
-  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
-  published_record = accelerated_rc_published_record!(records:, target_version:)
-  terminal_record = terminal_accelerated_rc_reconciliation_record!(published_record)
-  return terminal_record if terminal_record
+def validate_repository_accelerated_rc_reconciliation_history!(repo_slug:, tracker:, transition:, authorization:)
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:,
+    target_version: transition.fetch("target_version"),
+    candidate_sha: transition.fetch("candidate_sha"),
+    expected_tracker: tracker,
+    selected_authorization: authorization
+  )
+  repository_terminal = history.dig(:chain, :terminal)
+  return history unless repository_terminal &&
+                        !accelerated_rc_retry_equivalent?(repository_terminal, transition)
 
+  if repository_terminal["status"] == "candidate-rejected"
+    abort "❌ Repository-wide accelerated RC history permanently rejected this candidate; " \
+          "candidate-rejected is absorbing."
+  end
+
+  abort "❌ Repository-wide accelerated RC history contains a conflicting terminal transition."
+end
+
+def accelerated_rc_reconciliation_context!(records:, target_version:)
+  published_record = accelerated_rc_published_record!(records:, target_version:)
+  candidate_records = accelerated_rc_records_for_candidate(
+    records,
+    target_version: published_record.fetch("target_version"),
+    candidate_sha: published_record.fetch("candidate_sha")
+  )
+  authorization = validated_accelerated_rc_candidate_chain!(
+    candidate_records, require_publication: true
+  ).fetch(:authorization)
+  { published_record:, authorization: }
+end
+
+def existing_accelerated_rc_reconciliation_record!(repo_slug:, tracker:, context:)
+  terminal_record = context.fetch(:published_record)
+  return nil unless ACCELERATED_RC_TERMINAL_STATUSES.include?(terminal_record["status"])
+
+  validate_repository_accelerated_rc_reconciliation_history!(
+    repo_slug:, tracker:, transition: terminal_record, authorization: context.fetch(:authorization)
+  )
+  terminal_accelerated_rc_reconciliation_record!(terminal_record)
+end
+
+def accelerated_rc_reconciliation_gate_snapshots!(repo_slug:, monorepo_root:, published_record:)
   candidate_sha = published_record.fetch("candidate_sha")
   ci = json_compatible_release_value(
     fetch_accelerated_rc_ci_snapshot!(
@@ -3957,16 +4127,42 @@ def run_accelerated_rc_reconciliation!(repo_slug:, monorepo_root:, tracker:, tar
               else
                 accelerated_rc_shakaperf_snapshot!(repo_slug:, monorepo_root:, record: published_record)
               end
+  { ci:, shakaperf: }
+end
+
+def append_accelerated_rc_reconciliation_record!(repo_slug:, tracker:, record:, authorization:)
+  validate_repository_accelerated_rc_reconciliation_history!(
+    repo_slug:, tracker:, transition: record, authorization:
+  )
+  append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record:)
+  validate_repository_accelerated_rc_reconciliation_history!(
+    repo_slug:, tracker:, transition: record, authorization:
+  )
+  record
+end
+
+def run_accelerated_rc_reconciliation!(repo_slug:, monorepo_root:, tracker:, target_version:, reason:, evidence:)
+  fetch_release_tracker_issue!(repo_slug:, tracker:)
+  approved_by = current_release_approver!(repo_slug:)
+  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  context = accelerated_rc_reconciliation_context!(records:, target_version:)
+  terminal_record = existing_accelerated_rc_reconciliation_record!(repo_slug:, tracker:, context:)
+  return terminal_record if terminal_record
+
+  published_record = context.fetch(:published_record)
+  snapshots = accelerated_rc_reconciliation_gate_snapshots!(repo_slug:, monorepo_root:, published_record:)
   reconciled_record = reconcile_accelerated_rc_record(
     published_record:,
-    ci_snapshot: ci,
-    shakaperf:,
+    ci_snapshot: snapshots.fetch(:ci),
+    shakaperf: snapshots.fetch(:shakaperf),
     evidence:,
     approved_by:,
     reason: normalized_accelerated_rc_reason!(reason, action: "reconciliation"),
     recorded_at: Time.now.utc.iso8601
   )
-  append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record: reconciled_record)
+  append_accelerated_rc_reconciliation_record!(
+    repo_slug:, tracker:, record: reconciled_record, authorization: context.fetch(:authorization)
+  )
   if reconciled_record["status"] == "candidate-rejected"
     abort "❌ Accelerated RC candidate was rejected. Do not promote this immutable RC; " \
           "fix the failure and cut the next RC."
@@ -4169,10 +4365,11 @@ end
 def validate_final_promotion_shakaperf_publication_boundary!(monorepo_root:, context:, phase:)
   return unless context
 
-  record = context.fetch(:shakaperf_record)
-  expected_snapshot = record.fetch("shakaperf")
+  carried_record = context.fetch(:shakaperf_record)
+  expected_snapshot = carried_record.fetch("shakaperf")
+  refresh_record = final_promotion_shakaperf_refresh_record!(context:, carried_record:)
   refreshed_snapshot = accelerated_rc_shakaperf_snapshot!(
-    repo_slug: github_repo_slug(monorepo_root), monorepo_root:, record:
+    repo_slug: github_repo_slug(monorepo_root), monorepo_root:, record: refresh_record
   )
   unless refreshed_snapshot.is_a?(Hash) && refreshed_snapshot["status"] == "success"
     abort "❌ Final promotion #{phase} boundary ShakaPerf evidence is failed, missing, malformed, or unknown."
@@ -4181,6 +4378,19 @@ def validate_final_promotion_shakaperf_publication_boundary!(monorepo_root:, con
                                canonical_accelerated_rc_value(expected_snapshot)
 
   abort "❌ Final promotion #{phase} boundary found materially changed ShakaPerf evidence."
+end
+
+def final_promotion_shakaperf_refresh_record!(context:, carried_record:)
+  case context.fetch(:shakaperf_evidence_mode)
+  when FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE
+    carried_record.merge("candidate_sha" => context.fetch(:record).fetch("candidate_sha"))
+  when FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE
+    carried_record
+  else
+    abort "❌ Final promotion ShakaPerf boundary has an unknown evidence mode."
+  end
+rescue KeyError
+  abort "❌ Final promotion ShakaPerf boundary has incomplete evidence identity."
 end
 
 def accepted_rc_record_at_publication_boundary!(monorepo_root:, rc_tag:, final_head_sha:, tracker_input:, record:)
@@ -4222,33 +4432,44 @@ def strict_final_promotion_shakaperf_snapshot!(monorepo_root:, current_branch:, 
   unless run.is_a?(Hash) && run["status"] == "completed" && run["conclusion"] == "success"
     abort "❌ Final promotion is blocked: strict ShakaPerf gate identity is missing, malformed, or unknown."
   end
+  unless run["headSha"] == final_head_sha
+    abort "❌ Final promotion is blocked: strict ShakaPerf gate is not bound to the exact final candidate."
+  end
 
   accelerated_shakaperf_snapshot(
     repo_slug: github_repo_slug(monorepo_root),
     run:,
     ref: current_branch,
-    candidate_sha: run.fetch("headSha"),
+    candidate_sha: final_head_sha,
     target_version:,
     release_started_at:,
     status: "success"
   )
 end
 
-def final_promotion_boundary_context(final_head_sha:, current_branch:, record:, ci_snapshot:, shakaperf:,
-                                     source_rc_context:)
-  normalized_shakaperf = json_compatible_release_value(shakaperf)
-  {
+def final_promotion_boundary_context(final_head_sha:, current_branch:, record:, ci_snapshot:, shakaperf_evidence:,
+                                     final_target_version:, source_rc_context:)
+  normalized_shakaperf = json_compatible_release_value(shakaperf_evidence.fetch(:snapshot))
+  shakaperf_evidence_mode = shakaperf_evidence.fetch(:mode)
+  shakaperf_record = {
+    "release_branch" => current_branch,
+    "candidate_sha" => normalized_shakaperf.fetch("candidate_sha"),
+    "target_version" => normalized_shakaperf.fetch("target_version"),
+    "shakaperf" => normalized_shakaperf
+  }
+  context = {
     candidate_sha: final_head_sha,
     ci_branch: current_branch,
+    final_target_version:,
     record:,
     ci_snapshot: json_compatible_release_value(ci_snapshot),
-    shakaperf_record: {
-      "release_branch" => current_branch,
-      "candidate_sha" => final_head_sha,
-      "target_version" => normalized_shakaperf.fetch("target_version"),
-      "shakaperf" => normalized_shakaperf
-    }
-  }.merge(source_rc_context)
+    shakaperf_evidence_mode:,
+    shakaperf_record:
+  }
+  if shakaperf_evidence_mode == FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE
+    context[:strict_final_shakaperf_identity_anchor] = final_promotion_shakaperf_identity_anchor(shakaperf_record)
+  end
+  context.merge(source_rc_context)
 end
 
 def final_promotion_source_rc_context!(monorepo_root:, rc_tag:, record:)
@@ -4270,17 +4491,25 @@ def final_promotion_shakaperf_snapshot!(repo_slug:, monorepo_root:, current_bran
   reused = reuse_accepted_rc_shakaperf_evidence!(
     repo_slug:, monorepo_root:, ref: current_branch, head_sha: final_head_sha, record:
   )
-  return record.fetch("shakaperf") if reused
+  if reused
+    return {
+      mode: FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE,
+      snapshot: record.fetch("shakaperf")
+    }
+  end
 
-  strict_final_promotion_shakaperf_snapshot!(
-    monorepo_root:,
-    current_branch:,
-    final_head_sha:,
-    target_version:,
-    release_started_at:,
-    allow_ci_override:,
-    dry_run:
-  )
+  {
+    mode: FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE,
+    snapshot: strict_final_promotion_shakaperf_snapshot!(
+      monorepo_root:,
+      current_branch:,
+      final_head_sha:,
+      target_version:,
+      release_started_at:,
+      allow_ci_override:,
+      dry_run:
+    )
+  }
 end
 
 def run_accepted_rc_final_promotion_gates!(repo_slug:, monorepo_root:, current_branch:, rc_tag:, tracker_input:,
@@ -4296,7 +4525,7 @@ def run_accepted_rc_final_promotion_gates!(repo_slug:, monorepo_root:, current_b
   ci_snapshot = refresh_accepted_rc_ci_evidence_for_promotion!(
     repo_slug:, monorepo_root:, ci_branch: current_branch, record:
   )
-  shakaperf = final_promotion_shakaperf_snapshot!(
+  shakaperf_evidence = final_promotion_shakaperf_snapshot!(
     repo_slug:,
     monorepo_root:,
     current_branch:,
@@ -4327,7 +4556,8 @@ def run_accepted_rc_final_promotion_gates!(repo_slug:, monorepo_root:, current_b
     current_branch:,
     record: boundary_record,
     ci_snapshot: boundary_ci_snapshot,
-    shakaperf:,
+    shakaperf_evidence:,
+    final_target_version: target_version,
     source_rc_context:
   )
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2301,7 +2301,7 @@ def valid_accelerated_rc_tracker_record?(record)
 end
 
 def accelerated_rc_exact_keys?(value, expected_keys)
-  value.is_a?(Hash) && value.keys.sort == expected_keys.sort
+  value.is_a?(Hash) && value.length == expected_keys.length && expected_keys.all? { |key| value.key?(key) }
 end
 
 def valid_accelerated_rc_state?(record)
@@ -4527,19 +4527,20 @@ def accelerated_rc_runtime_equivalent?(record:, rc_sha:, final_head_sha:, monore
 
   candidate_fingerprint = shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: rc_sha)
   return false unless candidate_fingerprint == fingerprint
-
-  final_fingerprint = if final_head_sha == rc_sha
-                        candidate_fingerprint
-                      else
-                        shakaperf_runtime_tree_fingerprint(monorepo_root:, sha: final_head_sha)
-                      end
-  return false unless final_fingerprint == fingerprint
   return true if final_head_sha == rc_sha
 
   commits_after_rc = release_branch_commits_after_rc_tag(
     monorepo_root:, tag_sha: rc_sha, head_sha: final_head_sha
   )
-  commits_after_rc[:status] == :non_runtime_only
+  valid_accelerated_rc_non_runtime_classification?(commits_after_rc)
+end
+
+def valid_accelerated_rc_non_runtime_classification?(classification)
+  return false unless accelerated_rc_exact_keys?(classification, %i[status commits])
+
+  commits = classification[:commits]
+  classification[:status] == :non_runtime_only && commits.is_a?(Array) && !commits.empty? &&
+    commits.all? { |sha| sha.is_a?(String) && sha.match?(/\A[0-9a-f]{40}\z/) }
 end
 
 def reuse_accepted_rc_shakaperf_evidence!(repo_slug:, monorepo_root:, ref:, head_sha:, record:)

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -4060,28 +4060,39 @@ def accelerated_rc_published_record(authorized_record:, recorded_at:, approved_b
   )
 end
 
-def record_accelerated_rc_publication_complete!(repo_slug:, tracker:, authorized_record:, approved_by:, recorded_at:)
-  records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
-  candidate_records = accelerated_rc_records_for_candidate(
-    records,
-    target_version: authorized_record.fetch("target_version"),
-    candidate_sha: authorized_record.fetch("candidate_sha")
+def validated_repository_accelerated_rc_publication_completion_history!(repo_slug:, tracker:, authorization:)
+  history = validated_repository_accelerated_rc_candidate_history!(
+    repo_slug:,
+    target_version: authorization.fetch("target_version"),
+    candidate_sha: authorization.fetch("candidate_sha"),
+    expected_tracker: tracker,
+    selected_authorization: authorization
   )
-  chain = validated_accelerated_rc_candidate_chain!(
-    candidate_records, selected_authorization: authorized_record
-  )
-  terminal = chain.fetch(:terminal)
-  if terminal && terminal["status"] == "candidate-rejected"
-    abort "❌ Accelerated RC publication completion is blocked because this candidate was permanently rejected."
-  end
-  canonical_authorization = chain.fetch(:authorization)
-  publications = chain.fetch(:publications)
-  return publications.first unless publications.empty?
+  abort_if_accelerated_rc_retry_rejected!(history.fetch(:records))
+  history
+end
 
-  published_record = accelerated_rc_published_record(
-    authorized_record: canonical_authorization, recorded_at:, approved_by:
+def record_accelerated_rc_publication_complete!(repo_slug:, tracker:, authorized_record:, approved_by:, recorded_at:)
+  fetch_release_tracker_issue!(repo_slug:, tracker:)
+  history = validated_repository_accelerated_rc_publication_completion_history!(
+    repo_slug:, tracker:, authorization: authorized_record
   )
-  append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record: published_record)
+  publications = history.dig(:chain, :publications)
+  if publications.empty?
+    published_record = accelerated_rc_published_record(
+      authorized_record: history.dig(:chain, :authorization), recorded_at:, approved_by:
+    )
+    append_accelerated_rc_tracker_record!(repo_slug:, tracker:, record: published_record)
+  end
+
+  refreshed_history = validated_repository_accelerated_rc_publication_completion_history!(
+    repo_slug:, tracker:, authorization: authorized_record
+  )
+  canonical_publication = refreshed_history.dig(:chain, :publications).first
+  abort "❌ Canonical published-awaiting-gates transition is missing after publication completion." unless
+    canonical_publication
+
+  canonical_publication
 end
 
 def accelerated_rc_publication_completion_equivalent?(existing, expected)
@@ -6653,8 +6664,18 @@ def skip_existing_rubygem_publish?(gem_name:, published_version:, idempotent_ret
   true
 end
 
+def validated_gem_release_max_retries!(value)
+  max_retries = value.is_a?(String) ? Integer(value, 10) : value
+  return max_retries if max_retries.is_a?(Integer) && max_retries.positive?
+
+  abort "❌ GEM_RELEASE_MAX_RETRIES must be a positive base-10 integer; got #{value.inspect}."
+rescue ArgumentError, TypeError
+  abort "❌ GEM_RELEASE_MAX_RETRIES must be a positive base-10 integer; got #{value.inspect}."
+end
+
 def publish_gem_with_retry(dir, gem_name, otp: nil, published_version: nil, idempotent_retry: false,
-                           max_retries: ENV.fetch("GEM_RELEASE_MAX_RETRIES", "3").to_i)
+                           max_retries: ENV.fetch("GEM_RELEASE_MAX_RETRIES", "3"))
+  max_retries = validated_gem_release_max_retries!(max_retries)
   puts "\nPublishing #{gem_name} gem to RubyGems.org..."
   current_otp = normalize_otp_code(otp, service_name: "RubyGems")
 
@@ -7048,7 +7069,7 @@ Environment variables:
   RELEASE_ACCELERATED_RC=true           # Enable audited pending-gate publication from matching release/X.Y.Z
   RELEASE_TRACKER=<issue>               # Active release tracker (required for accelerated RC/final promotion)
   RELEASE_ACCELERATED_RC_REASON=<reason> # Single-line maintainer rationale for accelerated publication
-  GEM_RELEASE_MAX_RETRIES=<n>  # Override max retry attempts (default: 3)
+  GEM_RELEASE_MAX_RETRIES=<n>  # Positive base-10 integer max retry attempts (default: 3)
 
 Examples:
   rake release                                  # Auto-detect version; stable targets require changelog
@@ -7073,6 +7094,9 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   allow_version_policy_override = version_policy_override_enabled?(args_hash[:override_version_policy])
   npm_otp = ENV.fetch("NPM_OTP", nil)
   rubygems_otp = ENV.fetch("RUBYGEMS_OTP", nil)
+  gem_release_max_retries = unless is_dry_run
+                              validated_gem_release_max_retries!(ENV.fetch("GEM_RELEASE_MAX_RETRIES", "3"))
+                            end
 
   current_branch_output, current_branch_status = Open3.capture2e(
     "git", "-C", monorepo_root, "rev-parse", "--abbrev-ref", "HEAD"
@@ -7478,7 +7502,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
         "react_on_rails",
         otp: current_rubygems_otp,
         published_version: actual_gem_version,
-        idempotent_retry: idempotent_publish_retry
+        idempotent_retry: idempotent_publish_retry,
+        max_retries: gem_release_max_retries
       )
 
       publish_gem_with_retry(
@@ -7486,8 +7511,23 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
         "react_on_rails_pro",
         otp: current_rubygems_otp,
         published_version: actual_gem_version,
-        idempotent_retry: idempotent_publish_retry
+        idempotent_retry: idempotent_publish_retry,
+        max_retries: gem_release_max_retries
       )
+
+      if accelerated_publication_record
+        tracker = accelerated_publication_record.fetch("release_tracker")
+        record_accelerated_rc_publication_complete!(
+          repo_slug:,
+          tracker:,
+          authorized_record: accelerated_publication_record,
+          recorded_at: Time.now.utc,
+          approved_by: accelerated_approver
+        )
+        puts "⚠️ RC published with gates still reconciling. Before final promotion, run:"
+        puts "  RELEASE_TRACKER=#{tracker} bundle exec rake " \
+             "\"release:reconcile_accelerated_rc[#{actual_gem_version}]\""
+      end
     end
   end
 
@@ -7510,21 +7550,6 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
     puts "\nTo actually release, run: rake release[#{released_gem_version}]"
   else
     sync_github_release_after_publish(monorepo_root:, gem_version: released_gem_version, dry_run: false)
-    if accelerated_publication_record
-      repo_slug = github_repo_slug(monorepo_root)
-      tracker = accelerated_publication_record.fetch("release_tracker")
-      fetch_release_tracker_issue!(repo_slug:, tracker:)
-      record_accelerated_rc_publication_complete!(
-        repo_slug:,
-        tracker:,
-        authorized_record: accelerated_publication_record,
-        recorded_at: Time.now.utc,
-        approved_by: accelerated_approver
-      )
-      puts "⚠️ RC published with gates still reconciling. Before final promotion, run:"
-      puts "  RELEASE_TRACKER=#{tracker} bundle exec rake " \
-           "\"release:reconcile_accelerated_rc[#{released_gem_version}]\""
-    end
 
     changelog_path = File.join(monorepo_root, "CHANGELOG.md")
     has_changelog_section = extract_changelog_section(changelog_path:, version: released_gem_version)

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -54,6 +54,7 @@ SHAKAPERF_RELEASE_GATE_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION = 2
 ACCELERATED_RC_RECORD_SCHEMA_VERSION = 1
 ACCELERATED_RC_RECORD_MARKER = "react-on-rails-accelerated-rc"
+ACCELERATED_RC_RECORD_MARKER_OPENER = "<!-- #{ACCELERATED_RC_RECORD_MARKER} ".freeze
 ACCELERATED_RC_TAG_PROVENANCE_MARKER = "react-on-rails-accelerated-rc-provenance"
 ACCELERATED_RC_REPOSITORY_COMMENT_PAGE_SIZE = 100
 ACCELERATED_RC_REPOSITORY_COMMENT_MAX_PAGES = 250
@@ -2239,7 +2240,7 @@ def normalized_accelerated_rc_reason!(reason, action:)
 end
 
 def accelerated_rc_tracker_comment(record)
-  marker = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v#{ACCELERATED_RC_RECORD_SCHEMA_VERSION} " \
+  marker = "#{ACCELERATED_RC_RECORD_MARKER_OPENER}v#{ACCELERATED_RC_RECORD_SCHEMA_VERSION} " \
            "#{canonical_accelerated_rc_encoded_payload(record)} -->"
   ci = record.fetch("ci")
   shakaperf = record.fetch("shakaperf")
@@ -2260,15 +2261,21 @@ def accelerated_rc_records_from_comments(comments)
   comments.flat_map { |comment| accelerated_rc_records_from_comment(comment) }
 end
 
-def accelerated_rc_records_from_comment(comment)
-  marker = Regexp.escape(ACCELERATED_RC_RECORD_MARKER)
-  body = comment.fetch("body", "")
-  return [] unless body.include?(ACCELERATED_RC_RECORD_MARKER)
+def accelerated_rc_machine_marker_comment?(comment)
+  return false unless comment.is_a?(Hash) && comment["body"].is_a?(String)
 
-  marker_count = body.scan(/<!-- #{marker}\b/).length
+  comment.fetch("body").include?(ACCELERATED_RC_RECORD_MARKER_OPENER)
+end
+
+def accelerated_rc_records_from_comment(comment)
+  return [] unless accelerated_rc_machine_marker_comment?(comment)
+
+  body = comment.fetch("body")
+  marker_count = body.scan(ACCELERATED_RC_RECORD_MARKER_OPENER).length
   abort "❌ Release tracker contains a malformed accelerated RC record." unless marker_count == 1
 
-  matches = body.scan(/<!-- #{marker} v(\d+) ([0-9a-fA-F]+) -->/)
+  opener = Regexp.escape(ACCELERATED_RC_RECORD_MARKER_OPENER)
+  matches = body.scan(/#{opener}v(\d+) ([0-9a-fA-F]+) -->/)
   abort "❌ Release tracker contains a malformed accelerated RC record." unless matches.one?
 
   matches.map do |schema_version, encoded_payload|
@@ -2429,11 +2436,11 @@ end
 
 def fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
   comments = fetch_release_tracker_comments(repo_slug:, tracker:)
-  marker_comments = comments.select { |comment| comment.fetch("body", "").include?(ACCELERATED_RC_RECORD_MARKER) }
+  marker_comments = comments.select { |comment| accelerated_rc_machine_marker_comment?(comment) }
   permissions = {}
   records = marker_comments.flat_map do |comment|
-    login = comment.dig("user", "login").to_s
-    abort "❌ Accelerated RC tracker record has no attributable GitHub author." if login.empty?
+    login = accelerated_rc_comment_author_login!(comment)
+    next [] if login.nil?
 
     permission = accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
     permission_class = accelerated_rc_repository_permission_class!(permission:, login:)
@@ -2452,6 +2459,9 @@ end
 def fetch_repository_accelerated_rc_records_for_candidate!(repo_slug:, target_version:, candidate_sha:)
   comments = fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug:)
   marker_comments = comments.select do |comment|
+    next false unless accelerated_rc_machine_marker_comment?(comment)
+    next false if accelerated_rc_comment_author_login!(comment).nil?
+
     repository_accelerated_rc_comment_plausibly_targets_candidate?(
       comment:, target_version:, candidate_sha:
     )
@@ -2491,13 +2501,14 @@ def validated_repository_accelerated_rc_candidate_history!(
 end
 
 def repository_accelerated_rc_comment_plausibly_targets_candidate?(comment:, target_version:, candidate_sha:)
-  body = comment.fetch("body", "")
-  return false unless body.include?(ACCELERATED_RC_RECORD_MARKER)
+  return false unless accelerated_rc_machine_marker_comment?(comment)
+
+  body = comment.fetch("body")
   return true if body.include?("- RC: `#{target_version}` at `#{candidate_sha}`")
 
-  marker = Regexp.escape(ACCELERATED_RC_RECORD_MARKER)
-  marker_count = body.scan(/<!-- #{marker}\b/).length
-  matches = body.scan(/<!-- #{marker} v(\d+) ([0-9a-fA-F]+) -->/)
+  marker_count = body.scan(ACCELERATED_RC_RECORD_MARKER_OPENER).length
+  opener = Regexp.escape(ACCELERATED_RC_RECORD_MARKER_OPENER)
+  matches = body.scan(/#{opener}v(\d+) ([0-9a-fA-F]+) -->/)
   return true unless marker_count == 1 && matches.one?
 
   identities = matches.map do |schema_version, encoded_payload|
@@ -2603,7 +2614,7 @@ def fetch_bounded_accelerated_rc_marker_comments!(repo_slug:, tracker: nil)
     comments = fetch_accelerated_rc_comment_page!(repo_slug:, tracker:, page:, state:)
 
     marker_comments.concat(
-      comments.select { |comment| comment.fetch("body").include?(ACCELERATED_RC_RECORD_MARKER) }
+      comments.select { |comment| accelerated_rc_machine_marker_comment?(comment) }
     )
     if marker_comments.length > ACCELERATED_RC_REPOSITORY_MARKER_COMMENT_LIMIT
       source = accelerated_rc_comment_source_label(tracker)
@@ -2624,12 +2635,12 @@ end
 def trusted_accelerated_rc_records_from_repository_comment!(
   comment:, repo_slug:, permissions:, tracker_issues: {}
 )
+  login = accelerated_rc_comment_author_login!(comment)
+  return [] if login.nil?
+
   tracker = release_tracker_number_from_repository_comment_issue_url!(
     issue_url: comment.fetch("issue_url", nil), repo_slug:
   )
-
-  login = comment.dig("user", "login").to_s
-  abort "❌ Accelerated RC tracker record has no attributable GitHub author." if login.empty?
 
   permission = accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
   permission_class = accelerated_rc_repository_permission_class!(permission:, login:)
@@ -2642,6 +2653,20 @@ def trusted_accelerated_rc_records_from_repository_comment!(
   tracker_issues[tracker] = fetch_release_tracker_issue!(repo_slug:, tracker:) unless tracker_issues.key?(tracker)
 
   records
+end
+
+def accelerated_rc_comment_author_login!(comment)
+  unless comment.is_a?(Hash) && comment.key?("user")
+    abort "❌ Accelerated RC marker author envelope is malformed; durable history is unknown."
+  end
+
+  user = comment.fetch("user")
+  return nil if user.nil?
+
+  valid = user.is_a?(Hash) && user.key?("login") && user["login"].is_a?(String) && !user["login"].empty?
+  abort "❌ Accelerated RC marker author envelope is malformed; durable history is unknown." unless valid
+
+  user.fetch("login")
 end
 
 def release_tracker_number_from_repository_comment_issue_url!(issue_url:, repo_slug:)

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2720,8 +2720,6 @@ def fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
   permissions = {}
   records = marker_comments.flat_map do |comment|
     login = accelerated_rc_comment_author_login!(comment)
-    next [] if login.nil?
-
     permission = accelerated_rc_repository_comment_permission!(repo_slug:, login:, permissions:)
     permission_class = accelerated_rc_repository_permission_class!(permission:, login:)
     next [] if permission_class == :non_maintainer
@@ -2740,7 +2738,8 @@ def fetch_repository_accelerated_rc_records_for_candidate!(repo_slug:, target_ve
   comments = fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug:)
   marker_comments = comments.select do |comment|
     next false unless accelerated_rc_machine_marker_comment?(comment)
-    next false if accelerated_rc_comment_author_login!(comment).nil?
+
+    accelerated_rc_comment_author_login!(comment)
 
     repository_accelerated_rc_comment_plausibly_targets_candidate?(
       comment:, target_version:, candidate_sha:
@@ -2932,8 +2931,6 @@ def trusted_accelerated_rc_records_from_repository_comment!(
   comment:, repo_slug:, permissions:, tracker_issues: {}
 )
   login = accelerated_rc_comment_author_login!(comment)
-  return [] if login.nil?
-
   tracker = release_tracker_number_from_repository_comment_issue_url!(
     issue_url: comment.fetch("issue_url", nil), repo_slug:
   )
@@ -2957,7 +2954,7 @@ def accelerated_rc_comment_author_login!(comment)
   end
 
   user = comment.fetch("user")
-  return nil if user.nil?
+  abort "❌ Accelerated RC machine-marker author is unattributable; durable history is unknown." if user.nil?
 
   valid = user.is_a?(Hash) && user.key?("login") && user["login"].is_a?(String) && !user["login"].empty?
   abort "❌ Accelerated RC marker author envelope is malformed; durable history is unknown." unless valid

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -55,6 +55,9 @@ SHAKAPERF_RELEASE_GATE_EVIDENCE_SCHEMA_VERSION = 2
 ACCELERATED_RC_RECORD_SCHEMA_VERSION = 1
 ACCELERATED_RC_RECORD_MARKER = "react-on-rails-accelerated-rc"
 ACCELERATED_RC_TAG_PROVENANCE_MARKER = "react-on-rails-accelerated-rc-provenance"
+ACCELERATED_RC_REPOSITORY_COMMENT_PAGE_SIZE = 100
+ACCELERATED_RC_REPOSITORY_COMMENT_MAX_PAGES = 250
+ACCELERATED_RC_REPOSITORY_MARKER_COMMENT_LIMIT = 1_000
 ACCELERATED_RC_CANONICAL_TARGET_PATTERN =
   /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.rc\.(?:0|[1-9]\d*)\z/
 ACCELERATED_RC_CANONICAL_TARGET_CASE_INSENSITIVE_PATTERN =
@@ -2413,22 +2416,7 @@ rescue URI::InvalidURIError
 end
 
 def fetch_release_tracker_comments(repo_slug:, tracker:)
-  output, status = capture_gh_output(
-    "api", "--paginate", "--slurp", "repos/#{repo_slug}/issues/#{tracker}/comments"
-  )
-  abort "❌ Unable to read release tracker ##{tracker}.\n\n#{output}" unless status.success?
-
-  pages = JSON.parse(output)
-  unless pages.is_a?(Array) && pages.all?(Array)
-    abort "❌ Release tracker ##{tracker} comments returned an unexpected JSON structure."
-  end
-
-  comments = pages.flatten(1)
-  abort "❌ Release tracker ##{tracker} comments returned an unexpected JSON structure." unless comments.all?(Hash)
-
-  comments
-rescue JSON::ParserError => e
-  abort "❌ Release tracker ##{tracker} comments returned invalid JSON: #{e.message}"
+  fetch_bounded_accelerated_rc_marker_comments!(repo_slug:, tracker:)
 end
 
 def fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
@@ -2467,8 +2455,11 @@ def fetch_repository_accelerated_rc_records_for_candidate!(repo_slug:, target_ve
     )
   end
   permissions = {}
+  tracker_issues = {}
   records = marker_comments.flat_map do |comment|
-    trusted_accelerated_rc_records_from_repository_comment!(comment:, repo_slug:, permissions:)
+    trusted_accelerated_rc_records_from_repository_comment!(
+      comment:, repo_slug:, permissions:, tracker_issues:
+    )
   end
 
   accelerated_rc_records_for_candidate(records, target_version:, candidate_sha:)
@@ -2530,28 +2521,107 @@ rescue ArgumentError, JSON::ParserError
   nil
 end
 
-def fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug:)
-  output, status = capture_gh_output(
-    "api", "--paginate", "--slurp", "repos/#{repo_slug}/issues/comments?per_page=100"
+def validate_accelerated_rc_comment_schema!(comment:, repo_slug:)
+  valid = comment.is_a?(Hash) &&
+          comment["id"].is_a?(Integer) && comment["id"].positive? &&
+          comment["body"].is_a?(String) &&
+          comment["created_at"].is_a?(String)
+  abort "❌ Accelerated RC comment page contains an invalid comment schema." unless valid
+
+  tracker = release_tracker_number_from_repository_comment_issue_url!(
+    issue_url: comment["issue_url"], repo_slug:
   )
-  abort "❌ Unable to discover durable accelerated RC retry history.\n\n#{output}" unless status.success?
+  created_at = Time.iso8601(comment.fetch("created_at"))
 
-  pages = JSON.parse(output)
-  unless pages.is_a?(Array) && pages.all?(Array)
-    abort "❌ Repository issue comments returned an unexpected JSON structure during accelerated RC retry discovery."
-  end
-
-  comments = pages.flatten(1)
-  unless comments.all?(Hash)
-    abort "❌ Repository issue comments returned an unexpected JSON structure during accelerated RC retry discovery."
-  end
-
-  comments
-rescue JSON::ParserError => e
-  abort "❌ Repository issue comments returned invalid JSON during accelerated RC retry discovery: #{e.message}"
+  # GitHub can retain an ordinary comment after its author is deleted. Marker records still require
+  # an attributable trusted author later, but markerless comments need only this safe structural schema.
+  { id: comment.fetch("id"), tracker:, created_at: }
+rescue ArgumentError
+  abort "❌ Accelerated RC comment page contains an invalid comment schema."
 end
 
-def trusted_accelerated_rc_records_from_repository_comment!(comment:, repo_slug:, permissions:)
+def validate_accelerated_rc_comment_identity!(comment:, repo_slug:, state:, expected_tracker:)
+  metadata = validate_accelerated_rc_comment_schema!(comment:, repo_slug:)
+  if expected_tracker && metadata.fetch(:tracker) != expected_tracker
+    abort "❌ Accelerated RC comment page contains an issue URL inconsistent with its selected tracker."
+  end
+
+  comment_id = metadata.fetch(:id)
+  seen_ids = state.fetch(:seen_ids)
+  abort "❌ Accelerated RC comment pages contain a duplicate comment ID." if seen_ids.key?(comment_id)
+
+  created_at = metadata.fetch(:created_at)
+  previous_created_at = state[:last_created_at]
+  if previous_created_at && created_at < previous_created_at
+    abort "❌ Accelerated RC comment pages are out of chronological order."
+  end
+
+  seen_ids[comment_id] = true
+  state[:last_created_at] = created_at
+  metadata
+end
+
+def accelerated_rc_comment_page_endpoint(repo_slug:, tracker:, page:)
+  resource = tracker ? "repos/#{repo_slug}/issues/#{tracker}/comments" : "repos/#{repo_slug}/issues/comments"
+  "#{resource}?per_page=#{ACCELERATED_RC_REPOSITORY_COMMENT_PAGE_SIZE}" \
+    "&sort=created&direction=asc&page=#{page}"
+end
+
+def accelerated_rc_comment_source_label(tracker)
+  tracker ? "release tracker ##{tracker}" : "repository"
+end
+
+def fetch_accelerated_rc_comment_page!(repo_slug:, tracker:, page:, state:)
+  endpoint = accelerated_rc_comment_page_endpoint(repo_slug:, tracker:, page:)
+  output, status = capture_gh_output("api", endpoint)
+  source = accelerated_rc_comment_source_label(tracker)
+  abort "❌ Unable to read #{source} comments for accelerated RC history.\n\n#{output}" unless status.success?
+
+  comments = JSON.parse(output)
+  valid = comments.is_a?(Array) && comments.length <= ACCELERATED_RC_REPOSITORY_COMMENT_PAGE_SIZE &&
+          comments.all?(Hash)
+  if valid
+    comments.each do |comment|
+      validate_accelerated_rc_comment_identity!(
+        comment:, repo_slug:, state:, expected_tracker: tracker
+      )
+    end
+    return comments
+  end
+
+  abort "❌ #{source.capitalize} comments returned an unexpected JSON structure."
+rescue JSON::ParserError => e
+  abort "❌ #{source.capitalize} comments returned invalid JSON: #{e.message}"
+end
+
+def fetch_bounded_accelerated_rc_marker_comments!(repo_slug:, tracker: nil)
+  marker_comments = []
+  state = { seen_ids: {}, last_created_at: nil }
+  1.upto(ACCELERATED_RC_REPOSITORY_COMMENT_MAX_PAGES) do |page|
+    comments = fetch_accelerated_rc_comment_page!(repo_slug:, tracker:, page:, state:)
+
+    marker_comments.concat(
+      comments.select { |comment| comment.fetch("body").include?(ACCELERATED_RC_RECORD_MARKER) }
+    )
+    if marker_comments.length > ACCELERATED_RC_REPOSITORY_MARKER_COMMENT_LIMIT
+      source = accelerated_rc_comment_source_label(tracker)
+      abort "❌ Bounded #{source} accelerated-marker limit was exceeded; durable retry history is unknown."
+    end
+
+    return marker_comments if comments.length < ACCELERATED_RC_REPOSITORY_COMMENT_PAGE_SIZE
+  end
+
+  source = accelerated_rc_comment_source_label(tracker)
+  abort "❌ Bounded #{source} issue-comment page limit was reached; durable retry history is unknown."
+end
+
+def fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug:)
+  fetch_bounded_accelerated_rc_marker_comments!(repo_slug:)
+end
+
+def trusted_accelerated_rc_records_from_repository_comment!(
+  comment:, repo_slug:, permissions:, tracker_issues: {}
+)
   tracker = release_tracker_number_from_repository_comment_issue_url!(
     issue_url: comment.fetch("issue_url", nil), repo_slug:
   )
@@ -2565,6 +2635,7 @@ def trusted_accelerated_rc_records_from_repository_comment!(comment:, repo_slug:
   unless records.all? { |record| record["release_tracker"] == tracker }
     abort "❌ Accelerated RC retry history is bound to a different release tracker."
   end
+  tracker_issues[tracker] = fetch_release_tracker_issue!(repo_slug:, tracker:) unless tracker_issues.key?(tracker)
 
   records
 end
@@ -2880,6 +2951,52 @@ def validate_release_candidate_publication_boundary!(monorepo_root:, tag:, candi
   validate_release_tag_candidate_sha!(monorepo_root:, tag:, candidate_sha:)
 end
 
+def abort_malformed_remote_release_tag!(tag:, phase:)
+  abort "❌ Remote release tag #{tag} is missing or malformed before #{phase}; refusing to continue."
+end
+
+def valid_remote_release_tag_entry?(fields:, tag_ref:, peeled_ref:)
+  fields.length == 2 && fields.first.match?(/\A[0-9a-f]{40}\z/) &&
+    [tag_ref, peeled_ref].include?(fields.last)
+end
+
+def parse_remote_release_tag_refs!(output:, tag_ref:, peeled_ref:, tag:, phase:)
+  lines = output.lines.map(&:strip).reject(&:empty?)
+  refs = lines.to_h do |line|
+    fields = line.split(/\s+/)
+    abort_malformed_remote_release_tag!(tag:, phase:) unless
+      valid_remote_release_tag_entry?(fields:, tag_ref:, peeled_ref:)
+
+    [fields.last, fields.first]
+  end
+  abort_malformed_remote_release_tag!(tag:, phase:) unless refs.length == lines.length && refs.key?(tag_ref)
+
+  refs
+end
+
+def remote_release_tag_candidate_sha!(monorepo_root:, tag:, phase:)
+  tag_ref = "refs/tags/#{tag}"
+  peeled_ref = "#{tag_ref}^{}"
+  output, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "ls-remote", "--tags", "origin", tag_ref, peeled_ref
+  )
+  unless status.success?
+    abort "❌ Unable to verify remote release tag #{tag.inspect} before #{phase}.\n\n#{output.strip}"
+  end
+
+  refs = parse_remote_release_tag_refs!(output:, tag_ref:, peeled_ref:, tag:, phase:)
+
+  refs.fetch(peeled_ref, refs.fetch(tag_ref))
+end
+
+def validate_remote_release_tag_candidate_sha!(monorepo_root:, tag:, candidate_sha:, phase:)
+  remote_sha = remote_release_tag_candidate_sha!(monorepo_root:, tag:, phase:)
+  return remote_sha if remote_sha == candidate_sha
+
+  abort "❌ Remote release tag #{tag} moved away from the validated release candidate before #{phase}; " \
+        "refusing to continue."
+end
+
 def validate_repository_accelerated_rc_authorization_boundary!(monorepo_root:, record:, phase:)
   repo_slug = github_repo_slug(monorepo_root)
   history = validated_repository_accelerated_rc_candidate_history!(
@@ -2947,7 +3064,17 @@ def valid_final_promotion_context_identity?(context:, candidate_sha:)
     context.fetch(:candidate_sha) == candidate_sha &&
     ci_snapshot.fetch("sha") == context_record.fetch("candidate_sha") &&
     shakaperf_record.fetch("release_branch") == ci_branch &&
-    shakaperf_record.fetch("candidate_sha") == candidate_sha
+    shakaperf_record.fetch("candidate_sha") == candidate_sha &&
+    valid_final_promotion_source_rc_context_identity?(context:, context_record:)
+end
+
+def valid_final_promotion_source_rc_context_identity?(context:, context_record:)
+  source_rc_tag_provenance = context.fetch(:source_rc_tag_provenance)
+  context.fetch(:source_rc_tag) == "v#{context_record.fetch('target_version')}" &&
+    context.fetch(:source_rc_candidate_sha) == context_record.fetch("candidate_sha") &&
+    valid_accelerated_rc_tag_provenance?(source_rc_tag_provenance) &&
+    source_rc_tag_provenance.values_at("target_version", "candidate_sha", "release_tracker") ==
+      context_record.values_at("target_version", "candidate_sha", "release_tracker")
 end
 
 def validate_final_promotion_context!(boundary_record:, context:, candidate_sha:)
@@ -2978,6 +3105,32 @@ def validate_accelerated_tag_publication_boundary!(monorepo_root:, record:, fina
   validate_final_promotion_shakaperf_publication_boundary!(
     monorepo_root:, context: final_promotion_context, phase:
   )
+  validate_final_promotion_source_rc_tag_boundary!(
+    monorepo_root:, context: final_promotion_context, phase:
+  )
+end
+
+def validate_final_promotion_source_rc_tag_boundary!(monorepo_root:, context:, phase:)
+  return unless context
+
+  source_rc_tag = context.fetch(:source_rc_tag)
+  expected_candidate_sha = context.fetch(:source_rc_candidate_sha)
+  expected_provenance = context.fetch(:source_rc_tag_provenance)
+  unless remote_git_tag_exists?(monorepo_root:, tag: source_rc_tag)
+    abort "❌ Final promotion source RC tag #{source_rc_tag} disappeared before #{phase}; refusing to continue."
+  end
+
+  fetch_remote_rc_tag!(monorepo_root:, rc_tag: source_rc_tag)
+  actual_provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag: source_rc_tag)
+  unless actual_provenance == expected_provenance
+    abort "❌ Final promotion source RC tag #{source_rc_tag} lost or changed its canonical annotated " \
+          "authorization provenance before #{phase}; refusing to continue."
+  end
+
+  actual_candidate_sha = peeled_git_tag_sha(monorepo_root:, tag: source_rc_tag)
+  return actual_candidate_sha if actual_candidate_sha == expected_candidate_sha
+
+  abort "❌ Final promotion source RC tag #{source_rc_tag} moved before #{phase}; refusing to continue."
 end
 
 def ensure_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, tag_authorization:)
@@ -3027,6 +3180,9 @@ def push_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, accele
     final_promotion_context: accelerated_final_promotion_context, phase: "package publication"
   )
   validate_release_candidate_publication_boundary!(
+    monorepo_root:, tag:, candidate_sha:, phase: "package publication"
+  )
+  validate_remote_release_tag_candidate_sha!(
     monorepo_root:, tag:, candidate_sha:, phase: "package publication"
   )
 end
@@ -4078,7 +4234,8 @@ def strict_final_promotion_shakaperf_snapshot!(monorepo_root:, current_branch:, 
   )
 end
 
-def final_promotion_boundary_context(final_head_sha:, current_branch:, record:, ci_snapshot:, shakaperf:)
+def final_promotion_boundary_context(final_head_sha:, current_branch:, record:, ci_snapshot:, shakaperf:,
+                                     source_rc_context:)
   normalized_shakaperf = json_compatible_release_value(shakaperf)
   {
     candidate_sha: final_head_sha,
@@ -4091,6 +4248,20 @@ def final_promotion_boundary_context(final_head_sha:, current_branch:, record:, 
       "target_version" => normalized_shakaperf.fetch("target_version"),
       "shakaperf" => normalized_shakaperf
     }
+  }.merge(source_rc_context)
+end
+
+def final_promotion_source_rc_context!(monorepo_root:, rc_tag:, record:)
+  provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag: rc_tag)
+  expected_identity = record.values_at("target_version", "candidate_sha", "release_tracker")
+  valid = provenance && rc_tag == "v#{record.fetch('target_version')}" &&
+          provenance.values_at("target_version", "candidate_sha", "release_tracker") == expected_identity
+  abort "❌ Final promotion is blocked: source RC tag lacks matching canonical accelerated provenance." unless valid
+
+  {
+    source_rc_tag: rc_tag,
+    source_rc_candidate_sha: record.fetch("candidate_sha"),
+    source_rc_tag_provenance: provenance
   }
 end
 
@@ -4149,13 +4320,15 @@ def run_accepted_rc_final_promotion_gates!(repo_slug:, monorepo_root:, current_b
     abort "❌ Final promotion is blocked: exact-candidate CI evidence changed at the publication boundary."
   end
   validate_final_promotion_boundary_head!(monorepo_root:, final_head_sha:)
+  source_rc_context = final_promotion_source_rc_context!(monorepo_root:, rc_tag:, record: boundary_record)
 
   final_promotion_boundary_context(
     final_head_sha:,
     current_branch:,
     record: boundary_record,
     ci_snapshot: boundary_ci_snapshot,
-    shakaperf:
+    shakaperf:,
+    source_rc_context:
   )
 end
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -97,7 +97,7 @@ SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS = %w[
 ].freeze
 SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES = %w[queued in_progress requested waiting pending].freeze
 SHAKAPERF_RELEASE_GATE_CANONICAL_VERSION_PATTERN =
-  /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.rc\.(?:0|[1-9]\d*))?\z/
+  /\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:test|beta|alpha|rc|pre)\.(?:0|[1-9]\d*))?\z/
 SHAKAPERF_RELEASE_GATE_DISPLAY_TITLE_PATTERN =
   /\AShakaPerf Release Gates — (?<target_version>.+) on (?<ref>.+) @ (?<head_sha>[0-9a-f]{40})\z/
 SHAKAPERF_RELEASE_GATE_EVIDENCE_KEYS = %w[

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -3270,6 +3270,59 @@ def accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag:)
   provenance
 end
 
+def capture_accelerated_rc_tag_object_output!(monorepo_root:, arguments:, error:)
+  output, status = Open3.capture2e("git", "-C", monorepo_root, *arguments)
+  abort error unless status.success?
+
+  output
+end
+
+def release_tag_object_type_for_object!(monorepo_root:, tag:, tag_object_sha:)
+  unless tag_object_sha.is_a?(String) && tag_object_sha.match?(/\A[0-9a-f]{40}\z/)
+    abort "❌ Captured RC tag object for #{tag} is malformed."
+  end
+
+  type = capture_accelerated_rc_tag_object_output!(
+    monorepo_root:,
+    arguments: ["cat-file", "-t", tag_object_sha],
+    error: "❌ Captured RC tag object for #{tag} is unavailable."
+  ).strip
+  return type if %w[commit tag].include?(type)
+
+  abort "❌ Captured RC tag object for #{tag} has an unexpected git object type."
+end
+
+def accelerated_rc_tag_identity_for_object!(monorepo_root:, tag:, tag_object_sha:)
+  unless release_tag_object_type_for_object!(monorepo_root:, tag:, tag_object_sha:) == "tag"
+    abort "❌ Captured RC tag object for #{tag} is unavailable or is not an annotated tag; " \
+          "refusing publication recovery."
+  end
+
+  contents = capture_accelerated_rc_tag_object_output!(
+    monorepo_root:,
+    arguments: ["cat-file", "-p", tag_object_sha],
+    error: "❌ Unable to inspect captured RC tag object for #{tag}."
+  )
+
+  _headers, separator, message = contents.partition("\n\n")
+  abort "❌ Captured RC tag object for #{tag} is malformed." if separator.empty?
+
+  provenance = accelerated_rc_tag_provenance_from_message(message)
+  abort "❌ Captured annotated RC tag object for #{tag} lacks canonical accelerated provenance." unless provenance
+
+  candidate_output = capture_accelerated_rc_tag_object_output!(
+    monorepo_root:,
+    arguments: ["rev-parse", "--verify", "--quiet", "#{tag_object_sha}^{}"],
+    error: "❌ Unable to peel captured RC tag object for #{tag} to its candidate."
+  )
+  candidate_sha = candidate_output.strip
+  unless candidate_sha.match?(/\A[0-9a-f]{40}\z/)
+    abort "❌ Unable to peel captured RC tag object for #{tag} to its candidate."
+  end
+
+  { tag_object_sha:, candidate_sha:, provenance: }
+end
+
 def create_accelerated_rc_tag!(monorepo_root:, tag:, record:)
   candidate_sha = record.fetch("candidate_sha")
   head_sha = current_git_sha!(monorepo_root)
@@ -3334,7 +3387,7 @@ def parse_remote_release_tag_refs!(output:, tag_ref:, peeled_ref:, tag:, phase:)
   refs
 end
 
-def remote_release_tag_candidate_sha!(monorepo_root:, tag:, phase:)
+def remote_release_tag_refs!(monorepo_root:, tag:, phase:)
   tag_ref = "refs/tags/#{tag}"
   peeled_ref = "#{tag_ref}^{}"
   output, status = Open3.capture2e(
@@ -3344,9 +3397,65 @@ def remote_release_tag_candidate_sha!(monorepo_root:, tag:, phase:)
     abort "❌ Unable to verify remote release tag #{tag.inspect} before #{phase}.\n\n#{output.strip}"
   end
 
-  refs = parse_remote_release_tag_refs!(output:, tag_ref:, peeled_ref:, tag:, phase:)
+  parse_remote_release_tag_refs!(output:, tag_ref:, peeled_ref:, tag:, phase:)
+end
+
+def remote_release_tag_candidate_sha!(monorepo_root:, tag:, phase:)
+  tag_ref = "refs/tags/#{tag}"
+  peeled_ref = "#{tag_ref}^{}"
+  refs = remote_release_tag_refs!(monorepo_root:, tag:, phase:)
 
   refs.fetch(peeled_ref, refs.fetch(tag_ref))
+end
+
+def local_release_tag_object_sha!(monorepo_root:, tag:, phase:)
+  output, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}"
+  )
+  object_sha = output.strip
+  return object_sha if status.success? && object_sha.match?(/\A[0-9a-f]{40}\z/)
+
+  abort "❌ Unable to inspect the fetched local tag object for #{tag} before #{phase}."
+end
+
+def remote_annotated_release_tag_identity!(monorepo_root:, tag:, phase:)
+  tag_ref = "refs/tags/#{tag}"
+  peeled_ref = "#{tag_ref}^{}"
+  refs = remote_release_tag_refs!(monorepo_root:, tag:, phase:)
+  unless refs.key?(peeled_ref)
+    abort "❌ Remote release tag #{tag} is not an annotated tag before #{phase}; refusing to continue."
+  end
+
+  { tag_object_sha: refs.fetch(tag_ref), candidate_sha: refs.fetch(peeled_ref) }
+end
+
+def live_annotated_release_tag_identity!(monorepo_root:, tag:, phase:, tag_object_sha: nil)
+  captured_tag_object_sha = tag_object_sha || local_release_tag_object_sha!(monorepo_root:, tag:, phase:)
+  identity = accelerated_rc_tag_identity_for_object!(
+    monorepo_root:, tag:, tag_object_sha: captured_tag_object_sha
+  )
+  unless local_release_tag_object_sha!(monorepo_root:, tag:, phase:) == captured_tag_object_sha
+    abort "❌ Fetched local annotated tag ref for #{tag} changed while validating provenance before #{phase}."
+  end
+
+  remote_identity = remote_annotated_release_tag_identity!(monorepo_root:, tag:, phase:)
+  unless remote_identity.fetch(:tag_object_sha) == captured_tag_object_sha
+    abort "❌ Live remote annotated tag object for #{tag} does not match the fetched provenance object " \
+          "before #{phase}."
+  end
+  unless remote_identity.fetch(:candidate_sha) == identity.fetch(:candidate_sha)
+    abort "❌ Remote release tag #{tag} moved away from the captured annotated tag candidate before #{phase}."
+  end
+
+  identity
+end
+
+def valid_accelerated_rc_tag_object_identity?(identity)
+  accelerated_rc_exact_keys?(identity, %i[tag_object_sha candidate_sha provenance]) &&
+    identity[:tag_object_sha].is_a?(String) && identity[:tag_object_sha].match?(/\A[0-9a-f]{40}\z/) &&
+    identity[:candidate_sha].is_a?(String) && identity[:candidate_sha].match?(/\A[0-9a-f]{40}\z/) &&
+    valid_accelerated_rc_tag_provenance?(identity[:provenance]) &&
+    identity[:provenance]["candidate_sha"] == identity[:candidate_sha]
 end
 
 def validate_remote_release_tag_candidate_sha!(monorepo_root:, tag:, candidate_sha:, phase:)
@@ -3416,7 +3525,8 @@ def accelerated_repository_boundary_context!(accelerated_publication_record:, ac
 end
 
 def valid_final_promotion_context_identity?(context:, candidate_sha:,
-                                            expected_strict_final_shakaperf_identity_anchor:)
+                                            expected_strict_final_shakaperf_identity_anchor:,
+                                            expected_source_rc_tag_object_sha: nil)
   context_record = context.fetch(:record)
   ci_branch = context.fetch(:ci_branch)
   ci_snapshot = context.fetch(:ci_snapshot)
@@ -3433,7 +3543,9 @@ def valid_final_promotion_context_identity?(context:, candidate_sha:,
       shakaperf_record:, ci_branch:, context_record:, candidate_sha:, final_target_version:, shakaperf_evidence_mode:,
       strict_final_shakaperf_identity_anchor:
     ) &&
-    valid_final_promotion_source_rc_context_identity?(context:, context_record:)
+    valid_final_promotion_source_rc_context_identity?(
+      context:, context_record:, expected_source_rc_tag_object_sha:
+    )
 end
 
 def valid_final_promotion_shakaperf_context_identity?(shakaperf_record:, ci_branch:, context_record:, candidate_sha:,
@@ -3511,9 +3623,12 @@ def final_promotion_shakaperf_identity_anchor(shakaperf_record)
   canonical_accelerated_rc_json(shakaperf_record).freeze
 end
 
-def valid_final_promotion_source_rc_context_identity?(context:, context_record:)
+def valid_final_promotion_source_rc_context_identity?(context:, context_record:, expected_source_rc_tag_object_sha:)
   source_rc_tag_provenance = context.fetch(:source_rc_tag_provenance)
+  source_rc_tag_object_sha = context.fetch(:source_rc_tag_object_sha)
   context.fetch(:source_rc_tag) == "v#{context_record.fetch('target_version')}" &&
+    source_rc_tag_object_sha.is_a?(String) && source_rc_tag_object_sha.match?(/\A[0-9a-f]{40}\z/) &&
+    (expected_source_rc_tag_object_sha.nil? || source_rc_tag_object_sha == expected_source_rc_tag_object_sha) &&
     context.fetch(:source_rc_candidate_sha) == context_record.fetch("candidate_sha") &&
     valid_accelerated_rc_tag_provenance?(source_rc_tag_provenance) &&
     source_rc_tag_provenance.values_at("target_version", "candidate_sha", "release_tracker") ==
@@ -3521,7 +3636,8 @@ def valid_final_promotion_source_rc_context_identity?(context:, context_record:)
 end
 
 def validate_final_promotion_context!(boundary_record:, context:, candidate_sha:,
-                                      expected_strict_final_shakaperf_identity_anchor: nil)
+                                      expected_strict_final_shakaperf_identity_anchor: nil,
+                                      expected_source_rc_tag_object_sha: nil)
   unless context
     if boundary_record&.fetch("status", nil) == "candidate-accepted"
       abort "❌ Release tag handling is missing accelerated final-promotion context."
@@ -3534,7 +3650,8 @@ def validate_final_promotion_context!(boundary_record:, context:, candidate_sha:
   valid = boundary_record&.fetch("status", nil) == "candidate-accepted" &&
           accelerated_rc_retry_equivalent?(boundary_record, context_record) &&
           valid_final_promotion_context_identity?(
-            context:, candidate_sha:, expected_strict_final_shakaperf_identity_anchor:
+            context:, candidate_sha:, expected_strict_final_shakaperf_identity_anchor:,
+            expected_source_rc_tag_object_sha:
           )
   return if valid
 
@@ -3545,11 +3662,11 @@ end
 
 def validate_accelerated_tag_publication_boundary!(
   monorepo_root:, record:, final_promotion_context:, candidate_sha:,
-  expected_strict_final_shakaperf_identity_anchor:, phase:
+  expected_strict_final_shakaperf_identity_anchor:, expected_source_rc_tag_object_sha:, phase:
 )
   validate_final_promotion_context!(
     boundary_record: record, context: final_promotion_context, candidate_sha:,
-    expected_strict_final_shakaperf_identity_anchor:
+    expected_strict_final_shakaperf_identity_anchor:, expected_source_rc_tag_object_sha:
   )
   validate_accelerated_repository_publication_boundary!(monorepo_root:, record:, phase:)
   validate_final_promotion_ci_publication_boundary!(
@@ -3559,7 +3676,7 @@ def validate_accelerated_tag_publication_boundary!(
     monorepo_root:, context: final_promotion_context, phase:
   )
   validate_final_promotion_source_rc_tag_boundary!(
-    monorepo_root:, context: final_promotion_context, phase:
+    monorepo_root:, context: final_promotion_context, expected_source_rc_tag_object_sha:, phase:
   )
 end
 
@@ -3568,24 +3685,56 @@ def retain_final_promotion_shakaperf_identity_anchor(context)
   identity_anchor.is_a?(String) ? identity_anchor.dup.freeze : identity_anchor
 end
 
-def validate_final_promotion_source_rc_tag_boundary!(monorepo_root:, context:, phase:)
+def retain_final_promotion_source_rc_tag_object_anchor(context)
+  tag_object_sha = context&.fetch(:source_rc_tag_object_sha, nil)
+  tag_object_sha.is_a?(String) ? tag_object_sha.dup.freeze : tag_object_sha
+end
+
+def final_promotion_publication_identity_anchors(context)
+  {
+    shakaperf: retain_final_promotion_shakaperf_identity_anchor(context),
+    source_rc_tag_object: retain_final_promotion_source_rc_tag_object_anchor(context)
+  }
+end
+
+def validate_accelerated_tag_publication_phase!(monorepo_root:, record:, final_promotion_context:, candidate_sha:,
+                                                identity_anchors:, phase:)
+  validate_accelerated_tag_publication_boundary!(
+    monorepo_root:, record:, final_promotion_context:, candidate_sha:,
+    expected_strict_final_shakaperf_identity_anchor: identity_anchors.fetch(:shakaperf),
+    expected_source_rc_tag_object_sha: identity_anchors.fetch(:source_rc_tag_object),
+    phase:
+  )
+end
+
+def validate_final_promotion_source_rc_tag_boundary!(
+  monorepo_root:, context:, expected_source_rc_tag_object_sha:, phase:
+)
   return unless context
 
   source_rc_tag = context.fetch(:source_rc_tag)
   expected_candidate_sha = context.fetch(:source_rc_candidate_sha)
   expected_provenance = context.fetch(:source_rc_tag_provenance)
+  unless expected_source_rc_tag_object_sha == context.fetch(:source_rc_tag_object_sha)
+    abort "❌ Final promotion source RC tag object identity changed before #{phase}; refusing to continue."
+  end
   unless remote_git_tag_exists?(monorepo_root:, tag: source_rc_tag)
     abort "❌ Final promotion source RC tag #{source_rc_tag} disappeared before #{phase}; refusing to continue."
   end
 
   fetch_remote_rc_tag!(monorepo_root:, rc_tag: source_rc_tag)
-  actual_provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag: source_rc_tag)
-  unless actual_provenance == expected_provenance
+  actual_identity = live_annotated_release_tag_identity!(
+    monorepo_root:,
+    tag: source_rc_tag,
+    phase: "final promotion source RC #{phase}",
+    tag_object_sha: expected_source_rc_tag_object_sha
+  )
+  unless actual_identity.fetch(:provenance) == expected_provenance
     abort "❌ Final promotion source RC tag #{source_rc_tag} lost or changed its canonical annotated " \
           "authorization provenance before #{phase}; refusing to continue."
   end
 
-  actual_candidate_sha = peeled_git_tag_sha(monorepo_root:, tag: source_rc_tag)
+  actual_candidate_sha = actual_identity.fetch(:candidate_sha)
   return actual_candidate_sha if actual_candidate_sha == expected_candidate_sha
 
   abort "❌ Final promotion source RC tag #{source_rc_tag} moved before #{phase}; refusing to continue."
@@ -3617,35 +3766,28 @@ def push_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, accele
   )
   boundary_record = boundary_context.fetch(:record)
   tag_authorization = boundary_context.fetch(:tag_authorization)
-  strict_final_shakaperf_identity_anchor = retain_final_promotion_shakaperf_identity_anchor(
-    accelerated_final_promotion_context
-  )
+  identity_anchors = final_promotion_publication_identity_anchors(accelerated_final_promotion_context)
   validate_final_promotion_context!(
     boundary_record:, context: accelerated_final_promotion_context, candidate_sha:,
-    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor
+    expected_strict_final_shakaperf_identity_anchor: identity_anchors.fetch(:shakaperf),
+    expected_source_rc_tag_object_sha: identity_anchors.fetch(:source_rc_tag_object)
   )
-  validate_accelerated_tag_publication_boundary!(
-    monorepo_root:, record: boundary_record,
-    final_promotion_context: accelerated_final_promotion_context, candidate_sha:,
-    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor,
-    phase: "tag handling"
+  validate_accelerated_tag_publication_phase!(
+    monorepo_root:, record: boundary_record, final_promotion_context: accelerated_final_promotion_context,
+    candidate_sha:, identity_anchors:, phase: "tag handling"
   )
   ensure_release_tag_for_candidate!(monorepo_root:, tag:, candidate_sha:, tag_authorization:)
-  validate_accelerated_tag_publication_boundary!(
-    monorepo_root:, record: boundary_record,
-    final_promotion_context: accelerated_final_promotion_context, candidate_sha:,
-    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor,
-    phase: "git tag push"
+  validate_accelerated_tag_publication_phase!(
+    monorepo_root:, record: boundary_record, final_promotion_context: accelerated_final_promotion_context,
+    candidate_sha:, identity_anchors:, phase: "git tag push"
   )
   validate_release_candidate_publication_boundary!(
     monorepo_root:, tag:, candidate_sha:, phase: "git tag push"
   )
   sh_in_dir_for_release(monorepo_root, "LEFTHOOK=0 git push --tags")
-  validate_accelerated_tag_publication_boundary!(
-    monorepo_root:, record: boundary_record,
-    final_promotion_context: accelerated_final_promotion_context, candidate_sha:,
-    expected_strict_final_shakaperf_identity_anchor: strict_final_shakaperf_identity_anchor,
-    phase: "package publication"
+  validate_accelerated_tag_publication_phase!(
+    monorepo_root:, record: boundary_record, final_promotion_context: accelerated_final_promotion_context,
+    candidate_sha:, identity_anchors:, phase: "package publication"
   )
   validate_release_candidate_publication_boundary!(
     monorepo_root:, tag:, candidate_sha:, phase: "package publication"
@@ -4471,6 +4613,82 @@ def accelerated_rc_reconciliation_context!(records:, target_version:)
   { published_record:, authorization: }
 end
 
+def validate_accelerated_rc_publication_recovery_tag!(monorepo_root:, tag:, authorization:, candidate_sha:)
+  phase = "accelerated RC publication recovery"
+  fetch_remote_release_tag!(monorepo_root:, tag:, tag_type: "accelerated RC publication recovery")
+  local_tag_object_sha = local_release_tag_object_sha!(monorepo_root:, tag:, phase:)
+  local_identity = live_annotated_release_tag_identity!(
+    monorepo_root:, tag:, phase:, tag_object_sha: local_tag_object_sha
+  )
+  expected_provenance = accelerated_rc_tag_provenance(authorization)
+  unless local_identity.fetch(:provenance) == expected_provenance &&
+         candidate_sha == expected_provenance.fetch("candidate_sha")
+    abort "❌ Captured annotated tag object for #{tag} does not match the persisted accelerated publication " \
+          "authorization."
+  end
+  unless local_identity.fetch(:candidate_sha) == candidate_sha
+    abort "❌ Remote release tag #{tag} moved away from the validated release candidate before #{phase}; " \
+          "refusing to continue."
+  end
+
+  local_identity.slice(:tag_object_sha, :candidate_sha)
+end
+
+def validate_accelerated_rc_complete_publication_evidence!(
+  monorepo_root:, tag:, authorization:, candidate_sha:, target_version:
+)
+  initial_tag_identity = validate_accelerated_rc_publication_recovery_tag!(
+    monorepo_root:, tag:, authorization:, candidate_sha:
+  )
+  verify_complete_release_registry_publication!(gem_version: target_version)
+  final_tag_identity = validate_accelerated_rc_publication_recovery_tag!(
+    monorepo_root:, tag:, authorization:, candidate_sha:
+  )
+  return if final_tag_identity == initial_tag_identity
+
+  abort "❌ Live remote annotated tag object for #{tag} changed during registry verification; " \
+        "refusing publication recovery."
+end
+
+def recover_accelerated_rc_publication_for_reconciliation!(
+  repo_slug:, monorepo_root:, tracker:, target_version:, records:, approved_by:
+)
+  matching = accelerated_rc_records_for_target(records, target_version)
+  return records if matching.any? { |record| record["status"] == "published-awaiting-gates" }
+
+  candidate_shas = matching.map { |record| record["candidate_sha"] }.uniq
+  unless candidate_shas.one?
+    abort "❌ Missing accelerated RC publication cannot be recovered from absent or ambiguous candidate history."
+  end
+
+  candidate_sha = candidate_shas.first
+  candidate_records = accelerated_rc_records_for_candidate(
+    matching, target_version:, candidate_sha:
+  )
+  authorization = validated_accelerated_rc_candidate_chain!(candidate_records).fetch(:authorization)
+  history = validated_repository_accelerated_rc_publication_completion_history!(
+    repo_slug:, tracker:, authorization:
+  )
+  unless history.dig(:chain, :publications).any?
+    validate_canonical_accelerated_rc_target!(target_version)
+    tag = "v#{target_version}"
+    validate_accelerated_rc_complete_publication_evidence!(
+      monorepo_root:, tag:, authorization:, candidate_sha:, target_version:
+    )
+    record_accelerated_rc_publication_complete!(
+      repo_slug:,
+      tracker:,
+      authorized_record: authorization,
+      approved_by:,
+      recorded_at: Time.now.utc
+    )
+  end
+
+  refreshed_records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  accelerated_rc_published_record!(records: refreshed_records, target_version:)
+  refreshed_records
+end
+
 def existing_accelerated_rc_reconciliation_record!(repo_slug:, tracker:, context:)
   terminal_record = context.fetch(:published_record)
   return nil unless ACCELERATED_RC_TERMINAL_STATUSES.include?(terminal_record["status"])
@@ -4515,6 +4733,9 @@ def run_accelerated_rc_reconciliation!(repo_slug:, monorepo_root:, tracker:, tar
   fetch_release_tracker_issue!(repo_slug:, tracker:)
   approved_by = current_release_approver!(repo_slug:)
   records = fetch_accelerated_rc_tracker_records!(repo_slug:, tracker:)
+  records = recover_accelerated_rc_publication_for_reconciliation!(
+    repo_slug:, monorepo_root:, tracker:, target_version:, records:, approved_by:
+  )
   context = accelerated_rc_reconciliation_context!(records:, target_version:)
   terminal_record = existing_accelerated_rc_reconciliation_record!(repo_slug:, tracker:, context:)
   return terminal_record if terminal_record
@@ -4553,26 +4774,64 @@ def terminal_accelerated_rc_reconciliation_record!(record)
   record
 end
 
-def accepted_accelerated_rc_record_for_release_branch_promotion!(monorepo_root:, rc_tag:, final_head_sha:,
-                                                                 tracker_input:)
-  tag_provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag: rc_tag)
-  unless tag_provenance
-    if tracker_input
-      abort "❌ Final promotion is blocked: explicit RELEASE_TRACKER was supplied, but the RC tag lacks " \
-            "canonical accelerated provenance."
+def release_branch_promotion_tag_selection!(monorepo_root:, rc_tag:, source_rc_tag_identity:)
+  phase = "accepted accelerated RC selection"
+  if source_rc_tag_identity
+    unless valid_accelerated_rc_tag_object_identity?(source_rc_tag_identity)
+      abort "❌ Final promotion is blocked: supplied source RC tag identity is malformed."
+    end
+    tag_identity = live_annotated_release_tag_identity!(
+      monorepo_root:, tag: rc_tag, phase:, tag_object_sha: source_rc_tag_identity.fetch(:tag_object_sha)
+    )
+    unless tag_identity == source_rc_tag_identity
+      abort "❌ Final promotion is blocked: source RC tag identity changed during accepted-record selection."
     end
 
-    repo_slug = github_repo_slug(monorepo_root)
-    rc_version = parse_release_tag_to_gem_version(rc_tag)
-    rc_sha = peeled_git_tag_sha(monorepo_root:, tag: rc_tag)
-    history = fetch_repository_accelerated_rc_records_for_candidate!(
-      repo_slug:, target_version: rc_version, candidate_sha: rc_sha
-    )
-    return nil if history.empty?
-
-    abort "❌ Final promotion is blocked: lightweight RC tag #{rc_tag} has durable accelerated history " \
-          "but lacks canonical accelerated provenance."
+    return { tag_identity: }
   end
+
+  tag_object_sha = local_release_tag_object_sha!(monorepo_root:, tag: rc_tag, phase:)
+  tag_object_type = release_tag_object_type_for_object!(monorepo_root:, tag: rc_tag, tag_object_sha:)
+  return { ordinary_candidate_sha: tag_object_sha } if tag_object_type == "commit"
+
+  {
+    tag_identity: live_annotated_release_tag_identity!(
+      monorepo_root:, tag: rc_tag, phase:, tag_object_sha:
+    )
+  }
+end
+
+def ordinary_rc_record_for_release_branch_promotion!(monorepo_root:, rc_tag:, tracker_input:, candidate_sha:)
+  if tracker_input
+    abort "❌ Final promotion is blocked: explicit RELEASE_TRACKER was supplied, but the RC tag lacks " \
+          "canonical accelerated provenance."
+  end
+
+  repo_slug = github_repo_slug(monorepo_root)
+  rc_version = parse_release_tag_to_gem_version(rc_tag)
+  history = fetch_repository_accelerated_rc_records_for_candidate!(
+    repo_slug:, target_version: rc_version, candidate_sha:
+  )
+  return nil if history.empty?
+
+  abort "❌ Final promotion is blocked: lightweight RC tag #{rc_tag} has durable accelerated history " \
+        "but lacks canonical accelerated provenance."
+end
+
+def accepted_accelerated_rc_record_for_release_branch_promotion!(monorepo_root:, rc_tag:, final_head_sha:,
+                                                                 tracker_input:, source_rc_tag_identity: nil)
+  tag_selection = release_branch_promotion_tag_selection!(monorepo_root:, rc_tag:, source_rc_tag_identity:)
+  if tag_selection.key?(:ordinary_candidate_sha)
+    return ordinary_rc_record_for_release_branch_promotion!(
+      monorepo_root:,
+      rc_tag:,
+      tracker_input:,
+      candidate_sha: tag_selection.fetch(:ordinary_candidate_sha)
+    )
+  end
+
+  tag_identity = tag_selection.fetch(:tag_identity)
+  tag_provenance = tag_identity.fetch(:provenance)
 
   validate_literal_accelerated_rc_tag_name!(rc_tag:, tag_provenance:)
 
@@ -4585,7 +4844,7 @@ def accepted_accelerated_rc_record_for_release_branch_promotion!(monorepo_root:,
   repo_slug = github_repo_slug(monorepo_root)
   fetch_release_tracker_issue!(repo_slug:, tracker:)
   rc_version = tag_provenance.fetch("target_version")
-  rc_sha = peeled_git_tag_sha(monorepo_root:, tag: rc_tag)
+  rc_sha = tag_identity.fetch(:candidate_sha)
   history = validated_repository_accelerated_rc_candidate_history!(
     repo_slug:, target_version: rc_version, candidate_sha: rc_sha, expected_tracker: tracker
   )
@@ -4769,8 +5028,14 @@ def accepted_rc_record_at_publication_boundary!(monorepo_root:, rc_tag:, final_h
   end
   fetch_remote_rc_tag!(monorepo_root:, rc_tag:)
 
+  phase = "final promotion accepted-record publication boundary"
+  tag_object_sha = local_release_tag_object_sha!(monorepo_root:, tag: rc_tag, phase:)
+  source_rc_tag_identity = live_annotated_release_tag_identity!(
+    monorepo_root:, tag: rc_tag, phase:, tag_object_sha:
+  )
+
   boundary_record = accepted_accelerated_rc_record_for_release_branch_promotion!(
-    monorepo_root:, rc_tag:, final_head_sha:, tracker_input:
+    monorepo_root:, rc_tag:, final_head_sha:, tracker_input:, source_rc_tag_identity:
   )
   abort "❌ Final promotion is blocked: accelerated RC evidence disappeared at the publication boundary." unless
     boundary_record
@@ -4778,7 +5043,7 @@ def accepted_rc_record_at_publication_boundary!(monorepo_root:, rc_tag:, final_h
     abort "❌ Final promotion is blocked: the accepted RC record changed at the publication boundary."
   end
 
-  boundary_record
+  { record: boundary_record, source_rc_tag_identity: }
 end
 
 def validate_final_promotion_boundary_head!(monorepo_root:, final_head_sha:)
@@ -4842,15 +5107,28 @@ def final_promotion_boundary_context(final_head_sha:, current_branch:, record:, 
   context.merge(source_rc_context)
 end
 
-def final_promotion_source_rc_context!(monorepo_root:, rc_tag:, record:)
-  provenance = accelerated_rc_tag_provenance_for_tag!(monorepo_root:, tag: rc_tag)
+def final_promotion_source_rc_context!(monorepo_root:, rc_tag:, record:, source_rc_tag_identity:)
+  unless valid_accelerated_rc_tag_object_identity?(source_rc_tag_identity)
+    abort "❌ Final promotion is blocked: source RC tag identity is missing or malformed."
+  end
+  phase = "final-promotion context construction"
+  identity = live_annotated_release_tag_identity!(
+    monorepo_root:,
+    tag: rc_tag,
+    phase:,
+    tag_object_sha: source_rc_tag_identity.fetch(:tag_object_sha)
+  )
+  provenance = identity.fetch(:provenance)
   expected_identity = record.values_at("target_version", "candidate_sha", "release_tracker")
   valid = provenance && rc_tag == "v#{record.fetch('target_version')}" &&
-          provenance.values_at("target_version", "candidate_sha", "release_tracker") == expected_identity
+          identity == source_rc_tag_identity &&
+          provenance.values_at("target_version", "candidate_sha", "release_tracker") == expected_identity &&
+          identity.fetch(:candidate_sha) == record.fetch("candidate_sha")
   abort "❌ Final promotion is blocked: source RC tag lacks matching canonical accelerated provenance." unless valid
 
   {
     source_rc_tag: rc_tag,
+    source_rc_tag_object_sha: identity.fetch(:tag_object_sha),
     source_rc_candidate_sha: record.fetch("candidate_sha"),
     source_rc_tag_provenance: provenance
   }
@@ -4882,6 +5160,36 @@ def final_promotion_shakaperf_snapshot!(repo_slug:, monorepo_root:, current_bran
   }
 end
 
+def final_promotion_context_after_boundary!(repo_slug:, monorepo_root:, current_branch:, rc_tag:, final_head_sha:,
+                                            target_version:, ci_snapshot:, shakaperf_evidence:,
+                                            boundary_selection:)
+  boundary_record = boundary_selection.fetch(:record)
+  boundary_ci_snapshot = refresh_accepted_rc_ci_evidence_for_promotion!(
+    repo_slug:, monorepo_root:, ci_branch: current_branch, record: boundary_record
+  )
+  unless canonical_accelerated_rc_ci_snapshot_for_comparison(boundary_ci_snapshot) ==
+         canonical_accelerated_rc_ci_snapshot_for_comparison(ci_snapshot)
+    abort "❌ Final promotion is blocked: exact-candidate CI evidence changed at the publication boundary."
+  end
+  validate_final_promotion_boundary_head!(monorepo_root:, final_head_sha:)
+  source_rc_context = final_promotion_source_rc_context!(
+    monorepo_root:,
+    rc_tag:,
+    record: boundary_record,
+    source_rc_tag_identity: boundary_selection.fetch(:source_rc_tag_identity)
+  )
+
+  final_promotion_boundary_context(
+    final_head_sha:,
+    current_branch:,
+    record: boundary_record,
+    ci_snapshot: boundary_ci_snapshot,
+    shakaperf_evidence:,
+    final_target_version: target_version,
+    source_rc_context:
+  )
+end
+
 def run_accepted_rc_final_promotion_gates!(repo_slug:, monorepo_root:, current_branch:, rc_tag:, tracker_input:,
                                            final_head_sha:, record:, target_version:, release_started_at:,
                                            allow_ci_override:, dry_run:)
@@ -4907,28 +5215,12 @@ def run_accepted_rc_final_promotion_gates!(repo_slug:, monorepo_root:, current_b
     dry_run:
   )
 
-  boundary_record = accepted_rc_record_at_publication_boundary!(
+  boundary_selection = accepted_rc_record_at_publication_boundary!(
     monorepo_root:, rc_tag:, final_head_sha:, tracker_input:, record:
   )
-
-  boundary_ci_snapshot = refresh_accepted_rc_ci_evidence_for_promotion!(
-    repo_slug:, monorepo_root:, ci_branch: current_branch, record: boundary_record
-  )
-  unless canonical_accelerated_rc_ci_snapshot_for_comparison(boundary_ci_snapshot) ==
-         canonical_accelerated_rc_ci_snapshot_for_comparison(ci_snapshot)
-    abort "❌ Final promotion is blocked: exact-candidate CI evidence changed at the publication boundary."
-  end
-  validate_final_promotion_boundary_head!(monorepo_root:, final_head_sha:)
-  source_rc_context = final_promotion_source_rc_context!(monorepo_root:, rc_tag:, record: boundary_record)
-
-  final_promotion_boundary_context(
-    final_head_sha:,
-    current_branch:,
-    record: boundary_record,
-    ci_snapshot: boundary_ci_snapshot,
-    shakaperf_evidence:,
-    final_target_version: target_version,
-    source_rc_context:
+  final_promotion_context_after_boundary!(
+    repo_slug:, monorepo_root:, current_branch:, rc_tag:, final_head_sha:, target_version:, ci_snapshot:,
+    shakaperf_evidence:, boundary_selection:
   )
 end
 
@@ -6610,6 +6902,43 @@ rescue JSON::ParserError => e
 rescue StandardError => e
   warn "⚠️  Unable to check RubyGems metadata for #{gem_name}: #{e.class}: #{e.message}; attempting publish."
   false
+end
+
+def valid_rubygems_version_metadata?(versions)
+  versions.is_a?(Array) && versions.all? do |metadata|
+    metadata.is_a?(Hash) && metadata["number"].is_a?(String) && !metadata["number"].empty?
+  end
+end
+
+def verify_rubygem_version_published!(gem_name, expected_version, api_url: RUBYGEMS_VERSIONS_API_URL)
+  output, response = fetch_rubygems_versions(gem_name, api_url:)
+  unless response.is_a?(Net::HTTPSuccess)
+    abort "❌ Unable to verify exact RubyGem #{gem_name} #{expected_version} for publication recovery."
+  end
+
+  versions = JSON.parse(output)
+  unless valid_rubygems_version_metadata?(versions)
+    abort "❌ RubyGems returned malformed version metadata for #{gem_name}; publication recovery is unknown."
+  end
+  unless versions.any? { |metadata| metadata["number"] == expected_version }
+    abort "❌ Exact RubyGem #{gem_name} #{expected_version} is not visible; publication recovery is incomplete."
+  end
+
+  puts "✓ Verified RubyGem #{gem_name} #{expected_version}"
+rescue JSON::ParserError => e
+  abort "❌ Unable to parse RubyGems metadata for #{gem_name} during publication recovery: #{e.message}"
+rescue StandardError => e
+  abort "❌ Unable to verify RubyGem #{gem_name} during publication recovery: #{e.class}: #{e.message}"
+end
+
+def verify_complete_release_registry_publication!(gem_version:)
+  npm_version = ReactOnRails::VersionSyntaxConverter.new.rubygem_to_npm(gem_version)
+  NPM_RELEASE_PACKAGE_NAMES.each do |package_name|
+    verify_npm_package_published!(package_name, npm_version)
+  end
+  RUBYGEMS_RELEASE_GEM_NAMES.each do |gem_name|
+    verify_rubygem_version_published!(gem_name, gem_version)
+  end
 end
 
 def abort_existing_registry_artifact_without_retry!(artifact_ref:, registry_name:)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -5745,7 +5745,11 @@ RSpec.describe "release.rake helper methods" do
         "literal ASCII opener `<!-- react-on-rails-accelerated-rc `, including its single trailing space"
       )
       expect(normalized_guide).to include(
-        "Only an exactly present `user: nil` author is known deleted"
+        "A safely structured markerless ordinary comment may remain ignorable when its author envelope is " \
+        "exactly `user: nil`"
+      )
+      expect(normalized_guide).to include(
+        "An explicit machine-marker comment with `user: nil` instead blocks replay as unattributable history"
       )
       expect(normalized_guide).to include(
         "Missing, malformed, or unparseable creation or update timestamps block even on markerless API comments"
@@ -5837,7 +5841,95 @@ RSpec.describe "release.rake helper methods" do
       ).to eq([])
     end
 
-    it "ignores an unattributable explicit marker while retaining canonical trusted history" do
+    it "keeps a safely structured markerless deleted-author comment outside durable marker history (V58)" do
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: "ordinary release discussion",
+        user: nil
+      )
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output).and_return([JSON.generate([comment]), success])
+
+      expect(
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      ).to eq([])
+      expect(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      ).to eq([])
+    end
+
+    it "blocks a deleted-author candidate rejection during selected-tracker replay (V58)" do
+      rejected = accelerated_rc_test_rejected_history.last
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: accelerated_rc_tracker_comment(rejected),
+        user: nil
+      )
+      allow(self).to receive(:fetch_release_tracker_comments).and_return([comment])
+
+      expect do
+        fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /machine-marker author.*unattributable|author.*unknown/i)
+    end
+
+    it "does not omit a deleted-author rejection beside later acceptance in repository replay (V58)" do
+      rejected = accelerated_rc_test_rejected_history.last
+      accepted = accelerated_rc_test_accepted_history.last
+      comments = [
+        accelerated_rc_test_issue_comment(
+          id: 1,
+          body: accelerated_rc_tracker_comment(rejected),
+          user: nil
+        ),
+        accelerated_rc_test_issue_comment(
+          id: 2,
+          body: accelerated_rc_tracker_comment(accepted),
+          created_at: "2026-07-14T13:01:00Z",
+          user: { "login" => "justin808" }
+        )
+      ]
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: comments,
+        accelerated_rc_repository_comment_permission!: "maintain",
+        fetch_release_tracker_issue!: {}
+      )
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /machine-marker author.*unattributable|author.*unknown/i)
+    end
+
+    it "blocks malformed deleted-author machine markers before selected or repository omission (V58)" do
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->",
+        user: nil
+      )
+      allow(self).to receive_messages(
+        fetch_release_tracker_comments: [comment],
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [comment]
+      )
+
+      aggregate_failures do
+        expect do
+          fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+        end.to raise_error(SystemExit, /machine-marker author.*unattributable|author.*unknown/i)
+
+        expect do
+          fetch_repository_accelerated_rc_records_for_candidate!(
+            repo_slug: "shakacode/react_on_rails",
+            target_version: "17.0.0.rc.10",
+            candidate_sha: "f" * 40
+          )
+        end.to raise_error(SystemExit, /machine-marker author.*unattributable|author.*unknown/i)
+      end
+    end
+
+    it "blocks an unattributable explicit marker before using canonical trusted history" do
       authorization = build_accelerated_rc_publication_record(
         options: accelerated_rc_options,
         candidate_sha: "f" * 40,
@@ -5859,19 +5951,12 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive(:fetch_release_tracker_comments).and_return(
         [deleted_author_marker, trusted_marker]
       )
-      success = instance_double(Process::Status, success?: true)
-      allow(self).to receive(:capture_gh_output)
-        .with(
-          "api",
-          "repos/shakacode/react_on_rails/collaborators/justin808/permission",
-          "--jq",
-          ".permission"
-        ).and_return(["write\n", success])
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+      expect(self).not_to receive(:accelerated_rc_records_from_trusted_comment!)
 
-      expect(
+      expect do
         fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
-      ).to eq([authorization])
-      expect(self).to have_received(:capture_gh_output).once
+      end.to raise_error(SystemExit, /machine-marker author.*unattributable/i)
     end
 
     it "fails closed on every malformed selected-tracker marker author envelope before decoding" do
@@ -6445,7 +6530,7 @@ RSpec.describe "release.rake helper methods" do
       ).to eq([])
     end
 
-    it "ignores an unattributable repository marker while retaining canonical trusted candidate history" do
+    it "blocks an unattributable repository marker before using canonical trusted candidate history" do
       authorization = accelerated_rc_test_authorization
       deleted_author_marker = accelerated_rc_test_issue_comment(
         id: 1,
@@ -6458,22 +6543,18 @@ RSpec.describe "release.rake helper methods" do
         created_at: "2026-07-14T13:01:00Z",
         user: { "login" => "justin808" }
       )
-      allow(self).to receive_messages(
-        fetch_repository_issue_comments_for_accelerated_rc_retry!: [deleted_author_marker, trusted_marker],
-        accelerated_rc_repository_comment_permission!: "maintain"
-      )
-      expect(self).to receive(:fetch_release_tracker_issue!)
-        .once.with(repo_slug: "shakacode/react_on_rails", tracker: 3823)
-        .and_return({})
+      allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!)
+        .and_return([deleted_author_marker, trusted_marker])
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+      expect(self).not_to receive(:fetch_release_tracker_issue!)
 
-      expect(
+      expect do
         fetch_repository_accelerated_rc_records_for_candidate!(
           repo_slug: "shakacode/react_on_rails",
           target_version: "17.0.0.rc.10",
           candidate_sha: "f" * 40
         )
-      ).to eq([authorization])
-      expect(self).to have_received(:accelerated_rc_repository_comment_permission!).once
+      end.to raise_error(SystemExit, /machine-marker author.*unattributable/i)
     end
 
     it "fails closed on every malformed repository marker author envelope before decoding" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7834,14 +7834,23 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive_messages(
         fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
         fetch_accelerated_rc_tracker_records!: [authorization],
-        local_release_tag_exists?: false
+        local_release_tag_exists?: false,
+        refresh_shakaperf_release_gate_run!: {
+          "databaseId" => 123_456,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref: "release/17.0.0", head_sha: "f" * 40, target_version: "17.0.0.rc.10"
+          ),
+          "headSha" => "f" * 40,
+          "status" => "in_progress",
+          "conclusion" => nil,
+          "createdAt" => "2026-07-14T13:00:00Z",
+          "startedAt" => "2026-07-14T13:00:05Z",
+          "updatedAt" => "2026-07-14T13:01:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+        }
       )
       expect(self).not_to receive(:run_accelerated_shakaperf_release_gate!)
-      allow(self).to receive(:accelerated_rc_shakaperf_snapshot!).with(
-        repo_slug: "shakacode/react_on_rails",
-        monorepo_root: "/tmp/repo",
-        record: authorization
-      ).and_return(authorization.fetch("shakaperf"))
       allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).with(
         repo_slug: "shakacode/react_on_rails",
         sha: "f" * 40,
@@ -7866,8 +7875,57 @@ RSpec.describe "release.rake helper methods" do
         )
       end.to output(/Reusing canonical accelerated RC publication authorization/).to_stdout
       expect(result).to eq(authorization)
-      expect(self).to have_received(:accelerated_rc_shakaperf_snapshot!)
+      expect(self).to have_received(:refresh_shakaperf_release_gate_run!)
       expect(self).to have_received(:fetch_accelerated_rc_ci_snapshot!)
+    end
+
+    it "blocks persisted authorization reuse for an active different-SHA ShakaPerf run" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot.merge(candidate_sha: "e" * 40),
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        local_release_tag_exists?: false,
+        fetch_accelerated_rc_ci_snapshot!: accelerated_rc_ci_snapshot,
+        refresh_shakaperf_release_gate_run!: {
+          "databaseId" => 123_456,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref: "release/17.0.0", head_sha: "e" * 40, target_version: "17.0.0.rc.10"
+          ),
+          "headSha" => "e" * 40,
+          "status" => "in_progress",
+          "conclusion" => nil,
+          "createdAt" => "2026-07-14T12:55:00Z",
+          "startedAt" => "2026-07-14T12:56:00Z",
+          "updatedAt" => "2026-07-14T13:01:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+        }
+      )
+      expect(self).not_to receive(:fetch_shakaperf_release_gate_evidence)
+      expect(self).not_to receive(:shakaperf_runtime_tree_fingerprint)
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options: accelerated_rc_options,
+          approver: "another-maintainer",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /pending.*ShakaPerf.*exact.*candidate|pre-run.*completed/i)
     end
 
     it "fails closed when persisted authorization refresh returns malformed exact-candidate CI" do
@@ -8478,7 +8536,7 @@ RSpec.describe "release.rake helper methods" do
         ),
         "ShakaPerf attempt" => authorization.merge("shakaperf" => shakaperf.merge("attempt" => 2)),
         "ShakaPerf candidate identity" => authorization.merge(
-          "shakaperf" => shakaperf.merge("candidate_sha" => "e" * 40)
+          "shakaperf" => shakaperf.merge("status" => "success", "candidate_sha" => "e" * 40)
         ),
         "runtime fingerprint" => authorization.merge("runtime_tree_fingerprint" => "b" * 64),
         "approver metadata" => authorization.merge("approved_by" => "another-maintainer"),
@@ -8645,6 +8703,22 @@ RSpec.describe "release.rake helper methods" do
       expect(accelerated_rc_shakaperf_requires_prerun?(exact_record)).to be(false)
       expect(accelerated_rc_shakaperf_requires_prerun?(prerun_record)).to be(true)
     end
+
+    it "permits pending evidence only for the exact candidate while retaining completed pre-run representation" do
+      exact_pending = accelerated_rc_test_authorization
+      different_sha_pending = exact_pending.merge(
+        "shakaperf" => exact_pending.fetch("shakaperf").merge("candidate_sha" => "e" * 40)
+      )
+      completed_prerun = different_sha_pending.merge(
+        "shakaperf" => different_sha_pending.fetch("shakaperf").merge("status" => "success")
+      )
+
+      aggregate_failures do
+        expect(valid_accelerated_rc_tracker_record?(exact_pending)).to be(true)
+        expect(valid_accelerated_rc_tracker_record?(different_sha_pending)).to be(false)
+        expect(valid_accelerated_rc_tracker_record?(completed_prerun)).to be(true)
+      end
+    end
   end
 
   describe "#reconcile_accelerated_rc_record" do
@@ -8728,6 +8802,107 @@ RSpec.describe "release.rake helper methods" do
   end
 
   describe "#accelerated_rc_shakaperf_snapshot!" do
+    it "accepts completed different-SHA evidence only through the live mechanical pre-run verifier" do
+      record = accelerated_rc_test_authorization
+      prerun_sha = "e" * 40
+      record = record.merge(
+        "shakaperf" => record.fetch("shakaperf").merge(
+          "status" => "success",
+          "candidate_sha" => prerun_sha
+        )
+      )
+      completed_prerun = {
+        "databaseId" => record.dig("shakaperf", "run_id"),
+        "attempt" => record.dig("shakaperf", "attempt"),
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: record.fetch("release_branch"), head_sha: prerun_sha, target_version: record.fetch("target_version")
+        ),
+        "headSha" => prerun_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => record.dig("shakaperf", "run_url")
+      }
+      allow(self).to receive_messages(
+        refresh_shakaperf_release_gate_run!: completed_prerun,
+        shakaperf_release_gate_run_evidence_rejection: nil
+      )
+
+      snapshot = accelerated_rc_shakaperf_snapshot!(
+        repo_slug: "shakacode/react_on_rails", monorepo_root: "/tmp/repo", record:
+      )
+
+      aggregate_failures do
+        expect(snapshot).to include("status" => "success", "candidate_sha" => prerun_sha)
+        expect(self).to have_received(:shakaperf_release_gate_run_evidence_rejection).with(
+          hash_including(
+            monorepo_root: "/tmp/repo",
+            head_sha: record.fetch("candidate_sha"),
+            target_version: record.fetch("target_version"),
+            run: completed_prerun,
+            require_prerun: true
+          )
+        )
+      end
+    end
+
+    it "blocks non-successful or unverifiable completed different-SHA evidence during persisted reuse" do
+      record = accelerated_rc_test_authorization
+      prerun_sha = "e" * 40
+      record = record.merge(
+        "shakaperf" => record.fetch("shakaperf").merge(
+          "status" => "success",
+          "candidate_sha" => prerun_sha
+        )
+      )
+      completed_prerun = {
+        "databaseId" => record.dig("shakaperf", "run_id"),
+        "attempt" => record.dig("shakaperf", "attempt"),
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: record.fetch("release_branch"), head_sha: prerun_sha, target_version: record.fetch("target_version")
+        ),
+        "headSha" => prerun_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => record.dig("shakaperf", "run_url")
+      }
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).and_return(
+        status: "success",
+        sha: record.fetch("candidate_sha"),
+        checks_url: record.dig("ci", "checks_url"),
+        non_success: []
+      )
+      cases = {
+        "runtime difference" => [completed_prerun, "release runtime tree differs from the tested candidate"],
+        "unknown ancestry" => [completed_prerun, "tested candidate ancestry cannot be verified"],
+        "stale artifact" => [completed_prerun, "evidence is stale"],
+        "missing artifact" => [completed_prerun, "evidence artifact is missing or unreadable"],
+        "known failure" => [completed_prerun.merge("conclusion" => "failure"), nil],
+        "unknown conclusion" => [completed_prerun.merge("conclusion" => "future_failure"), nil],
+        "malformed URL" => [completed_prerun.merge("url" => "https://example.com/run"), nil]
+      }
+
+      aggregate_failures do
+        cases.each do |label, (run, rejection)|
+          allow(self).to receive_messages(
+            refresh_shakaperf_release_gate_run!: run,
+            shakaperf_release_gate_run_evidence_rejection: rejection
+          )
+
+          expect do
+            validate_persisted_accelerated_rc_authorization_evidence!(
+              repo_slug: "shakacode/react_on_rails", monorepo_root: "/tmp/repo", authorization: record
+            )
+          end.to raise_error(SystemExit), label
+        end
+      end
+    end
+
     it "never synthesizes or accepts a noncanonical refreshed run URL" do
       record = {
         "candidate_sha" => "f" * 40,
@@ -8892,6 +9067,54 @@ RSpec.describe "release.rake helper methods" do
           record:
         )
       end.to raise_error(SystemExit, /run identity is unknown or malformed/)
+    end
+  end
+
+  describe "#validate_accelerated_rc_authorization_live_evidence_boundary!" do
+    it "blocks active different-SHA evidence at every accelerated RC publication phase" do
+      authorization = accelerated_rc_test_authorization
+      prerun_sha = "e" * 40
+      authorization = authorization.merge(
+        "shakaperf" => authorization.fetch("shakaperf").merge("candidate_sha" => prerun_sha)
+      )
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "pending",
+          sha: authorization.fetch("candidate_sha"),
+          checks_url: authorization.dig("ci", "checks_url"),
+          non_success: authorization.dig("ci", "non_success").map { |check| check.transform_keys(&:to_sym) }
+        },
+        refresh_shakaperf_release_gate_run!: {
+          "databaseId" => authorization.dig("shakaperf", "run_id"),
+          "attempt" => authorization.dig("shakaperf", "attempt"),
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref: authorization.fetch("release_branch"),
+            head_sha: prerun_sha,
+            target_version: authorization.fetch("target_version")
+          ),
+          "headSha" => prerun_sha,
+          "status" => "in_progress",
+          "conclusion" => nil,
+          "createdAt" => "2026-07-14T12:55:00Z",
+          "startedAt" => "2026-07-14T12:56:00Z",
+          "updatedAt" => "2026-07-14T13:01:00Z",
+          "url" => authorization.dig("shakaperf", "run_url")
+        }
+      )
+      expect(self).not_to receive(:fetch_shakaperf_release_gate_evidence)
+
+      aggregate_failures do
+        ["tag handling", "git tag push", "package publication"].each do |phase|
+          expect do
+            validate_accelerated_rc_authorization_live_evidence_boundary!(
+              repo_slug: "shakacode/react_on_rails",
+              monorepo_root: "/tmp/repo",
+              authorization:,
+              phase:
+            )
+          end.to raise_error(SystemExit, /pending.*ShakaPerf.*exact.*candidate|pre-run.*completed/i), phase
+        end
+      end
     end
   end
 
@@ -11432,6 +11655,73 @@ RSpec.describe "release.rake helper methods" do
         expect(failure&.message).to match(/live.*exact-candidate CI.*failed|known failed.*CI/i)
         expect(pushed).to be(false)
         expect(package_publication_started).to be(false)
+      end
+    end
+
+    it "blocks persisted pending different-SHA ShakaPerf evidence before accelerated RC tag handling" do
+      authorization = accelerated_rc_test_authorization
+      prerun_sha = "e" * 40
+      authorization = authorization.merge(
+        "shakaperf" => authorization.fetch("shakaperf").merge("candidate_sha" => prerun_sha)
+      )
+      pending_ci = {
+        status: "pending",
+        sha: authorization.fetch("candidate_sha"),
+        checks_url: authorization.dig("ci", "checks_url"),
+        non_success: authorization.dig("ci", "non_success").map do |check|
+          check.transform_keys(&:to_sym)
+        end
+      }
+      active_prerun = {
+        "databaseId" => authorization.dig("shakaperf", "run_id"),
+        "attempt" => authorization.dig("shakaperf", "attempt"),
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: authorization.fetch("release_branch"),
+          head_sha: prerun_sha,
+          target_version: authorization.fetch("target_version")
+        ),
+        "headSha" => prerun_sha,
+        "status" => "in_progress",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T12:55:00Z",
+        "startedAt" => "2026-07-14T12:56:00Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
+        "url" => authorization.dig("shakaperf", "run_url")
+      }
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_accelerated_rc_ci_snapshot!: pending_ci,
+        refresh_shakaperf_release_gate_run!: active_prerun,
+        system: true,
+        validate_existing_accelerated_rc_tag!: nil,
+        validate_release_candidate_publication_boundary!: authorization.fetch("candidate_sha"),
+        validate_remote_release_tag_candidate_sha!: authorization.fetch("candidate_sha")
+      )
+      expect(self).not_to receive(:fetch_shakaperf_release_gate_evidence)
+      expect(self).not_to receive(:shakaperf_runtime_tree_fingerprint)
+      pushed = false
+      package_continuation_reached = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      failure = begin
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha: authorization.fetch("candidate_sha"),
+          accelerated_publication_record: authorization
+        )
+        package_continuation_reached = true
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/pending.*ShakaPerf.*exact.*candidate|pre-run.*completed/i)
+        expect(pushed).to be(false)
+        expect(package_continuation_reached).to be(false)
       end
     end
 

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -11088,7 +11088,8 @@ RSpec.describe "release.rake helper methods" do
       expect(help).to include(
         "RELEASE_ACCELERATED_RC=true",
         "RELEASE_TRACKER=<issue>",
-        "RELEASE_ACCELERATED_RC_REASON=<reason>"
+        "RELEASE_ACCELERATED_RC_REASON=<reason>",
+        "from matching release/X.Y.Z"
       )
       expect(Rake::Task.task_defined?("release:reconcile_accelerated_rc")).to be(true)
     end
@@ -11099,6 +11100,8 @@ RSpec.describe "release.rake helper methods" do
       tag_push_helper = rakefile.match(/def push_release_tag_for_candidate!.*?^end$/m)[0]
       tag_retry_index = release_task.index("release_tag_retry_state_for_current_head")
       retry_mode_index = release_task.index("resolve_accelerated_rc_options_for_release!")
+      accelerated_branch_guard_index = release_task.index("ensure_accelerated_rc_release_branch!")
+      accelerated_tag_preflight_index = release_task.index("preflight_explicit_accelerated_rc_target_tag!")
       ci_gate_index = release_task.index("validate_main_ci_status!")
       final_refresh_index = release_task.index("run_accepted_rc_final_promotion_gates!")
       tag_push_index = release_task.index("push_release_tag_for_candidate!")
@@ -11110,6 +11113,9 @@ RSpec.describe "release.rake helper methods" do
       package_boundary_index = tag_push_helper.index('phase: "package publication"')
 
       expect(tag_retry_index).to be < retry_mode_index
+      expect(retry_mode_index).to be < accelerated_branch_guard_index
+      expect(accelerated_branch_guard_index).to be < accelerated_tag_preflight_index
+      expect(accelerated_branch_guard_index).to be < ci_gate_index
       expect(retry_mode_index).to be < ci_gate_index
       expect(final_refresh_index).to be < tag_push_index
       expect(tag_push_index).to be < package_publish_index
@@ -11131,6 +11137,299 @@ RSpec.describe "release.rake helper methods" do
   end
 
   describe "release task accelerated RC preflight" do
+    def invoke_release_task_and_capture_exit(release_task, version: "17.0.0.rc.10", dry_run: true)
+      release_task.reenable
+      release_task.invoke(version, dry_run, true, false)
+      nil
+    rescue SystemExit => error
+      error
+    ensure
+      release_task.reenable
+    end
+
+    it "blocks accelerated RCs from feature branches before release side effects" do
+      release_task = Rake::Task["release"]
+      task_receiver = release_task.actions.first.binding.receiver
+      success_status = instance_double(Process::Status, success?: true)
+      events = []
+
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--abbrev-ref", "HEAD")
+        .and_return(["feature/accelerated-cut\n", success_status])
+      allow(ReactOnRails::GitUtils).to receive(:uncommitted_changes?)
+      allow(task_receiver).to receive(:with_release_checkout) { |**_, &block| block.call("/tmp/repo") }
+      allow(task_receiver).to receive_messages(
+        current_monorepo_root: "/tmp/repo",
+        verbose: nil,
+        release_paths: { monorepo_root: "/tmp/repo", gem_root: "/tmp/repo/react_on_rails" },
+        resolve_release_version_before_auth!: "17.0.0.rc.10",
+        current_gem_version: "16.9.0",
+        release_tag_retry_state_for_current_head: :none,
+        github_repo_slug: "shakacode/react_on_rails",
+        validate_release_version_policy!: nil
+      )
+      allow(task_receiver).to receive(:preflight_explicit_accelerated_rc_target_tag!) do
+        events << :target_tag_preflight
+      end
+      allow(task_receiver).to receive(:fetch_release_tracker_issue!) do
+        events << :tracker_read
+        {}
+      end
+      allow(task_receiver).to receive(:current_release_approver!) do
+        events << :approver_read
+        "justin808"
+      end
+      allow(task_receiver).to receive(:validate_main_ci_status!) { events << :ci }
+      allow(task_receiver).to receive(:confirm_release!) { events << :confirmation }
+      allow(task_receiver).to receive(:append_accelerated_rc_tracker_record!) { events << :tracker_append }
+      allow(task_receiver).to receive(:sh_in_dir_for_release) do |_dir, command|
+        next unless command.include?("gem bump")
+
+        events << :version_mutation
+        abort "V70 regression reached the version-mutation boundary"
+      end
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return("true")
+      allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return("3823")
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil)
+                                   .and_return("Start published-artifact QA while exact-head checks finish")
+
+      failure = begin
+        release_task.reenable
+        release_task.invoke("17.0.0.rc.10", true, true, false)
+        nil
+      rescue SystemExit => error
+        error
+      ensure
+        release_task.reenable
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/accelerated RC.*matching release branch/i)
+        expect(events).to be_empty
+        expect(task_receiver).not_to have_received(:preflight_explicit_accelerated_rc_target_tag!)
+        expect(task_receiver).not_to have_received(:fetch_release_tracker_issue!)
+        expect(task_receiver).not_to have_received(:current_release_approver!)
+        expect(task_receiver).not_to have_received(:validate_main_ci_status!)
+        expect(task_receiver).not_to have_received(:confirm_release!)
+        expect(task_receiver).not_to have_received(:append_accelerated_rc_tracker_record!)
+      end
+    end
+
+    it "blocks an unflagged durable retry on a feature branch after read-only history discovery" do
+      release_task = Rake::Task["release"]
+      task_receiver = release_task.actions.first.binding.receiver
+      success_status = instance_double(Process::Status, success?: true)
+      candidate_sha = "e" * 40
+      reason = "Start published-artifact QA while exact-head checks finish"
+      events = []
+
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--abbrev-ref", "HEAD")
+        .and_return(["feature/durable-retry\n", success_status])
+      allow(ReactOnRails::GitUtils).to receive(:uncommitted_changes?)
+      allow(task_receiver).to receive(:with_release_checkout) { |**_, &block| block.call("/tmp/repo") }
+      allow(task_receiver).to receive_messages(
+        current_monorepo_root: "/tmp/repo",
+        verbose: nil,
+        release_paths: { monorepo_root: "/tmp/repo", gem_root: "/tmp/repo/react_on_rails" },
+        resolve_release_version_before_auth!: "17.0.0.rc.10",
+        current_gem_version: "17.0.0.rc.10",
+        release_tag_retry_state_for_current_head: :none,
+        github_repo_slug: "shakacode/react_on_rails",
+        current_git_sha!: candidate_sha
+      )
+      allow(task_receiver).to receive(:accelerated_rc_authorization_for_same_candidate_retry!) do
+        events << :read_only_durable_retry_discovery
+        { "release_tracker" => 3823, "reason" => reason }
+      end
+      allow(task_receiver).to receive(:ensure_accelerated_rc_release_branch!).and_call_original
+      allow(task_receiver).to receive(:preflight_explicit_accelerated_rc_target_tag!) do
+        events << :target_tag_preflight
+      end
+      allow(task_receiver).to receive(:fetch_release_tracker_issue!) do
+        events << :selected_tracker_read
+        {}
+      end
+      allow(task_receiver).to receive(:current_release_approver!) do
+        events << :approver_read
+        "justin808"
+      end
+      allow(task_receiver).to receive(:validate_main_ci_status!) do
+        events << :ci
+        abort "V72 durable retry reached CI without the branch guard"
+      end
+      allow(task_receiver).to receive(:confirm_release!) { events << :confirmation }
+      allow(task_receiver).to receive(:append_accelerated_rc_tracker_record!) { events << :tracker_append }
+      allow(task_receiver).to receive(:sh_in_dir_for_release) do |_dir, command|
+        events << :push if command.include?("git push")
+        events << :version_mutation if command.include?("gem bump")
+      end
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil).and_return(nil)
+
+      failure = invoke_release_task_and_capture_exit(release_task)
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/accelerated RC.*matching release branch/i)
+        expect(events).to eq([:read_only_durable_retry_discovery])
+        expect(task_receiver).to have_received(:accelerated_rc_authorization_for_same_candidate_retry!).with(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          target_version: "17.0.0.rc.10",
+          candidate_sha:,
+          accelerated_requested: false
+        )
+        expect(task_receiver).to have_received(:ensure_accelerated_rc_release_branch!).with(
+          current_branch: "feature/durable-retry",
+          target_gem_version: "17.0.0.rc.10"
+        )
+        expect(task_receiver).not_to have_received(:preflight_explicit_accelerated_rc_target_tag!)
+        expect(task_receiver).not_to have_received(:fetch_release_tracker_issue!)
+        expect(task_receiver).not_to have_received(:current_release_approver!)
+        expect(task_receiver).not_to have_received(:validate_main_ci_status!)
+        expect(task_receiver).not_to have_received(:confirm_release!)
+        expect(task_receiver).not_to have_received(:append_accelerated_rc_tracker_record!)
+      end
+    end
+
+    it "allows an ordinary non-accelerated RC on a feature branch to reach CI" do
+      release_task = Rake::Task["release"]
+      task_receiver = release_task.actions.first.binding.receiver
+      success_status = instance_double(Process::Status, success?: true)
+      events = []
+
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--abbrev-ref", "HEAD")
+        .and_return(["feature/ordinary-rc\n", success_status])
+      allow(ReactOnRails::GitUtils).to receive(:uncommitted_changes?)
+      allow(task_receiver).to receive(:with_release_checkout) { |**_, &block| block.call("/tmp/repo") }
+      allow(task_receiver).to receive_messages(
+        current_monorepo_root: "/tmp/repo",
+        verbose: nil,
+        release_paths: { monorepo_root: "/tmp/repo", gem_root: "/tmp/repo/react_on_rails" },
+        resolve_release_version_before_auth!: "17.0.0.rc.10",
+        current_gem_version: "16.9.0",
+        release_tag_retry_state_for_current_head: :none
+      )
+      allow(task_receiver).to receive(:ensure_accelerated_rc_release_branch!).and_call_original
+      allow(task_receiver).to receive(:preflight_explicit_accelerated_rc_target_tag!)
+      allow(task_receiver).to receive(:fetch_release_tracker_issue!)
+      allow(task_receiver).to receive(:current_release_approver!)
+      allow(task_receiver).to receive(:validate_main_ci_status!) do
+        events << :ci
+        abort "V72 ordinary RC reached the CI boundary"
+      end
+      allow(task_receiver).to receive(:confirm_release!) { events << :confirmation }
+      allow(task_receiver).to receive(:append_accelerated_rc_tracker_record!) { events << :tracker_append }
+      allow(task_receiver).to receive(:sh_in_dir_for_release) do |_dir, command|
+        events << :push if command.include?("git push")
+        events << :version_mutation if command.include?("gem bump")
+      end
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil).and_return(nil)
+
+      failure = invoke_release_task_and_capture_exit(release_task)
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to eq("V72 ordinary RC reached the CI boundary")
+        expect(events).to eq([:ci])
+        expect(task_receiver).not_to have_received(:ensure_accelerated_rc_release_branch!)
+        expect(task_receiver).not_to have_received(:preflight_explicit_accelerated_rc_target_tag!)
+        expect(task_receiver).not_to have_received(:fetch_release_tracker_issue!)
+        expect(task_receiver).not_to have_received(:current_release_approver!)
+        expect(task_receiver).not_to have_received(:confirm_release!)
+        expect(task_receiver).not_to have_received(:append_accelerated_rc_tracker_record!)
+      end
+    end
+
+    it "allows explicit acceleration on the matching release branch to reach CI in order" do
+      release_task = Rake::Task["release"]
+      task_receiver = release_task.actions.first.binding.receiver
+      success_status = instance_double(Process::Status, success?: true)
+      events = []
+
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--abbrev-ref", "HEAD")
+        .and_return(["release/17.0.0\n", success_status])
+      allow(ReactOnRails::GitUtils).to receive(:uncommitted_changes?)
+      allow(task_receiver).to receive(:with_release_checkout) { |**_, &block| block.call("/tmp/repo") }
+      allow(task_receiver).to receive_messages(
+        current_monorepo_root: "/tmp/repo",
+        verbose: nil,
+        release_paths: { monorepo_root: "/tmp/repo", gem_root: "/tmp/repo/react_on_rails" },
+        resolve_release_version_before_auth!: "17.0.0.rc.10",
+        current_gem_version: "16.9.0",
+        release_tag_retry_state_for_current_head: :none,
+        github_repo_slug: "shakacode/react_on_rails"
+      )
+      allow(task_receiver).to receive(:ensure_accelerated_rc_release_branch!).and_wrap_original do |method, **arguments|
+        events << :accelerated_branch_guard
+        method.call(**arguments)
+      end
+      allow(task_receiver).to receive(:preflight_explicit_accelerated_rc_target_tag!) do
+        events << :target_tag_preflight
+      end
+      allow(task_receiver).to receive(:fetch_release_tracker_issue!) do
+        events << :selected_tracker_read
+        {}
+      end
+      allow(task_receiver).to receive(:current_release_approver!) do
+        events << :approver_read
+        "justin808"
+      end
+      allow(task_receiver).to receive(:validate_main_ci_status!) do
+        events << :ci
+        abort "V72 matching accelerated RC reached the CI boundary"
+      end
+      allow(task_receiver).to receive(:confirm_release!) { events << :confirmation }
+      allow(task_receiver).to receive(:append_accelerated_rc_tracker_record!) { events << :tracker_append }
+      allow(task_receiver).to receive(:sh_in_dir_for_release) do |_dir, command|
+        events << :push if command.include?("git push")
+        events << :version_mutation if command.include?("gem bump")
+      end
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return("true")
+      allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return("3823")
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil)
+                                   .and_return("Start published-artifact QA while exact-head checks finish")
+
+      failure = invoke_release_task_and_capture_exit(release_task)
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to eq("V72 matching accelerated RC reached the CI boundary")
+        expect(events).to eq(
+          %i[accelerated_branch_guard target_tag_preflight selected_tracker_read approver_read ci]
+        )
+        expect(task_receiver).to have_received(:ensure_accelerated_rc_release_branch!).with(
+          current_branch: "release/17.0.0",
+          target_gem_version: "17.0.0.rc.10"
+        )
+        expect(task_receiver).to have_received(:preflight_explicit_accelerated_rc_target_tag!).with(
+          monorepo_root: "/tmp/repo",
+          target_gem_version: "17.0.0.rc.10",
+          current_checkout_version: "16.9.0"
+        )
+        expect(task_receiver).to have_received(:fetch_release_tracker_issue!).with(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823
+        )
+        expect(task_receiver).to have_received(:current_release_approver!).with(
+          repo_slug: "shakacode/react_on_rails"
+        )
+        expect(task_receiver).not_to have_received(:confirm_release!)
+        expect(task_receiver).not_to have_received(:append_accelerated_rc_tracker_record!)
+      end
+    end
+
     it "blocks a remote-only ordinary target tag before gates or release side effects from a mismatched checkout" do
       release_task = Rake::Task["release"]
       task_receiver = release_task.actions.first.binding.receiver
@@ -16241,6 +16540,35 @@ RSpec.describe "release.rake helper methods" do
           target_gem_version: "17.0.0.rc.0"
         )
       end.to raise_error(SystemExit, /Release branch must match the target release line/)
+    end
+  end
+
+  describe "#ensure_accelerated_rc_release_branch!" do
+    it "allows accelerated publication from the matching release branch" do
+      expect do
+        ensure_accelerated_rc_release_branch!(
+          current_branch: "release/17.0.0",
+          target_gem_version: "17.0.0.rc.10"
+        )
+      end.not_to raise_error
+    end
+
+    it "rejects accelerated publication from a feature branch" do
+      expect do
+        ensure_accelerated_rc_release_branch!(
+          current_branch: "feature/accelerated-cut",
+          target_gem_version: "17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /Accelerated RC publication must run from the matching release branch/)
+    end
+
+    it "rejects accelerated publication from a different release line" do
+      expect do
+        ensure_accelerated_rc_release_branch!(
+          current_branch: "release/16.7.1",
+          target_gem_version: "17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, %r{Expected branch: release/17\.0\.0})
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -93,6 +93,36 @@ RSpec.describe "release.rake helper methods" do
     [authorization, publication, rejected]
   end
 
+  def accelerated_final_promotion_test_context(record:, ci_snapshot:, ci_branch: "release/17.0.0",
+                                               final_candidate_sha: "e" * 40)
+    authorization = accelerated_rc_test_authorization(tracker: record.fetch("release_tracker"))
+    {
+      candidate_sha: final_candidate_sha,
+      ci_branch:,
+      record:,
+      source_rc_tag: "v#{record.fetch('target_version')}",
+      source_rc_candidate_sha: record.fetch("candidate_sha"),
+      source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
+      ci_snapshot: json_compatible_release_value(ci_snapshot),
+      shakaperf_record: {
+        "release_branch" => ci_branch,
+        "candidate_sha" => final_candidate_sha,
+        "target_version" => record.fetch("target_version"),
+        "shakaperf" => record.fetch("shakaperf")
+      }
+    }
+  end
+
+  def accelerated_rc_test_issue_comment(id:, body:, tracker: 3823, created_at: "2026-07-14T13:00:00Z", user: nil)
+    {
+      "id" => id,
+      "body" => body,
+      "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/#{tracker}",
+      "created_at" => created_at,
+      "user" => user
+    }
+  end
+
   before do
     next if Object.instance_variable_defined?(:@release_rake_helpers_loaded)
 
@@ -3875,6 +3905,134 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /unexpected JSON structure/)
     end
 
+    it "loads selected-tracker comments incrementally and retains only marker comments" do
+      success = instance_double(Process::Status, success?: true)
+      ordinary_comments = Array.new(99) do |index|
+        accelerated_rc_test_issue_comment(id: index + 1, body: "ordinary tracker discussion")
+      end
+      marker_comment = accelerated_rc_test_issue_comment(
+        id: 100, body: ACCELERATED_RC_RECORD_MARKER
+      )
+      endpoint = lambda do |page|
+        "repos/shakacode/react_on_rails/issues/3823/comments?per_page=100" \
+          "&sort=created&direction=asc&page=#{page}"
+      end
+      expect(self).to receive(:capture_gh_output)
+        .ordered.with("api", endpoint.call(1))
+        .and_return([JSON.generate(ordinary_comments + [marker_comment]), success])
+      expect(self).to receive(:capture_gh_output)
+        .ordered.with("api", endpoint.call(2))
+        .and_return([JSON.generate([]), success])
+
+      expect(
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      ).to eq([marker_comment])
+    end
+
+    it "fails closed when selected-tracker discovery reaches its configured page bound on a full page" do
+      success = instance_double(Process::Status, success?: true)
+      page_count = 0
+      allow(self).to receive(:capture_gh_output) do
+        page_count += 1
+        comments = Array.new(100) do |index|
+          accelerated_rc_test_issue_comment(
+            id: ((page_count - 1) * 100) + index + 1,
+            body: "ordinary tracker discussion"
+          )
+        end
+        [JSON.generate(comments), success]
+      end
+
+      expect do
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /bounded release tracker.*page limit.*unknown/i)
+      expect(page_count).to eq(250)
+    end
+
+    it "allows selected-tracker discovery to complete on a short 250th page" do
+      success = instance_double(Process::Status, success?: true)
+      page_count = 0
+      final_marker = nil
+      allow(self).to receive(:capture_gh_output) do
+        page_count += 1
+        comments = if page_count == 250
+                     final_marker = accelerated_rc_test_issue_comment(
+                       id: 24_901, body: ACCELERATED_RC_RECORD_MARKER
+                     )
+                     [final_marker]
+                   else
+                     Array.new(100) do |index|
+                       accelerated_rc_test_issue_comment(
+                         id: ((page_count - 1) * 100) + index + 1,
+                         body: "ordinary tracker discussion"
+                       )
+                     end
+                   end
+        [JSON.generate(comments), success]
+      end
+
+      expect(
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      ).to eq([final_marker])
+      expect(page_count).to eq(250)
+    end
+
+    it "allows exactly 1,000 marker comments in selected-tracker discovery" do
+      success = instance_double(Process::Status, success?: true)
+      pages = Array.new(10) do |page|
+        Array.new(100) do |index|
+          accelerated_rc_test_issue_comment(
+            id: (page * 100) + index + 1,
+            body: ACCELERATED_RC_RECORD_MARKER
+          )
+        end
+      end
+      pages << []
+      allow(self).to receive(:capture_gh_output) do
+        [JSON.generate(pages.shift), success]
+      end
+
+      comments = nil
+      expect do
+        comments = fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.not_to raise_error
+      expect(comments).to have_attributes(length: 1_000)
+    end
+
+    it "fails closed on marker 1,001 in selected-tracker discovery" do
+      success = instance_double(Process::Status, success?: true)
+      pages = Array.new(10) do |page|
+        Array.new(100) do |index|
+          accelerated_rc_test_issue_comment(
+            id: (page * 100) + index + 1,
+            body: ACCELERATED_RC_RECORD_MARKER
+          )
+        end
+      end
+      pages << [accelerated_rc_test_issue_comment(id: 1_001, body: ACCELERATED_RC_RECORD_MARKER)]
+      allow(self).to receive(:capture_gh_output) do
+        [JSON.generate(pages.shift), success]
+      end
+
+      expect do
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /bounded release tracker.*marker.*limit.*unknown/i)
+    end
+
+    it "documents the exact accelerated-comment discovery boundaries" do
+      guide = File.read(
+        File.expand_path("../../../internal/contributor-info/releasing.md", __dir__)
+      )
+      normalized_guide = guide.gsub(/\s+/, " ")
+
+      expect(normalized_guide).to include(
+        "Exactly 1,000 retained marker comments are allowed, and a short 250th page completes discovery"
+      )
+      expect(normalized_guide).to include(
+        "exceeding 1,000 markers or requiring a 251st page blocks as unknown"
+      )
+    end
+
     it "rejects a closed release tracker" do
       expect do
         validate_release_tracker_issue!(
@@ -3931,6 +4089,151 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /write, maintain, or admin/)
     end
 
+    it "loads repository issue-comment discovery incrementally and retains only marker comments" do
+      success = instance_double(Process::Status, success?: true)
+      ordinary_comments = Array.new(99) do |index|
+        accelerated_rc_test_issue_comment(id: index + 1, body: "ordinary repository discussion")
+      end
+      marker_comment = accelerated_rc_test_issue_comment(
+        id: 100, body: "prefix #{ACCELERATED_RC_RECORD_MARKER} suffix"
+      )
+      full_page = ordinary_comments + [marker_comment]
+      endpoint = lambda do |page|
+        "repos/shakacode/react_on_rails/issues/comments?per_page=100&sort=created&direction=asc&page=#{page}"
+      end
+      expect(self).to receive(:capture_gh_output)
+        .ordered.with("api", endpoint.call(1))
+        .and_return([JSON.generate(full_page), success])
+      expect(self).to receive(:capture_gh_output)
+        .ordered.with("api", endpoint.call(2))
+        .and_return([JSON.generate([]), success])
+
+      expect(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      ).to eq([marker_comment])
+    end
+
+    it "allows a safely structured markerless repository comment whose author was deleted" do
+      success = instance_double(Process::Status, success?: true)
+      deleted_user_comment = accelerated_rc_test_issue_comment(
+        id: 1, body: "ordinary repository discussion", user: nil
+      )
+      allow(self).to receive(:capture_gh_output)
+        .and_return([JSON.generate([deleted_user_comment]), success])
+
+      expect(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      ).to eq([])
+    end
+
+    it "fails closed when a repository comment page contains a malformed comment hash" do
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output).and_return([JSON.generate([{}]), success])
+
+      expect do
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      end.to raise_error(SystemExit, /comment.*schema|unexpected JSON structure/i)
+    end
+
+    it "fails closed on duplicate repository comment IDs within one page" do
+      success = instance_double(Process::Status, success?: true)
+      comments = [
+        accelerated_rc_test_issue_comment(id: 1, body: "ordinary comment"),
+        accelerated_rc_test_issue_comment(id: 1, body: "another ordinary comment")
+      ]
+      allow(self).to receive(:capture_gh_output).and_return([JSON.generate(comments), success])
+
+      expect do
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      end.to raise_error(SystemExit, /duplicate.*comment.*id|comment.*identity/i)
+    end
+
+    it "fails closed on duplicate repository comment IDs across pages" do
+      success = instance_double(Process::Status, success?: true)
+      full_page = Array.new(100) do |index|
+        accelerated_rc_test_issue_comment(id: index + 1, body: "ordinary comment")
+      end
+      duplicate = accelerated_rc_test_issue_comment(id: 100, body: "duplicate on next page")
+      responses = [full_page, [duplicate]]
+      allow(self).to receive(:capture_gh_output) do
+        [JSON.generate(responses.shift), success]
+      end
+
+      expect do
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      end.to raise_error(SystemExit, /duplicate.*comment.*id|comment.*identity/i)
+    end
+
+    it "fails closed on out-of-order repository comments within one page" do
+      success = instance_double(Process::Status, success?: true)
+      comments = [
+        accelerated_rc_test_issue_comment(
+          id: 1, body: "ordinary comment", created_at: "2026-07-14T13:01:00Z"
+        ),
+        accelerated_rc_test_issue_comment(
+          id: 2, body: "older ordinary comment", created_at: "2026-07-14T13:00:00Z"
+        )
+      ]
+      allow(self).to receive(:capture_gh_output).and_return([JSON.generate(comments), success])
+
+      expect do
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      end.to raise_error(SystemExit, /comment.*chronolog|out.of.order/i)
+    end
+
+    it "fails closed on out-of-order repository comment pages" do
+      success = instance_double(Process::Status, success?: true)
+      full_page = Array.new(100) do |index|
+        accelerated_rc_test_issue_comment(
+          id: index + 1, body: "ordinary comment", created_at: "2026-07-14T13:01:00Z"
+        )
+      end
+      older_comment = accelerated_rc_test_issue_comment(
+        id: 101, body: "older comment on next page", created_at: "2026-07-14T13:00:00Z"
+      )
+      responses = [full_page, [older_comment]]
+      allow(self).to receive(:capture_gh_output) do
+        [JSON.generate(responses.shift), success]
+      end
+
+      expect do
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      end.to raise_error(SystemExit, /comment.*chronolog|out.of.order/i)
+    end
+
+    it "fails closed at the bounded repository issue-comment page limit" do
+      stub_const("ACCELERATED_RC_REPOSITORY_COMMENT_MAX_PAGES", 2)
+      success = instance_double(Process::Status, success?: true)
+      pages = Array.new(2) do |page|
+        Array.new(100) do |index|
+          accelerated_rc_test_issue_comment(
+            id: (page * 100) + index + 1, body: "ordinary repository discussion"
+          )
+        end
+      end
+      allow(self).to receive(:capture_gh_output) do
+        [JSON.generate(pages.shift), success]
+      end
+
+      expect do
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      end.to raise_error(SystemExit, /bounded repository.*page limit.*unknown/i)
+      expect(self).to have_received(:capture_gh_output).twice
+    end
+
+    it "fails closed at the bounded repository accelerated-marker retention limit" do
+      stub_const("ACCELERATED_RC_REPOSITORY_MARKER_COMMENT_LIMIT", 1)
+      success = instance_double(Process::Status, success?: true)
+      marker_comments = Array.new(2) do |index|
+        accelerated_rc_test_issue_comment(id: index + 1, body: ACCELERATED_RC_RECORD_MARKER)
+      end
+      allow(self).to receive(:capture_gh_output).and_return([JSON.generate(marker_comments), success])
+
+      expect do
+        fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+      end.to raise_error(SystemExit, /bounded repository.*marker.*limit.*unknown/i)
+    end
+
     it "discovers exact candidate history from trusted repository issue comments" do
       authorization = build_accelerated_rc_publication_record(
         options: accelerated_rc_options,
@@ -3942,19 +4245,22 @@ RSpec.describe "release.rake helper methods" do
         approved_by: "justin808",
         recorded_at: Time.utc(2026, 7, 14, 13, 30)
       )
-      comment = {
-        "body" => accelerated_rc_tracker_comment(authorization),
-        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
-        "user" => { "login" => "justin808" }
-      }
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: accelerated_rc_tracker_comment(authorization),
+        user: { "login" => "justin808" }
+      )
       success = instance_double(Process::Status, success?: true)
       allow(self).to receive(:capture_gh_output)
-        .with("api", "--paginate", "--slurp", "repos/shakacode/react_on_rails/issues/comments?per_page=100")
-        .and_return([JSON.generate([[comment]]), success])
+        .with(
+          "api",
+          "repos/shakacode/react_on_rails/issues/comments?per_page=100&sort=created&direction=asc&page=1"
+        ).and_return([JSON.generate([comment]), success])
       allow(self).to receive(:capture_gh_output)
         .with(
           "api", "repos/shakacode/react_on_rails/collaborators/justin808/permission", "--jq", ".permission"
         ).and_return(["maintain\n", success])
+      allow(self).to receive(:fetch_release_tracker_issue!).and_return({})
 
       expect(
         fetch_repository_accelerated_rc_records_for_candidate!(
@@ -3963,6 +4269,71 @@ RSpec.describe "release.rake helper methods" do
           candidate_sha: "f" * 40
         )
       ).to eq([authorization])
+    end
+
+    it "caches eligibility for repeated repository-discovered markers on the same tracker" do
+      authorization = accelerated_rc_test_authorization
+      comments = [
+        accelerated_rc_test_issue_comment(
+          id: 1,
+          body: accelerated_rc_tracker_comment(authorization),
+          user: { "login" => "justin808" }
+        ),
+        accelerated_rc_test_issue_comment(
+          id: 2,
+          body: accelerated_rc_tracker_comment(authorization),
+          created_at: "2026-07-14T13:01:00Z",
+          user: { "login" => "justin808" }
+        )
+      ]
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: comments,
+        accelerated_rc_repository_comment_permission!: "maintain"
+      )
+      expect(self).to receive(:fetch_release_tracker_issue!)
+        .once.with(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+        .and_return({})
+
+      expect(
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      ).to eq([authorization, authorization])
+    end
+
+    it "rejects repository-discovered candidate history whose canonical issue URL resolves to a pull request" do
+      authorization = accelerated_rc_test_authorization
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: accelerated_rc_tracker_comment(authorization),
+        user: { "login" => "justin808" }
+      )
+      success = instance_double(Process::Status, success?: true)
+      pull_request_issue = {
+        "number" => 3823,
+        "state" => "open",
+        "title" => "Release gate: React on Rails 17.0.0",
+        "labels" => [{ "name" => "release" }, { "name" => "TRACKING" }],
+        "pull_request" => { "url" => "https://api.github.com/repos/shakacode/react_on_rails/pulls/3823" }
+      }
+      allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return([comment])
+      allow(self).to receive(:capture_gh_output)
+        .with("api", "repos/shakacode/react_on_rails/issues/3823")
+        .and_return([JSON.generate(pull_request_issue), success])
+      allow(self).to receive(:capture_gh_output)
+        .with(
+          "api", "repos/shakacode/react_on_rails/collaborators/justin808/permission", "--jq", ".permission"
+        ).and_return(["maintain\n", success])
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /active open release tracker/)
     end
 
     it "ignores one clearly unrelated valid repository marker before author permission checks" do
@@ -3988,6 +4359,7 @@ RSpec.describe "release.rake helper methods" do
       }]
       allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return(comments)
       expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+      expect(self).not_to receive(:fetch_release_tracker_issue!)
 
       expect(
         fetch_repository_accelerated_rc_records_for_candidate!(
@@ -4295,7 +4667,10 @@ RSpec.describe "release.rake helper methods" do
         "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
         "user" => { "login" => "justin808" }
       }
-      allow(self).to receive(:accelerated_rc_repository_comment_permission!).and_return("maintain")
+      allow(self).to receive_messages(
+        accelerated_rc_repository_comment_permission!: "maintain",
+        fetch_release_tracker_issue!: {}
+      )
 
       expect(
         trusted_accelerated_rc_records_from_repository_comment!(
@@ -4334,9 +4709,9 @@ RSpec.describe "release.rake helper methods" do
         "status" => "published-awaiting-gates",
         "target_version" => "17.0.0.rc.10",
         "candidate_sha" => "f" * 40,
+        "release_tracker" => 3823,
         "runtime_tree_fingerprint" => "a" * 64,
         "release_branch" => "release/17.0.0",
-        "release_tracker" => 3823,
         "ci" => {
           "status" => "pending",
           "sha" => "f" * 40,
@@ -5684,9 +6059,9 @@ RSpec.describe "release.rake helper methods" do
         "status" => "published-awaiting-gates",
         "target_version" => "17.0.0.rc.10",
         "candidate_sha" => "f" * 40,
+        "release_tracker" => 3823,
         "runtime_tree_fingerprint" => "a" * 64,
         "release_branch" => "release/17.0.0",
-        "release_tracker" => 3823,
         "ci" => { "status" => "pending" },
         "shakaperf" => { "status" => "pending" },
         "reason" => "Start fleet QA now",
@@ -6835,6 +7210,7 @@ RSpec.describe "release.rake helper methods" do
       {
         "target_version" => "17.0.0.rc.10",
         "candidate_sha" => "f" * 40,
+        "release_tracker" => 3823,
         "runtime_tree_fingerprint" => "a" * 64,
         "release_branch" => "release/17.0.0",
         "shakaperf" => {
@@ -6897,13 +7273,24 @@ RSpec.describe "release.rake helper methods" do
       }
     end
 
+    let(:source_rc_tag_provenance) do
+      {
+        "schema_version" => ACCELERATED_RC_RECORD_SCHEMA_VERSION,
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "release_tracker" => 3823,
+        "authorization_digest" => "b" * 64
+      }
+    end
+
     before do
       allow(self).to receive_messages(
         remote_git_tag_exists?: true,
         fetch_remote_rc_tag!: nil,
         current_git_sha!: "e" * 40,
         github_repo_slug: "shakacode/react_on_rails",
-        accelerated_shakaperf_snapshot: strict_final_shakaperf_snapshot
+        accelerated_shakaperf_snapshot: strict_final_shakaperf_snapshot,
+        accelerated_rc_tag_provenance_for_tag!: source_rc_tag_provenance
       )
     end
 
@@ -7079,7 +7466,13 @@ RSpec.describe "release.rake helper methods" do
 
       context = run_accepted_rc_final_promotion_gates!(**gate_arguments)
 
-      expect(context).to include(candidate_sha: "e" * 40, record: accepted_record)
+      expect(context).to include(
+        candidate_sha: "e" * 40,
+        record: accepted_record,
+        source_rc_tag: "v17.0.0.rc.10",
+        source_rc_candidate_sha: "f" * 40,
+        source_rc_tag_provenance:
+      )
       expect(context.fetch(:shakaperf_record).fetch("shakaperf")).to eq(accepted_record.fetch("shakaperf"))
     end
 
@@ -7454,6 +7847,133 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    it "blocks stable-tag push when the live source RC tag disappears after initial final gates" do
+      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      candidate_sha = "e" * 40
+      source_candidate_sha = accepted.fetch("candidate_sha")
+      successful_ci = {
+        status: "success",
+        sha: source_candidate_sha,
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      context = accelerated_final_promotion_test_context(record: accepted, ci_snapshot: successful_ci)
+      allow(self).to receive_messages(
+        validate_accelerated_repository_publication_boundary!: nil,
+        validate_final_promotion_ci_publication_boundary!: nil,
+        validate_final_promotion_shakaperf_publication_boundary!: nil,
+        system: true,
+        validate_release_tag_candidate_sha!: candidate_sha,
+        validate_release_candidate_publication_boundary!: candidate_sha,
+        remote_git_tag_exists?: true,
+        fetch_remote_rc_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: context.fetch(:source_rc_tag_provenance),
+        peeled_git_tag_sha: source_candidate_sha,
+        validate_remote_release_tag_candidate_sha!: candidate_sha
+      )
+      allow(self).to receive(:remote_git_tag_exists?).and_return(true, false)
+      expect(self).not_to receive(:sh_in_dir_for_release)
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha:,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: context
+        )
+      end.to raise_error(SystemExit, /source RC tag.*disappeared.*git tag push/i)
+    end
+
+    it "blocks packages when the live source RC tag moves after stable-tag push" do
+      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      candidate_sha = "e" * 40
+      source_candidate_sha = accepted.fetch("candidate_sha")
+      moved_sha = "d" * 40
+      successful_ci = {
+        status: "success",
+        sha: source_candidate_sha,
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      context = accelerated_final_promotion_test_context(record: accepted, ci_snapshot: successful_ci)
+      allow(self).to receive_messages(
+        validate_accelerated_repository_publication_boundary!: nil,
+        validate_final_promotion_ci_publication_boundary!: nil,
+        validate_final_promotion_shakaperf_publication_boundary!: nil,
+        system: true,
+        validate_release_tag_candidate_sha!: candidate_sha,
+        remote_git_tag_exists?: true,
+        fetch_remote_rc_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: context.fetch(:source_rc_tag_provenance),
+        validate_release_candidate_publication_boundary!: candidate_sha,
+        validate_remote_release_tag_candidate_sha!: candidate_sha
+      )
+      allow(self).to receive(:peeled_git_tag_sha)
+        .and_return(source_candidate_sha, source_candidate_sha, moved_sha)
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha:,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: context
+        )
+        package_publication_started = true
+      end.to raise_error(SystemExit, /source RC tag.*moved.*package publication/i)
+
+      aggregate_failures do
+        expect(pushed).to be(true)
+        expect(package_publication_started).to be(false)
+      end
+    end
+
+    it "still validates the live stable tag after all source RC boundaries pass" do
+      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      candidate_sha = "e" * 40
+      source_candidate_sha = accepted.fetch("candidate_sha")
+      successful_ci = {
+        status: "success",
+        sha: source_candidate_sha,
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      context = accelerated_final_promotion_test_context(record: accepted, ci_snapshot: successful_ci)
+      allow(self).to receive_messages(
+        validate_accelerated_repository_publication_boundary!: nil,
+        validate_final_promotion_ci_publication_boundary!: nil,
+        validate_final_promotion_shakaperf_publication_boundary!: nil,
+        system: true,
+        validate_release_tag_candidate_sha!: candidate_sha,
+        validate_release_candidate_publication_boundary!: candidate_sha,
+        remote_git_tag_exists?: true,
+        fetch_remote_rc_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: context.fetch(:source_rc_tag_provenance),
+        peeled_git_tag_sha: source_candidate_sha
+      )
+      allow(self).to receive(:sh_in_dir_for_release)
+      allow(self).to receive(:validate_remote_release_tag_candidate_sha!).with(
+        monorepo_root: "/tmp/repo", tag: "v17.0.0", candidate_sha:, phase: "package publication"
+      ).and_return(candidate_sha)
+
+      push_release_tag_for_candidate!(
+        monorepo_root: "/tmp/repo",
+        tag: "v17.0.0",
+        candidate_sha:,
+        accelerated_boundary_record: accepted,
+        accelerated_final_promotion_context: context
+      )
+
+      expect(self).to have_received(:fetch_remote_rc_tag!).exactly(3).times
+      expect(self).to have_received(:validate_remote_release_tag_candidate_sha!).with(
+        monorepo_root: "/tmp/repo", tag: "v17.0.0", candidate_sha:, phase: "package publication"
+      )
+    end
+
     it "blocks newly failed live CI immediately before accelerated RC tag push" do
       authorization = accelerated_rc_test_authorization
       pending_ci = {
@@ -7613,6 +8133,9 @@ RSpec.describe "release.rake helper methods" do
         candidate_sha: "e" * 40,
         ci_branch: "release/17.0.0",
         record: accepted,
+        source_rc_tag: "v17.0.0.rc.10",
+        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
+        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
         ci_snapshot: json_compatible_release_value(successful_ci),
         shakaperf_record: {
           "release_branch" => "release/17.0.0",
@@ -7623,6 +8146,7 @@ RSpec.describe "release.rake helper methods" do
       }
       allow(self).to receive_messages(
         github_repo_slug: "shakacode/react_on_rails",
+        validate_final_promotion_source_rc_tag_boundary!: nil,
         fetch_accelerated_rc_ci_snapshot!: successful_ci,
         accelerated_rc_shakaperf_snapshot!: accepted.fetch("shakaperf"),
         system: true,
@@ -7670,6 +8194,9 @@ RSpec.describe "release.rake helper methods" do
         candidate_sha: "e" * 40,
         ci_branch: "release/17.0.0",
         record: accepted,
+        source_rc_tag: "v17.0.0.rc.10",
+        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
+        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
         ci_snapshot: json_compatible_release_value(successful_ci),
         shakaperf_record: {
           "release_branch" => "release/17.0.0",
@@ -7680,6 +8207,7 @@ RSpec.describe "release.rake helper methods" do
       }
       allow(self).to receive_messages(
         github_repo_slug: "shakacode/react_on_rails",
+        validate_final_promotion_source_rc_tag_boundary!: nil,
         fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
         accelerated_rc_shakaperf_snapshot!: accepted.fetch("shakaperf"),
         system: true,
@@ -7719,6 +8247,9 @@ RSpec.describe "release.rake helper methods" do
         candidate_sha: "e" * 40,
         ci_branch: "release/17.0.0",
         record: accepted,
+        source_rc_tag: "v17.0.0.rc.10",
+        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
+        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
         ci_snapshot: json_compatible_release_value(successful_ci),
         shakaperf_record: {
           "release_branch" => "release/17.0.0",
@@ -7729,6 +8260,7 @@ RSpec.describe "release.rake helper methods" do
       }
       allow(self).to receive_messages(
         github_repo_slug: "shakacode/react_on_rails",
+        validate_final_promotion_source_rc_tag_boundary!: nil,
         fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
         fetch_accelerated_rc_ci_snapshot!: successful_ci,
         system: true,
@@ -7768,6 +8300,9 @@ RSpec.describe "release.rake helper methods" do
         candidate_sha: "e" * 40,
         ci_branch: "release/17.0.0",
         record: accepted,
+        source_rc_tag: "v17.0.0.rc.10",
+        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
+        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
         ci_snapshot: json_compatible_release_value(successful_ci),
         shakaperf_record: {
           "release_branch" => "release/17.0.0",
@@ -7781,6 +8316,7 @@ RSpec.describe "release.rake helper methods" do
       )
       allow(self).to receive_messages(
         github_repo_slug: "shakacode/react_on_rails",
+        validate_final_promotion_source_rc_tag_boundary!: nil,
         fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
         fetch_accelerated_rc_ci_snapshot!: successful_ci,
         system: true,
@@ -7809,7 +8345,7 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "uses the promotion CI branch at all final boundaries and blocks its post-push failure" do
-      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
       source_record = accepted.merge("release_branch" => "release/17.0.0-rc-source")
       promotion_branch = "release/17.0.0"
       successful_ci = {
@@ -7830,6 +8366,9 @@ RSpec.describe "release.rake helper methods" do
         candidate_sha: "e" * 40,
         ci_branch: promotion_branch,
         record: source_record,
+        source_rc_tag: "v17.0.0.rc.10",
+        source_rc_candidate_sha: source_record.fetch("candidate_sha"),
+        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
         ci_snapshot: json_compatible_release_value(successful_ci),
         shakaperf_record: {
           "release_branch" => promotion_branch,
@@ -7844,6 +8383,7 @@ RSpec.describe "release.rake helper methods" do
         github_repo_slug: "shakacode/react_on_rails",
         validate_accelerated_repository_publication_boundary!: nil,
         validate_final_promotion_shakaperf_publication_boundary!: nil,
+        validate_final_promotion_source_rc_tag_boundary!: nil,
         system: true,
         validate_release_tag_candidate_sha!: "e" * 40,
         validate_release_candidate_publication_boundary!: "e" * 40
@@ -7873,6 +8413,77 @@ RSpec.describe "release.rake helper methods" do
         expect(pushed).to be(true)
         expect(package_publication_started).to be(false)
       end
+    end
+
+    it "blocks package continuation when the remote tag moves after tag push" do
+      candidate_sha = "e" * 40
+      moved_sha = "d" * 40
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive_messages(
+        system: true,
+        validate_accelerated_tag_publication_boundary!: nil,
+        validate_release_tag_candidate_sha!: candidate_sha,
+        validate_release_candidate_publication_boundary!: candidate_sha
+      )
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0", "refs/tags/v17.0.0^{}"
+      ).and_return(["#{moved_sha}\trefs/tags/v17.0.0\n", success])
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      failure = begin
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha:
+        )
+        package_publication_started = true
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/remote release tag.*moved.*package publication/i)
+        expect(pushed).to be(true)
+        expect(package_publication_started).to be(false)
+      end
+      expect(Open3).to have_received(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0", "refs/tags/v17.0.0^{}"
+      )
+    end
+
+    it "uses the peeled remote SHA for an annotated accelerated RC tag" do
+      candidate_sha = "e" * 40
+      tag_object_sha = "a" * 40
+      success = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      ).and_return(
+        [
+          "#{tag_object_sha}\trefs/tags/v17.0.0.rc.10\n" \
+          "#{candidate_sha}\trefs/tags/v17.0.0.rc.10^{}\n",
+          success
+        ]
+      )
+
+      expect(
+        validate_remote_release_tag_candidate_sha!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha:,
+          phase: "package publication"
+        )
+      ).to eq(candidate_sha)
+      expect(Open3).to have_received(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      )
     end
 
     it "blocks an existing stable tag before push when HEAD moved after final gates" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -4136,7 +4136,7 @@ RSpec.describe "release.rake helper methods" do
         accelerated_rc_test_issue_comment(id: index + 1, body: "ordinary tracker discussion")
       end
       marker_comment = accelerated_rc_test_issue_comment(
-        id: 100, body: ACCELERATED_RC_RECORD_MARKER
+        id: 100, body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
       )
       endpoint = lambda do |page|
         "repos/shakacode/react_on_rails/issues/3823/comments?per_page=100" \
@@ -4152,6 +4152,59 @@ RSpec.describe "release.rake helper methods" do
       expect(
         fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
       ).to eq([marker_comment])
+    end
+
+    it "uses the explicit hidden machine-marker opener in selected and repository discovery" do
+      success = instance_double(Process::Status, success?: true)
+      casual_mention = accelerated_rc_test_issue_comment(
+        id: 1, body: "Discussion about #{ACCELERATED_RC_RECORD_MARKER} availability"
+      )
+      explicit_marker = accelerated_rc_test_issue_comment(
+        id: 2, body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
+      )
+      allow(self).to receive(:capture_gh_output)
+        .and_return([JSON.generate([casual_mention, explicit_marker]), success])
+
+      aggregate_failures do
+        expect(
+          fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+        ).to eq([explicit_marker])
+        expect(
+          fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+        ).to eq([explicit_marker])
+      end
+    end
+
+    it "retains only the literal ASCII machine-marker opener in bounded selected and repository discovery" do
+      success = instance_double(Process::Status, success?: true)
+      lookalike_bodies = {
+        "near prefix" => "<!-- react-on-rails-accelerated-r v1 malformed -->",
+        "alphabetic suffix" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}x v1 malformed -->",
+        "hyphen suffix" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}-provenance v1 malformed -->",
+        "dot suffix" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}.lookalike v1 malformed -->",
+        "tab delimiter" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}\tv1 malformed -->",
+        "newline delimiter" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}\nv1 malformed -->",
+        "doubled space after comment opener" => "<!--  #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->",
+        "escaped HTML" => "&lt;!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed --&gt;"
+      }
+      lookalikes = lookalike_bodies.each_with_index.map do |(_description, body), index|
+        accelerated_rc_test_issue_comment(id: index + 1, body:)
+      end
+      exact_marker = accelerated_rc_test_issue_comment(
+        id: lookalikes.length + 1,
+        body: "prefix <!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed --> suffix"
+      )
+      allow(self).to receive(:capture_gh_output)
+        .and_return([JSON.generate(lookalikes + [exact_marker]), success])
+
+      aggregate_failures do
+        expect(
+          fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+        ).to eq([exact_marker])
+        expect(
+          fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+        ).to eq([exact_marker])
+      end
     end
 
     it "fails closed when selected-tracker discovery reaches its configured page bound on a full page" do
@@ -4182,7 +4235,7 @@ RSpec.describe "release.rake helper methods" do
         page_count += 1
         comments = if page_count == 250
                      final_marker = accelerated_rc_test_issue_comment(
-                       id: 24_901, body: ACCELERATED_RC_RECORD_MARKER
+                       id: 24_901, body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
                      )
                      [final_marker]
                    else
@@ -4208,7 +4261,7 @@ RSpec.describe "release.rake helper methods" do
         Array.new(100) do |index|
           accelerated_rc_test_issue_comment(
             id: (page * 100) + index + 1,
-            body: ACCELERATED_RC_RECORD_MARKER
+            body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
           )
         end
       end
@@ -4230,11 +4283,15 @@ RSpec.describe "release.rake helper methods" do
         Array.new(100) do |index|
           accelerated_rc_test_issue_comment(
             id: (page * 100) + index + 1,
-            body: ACCELERATED_RC_RECORD_MARKER
+            body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
           )
         end
       end
-      pages << [accelerated_rc_test_issue_comment(id: 1_001, body: ACCELERATED_RC_RECORD_MARKER)]
+      pages << [
+        accelerated_rc_test_issue_comment(
+          id: 1_001, body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
+        )
+      ]
       allow(self).to receive(:capture_gh_output) do
         [JSON.generate(pages.shift), success]
       end
@@ -4244,6 +4301,58 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /bounded release tracker.*marker.*limit.*unknown/i)
     end
 
+    it "does not count casual feature-name mentions against the bounded machine-marker limit" do
+      success = instance_double(Process::Status, success?: true)
+      pages = Array.new(10) do |page|
+        Array.new(100) do |index|
+          accelerated_rc_test_issue_comment(
+            id: (page * 100) + index + 1,
+            body: "Discussion about #{ACCELERATED_RC_RECORD_MARKER} availability"
+          )
+        end
+      end
+      explicit_marker = accelerated_rc_test_issue_comment(
+        id: 1_001, body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
+      )
+      pages << [explicit_marker]
+      allow(self).to receive(:capture_gh_output) do
+        [JSON.generate(pages.shift), success]
+      end
+
+      expect(
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      ).to eq([explicit_marker])
+    end
+
+    it "does not count machine-marker opener lookalikes against the bounded marker limit" do
+      success = instance_double(Process::Status, success?: true)
+      lookalikes = [
+        "<!-- #{ACCELERATED_RC_RECORD_MARKER}-provenance v1 malformed -->",
+        "<!-- #{ACCELERATED_RC_RECORD_MARKER}.lookalike v1 malformed -->",
+        "<!-- #{ACCELERATED_RC_RECORD_MARKER}\tv1 malformed -->",
+        "<!-- #{ACCELERATED_RC_RECORD_MARKER}\nv1 malformed -->"
+      ]
+      pages = Array.new(10) do |page|
+        Array.new(100) do |index|
+          accelerated_rc_test_issue_comment(
+            id: (page * 100) + index + 1,
+            body: lookalikes.fetch(index % lookalikes.length)
+          )
+        end
+      end
+      exact_marker = accelerated_rc_test_issue_comment(
+        id: 1_001, body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
+      )
+      pages << [exact_marker]
+      allow(self).to receive(:capture_gh_output) do
+        [JSON.generate(pages.shift), success]
+      end
+
+      expect(
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      ).to eq([exact_marker])
+    end
+
     it "documents the exact accelerated-comment discovery boundaries" do
       guide = File.read(
         File.expand_path("../../../internal/contributor-info/releasing.md", __dir__)
@@ -4251,10 +4360,16 @@ RSpec.describe "release.rake helper methods" do
       normalized_guide = guide.gsub(/\s+/, " ")
 
       expect(normalized_guide).to include(
-        "Exactly 1,000 retained marker comments are allowed, and a short 250th page completes discovery"
+        "Exactly 1,000 retained machine-marker comments are allowed, and a short 250th page completes discovery"
       )
       expect(normalized_guide).to include(
         "exceeding 1,000 markers or requiring a 251st page blocks as unknown"
+      )
+      expect(normalized_guide).to include(
+        "literal ASCII opener `<!-- react-on-rails-accelerated-rc `, including its single trailing space"
+      )
+      expect(normalized_guide).to include(
+        "Only an exactly present `user: nil` author is known deleted"
       )
     end
 
@@ -4291,6 +4406,99 @@ RSpec.describe "release.rake helper methods" do
       expect do
         validate_release_approver!(login: "external-user", permission: "read")
       end.to raise_error(SystemExit, /write, maintain, or admin/)
+    end
+
+    it "ignores a plain-text feature-name mention before selected-tracker trust or parsing" do
+      casual_mention = {
+        "body" => "Can we discuss #{ACCELERATED_RC_RECORD_MARKER} in the release guide?",
+        "user" => { "login" => "external-user" }
+      }
+      allow(self).to receive(:fetch_release_tracker_comments).and_return([casual_mention])
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+      expect(self).not_to receive(:accelerated_rc_records_from_trusted_comment!)
+
+      expect(
+        fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      ).to eq([])
+    end
+
+    it "ignores an unattributable explicit marker while retaining canonical trusted history" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      deleted_author_marker = {
+        "body" => "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->",
+        "user" => nil
+      }
+      trusted_marker = {
+        "body" => accelerated_rc_tracker_comment(authorization),
+        "user" => { "login" => "justin808" }
+      }
+      allow(self).to receive(:fetch_release_tracker_comments).and_return(
+        [deleted_author_marker, trusted_marker]
+      )
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output)
+        .with(
+          "api",
+          "repos/shakacode/react_on_rails/collaborators/justin808/permission",
+          "--jq",
+          ".permission"
+        ).and_return(["write\n", success])
+
+      expect(
+        fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      ).to eq([authorization])
+      expect(self).to have_received(:capture_gh_output).once
+    end
+
+    it "fails closed on every malformed selected-tracker marker author envelope before decoding" do
+      malformed_author_envelopes = {
+        "missing user key" => {},
+        "non-Hash user" => { "user" => "deleted" },
+        "empty user Hash" => { "user" => {} },
+        "missing login key" => { "user" => { "name" => "unknown" } },
+        "nil login" => { "user" => { "login" => nil } },
+        "empty login" => { "user" => { "login" => "" } },
+        "non-String login" => { "user" => { "login" => 123 } }
+      }
+      marker_body = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+      expect(self).not_to receive(:accelerated_rc_records_from_trusted_comment!)
+
+      aggregate_failures do
+        malformed_author_envelopes.each do |description, envelope|
+          comment = { "body" => marker_body }.merge(envelope)
+          allow(self).to receive(:fetch_release_tracker_comments).and_return([comment])
+
+          expect do
+            fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+          end.to raise_error(SystemExit, /author envelope.*malformed|author metadata.*unknown/i), description
+        end
+      end
+    end
+
+    it "fails closed on a trusted maintainer's malformed explicit machine marker" do
+      malformed_marker = {
+        "body" => "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->",
+        "user" => { "login" => "justin808" }
+      }
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive_messages(
+        fetch_release_tracker_comments: [malformed_marker],
+        capture_gh_output: ["write\n", success]
+      )
+
+      expect do
+        fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /malformed accelerated RC record/i)
     end
 
     it "ignores a known non-maintainer marker at an idempotent tracker append boundary" do
@@ -4384,7 +4592,7 @@ RSpec.describe "release.rake helper methods" do
         accelerated_rc_test_issue_comment(id: index + 1, body: "ordinary repository discussion")
       end
       marker_comment = accelerated_rc_test_issue_comment(
-        id: 100, body: "prefix #{ACCELERATED_RC_RECORD_MARKER} suffix"
+        id: 100, body: "prefix <!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed --> suffix"
       )
       full_page = ordinary_comments + [marker_comment]
       endpoint = lambda do |page|
@@ -4514,7 +4722,9 @@ RSpec.describe "release.rake helper methods" do
       stub_const("ACCELERATED_RC_REPOSITORY_MARKER_COMMENT_LIMIT", 1)
       success = instance_double(Process::Status, success?: true)
       marker_comments = Array.new(2) do |index|
-        accelerated_rc_test_issue_comment(id: index + 1, body: ACCELERATED_RC_RECORD_MARKER)
+        accelerated_rc_test_issue_comment(
+          id: index + 1, body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->"
+        )
       end
       allow(self).to receive(:capture_gh_output).and_return([JSON.generate(marker_comments), success])
 
@@ -4659,6 +4869,25 @@ RSpec.describe "release.rake helper methods" do
       ).to eq([])
     end
 
+    it "ignores a casual repository feature-name mention before candidate trust attribution" do
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: "Discussion about #{ACCELERATED_RC_RECORD_MARKER} availability",
+        user: { "login" => "justin808" }
+      )
+      allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return([comment])
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+      expect(self).not_to receive(:fetch_release_tracker_issue!)
+
+      expect(
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      ).to eq([])
+    end
+
     it "ignores an exact-candidate repository marker after proving its author is not a maintainer" do
       authorization = accelerated_rc_test_authorization
       comment = accelerated_rc_test_issue_comment(
@@ -4679,6 +4908,72 @@ RSpec.describe "release.rake helper methods" do
           candidate_sha: "f" * 40
         )
       ).to eq([])
+    end
+
+    it "ignores an unattributable repository marker while retaining canonical trusted candidate history" do
+      authorization = accelerated_rc_test_authorization
+      deleted_author_marker = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->",
+        user: nil
+      )
+      trusted_marker = accelerated_rc_test_issue_comment(
+        id: 2,
+        body: accelerated_rc_tracker_comment(authorization),
+        created_at: "2026-07-14T13:01:00Z",
+        user: { "login" => "justin808" }
+      )
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [deleted_author_marker, trusted_marker],
+        accelerated_rc_repository_comment_permission!: "maintain"
+      )
+      expect(self).to receive(:fetch_release_tracker_issue!)
+        .once.with(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+        .and_return({})
+
+      expect(
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      ).to eq([authorization])
+      expect(self).to have_received(:accelerated_rc_repository_comment_permission!).once
+    end
+
+    it "fails closed on every malformed repository marker author envelope before decoding" do
+      authorization = accelerated_rc_test_authorization
+      malformed_author_envelopes = {
+        "missing user key" => {},
+        "non-Hash user" => { "user" => "deleted" },
+        "empty user Hash" => { "user" => {} },
+        "missing login key" => { "user" => { "name" => "unknown" } },
+        "nil login" => { "user" => { "login" => nil } },
+        "empty login" => { "user" => { "login" => "" } },
+        "non-String login" => { "user" => { "login" => 123 } }
+      }
+      marker_body = accelerated_rc_tracker_comment(authorization).lines.first.strip
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+      expect(self).not_to receive(:accelerated_rc_records_from_trusted_comment!)
+      expect(self).not_to receive(:repository_accelerated_rc_marker_candidate_identity)
+
+      aggregate_failures do
+        malformed_author_envelopes.each_with_index do |(description, envelope), index|
+          comment = accelerated_rc_test_issue_comment(
+            id: index + 1, body: marker_body, user: { "login" => "placeholder" }
+          ).merge(envelope)
+          comment.delete("user") unless envelope.key?("user")
+          allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return([comment])
+
+          expect do
+            fetch_repository_accelerated_rc_records_for_candidate!(
+              repo_slug: "shakacode/react_on_rails",
+              target_version: "17.0.0.rc.10",
+              candidate_sha: "f" * 40
+            )
+          end.to raise_error(SystemExit, /author envelope.*malformed|author metadata.*unknown/i), description
+        end
+      end
     end
 
     it "fails closed when exact-candidate marker author permission cannot be determined" do
@@ -5131,6 +5426,96 @@ RSpec.describe "release.rake helper methods" do
       expect(comment).to include("published-awaiting-gates", "17.0.0.rc.10", "123456")
       expect(comment).to include(canonical_accelerated_rc_encoded_payload(record))
       expect(accelerated_rc_records_from_comments([{ "body" => comment }])).to eq([record])
+    end
+
+    it "ignores a casual feature-name mention in the direct marker parser" do
+      comment = { "body" => "Discussion about #{ACCELERATED_RC_RECORD_MARKER} availability" }
+
+      expect(accelerated_rc_records_from_comments([comment])).to eq([])
+    end
+
+    it "uses the literal ASCII opener for direct parsing and repository candidate plausibility" do
+      lookalike_bodies = {
+        "bare prose" => "Discussion about #{ACCELERATED_RC_RECORD_MARKER} availability",
+        "near prefix" => "<!-- react-on-rails-accelerated-r v1 malformed -->",
+        "alphabetic suffix" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}x v1 malformed -->",
+        "hyphen suffix" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}-provenance v1 malformed -->",
+        "dot suffix" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}.lookalike v1 malformed -->",
+        "tab delimiter" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}\tv1 malformed -->",
+        "newline delimiter" => "<!-- #{ACCELERATED_RC_RECORD_MARKER}\nv1 malformed -->",
+        "doubled space after comment opener" => "<!--  #{ACCELERATED_RC_RECORD_MARKER} v1 malformed -->",
+        "escaped HTML" => "&lt;!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed --&gt;"
+      }
+
+      aggregate_failures do
+        lookalike_bodies.each do |description, body|
+          comment = { "body" => body }
+          result = nil
+          failure = begin
+            result = accelerated_rc_records_from_comment(comment)
+            nil
+          rescue SystemExit, StandardError => error
+            error
+          end
+
+          expect(accelerated_rc_machine_marker_comment?(comment)).to be(false), description
+          expect(
+            repository_accelerated_rc_comment_plausibly_targets_candidate?(
+              comment:, target_version: "17.0.0.rc.10", candidate_sha: "f" * 40
+            )
+          ).to be(false), description
+          expect(failure).to be_nil, description
+          expect(result).to eq([]), description
+        end
+      end
+    end
+
+    it "recognizes the exact literal opener and keeps a trusted malformed exact marker fail closed" do
+      comment = { "body" => "prefix <!-- #{ACCELERATED_RC_RECORD_MARKER} v1 malformed --> suffix" }
+
+      aggregate_failures do
+        expect(accelerated_rc_machine_marker_comment?(comment)).to be(true)
+        expect(
+          repository_accelerated_rc_comment_plausibly_targets_candidate?(
+            comment:, target_version: "17.0.0.rc.10", candidate_sha: "f" * 40
+          )
+        ).to be(true)
+        expect do
+          accelerated_rc_records_from_comment(comment)
+        end.to raise_error(SystemExit, /malformed accelerated RC record/i)
+      end
+    end
+
+    it "safely ignores non-Hash and non-String-body inputs before direct body access" do
+      invalid_inputs = {
+        "nil" => nil,
+        "String" => "not a comment",
+        "Array" => [],
+        "Integer" => 1,
+        "Hash without body" => {},
+        "nil body" => { "body" => nil },
+        "Array body" => { "body" => [] }
+      }
+
+      aggregate_failures do
+        invalid_inputs.each do |description, comment|
+          result = nil
+          failure = begin
+            result = accelerated_rc_records_from_comment(comment)
+            nil
+          rescue StandardError => error
+            error
+          end
+
+          expect(failure).to be_nil, description
+          expect(result).to eq([]), description
+          expect(
+            repository_accelerated_rc_comment_plausibly_targets_candidate?(
+              comment:, target_version: "17.0.0.rc.10", candidate_sha: "f" * 40
+            )
+          ).to be(false), description
+        end
+      end
     end
 
     it "fails closed when a tracker marker is malformed instead of ignoring it" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -99,18 +99,113 @@ RSpec.describe "release.rake helper methods" do
     {
       candidate_sha: final_candidate_sha,
       ci_branch:,
+      final_target_version: Gem::Version.new(record.fetch("target_version")).release.to_s,
       record:,
       source_rc_tag: "v#{record.fetch('target_version')}",
       source_rc_candidate_sha: record.fetch("candidate_sha"),
       source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
       ci_snapshot: json_compatible_release_value(ci_snapshot),
+      shakaperf_evidence_mode: FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE,
       shakaperf_record: {
         "release_branch" => ci_branch,
-        "candidate_sha" => final_candidate_sha,
+        "candidate_sha" => record.dig("shakaperf", "candidate_sha"),
         "target_version" => record.fetch("target_version"),
         "shakaperf" => record.fetch("shakaperf")
       }
     }
+  end
+
+  def strict_final_promotion_test_context(record:, ci_snapshot:, ci_branch: "release/17.0.0",
+                                          final_candidate_sha: "e" * 40)
+    context = accelerated_final_promotion_test_context(
+      record:, ci_snapshot:, ci_branch:, final_candidate_sha:
+    )
+    strict_snapshot = record.fetch("shakaperf").merge(
+      "candidate_sha" => final_candidate_sha,
+      "target_version" => context.fetch(:final_target_version)
+    )
+    strict_record = {
+      "release_branch" => ci_branch,
+      "candidate_sha" => final_candidate_sha,
+      "target_version" => context.fetch(:final_target_version),
+      "shakaperf" => strict_snapshot
+    }
+    context.merge(
+      shakaperf_evidence_mode: FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE,
+      shakaperf_record: strict_record,
+      strict_final_shakaperf_identity_anchor: final_promotion_shakaperf_identity_anchor(strict_record)
+    )
+  end
+
+  def mutate_strict_final_promotion_test_identity!(context, component)
+    record = context.fetch(:shakaperf_record)
+    snapshot = record.fetch("shakaperf")
+    case component
+    when :release_branch
+      mutate_strict_final_promotion_test_branch!(context:, record:)
+    when :candidate_sha
+      mutate_strict_final_promotion_test_candidate!(context:, record:, snapshot:)
+    when :target_version
+      mutate_strict_final_promotion_test_target!(context:, record:, snapshot:)
+    when :missing_anchor, :changed_anchor, :mutable_anchor
+      mutate_strict_final_promotion_test_anchor!(context:, component:)
+    else
+      field, value = {
+        run_id: ["run_id", 777_777],
+        attempt: ["attempt", 2],
+        run_url: ["run_url", "https://github.com/shakacode/react_on_rails/actions/runs/777777"],
+        release_started_at: ["release_started_at", "2026-07-14T15:00:00Z"]
+      }.fetch(component)
+      snapshot[field] = value
+    end
+  end
+
+  def redefine_strict_final_promotion_test_identity_and_anchor!(context, component)
+    if component == :run_identity
+      snapshot = context.dig(:shakaperf_record, "shakaperf")
+      snapshot.merge!(
+        "run_id" => 777_777,
+        "attempt" => 2,
+        "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/777777"
+      )
+    else
+      mutate_strict_final_promotion_test_identity!(context, component)
+    end
+    context[:strict_final_shakaperf_identity_anchor] =
+      final_promotion_shakaperf_identity_anchor(context.fetch(:shakaperf_record))
+  end
+
+  def mutate_strict_final_promotion_test_branch!(context:, record:)
+    context[:ci_branch] = "release/17.0.0-mutated"
+    record["release_branch"] = context.fetch(:ci_branch)
+  end
+
+  def mutate_strict_final_promotion_test_anchor!(context:, component:)
+    case component
+    when :missing_anchor
+      context.delete(:strict_final_shakaperf_identity_anchor)
+    when :changed_anchor
+      context[:strict_final_shakaperf_identity_anchor] = "{}"
+    when :mutable_anchor
+      context[:strict_final_shakaperf_identity_anchor] =
+        context.fetch(:strict_final_shakaperf_identity_anchor).dup
+    end
+  end
+
+  def mutate_strict_final_promotion_test_candidate!(context:, record:, snapshot:)
+    context.fetch(:candidate_sha).replace("d" * 40)
+    record["candidate_sha"] = context.fetch(:candidate_sha)
+    snapshot["candidate_sha"] = context.fetch(:candidate_sha)
+  end
+
+  def mutate_strict_final_promotion_test_target!(context:, record:, snapshot:)
+    mutated_rc_target = "17.0.1.rc.10"
+    context.fetch(:record)["target_version"] = mutated_rc_target
+    context[:source_rc_tag] = "v#{mutated_rc_target}"
+    context.fetch(:source_rc_tag_provenance)["target_version"] = mutated_rc_target
+    context[:final_target_version] = "17.0.1"
+    record["target_version"] = context.fetch(:final_target_version)
+    snapshot["target_version"] = context.fetch(:final_target_version)
   end
 
   def accelerated_rc_test_issue_comment(id:, body:, tracker: 3823, created_at: "2026-07-14T13:00:00Z", user: nil)
@@ -1192,6 +1287,41 @@ RSpec.describe "release.rake helper methods" do
       )
     end
 
+    it "selects an exact-head run for the requested target when another target has a newer run" do
+      matching_run = run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      other_target_run = matching_run.merge(
+        "databaseId" => 654_321,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha:, target_version: "17.0.0.rc.7"
+        ),
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/654321"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch").and_return([matching_run, other_target_run])
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection)
+        .with(hash_including(run: matching_run, target_version:)).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect(
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      ).to eq(matching_run)
+      expect(self).to have_received(:shakaperf_release_gate_run_evidence_rejection)
+        .with(hash_including(run: matching_run, target_version:))
+    end
+
     it "dispatches a fresh exact-head gate when a successful run has no verifiable evidence" do
       successful_run = run.merge(
         "status" => "completed",
@@ -1285,6 +1415,9 @@ RSpec.describe "release.rake helper methods" do
     it "reuses successful pre-run evidence for a runtime-equivalent metadata bump" do
       candidate_sha = "feedface" * 5
       successful_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: candidate_sha, target_version: "17.0.0.rc.8"
+        ),
         "headSha" => candidate_sha,
         "status" => "completed",
         "conclusion" => "success",
@@ -1323,9 +1456,55 @@ RSpec.describe "release.rake helper methods" do
       )
     end
 
+    it "selects a pre-run for the requested target when another target has a newer pre-run" do
+      matching_sha = "feedface" * 5
+      matching_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: matching_sha, target_version:
+        ),
+        "headSha" => matching_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T12:00:30Z"
+      )
+      other_target_prerun = matching_prerun.merge(
+        "databaseId" => 654_321,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: "badc0ffe" * 5, target_version: "17.0.0.rc.7"
+        ),
+        "headSha" => "badc0ffe" * 5,
+        "createdAt" => "2026-07-14T12:30:00Z",
+        "startedAt" => "2026-07-14T12:30:05Z",
+        "updatedAt" => "2026-07-14T12:30:30Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/654321"
+      )
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch").and_return([matching_prerun, other_target_prerun])
+      allow(self).to receive(:fetch_shakaperf_release_gate_evidence)
+        .with(repo_slug:, run: matching_prerun).and_return({ "candidate_sha" => matching_sha })
+      allow(self).to receive(:shakaperf_release_gate_evidence_rejection).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect(
+        run_shakaperf_release_gate!(
+          monorepo_root:,
+          ref: "release-branch",
+          head_sha:,
+          target_version:,
+          release_started_at:,
+          allow_override: false,
+          dry_run: false
+        )
+      ).to eq(matching_prerun)
+      expect(self).to have_received(:fetch_shakaperf_release_gate_evidence).with(repo_slug:, run: matching_prerun)
+    end
+
     it "waits for an in-progress pre-run before reusing its evidence" do
       candidate_sha = "feedface" * 5
       in_progress_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: candidate_sha, target_version:
+        ),
         "headSha" => candidate_sha,
         "status" => "in_progress",
         "conclusion" => nil,
@@ -1403,6 +1582,9 @@ RSpec.describe "release.rake helper methods" do
     it "dispatches an exact-head gate when the active pre-run attempt changes while waiting" do
       candidate_sha = "feedface" * 5
       in_progress_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: candidate_sha, target_version:
+        ),
         "headSha" => candidate_sha,
         "status" => "in_progress",
         "conclusion" => nil,
@@ -1454,6 +1636,9 @@ RSpec.describe "release.rake helper methods" do
     it "dispatches an exact-head gate when the active pre-run start time changes while waiting" do
       candidate_sha = "feedface" * 5
       in_progress_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: candidate_sha, target_version:
+        ),
         "headSha" => candidate_sha,
         "startedAt" => "2026-07-14T13:01:00Z",
         "status" => "in_progress",
@@ -1506,6 +1691,9 @@ RSpec.describe "release.rake helper methods" do
     it "dispatches an exact-head gate when an in-progress pre-run finishes unsuccessfully" do
       candidate_sha = "feedface" * 5
       in_progress_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: candidate_sha, target_version:
+        ),
         "headSha" => candidate_sha,
         "status" => "in_progress",
         "conclusion" => nil
@@ -1560,6 +1748,9 @@ RSpec.describe "release.rake helper methods" do
         "updatedAt" => "2026-07-14T12:30:00Z"
       )
       successful_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: candidate_sha, target_version:
+        ),
         "headSha" => candidate_sha,
         "status" => "completed",
         "conclusion" => "success",
@@ -1644,6 +1835,9 @@ RSpec.describe "release.rake helper methods" do
         "updatedAt" => "2026-07-14T13:30:00Z"
       )
       successful_prerun = run.merge(
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha: candidate_sha, target_version:
+        ),
         "headSha" => candidate_sha,
         "status" => "completed",
         "conclusion" => "success",
@@ -2385,6 +2579,37 @@ RSpec.describe "release.rake helper methods" do
           release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
         )
       end.to raise_error(SystemExit, %r{known ShakaPerf failure.*actions/runs/123456}mi)
+    end
+
+    it "keeps an unknown completed exact-head conclusion distinct from a known failure" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "completed",
+        "conclusion" => "future_conclusion",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([run])
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref: "release/17.0.0",
+          head_sha: "d" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+        )
+      end.to raise_error(SystemExit, /ShakaPerf.*unknown.*refusing unaudited publication/i)
     end
 
     it "reuses a completed pre-run only when runtime-equivalent evidence verifies" do
@@ -4370,6 +4595,103 @@ RSpec.describe "release.rake helper methods" do
       ).to eq([])
     end
 
+    it "ignores an exact-candidate repository marker after proving its author is not a maintainer" do
+      authorization = accelerated_rc_test_authorization
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: accelerated_rc_tracker_comment(authorization),
+        user: { "login" => "read-only-user" }
+      )
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [comment],
+        accelerated_rc_repository_comment_permission!: "read"
+      )
+      expect(self).not_to receive(:fetch_release_tracker_issue!)
+
+      expect(
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      ).to eq([])
+    end
+
+    it "fails closed when exact-candidate marker author permission cannot be determined" do
+      authorization = accelerated_rc_test_authorization
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: accelerated_rc_tracker_comment(authorization),
+        user: { "login" => "unknown-user" }
+      )
+      allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return([comment])
+      allow(self).to receive(:accelerated_rc_repository_comment_permission!).and_raise(
+        SystemExit, "Unable to verify repository permission"
+      )
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /Unable to verify repository permission/)
+    end
+
+    it "fails closed on blank or unrecognized successful repository permission responses" do
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output)
+        .with(
+          "api", "repos/shakacode/react_on_rails/collaborators/blank-user/permission", "--jq", ".permission"
+        ).and_return(["\n", success])
+
+      aggregate_failures do
+        expect do
+          accelerated_rc_repository_comment_permission!(
+            repo_slug: "shakacode/react_on_rails", login: "blank-user", permissions: {}
+          )
+        end.to raise_error(SystemExit, /repository permission.*unknown/i)
+
+        expect do
+          accelerated_rc_repository_comment_permission!(
+            repo_slug: "shakacode/react_on_rails",
+            login: "future-user",
+            permissions: { "future-user" => "future_permission" }
+          )
+        end.to raise_error(SystemExit, /repository permission.*unknown/i)
+
+        expect do
+          accelerated_rc_repository_comment_permission!(
+            repo_slug: "shakacode/react_on_rails", login: "nil-user", permissions: { "nil-user" => nil }
+          )
+        end.to raise_error(SystemExit, /repository permission.*unknown/i)
+      end
+    end
+
+    it "fails closed when repository discovery receives a blank or unrecognized permission classification" do
+      authorization = accelerated_rc_test_authorization
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: accelerated_rc_tracker_comment(authorization),
+        user: { "login" => "unknown-user" }
+      )
+      allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return([comment])
+
+      aggregate_failures do
+        ["", "future_permission"].each do |permission|
+          allow(self).to receive(:accelerated_rc_repository_comment_permission!).and_return(permission)
+
+          expect do
+            fetch_repository_accelerated_rc_records_for_candidate!(
+              repo_slug: "shakacode/react_on_rails",
+              target_version: "17.0.0.rc.10",
+              candidate_sha: "f" * 40
+            )
+          end.to raise_error(SystemExit, /repository permission.*unknown/i), permission.inspect
+        end
+      end
+    end
+
     it "strictly rejects complete unrelated records whose marker encoding is noncanonical" do
       unrelated_authorization = accelerated_rc_test_authorization.merge(
         "target_version" => "16.9.0.rc.1",
@@ -6302,7 +6624,8 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive_messages(
         fetch_release_tracker_issue!: nil,
         current_release_approver!: "justin808",
-        fetch_accelerated_rc_tracker_records!: [authorization_record, published_record]
+        fetch_accelerated_rc_tracker_records!: [authorization_record, published_record],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record, published_record]
       )
     end
 
@@ -6542,6 +6865,97 @@ RSpec.describe "release.rake helper methods" do
           }
         )
       end.to raise_error(SystemExit, /publication set.*not the canonical authorized transition/i)
+    end
+
+    it "blocks a repository-wide cross-tracker authorization before terminal reconciliation append" do
+      conflicting_authorization = authorization_record.merge("release_tracker" => 3824)
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [
+          authorization_record, published_record, conflicting_authorization
+        ],
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "success",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: []
+        },
+        accelerated_rc_shakaperf_snapshot!: published_record.fetch("shakaperf").merge("status" => "success")
+      )
+      appended = false
+      allow(self).to receive(:append_accelerated_rc_tracker_record!) { appended = true }
+
+      failure = begin
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "All required evidence passed",
+          evidence: {
+            "demo_fleet" => "https://github.com/demo-fleet",
+            "behavioral" => "https://github.com/behavioral",
+            "artifacts" => "https://github.com/artifacts"
+          }
+        )
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/repository-wide.*conflicting release trackers/i)
+        expect(appended).to be(false)
+      end
+    end
+
+    it "blocks a repository-wide authorization conflict after terminal append re-fetch and before success" do
+      conflicting_authorization = authorization_record.merge("release_tracker" => 3824)
+      repository_reads = 0
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!) do
+        repository_reads += 1
+        if repository_reads == 1
+          [authorization_record, published_record]
+        else
+          [authorization_record, published_record, conflicting_authorization]
+        end
+      end
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "success",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: []
+        },
+        accelerated_rc_shakaperf_snapshot!: published_record.fetch("shakaperf").merge("status" => "success")
+      )
+      append_completed = false
+      allow(self).to receive(:append_accelerated_rc_tracker_record!) { append_completed = true }
+
+      failure = begin
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "All required evidence passed",
+          evidence: {
+            "demo_fleet" => "https://github.com/demo-fleet",
+            "behavioral" => "https://github.com/behavioral",
+            "artifacts" => "https://github.com/artifacts"
+          }
+        )
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/repository-wide.*conflicting release trackers/i)
+        expect(append_completed).to be(true)
+        expect(repository_reads).to eq(2)
+      end
     end
   end
 
@@ -7294,6 +7708,50 @@ RSpec.describe "release.rake helper methods" do
       )
     end
 
+    it "rejects a successful reusable pre-run that is not bound to the strict final candidate" do
+      reusable_prerun = strict_final_shakaperf_run.merge("headSha" => "f" * 40)
+      allow(self).to receive(:run_shakaperf_release_gate!).and_return(reusable_prerun)
+      expect(self).not_to receive(:accelerated_shakaperf_snapshot)
+
+      expect do
+        strict_final_promotion_shakaperf_snapshot!(
+          monorepo_root: "/tmp/repo",
+          current_branch: "release/17.0.0",
+          final_head_sha: "e" * 40,
+          target_version: "17.0.0",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          allow_ci_override: false,
+          dry_run: false
+        )
+      end.to raise_error(SystemExit, /strict ShakaPerf.*exact final candidate/i)
+    end
+
+    it "rejects accepted-RC identity presented as newly run strict-final evidence" do
+      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      successful_ci = {
+        status: "success",
+        sha: accepted.fetch("candidate_sha"),
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      stable_target_snapshot = accepted.fetch("shakaperf").merge("target_version" => "17.0.0")
+      context = accelerated_final_promotion_test_context(record: accepted, ci_snapshot: successful_ci)
+      context[:shakaperf_evidence_mode] = FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE
+      context[:final_target_version] = "17.0.0"
+      context[:shakaperf_record] = {
+        "release_branch" => "release/17.0.0",
+        "candidate_sha" => accepted.fetch("candidate_sha"),
+        "target_version" => "17.0.0",
+        "shakaperf" => stable_target_snapshot
+      }
+
+      expect do
+        validate_final_promotion_context!(
+          boundary_record: accepted, context:, candidate_sha: "e" * 40
+        )
+      end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+    end
+
     it "aborts post-bump runtime drift instead of falling back to a fresh ShakaPerf gate" do
       allow(self).to receive(:accelerated_rc_runtime_equivalent?).and_return(false)
       expect(self).not_to receive(:refresh_accepted_rc_ci_evidence_for_promotion!)
@@ -7468,12 +7926,180 @@ RSpec.describe "release.rake helper methods" do
 
       expect(context).to include(
         candidate_sha: "e" * 40,
+        final_target_version: "17.0.0",
         record: accepted_record,
+        shakaperf_evidence_mode: FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE,
         source_rc_tag: "v17.0.0.rc.10",
         source_rc_candidate_sha: "f" * 40,
         source_rc_tag_provenance:
       )
       expect(context.fetch(:shakaperf_record).fetch("shakaperf")).to eq(accepted_record.fetch("shakaperf"))
+    end
+
+    it "keeps reused accepted-RC ShakaPerf evidence bound to the exact RC SHA at publication boundaries" do
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        refresh_accepted_rc_ci_evidence_for_promotion!: successful_final_ci_snapshot,
+        reuse_accepted_rc_shakaperf_evidence!: true,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: accepted_record
+      )
+      context = run_accepted_rc_final_promotion_gates!(**gate_arguments)
+      refreshed_run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "f" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "f" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(refreshed_run)
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection) do |require_prerun:, **|
+        require_prerun ? "pre-run completed after release started" : nil
+      end
+
+      expect do
+        validate_final_promotion_shakaperf_publication_boundary!(
+          monorepo_root: "/tmp/repo", context:, phase: "package publication"
+        )
+      end.not_to raise_error
+      expect(context.fetch(:shakaperf_record).fetch("candidate_sha")).to eq("f" * 40)
+    end
+
+    it "carries exact accepted pre-run evidence through final promotion and every publication boundary" do
+      prerun_sha = "d" * 40
+      record = accelerated_rc_test_accepted_history.last
+      record = record.merge(
+        "runtime_tree_fingerprint" => "a" * 64,
+        "shakaperf" => record.fetch("shakaperf").merge("candidate_sha" => prerun_sha)
+      )
+      prerun = {
+        "databaseId" => record.dig("shakaperf", "run_id"),
+        "attempt" => record.dig("shakaperf", "attempt"),
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: prerun_sha, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => prerun_sha,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => record.dig("shakaperf", "run_url")
+      }
+      runtime_checks = []
+      live_shakaperf_policies = []
+      allow(self).to receive(:accelerated_rc_runtime_equivalent?) do |**arguments|
+        runtime_checks << arguments
+        true
+      end
+      allow(self).to receive_messages(
+        refresh_accepted_rc_ci_evidence_for_promotion!: successful_final_ci_snapshot,
+        refresh_shakaperf_release_gate_run!: prerun,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: record
+      )
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection) do |head_sha:, require_prerun:, **|
+        live_shakaperf_policies << [head_sha, require_prerun]
+        nil
+      end
+      expect(self).not_to receive(:run_shakaperf_release_gate!)
+
+      context = run_accepted_rc_final_promotion_gates!(**gate_arguments.merge(record:))
+
+      aggregate_failures do
+        expect(context).to include(
+          candidate_sha: "e" * 40,
+          shakaperf_evidence_mode: FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE,
+          record:
+        )
+        expect(context).not_to have_key(:strict_final_shakaperf_identity_anchor)
+        expect(context.dig(:shakaperf_record, "shakaperf")).to eq(record.fetch("shakaperf"))
+      end
+
+      boundary_phases = Hash.new { |phases, boundary| phases[boundary] = [] }
+      allow(self).to receive(:validate_accelerated_repository_publication_boundary!) do |phase:, **|
+        boundary_phases[:repository] << phase
+      end
+      {
+        validate_final_promotion_ci_publication_boundary!: :ci,
+        validate_final_promotion_shakaperf_publication_boundary!: :shakaperf,
+        validate_final_promotion_source_rc_tag_boundary!: :source_rc_tag
+      }.each do |validator, boundary|
+        allow(self).to receive(validator).and_wrap_original do |method, **arguments|
+          boundary_phases[boundary] << arguments.fetch(:phase)
+          method.call(**arguments)
+        end
+      end
+      allow(self).to receive(:validate_release_candidate_publication_boundary!)
+        .and_wrap_original do |method, **arguments|
+        boundary_phases[:candidate] << arguments.fetch(:phase)
+        method.call(**arguments)
+      end
+      allow(self).to receive(:validate_remote_release_tag_candidate_sha!).and_wrap_original do |method, **arguments|
+        boundary_phases[:stable_tag] << arguments.fetch(:phase)
+        method.call(**arguments)
+      end
+      allow(self).to receive_messages(
+        system: true,
+        remote_release_tag_candidate_sha!: "e" * 40
+      )
+      allow(self).to receive(:peeled_git_tag_sha) do |tag:, **|
+        tag == "v17.0.0.rc.10" ? "f" * 40 : "e" * 40
+      end
+      pushed = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+      package_continuation_reached = false
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: record,
+          accelerated_final_promotion_context: context
+        )
+        package_continuation_reached = true
+      end.not_to raise_error
+
+      expected_accelerated_phases = ["tag handling", "git tag push", "package publication"]
+      aggregate_failures do
+        expect(runtime_checks.length).to eq(1)
+        expect(runtime_checks.first).to include(
+          record:, rc_sha: "f" * 40, final_head_sha: "e" * 40, monorepo_root: "/tmp/repo"
+        )
+        expect(live_shakaperf_policies).to eq(
+          [["e" * 40, true]] + Array.new(3) { ["f" * 40, true] }
+        )
+        expect(boundary_phases.values_at(:repository, :ci, :shakaperf, :source_rc_tag)).to all(
+          eq(expected_accelerated_phases)
+        )
+        expect(boundary_phases[:candidate]).to eq(["git tag push", "package publication"])
+        expect(boundary_phases[:stable_tag]).to eq(["package publication"])
+        expect(pushed).to be(true)
+        expect(package_continuation_reached).to be(true)
+      end
+    end
+
+    it "rejects a substituted accepted pre-run snapshot that differs from the trusted record" do
+      record = accelerated_rc_test_accepted_history.last
+      record = record.merge(
+        "shakaperf" => record.fetch("shakaperf").merge("candidate_sha" => "d" * 40)
+      )
+      context = accelerated_final_promotion_test_context(
+        record:, ci_snapshot: successful_final_ci_snapshot
+      )
+      substituted_snapshot = context.dig(:shakaperf_record, "shakaperf").merge(
+        "candidate_sha" => "c" * 40
+      )
+      context[:shakaperf_record] = context.fetch(:shakaperf_record).merge(
+        "candidate_sha" => "c" * 40,
+        "shakaperf" => substituted_snapshot
+      )
+
+      expect do
+        validate_final_promotion_context!(
+          boundary_record: record, context:, candidate_sha: "e" * 40
+        )
+      end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
     end
 
     it "carries the promotion CI branch when accepted evidence originated on another branch" do
@@ -7534,13 +8160,23 @@ RSpec.describe "release.rake helper methods" do
       context = run_accepted_rc_final_promotion_gates!(**gate_arguments)
 
       aggregate_failures do
-        expect(context).to include(candidate_sha: "e" * 40, record: accepted_record)
+        expect(context).to include(
+          candidate_sha: "e" * 40,
+          final_target_version: "17.0.0",
+          record: accepted_record,
+          shakaperf_evidence_mode: FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE
+        )
         expect(context.fetch(:ci_snapshot)).to eq(json_compatible_release_value(ci_snapshot))
         expect(context.fetch(:shakaperf_record)).to include(
           "release_branch" => "release/17.0.0",
           "candidate_sha" => "e" * 40,
           "target_version" => "17.0.0",
           "shakaperf" => json_compatible_release_value(strict_snapshot)
+        )
+        identity_anchor = context.fetch(:strict_final_shakaperf_identity_anchor)
+        expect(identity_anchor).to be_frozen
+        expect(identity_anchor).to eq(
+          final_promotion_shakaperf_identity_anchor(context.fetch(:shakaperf_record))
         )
       end
     end
@@ -7847,6 +8483,271 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    context "when final-promotion evidence mode changes after initial validation" do
+      let(:accepted_record) { accelerated_rc_test_accepted_history.last }
+      let(:candidate_sha) { "e" * 40 }
+      let(:successful_ci) do
+        {
+          status: "success",
+          sha: accepted_record.fetch("candidate_sha"),
+          checks_url: accepted_record.dig("ci", "checks_url"),
+          non_success: []
+        }
+      end
+      let(:accepted_context) do
+        accelerated_final_promotion_test_context(record: accepted_record, ci_snapshot: successful_ci)
+      end
+
+      before do
+        allow(self).to receive_messages(
+          validate_accelerated_repository_publication_boundary!: nil,
+          validate_final_promotion_ci_publication_boundary!: nil,
+          validate_final_promotion_shakaperf_publication_boundary!: nil,
+          validate_final_promotion_source_rc_tag_boundary!: nil,
+          validate_release_candidate_publication_boundary!: candidate_sha,
+          validate_remote_release_tag_candidate_sha!: candidate_sha
+        )
+      end
+
+      it "rejects a missing mode at the later tag-handling boundary" do
+        initial_validation_complete = false
+        allow(self).to receive(:validate_final_promotion_context!).and_wrap_original do |method, **arguments|
+          result = method.call(**arguments)
+          unless initial_validation_complete
+            initial_validation_complete = true
+            accepted_context.delete(:shakaperf_evidence_mode)
+          end
+          result
+        end
+        tag_handled = false
+        allow(self).to receive(:ensure_release_tag_for_candidate!) { tag_handled = true }
+        expect(self).not_to receive(:sh_in_dir_for_release)
+
+        expect do
+          push_release_tag_for_candidate!(
+            monorepo_root: "/tmp/repo",
+            tag: "v17.0.0",
+            candidate_sha:,
+            accelerated_boundary_record: accepted_record,
+            accelerated_final_promotion_context: accepted_context
+          )
+        end.to raise_error(SystemExit, /incomplete accelerated final-promotion boundary evidence/i)
+        expect(tag_handled).to be(false)
+      end
+
+      it "rejects an unknown mode at the later pre-push boundary" do
+        allow(self).to receive(:ensure_release_tag_for_candidate!) do
+          accepted_context[:shakaperf_evidence_mode] = "future-mode"
+        end
+        expect(self).not_to receive(:sh_in_dir_for_release)
+
+        expect do
+          push_release_tag_for_candidate!(
+            monorepo_root: "/tmp/repo",
+            tag: "v17.0.0",
+            candidate_sha:,
+            accelerated_boundary_record: accepted_record,
+            accelerated_final_promotion_context: accepted_context
+          )
+        end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+      end
+
+      it "rejects accepted-RC evidence relabeled strict-final after tag push" do
+        package_publication_continued = false
+        allow(self).to receive(:ensure_release_tag_for_candidate!)
+        allow(self).to receive(:sh_in_dir_for_release) do
+          accepted_context[:shakaperf_evidence_mode] = FINAL_PROMOTION_SHAKAPERF_STRICT_FINAL_MODE
+        end
+        allow(self).to receive(:validate_remote_release_tag_candidate_sha!) do
+          package_publication_continued = true
+        end
+
+        expect do
+          push_release_tag_for_candidate!(
+            monorepo_root: "/tmp/repo",
+            tag: "v17.0.0",
+            candidate_sha:,
+            accelerated_boundary_record: accepted_record,
+            accelerated_final_promotion_context: accepted_context
+          )
+        end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+        expect(package_publication_continued).to be(false)
+      end
+
+      it "rejects strict-final evidence relabeled accepted-RC at the later pre-push boundary" do
+        strict_context = strict_final_promotion_test_context(record: accepted_record, ci_snapshot: successful_ci)
+        allow(self).to receive(:ensure_release_tag_for_candidate!) do
+          strict_context[:shakaperf_evidence_mode] = FINAL_PROMOTION_SHAKAPERF_ACCEPTED_RC_MODE
+        end
+        expect(self).not_to receive(:sh_in_dir_for_release)
+
+        expect do
+          push_release_tag_for_candidate!(
+            monorepo_root: "/tmp/repo",
+            tag: "v17.0.0",
+            candidate_sha:,
+            accelerated_boundary_record: accepted_record,
+            accelerated_final_promotion_context: strict_context
+          )
+        end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+      end
+    end
+
+    context "when strict-final ShakaPerf identity changes after initial validation" do
+      let(:accepted_record) { accelerated_rc_test_accepted_history.last }
+      let(:candidate_sha) { "e" * 40 }
+      let(:successful_ci) do
+        {
+          status: "success",
+          sha: accepted_record.fetch("candidate_sha"),
+          checks_url: accepted_record.dig("ci", "checks_url"),
+          non_success: []
+        }
+      end
+      let(:strict_context) do
+        strict_final_promotion_test_context(
+          record: accepted_record, ci_snapshot: successful_ci, final_candidate_sha: candidate_sha
+        )
+      end
+
+      before do
+        allow(self).to receive_messages(
+          validate_accelerated_repository_publication_boundary!: nil,
+          validate_final_promotion_ci_publication_boundary!: nil,
+          validate_final_promotion_shakaperf_publication_boundary!: nil,
+          validate_final_promotion_source_rc_tag_boundary!: nil,
+          validate_release_candidate_publication_boundary!: candidate_sha,
+          validate_remote_release_tag_candidate_sha!: candidate_sha
+        )
+      end
+
+      {
+        "a changed run ID" => :run_id,
+        "a changed attempt" => :attempt,
+        "a changed run URL" => :run_url,
+        "a changed release start" => :release_started_at,
+        "a changed release branch/ref" => :release_branch,
+        "a changed candidate SHA" => :candidate_sha,
+        "a changed target version" => :target_version,
+        "a missing identity anchor" => :missing_anchor,
+        "a replaced identity anchor" => :changed_anchor,
+        "an unfrozen identity anchor" => :mutable_anchor
+      }.each do |description, component|
+        it "rejects #{description} before tag push" do
+          allow(self).to receive(:ensure_release_tag_for_candidate!) do
+            mutate_strict_final_promotion_test_identity!(strict_context, component)
+          end
+          expect(self).not_to receive(:sh_in_dir_for_release)
+
+          expect do
+            push_release_tag_for_candidate!(
+              monorepo_root: "/tmp/repo",
+              tag: "v17.0.0",
+              candidate_sha:,
+              accelerated_boundary_record: accepted_record,
+              accelerated_final_promotion_context: strict_context
+            )
+          end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+        end
+
+        it "rejects #{description} after tag push and before package publication" do
+          package_publication_continued = false
+          allow(self).to receive(:ensure_release_tag_for_candidate!)
+          allow(self).to receive(:sh_in_dir_for_release) do
+            mutate_strict_final_promotion_test_identity!(strict_context, component)
+          end
+          allow(self).to receive(:validate_remote_release_tag_candidate_sha!) do
+            package_publication_continued = true
+          end
+
+          expect do
+            push_release_tag_for_candidate!(
+              monorepo_root: "/tmp/repo",
+              tag: "v17.0.0",
+              candidate_sha:,
+              accelerated_boundary_record: accepted_record,
+              accelerated_final_promotion_context: strict_context
+            )
+          end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+          expect(package_publication_continued).to be(false)
+        end
+      end
+    end
+
+    context "when strict-final identity and its context anchor are redefined together" do
+      let(:accepted_record) { accelerated_rc_test_accepted_history.last }
+      let(:candidate_sha) { "e" * 40 }
+      let(:successful_ci) do
+        {
+          status: "success",
+          sha: accepted_record.fetch("candidate_sha"),
+          checks_url: accepted_record.dig("ci", "checks_url"),
+          non_success: []
+        }
+      end
+      let(:strict_context) do
+        strict_final_promotion_test_context(
+          record: accepted_record, ci_snapshot: successful_ci, final_candidate_sha: candidate_sha
+        )
+      end
+
+      before do
+        allow(self).to receive_messages(
+          validate_accelerated_repository_publication_boundary!: nil,
+          validate_final_promotion_ci_publication_boundary!: nil,
+          validate_final_promotion_shakaperf_publication_boundary!: nil,
+          validate_final_promotion_source_rc_tag_boundary!: nil,
+          validate_release_candidate_publication_boundary!: candidate_sha,
+          validate_remote_release_tag_candidate_sha!: candidate_sha
+        )
+      end
+
+      {
+        "run identity" => :run_identity,
+        "candidate SHA" => :candidate_sha,
+        "target version" => :target_version
+      }.each do |description, component|
+        it "rejects coordinated #{description} and anchor redefinition before tag push" do
+          allow(self).to receive(:ensure_release_tag_for_candidate!) do
+            redefine_strict_final_promotion_test_identity_and_anchor!(strict_context, component)
+          end
+          expect(self).not_to receive(:sh_in_dir_for_release)
+
+          expect do
+            push_release_tag_for_candidate!(
+              monorepo_root: "/tmp/repo",
+              tag: "v17.0.0",
+              candidate_sha:,
+              accelerated_boundary_record: accepted_record,
+              accelerated_final_promotion_context: strict_context
+            )
+          end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+        end
+
+        it "rejects coordinated #{description} and anchor redefinition after tag push" do
+          package_publication_continued = false
+          allow(self).to receive(:ensure_release_tag_for_candidate!)
+          allow(self).to receive(:sh_in_dir_for_release) do
+            redefine_strict_final_promotion_test_identity_and_anchor!(strict_context, component)
+          end
+          allow(self).to receive(:validate_remote_release_tag_candidate_sha!) do
+            package_publication_continued = true
+          end
+
+          expect do
+            push_release_tag_for_candidate!(
+              monorepo_root: "/tmp/repo",
+              tag: "v17.0.0",
+              candidate_sha:,
+              accelerated_boundary_record: accepted_record,
+              accelerated_final_promotion_context: strict_context
+            )
+          end.to raise_error(SystemExit, /inconsistent accelerated final-promotion boundary evidence/i)
+          expect(package_publication_continued).to be(false)
+        end
+      end
+    end
+
     it "blocks stable-tag push when the live source RC tag disappears after initial final gates" do
       _authorization, _publication, accepted = accelerated_rc_test_accepted_history
       candidate_sha = "e" * 40
@@ -8129,21 +9030,9 @@ RSpec.describe "release.rake helper methods" do
         checks_url: accepted.dig("ci", "checks_url"),
         non_success: []
       }
-      final_promotion_context = {
-        candidate_sha: "e" * 40,
-        ci_branch: "release/17.0.0",
-        record: accepted,
-        source_rc_tag: "v17.0.0.rc.10",
-        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
-        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
-        ci_snapshot: json_compatible_release_value(successful_ci),
-        shakaperf_record: {
-          "release_branch" => "release/17.0.0",
-          "candidate_sha" => "e" * 40,
-          "target_version" => accepted.fetch("target_version"),
-          "shakaperf" => accepted.fetch("shakaperf")
-        }
-      }
+      final_promotion_context = accelerated_final_promotion_test_context(
+        record: accepted, ci_snapshot: successful_ci
+      )
       allow(self).to receive_messages(
         github_repo_slug: "shakacode/react_on_rails",
         validate_final_promotion_source_rc_tag_boundary!: nil,
@@ -8190,21 +9079,9 @@ RSpec.describe "release.rake helper methods" do
           url: "https://github.com/shakacode/react_on_rails/actions/runs/999"
         }]
       )
-      final_promotion_context = {
-        candidate_sha: "e" * 40,
-        ci_branch: "release/17.0.0",
-        record: accepted,
-        source_rc_tag: "v17.0.0.rc.10",
-        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
-        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
-        ci_snapshot: json_compatible_release_value(successful_ci),
-        shakaperf_record: {
-          "release_branch" => "release/17.0.0",
-          "candidate_sha" => "e" * 40,
-          "target_version" => accepted.fetch("target_version"),
-          "shakaperf" => accepted.fetch("shakaperf")
-        }
-      }
+      final_promotion_context = accelerated_final_promotion_test_context(
+        record: accepted, ci_snapshot: successful_ci
+      )
       allow(self).to receive_messages(
         github_repo_slug: "shakacode/react_on_rails",
         validate_final_promotion_source_rc_tag_boundary!: nil,
@@ -8243,21 +9120,9 @@ RSpec.describe "release.rake helper methods" do
         checks_url: accepted.dig("ci", "checks_url"),
         non_success: []
       }
-      final_promotion_context = {
-        candidate_sha: "e" * 40,
-        ci_branch: "release/17.0.0",
-        record: accepted,
-        source_rc_tag: "v17.0.0.rc.10",
-        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
-        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
-        ci_snapshot: json_compatible_release_value(successful_ci),
-        shakaperf_record: {
-          "release_branch" => "release/17.0.0",
-          "candidate_sha" => "e" * 40,
-          "target_version" => accepted.fetch("target_version"),
-          "shakaperf" => accepted.fetch("shakaperf")
-        }
-      }
+      final_promotion_context = accelerated_final_promotion_test_context(
+        record: accepted, ci_snapshot: successful_ci
+      )
       allow(self).to receive_messages(
         github_repo_slug: "shakacode/react_on_rails",
         validate_final_promotion_source_rc_tag_boundary!: nil,
@@ -8296,21 +9161,9 @@ RSpec.describe "release.rake helper methods" do
         checks_url: accepted.dig("ci", "checks_url"),
         non_success: []
       }
-      final_promotion_context = {
-        candidate_sha: "e" * 40,
-        ci_branch: "release/17.0.0",
-        record: accepted,
-        source_rc_tag: "v17.0.0.rc.10",
-        source_rc_candidate_sha: accepted.fetch("candidate_sha"),
-        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
-        ci_snapshot: json_compatible_release_value(successful_ci),
-        shakaperf_record: {
-          "release_branch" => "release/17.0.0",
-          "candidate_sha" => "e" * 40,
-          "target_version" => accepted.fetch("target_version"),
-          "shakaperf" => accepted.fetch("shakaperf")
-        }
-      }
+      final_promotion_context = accelerated_final_promotion_test_context(
+        record: accepted, ci_snapshot: successful_ci
+      )
       changed_shakaperf = accepted.fetch("shakaperf").merge(
         "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/654321"
       )
@@ -8345,7 +9198,7 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "uses the promotion CI branch at all final boundaries and blocks its post-push failure" do
-      authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
       source_record = accepted.merge("release_branch" => "release/17.0.0-rc-source")
       promotion_branch = "release/17.0.0"
       successful_ci = {
@@ -8362,21 +9215,9 @@ RSpec.describe "release.rake helper methods" do
           url: "https://github.com/shakacode/react_on_rails/actions/runs/999"
         }]
       )
-      final_promotion_context = {
-        candidate_sha: "e" * 40,
-        ci_branch: promotion_branch,
-        record: source_record,
-        source_rc_tag: "v17.0.0.rc.10",
-        source_rc_candidate_sha: source_record.fetch("candidate_sha"),
-        source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
-        ci_snapshot: json_compatible_release_value(successful_ci),
-        shakaperf_record: {
-          "release_branch" => promotion_branch,
-          "candidate_sha" => "e" * 40,
-          "target_version" => source_record.fetch("target_version"),
-          "shakaperf" => source_record.fetch("shakaperf")
-        }
-      }
+      final_promotion_context = accelerated_final_promotion_test_context(
+        record: source_record, ci_snapshot: successful_ci, ci_branch: promotion_branch
+      )
       promotion_snapshots = [successful_ci, successful_ci, failed_ci]
       fetched_branches = []
       allow(self).to receive_messages(

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -2546,6 +2546,95 @@ RSpec.describe "release.rake helper methods" do
       expect(result).to include(status: "pending", run_id: 123_456)
     end
 
+    it "ignores canonical workflow-supported non-RC runs but rejects invalid target identities" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_run = lambda do |run_id:, candidate_sha:, run_target:, status:, conclusion:|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version: run_target
+          ),
+          "headSha" => candidate_sha,
+          "status" => status,
+          "conclusion" => conclusion,
+          "createdAt" => "2026-07-14T12:00:00Z",
+          "startedAt" => "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      active_exact_run = build_run.call(
+        run_id: 123_456,
+        candidate_sha: head_sha,
+        run_target: target_version,
+        status: "in_progress",
+        conclusion: nil
+      )
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      aggregate_failures do
+        %w[test beta alpha pre].each_with_index do |prerelease_type, index|
+          unrelated_run = build_run.call(
+            run_id: 200_000 + index,
+            candidate_sha: "e" * 40,
+            run_target: "17.0.0.#{prerelease_type}.1",
+            status: "completed",
+            conclusion: "success"
+          )
+          [[active_exact_run, unrelated_run], [unrelated_run, active_exact_run]].each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            result = nil
+            expect do
+              result = run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.not_to raise_error, "#{prerelease_type}, order #{order}"
+            expect(result).to include(status: "pending", run_id: 123_456),
+                              "#{prerelease_type}, order #{order}"
+          end
+        end
+
+        invalid_targets = {
+          "malformed" => "17.0.0.beta",
+          "ambiguous" => "17.0.0.beta.1.rc.2",
+          "unsupported" => "17.0.0.preview.1"
+        }
+        invalid_targets.each do |label, invalid_target|
+          invalid_run = build_run.call(
+            run_id: 300_000 + invalid_targets.keys.index(label),
+            candidate_sha: "e" * 40,
+            run_target: invalid_target,
+            status: "completed",
+            conclusion: "success"
+          )
+          [[active_exact_run, invalid_run], [invalid_run, active_exact_run]].each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, /target identity.*(?:unknown|malformed)/i), "#{label}, order #{order}"
+          end
+        end
+      end
+    end
+
     it "classifies a selected terminal pre-run before reusing an active exact-head run (V62)" do
       target_version = "17.0.0.rc.10"
       ref = "release/17.0.0"

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -4339,6 +4339,21 @@ RSpec.describe "release.rake helper methods" do
         )
       end.to output(/already visible on RubyGems\.org/).to_stdout
     end
+
+    [0, -1, "not-a-number", "1.5"].each do |invalid_max_retries|
+      it "rejects invalid max retries #{invalid_max_retries.inspect} before invoking RubyGems" do
+        expect(self).not_to receive(:sh_args_in_dir_for_release)
+
+        expect do
+          publish_gem_with_retry(
+            "/tmp/gem",
+            "react_on_rails",
+            otp: "123456",
+            max_retries: invalid_max_retries
+          )
+        end.to raise_error(SystemExit, /GEM_RELEASE_MAX_RETRIES.*positive.*integer/i)
+      end
+    end
   end
 
   describe "#publish_npm_with_retry" do
@@ -8452,7 +8467,10 @@ RSpec.describe "release.rake helper methods" do
         authorized_record: authorization,
         recorded_at: Time.utc(2026, 7, 14, 14)
       ).merge("reason" => "Mutated after authorization")
-      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return([authorization, existing])
+      allow(self).to receive_messages(
+        fetch_release_tracker_issue!: {},
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, existing]
+      )
       expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
 
       expect do
@@ -8482,7 +8500,110 @@ RSpec.describe "release.rake helper methods" do
         approved_by: "first-completing-maintainer",
         recorded_at: Time.utc(2026, 7, 14, 14)
       )
-      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return([authorization, existing])
+      allow(self).to receive(:fetch_release_tracker_issue!).and_return({})
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!)
+        .and_return([authorization, existing], [authorization, existing])
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect(
+        record_accelerated_rc_publication_complete!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          approved_by: "retrying-maintainer",
+          recorded_at: Time.utc(2026, 7, 14, 15)
+        )
+      ).to eq(existing)
+    end
+
+    it "revalidates tracker eligibility before recording publication completion" do
+      authorization = accelerated_rc_test_authorization
+      allow(self).to receive(:fetch_release_tracker_issue!) do
+        abort "V78 simulated closed release tracker"
+      end
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        append_accelerated_rc_tracker_record!: accelerated_rc_published_record(
+          authorized_record: authorization,
+          recorded_at: Time.utc(2026, 7, 14, 14)
+        )
+      )
+
+      expect do
+        record_accelerated_rc_publication_complete!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          approved_by: "retrying-maintainer",
+          recorded_at: Time.utc(2026, 7, 14, 15)
+        )
+      end.to raise_error(SystemExit, /closed release tracker/)
+    end
+
+    [
+      ["authorization", -> { accelerated_rc_test_authorization(tracker: 999) }],
+      ["rejection", -> { accelerated_rc_test_rejected_history(tracker: 999).last }]
+    ].each do |conflict_name, conflicting_record|
+      it "rejects a cross-tracker #{conflict_name} before publication completion append" do
+        authorization = accelerated_rc_test_authorization
+        allow(self).to receive_messages(
+          fetch_release_tracker_issue!: {},
+          fetch_repository_accelerated_rc_records_for_candidate!: [
+            authorization, instance_exec(&conflicting_record)
+          ],
+          fetch_accelerated_rc_tracker_records!: [authorization]
+        )
+        expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+        expect do
+          record_accelerated_rc_publication_complete!(
+            repo_slug: "shakacode/react_on_rails",
+            tracker: 3823,
+            authorized_record: authorization,
+            approved_by: "retrying-maintainer",
+            recorded_at: Time.utc(2026, 7, 14, 15)
+          )
+        end.to raise_error(SystemExit, /conflicting release trackers/)
+      end
+    end
+
+    it "rejects a repository conflict introduced between append and completion re-fetch" do
+      authorization = accelerated_rc_test_authorization
+      conflicting_authorization = accelerated_rc_test_authorization(tracker: 999)
+      published = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      allow(self).to receive_messages(
+        fetch_release_tracker_issue!: {},
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        append_accelerated_rc_tracker_record!: published
+      )
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!)
+        .and_return([authorization], [authorization, conflicting_authorization])
+
+      expect do
+        record_accelerated_rc_publication_complete!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          approved_by: "retrying-maintainer",
+          recorded_at: Time.utc(2026, 7, 14, 15)
+        )
+      end.to raise_error(SystemExit, /conflicting release trackers/)
+    end
+
+    it "revalidates clean repository history when reusing completion across approvers" do
+      authorization = accelerated_rc_test_authorization
+      existing = accelerated_rc_published_record(
+        authorized_record: authorization,
+        approved_by: "first-completing-maintainer",
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      allow(self).to receive(:fetch_release_tracker_issue!).and_return({})
+      expect(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!)
+        .twice
+        .and_return([authorization, existing], [authorization, existing])
       expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
 
       expect(
@@ -8515,8 +8636,12 @@ RSpec.describe "release.rake helper methods" do
       mutated_publication = canonical_publication.merge(
         "reason" => "Mutated after the canonical publication record"
       )
-      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
-        .and_return([authorization, canonical_publication, mutated_publication])
+      allow(self).to receive_messages(
+        fetch_release_tracker_issue!: {},
+        fetch_repository_accelerated_rc_records_for_candidate!: [
+          authorization, canonical_publication, mutated_publication
+        ]
+      )
       expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
 
       expect do
@@ -8546,8 +8671,12 @@ RSpec.describe "release.rake helper methods" do
         authorized_record: authorization,
         recorded_at: Time.utc(2026, 7, 14, 14)
       )
-      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
-        .and_return([authorization, conflicting_authorization, canonical_publication])
+      allow(self).to receive_messages(
+        fetch_release_tracker_issue!: {},
+        fetch_repository_accelerated_rc_records_for_candidate!: [
+          authorization, conflicting_authorization, canonical_publication
+        ]
+      )
       expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
 
       expect do
@@ -11178,7 +11307,8 @@ RSpec.describe "release.rake helper methods" do
         "RELEASE_ACCELERATED_RC=true",
         "RELEASE_TRACKER=<issue>",
         "RELEASE_ACCELERATED_RC_REASON=<reason>",
-        "from matching release/X.Y.Z"
+        "from matching release/X.Y.Z",
+        "GEM_RELEASE_MAX_RETRIES=<n>  # Positive base-10 integer"
       )
       expect(Rake::Task.task_defined?("release:reconcile_accelerated_rc")).to be(true)
     end
@@ -11581,6 +11711,228 @@ RSpec.describe "release.rake helper methods" do
           .with(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10", tag_type: "accelerated RC")
         expect(task_receiver).not_to have_received(:confirm_release!)
         expect(task_receiver).not_to have_received(:append_accelerated_rc_tracker_record!)
+      end
+    end
+  end
+
+  describe "release task accelerated RC publication completion" do
+    let(:release_task) { Rake::Task["release"] }
+    let(:task_receiver) { release_task.actions.first.binding.receiver }
+    let(:release_root) { "/tmp/v76-release" }
+    let(:success_status) { instance_double(Process::Status, success?: true) }
+    let(:events) { [] }
+    let(:authorization) { accelerated_rc_test_authorization }
+
+    before do
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", release_root, "rev-parse", "--abbrev-ref", "HEAD")
+        .and_return(["release/17.0.0\n", success_status])
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", release_root, "diff", "--cached", "--quiet")
+        .and_return(["", success_status])
+      allow(ReactOnRails::GitUtils).to receive(:uncommitted_changes?)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("NPM_OTP", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RUBYGEMS_OTP", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return("true")
+      allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return("3823")
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil)
+                                   .and_return("Start published-artifact QA while exact-head checks finish")
+      allow(task_receiver).to receive(:with_release_checkout) { |**_, &block| block.call(release_root) }
+      allow(task_receiver).to receive_messages(
+        current_monorepo_root: release_root,
+        verbose: nil,
+        release_paths: {
+          monorepo_root: release_root,
+          gem_root: "#{release_root}/react_on_rails",
+          pro_gem_root: "#{release_root}/react_on_rails_pro",
+          dummy_app_dir: "#{release_root}/react_on_rails/spec/dummy",
+          pro_dummy_app_dir: "#{release_root}/missing-pro-dummy",
+          pro_execjs_dummy_app_dir: "#{release_root}/missing-pro-execjs-dummy"
+        },
+        resolve_release_version_before_auth!: "17.0.0.rc.10",
+        release_tag_retry_state_for_current_head: :none,
+        github_repo_slug: "shakacode/react_on_rails",
+        resolve_accelerated_rc_options_for_release!: {
+          target_gem_version: "17.0.0.rc.10",
+          tracker: 3823,
+          reason: "Start published-artifact QA while exact-head checks finish"
+        },
+        ensure_accelerated_rc_release_branch!: nil,
+        preflight_explicit_accelerated_rc_target_tag!: nil,
+        fetch_release_tracker_issue!: nil,
+        current_release_approver!: "justin808",
+        maybe_offer_release_branch_cut!: nil,
+        ensure_release_branch_matches_target_base!: nil,
+        release_tag_at_current_head?: false,
+        remote_release_tag_retry?: false,
+        validate_main_ci_status!: nil,
+        validate_release_version_policy!: nil,
+        preflight_registry_publish_conflicts!: nil,
+        confirm_release!: nil,
+        sh_in_dir_for_release: nil,
+        unbundled_sh_in_dir_for_release: nil,
+        current_git_sha!: "f" * 40,
+        authorize_accelerated_rc_publication!: authorization,
+        push_release_tag_for_candidate!: nil,
+        resolve_rubygems_otp_for_publish: nil
+      )
+      allow(task_receiver).to receive(:current_gem_version).and_return("16.9.0", "17.0.0.rc.10")
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read)
+        .with("#{release_root}/react_on_rails_pro/lib/react_on_rails_pro/version.rb")
+        .and_return(+"VERSION = \"16.9.0\"\n")
+      [
+        "#{release_root}/package.json",
+        "#{release_root}/packages/react-on-rails/package.json",
+        "#{release_root}/packages/react-on-rails-pro/package.json",
+        "#{release_root}/packages/react-on-rails-pro-node-renderer/package.json",
+        "#{release_root}/packages/create-react-on-rails-app/package.json"
+      ].each do |package_json|
+        allow(File).to receive(:read).with(package_json).and_return("{\"version\":\"16.9.0\"}\n")
+      end
+      allow(File).to receive(:write)
+      allow(task_receiver).to receive(:publish_npm_with_retry) do |_dir, package, **_options|
+        events << [:npm, package]
+        nil
+      end
+      allow(task_receiver).to receive(:publish_gem_with_retry) do |_dir, package, **_options|
+        events << [:gem, package]
+        nil
+      end
+      allow(task_receiver).to receive(:record_accelerated_rc_publication_complete!) do
+        events << :publication_complete
+      end
+      allow(task_receiver).to receive(:sync_github_release_after_publish)
+    end
+
+    after { release_task.reenable }
+
+    def invoke_accelerated_release_task(release_task)
+      release_task.reenable
+      release_task.invoke("17.0.0.rc.10", false, true, false)
+      nil
+    rescue SystemExit => error
+      error
+    end
+
+    it "records complete package publication before fallible GitHub release sync" do
+      repository_history_reads = 0
+      persisted_publication = nil
+      allow(task_receiver).to receive(:fetch_repository_accelerated_rc_records_for_candidate!) do
+        repository_history_reads += 1
+        persisted_publication ? [authorization, persisted_publication] : [authorization]
+      end
+      allow(task_receiver).to receive(:fetch_accelerated_rc_tracker_records!).and_return([authorization])
+      allow(task_receiver).to receive(:append_accelerated_rc_tracker_record!) do |record:, **_options|
+        persisted_publication = record
+      end
+      allow(task_receiver).to receive(:record_accelerated_rc_publication_complete!)
+        .and_wrap_original do |method, **args|
+        events << :publication_complete
+        method.call(**args)
+      end
+      allow(task_receiver).to receive(:sync_github_release_after_publish) do
+        events << :github_release_sync
+        abort "V76 simulated post-publish GitHub release sync failure"
+      end
+
+      failure = invoke_accelerated_release_task(release_task)
+
+      aggregate_failures do
+        expect(failure&.message).to eq("V76 simulated post-publish GitHub release sync failure")
+        expect(events).to eq(
+          [
+            [:npm, "react-on-rails@17.0.0-rc.10"],
+            [:npm, "react-on-rails-pro@17.0.0-rc.10"],
+            [:npm, "react-on-rails-pro-node-renderer@17.0.0-rc.10"],
+            [:npm, "create-react-on-rails-app@17.0.0-rc.10"],
+            [:gem, "react_on_rails"],
+            [:gem, "react_on_rails_pro"],
+            :publication_complete,
+            :github_release_sync
+          ]
+        )
+        expect(task_receiver).to have_received(:record_accelerated_rc_publication_complete!).with(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          recorded_at: a_kind_of(Time),
+          approved_by: "justin808"
+        ).once
+        expect(repository_history_reads).to eq(2)
+      end
+    end
+
+    ["0", "-1", "not-a-number", "1.5"].each do |invalid_max_retries|
+      it "rejects GEM_RELEASE_MAX_RETRIES=#{invalid_max_retries.inspect} before any package publication" do
+        allow(ENV).to receive(:fetch)
+          .with("GEM_RELEASE_MAX_RETRIES", "3")
+          .and_return(invalid_max_retries)
+        allow(task_receiver).to receive(:publish_npm_with_retry) do |*_args|
+          events << :npm_publisher_reached
+          abort "V78 npm publisher reached with invalid retry configuration"
+        end
+
+        failure = invoke_accelerated_release_task(release_task)
+
+        aggregate_failures do
+          expect(failure&.message).to match(/GEM_RELEASE_MAX_RETRIES.*positive.*integer/i)
+          expect(events).to be_empty
+          expect(task_receiver).not_to have_received(:publish_gem_with_retry)
+          expect(task_receiver).not_to have_received(:record_accelerated_rc_publication_complete!)
+          expect(task_receiver).not_to have_received(:sync_github_release_after_publish)
+        end
+      end
+    end
+
+    it "does not record publication completion when npm publication stops partway through" do
+      allow(task_receiver).to receive(:publish_npm_with_retry) do |_dir, package, **_options|
+        events << [:npm, package]
+        abort "V76 simulated partial npm publication failure" if package.start_with?("react-on-rails-pro@")
+
+        nil
+      end
+
+      failure = invoke_accelerated_release_task(release_task)
+
+      aggregate_failures do
+        expect(failure&.message).to eq("V76 simulated partial npm publication failure")
+        expect(events).to eq(
+          [
+            [:npm, "react-on-rails@17.0.0-rc.10"],
+            [:npm, "react-on-rails-pro@17.0.0-rc.10"]
+          ]
+        )
+        expect(task_receiver).not_to have_received(:record_accelerated_rc_publication_complete!)
+        expect(task_receiver).not_to have_received(:sync_github_release_after_publish)
+      end
+    end
+
+    it "does not record publication completion when the final gem publication fails" do
+      allow(task_receiver).to receive(:publish_gem_with_retry) do |_dir, package, **_options|
+        events << [:gem, package]
+        abort "V76 simulated final gem publication failure" if package == "react_on_rails_pro"
+
+        nil
+      end
+
+      failure = invoke_accelerated_release_task(release_task)
+
+      aggregate_failures do
+        expect(failure&.message).to eq("V76 simulated final gem publication failure")
+        expect(events).to eq(
+          [
+            [:npm, "react-on-rails@17.0.0-rc.10"],
+            [:npm, "react-on-rails-pro@17.0.0-rc.10"],
+            [:npm, "react-on-rails-pro-node-renderer@17.0.0-rc.10"],
+            [:npm, "create-react-on-rails-app@17.0.0-rc.10"],
+            [:gem, "react_on_rails"],
+            [:gem, "react_on_rails_pro"]
+          ]
+        )
+        expect(task_receiver).not_to have_received(:record_accelerated_rc_publication_complete!)
+        expect(task_receiver).not_to have_received(:sync_github_release_after_publish)
       end
     end
   end

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -93,6 +93,91 @@ RSpec.describe "release.rake helper methods" do
     [authorization, publication, rejected]
   end
 
+  def stub_accelerated_rc_publication_recovery_tag(
+    authorization:, candidate_sha: "f" * 40, tag_object_sha: "a" * 40
+  )
+    allow(self).to receive_messages(
+      fetch_remote_release_tag!: nil,
+      local_release_tag_object_sha!: tag_object_sha,
+      accelerated_rc_tag_identity_for_object!: {
+        tag_object_sha:,
+        candidate_sha:,
+        provenance: accelerated_rc_tag_provenance(authorization)
+      },
+      remote_annotated_release_tag_identity!: {
+        tag_object_sha:,
+        candidate_sha:
+      }
+    )
+  end
+
+  def stub_accelerated_rc_tag_object_commands(
+    authorization:, status:, tag_object_sha: "a" * 40, candidate_sha: "f" * 40
+  )
+    contents = <<~TAG_OBJECT
+      object #{candidate_sha}
+      type commit
+      tag v#{authorization.fetch('target_version')}
+      tagger Maintainer <maintainer@example.com> 1784000000 +0000
+
+      #{accelerated_rc_tag_message(authorization)}
+    TAG_OBJECT
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "cat-file", "-t", tag_object_sha
+    ).and_return(["tag\n", status])
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "cat-file", "-p", tag_object_sha
+    ).and_return([contents, status])
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "#{tag_object_sha}^{}"
+    ).and_return(["#{candidate_sha}\n", status])
+  end
+
+  def accelerated_rc_remote_tag_output(tag:, tag_object_sha:, candidate_sha:, annotated:)
+    return "#{candidate_sha}\trefs/tags/#{tag}\n" unless annotated
+
+    "#{tag_object_sha}\trefs/tags/#{tag}\n#{candidate_sha}\trefs/tags/#{tag}^{}\n"
+  end
+
+  def stub_final_promotion_source_rc_ref_commands(
+    authorization:, tag:, tag_object_sha:, candidate_sha:, status:
+  )
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}"
+    ).and_return(["#{tag_object_sha}\n", status])
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/#{tag}"
+    ).and_return(["tag\n", status])
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "for-each-ref", "--format=%(contents)", "refs/tags/#{tag}"
+    ).and_return([accelerated_rc_tag_message(authorization), status])
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}^{}"
+    ).and_return(["#{candidate_sha}\n", status])
+  end
+
+  def stub_final_promotion_source_rc_tag_commands(
+    object_authorization:, ref_authorization: object_authorization, tag_object_sha: "a" * 40,
+    candidate_sha: "f" * 40, remote_tag_object_sha: tag_object_sha,
+    remote_candidate_sha: candidate_sha, remote_annotated: true,
+    tag: "v#{ref_authorization.fetch('target_version')}"
+  )
+    status = instance_double(Process::Status, success?: true)
+    stub_accelerated_rc_tag_object_commands(
+      authorization: object_authorization, status:, tag_object_sha:, candidate_sha:
+    )
+    stub_final_promotion_source_rc_ref_commands(
+      authorization: ref_authorization, tag:, tag_object_sha:, candidate_sha:, status:
+    )
+    remote_output = accelerated_rc_remote_tag_output(
+      tag:, tag_object_sha: remote_tag_object_sha, candidate_sha: remote_candidate_sha, annotated: remote_annotated
+    )
+    allow(Open3).to receive(:capture2e).with(
+      "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+      "refs/tags/#{tag}", "refs/tags/#{tag}^{}"
+    ).and_return([remote_output, status])
+  end
+
   def accelerated_final_promotion_test_context(record:, ci_snapshot:, ci_branch: "release/17.0.0",
                                                final_candidate_sha: "e" * 40)
     authorization = accelerated_rc_test_authorization(tracker: record.fetch("release_tracker"))
@@ -102,6 +187,7 @@ RSpec.describe "release.rake helper methods" do
       final_target_version: Gem::Version.new(record.fetch("target_version")).release.to_s,
       record:,
       source_rc_tag: "v#{record.fetch('target_version')}",
+      source_rc_tag_object_sha: "a" * 40,
       source_rc_candidate_sha: record.fetch("candidate_sha"),
       source_rc_tag_provenance: accelerated_rc_tag_provenance(authorization),
       ci_snapshot: json_compatible_release_value(ci_snapshot),
@@ -9588,6 +9674,473 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /No published-awaiting-gates record exists/)
     end
 
+    it "recovers complete immutable publication before recording a late rejection" do
+      tracker_records = [authorization_record]
+      repository_records = [authorization_record]
+      npm_refs = []
+      rubygem_refs = []
+      tag_object_sha = "a" * 40
+      success_status = instance_double(Process::Status, success?: true)
+      rubygems_response = Net::HTTPOK.new("1.1", "200", "OK")
+      stub_accelerated_rc_tag_object_commands(
+        authorization: authorization_record, status: success_status, tag_object_sha:
+      )
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!) { tracker_records }
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!) { repository_records }
+      allow(self).to receive_messages(
+        fetch_remote_release_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(authorization_record),
+        peeled_git_tag_sha: "f" * 40,
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "failed",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: [{
+            name: "generator",
+            state: "failure",
+            url: "https://github.com/shakacode/react_on_rails/actions/runs/999"
+          }]
+        }
+      )
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10"
+      ).and_return(["#{tag_object_sha}\n", success_status])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      ).and_return(
+        [
+          "#{tag_object_sha}\trefs/tags/v17.0.0.rc.10\n" \
+          "#{'f' * 40}\trefs/tags/v17.0.0.rc.10^{}\n",
+          success_status
+        ]
+      )
+      allow(self).to receive(:fetch_npm_package_metadata_with_retries) do |package_ref, **|
+        npm_refs << package_ref
+        metadata = { "version" => "17.0.0-rc.10" }
+        [JSON.generate(metadata), success_status]
+      end
+      allow(self).to receive(:fetch_rubygems_versions) do |gem_name, **|
+        rubygem_refs << gem_name
+        [JSON.generate([{ "number" => "17.0.0.rc.10" }]), rubygems_response]
+      end
+      allow(self).to receive(:append_accelerated_rc_tracker_record!) do |record:, **|
+        tracker_records << record
+        repository_records << record
+        record
+      end
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Exact-head generator CI failed after publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /candidate was rejected/i)
+
+      aggregate_failures do
+        expect(tracker_records.map { |record| record.fetch("status") }).to eq(
+          %w[publication-authorized published-awaiting-gates candidate-rejected]
+        )
+        expect(npm_refs).to contain_exactly(
+          "react-on-rails@17.0.0-rc.10",
+          "react-on-rails-pro@17.0.0-rc.10",
+          "react-on-rails-pro-node-renderer@17.0.0-rc.10",
+          "create-react-on-rails-app@17.0.0-rc.10"
+        )
+        expect(rubygem_refs).to contain_exactly("react_on_rails", "react_on_rails_pro")
+      end
+    end
+
+    it "blocks missing, mismatched, malformed, or unknown registry evidence before recovery append" do
+      success_status = instance_double(Process::Status, success?: true)
+      failed_status = instance_double(Process::Status, success?: false)
+      rubygems_success = Net::HTTPOK.new("1.1", "200", "OK")
+      rubygems_unknown = Net::HTTPServiceUnavailable.new("1.1", "503", "Unavailable")
+      variants = {
+        "missing npm artifact" => {
+          npm: ->(ref) { ref.start_with?("react-on-rails-pro@") ? ["not found", failed_status] : nil }
+        },
+        "mismatched RubyGem version" => {
+          rubygems: ->(_name) { [JSON.generate([{ "number" => "17.0.0.rc.9" }]), rubygems_success] }
+        },
+        "malformed RubyGems metadata" => {
+          rubygems: ->(_name) { [JSON.generate([{ "number" => nil }]), rubygems_success] }
+        },
+        "unknown RubyGems response" => {
+          rubygems: ->(_name) { ["service unavailable", rubygems_unknown] }
+        }
+      }
+
+      aggregate_failures do
+        variants.each do |name, behavior|
+          tracker_records = [authorization_record]
+          repository_records = [authorization_record]
+          appended = false
+          allow(self).to receive(:fetch_accelerated_rc_tracker_records!) { tracker_records }
+          allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!) { repository_records }
+          stub_accelerated_rc_publication_recovery_tag(authorization: authorization_record)
+          allow(self).to receive(:fetch_npm_package_metadata_with_retries) do |package_ref, **|
+            behavior.fetch(:npm, ->(_ref) {}).call(package_ref) ||
+              [JSON.generate({ "version" => "17.0.0-rc.10" }), success_status]
+          end
+          allow(self).to receive(:fetch_rubygems_versions) do |gem_name, **|
+            behavior.fetch(
+              :rubygems,
+              ->(_name) { [JSON.generate([{ "number" => "17.0.0.rc.10" }]), rubygems_success] }
+            ).call(gem_name)
+          end
+          allow(self).to receive(:append_accelerated_rc_tracker_record!) { appended = true }
+
+          expect do
+            run_accelerated_rc_reconciliation!(
+              repo_slug: "shakacode/react_on_rails",
+              monorepo_root: "/tmp/repo",
+              tracker: 3823,
+              target_version: "17.0.0.rc.10",
+              reason: "Recover publication",
+              evidence: {}
+            )
+          end.to raise_error(SystemExit), name
+          expect(appended).to be(false), name
+        end
+      end
+    end
+
+    it "blocks recovery when the remote annotated tag loses provenance or moves candidates" do
+      variants = {
+        "changed provenance" => [
+          accelerated_rc_tag_provenance(authorization_record).merge("authorization_digest" => "0" * 64),
+          "f" * 40,
+          /does not match.*authorization/i
+        ],
+        "moved candidate" => [
+          accelerated_rc_tag_provenance(authorization_record),
+          "e" * 40,
+          /moved away.*candidate/i
+        ]
+      }
+
+      aggregate_failures do
+        variants.each do |name, (provenance, remote_sha, expected_error)|
+          allow(self).to receive_messages(
+            fetch_accelerated_rc_tracker_records!: [authorization_record],
+            fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record],
+            fetch_remote_release_tag!: nil,
+            local_release_tag_object_sha!: "a" * 40,
+            accelerated_rc_tag_identity_for_object!: {
+              tag_object_sha: "a" * 40,
+              candidate_sha: "f" * 40,
+              provenance:
+            },
+            remote_annotated_release_tag_identity!: {
+              tag_object_sha: "a" * 40,
+              candidate_sha: remote_sha
+            }
+          )
+          expect(self).not_to receive(:verify_complete_release_registry_publication!)
+          expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+          expect do
+            run_accelerated_rc_reconciliation!(
+              repo_slug: "shakacode/react_on_rails",
+              monorepo_root: "/tmp/repo",
+              tracker: 3823,
+              target_version: "17.0.0.rc.10",
+              reason: "Recover publication",
+              evidence: {}
+            )
+          end.to raise_error(SystemExit, expected_error), name
+        end
+      end
+    end
+
+    it "binds recovery provenance to the captured object across a local A-to-B-to-A ref race" do
+      candidate_sha = "f" * 40
+      captured_tag_object_sha = "a" * 40
+      success = instance_double(Process::Status, success?: true)
+      wrong_authorization = authorization_record.merge("reason" => "Different authorization for object A")
+      captured_object = <<~TAG_OBJECT
+        object #{candidate_sha}
+        type commit
+        tag v17.0.0.rc.10
+        tagger Maintainer <maintainer@example.com> 1784000000 +0000
+
+        #{accelerated_rc_tag_message(wrong_authorization)}
+      TAG_OBJECT
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization_record],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record],
+        fetch_remote_release_tag!: nil
+      )
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10"
+      ).and_return(["#{captured_tag_object_sha}\n", success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10"
+      ).and_return(["tag\n", success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "for-each-ref", "--format=%(contents)", "refs/tags/v17.0.0.rc.10"
+      ).and_return([accelerated_rc_tag_message(authorization_record), success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10^{}"
+      ).and_return(["#{candidate_sha}\n", success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "cat-file", "-t", captured_tag_object_sha
+      ).and_return(["tag\n", success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "cat-file", "-p", captured_tag_object_sha
+      ).and_return([captured_object, success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "#{captured_tag_object_sha}^{}"
+      ).and_return(["#{candidate_sha}\n", success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      ).and_return(
+        [
+          "#{captured_tag_object_sha}\trefs/tags/v17.0.0.rc.10\n" \
+          "#{candidate_sha}\trefs/tags/v17.0.0.rc.10^{}\n",
+          success
+        ]
+      )
+      expect(self).not_to receive(:verify_complete_release_registry_publication!)
+      expect(self).not_to receive(:record_accelerated_rc_publication_complete!)
+      expect(self).not_to receive(:fetch_accelerated_rc_ci_snapshot!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Recover publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /captured annotated tag object.*persisted.*authorization/i)
+    end
+
+    it "blocks recovery when the live remote annotated object differs from the fetched provenance object" do
+      candidate_sha = "f" * 40
+      fetched_tag_object_sha = "a" * 40
+      replacement_tag_object_sha = "b" * 40
+      success = instance_double(Process::Status, success?: true)
+      stub_accelerated_rc_tag_object_commands(
+        authorization: authorization_record, status: success, tag_object_sha: fetched_tag_object_sha,
+        candidate_sha:
+      )
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization_record],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record],
+        fetch_remote_release_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(authorization_record),
+        peeled_git_tag_sha: candidate_sha
+      )
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10"
+      ).and_return(["#{fetched_tag_object_sha}\n", success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      ).and_return(
+        [
+          "#{replacement_tag_object_sha}\trefs/tags/v17.0.0.rc.10\n" \
+          "#{candidate_sha}\trefs/tags/v17.0.0.rc.10^{}\n",
+          success
+        ]
+      )
+      expect(self).not_to receive(:verify_complete_release_registry_publication!)
+      expect(self).not_to receive(:record_accelerated_rc_publication_complete!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Recover publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /remote annotated tag object.*fetched provenance object/i)
+    end
+
+    it "blocks recovery when the live remote tag becomes lightweight at the same candidate" do
+      candidate_sha = "f" * 40
+      fetched_tag_object_sha = "a" * 40
+      success = instance_double(Process::Status, success?: true)
+      stub_accelerated_rc_tag_object_commands(
+        authorization: authorization_record, status: success, tag_object_sha: fetched_tag_object_sha,
+        candidate_sha:
+      )
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization_record],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record],
+        fetch_remote_release_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(authorization_record),
+        peeled_git_tag_sha: candidate_sha
+      )
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10"
+      ).and_return(["#{fetched_tag_object_sha}\n", success])
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      ).and_return(["#{candidate_sha}\trefs/tags/v17.0.0.rc.10\n", success])
+      expect(self).not_to receive(:verify_complete_release_registry_publication!)
+      expect(self).not_to receive(:record_accelerated_rc_publication_complete!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Recover publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /remote release tag.*not an annotated tag/i)
+    end
+
+    it "blocks a same-candidate annotated object substitution during registry verification" do
+      candidate_sha = "f" * 40
+      original_tag_object_sha = "a" * 40
+      replacement_tag_object_sha = "b" * 40
+      success = instance_double(Process::Status, success?: true)
+      stub_accelerated_rc_tag_object_commands(
+        authorization: authorization_record, status: success, tag_object_sha: original_tag_object_sha,
+        candidate_sha:
+      )
+      stub_accelerated_rc_tag_object_commands(
+        authorization: authorization_record, status: success, tag_object_sha: replacement_tag_object_sha,
+        candidate_sha:
+      )
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization_record],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record],
+        fetch_remote_release_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(authorization_record),
+        peeled_git_tag_sha: candidate_sha,
+        verify_complete_release_registry_publication!: nil
+      )
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10"
+      ).and_return(
+        ["#{original_tag_object_sha}\n", success],
+        ["#{original_tag_object_sha}\n", success],
+        ["#{replacement_tag_object_sha}\n", success],
+        ["#{replacement_tag_object_sha}\n", success]
+      )
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      ).and_return(
+        [
+          "#{original_tag_object_sha}\trefs/tags/v17.0.0.rc.10\n" \
+          "#{candidate_sha}\trefs/tags/v17.0.0.rc.10^{}\n",
+          success
+        ],
+        [
+          "#{replacement_tag_object_sha}\trefs/tags/v17.0.0.rc.10\n" \
+          "#{candidate_sha}\trefs/tags/v17.0.0.rc.10^{}\n",
+          success
+        ]
+      )
+      expect(self).not_to receive(:record_accelerated_rc_publication_complete!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Recover publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /remote annotated tag object.*changed during registry verification/i)
+    end
+
+    it "revalidates the remote annotated tag after registry proof before completion append" do
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization_record],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record],
+        fetch_remote_release_tag!: nil,
+        local_release_tag_object_sha!: "a" * 40,
+        accelerated_rc_tag_identity_for_object!: {
+          tag_object_sha: "a" * 40,
+          candidate_sha: "f" * 40,
+          provenance: accelerated_rc_tag_provenance(authorization_record)
+        },
+        verify_complete_release_registry_publication!: nil
+      )
+      allow(self).to receive(:remote_annotated_release_tag_identity!).and_return(
+        { tag_object_sha: "a" * 40, candidate_sha: "f" * 40 },
+        { tag_object_sha: "a" * 40, candidate_sha: "e" * 40 }
+      )
+      expect(self).not_to receive(:record_accelerated_rc_publication_complete!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Recover publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /moved away.*candidate/i)
+    end
+
+    it "blocks ambiguous candidate history before registry verification" do
+      other_authorization = authorization_record.merge(
+        "candidate_sha" => "e" * 40,
+        "ci" => authorization_record.fetch("ci").merge("sha" => "e" * 40),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("candidate_sha" => "e" * 40)
+      )
+      expect(validate_accelerated_rc_tracker_record!(other_authorization)).to eq(other_authorization)
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .and_return([authorization_record, other_authorization])
+      expect(self).not_to receive(:verify_complete_release_registry_publication!)
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Recover publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /absent or ambiguous candidate history/i)
+    end
+
+    it "blocks gate reconciliation when the durable completion append fails" do
+      stub_accelerated_rc_publication_recovery_tag(authorization: authorization_record)
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization_record],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization_record],
+        verify_complete_release_registry_publication!: nil
+      )
+      allow(self).to receive(:record_accelerated_rc_publication_complete!) do
+        abort "V80 simulated GitHub completion append outage"
+      end
+      expect(self).not_to receive(:fetch_accelerated_rc_ci_snapshot!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Recover publication",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /completion append outage/i)
+    end
+
     it "blocks reconciliation when a later authorization contradicts the canonical first" do
       conflicting_authorization = authorization_record.merge(
         "shakaperf" => authorization_record.fetch("shakaperf").merge(
@@ -9755,10 +10308,36 @@ RSpec.describe "release.rake helper methods" do
   end
 
   describe "#accepted_accelerated_rc_record_for_release_branch_promotion!" do
+    it "binds accepted accelerated selection provenance and candidate to one tag object" do
+      authorization, publication, accepted = accelerated_rc_test_accepted_history
+      wrong_object_authorization = authorization.merge("reason" => "Different authorization on object A")
+      stub_final_promotion_source_rc_tag_commands(
+        object_authorization: wrong_object_authorization,
+        ref_authorization: authorization
+      )
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_release_tracker_issue!: nil,
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
+        fetch_accelerated_rc_tracker_records!: [authorization, publication, accepted],
+        shakaperf_runtime_tree_fingerprint: "a" * 64
+      )
+
+      expect do
+        accepted_accelerated_rc_record_for_release_branch_promotion!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          final_head_sha: "f" * 40,
+          tracker_input: "3823"
+        )
+      end.to raise_error(SystemExit, /does not match.*tag provenance|provenance.*authorization/i)
+    end
+
     it "rejects cross-tracker exact-candidate history during final promotion" do
       authorization, publication, accepted = accelerated_rc_test_accepted_history
       conflicting_authorization = accelerated_rc_test_authorization(tracker: 3824)
       provenance = accelerated_rc_tag_provenance(authorization)
+      stub_final_promotion_source_rc_tag_commands(object_authorization: authorization)
       allow(self).to receive_messages(
         accelerated_rc_tag_provenance_for_tag!: provenance,
         github_repo_slug: "shakacode/react_on_rails",
@@ -9784,6 +10363,9 @@ RSpec.describe "release.rake helper methods" do
     it "requires the literal canonical tag name for accelerated provenance" do
       authorization, publication, accepted = accelerated_rc_test_accepted_history
       provenance = accelerated_rc_tag_provenance(authorization)
+      ["v17.0.0-rc.10", "v17.0.0.RC.10", "v17.0.0.rc.10"].each do |tag|
+        stub_final_promotion_source_rc_tag_commands(object_authorization: authorization, tag:)
+      end
       allow(self).to receive_messages(
         accelerated_rc_tag_provenance_for_tag!: provenance,
         github_repo_slug: "shakacode/react_on_rails",
@@ -9820,6 +10402,12 @@ RSpec.describe "release.rake helper methods" do
     it "does not require a tracker for an ordinary lightweight RC tag" do
       status = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10")
+        .and_return(["#{'f' * 40}\n", status])
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "f" * 40)
+        .and_return(["commit\n", status])
+      allow(Open3).to receive(:capture2e)
         .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
         .and_return(["commit\n", status])
       allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
@@ -9832,6 +10420,7 @@ RSpec.describe "release.rake helper methods" do
       ).and_return([])
       expect(self).not_to receive(:fetch_release_tracker_issue!)
       expect(self).not_to receive(:fetch_accelerated_rc_tracker_records!)
+      expect(self).not_to receive(:remote_annotated_release_tag_identity!)
 
       result = accepted_accelerated_rc_record_for_release_branch_promotion!(
         monorepo_root: "/tmp/repo",
@@ -9851,8 +10440,10 @@ RSpec.describe "release.rake helper methods" do
     it "blocks a lightweight RC tag when durable accelerated history exists for the exact candidate" do
       status = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture2e)
-        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
-        .and_return(["commit\n", status])
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10")
+        .and_return(["#{'f' * 40}\n", status])
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "f" * 40).and_return(["commit\n", status])
       allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
       allow(self).to receive(:peeled_git_tag_sha)
         .with(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10").and_return("f" * 40)
@@ -9879,12 +10470,15 @@ RSpec.describe "release.rake helper methods" do
     it "blocks a markerless annotated RC tag even when no tracker is supplied" do
       status = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture2e)
-        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
-        .and_return(["tag\n", status])
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10")
+        .and_return(["#{'a' * 40}\n", status])
       allow(Open3).to receive(:capture2e)
-        .with(
-          "git", "-C", "/tmp/repo", "for-each-ref", "--format=%(contents)", "refs/tags/v17.0.0.rc.10"
-        ).and_return(["Ordinary-looking annotation without canonical provenance\n", status])
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "a" * 40).and_return(["tag\n", status])
+      contents = "object #{'f' * 40}\ntype commit\ntag v17.0.0.rc.10\n\n" \
+                 "Ordinary-looking annotation without canonical provenance\n"
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "cat-file", "-p", "a" * 40
+      ).and_return([contents, status])
       expect(self).not_to receive(:github_repo_slug)
 
       expect do
@@ -9900,12 +10494,15 @@ RSpec.describe "release.rake helper methods" do
     it "blocks a markerless annotated RC tag when an explicit tracker is supplied" do
       status = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture2e)
-        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
-        .and_return(["tag\n", status])
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10")
+        .and_return(["#{'a' * 40}\n", status])
       allow(Open3).to receive(:capture2e)
-        .with(
-          "git", "-C", "/tmp/repo", "for-each-ref", "--format=%(contents)", "refs/tags/v17.0.0.rc.10"
-        ).and_return(["Ordinary-looking annotation without canonical provenance\n", status])
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "a" * 40).and_return(["tag\n", status])
+      contents = "object #{'f' * 40}\ntype commit\ntag v17.0.0.rc.10\n\n" \
+                 "Ordinary-looking annotation without canonical provenance\n"
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "cat-file", "-p", "a" * 40
+      ).and_return([contents, status])
       expect(self).not_to receive(:github_repo_slug)
       expect(self).not_to receive(:fetch_release_tracker_issue!)
       expect(self).not_to receive(:fetch_accelerated_rc_tracker_records!)
@@ -9921,10 +10518,14 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "blocks when the RC tag object type cannot be determined" do
-      status = instance_double(Process::Status, success?: false)
+      success = instance_double(Process::Status, success?: true)
+      failure = instance_double(Process::Status, success?: false)
       allow(Open3).to receive(:capture2e)
-        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
-        .and_return(["fatal: object unavailable\n", status])
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--verify", "--quiet", "refs/tags/v17.0.0.rc.10")
+        .and_return(["#{'a' * 40}\n", success])
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "a" * 40)
+        .and_return(["fatal: object unavailable\n", failure])
       expect(self).not_to receive(:github_repo_slug)
 
       expect do
@@ -9934,14 +10535,12 @@ RSpec.describe "release.rake helper methods" do
           final_head_sha: "f" * 40,
           tracker_input: nil
         )
-      end.to raise_error(SystemExit, /Unable to inspect RC tag provenance.*object unavailable/i)
+      end.to raise_error(SystemExit, /Captured RC tag object.*unavailable/i)
     end
 
     it "requires the tracker encoded by an accelerated RC tag" do
-      allow(self).to receive(:accelerated_rc_tag_provenance_for_tag!).and_return(
-        "target_version" => "17.0.0.rc.10",
-        "release_tracker" => 3823
-      )
+      authorization = accelerated_rc_test_authorization
+      stub_final_promotion_source_rc_tag_commands(object_authorization: authorization)
       expect(self).not_to receive(:github_repo_slug)
 
       expect do
@@ -9952,6 +10551,30 @@ RSpec.describe "release.rake helper methods" do
           tracker_input: "3824"
         )
       end.to raise_error(SystemExit, /RELEASE_TRACKER must match the canonical tracker/)
+    end
+  end
+
+  describe "#final_promotion_source_rc_context!" do
+    it "binds context provenance to the captured object across a local A-to-B-to-A ref race" do
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      wrong_object_authorization = authorization.merge("reason" => "Different authorization on object A")
+      stub_final_promotion_source_rc_tag_commands(
+        object_authorization: wrong_object_authorization,
+        ref_authorization: authorization
+      )
+
+      expect do
+        final_promotion_source_rc_context!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          record: accepted,
+          source_rc_tag_identity: {
+            tag_object_sha: "a" * 40,
+            candidate_sha: "f" * 40,
+            provenance: accelerated_rc_tag_provenance(authorization)
+          }
+        )
+      end.to raise_error(SystemExit, /source RC tag.*matching canonical accelerated provenance/i)
     end
   end
 
@@ -10611,6 +11234,12 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive_messages(
         remote_git_tag_exists?: true,
         fetch_remote_rc_tag!: nil,
+        local_release_tag_object_sha!: "a" * 40,
+        live_annotated_release_tag_identity!: {
+          tag_object_sha: "a" * 40,
+          candidate_sha: "f" * 40,
+          provenance: source_rc_tag_provenance
+        },
         current_git_sha!: "e" * 40,
         github_repo_slug: "shakacode/react_on_rails",
         accelerated_shakaperf_snapshot: strict_final_shakaperf_snapshot,
@@ -12235,8 +12864,129 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    it "rejects a live remote same-candidate source RC object replacement before stable-tag push" do
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      candidate_sha = "e" * 40
+      source_candidate_sha = accepted.fetch("candidate_sha")
+      context = accelerated_final_promotion_test_context(
+        record: accepted,
+        ci_snapshot: {
+          status: "success",
+          sha: source_candidate_sha,
+          checks_url: accepted.dig("ci", "checks_url"),
+          non_success: []
+        }
+      )
+      stub_final_promotion_source_rc_tag_commands(
+        object_authorization: authorization,
+        remote_tag_object_sha: "b" * 40
+      )
+      allow(self).to receive_messages(
+        validate_accelerated_repository_publication_boundary!: nil,
+        validate_final_promotion_ci_publication_boundary!: nil,
+        validate_final_promotion_shakaperf_publication_boundary!: nil,
+        remote_git_tag_exists?: true,
+        fetch_remote_rc_tag!: nil,
+        system: true,
+        validate_release_tag_candidate_sha!: candidate_sha,
+        validate_release_candidate_publication_boundary!: candidate_sha,
+        validate_remote_release_tag_candidate_sha!: candidate_sha
+      )
+      expect(self).not_to receive(:sh_in_dir_for_release)
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha:,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: context
+        )
+      end.to raise_error(SystemExit, /remote annotated tag object.*source RC|source RC.*tag object/i)
+    end
+
+    it "rejects a live remote lightweight source RC replacement at the accepted candidate" do
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      source_candidate_sha = accepted.fetch("candidate_sha")
+      context = accelerated_final_promotion_test_context(
+        record: accepted,
+        ci_snapshot: {
+          status: "success",
+          sha: source_candidate_sha,
+          checks_url: accepted.dig("ci", "checks_url"),
+          non_success: []
+        }
+      )
+      stub_final_promotion_source_rc_tag_commands(
+        object_authorization: authorization,
+        remote_annotated: false
+      )
+      allow(self).to receive_messages(
+        validate_accelerated_repository_publication_boundary!: nil,
+        validate_final_promotion_ci_publication_boundary!: nil,
+        validate_final_promotion_shakaperf_publication_boundary!: nil,
+        remote_git_tag_exists?: true,
+        fetch_remote_rc_tag!: nil
+      )
+      expect(self).not_to receive(:ensure_release_tag_for_candidate!)
+      expect(self).not_to receive(:sh_in_dir_for_release)
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: context
+        )
+      end.to raise_error(SystemExit, /source RC tag.*not an annotated tag|not an annotated tag.*source RC/i)
+    end
+
+    it "validates one exact source RC tag object through all three irreversible boundaries" do
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      candidate_sha = "e" * 40
+      source_candidate_sha = accepted.fetch("candidate_sha")
+      context = accelerated_final_promotion_test_context(
+        record: accepted,
+        ci_snapshot: {
+          status: "success",
+          sha: source_candidate_sha,
+          checks_url: accepted.dig("ci", "checks_url"),
+          non_success: []
+        }
+      )
+      stub_final_promotion_source_rc_tag_commands(object_authorization: authorization)
+      allow(self).to receive_messages(
+        validate_accelerated_repository_publication_boundary!: nil,
+        validate_final_promotion_ci_publication_boundary!: nil,
+        validate_final_promotion_shakaperf_publication_boundary!: nil,
+        remote_git_tag_exists?: true,
+        fetch_remote_rc_tag!: nil,
+        system: true,
+        validate_release_tag_candidate_sha!: candidate_sha,
+        validate_release_candidate_publication_boundary!: candidate_sha,
+        validate_remote_release_tag_candidate_sha!: candidate_sha
+      )
+      allow(self).to receive(:sh_in_dir_for_release)
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha:,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: context
+        )
+      end.not_to raise_error
+      expect(self).to have_received(:fetch_remote_rc_tag!).exactly(3).times
+      expect(Open3).to have_received(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin",
+        "refs/tags/v17.0.0.rc.10", "refs/tags/v17.0.0.rc.10^{}"
+      ).exactly(3).times
+    end
+
     it "blocks stable-tag push when the live source RC tag disappears after initial final gates" do
-      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
       candidate_sha = "e" * 40
       source_candidate_sha = accepted.fetch("candidate_sha")
       successful_ci = {
@@ -12246,6 +12996,7 @@ RSpec.describe "release.rake helper methods" do
         non_success: []
       }
       context = accelerated_final_promotion_test_context(record: accepted, ci_snapshot: successful_ci)
+      stub_final_promotion_source_rc_tag_commands(object_authorization: authorization)
       allow(self).to receive_messages(
         validate_accelerated_repository_publication_boundary!: nil,
         validate_final_promotion_ci_publication_boundary!: nil,
@@ -12255,8 +13006,6 @@ RSpec.describe "release.rake helper methods" do
         validate_release_candidate_publication_boundary!: candidate_sha,
         remote_git_tag_exists?: true,
         fetch_remote_rc_tag!: nil,
-        accelerated_rc_tag_provenance_for_tag!: context.fetch(:source_rc_tag_provenance),
-        peeled_git_tag_sha: source_candidate_sha,
         validate_remote_release_tag_candidate_sha!: candidate_sha
       )
       allow(self).to receive(:remote_git_tag_exists?).and_return(true, false)
@@ -12274,7 +13023,7 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "blocks packages when the live source RC tag moves after stable-tag push" do
-      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
       candidate_sha = "e" * 40
       source_candidate_sha = accepted.fetch("candidate_sha")
       moved_sha = "d" * 40
@@ -12285,6 +13034,18 @@ RSpec.describe "release.rake helper methods" do
         non_success: []
       }
       context = accelerated_final_promotion_test_context(record: accepted, ci_snapshot: successful_ci)
+      stub_final_promotion_source_rc_tag_commands(object_authorization: authorization)
+      success_status = instance_double(Process::Status, success?: true)
+      source_tag_ref = "refs/tags/v17.0.0.rc.10"
+      matching_remote = "#{'a' * 40}\t#{source_tag_ref}\n#{source_candidate_sha}\t#{source_tag_ref}^{}\n"
+      moved_remote = "#{'a' * 40}\t#{source_tag_ref}\n#{moved_sha}\t#{source_tag_ref}^{}\n"
+      allow(Open3).to receive(:capture2e).with(
+        "git", "-C", "/tmp/repo", "ls-remote", "--tags", "origin", source_tag_ref, "#{source_tag_ref}^{}"
+      ).and_return(
+        [matching_remote, success_status],
+        [matching_remote, success_status],
+        [moved_remote, success_status]
+      )
       allow(self).to receive_messages(
         validate_accelerated_repository_publication_boundary!: nil,
         validate_final_promotion_ci_publication_boundary!: nil,
@@ -12293,12 +13054,9 @@ RSpec.describe "release.rake helper methods" do
         validate_release_tag_candidate_sha!: candidate_sha,
         remote_git_tag_exists?: true,
         fetch_remote_rc_tag!: nil,
-        accelerated_rc_tag_provenance_for_tag!: context.fetch(:source_rc_tag_provenance),
         validate_release_candidate_publication_boundary!: candidate_sha,
         validate_remote_release_tag_candidate_sha!: candidate_sha
       )
-      allow(self).to receive(:peeled_git_tag_sha)
-        .and_return(source_candidate_sha, source_candidate_sha, moved_sha)
       pushed = false
       package_publication_started = false
       allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
@@ -12312,7 +13070,7 @@ RSpec.describe "release.rake helper methods" do
           accelerated_final_promotion_context: context
         )
         package_publication_started = true
-      end.to raise_error(SystemExit, /source RC tag.*moved.*package publication/i)
+      end.to raise_error(SystemExit, /moved away.*source RC package publication/i)
 
       aggregate_failures do
         expect(pushed).to be(true)
@@ -12321,7 +13079,7 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "still validates the live stable tag after all source RC boundaries pass" do
-      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      authorization, _publication, accepted = accelerated_rc_test_accepted_history
       candidate_sha = "e" * 40
       source_candidate_sha = accepted.fetch("candidate_sha")
       successful_ci = {
@@ -12331,6 +13089,7 @@ RSpec.describe "release.rake helper methods" do
         non_success: []
       }
       context = accelerated_final_promotion_test_context(record: accepted, ci_snapshot: successful_ci)
+      stub_final_promotion_source_rc_tag_commands(object_authorization: authorization)
       allow(self).to receive_messages(
         validate_accelerated_repository_publication_boundary!: nil,
         validate_final_promotion_ci_publication_boundary!: nil,
@@ -12339,9 +13098,7 @@ RSpec.describe "release.rake helper methods" do
         validate_release_tag_candidate_sha!: candidate_sha,
         validate_release_candidate_publication_boundary!: candidate_sha,
         remote_git_tag_exists?: true,
-        fetch_remote_rc_tag!: nil,
-        accelerated_rc_tag_provenance_for_tag!: context.fetch(:source_rc_tag_provenance),
-        peeled_git_tag_sha: source_candidate_sha
+        fetch_remote_rc_tag!: nil
       )
       allow(self).to receive(:sh_in_dir_for_release)
       allow(self).to receive(:validate_remote_release_tag_candidate_sha!).with(

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -16,6 +16,83 @@ RSpec.describe "release.rake helper methods" do
     $stdout = original_stdout
   end
 
+  def accelerated_rc_test_authorization(tracker: 3823)
+    build_accelerated_rc_publication_record(
+      options: {
+        target_gem_version: "17.0.0.rc.10",
+        tracker:,
+        reason: "Start published-artifact QA while remaining checks finish"
+      },
+      candidate_sha: "f" * 40,
+      runtime_tree_fingerprint: "a" * 64,
+      release_branch: "release/17.0.0",
+      ci_snapshot: {
+        status: "pending",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: [
+          {
+            name: "generator",
+            state: "in_progress",
+            url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+          }
+        ]
+      },
+      shakaperf: {
+        status: "pending",
+        run_id: 123_456,
+        attempt: 1,
+        run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+        candidate_sha: "f" * 40,
+        target_version: "17.0.0.rc.10",
+        release_started_at: "2026-07-14T13:00:00Z"
+      },
+      approved_by: "justin808",
+      recorded_at: Time.utc(2026, 7, 14, 13, 30)
+    )
+  end
+
+  def accelerated_rc_test_accepted_history(tracker: 3823)
+    authorization = accelerated_rc_test_authorization(tracker:)
+    publication = accelerated_rc_published_record(
+      authorized_record: authorization,
+      recorded_at: Time.utc(2026, 7, 14, 14)
+    )
+    accepted = publication.merge(
+      "status" => "candidate-accepted",
+      "ci" => publication.fetch("ci").merge("status" => "success", "non_success" => []),
+      "shakaperf" => publication.fetch("shakaperf").merge("status" => "success"),
+      "reason" => "All required evidence passed",
+      "recorded_at" => "2026-07-14T15:00:00Z",
+      "required_follow_up" => "Proceed only through the strict final promotion gates.",
+      "evidence" => {
+        "demo_fleet" => "https://github.com/demo-fleet",
+        "behavioral" => "https://github.com/behavioral",
+        "artifacts" => "https://github.com/artifacts"
+      }
+    )
+    [authorization, publication, accepted]
+  end
+
+  def accelerated_rc_test_rejected_history(tracker: 3823)
+    authorization, publication, accepted = accelerated_rc_test_accepted_history(tracker:)
+    rejected = accepted.merge(
+      "status" => "candidate-rejected",
+      "ci" => accepted.fetch("ci").merge(
+        "status" => "failed",
+        "non_success" => [{
+          "name" => "generator",
+          "state" => "failure",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/999"
+        }]
+      ),
+      "reason" => "Current exact-candidate CI failed",
+      "required_follow_up" => "Do not promote this immutable RC; fix the failure and cut the next RC.",
+      "evidence" => {}
+    )
+    [authorization, publication, rejected]
+  end
+
   before do
     next if Object.instance_variable_defined?(:@release_rake_helpers_loaded)
 
@@ -892,7 +969,7 @@ RSpec.describe "release.rake helper methods" do
         "attempt" => 1,
         "headSha" => "abc123",
         "status" => "in_progress",
-        "conclusion" => ""
+        "conclusion" => nil
       }
     end
     let(:terminal_run) { original_run.merge("status" => "completed", "conclusion" => "failure") }
@@ -938,6 +1015,9 @@ RSpec.describe "release.rake helper methods" do
       {
         "databaseId" => 123_456,
         "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha:, target_version:
+        ),
         "headSha" => head_sha,
         "createdAt" => "2026-07-14T12:00:00Z",
         "startedAt" => "2026-07-14T12:00:05Z",
@@ -978,6 +1058,7 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           ignored_run_ids: ["999999"],
           earliest_created_at: kind_of(Time)
         )
@@ -998,8 +1079,9 @@ RSpec.describe "release.rake helper methods" do
         Regexp::IGNORECASE | Regexp::MULTILINE
       )
 
+      validated_run = nil
       expect do
-        run_shakaperf_release_gate!(
+        validated_run = run_shakaperf_release_gate!(
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
@@ -1022,6 +1104,7 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           ignored_run_ids: ["999999"],
           earliest_created_at: kind_of(Time)
         )
@@ -1030,6 +1113,20 @@ RSpec.describe "release.rake helper methods" do
           "run", "watch", "123456", "--repo", repo_slug, "--exit-status",
           timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
         )
+      expect(validated_run).to include(
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "headSha" => head_sha,
+        "status" => "completed",
+        "conclusion" => "success"
+      )
+      expect(validated_run).to eq(
+        run.merge(
+          "status" => "completed",
+          "conclusion" => "success",
+          "updatedAt" => "2026-07-14T13:30:00Z"
+        )
+      )
     end
 
     it "reuses an already successful gate run for the same head SHA without dispatching another run" do
@@ -1043,8 +1140,9 @@ RSpec.describe "release.rake helper methods" do
       expect(self).not_to receive(:capture_gh_output)
       expect(self).not_to receive(:capture_gh_output_with_timeout)
 
+      validated_run = nil
       expect do
-        run_shakaperf_release_gate!(
+        validated_run = run_shakaperf_release_gate!(
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
@@ -1054,6 +1152,14 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false
         )
       end.to output(%r{ShakaPerf release gate already passed.*actions/runs/123456}m).to_stdout
+      expect(validated_run).to eq(successful_run)
+      expect(validated_run).to include(
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "headSha" => head_sha,
+        "status" => "completed",
+        "conclusion" => "success"
+      )
     end
 
     it "dispatches a fresh exact-head gate when a successful run has no verifiable evidence" do
@@ -1091,8 +1197,9 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive(:refresh_shakaperf_release_gate_run!)
         .with(repo_slug:, run: fresh_run).and_return(refreshed_fresh_run)
 
+      validated_run = nil
       expect do
-        run_shakaperf_release_gate!(
+        validated_run = run_shakaperf_release_gate!(
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
@@ -1103,6 +1210,14 @@ RSpec.describe "release.rake helper methods" do
         )
       end.to output(/dispatching a fresh exact-head gate.*ShakaPerf release gate passed with verified evidence/m)
         .to_stdout
+      expect(validated_run).to eq(refreshed_fresh_run)
+      expect(validated_run).to include(
+        "databaseId" => 654_321,
+        "attempt" => 1,
+        "headSha" => head_sha,
+        "status" => "completed",
+        "conclusion" => "success"
+      )
     end
 
     it "fails closed when a freshly dispatched gate refresh changes run identity" do
@@ -1156,8 +1271,9 @@ RSpec.describe "release.rake helper methods" do
       expect(self).not_to receive(:capture_gh_output_with_timeout)
       expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
 
+      validated_run = nil
       expect do
-        run_shakaperf_release_gate!(
+        validated_run = run_shakaperf_release_gate!(
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
@@ -1167,6 +1283,14 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false
         )
       end.to output(%r{Reusing successful ShakaPerf pre-run.*actions/runs/123456}m).to_stdout
+      expect(validated_run).to eq(successful_prerun)
+      expect(validated_run).to include(
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "headSha" => candidate_sha,
+        "status" => "completed",
+        "conclusion" => "success"
+      )
     end
 
     it "waits for an in-progress pre-run before reusing its evidence" do
@@ -1174,7 +1298,7 @@ RSpec.describe "release.rake helper methods" do
       in_progress_prerun = run.merge(
         "headSha" => candidate_sha,
         "status" => "in_progress",
-        "conclusion" => "",
+        "conclusion" => nil,
         "updatedAt" => "2026-07-14T12:00:30Z"
       )
       completed_prerun = in_progress_prerun.merge(
@@ -1211,8 +1335,9 @@ RSpec.describe "release.rake helper methods" do
       ).and_return(nil)
       expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
 
+      validated_run = nil
       expect do
-        run_shakaperf_release_gate!(
+        validated_run = run_shakaperf_release_gate!(
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
@@ -1235,6 +1360,14 @@ RSpec.describe "release.rake helper methods" do
         require_prerun: true,
         allow_prerun_completion_after_release_start: true
       )
+      expect(validated_run).to eq(completed_prerun)
+      expect(validated_run).to include(
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "headSha" => candidate_sha,
+        "status" => "completed",
+        "conclusion" => "success"
+      )
     end
 
     it "dispatches an exact-head gate when the active pre-run attempt changes while waiting" do
@@ -1242,7 +1375,7 @@ RSpec.describe "release.rake helper methods" do
       in_progress_prerun = run.merge(
         "headSha" => candidate_sha,
         "status" => "in_progress",
-        "conclusion" => "",
+        "conclusion" => nil,
         "updatedAt" => "2026-07-14T12:00:30Z"
       )
       rerun_prerun = in_progress_prerun.merge(
@@ -1294,7 +1427,7 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => candidate_sha,
         "startedAt" => "2026-07-14T13:01:00Z",
         "status" => "in_progress",
-        "conclusion" => "",
+        "conclusion" => nil,
         "updatedAt" => "2026-07-14T13:01:30Z"
       )
       changed_prerun = in_progress_prerun.merge(
@@ -1345,7 +1478,7 @@ RSpec.describe "release.rake helper methods" do
       in_progress_prerun = run.merge(
         "headSha" => candidate_sha,
         "status" => "in_progress",
-        "conclusion" => ""
+        "conclusion" => nil
       )
       failed_prerun = in_progress_prerun.merge(
         "status" => "completed",
@@ -1426,7 +1559,12 @@ RSpec.describe "release.rake helper methods" do
       in_progress_run = run.merge(
         "databaseId" => 321_654,
         "status" => "in_progress",
-        "conclusion" => ""
+        "conclusion" => nil
+      )
+      completed_run = in_progress_run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "updatedAt" => "2026-07-14T13:30:00Z"
       )
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
@@ -1438,9 +1576,12 @@ RSpec.describe "release.rake helper methods" do
           timeout_seconds: SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS
         )
         .and_return(["", success_status, false])
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+        .with(repo_slug:, run: in_progress_run).and_return(completed_run)
 
+      validated_run = nil
       expect do
-        run_shakaperf_release_gate!(
+        validated_run = run_shakaperf_release_gate!(
           monorepo_root:,
           ref: "release-branch",
           head_sha:,
@@ -1450,6 +1591,14 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false
         )
       end.to output(/watching it instead.*ShakaPerf release gate passed/m).to_stdout
+      expect(validated_run).to eq(completed_run)
+      expect(validated_run).to include(
+        "databaseId" => 321_654,
+        "attempt" => 1,
+        "headSha" => head_sha,
+        "status" => "completed",
+        "conclusion" => "success"
+      )
     end
 
     it "considers reusable pre-run evidence when an in-progress exact-head run finishes unsuccessfully" do
@@ -1457,7 +1606,7 @@ RSpec.describe "release.rake helper methods" do
       in_progress_exact_head_run = run.merge(
         "databaseId" => 654_321,
         "status" => "in_progress",
-        "conclusion" => ""
+        "conclusion" => nil
       )
       failed_exact_head_run = in_progress_exact_head_run.merge(
         "status" => "completed",
@@ -1498,7 +1647,7 @@ RSpec.describe "release.rake helper methods" do
       in_progress_run = run.merge(
         "databaseId" => 654_321,
         "status" => "in_progress",
-        "conclusion" => ""
+        "conclusion" => nil
       )
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
@@ -1526,7 +1675,7 @@ RSpec.describe "release.rake helper methods" do
       in_progress_run = run.merge(
         "databaseId" => 654_321,
         "status" => "in_progress",
-        "conclusion" => ""
+        "conclusion" => nil
       )
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
@@ -1583,6 +1732,7 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           ignored_run_ids: %w[222222 111111],
           earliest_created_at: kind_of(Time)
         )
@@ -1692,6 +1842,7 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           ignored_run_ids: [],
           earliest_created_at: kind_of(Time)
         )
@@ -1769,6 +1920,7 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           ignored_run_ids: [],
           earliest_created_at: kind_of(Time)
         )
@@ -1794,19 +1946,33 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "finds the workflow_dispatch run for the pushed head SHA" do
-      matching_run = { "databaseId" => 2, "headSha" => head_sha }
+      matching_run = {
+        "databaseId" => 2,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha:, target_version:
+        ),
+        "headSha" => head_sha
+      }
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
         .and_return([{ "databaseId" => 1, "headSha" => "old" }, matching_run])
 
       expect(
-        wait_for_shakaperf_release_gate_run!(repo_slug:, ref: "release-branch", head_sha:)
+        wait_for_shakaperf_release_gate_run!(repo_slug:, ref: "release-branch", head_sha:, target_version:)
       ).to eq(matching_run)
     end
 
     it "ignores stale workflow_dispatch runs for the same head SHA" do
-      stale_run = { "databaseId" => 1, "headSha" => head_sha }
-      matching_run = { "databaseId" => 2, "headSha" => head_sha }
+      run_identity = {
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha:, target_version:
+        ),
+        "headSha" => head_sha
+      }
+      stale_run = run_identity.merge("databaseId" => 1)
+      matching_run = run_identity.merge("databaseId" => 2)
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
         .and_return([stale_run, matching_run])
@@ -1816,14 +1982,22 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           ignored_run_ids: [1]
         )
       ).to eq(matching_run)
     end
 
     it "ignores workflow_dispatch runs created before the new dispatch starts" do
-      stale_run = { "databaseId" => 1, "headSha" => head_sha, "createdAt" => "2026-06-05T01:00:00Z" }
-      matching_run = { "databaseId" => 2, "headSha" => head_sha, "createdAt" => "2026-06-05T01:00:10Z" }
+      run_identity = {
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha:, target_version:
+        ),
+        "headSha" => head_sha
+      }
+      stale_run = run_identity.merge("databaseId" => 1, "createdAt" => "2026-06-05T01:00:00Z")
+      matching_run = run_identity.merge("databaseId" => 2, "createdAt" => "2026-06-05T01:00:10Z")
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
         .and_return([stale_run, matching_run])
@@ -1833,6 +2007,7 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           earliest_created_at: Time.iso8601("2026-06-05T01:00:05Z")
         )
       ).to eq(matching_run)
@@ -1840,7 +2015,15 @@ RSpec.describe "release.rake helper methods" do
 
     it "uses GitHub's second-precision timestamps when matching newly dispatched runs" do
       allow(Time).to receive(:now).and_return(Time.iso8601("2026-06-05T01:00:05.900Z"))
-      newly_dispatched_run = { "databaseId" => 1, "headSha" => head_sha, "createdAt" => "2026-06-05T01:00:05Z" }
+      newly_dispatched_run = {
+        "databaseId" => 1,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha:, target_version:
+        ),
+        "headSha" => head_sha,
+        "createdAt" => "2026-06-05T01:00:05Z"
+      }
       allow(self).to receive(:fetch_shakaperf_release_gate_runs)
         .with(repo_slug:, ref: "release-branch")
         .and_return([newly_dispatched_run])
@@ -1850,6 +2033,7 @@ RSpec.describe "release.rake helper methods" do
           repo_slug:,
           ref: "release-branch",
           head_sha:,
+          target_version:,
           earliest_created_at: shakaperf_release_gate_dispatch_started_at
         )
       ).to eq(newly_dispatched_run)
@@ -1865,9 +2049,344 @@ RSpec.describe "release.rake helper methods" do
         wait_for_shakaperf_release_gate_run!(
           repo_slug:,
           ref: "release-branch",
-          head_sha:
+          head_sha:,
+          target_version:
         )
       end.to raise_error(SystemExit, /Timed out waiting for ShakaPerf release gate workflow to start/)
+    end
+  end
+
+  describe "#run_accelerated_shakaperf_release_gate!" do
+    it "rejects every active status when its conclusion is non-nil" do
+      non_nil_conclusions = ["failure", ""]
+      aggregate_failures do
+        SHAKAPERF_RELEASE_GATE_ACTIVE_STATUSES.each do |status|
+          non_nil_conclusions.each do |conclusion|
+            expect do
+              active_shakaperf_release_gate_run?("status" => status, "conclusion" => conclusion)
+            end.to raise_error(SystemExit, /active ShakaPerf run.*terminal conclusion/i)
+          end
+        end
+      end
+    end
+
+    it "dispatches an exact-head gate and returns its URL without watching it" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "queued",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => nil,
+        "updatedAt" => "2026-07-14T13:00:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([])
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil
+      )
+      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(run)
+      expect(self).not_to receive(:watch_shakaperf_release_gate_run!)
+
+      result = run_accelerated_shakaperf_release_gate!(
+        monorepo_root: "/tmp/repo",
+        ref: "release/17.0.0",
+        head_sha: "d" * 40,
+        target_version: "17.0.0.rc.10",
+        release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+      )
+
+      expect(result).to include(
+        status: "pending",
+        run_id: 123_456,
+        run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      )
+    end
+
+    it "blocks a freshly dispatched active run that already has a terminal conclusion" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "queued",
+        "conclusion" => "failure",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => nil,
+        "updatedAt" => "2026-07-14T13:00:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([])
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil
+      )
+      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(run)
+
+      expect do
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref: "release/17.0.0",
+          head_sha: "d" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+        )
+      end.to raise_error(SystemExit, /active ShakaPerf run.*terminal conclusion/i)
+    end
+
+    it "blocks a freshly dispatched run that is already known to have failed" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "completed",
+        "conclusion" => "failure",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:01Z",
+        "updatedAt" => "2026-07-14T13:00:02Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([])
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil
+      )
+      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(run)
+
+      expect do
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref: "release/17.0.0",
+          head_sha: "d" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+        )
+      end.to raise_error(SystemExit, /known ShakaPerf failure/)
+    end
+
+    it "reuses an active exact-head run without dispatching a duplicate" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "in_progress",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([run])
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      result = run_accelerated_shakaperf_release_gate!(
+        monorepo_root: "/tmp/repo",
+        ref: "release/17.0.0",
+        head_sha: "d" * 40,
+        target_version: "17.0.0.rc.10",
+        release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+      )
+
+      expect(result).to include(status: "pending", run_id: 123_456)
+    end
+
+    it "blocks an existing active exact-head run that already has a terminal conclusion" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "in_progress",
+        "conclusion" => "failure",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([run])
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref: "release/17.0.0",
+          head_sha: "d" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+        )
+      end.to raise_error(SystemExit, /active ShakaPerf run.*terminal conclusion/i)
+    end
+
+    it "ignores a same-SHA run dispatched for another target version" do
+      wrong_target = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.9"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "in_progress"
+      }
+
+      expect(
+        find_latest_shakaperf_release_gate_run(
+          [wrong_target],
+          "d" * 40,
+          ref: "release/17.0.0",
+          target_version: "17.0.0.rc.10"
+        )
+      ).to be_nil
+    end
+
+    it "fails closed when an active exact-head run has no trustworthy GitHub identity" do
+      run = {
+        "databaseId" => nil,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "in_progress",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/unknown"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([run])
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref: "release/17.0.0",
+          head_sha: "d" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+        )
+      end.to raise_error(SystemExit, /identity is unknown/)
+    end
+
+    it "reuses a completed exact-head run only after verifying its evidence" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([run])
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      result = run_accelerated_shakaperf_release_gate!(
+        monorepo_root: "/tmp/repo",
+        ref: "release/17.0.0",
+        head_sha: "d" * 40,
+        target_version: "17.0.0.rc.10",
+        release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+      )
+
+      expect(result).to include(status: "success", run_id: 123_456)
+    end
+
+    it "fails closed on a completed exact-head ShakaPerf failure" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "d" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "d" * 40,
+        "status" => "completed",
+        "conclusion" => "failure",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([run])
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref: "release/17.0.0",
+          head_sha: "d" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+        )
+      end.to raise_error(SystemExit, %r{known ShakaPerf failure.*actions/runs/123456}mi)
+    end
+
+    it "reuses a completed pre-run only when runtime-equivalent evidence verifies" do
+      run = {
+        "databaseId" => 222_222,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "e" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/222222"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref: "release/17.0.0").and_return([run])
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      result = run_accelerated_shakaperf_release_gate!(
+        monorepo_root: "/tmp/repo",
+        ref: "release/17.0.0",
+        head_sha: "d" * 40,
+        target_version: "17.0.0.rc.10",
+        release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+      )
+
+      expect(result).to include(status: "success", run_id: 222_222)
     end
   end
 
@@ -2423,6 +2942,69 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#preflight_explicit_accelerated_rc_target_tag!" do
+    let(:tag) { "v17.0.0.rc.10" }
+
+    it "allows a canonical annotated retry only from the exact tagged candidate" do
+      provenance = {
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40
+      }
+      allow(self).to receive_messages(
+        local_release_tag_exists?: true,
+        remote_git_tag_exists?: true,
+        fetch_remote_release_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: provenance,
+        peeled_git_tag_sha: "f" * 40,
+        current_git_sha!: "f" * 40
+      )
+
+      expect(
+        preflight_explicit_accelerated_rc_target_tag!(
+          monorepo_root: "/tmp/repo",
+          target_gem_version: "17.0.0.rc.10",
+          current_checkout_version: "17.0.0.rc.10"
+        )
+      ).to eq(provenance)
+      expect(self).to have_received(:fetch_remote_release_tag!).with(
+        monorepo_root: "/tmp/repo", tag:, tag_type: "accelerated RC"
+      )
+    end
+
+    it "fails closed when exact-target remote discovery is unknown" do
+      allow(self).to receive(:local_release_tag_exists?).and_return(false)
+      allow(self).to receive(:remote_git_tag_exists?)
+        .and_raise(SystemExit, "Unable to verify remote git tag")
+      expect(self).not_to receive(:accelerated_rc_tag_provenance_for_tag!)
+
+      expect do
+        preflight_explicit_accelerated_rc_target_tag!(
+          monorepo_root: "/tmp/repo",
+          target_gem_version: "17.0.0.rc.10",
+          current_checkout_version: "16.9.0"
+        )
+      end.to raise_error(SystemExit, /Unable to verify remote git tag/)
+    end
+
+    it "fails closed when a discovered exact-target tag cannot be classified" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: false,
+        remote_git_tag_exists?: true,
+        fetch_remote_release_tag!: nil
+      )
+      allow(self).to receive(:accelerated_rc_tag_provenance_for_tag!)
+        .and_raise(SystemExit, "RC tag has an unexpected git object type")
+
+      expect do
+        preflight_explicit_accelerated_rc_target_tag!(
+          monorepo_root: "/tmp/repo",
+          target_gem_version: "17.0.0.rc.10",
+          current_checkout_version: "16.9.0"
+        )
+      end.to raise_error(SystemExit, /unexpected git object type/)
+    end
+  end
+
   describe "#ci_status_override_enabled?" do
     it "returns true when the override flag is truthy" do
       expect(ci_status_override_enabled?("true")).to be true
@@ -2461,6 +3043,4258 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#resolve_accelerated_rc_options!" do
+    it "rejects an argument-less accelerated RC release" do
+      expect do
+        resolve_accelerated_rc_options!(
+          requested: true,
+          explicit_version_input: "",
+          target_gem_version: "17.0.0.rc.10",
+          tracker: "3823",
+          reason: "Start published-artifact QA while exact-head checks finish",
+          allow_ci_override: false
+        )
+      end.to raise_error(SystemExit, /explicit RC version/)
+    end
+
+    it "rejects accelerated publication for a stable target" do
+      expect do
+        resolve_accelerated_rc_options!(
+          requested: true,
+          explicit_version_input: "17.0.0",
+          target_gem_version: "17.0.0",
+          tracker: "3823",
+          reason: "Start published-artifact QA while exact-head checks finish",
+          allow_ci_override: false
+        )
+      end.to raise_error(SystemExit, /RC targets only/)
+    end
+
+    it "requires a numeric release tracker" do
+      expect do
+        resolve_accelerated_rc_options!(
+          requested: true,
+          explicit_version_input: "17.0.0.rc.10",
+          target_gem_version: "17.0.0.rc.10",
+          tracker: "",
+          reason: "Start published-artifact QA while exact-head checks finish",
+          allow_ci_override: false
+        )
+      end.to raise_error(SystemExit, /release tracker issue number/)
+    end
+
+    it "requires a single-line maintainer reason" do
+      expect do
+        resolve_accelerated_rc_options!(
+          requested: true,
+          explicit_version_input: "17.0.0.rc.10",
+          target_gem_version: "17.0.0.rc.10",
+          tracker: "3823",
+          reason: "",
+          allow_ci_override: false
+        )
+      end.to raise_error(SystemExit, /maintainer reason/)
+    end
+
+    it "rejects comment-breaking content in the maintainer reason" do
+      expect do
+        resolve_accelerated_rc_options!(
+          requested: true,
+          explicit_version_input: "17.0.0.rc.10",
+          target_gem_version: "17.0.0.rc.10",
+          tracker: "3823",
+          reason: "approved --> forged record",
+          allow_ci_override: false
+        )
+      end.to raise_error(SystemExit, /single-line plain text/)
+    end
+
+    it "rejects the broad CI override in accelerated mode" do
+      expect do
+        resolve_accelerated_rc_options!(
+          requested: true,
+          explicit_version_input: "17.0.0.rc.10",
+          target_gem_version: "17.0.0.rc.10",
+          tracker: "3823",
+          reason: "Start published-artifact QA while exact-head checks finish",
+          allow_ci_override: true
+        )
+      end.to raise_error(SystemExit, /cannot be combined.*CI status override/i)
+    end
+
+    it "rejects a derived RC target instead of accepting a non-RC version input" do
+      expect do
+        resolve_accelerated_rc_options!(
+          requested: true,
+          explicit_version_input: "patch",
+          target_gem_version: "17.0.0.rc.10",
+          tracker: "3823",
+          reason: "Start published-artifact QA while exact-head checks finish",
+          allow_ci_override: false
+        )
+      end.to raise_error(SystemExit, /explicit version must exactly match/)
+    end
+
+    it "rejects case-varied accelerated identities before persistence or tag provenance" do
+      uppercase_options = {
+        target_gem_version: "17.0.0.RC.10",
+        tracker: 3823,
+        reason: "Start published-artifact QA while exact-head checks finish"
+      }
+      uppercase_record = build_accelerated_rc_publication_record(
+        options: uppercase_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: {
+          status: "pending",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: [{
+            name: "generator",
+            state: "in_progress",
+            url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+          }]
+        },
+        shakaperf: {
+          status: "pending",
+          run_id: 123_456,
+          attempt: 1,
+          run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          candidate_sha: "f" * 40,
+          target_version: "17.0.0.RC.10",
+          release_started_at: "2026-07-14T13:00:00Z"
+        },
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      uppercase_provenance = {
+        "schema_version" => 1,
+        "target_version" => "17.0.0.RC.10",
+        "candidate_sha" => "f" * 40,
+        "release_tracker" => 3823,
+        "authorization_digest" => "b" * 64
+      }
+
+      aggregate_failures do
+        expect do
+          resolve_accelerated_rc_options!(
+            requested: true,
+            explicit_version_input: "17.0.0.RC.10",
+            target_gem_version: "17.0.0.RC.10",
+            tracker: "3823",
+            reason: uppercase_options.fetch(:reason),
+            allow_ci_override: false
+          )
+        end.to raise_error(SystemExit, /canonical lowercase.*\.rc\./i)
+        expect do
+          validate_accelerated_rc_tracker_record!(uppercase_record)
+        end.to raise_error(SystemExit, /malformed accelerated RC record/)
+        expect(valid_accelerated_rc_tag_provenance?(uppercase_provenance)).to be(false)
+      end
+    end
+
+    it "rejects accelerated RC numeric identifiers with leading zeroes" do
+      invalid_versions = %w[
+        17.0.0.rc.01
+        017.0.0.rc.1
+        17.00.0.rc.1
+        17.0.00.rc.1
+      ]
+
+      aggregate_failures do
+        invalid_versions.each do |version|
+          expect do
+            resolve_accelerated_rc_options!(
+              requested: true,
+              explicit_version_input: version,
+              target_gem_version: version,
+              tracker: "3823",
+              reason: "Start published-artifact QA while exact-head checks finish",
+              allow_ci_override: false
+            )
+          end.to raise_error(SystemExit, /canonical npm semver.*leading zero/i), version
+        end
+      end
+    end
+
+    it "accepts canonical accelerated RC versions with zero and positive numeric components" do
+      valid_versions = %w[0.0.0.rc.0 17.0.0.rc.10]
+
+      aggregate_failures do
+        valid_versions.each do |version|
+          options = resolve_accelerated_rc_options!(
+            requested: true,
+            explicit_version_input: version,
+            target_gem_version: version,
+            tracker: "3823",
+            reason: "Start published-artifact QA while exact-head checks finish",
+            allow_ci_override: false
+          )
+          expect(options.fetch(:target_gem_version)).to eq(version)
+        end
+      end
+    end
+
+    it "carries a canonical lowercase accelerated identity through final-promotion validation" do
+      options = resolve_accelerated_rc_options!(
+        requested: true,
+        explicit_version_input: "17.0.0.rc.10",
+        target_gem_version: "17.0.0.rc.10",
+        tracker: "3823",
+        reason: "Start published-artifact QA while exact-head checks finish",
+        allow_ci_override: false
+      )
+      authorization = build_accelerated_rc_publication_record(
+        options:,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: {
+          status: "pending",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: [{
+            name: "generator",
+            state: "in_progress",
+            url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+          }]
+        },
+        shakaperf: {
+          status: "pending",
+          run_id: 123_456,
+          attempt: 1,
+          run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          candidate_sha: "f" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: "2026-07-14T13:00:00Z"
+        },
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      accepted = reconcile_accelerated_rc_record(
+        published_record: publication,
+        ci_snapshot: authorization.fetch("ci").merge("status" => "success", "non_success" => []),
+        shakaperf: authorization.fetch("shakaperf").merge("status" => "success"),
+        evidence: {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        },
+        approved_by: "justin808",
+        reason: "All required evidence passed",
+        recorded_at: "2026-07-14T15:00:00Z"
+      )
+      provenance = accelerated_rc_tag_provenance(authorization)
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint).and_return("a" * 64)
+
+      expect(
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization, publication, accepted],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance: provenance
+        )
+      ).to eq(accepted)
+    end
+  end
+
+  describe "#resolve_accelerated_rc_options_for_release!" do
+    let(:authorization) do
+      build_accelerated_rc_publication_record(
+        options: {
+          target_gem_version: "17.0.0.rc.10",
+          tracker: 3823,
+          reason: "Start published-artifact QA while remaining checks finish"
+        },
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: {
+          status: "pending",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: [
+            {
+              name: "generator",
+              state: "in_progress",
+              url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+            }
+          ]
+        },
+        shakaperf: {
+          status: "pending",
+          run_id: 123_456,
+          attempt: 1,
+          run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          candidate_sha: "f" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: "2026-07-14T13:00:00Z"
+        },
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+    end
+
+    def resolve_unflagged_accelerated_retry(allow_ci_override: false)
+      resolve_accelerated_rc_options_for_release!(
+        requested: false,
+        explicit_version_input: "17.0.0.rc.10",
+        target_gem_version: "17.0.0.rc.10",
+        tracker: nil,
+        reason: nil,
+        allow_ci_override:,
+        repo_slug: "shakacode/react_on_rails",
+        monorepo_root: "/tmp/repo",
+        current_checkout_version: "17.0.0.rc.10",
+        candidate_sha: "f" * 40
+      )
+    end
+
+    def resolve_flagged_accelerated_retry(tracker: 3823, reason: nil)
+      resolve_accelerated_rc_options_for_release!(
+        requested: true,
+        explicit_version_input: "17.0.0.rc.10",
+        target_gem_version: "17.0.0.rc.10",
+        tracker: tracker.to_s,
+        reason: reason || authorization.fetch("reason"),
+        allow_ci_override: false,
+        repo_slug: "shakacode/react_on_rails",
+        monorepo_root: "/tmp/repo",
+        current_checkout_version: "17.0.0.rc.10",
+        candidate_sha: "f" * 40
+      )
+    end
+
+    it "resumes persisted pre-tag authorization when accelerated variables are omitted" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: false,
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_release_tracker_issue!: {}
+      )
+
+      expect(resolve_unflagged_accelerated_retry).to include(
+        target_gem_version: "17.0.0.rc.10",
+        tracker: 3823,
+        reason: authorization.fetch("reason")
+      )
+    end
+
+    it "resumes an annotated accelerated-tag retry when accelerated variables are omitted" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: true,
+        accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(authorization),
+        fetch_release_tracker_issue!: {},
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization]
+      )
+
+      expect(resolve_unflagged_accelerated_retry).to include(
+        target_gem_version: "17.0.0.rc.10",
+        tracker: 3823,
+        reason: authorization.fetch("reason")
+      )
+    end
+
+    it "preserves an ordinary RC retry when no accelerated history exists" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: true,
+        accelerated_rc_tag_provenance_for_tag!: nil,
+        fetch_repository_accelerated_rc_records_for_candidate!: []
+      )
+
+      expect(resolve_unflagged_accelerated_retry).to be_nil
+    end
+
+    it "blocks a flagged retry over an existing ordinary lightweight tag before authorization append" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: true,
+        accelerated_rc_tag_provenance_for_tag!: nil,
+        fetch_repository_accelerated_rc_records_for_candidate!: [],
+        append_accelerated_rc_tracker_record!: nil
+      )
+
+      failure = begin
+        options = resolve_flagged_accelerated_retry
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: options.fetch(:tracker),
+          record: authorization
+        )
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/ordinary lightweight RC tag.*accelerated/i)
+        expect(self).not_to have_received(:append_accelerated_rc_tracker_record!)
+      end
+    end
+
+    it "rejects the broad prerelease override when durable accelerated history is discovered" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: false,
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_release_tracker_issue!: {}
+      )
+
+      expect do
+        resolve_unflagged_accelerated_retry(allow_ci_override: true)
+      end.to raise_error(SystemExit, /accelerated RC retry.*broad CI status override/i)
+    end
+
+    it "blocks a flagged same-candidate retry that switches the durable tracker or reason" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: false,
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_release_tracker_issue!: {}
+      )
+
+      aggregate_failures do
+        expect do
+          resolve_flagged_accelerated_retry(tracker: 3824)
+        end.to raise_error(SystemExit, /explicit accelerated RC retry.*canonical authorization/i)
+        expect do
+          resolve_flagged_accelerated_retry(reason: "A different retry reason")
+        end.to raise_error(SystemExit, /explicit accelerated RC retry.*canonical authorization/i)
+      end
+    end
+
+    it "reuses the canonical authorization for a flagged same-tracker retry with a deleted tag" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: false,
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_release_tracker_issue!: {}
+      )
+
+      expect(resolve_flagged_accelerated_retry).to eq(
+        target_gem_version: "17.0.0.rc.10",
+        tracker: 3823,
+        reason: authorization.fetch("reason"),
+        allow_ci_override: false
+      )
+      expect(self).to have_received(:fetch_repository_accelerated_rc_records_for_candidate!).with(
+        repo_slug: "shakacode/react_on_rails",
+        target_version: "17.0.0.rc.10",
+        candidate_sha: "f" * 40
+      )
+    end
+
+    it "keeps candidate-rejected absorbing for a flagged retry after its tag is deleted" do
+      publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      failed_ci = authorization.fetch("ci").merge(
+        "status" => "failed",
+        "non_success" => [authorization.dig("ci", "non_success").first.merge("state" => "failure")]
+      )
+      rejected = reconcile_accelerated_rc_record(
+        published_record: publication,
+        ci_snapshot: failed_ci,
+        shakaperf: authorization.fetch("shakaperf"),
+        evidence: {},
+        approved_by: "justin808",
+        reason: "Exact-head CI failed after publication",
+        recorded_at: "2026-07-14T15:00:00Z"
+      )
+      allow(self).to receive_messages(
+        local_release_tag_exists?: false,
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, rejected],
+        fetch_release_tracker_issue!: {}
+      )
+
+      expect do
+        resolve_flagged_accelerated_retry
+      end.to raise_error(SystemExit, /permanently rejected/i)
+    end
+
+    it "blocks conflicting durable trackers and authorizations before a flagged retry" do
+      conflicting_tracker = authorization.merge("release_tracker" => 3824)
+      conflicting_authorization = authorization.merge("reason" => "Conflicting durable authorization")
+      histories = {
+        "trackers" => [authorization, conflicting_tracker],
+        "authorizations" => [authorization, conflicting_authorization]
+      }
+      allow(self).to receive_messages(local_release_tag_exists?: false, fetch_release_tracker_issue!: {})
+
+      aggregate_failures do
+        histories.each do |description, records|
+          allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!).and_return(records)
+          expect do
+            resolve_flagged_accelerated_retry
+          end.to raise_error(SystemExit, /conflicting.*(?:trackers|authorizations)/i), description
+        end
+      end
+    end
+
+    it "allows a history-free explicit first attempt only after exact-candidate discovery" do
+      allow(self).to receive_messages(
+        local_release_tag_exists?: false,
+        fetch_repository_accelerated_rc_records_for_candidate!: []
+      )
+
+      expect(resolve_flagged_accelerated_retry).to include(
+        target_gem_version: "17.0.0.rc.10",
+        tracker: 3823,
+        reason: authorization.fetch("reason")
+      )
+      expect(self).to have_received(:fetch_repository_accelerated_rc_records_for_candidate!).with(
+        repo_slug: "shakacode/react_on_rails",
+        target_version: "17.0.0.rc.10",
+        candidate_sha: "f" * 40
+      )
+    end
+  end
+
+  describe "#accelerated_rc_ci_snapshot" do
+    it "captures every pending or skipped exact-head check with its URL" do
+      snapshot = accelerated_rc_ci_snapshot(
+        sha: "a" * 40,
+        repo_slug: "shakacode/react_on_rails",
+        check_runs: [
+          {
+            "id" => 1,
+            "name" => "lint",
+            "status" => "completed",
+            "conclusion" => "success",
+            "html_url" => "https://github.com/shakacode/react_on_rails/actions/runs/1"
+          },
+          {
+            "id" => 2,
+            "name" => "generator-1",
+            "status" => "in_progress",
+            "conclusion" => nil,
+            "html_url" => "https://github.com/shakacode/react_on_rails/actions/runs/2"
+          },
+          {
+            "id" => 3,
+            "name" => "intentional-skip",
+            "status" => "completed",
+            "conclusion" => "skipped",
+            "html_url" => "https://github.com/shakacode/react_on_rails/actions/runs/3"
+          }
+        ],
+        statuses: []
+      )
+
+      expect(snapshot).to include(status: "pending", sha: "a" * 40)
+      expect(snapshot[:non_success]).to contain_exactly(
+        include(name: "generator-1", state: "in_progress", url: %r{runs/2}),
+        include(name: "intentional-skip", state: "skipped", url: %r{runs/3})
+      )
+    end
+
+    it "uses the exact-SHA checks page when a non-success check has no direct URL" do
+      snapshot = accelerated_rc_ci_snapshot(
+        sha: "a" * 40,
+        repo_slug: "shakacode/react_on_rails",
+        check_runs: [
+          {
+            "id" => 2,
+            "name" => "generator-1",
+            "status" => "in_progress",
+            "conclusion" => nil,
+            "html_url" => nil
+          }
+        ],
+        statuses: []
+      )
+
+      expect(snapshot.fetch(:non_success)).to contain_exactly(
+        include(url: "https://github.com/shakacode/react_on_rails/commit/#{'a' * 40}/checks")
+      )
+    end
+
+    it "fails closed on a known failed exact-head check" do
+      expect do
+        accelerated_rc_ci_snapshot(
+          sha: "b" * 40,
+          repo_slug: "shakacode/react_on_rails",
+          check_runs: [
+            {
+              "id" => 4,
+              "name" => "generator-2",
+              "status" => "completed",
+              "conclusion" => "failure",
+              "html_url" => "https://github.com/shakacode/react_on_rails/actions/runs/4"
+            }
+          ],
+          statuses: []
+        )
+      end.to raise_error(SystemExit, %r{known failed.*generator-2.*actions/runs/4}mi)
+    end
+
+    it "fails closed when the exact-head CI API returns no evidence" do
+      expect do
+        accelerated_rc_ci_snapshot(
+          sha: "c" * 40,
+          repo_slug: "shakacode/react_on_rails",
+          check_runs: [],
+          statuses: []
+        )
+      end.to raise_error(SystemExit, /exact-head CI evidence is unknown/)
+    end
+
+    it "fails closed while a required exact-head check has not appeared" do
+      expect do
+        accelerated_rc_ci_snapshot(
+          sha: "d" * 40,
+          repo_slug: "shakacode/react_on_rails",
+          check_runs: [
+            {
+              "id" => 5,
+              "name" => "optional-docs",
+              "status" => "completed",
+              "conclusion" => "success",
+              "html_url" => "https://github.com/shakacode/react_on_rails/actions/runs/5"
+            }
+          ],
+          statuses: [],
+          required_names: { contexts: [], checks: [{ context: "generator", app_id: nil }] }
+        )
+      end.to raise_error(SystemExit, /required exact-head CI checks have not appeared.*generator/i)
+    end
+  end
+
+  describe "#fetch_accelerated_rc_ci_snapshot!" do
+    it "fails closed when either exact-head CI API is unknown" do
+      allow(self).to receive(:fetch_ci_check_runs_for_sha)
+        .and_return(error: "GitHub Checks API unavailable")
+      expect(self).not_to receive(:fetch_ci_statuses_for_sha)
+
+      expect do
+        fetch_accelerated_rc_ci_snapshot!(
+          repo_slug: "shakacode/react_on_rails",
+          sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /Checks API unavailable.*unknown/mi)
+    end
+  end
+
+  describe "accelerated RC tracker records" do
+    let(:accelerated_rc_options) do
+      {
+        target_gem_version: "17.0.0.rc.10",
+        tracker: 3823,
+        reason: "Start published-artifact QA while remaining checks finish"
+      }
+    end
+
+    let(:accelerated_rc_ci_snapshot) do
+      {
+        status: "pending",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: [
+          {
+            name: "generator",
+            state: "in_progress",
+            url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+          }
+        ]
+      }
+    end
+
+    let(:accelerated_rc_shakaperf_snapshot) do
+      {
+        status: "pending",
+        run_id: 123_456,
+        attempt: 1,
+        run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+        candidate_sha: "f" * 40,
+        target_version: "17.0.0.rc.10",
+        release_started_at: "2026-07-14T13:00:00Z"
+      }
+    end
+
+    it "blocks a fresh accelerated request over an existing ordinary lightweight target tag" do
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [],
+        local_release_tag_exists?: true,
+        accelerated_rc_tag_provenance_for_tag!: nil,
+        run_accelerated_shakaperf_release_gate!: accelerated_rc_shakaperf_snapshot,
+        fetch_accelerated_rc_ci_snapshot!: accelerated_rc_ci_snapshot,
+        confirm_accelerated_rc_publication!: nil,
+        shakaperf_runtime_tree_fingerprint: "a" * 64,
+        fetch_release_tracker_issue!: nil,
+        append_accelerated_rc_tracker_record!: nil,
+        push_release_tag_for_candidate!: nil
+      )
+
+      failure = begin
+        options = resolve_accelerated_rc_options_for_release!(
+          requested: true,
+          explicit_version_input: "17.0.0.rc.10",
+          target_gem_version: "17.0.0.rc.10",
+          tracker: "3823",
+          reason: accelerated_rc_options.fetch(:reason),
+          allow_ci_override: false,
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          current_checkout_version: "16.9.0",
+          candidate_sha: nil
+        )
+        authorization = authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options:,
+          approver: "justin808",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          accelerated_publication_record: authorization
+        )
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/ordinary lightweight RC tag.*accelerated/i)
+        expect(self).not_to have_received(:run_accelerated_shakaperf_release_gate!)
+        expect(self).not_to have_received(:confirm_accelerated_rc_publication!)
+        expect(self).not_to have_received(:append_accelerated_rc_tracker_record!)
+        expect(self).not_to have_received(:push_release_tag_for_candidate!)
+      end
+    end
+
+    it "blocks authorization when exact-candidate history already exists on another tracker" do
+      conflicting_authorization = accelerated_rc_test_authorization(tracker: 3824)
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [conflicting_authorization],
+        fetch_accelerated_rc_tracker_records!: [],
+        local_release_tag_exists?: false,
+        run_accelerated_shakaperf_release_gate!: accelerated_rc_shakaperf_snapshot,
+        fetch_accelerated_rc_ci_snapshot!: accelerated_rc_ci_snapshot,
+        confirm_accelerated_rc_publication!: nil,
+        shakaperf_runtime_tree_fingerprint: "a" * 64,
+        fetch_release_tracker_issue!: nil,
+        append_accelerated_rc_tracker_record!: nil
+      )
+
+      expect do
+        authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options: accelerated_rc_options,
+          approver: "justin808",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /repository-wide.*tracker|different release tracker/i)
+    end
+
+    it "blocks immutable tag handling when a cross-tracker conflict appears after authorization append" do
+      authorization = accelerated_rc_test_authorization
+      conflicting_authorization = accelerated_rc_test_authorization(tracker: 3824)
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, conflicting_authorization],
+        github_repo_slug: "shakacode/react_on_rails",
+        system: true,
+        validate_existing_accelerated_rc_tag!: nil,
+        validate_release_candidate_publication_boundary!: nil,
+        sh_in_dir_for_release: nil
+      )
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          accelerated_publication_record: authorization
+        )
+      end.to raise_error(SystemExit, /repository-wide.*tracker|conflicting release trackers/i)
+    end
+
+    it "records a durable authorization state before immutable publication" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+
+      expect(record).to include(
+        "status" => "publication-authorized",
+        "recorded_at" => "2026-07-14T13:30:00Z",
+        "required_follow_up" => /complete immutable publication/i
+      )
+      expect(validate_accelerated_rc_tracker_record!(record)).to eq(record)
+    end
+
+    it "transitions the authorized snapshot only after immutable publication completes" do
+      authorized_record = {
+        "status" => "publication-authorized",
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "recorded_at" => "2026-07-14T13:30:00Z"
+      }
+
+      published_record = accelerated_rc_published_record(
+        authorized_record:,
+        recorded_at: Time.utc(2026, 7, 14, 14, 0)
+      )
+
+      expect(published_record).to include(
+        "status" => "published-awaiting-gates",
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "recorded_at" => "2026-07-14T14:00:00Z",
+        "required_follow_up" => /reconcile_accelerated_rc/
+      )
+      expect(authorized_record["status"]).to eq("publication-authorized")
+    end
+
+    it "fails closed when paginated tracker comments have an unexpected JSON shape" do
+      status = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output).and_return([JSON.generate("not-pages"), status])
+
+      expect do
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /unexpected JSON structure/)
+    end
+
+    it "rejects a closed release tracker" do
+      expect do
+        validate_release_tracker_issue!(
+          {
+            "number" => 3823,
+            "state" => "closed",
+            "title" => "Release gate: React on Rails 17.0.0",
+            "labels" => [{ "name" => "release" }, { "name" => "TRACKING" }]
+          },
+          tracker: 3823
+        )
+      end.to raise_error(SystemExit, /active open release tracker/)
+    end
+
+    it "rejects a pull request even when its issue fields otherwise look like a release tracker" do
+      expect do
+        validate_release_tracker_issue!(
+          {
+            "number" => 3823,
+            "state" => "open",
+            "title" => "Release gate: React on Rails 17.0.0",
+            "labels" => [{ "name" => "release" }, { "name" => "TRACKING" }],
+            "pull_request" => { "url" => "https://api.github.com/repos/shakacode/react_on_rails/pulls/3823" }
+          },
+          tracker: 3823
+        )
+      end.to raise_error(SystemExit, /active open release tracker/)
+    end
+
+    it "rejects an approver without maintainer repository permission" do
+      expect do
+        validate_release_approver!(login: "external-user", permission: "read")
+      end.to raise_error(SystemExit, /write, maintain, or admin/)
+    end
+
+    it "rejects tracker markers authored without maintainer repository permission" do
+      record = { "schema_version" => 1 }
+      marker = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 " \
+               "#{JSON.generate(record).unpack1('H*')} -->"
+      allow(self).to receive(:fetch_release_tracker_comments).and_return(
+        [{ "body" => marker, "user" => { "login" => "external-user" } }]
+      )
+      status = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output)
+        .with(
+          "api",
+          "repos/shakacode/react_on_rails/collaborators/external-user/permission",
+          "--jq",
+          ".permission"
+        ).and_return(["read\n", status])
+
+      expect do
+        fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /write, maintain, or admin/)
+    end
+
+    it "discovers exact candidate history from trusted repository issue comments" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      comment = {
+        "body" => accelerated_rc_tracker_comment(authorization),
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
+        "user" => { "login" => "justin808" }
+      }
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output)
+        .with("api", "--paginate", "--slurp", "repos/shakacode/react_on_rails/issues/comments?per_page=100")
+        .and_return([JSON.generate([[comment]]), success])
+      allow(self).to receive(:capture_gh_output)
+        .with(
+          "api", "repos/shakacode/react_on_rails/collaborators/justin808/permission", "--jq", ".permission"
+        ).and_return(["maintain\n", success])
+
+      expect(
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      ).to eq([authorization])
+    end
+
+    it "ignores one clearly unrelated valid repository marker before author permission checks" do
+      unrelated_options = accelerated_rc_options.merge(target_gem_version: "16.9.0.rc.1")
+      unrelated_authorization = build_accelerated_rc_publication_record(
+        options: unrelated_options,
+        candidate_sha: "e" * 40,
+        runtime_tree_fingerprint: "b" * 64,
+        release_branch: "release/16.9.0",
+        ci_snapshot: accelerated_rc_ci_snapshot.merge(sha: "e" * 40),
+        shakaperf: accelerated_rc_shakaperf_snapshot.merge(
+          candidate_sha: "e" * 40,
+          target_version: "16.9.0.rc.1"
+        ),
+        approved_by: "read-only-user",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      unrelated_marker = accelerated_rc_tracker_comment(unrelated_authorization).lines.first
+      comments = [{
+        "body" => unrelated_marker,
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3800",
+        "user" => { "login" => "read-only-user" }
+      }]
+      allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return(comments)
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+
+      expect(
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      ).to eq([])
+    end
+
+    it "strictly rejects complete unrelated records whose marker encoding is noncanonical" do
+      unrelated_authorization = accelerated_rc_test_authorization.merge(
+        "target_version" => "16.9.0.rc.1",
+        "candidate_sha" => "e" * 40,
+        "release_branch" => "release/16.9.0",
+        "ci" => accelerated_rc_test_authorization.fetch("ci").merge("sha" => "e" * 40),
+        "shakaperf" => accelerated_rc_test_authorization.fetch("shakaperf").merge(
+          "candidate_sha" => "e" * 40,
+          "target_version" => "16.9.0.rc.1"
+        )
+      )
+      canonical_json = JSON.generate(canonical_accelerated_rc_value(unrelated_authorization))
+      noncanonical_payloads = {
+        "reordered whitespace JSON" => JSON.pretty_generate(unrelated_authorization.to_a.reverse.to_h).unpack1("H*"),
+        "uppercase hexadecimal" => canonical_json.unpack1("H*").upcase
+      }
+      allow(self).to receive(:accelerated_rc_repository_comment_permission!).and_return("maintain")
+
+      aggregate_failures do
+        noncanonical_payloads.each do |description, encoded_payload|
+          comment = {
+            "body" => "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{encoded_payload} -->",
+            "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
+            "user" => { "login" => "justin808" }
+          }
+          allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return([comment])
+
+          expect do
+            fetch_repository_accelerated_rc_records_for_candidate!(
+              repo_slug: "shakacode/react_on_rails",
+              target_version: "17.0.0.rc.10",
+              candidate_sha: "f" * 40
+            )
+          end.to raise_error(SystemExit, /malformed accelerated RC record/), description
+        end
+      end
+      expect(self).to have_received(:accelerated_rc_repository_comment_permission!).twice
+    end
+
+    it "strictly rejects an incomplete valid-JSON unrelated repository marker" do
+      incomplete_record = {
+        "target_version" => "16.9.0.rc.1",
+        "candidate_sha" => "e" * 40
+      }
+      encoded_payload = JSON.generate(incomplete_record).unpack1("H*")
+      comment = {
+        "body" => "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{encoded_payload} -->",
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3800",
+        "user" => { "login" => "justin808" }
+      }
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [comment],
+        accelerated_rc_repository_comment_permission!: "maintain"
+      )
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+      expect(self).to have_received(:accelerated_rc_repository_comment_permission!)
+    end
+
+    it "strictly rejects duplicated valid unrelated repository markers as malformed" do
+      unrelated_authorization = accelerated_rc_test_authorization.merge(
+        "target_version" => "16.9.0.rc.1",
+        "candidate_sha" => "e" * 40,
+        "release_branch" => "release/16.9.0",
+        "ci" => accelerated_rc_test_authorization.fetch("ci").merge("sha" => "e" * 40),
+        "shakaperf" => accelerated_rc_test_authorization.fetch("shakaperf").merge(
+          "candidate_sha" => "e" * 40,
+          "target_version" => "16.9.0.rc.1"
+        )
+      )
+      unrelated_marker = accelerated_rc_tracker_comment(unrelated_authorization).lines.first
+      comment = {
+        "body" => "#{unrelated_marker}#{unrelated_marker}",
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3800",
+        "user" => { "login" => "justin808" }
+      }
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [comment],
+        accelerated_rc_repository_comment_permission!: "maintain"
+      )
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "fails closed when a malformed repository marker plausibly names the exact candidate" do
+      comment = {
+        "body" => "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 not-hex -->\n" \
+                  "- RC: `17.0.0.rc.10` at `#{'f' * 40}`",
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
+        "user" => { "login" => "justin808" }
+      }
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [comment],
+        accelerated_rc_repository_comment_permission!: "maintain"
+      )
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "strictly parses a corrupted encoded marker that names the exact candidate despite a spoofed summary" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      corrupted_payload = "#{JSON.generate(authorization)} trailing-corruption".unpack1("H*")
+      comment = {
+        "body" => "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{corrupted_payload} -->\n" \
+                  "- RC: `16.9.0.rc.1` at `#{'e' * 40}`",
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
+        "user" => { "login" => "justin808" }
+      }
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [comment],
+        accelerated_rc_repository_comment_permission!: "maintain"
+      )
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "strictly parses uppercase encoded exact-candidate markers before ignoring malformed JSON" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      corrupted_payload = "#{JSON.generate(authorization)} trailing-corruption".unpack1("H*").upcase
+      comment = {
+        "body" => "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{corrupted_payload} -->",
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
+        "user" => { "login" => "justin808" }
+      }
+      allow(self).to receive_messages(
+        fetch_repository_issue_comments_for_accelerated_rc_retry!: [comment],
+        accelerated_rc_repository_comment_permission!: "maintain"
+      )
+
+      expect do
+        fetch_repository_accelerated_rc_records_for_candidate!(
+          repo_slug: "shakacode/react_on_rails",
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40
+        )
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "fails closed for every malformed marker shape that cannot prove it targets another candidate" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      unrelated_authorization = authorization.merge(
+        "target_version" => "16.9.0.rc.1",
+        "candidate_sha" => "e" * 40,
+        "release_branch" => "release/16.9.0",
+        "ci" => authorization.fetch("ci").merge("sha" => "e" * 40),
+        "shakaperf" => authorization.fetch("shakaperf").merge(
+          "candidate_sha" => "e" * 40,
+          "target_version" => "16.9.0.rc.1"
+        )
+      )
+      exact_payload = JSON.generate(authorization).unpack1("H*")
+      odd_exact_payload = exact_payload[0...-1]
+      escaped_version = ["17", '\u002e', "0", '\u002e', "0", '\u002e', "rc", '\u002e', "10"].join
+      escaped_sha = '\u0066' * 40
+      escaped_corrupt_payload =
+        %({"target_version":"#{escaped_version}","candidate_sha":"#{escaped_sha}"} trailing-corruption).unpack1("H*")
+      unrelated_marker = accelerated_rc_tracker_comment(unrelated_authorization).lines.first.strip
+      spoofed_summary = "- RC: `16.8.0.rc.2` at `#{'d' * 40}`"
+      malformed_bodies = {
+        "odd-length exact payload" =>
+          "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{odd_exact_payload} -->\n#{spoofed_summary}",
+        "Unicode-escaped exact identity with trailing corruption" =>
+          "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{escaped_corrupt_payload} -->\n#{spoofed_summary}",
+        "corrupted marker boundary" =>
+          "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{exact_payload} --!>\n#{spoofed_summary}",
+        "unrelated marker followed by a duplicated malformed exact marker" =>
+          "#{unrelated_marker}\n<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{odd_exact_payload} -->\n#{spoofed_summary}"
+      }
+      allow(self).to receive(:accelerated_rc_repository_comment_permission!).and_return("maintain")
+
+      aggregate_failures do
+        malformed_bodies.each do |description, body|
+          comment = {
+            "body" => body,
+            "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
+            "user" => { "login" => "justin808" }
+          }
+          allow(self).to receive(:fetch_repository_issue_comments_for_accelerated_rc_retry!).and_return([comment])
+
+          expect do
+            fetch_repository_accelerated_rc_records_for_candidate!(
+              repo_slug: "shakacode/react_on_rails",
+              target_version: "17.0.0.rc.10",
+              candidate_sha: "f" * 40
+            )
+          end.to raise_error(SystemExit, /malformed accelerated RC record/), description
+        end
+      end
+    end
+
+    it "rejects repository discovery comments whose issue URL is not the exact requested repository issue" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      invalid_urls = [
+        "https://github.com/shakacode/react_on_rails/issues/3823",
+        "https://api.github.example/repos/shakacode/react_on_rails/issues/3823",
+        "https://api.github.com/repos/other/react_on_rails/issues/3823",
+        "https://api.github.com/repos/shakacode/other/issues/3823",
+        "https://api.github.com/repos/shakacode/react_on_rails/pulls/3823",
+        "https://api.github.com/repos/shakacode/react_on_rails/issues/3823/extra",
+        "https://api.github.com/repos/shakacode/react_on_rails/issues/3823?redirect=/issues/3824",
+        "https://api.github.com/repos/shakacode/react_on_rails/issues/3823#issues/3824",
+        "not-a-url/issues/3823"
+      ]
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+
+      aggregate_failures do
+        invalid_urls.each do |issue_url|
+          comment = {
+            "body" => accelerated_rc_tracker_comment(authorization),
+            "issue_url" => issue_url,
+            "user" => { "login" => "justin808" }
+          }
+          expect do
+            trusted_accelerated_rc_records_from_repository_comment!(
+              comment:, repo_slug: "shakacode/react_on_rails", permissions: {}
+            )
+          end.to raise_error(SystemExit, /exact requested repository issue URL/i), issue_url
+        end
+      end
+    end
+
+    it "accepts the canonical API issue URL for the exact requested repository" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      comment = {
+        "body" => accelerated_rc_tracker_comment(authorization),
+        "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/3823",
+        "user" => { "login" => "justin808" }
+      }
+      allow(self).to receive(:accelerated_rc_repository_comment_permission!).and_return("maintain")
+
+      expect(
+        trusted_accelerated_rc_records_from_repository_comment!(
+          comment:, repo_slug: "shakacode/react_on_rails", permissions: {}
+        )
+      ).to eq([authorization])
+    end
+
+    it "rejects an auditable record that names a different approver than its comment author" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "claimed-approver",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      status = instance_double(Process::Status, success?: true)
+      allow(self).to receive_messages(
+        fetch_release_tracker_comments: [
+          { "body" => accelerated_rc_tracker_comment(record), "user" => { "login" => "actual-author" } }
+        ],
+        capture_gh_output: ["write\n", status]
+      )
+
+      expect do
+        fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /approver does not match.*comment author/i)
+    end
+
+    it "round-trips a published-awaiting-gates record through the auditable comment marker" do
+      record = {
+        "schema_version" => 1,
+        "status" => "published-awaiting-gates",
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "runtime_tree_fingerprint" => "a" * 64,
+        "release_branch" => "release/17.0.0",
+        "release_tracker" => 3823,
+        "ci" => {
+          "status" => "pending",
+          "sha" => "f" * 40,
+          "checks_url" => "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          "non_success" => [
+            {
+              "name" => "generator",
+              "state" => "in_progress",
+              "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123"
+            }
+          ]
+        },
+        "shakaperf" => {
+          "status" => "pending",
+          "run_id" => 123_456,
+          "attempt" => 1,
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          "candidate_sha" => "f" * 40,
+          "target_version" => "17.0.0.rc.10",
+          "release_started_at" => "2026-07-14T13:00:00Z"
+        },
+        "reason" => "Start published-artifact QA while remaining checks finish",
+        "approved_by" => "justin808",
+        "recorded_at" => "2026-07-14T13:30:00Z",
+        "required_follow_up" => "Run reconciliation before final promotion.",
+        "evidence" => {}
+      }
+
+      comment = accelerated_rc_tracker_comment(record)
+
+      expect(comment).to include("published-awaiting-gates", "17.0.0.rc.10", "123456")
+      expect(comment).to include(canonical_accelerated_rc_encoded_payload(record))
+      expect(accelerated_rc_records_from_comments([{ "body" => comment }])).to eq([record])
+    end
+
+    it "fails closed when a tracker marker is malformed instead of ignoring it" do
+      comment = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 {not-json} -->"
+
+      expect do
+        accelerated_rc_records_from_comments([{ "body" => comment }])
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "fails closed when a tracker marker contains an incomplete hex payload" do
+      comment = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 f -->"
+
+      expect do
+        accelerated_rc_records_from_comments([{ "body" => comment }])
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "fails closed when a tracker marker uses an unsupported schema" do
+      record = { "schema_version" => 2, "status" => "candidate-accepted" }
+      payload = JSON.generate(record).unpack1("H*")
+      comment = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v2 #{payload} -->"
+
+      expect do
+        accelerated_rc_records_from_comments([{ "body" => comment }])
+      end.to raise_error(SystemExit, /unsupported accelerated RC record schema/)
+    end
+
+    it "fails closed when a versioned tracker record omits required identity fields" do
+      record = { "schema_version" => 1, "status" => "candidate-accepted" }
+      payload = JSON.generate(record).unpack1("H*")
+      comment = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 #{payload} -->"
+
+      expect do
+        accelerated_rc_records_from_comments([{ "body" => comment }])
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "rejects a candidate-accepted state whose required evidence is incomplete" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot.merge(status: "success"),
+        shakaperf: accelerated_rc_shakaperf_snapshot.merge(status: "success"),
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      ).merge("status" => "candidate-accepted")
+
+      expect do
+        validate_accelerated_rc_tracker_record!(record)
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "rejects malformed nested CI evidence and unknown ShakaPerf fields" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+
+      malformed_ci = Marshal.load(Marshal.dump(record))
+      malformed_ci["ci"]["non_success"] = "malformed"
+      expect do
+        validate_accelerated_rc_tracker_record!(malformed_ci)
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+
+      malformed_shakaperf = Marshal.load(Marshal.dump(record))
+      malformed_shakaperf["shakaperf"]["unexpected"] = true
+      expect do
+        validate_accelerated_rc_tracker_record!(malformed_shakaperf)
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+
+      nil_ci = Marshal.load(Marshal.dump(record))
+      nil_ci["ci"] = nil
+      expect do
+        validate_accelerated_rc_tracker_record!(nil_ci)
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "refuses to publish an invalid locally generated tracker record" do
+      expect(self).not_to receive(:fetch_accelerated_rc_tracker_records!)
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: { "schema_version" => 1 }
+        )
+      end.to raise_error(SystemExit, /malformed accelerated RC record/)
+    end
+
+    it "re-reads the tracker after posting and rejects a concurrently appended authorization" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      conflicting_authorization = authorization.merge("reason" => "Concurrent authorization")
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!).and_return([])
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return(
+        [],
+        [authorization, conflicting_authorization]
+      )
+      allow(self).to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: authorization
+        )
+      end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
+    end
+
+    it "requires the exact posted payload instead of a concurrent retry-equivalent publication" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      concurrent_publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        approved_by: "first-maintainer",
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      posted_publication = concurrent_publication.merge(
+        "approved_by" => "second-maintainer",
+        "recorded_at" => "2026-07-14T14:01:00Z"
+      )
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return(
+        [authorization],
+        [authorization, concurrent_publication]
+      )
+      allow(self).to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: posted_publication
+        )
+      end.to raise_error(SystemExit, /append could not be verified after posting/i)
+    end
+
+    it "reuses only the canonical persisted record for an equivalent retry" do
+      authorized_record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      persisted_record = accelerated_rc_published_record(
+        authorized_record:,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      retry_record = persisted_record.merge(
+        "approved_by" => "another-maintainer",
+        "recorded_at" => "2026-07-14T14:01:00Z"
+      )
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .with(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+        .and_return([authorized_record, persisted_record])
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      result = nil
+      expect do
+        result = append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: retry_record
+        )
+      end.not_to raise_error
+      expect(result).to eq(persisted_record)
+    end
+
+    it "rejects the complete publication set before an append can reuse its canonical first record" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      canonical_publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      mutated_publication = canonical_publication.merge(
+        "shakaperf" => canonical_publication.fetch("shakaperf").merge(
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/654321"
+        )
+      )
+      retry_record = canonical_publication.merge(
+        "approved_by" => "another-maintainer",
+        "recorded_at" => "2026-07-14T14:01:00Z"
+      )
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .and_return([authorization, canonical_publication, mutated_publication])
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: retry_record
+        )
+      end.to raise_error(SystemExit, /publication set.*not the canonical authorized transition/i)
+    end
+
+    it "rejects conflicting authorizations before an append can reuse canonical publication state" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      conflicting_authorization = authorization.merge(
+        "ci" => authorization.fetch("ci").merge("status" => "success", "non_success" => [])
+      )
+      canonical_publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      retry_record = canonical_publication.merge("recorded_at" => "2026-07-14T14:01:00Z")
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .and_return([authorization, conflicting_authorization, canonical_publication])
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: retry_record
+        )
+      end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
+    end
+
+    it "rejects appending terminal candidate state before canonical publication" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      accepted = authorization.merge(
+        "status" => "candidate-accepted",
+        "ci" => authorization.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        },
+        "required_follow_up" => "Proceed only through the strict final promotion gates."
+      )
+      expect(validate_accelerated_rc_tracker_record!(accepted)).to eq(accepted)
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return([authorization])
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: accepted
+        )
+      end.to raise_error(SystemExit, /canonical published-awaiting-gates transition is missing/i)
+    end
+
+    it "does not append candidate-accepted after candidate-rejected" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      rejected = publication.merge(
+        "status" => "candidate-rejected",
+        "ci" => publication.fetch("ci").merge(
+          "status" => "failed",
+          "non_success" => [
+            { "name" => "generator", "state" => "failure", "url" => "https://example.com/failure" }
+          ]
+        ),
+        "reason" => "Exact-head CI failed",
+        "required_follow_up" => "Do not promote this immutable RC; fix the failure and cut the next RC."
+      )
+      accepted = publication.merge(
+        "status" => "candidate-accepted",
+        "ci" => publication.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => publication.fetch("shakaperf").merge("status" => "success"),
+        "reason" => "All required evidence passed",
+        "required_follow_up" => "Proceed only through the strict final promotion gates.",
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      expect(validate_accelerated_rc_tracker_record!(rejected)).to eq(rejected)
+      expect(validate_accelerated_rc_tracker_record!(accepted)).to eq(accepted)
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .and_return([authorization, publication, rejected])
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: accepted
+        )
+      end.to raise_error(SystemExit, /permanently rejected.*absorbing/i)
+    end
+
+    it "rejects a same-state retry when its authorization evidence changed" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [record],
+        fetch_accelerated_rc_tracker_records!: [record]
+      )
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      expect do
+        append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          record: record.merge("reason" => "Changed authorization after interruption")
+        )
+      end.to raise_error(SystemExit, /not canonical|conflicting canonical publication authorizations/i)
+    end
+
+    it "blocks fresh authorization when pending CI fails during confirmation" do
+      failed_ci = accelerated_rc_ci_snapshot.merge(
+        status: "failed",
+        non_success: [accelerated_rc_ci_snapshot.fetch(:non_success).first.merge(state: "failure")]
+      )
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [],
+        local_release_tag_exists?: false,
+        run_accelerated_shakaperf_release_gate!: accelerated_rc_shakaperf_snapshot,
+        confirm_accelerated_rc_publication!: nil,
+        accelerated_rc_shakaperf_snapshot!: json_compatible_release_value(accelerated_rc_shakaperf_snapshot),
+        shakaperf_runtime_tree_fingerprint: "a" * 64,
+        fetch_release_tracker_issue!: nil,
+        append_accelerated_rc_tracker_record!: nil,
+        push_release_tag_for_candidate!: nil
+      )
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!)
+        .and_return(accelerated_rc_ci_snapshot, failed_ci)
+
+      failure = begin
+        authorization = authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options: accelerated_rc_options,
+          approver: "justin808",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          accelerated_publication_record: authorization
+        )
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/refreshed.*exact-candidate CI.*failed|known failed.*CI/i)
+        expect(self).to have_received(:accelerated_rc_shakaperf_snapshot!).once
+        expect(self).to have_received(:fetch_accelerated_rc_ci_snapshot!).twice
+        expect(self).not_to have_received(:append_accelerated_rc_tracker_record!)
+        expect(self).not_to have_received(:push_release_tag_for_candidate!)
+      end
+    end
+
+    it "reconfirms materially changed pending evidence before recording fresh authorization" do
+      changed_ci = accelerated_rc_ci_snapshot.merge(
+        non_success: accelerated_rc_ci_snapshot.fetch(:non_success) + [{
+          name: "docs",
+          state: "queued",
+          url: "https://github.com/shakacode/react_on_rails/actions/runs/124"
+        }]
+      )
+      persisted_record = nil
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [],
+        local_release_tag_exists?: false,
+        run_accelerated_shakaperf_release_gate!: accelerated_rc_shakaperf_snapshot,
+        confirm_accelerated_rc_publication!: nil,
+        accelerated_rc_shakaperf_snapshot!: json_compatible_release_value(accelerated_rc_shakaperf_snapshot),
+        shakaperf_runtime_tree_fingerprint: "a" * 64,
+        fetch_release_tracker_issue!: nil
+      )
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!)
+        .and_return(accelerated_rc_ci_snapshot, changed_ci, changed_ci)
+      allow(self).to receive(:append_accelerated_rc_tracker_record!) do |record:, **|
+        persisted_record = record
+      end
+
+      authorize_accelerated_rc_publication!(
+        repo_slug: "shakacode/react_on_rails",
+        monorepo_root: "/tmp/repo",
+        release_branch: "release/17.0.0",
+        candidate_sha: "f" * 40,
+        options: accelerated_rc_options,
+        approver: "justin808",
+        release_started_at: Time.utc(2026, 7, 14, 14),
+        tag: "v17.0.0.rc.10"
+      )
+
+      aggregate_failures do
+        expect(self).to have_received(:confirm_accelerated_rc_publication!).twice
+        expect(self).to have_received(:accelerated_rc_shakaperf_snapshot!).twice
+        expect(self).to have_received(:fetch_accelerated_rc_ci_snapshot!).exactly(3).times
+        expect(persisted_record.fetch("ci")).to eq(json_compatible_release_value(changed_ci))
+      end
+    end
+
+    it "does not reconfirm when pending CI checks only arrive in a different order" do
+      check_runs = [
+        {
+          "id" => 1,
+          "name" => "generator",
+          "status" => "in_progress",
+          "conclusion" => nil,
+          "html_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123"
+        },
+        {
+          "id" => 2,
+          "name" => "docs",
+          "status" => "queued",
+          "conclusion" => nil,
+          "html_url" => "https://github.com/shakacode/react_on_rails/actions/runs/124"
+        }
+      ]
+      snapshot_arguments = {
+        sha: "f" * 40,
+        repo_slug: "shakacode/react_on_rails",
+        statuses: []
+      }
+      snapshot_builder = Object.instance_method(:accelerated_rc_ci_snapshot).bind(self)
+      prompted_ci = snapshot_builder.call(**snapshot_arguments, check_runs:)
+      refreshed_ci = snapshot_builder.call(**snapshot_arguments, check_runs: check_runs.reverse)
+      allow(self).to receive(:confirm_accelerated_rc_publication!)
+      allow(self).to receive(:refresh_accelerated_rc_live_evidence!).and_return(
+        ci: refreshed_ci,
+        shakaperf: accelerated_rc_shakaperf_snapshot
+      )
+
+      evidence = confirmed_fresh_accelerated_rc_evidence!(
+        repo_slug: "shakacode/react_on_rails",
+        monorepo_root: "/tmp/repo",
+        release_branch: "release/17.0.0",
+        candidate_sha: "f" * 40,
+        target_version: "17.0.0.rc.10",
+        tracker: 3823,
+        reason: accelerated_rc_options.fetch(:reason),
+        ci_snapshot: prompted_ci,
+        shakaperf: accelerated_rc_shakaperf_snapshot
+      )
+
+      aggregate_failures do
+        expect(self).to have_received(:confirm_accelerated_rc_publication!).once
+        expect(evidence.fetch(:ci)).to eq(prompted_ci)
+      end
+    end
+
+    it "refreshes live pending evidence before reusing persisted authorization" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        local_release_tag_exists?: false
+      )
+      expect(self).not_to receive(:run_accelerated_shakaperf_release_gate!)
+      allow(self).to receive(:accelerated_rc_shakaperf_snapshot!).with(
+        repo_slug: "shakacode/react_on_rails",
+        monorepo_root: "/tmp/repo",
+        record: authorization
+      ).and_return(authorization.fetch("shakaperf"))
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).with(
+        repo_slug: "shakacode/react_on_rails",
+        sha: "f" * 40,
+        monorepo_root: "/tmp/repo",
+        ci_branch: "release/17.0.0"
+      ).and_return(accelerated_rc_ci_snapshot)
+      expect(self).not_to receive(:confirm_accelerated_rc_publication!)
+      expect(self).not_to receive(:shakaperf_runtime_tree_fingerprint)
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      result = nil
+      expect do
+        result = authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options: accelerated_rc_options,
+          approver: "another-maintainer",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+      end.to output(/Reusing canonical accelerated RC publication authorization/).to_stdout
+      expect(result).to eq(authorization)
+      expect(self).to have_received(:accelerated_rc_shakaperf_snapshot!)
+      expect(self).to have_received(:fetch_accelerated_rc_ci_snapshot!)
+    end
+
+    it "fails closed when persisted authorization refresh returns malformed exact-candidate CI" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        local_release_tag_exists?: false,
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "pending",
+          sha: "f" * 40,
+          non_success: nil
+        }
+      )
+      expect(self).not_to receive(:accelerated_rc_shakaperf_snapshot!)
+
+      expect do
+        authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options: accelerated_rc_options,
+          approver: "another-maintainer",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /current exact-candidate CI.*malformed/i)
+    end
+
+    %w[failed missing stale unknown].each do |outcome|
+      it "blocks persisted authorization reuse when current exact-candidate CI is #{outcome}" do
+        authorization = build_accelerated_rc_publication_record(
+          options: accelerated_rc_options,
+          candidate_sha: "f" * 40,
+          runtime_tree_fingerprint: "a" * 64,
+          release_branch: "release/17.0.0",
+          ci_snapshot: accelerated_rc_ci_snapshot,
+          shakaperf: accelerated_rc_shakaperf_snapshot,
+          approved_by: "justin808",
+          recorded_at: Time.utc(2026, 7, 14, 13, 30)
+        )
+        current_ci = case outcome
+                     when "failed"
+                       accelerated_rc_ci_snapshot.merge(
+                         status: "failed",
+                         non_success: [
+                           accelerated_rc_ci_snapshot.fetch(:non_success).first.merge(state: "failure")
+                         ]
+                       )
+                     when "missing"
+                       accelerated_rc_ci_snapshot.merge(non_success: [])
+                     when "stale"
+                       accelerated_rc_ci_snapshot.merge(sha: "e" * 40)
+                     when "unknown"
+                       accelerated_rc_ci_snapshot.merge(
+                         status: "success",
+                         non_success: [
+                           accelerated_rc_ci_snapshot.fetch(:non_success).first.merge(state: "future_state")
+                         ]
+                       )
+                     end
+        allow(self).to receive_messages(
+          fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+          fetch_accelerated_rc_tracker_records!: [authorization],
+          local_release_tag_exists?: false,
+          fetch_accelerated_rc_ci_snapshot!: current_ci
+        )
+        expect(self).not_to receive(:accelerated_rc_shakaperf_snapshot!)
+
+        expect do
+          authorize_accelerated_rc_publication!(
+            repo_slug: "shakacode/react_on_rails",
+            monorepo_root: "/tmp/repo",
+            release_branch: "release/17.0.0",
+            candidate_sha: "f" * 40,
+            options: accelerated_rc_options,
+            approver: "another-maintainer",
+            release_started_at: Time.utc(2026, 7, 14, 14),
+            tag: "v17.0.0.rc.10"
+          )
+        end.to raise_error(SystemExit, /current exact-candidate CI/i)
+      end
+    end
+
+    it "blocks persisted authorization reuse when refreshed ShakaPerf has failed" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        local_release_tag_exists?: false,
+        fetch_accelerated_rc_ci_snapshot!: accelerated_rc_ci_snapshot,
+        accelerated_rc_shakaperf_snapshot!: authorization.fetch("shakaperf").merge("status" => "failed")
+      )
+
+      expect do
+        authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options: accelerated_rc_options,
+          approver: "another-maintainer",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /current ShakaPerf evidence failed/i)
+    end
+
+    it "blocks persisted authorization reuse when an active ShakaPerf run has a terminal conclusion" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        local_release_tag_exists?: false,
+        fetch_accelerated_rc_ci_snapshot!: accelerated_rc_ci_snapshot,
+        refresh_shakaperf_release_gate_run!: {
+          "databaseId" => 123_456,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref: "release/17.0.0", head_sha: "f" * 40, target_version: "17.0.0.rc.10"
+          ),
+          "headSha" => "f" * 40,
+          "status" => "in_progress",
+          "conclusion" => "failure",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+        }
+      )
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        authorize_accelerated_rc_publication!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          options: accelerated_rc_options,
+          approver: "another-maintainer",
+          release_started_at: Time.utc(2026, 7, 14, 14),
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /active ShakaPerf run.*terminal conclusion/i)
+    end
+
+    it "blocks an untagged retry when a later valid authorization changes CI detail" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      ci = authorization.fetch("ci")
+      conflicting_authorization = authorization.merge(
+        "ci" => ci.merge(
+          "non_success" => [ci.fetch("non_success").first.merge("url" => "https://example.com/other-check")]
+        )
+      )
+      expect(validate_accelerated_rc_tracker_record!(conflicting_authorization)).to eq(conflicting_authorization)
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization, conflicting_authorization],
+        local_release_tag_exists?: false
+      )
+
+      expect do
+        accelerated_rc_publication_authorization_for_retry!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
+    end
+
+    it "blocks a tagged retry whose provenance names another immutable candidate" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization],
+        local_release_tag_exists?: true,
+        accelerated_rc_tag_provenance_for_tag!: {
+          "target_version" => "17.0.0.rc.10",
+          "candidate_sha" => "e" * 40,
+          "release_tracker" => 3823,
+          "authorization_digest" => accelerated_rc_record_digest(authorization)
+        }
+      )
+
+      expect do
+        accelerated_rc_publication_authorization_for_retry!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /lacks matching canonical accelerated publication provenance/)
+    end
+
+    it "blocks a tagged retry when provenance selects the canonical first of conflicting authorizations" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      conflicting_authorization = authorization.merge("reason" => "Mutated authorization reason")
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization, conflicting_authorization],
+        local_release_tag_exists?: true,
+        accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(authorization)
+      )
+
+      expect do
+        accelerated_rc_publication_authorization_for_retry!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
+    end
+
+    it "blocks a retry when accepted terminal records contradict each other" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      accepted = publication.merge(
+        "status" => "candidate-accepted",
+        "ci" => publication.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => publication.fetch("shakaperf").merge("status" => "success"),
+        "reason" => "All required evidence passed",
+        "required_follow_up" => "Proceed only through the strict final promotion gates.",
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      conflicting_accepted = accepted.merge("approved_by" => "other-maintainer")
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [
+          authorization, publication, accepted, conflicting_accepted
+        ],
+        local_release_tag_exists?: false
+      )
+
+      expect do
+        accelerated_rc_publication_authorization_for_retry!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /conflicting candidate-accepted terminal records/i)
+    end
+
+    it "round-trips canonical accelerated provenance through the annotated tag message" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+
+      provenance = accelerated_rc_tag_provenance_from_message(accelerated_rc_tag_message(record))
+
+      expect(provenance).to include(
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "release_tracker" => 3823,
+        "authorization_digest" => accelerated_rc_record_digest(record)
+      )
+    end
+
+    it "creates the annotated tag at the explicitly authorized candidate SHA" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive(:current_git_sha!).with("/tmp/repo").and_return("f" * 40)
+      expect(self).to receive(:sh_args_in_dir_for_release).with(
+        "/tmp/repo",
+        "git", "tag", "-a", "v17.0.0.rc.10", "f" * 40, "-m", accelerated_rc_tag_message(record)
+      )
+
+      create_accelerated_rc_tag!(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10", record:)
+    end
+
+    it "refuses tag creation when HEAD moved after publication authorization" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive(:current_git_sha!).with("/tmp/repo").and_return("e" * 40)
+      expect(self).not_to receive(:sh_args_in_dir_for_release)
+
+      expect do
+        create_accelerated_rc_tag!(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10", record:)
+      end.to raise_error(SystemExit, /HEAD moved after accelerated RC authorization/)
+    end
+
+    it "rejects an existing accelerated tag whose peeled target is not the authorized candidate" do
+      record = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      allow(self).to receive_messages(
+        accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(record),
+        peeled_git_tag_sha: "e" * 40
+      )
+
+      expect do
+        validate_existing_accelerated_rc_tag!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          record:
+        )
+      end.to raise_error(SystemExit, /does not match the persisted accelerated publication authorization/)
+    end
+
+    it "rejects a mutated existing publication-complete record on retry" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      existing = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      ).merge("reason" => "Mutated after authorization")
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return([authorization, existing])
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        record_accelerated_rc_publication_complete!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          approved_by: "another-maintainer",
+          recorded_at: Time.utc(2026, 7, 14, 15)
+        )
+      end.to raise_error(SystemExit, /not the canonical authorized transition/)
+    end
+
+    it "reuses the canonical publication-complete transition across trusted retry approvers" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      existing = accelerated_rc_published_record(
+        authorized_record: authorization,
+        approved_by: "first-completing-maintainer",
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return([authorization, existing])
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect(
+        record_accelerated_rc_publication_complete!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          approved_by: "retrying-maintainer",
+          recorded_at: Time.utc(2026, 7, 14, 15)
+        )
+      ).to eq(existing)
+    end
+
+    it "rejects the complete publication set when a later same-identity record contradicts the canonical first" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      canonical_publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        approved_by: "first-completing-maintainer",
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      mutated_publication = canonical_publication.merge(
+        "reason" => "Mutated after the canonical publication record"
+      )
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .and_return([authorization, canonical_publication, mutated_publication])
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        record_accelerated_rc_publication_complete!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          approved_by: "retrying-maintainer",
+          recorded_at: Time.utc(2026, 7, 14, 15)
+        )
+      end.to raise_error(SystemExit, /publication set.*not the canonical authorized transition/i)
+    end
+
+    it "rejects publication completion when a later authorization contradicts the canonical first" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      conflicting_authorization = authorization.merge("required_follow_up" => "Skip canonical publication")
+      canonical_publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .and_return([authorization, conflicting_authorization, canonical_publication])
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        record_accelerated_rc_publication_complete!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          authorized_record: authorization,
+          approved_by: "retrying-maintainer",
+          recorded_at: Time.utc(2026, 7, 14, 15)
+        )
+      end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
+    end
+
+    it "treats every non-metadata publication mutation as contradictory" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      canonical_publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      mutations = {
+        "reason" => canonical_publication.merge("reason" => "Changed reason"),
+        "required follow-up" => canonical_publication.merge("required_follow_up" => "Skip reconciliation"),
+        "CI status" => canonical_publication.merge(
+          "ci" => canonical_publication.fetch("ci").merge("status" => "failed")
+        ),
+        "CI checks URL" => canonical_publication.merge(
+          "ci" => canonical_publication.fetch("ci").merge("checks_url" => "https://example.com/other-checks")
+        ),
+        "CI non-success detail" => canonical_publication.merge(
+          "ci" => canonical_publication.fetch("ci").merge(
+            "non_success" => [{ "name" => "generator", "state" => "failure", "url" => "https://example.com/fail" }]
+          )
+        ),
+        "ShakaPerf status" => canonical_publication.merge(
+          "shakaperf" => canonical_publication.fetch("shakaperf").merge("status" => "failed")
+        ),
+        "ShakaPerf run URL" => canonical_publication.merge(
+          "shakaperf" => canonical_publication.fetch("shakaperf").merge("run_url" => "https://example.com/other-run")
+        ),
+        "evidence" => canonical_publication.merge("evidence" => { "unexpected" => "https://example.com" })
+      }
+
+      aggregate_failures do
+        mutations.each do |name, mutated_publication|
+          expect do
+            validated_accelerated_rc_publication_set!(
+              [authorization, canonical_publication, mutated_publication], authorization
+            )
+          end.to raise_error(
+            SystemExit,
+            /publication set.*not the canonical authorized transition/i
+          ), name
+        end
+      end
+    end
+
+    it "treats every distinct valid authorization digest as conflicting" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      ci = authorization.fetch("ci")
+      shakaperf = authorization.fetch("shakaperf")
+      mutations = {
+        "reason" => authorization.merge("reason" => "Changed authorization reason"),
+        "required follow-up" => authorization.merge("required_follow_up" => "Changed required follow-up"),
+        "CI status" => authorization.merge("ci" => ci.merge("status" => "success", "non_success" => [])),
+        "CI checks URL" => authorization.merge(
+          "ci" => ci.merge("checks_url" => "https://example.com/other-checks")
+        ),
+        "CI check detail" => authorization.merge(
+          "ci" => ci.merge(
+            "non_success" => [ci.fetch("non_success").first.merge("name" => "mutated-generator")]
+          )
+        ),
+        "ShakaPerf status" => authorization.merge("shakaperf" => shakaperf.merge("status" => "success")),
+        "ShakaPerf run URL" => authorization.merge(
+          "shakaperf" => shakaperf.merge("run_url" => "https://example.com/other-run")
+        ),
+        "ShakaPerf attempt" => authorization.merge("shakaperf" => shakaperf.merge("attempt" => 2)),
+        "ShakaPerf candidate identity" => authorization.merge(
+          "shakaperf" => shakaperf.merge("candidate_sha" => "e" * 40)
+        ),
+        "runtime fingerprint" => authorization.merge("runtime_tree_fingerprint" => "b" * 64),
+        "approver metadata" => authorization.merge("approved_by" => "another-maintainer"),
+        "recorded-at metadata" => authorization.merge("recorded_at" => "2026-07-14T13:31:00Z")
+      }
+
+      aggregate_failures do
+        mutations.each do |name, conflicting_authorization|
+          expect(validate_accelerated_rc_tracker_record!(conflicting_authorization)).to eq(
+            conflicting_authorization
+          ), name
+          expect do
+            validated_accelerated_rc_authorization_set!(
+              [authorization, conflicting_authorization], selected_authorization: authorization
+            )
+          end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i), name
+        end
+      end
+    end
+
+    it "allows exact duplicate authorization copies to remain idempotent" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      duplicate = JSON.parse(JSON.generate(authorization))
+
+      expect(
+        validated_accelerated_rc_authorization_set!(
+          [authorization, duplicate], selected_authorization: authorization
+        )
+      ).to eq(authorization)
+    end
+
+    it "rejects mutated publication-complete state before an interrupted retry republishes" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+      mutated_publication = accelerated_rc_published_record(
+        authorized_record: authorization,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      ).merge("required_follow_up" => "Skip reconciliation")
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization, mutated_publication],
+        local_release_tag_exists?: false
+      )
+
+      expect do
+        accelerated_rc_publication_authorization_for_retry!(
+          repo_slug: "shakacode/react_on_rails",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /not the canonical authorized transition/)
+    end
+  end
+
+  describe "#confirm_accelerated_rc_publication!" do
+    it "names the exact candidate, tracker, non-success checks, ShakaPerf run, and reason" do
+      allow($stdin).to receive(:gets).and_return("y\n")
+      ci = {
+        status: "pending",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: [
+          {
+            name: "generator-1",
+            state: "in_progress",
+            url: "https://github.com/shakacode/react_on_rails/actions/runs/1"
+          }
+        ]
+      }
+      shakaperf = {
+        status: "pending",
+        run_id: 123_456,
+        run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+
+      expect do
+        confirm_accelerated_rc_publication!(
+          version: "17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          tracker: 3823,
+          reason: "Start fleet QA now",
+          ci_snapshot: ci,
+          shakaperf:
+        )
+      end.to output(
+        %r{17\.0\.0\.rc\.10.*#{'f' * 40}.*#3823.*generator-1.*actions/runs/1.*actions/runs/123456.*Start fleet QA now}m
+      ).to_stdout
+    end
+  end
+
+  describe "#accelerated_rc_shakaperf_requires_prerun?" do
+    it "distinguishes a runtime-equivalent pre-run from an exact-candidate run" do
+      exact_record = {
+        "candidate_sha" => "f" * 40,
+        "shakaperf" => { "candidate_sha" => "f" * 40 }
+      }
+      prerun_record = {
+        "candidate_sha" => "f" * 40,
+        "shakaperf" => { "candidate_sha" => "e" * 40 }
+      }
+
+      expect(accelerated_rc_shakaperf_requires_prerun?(exact_record)).to be(false)
+      expect(accelerated_rc_shakaperf_requires_prerun?(prerun_record)).to be(true)
+    end
+  end
+
+  describe "#reconcile_accelerated_rc_record" do
+    let(:published_record) do
+      {
+        "schema_version" => 1,
+        "status" => "published-awaiting-gates",
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "runtime_tree_fingerprint" => "a" * 64,
+        "release_branch" => "release/17.0.0",
+        "release_tracker" => 3823,
+        "ci" => { "status" => "pending" },
+        "shakaperf" => { "status" => "pending" },
+        "reason" => "Start fleet QA now",
+        "approved_by" => "justin808",
+        "recorded_at" => "2026-07-14T13:30:00Z",
+        "evidence" => {}
+      }
+    end
+
+    it "records candidate-accepted only after every deferred and downstream gate is evidenced" do
+      record = reconcile_accelerated_rc_record(
+        published_record:,
+        ci_snapshot: { "status" => "success", "checks_url" => "https://github.com/checks" },
+        shakaperf: { "status" => "success", "run_url" => "https://github.com/shakaperf" },
+        evidence: {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        },
+        approved_by: "justin808",
+        reason: "All RC gates and published-artifact checks passed",
+        recorded_at: "2026-07-14T15:00:00Z"
+      )
+
+      expect(record).to include(
+        "status" => "candidate-accepted",
+        "candidate_sha" => "f" * 40,
+        "approved_by" => "justin808",
+        "required_follow_up" => /strict final promotion gates/i
+      )
+      expect(record.fetch("evidence").keys).to contain_exactly("demo_fleet", "behavioral", "artifacts")
+    end
+
+    it "records candidate-rejected with do-not-promote guidance after a relevant late failure" do
+      record = reconcile_accelerated_rc_record(
+        published_record:,
+        ci_snapshot: { "status" => "failed", "checks_url" => "https://github.com/checks" },
+        shakaperf: { "status" => "success", "run_url" => "https://github.com/shakaperf" },
+        evidence: {},
+        approved_by: "justin808",
+        reason: "Generator validation failed on the published candidate",
+        recorded_at: "2026-07-14T15:00:00Z"
+      )
+
+      expect(record).to include(
+        "status" => "candidate-rejected",
+        "candidate_sha" => "f" * 40,
+        "required_follow_up" => /Do not promote.*cut the next RC/i
+      )
+    end
+
+    it "does not accept syntactically incomplete HTTPS evidence URLs" do
+      expect do
+        reconcile_accelerated_rc_record(
+          published_record:,
+          ci_snapshot: { "status" => "success", "checks_url" => "https://github.com/checks" },
+          shakaperf: { "status" => "success", "run_url" => "https://github.com/shakaperf" },
+          evidence: {
+            "demo_fleet" => "https://",
+            "behavioral" => "https://github.com/behavioral",
+            "artifacts" => "https://github.com/artifacts"
+          },
+          approved_by: "justin808",
+          reason: "All RC gates and published-artifact checks passed",
+          recorded_at: "2026-07-14T15:00:00Z"
+        )
+      end.to raise_error(SystemExit, /required gate evidence is incomplete/)
+    end
+  end
+
+  describe "#accelerated_rc_shakaperf_snapshot!" do
+    it "fails closed when the refreshed pending run no longer matches the recorded candidate" do
+      record = {
+        "candidate_sha" => "f" * 40,
+        "release_branch" => "release/17.0.0",
+        "shakaperf" => {
+          "status" => "pending",
+          "run_id" => 123_456,
+          "attempt" => 1,
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          "candidate_sha" => "f" * 40,
+          "target_version" => "17.0.0.rc.10",
+          "release_started_at" => "2026-07-14T13:00:00Z"
+        }
+      }
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "e" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "e" * 40,
+        "status" => "in_progress",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      )
+
+      expect do
+        accelerated_rc_shakaperf_snapshot!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          record:
+        )
+      end.to raise_error(SystemExit, /run identity is unknown or malformed/)
+    end
+
+    it "keeps an unknown completed conclusion unresolved instead of rejecting the immutable RC" do
+      record = {
+        "candidate_sha" => "f" * 40,
+        "release_branch" => "release/17.0.0",
+        "shakaperf" => {
+          "status" => "pending",
+          "run_id" => 123_456,
+          "attempt" => 1,
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          "candidate_sha" => "f" * 40,
+          "target_version" => "17.0.0.rc.10",
+          "release_started_at" => "2026-07-14T13:00:00Z"
+        }
+      }
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "f" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "f" * 40,
+        "status" => "completed",
+        "conclusion" => "unrecognized",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      )
+
+      expect do
+        accelerated_rc_shakaperf_snapshot!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          record:
+        )
+      end.to raise_error(SystemExit, /reconciliation is unknown.*refusing to accept or reject/i)
+    end
+
+    it "fails closed when the refreshed run attempt differs from the authorized attempt" do
+      record = {
+        "candidate_sha" => "f" * 40,
+        "release_branch" => "release/17.0.0",
+        "shakaperf" => {
+          "status" => "pending",
+          "run_id" => 123_456,
+          "attempt" => 1,
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          "candidate_sha" => "f" * 40,
+          "target_version" => "17.0.0.rc.10",
+          "release_started_at" => "2026-07-14T13:00:00Z"
+        }
+      }
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(
+        "databaseId" => 123_456,
+        "attempt" => 2,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "f" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "f" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      )
+
+      expect do
+        accelerated_rc_shakaperf_snapshot!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          record:
+        )
+      end.to raise_error(SystemExit, /run identity is unknown or malformed/)
+    end
+  end
+
+  describe "#run_accelerated_rc_reconciliation!" do
+    let(:authorization_record) do
+      build_accelerated_rc_publication_record(
+        options: {
+          target_gem_version: "17.0.0.rc.10",
+          tracker: 3823,
+          reason: "Start fleet QA now"
+        },
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: {
+          status: "pending",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: [
+            {
+              name: "generator",
+              state: "in_progress",
+              url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+            }
+          ]
+        },
+        shakaperf: {
+          status: "pending",
+          run_id: 123_456,
+          attempt: 1,
+          run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          candidate_sha: "f" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: "2026-07-14T13:00:00Z"
+        },
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+    end
+
+    let(:published_record) do
+      accelerated_rc_published_record(
+        authorized_record: authorization_record,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+    end
+
+    let(:accepted_record) do
+      published_record.merge(
+        "status" => "candidate-accepted",
+        "ci" => published_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => published_record.fetch("shakaperf").merge("status" => "success"),
+        "reason" => "All required evidence passed",
+        "recorded_at" => "2026-07-14T15:00:00Z",
+        "required_follow_up" => "Proceed only through the strict final promotion gates.",
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+    end
+
+    before do
+      allow(self).to receive_messages(
+        fetch_release_tracker_issue!: nil,
+        current_release_approver!: "justin808",
+        fetch_accelerated_rc_tracker_records!: [authorization_record, published_record]
+      )
+    end
+
+    it "is idempotent after a terminal tracker record and does not re-query deferred gates" do
+      retry_equivalent_accepted = accepted_record.merge("recorded_at" => "2026-07-14T15:01:00Z")
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!)
+        .and_return([authorization_record, published_record, accepted_record, retry_equivalent_accepted])
+      expect(self).not_to receive(:fetch_accelerated_rc_ci_snapshot!)
+      expect(self).not_to receive(:accelerated_rc_shakaperf_snapshot!)
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        expect(
+          run_accelerated_rc_reconciliation!(
+            repo_slug: "shakacode/react_on_rails",
+            monorepo_root: "/tmp/repo",
+            tracker: 3823,
+            target_version: "17.0.0.rc.10",
+            reason: "All required evidence passed",
+            evidence: {}
+          )
+        ).to eq(accepted_record)
+      end.to output(/already terminal.*candidate-accepted/i).to_stdout
+    end
+
+    it "rejects out-of-order candidate histories before reconciliation consumes terminal state" do
+      publication_after_terminal = published_record.merge(
+        "approved_by" => "retrying-maintainer",
+        "recorded_at" => "2026-07-14T15:01:00Z"
+      )
+      histories = {
+        "publication before authorization" => [published_record, authorization_record],
+        "acceptance before publication" => [authorization_record, accepted_record, published_record],
+        "pending publication after terminal" => [
+          authorization_record, published_record, accepted_record, publication_after_terminal
+        ]
+      }
+
+      aggregate_failures do
+        histories.each do |name, records|
+          expect do
+            accelerated_rc_published_record!(records:, target_version: "17.0.0.rc.10")
+          end.to raise_error(SystemExit, /transition order/i), name
+        end
+      end
+    end
+
+    it "rejects non-monotonic candidate transition timestamps" do
+      early_publication = published_record.merge("recorded_at" => "2026-07-14T13:00:00Z")
+
+      expect do
+        accelerated_rc_published_record!(
+          records: [authorization_record, early_publication],
+          target_version: "17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /timestamps.*monotonic/i)
+    end
+
+    it "fails closed when reconciliation sees conflicting accepted terminal records" do
+      conflicting_accepted = accepted_record.merge("reason" => "Different claimed acceptance basis")
+      expect(validate_accelerated_rc_tracker_record!(accepted_record)).to eq(accepted_record)
+      expect(validate_accelerated_rc_tracker_record!(conflicting_accepted)).to eq(conflicting_accepted)
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return(
+        [authorization_record, published_record, accepted_record, conflicting_accepted]
+      )
+      expect(self).not_to receive(:fetch_accelerated_rc_ci_snapshot!)
+      expect(self).not_to receive(:accelerated_rc_shakaperf_snapshot!)
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "All required evidence passed",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /conflicting candidate-accepted terminal records/i)
+    end
+
+    it "records a known late failure as rejected before stopping promotion" do
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).and_return(
+        status: "failed",
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks"
+      )
+      expect(self).not_to receive(:accelerated_rc_shakaperf_snapshot!)
+      expect(self).to receive(:append_accelerated_rc_tracker_record!) do |record:, **|
+        expect(record["status"]).to eq("candidate-rejected")
+      end
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "Exact-head generator CI failed",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /Do not promote.*cut the next RC/i)
+    end
+
+    it "cannot append acceptance when concurrent reconciliation has already rejected the candidate" do
+      rejected_record = published_record.merge(
+        "status" => "candidate-rejected",
+        "ci" => published_record.fetch("ci").merge(
+          "status" => "failed",
+          "non_success" => [
+            { "name" => "generator", "state" => "failure", "url" => "https://example.com/failure" }
+          ]
+        ),
+        "reason" => "Concurrent reconciliation found failed CI",
+        "recorded_at" => "2026-07-14T14:55:00Z",
+        "required_follow_up" => "Do not promote this immutable RC; fix the failure and cut the next RC."
+      )
+      expect(validate_accelerated_rc_tracker_record!(rejected_record)).to eq(rejected_record)
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return(
+        [authorization_record, published_record],
+        [authorization_record, published_record],
+        [authorization_record, published_record, rejected_record]
+      )
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "success",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: []
+        },
+        accelerated_rc_shakaperf_snapshot!: published_record.fetch("shakaperf").merge("status" => "success")
+      )
+      expect(self).to receive(:post_release_tracker_comment!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "All required evidence passed",
+          evidence: {
+            "demo_fleet" => "https://github.com/demo-fleet",
+            "behavioral" => "https://github.com/behavioral",
+            "artifacts" => "https://github.com/artifacts"
+          }
+        )
+      end.to raise_error(SystemExit, /permanently rejected.*absorbing/i)
+    end
+
+    it "blocks reconciliation when the canonical publication transition is missing" do
+      allow(self).to receive(:fetch_accelerated_rc_tracker_records!).and_return([authorization_record])
+      expect(self).not_to receive(:fetch_accelerated_rc_ci_snapshot!)
+      expect(self).not_to receive(:accelerated_rc_shakaperf_snapshot!)
+      expect(self).not_to receive(:append_accelerated_rc_tracker_record!)
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "All required evidence passed",
+          evidence: {}
+        )
+      end.to raise_error(SystemExit, /No published-awaiting-gates record exists/)
+    end
+
+    it "blocks reconciliation when a later authorization contradicts the canonical first" do
+      conflicting_authorization = authorization_record.merge(
+        "shakaperf" => authorization_record.fetch("shakaperf").merge(
+          "status" => "success",
+          "run_url" => "https://example.com/mutated-run"
+        )
+      )
+      expect(validate_accelerated_rc_tracker_record!(conflicting_authorization)).to eq(conflicting_authorization)
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [
+          authorization_record, conflicting_authorization, published_record
+        ],
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "success",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: []
+        },
+        accelerated_rc_shakaperf_snapshot!: {
+          "status" => "success",
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+        },
+        append_accelerated_rc_tracker_record!: nil
+      )
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "All required evidence passed",
+          evidence: {
+            "demo_fleet" => "https://github.com/demo-fleet",
+            "behavioral" => "https://github.com/behavioral",
+            "artifacts" => "https://github.com/artifacts"
+          }
+        )
+      end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
+    end
+
+    it "rejects a later contradictory publication record before reconciliation accepts the candidate" do
+      mutated_publication = published_record.merge("reason" => "Mutated after the canonical publication record")
+      allow(self).to receive_messages(
+        fetch_accelerated_rc_tracker_records!: [authorization_record, published_record, mutated_publication],
+        fetch_accelerated_rc_ci_snapshot!: {
+          status: "success",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: []
+        },
+        accelerated_rc_shakaperf_snapshot!: {
+          "status" => "success",
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+        },
+        append_accelerated_rc_tracker_record!: nil
+      )
+
+      expect do
+        run_accelerated_rc_reconciliation!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          tracker: 3823,
+          target_version: "17.0.0.rc.10",
+          reason: "All required evidence passed",
+          evidence: {
+            "demo_fleet" => "https://github.com/demo-fleet",
+            "behavioral" => "https://github.com/behavioral",
+            "artifacts" => "https://github.com/artifacts"
+          }
+        )
+      end.to raise_error(SystemExit, /publication set.*not the canonical authorized transition/i)
+    end
+  end
+
+  describe "#accepted_accelerated_rc_record_for_release_branch_promotion!" do
+    it "rejects cross-tracker exact-candidate history during final promotion" do
+      authorization, publication, accepted = accelerated_rc_test_accepted_history
+      conflicting_authorization = accelerated_rc_test_authorization(tracker: 3824)
+      provenance = accelerated_rc_tag_provenance(authorization)
+      allow(self).to receive_messages(
+        accelerated_rc_tag_provenance_for_tag!: provenance,
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_release_tracker_issue!: nil,
+        fetch_repository_accelerated_rc_records_for_candidate!: [
+          authorization, publication, accepted, conflicting_authorization
+        ],
+        fetch_accelerated_rc_tracker_records!: [authorization, publication, accepted],
+        peeled_git_tag_sha: "f" * 40,
+        shakaperf_runtime_tree_fingerprint: "a" * 64
+      )
+
+      expect do
+        accepted_accelerated_rc_record_for_release_branch_promotion!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          final_head_sha: "f" * 40,
+          tracker_input: "3823"
+        )
+      end.to raise_error(SystemExit, /repository-wide.*tracker|conflicting release trackers/i)
+    end
+
+    it "requires the literal canonical tag name for accelerated provenance" do
+      authorization, publication, accepted = accelerated_rc_test_accepted_history
+      provenance = accelerated_rc_tag_provenance(authorization)
+      allow(self).to receive_messages(
+        accelerated_rc_tag_provenance_for_tag!: provenance,
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_release_tracker_issue!: nil,
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
+        fetch_accelerated_rc_tracker_records!: [authorization, publication, accepted],
+        peeled_git_tag_sha: "f" * 40,
+        shakaperf_runtime_tree_fingerprint: "a" * 64
+      )
+
+      aggregate_failures do
+        ["v17.0.0-rc.10", "v17.0.0.RC.10"].each do |alias_tag|
+          expect do
+            accepted_accelerated_rc_record_for_release_branch_promotion!(
+              monorepo_root: "/tmp/repo",
+              rc_tag: alias_tag,
+              final_head_sha: "f" * 40,
+              tracker_input: "3823"
+            )
+          end.to raise_error(SystemExit, /literal canonical accelerated RC tag.*v17\.0\.0\.rc\.10/i), alias_tag
+        end
+
+        expect(
+          accepted_accelerated_rc_record_for_release_branch_promotion!(
+            monorepo_root: "/tmp/repo",
+            rc_tag: "v17.0.0.rc.10",
+            final_head_sha: "f" * 40,
+            tracker_input: "3823"
+          )
+        ).to eq(accepted)
+      end
+    end
+
+    it "does not require a tracker for an ordinary lightweight RC tag" do
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
+        .and_return(["commit\n", status])
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:peeled_git_tag_sha)
+        .with(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10").and_return("f" * 40)
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!).with(
+        repo_slug: "shakacode/react_on_rails",
+        target_version: "17.0.0.rc.10",
+        candidate_sha: "f" * 40
+      ).and_return([])
+      expect(self).not_to receive(:fetch_release_tracker_issue!)
+      expect(self).not_to receive(:fetch_accelerated_rc_tracker_records!)
+
+      result = accepted_accelerated_rc_record_for_release_branch_promotion!(
+        monorepo_root: "/tmp/repo",
+        rc_tag: "v17.0.0.rc.10",
+        final_head_sha: "f" * 40,
+        tracker_input: nil
+      )
+
+      expect(result).to be_nil
+      expect(self).to have_received(:fetch_repository_accelerated_rc_records_for_candidate!).with(
+        repo_slug: "shakacode/react_on_rails",
+        target_version: "17.0.0.rc.10",
+        candidate_sha: "f" * 40
+      )
+    end
+
+    it "blocks a lightweight RC tag when durable accelerated history exists for the exact candidate" do
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
+        .and_return(["commit\n", status])
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:peeled_git_tag_sha)
+        .with(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10").and_return("f" * 40)
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!).with(
+        repo_slug: "shakacode/react_on_rails",
+        target_version: "17.0.0.rc.10",
+        candidate_sha: "f" * 40
+      ).and_return(
+        [{ "status" => "publication-authorized", "release_tracker" => 3823 }]
+      )
+      expect(self).not_to receive(:fetch_release_tracker_issue!)
+      expect(self).not_to receive(:fetch_accelerated_rc_tracker_records!)
+
+      expect do
+        accepted_accelerated_rc_record_for_release_branch_promotion!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          final_head_sha: "f" * 40,
+          tracker_input: nil
+        )
+      end.to raise_error(SystemExit, /lightweight RC tag.*durable accelerated history/i)
+    end
+
+    it "blocks a markerless annotated RC tag even when no tracker is supplied" do
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
+        .and_return(["tag\n", status])
+      allow(Open3).to receive(:capture2e)
+        .with(
+          "git", "-C", "/tmp/repo", "for-each-ref", "--format=%(contents)", "refs/tags/v17.0.0.rc.10"
+        ).and_return(["Ordinary-looking annotation without canonical provenance\n", status])
+      expect(self).not_to receive(:github_repo_slug)
+
+      expect do
+        accepted_accelerated_rc_record_for_release_branch_promotion!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          final_head_sha: "f" * 40,
+          tracker_input: nil
+        )
+      end.to raise_error(SystemExit, /annotated RC tag.*lacks canonical accelerated provenance/i)
+    end
+
+    it "blocks a markerless annotated RC tag when an explicit tracker is supplied" do
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
+        .and_return(["tag\n", status])
+      allow(Open3).to receive(:capture2e)
+        .with(
+          "git", "-C", "/tmp/repo", "for-each-ref", "--format=%(contents)", "refs/tags/v17.0.0.rc.10"
+        ).and_return(["Ordinary-looking annotation without canonical provenance\n", status])
+      expect(self).not_to receive(:github_repo_slug)
+      expect(self).not_to receive(:fetch_release_tracker_issue!)
+      expect(self).not_to receive(:fetch_accelerated_rc_tracker_records!)
+
+      expect do
+        accepted_accelerated_rc_record_for_release_branch_promotion!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          final_head_sha: "f" * 40,
+          tracker_input: "3823"
+        )
+      end.to raise_error(SystemExit, /annotated RC tag.*lacks canonical accelerated provenance/i)
+    end
+
+    it "blocks when the RC tag object type cannot be determined" do
+      status = instance_double(Process::Status, success?: false)
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "cat-file", "-t", "refs/tags/v17.0.0.rc.10")
+        .and_return(["fatal: object unavailable\n", status])
+      expect(self).not_to receive(:github_repo_slug)
+
+      expect do
+        accepted_accelerated_rc_record_for_release_branch_promotion!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          final_head_sha: "f" * 40,
+          tracker_input: nil
+        )
+      end.to raise_error(SystemExit, /Unable to inspect RC tag provenance.*object unavailable/i)
+    end
+
+    it "requires the tracker encoded by an accelerated RC tag" do
+      allow(self).to receive(:accelerated_rc_tag_provenance_for_tag!).and_return(
+        "target_version" => "17.0.0.rc.10",
+        "release_tracker" => 3823
+      )
+      expect(self).not_to receive(:github_repo_slug)
+
+      expect do
+        accepted_accelerated_rc_record_for_release_branch_promotion!(
+          monorepo_root: "/tmp/repo",
+          rc_tag: "v17.0.0.rc.10",
+          final_head_sha: "f" * 40,
+          tracker_input: "3824"
+        )
+      end.to raise_error(SystemExit, /RELEASE_TRACKER must match the canonical tracker/)
+    end
+  end
+
+  describe "#accepted_accelerated_rc_record_for_promotion!" do
+    let(:authorization_record) do
+      build_accelerated_rc_publication_record(
+        options: {
+          target_gem_version: "17.0.0.rc.10",
+          tracker: 3823,
+          reason: "Start fleet QA now"
+        },
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: {
+          status: "pending",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: [
+            {
+              name: "generator",
+              state: "in_progress",
+              url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+            }
+          ]
+        },
+        shakaperf: {
+          status: "pending",
+          run_id: 123_456,
+          attempt: 1,
+          run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          candidate_sha: "f" * 40,
+          target_version: "17.0.0.rc.10",
+          release_started_at: "2026-07-14T13:00:00Z"
+        },
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
+      )
+    end
+
+    let(:tag_provenance) do
+      {
+        "schema_version" => 1,
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "release_tracker" => 3823,
+        "authorization_digest" => accelerated_rc_record_digest(authorization_record)
+      }
+    end
+
+    let(:canonical_publication) do
+      accelerated_rc_published_record(
+        authorized_record: authorization_record,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+    end
+
+    it "blocks final promotion while accelerated RC evidence is unresolved" do
+      expect(self).not_to receive(:shakaperf_runtime_tree_fingerprint)
+
+      %w[publication-authorized published-awaiting-gates].each do |status|
+        pending_record = if status == "publication-authorized"
+                           authorization_record
+                         else
+                           accelerated_rc_published_record(
+                             authorized_record: authorization_record,
+                             recorded_at: Time.utc(2026, 7, 14, 14)
+                           )
+                         end
+        records = status == "publication-authorized" ? [authorization_record] : [authorization_record, pending_record]
+        expected_error = if status == "publication-authorized"
+                           /canonical published-awaiting-gates transition is missing/i
+                         else
+                           /pending, rejected, or unreconciled evidence/
+                         end
+
+        expect do
+          accepted_accelerated_rc_record_for_promotion!(
+            records:,
+            rc_version: "17.0.0.rc.10",
+            rc_sha: "f" * 40,
+            final_head_sha: "f" * 40,
+            monorepo_root: "/tmp/repo",
+            tag_provenance:
+          )
+        end.to raise_error(SystemExit, expected_error)
+      end
+    end
+
+    it "blocks when canonical tag provenance has no matching authorization record" do
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /canonical accelerated RC publication authorization is missing/)
+    end
+
+    it "blocks tracker records whose RC tag lacks canonical accelerated provenance" do
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance: nil
+        )
+      end.to raise_error(SystemExit, /RC tag lacks canonical accelerated-publication provenance/)
+    end
+
+    it "treats candidate-rejected as absorbing even if a later accepted record exists" do
+      rejected = authorization_record.merge("status" => "candidate-rejected")
+      accepted = rejected.merge("status" => "candidate-accepted")
+
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, rejected, accepted],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /permanently rejected/)
+    end
+
+    it "fails closed when final promotion sees conflicting accepted terminal records" do
+      accepted = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "reason" => "All required evidence passed",
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      conflicting_accepted = accepted.merge("approved_by" => "other-maintainer")
+      expect(validate_accelerated_rc_tracker_record!(accepted)).to eq(accepted)
+      expect(validate_accelerated_rc_tracker_record!(conflicting_accepted)).to eq(conflicting_accepted)
+      expect(self).not_to receive(:shakaperf_runtime_tree_fingerprint)
+
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, accepted, conflicting_accepted],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /conflicting candidate-accepted terminal records/i)
+    end
+
+    it "blocks terminal tracker state that mutates authorization-bound evidence" do
+      accepted = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "release_branch" => "release/tampered"
+      )
+
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, accepted],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /tracker state is not bound to the canonical publication authorization/)
+    end
+
+    it "blocks final promotion when the canonical publication transition is missing" do
+      accepted = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      expect(self).not_to receive(:shakaperf_runtime_tree_fingerprint)
+
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, accepted],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /canonical published-awaiting-gates transition is missing/i)
+    end
+
+    it "blocks final promotion when tag provenance selects the canonical first of conflicting authorizations" do
+      conflicting_authorization = authorization_record.merge("reason" => "Mutated authorization reason")
+      expect(validate_accelerated_rc_tracker_record!(conflicting_authorization)).to eq(conflicting_authorization)
+      accepted = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
+
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, conflicting_authorization, canonical_publication, accepted],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
+    end
+
+    it "blocks final promotion when a later publication record contradicts the canonical first" do
+      canonical_publication = accelerated_rc_published_record(
+        authorized_record: authorization_record,
+        recorded_at: Time.utc(2026, 7, 14, 14)
+      )
+      mutated_publication = canonical_publication.merge(
+        "ci" => canonical_publication.fetch("ci").merge(
+          "status" => "failed",
+          "non_success" => [{ "name" => "generator", "state" => "failure", "url" => "https://example.com/fail" }]
+        )
+      )
+      accepted = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
+
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, mutated_publication, accepted],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /publication set.*not the canonical authorized transition/i)
+    end
+
+    it "reuses accepted evidence bound to the exact RC candidate SHA" do
+      record = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "recorded_at" => "2026-07-14T15:00:00Z",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
+
+      expect(
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, record],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "f" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      ).to eq(record)
+    end
+
+    it "reuses accepted evidence for a mechanically runtime-equivalent final tip" do
+      record = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "recorded_at" => "2026-07-14T15:00:00Z",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "e" * 40).and_return("a" * 64)
+      allow(self).to receive(:release_branch_commits_after_rc_tag).with(
+        monorepo_root: "/tmp/repo",
+        tag_sha: "f" * 40,
+        head_sha: "e" * 40
+      ).and_return(status: :non_runtime_only, commits: ["metadata-only-sha"])
+
+      expect(
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, record],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "e" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      ).to eq(record)
+    end
+
+    it "blocks accepted evidence when the final tip changes the runtime tree" do
+      record = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "recorded_at" => "2026-07-14T15:00:00Z",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "e" * 40).and_return("b" * 64)
+
+      expect do
+        accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, record],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "e" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.to raise_error(SystemExit, /not runtime-equivalent/)
+    end
+  end
+
+  describe "#refresh_accepted_rc_ci_evidence_for_promotion!" do
+    let(:record) { { "candidate_sha" => "f" * 40 } }
+
+    it "requires a fresh successful exact-candidate CI snapshot before final promotion" do
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).and_return(
+        status: "success",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: []
+      )
+
+      expect(
+        refresh_accepted_rc_ci_evidence_for_promotion!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          ci_branch: "release/17.0.0",
+          record:
+        )
+      ).to include(status: "success", sha: "f" * 40)
+    end
+
+    it "blocks when the refreshed exact-candidate CI is still pending" do
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).and_return(
+        status: "pending",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: []
+      )
+
+      expect do
+        refresh_accepted_rc_ci_evidence_for_promotion!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          ci_branch: "release/17.0.0",
+          record:
+        )
+      end.to raise_error(SystemExit, /refreshed exact-RC CI is failed, pending/)
+    end
+  end
+
+  describe "#validate_final_promotion_ci_publication_boundary!" do
+    let(:candidate_sha) { "f" * 40 }
+    let(:record) { { "candidate_sha" => candidate_sha } }
+    let(:promotion_branch) { "release/17.0.0" }
+    let(:checks) do
+      [
+        {
+          name: "generator",
+          state: "skipped",
+          url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+        },
+        {
+          name: "docs",
+          state: "neutral",
+          url: "https://github.com/shakacode/react_on_rails/actions/runs/124"
+        }
+      ]
+    end
+    let(:expected_snapshot) do
+      {
+        status: "success",
+        sha: candidate_sha,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{candidate_sha}/checks",
+        non_success: checks
+      }
+    end
+    let(:context) do
+      {
+        record:,
+        ci_branch: promotion_branch,
+        ci_snapshot: json_compatible_release_value(expected_snapshot)
+      }
+    end
+
+    before do
+      allow(self).to receive(:github_repo_slug).and_return("shakacode/react_on_rails")
+    end
+
+    it "accepts the same logical non-success checks in a different order" do
+      refreshed_snapshot = expected_snapshot.merge(non_success: checks.reverse)
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).and_return(refreshed_snapshot)
+
+      expect(
+        validate_final_promotion_ci_publication_boundary!(
+          monorepo_root: "/tmp/repo", context:, phase: "package publication"
+        )
+      ).to eq(refreshed_snapshot)
+    end
+
+    it "blocks a real non-success check identity change" do
+      changed_checks = checks.map(&:dup)
+      changed_checks.first[:url] = "https://github.com/shakacode/react_on_rails/actions/runs/999"
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!).and_return(
+        expected_snapshot.merge(non_success: changed_checks)
+      )
+
+      expect do
+        validate_final_promotion_ci_publication_boundary!(
+          monorepo_root: "/tmp/repo", context:, phase: "package publication"
+        )
+      end.to raise_error(SystemExit, /materially changed exact-candidate CI evidence/)
+    end
+  end
+
+  describe "#run_accepted_rc_final_promotion_gates!" do
+    let(:accepted_record) do
+      {
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "f" * 40,
+        "runtime_tree_fingerprint" => "a" * 64,
+        "release_branch" => "release/17.0.0",
+        "shakaperf" => {
+          "status" => "success",
+          "run_id" => 123_456,
+          "attempt" => 1,
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          "candidate_sha" => "f" * 40,
+          "target_version" => "17.0.0.rc.10",
+          "release_started_at" => "2026-07-14T13:00:00Z"
+        }
+      }
+    end
+
+    let(:gate_arguments) do
+      {
+        repo_slug: "shakacode/react_on_rails",
+        monorepo_root: "/tmp/repo",
+        current_branch: "release/17.0.0",
+        rc_tag: "v17.0.0.rc.10",
+        tracker_input: "3823",
+        final_head_sha: "e" * 40,
+        record: accepted_record,
+        target_version: "17.0.0",
+        release_started_at: Time.utc(2026, 7, 14, 14),
+        allow_ci_override: false,
+        dry_run: false
+      }
+    end
+
+    let(:successful_final_ci_snapshot) do
+      {
+        status: "success",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: []
+      }
+    end
+
+    let(:strict_final_shakaperf_run) do
+      {
+        "databaseId" => 654_321,
+        "attempt" => 1,
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/654321"
+      }
+    end
+
+    let(:strict_final_shakaperf_snapshot) do
+      {
+        status: "success",
+        run_id: 654_321,
+        attempt: 1,
+        run_url: strict_final_shakaperf_run.fetch("url"),
+        candidate_sha: "e" * 40,
+        target_version: "17.0.0",
+        release_started_at: "2026-07-14T14:00:00Z"
+      }
+    end
+
+    before do
+      allow(self).to receive_messages(
+        remote_git_tag_exists?: true,
+        fetch_remote_rc_tag!: nil,
+        current_git_sha!: "e" * 40,
+        github_repo_slug: "shakacode/react_on_rails",
+        accelerated_shakaperf_snapshot: strict_final_shakaperf_snapshot
+      )
+    end
+
+    it "aborts post-bump runtime drift instead of falling back to a fresh ShakaPerf gate" do
+      allow(self).to receive(:accelerated_rc_runtime_equivalent?).and_return(false)
+      expect(self).not_to receive(:refresh_accepted_rc_ci_evidence_for_promotion!)
+      expect(self).not_to receive(:reuse_accepted_rc_shakaperf_evidence!)
+      expect(self).not_to receive(:run_shakaperf_release_gate!)
+      expect(self).not_to receive(:accepted_accelerated_rc_record_for_release_branch_promotion!)
+
+      expect do
+        run_accepted_rc_final_promotion_gates!(**gate_arguments)
+      end.to raise_error(SystemExit, /post-bump.*runtime.*new accepted RC/i)
+    end
+
+    it "reuses accepted evidence only after content-validating version-only finalization commits" do
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint).and_return("a" * 64)
+      allow(self).to receive(:release_branch_commits_after_rc_tag).with(
+        monorepo_root: "/tmp/repo",
+        tag_sha: "f" * 40,
+        head_sha: "e" * 40
+      ).and_return(status: :non_runtime_only, commits: ["version-only-sha"])
+      allow(self).to receive_messages(
+        refresh_accepted_rc_ci_evidence_for_promotion!: successful_final_ci_snapshot,
+        reuse_accepted_rc_shakaperf_evidence!: true,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: accepted_record
+      )
+
+      expect(run_accepted_rc_final_promotion_gates!(**gate_arguments)).to include(candidate_sha: "e" * 40)
+    end
+
+    it "blocks dependency and lockfile drift even when the coarse runtime fingerprints still match" do
+      allow(self).to receive_messages(
+        shakaperf_runtime_tree_fingerprint: "a" * 64,
+        refresh_accepted_rc_ci_evidence_for_promotion!: nil,
+        reuse_accepted_rc_shakaperf_evidence!: true,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: accepted_record
+      )
+
+      aggregate_failures do
+        {
+          "package.json dependency drift" => "package-dependency-sha",
+          "Gemfile.lock dependency drift" => "lockfile-dependency-sha"
+        }.each do |description, sha|
+          allow(self).to receive(:release_branch_commits_after_rc_tag).and_return(
+            status: :runtime_bearing,
+            commits: [sha]
+          )
+
+          expect do
+            run_accepted_rc_final_promotion_gates!(**gate_arguments)
+          end.to raise_error(SystemExit, /post-bump.*runtime.*new accepted RC/i), description
+        end
+      end
+    end
+
+    it "re-fetches tracker state after the final gate and blocks a newly appended rejection" do
+      allow(self).to receive(:accelerated_rc_runtime_equivalent?).and_return(true)
+      expect(self).to receive(:refresh_accepted_rc_ci_evidence_for_promotion!).ordered
+                                                                              .and_return(successful_final_ci_snapshot)
+      expect(self).to receive(:reuse_accepted_rc_shakaperf_evidence!).ordered.and_return(false)
+      expect(self).to receive(:run_shakaperf_release_gate!).ordered.and_return(strict_final_shakaperf_run)
+      expect(self).to receive(:accepted_accelerated_rc_record_for_release_branch_promotion!).ordered.and_raise(
+        SystemExit, "Final promotion is blocked: RC was permanently rejected"
+      )
+
+      expect do
+        run_accepted_rc_final_promotion_gates!(**gate_arguments)
+      end.to raise_error(SystemExit, /permanently rejected/)
+    end
+
+    it "blocks when the live remote RC tag is deleted at the irreversible boundary" do
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        refresh_accepted_rc_ci_evidence_for_promotion!: nil,
+        reuse_accepted_rc_shakaperf_evidence!: true,
+        remote_git_tag_exists?: false
+      )
+      expect(self).not_to receive(:fetch_remote_rc_tag!)
+      expect(self).not_to receive(:accepted_accelerated_rc_record_for_release_branch_promotion!)
+
+      expect do
+        run_accepted_rc_final_promotion_gates!(**gate_arguments)
+      end.to raise_error(SystemExit, /live remote RC tag.*publication boundary/i)
+    end
+
+    it "force-fetches the live remote RC tag before rejecting a moved tag" do
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        refresh_accepted_rc_ci_evidence_for_promotion!: nil,
+        reuse_accepted_rc_shakaperf_evidence!: true
+      )
+      expect(self).to receive(:fetch_remote_rc_tag!).ordered
+      expect(self).to receive(:accepted_accelerated_rc_record_for_release_branch_promotion!).ordered.and_raise(
+        SystemExit, "RC tag provenance does not match the selected RC SHA"
+      )
+
+      expect do
+        run_accepted_rc_final_promotion_gates!(**gate_arguments)
+      end.to raise_error(SystemExit, /RC tag provenance.*RC SHA/)
+    end
+
+    it "refreshes exact accepted-RC CI again at the irreversible boundary" do
+      boundary_record = accepted_record.merge("recorded_at" => "2026-07-14T14:30:00Z")
+      allow(self).to receive(:accelerated_rc_runtime_equivalent?).and_return(true)
+      expect(self).to receive(:refresh_accepted_rc_ci_evidence_for_promotion!).ordered.with(
+        hash_including(record: accepted_record)
+      ).and_return(successful_final_ci_snapshot)
+      expect(self).to receive(:reuse_accepted_rc_shakaperf_evidence!).ordered.and_return(false)
+      expect(self).to receive(:run_shakaperf_release_gate!).ordered.and_return(strict_final_shakaperf_run)
+      expect(self).to receive(:accepted_accelerated_rc_record_for_release_branch_promotion!).ordered.and_return(
+        boundary_record
+      )
+      expect(self).to receive(:refresh_accepted_rc_ci_evidence_for_promotion!).ordered.with(
+        hash_including(record: boundary_record)
+      ).and_raise(SystemExit, "refreshed exact-RC CI is pending")
+
+      expect do
+        run_accepted_rc_final_promotion_gates!(**gate_arguments)
+      end.to raise_error(SystemExit, /exact-RC CI is pending/)
+    end
+
+    it "blocks a valid but mutated accepted record at the irreversible boundary" do
+      mutations = {
+        "reason" => accepted_record.merge("reason" => "Changed acceptance basis"),
+        "approver" => accepted_record.merge("approved_by" => "another-maintainer"),
+        "evidence" => accepted_record.merge("evidence" => { "demo_fleet" => "https://example.com/changed" })
+      }
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        refresh_accepted_rc_ci_evidence_for_promotion!: nil,
+        reuse_accepted_rc_shakaperf_evidence!: true
+      )
+
+      aggregate_failures do
+        mutations.each do |name, boundary_record|
+          allow(self).to receive(:accepted_accelerated_rc_record_for_release_branch_promotion!)
+            .and_return(boundary_record)
+
+          expect do
+            run_accepted_rc_final_promotion_gates!(**gate_arguments)
+          end.to raise_error(SystemExit, /accepted RC record.*changed.*boundary/i), name
+        end
+      end
+    end
+
+    it "blocks when local HEAD moves after the boundary evidence refresh" do
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        refresh_accepted_rc_ci_evidence_for_promotion!: successful_final_ci_snapshot,
+        reuse_accepted_rc_shakaperf_evidence!: true,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: accepted_record,
+        current_git_sha!: "d" * 40
+      )
+
+      expect do
+        run_accepted_rc_final_promotion_gates!(**gate_arguments)
+      end.to raise_error(SystemExit, /local HEAD moved.*publication boundary/i)
+    end
+
+    it "returns the validated final candidate SHA for tag and publication handling" do
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        refresh_accepted_rc_ci_evidence_for_promotion!: {
+          status: "success",
+          sha: "f" * 40,
+          checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+          non_success: []
+        },
+        reuse_accepted_rc_shakaperf_evidence!: true,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: accepted_record
+      )
+
+      context = run_accepted_rc_final_promotion_gates!(**gate_arguments)
+
+      expect(context).to include(candidate_sha: "e" * 40, record: accepted_record)
+      expect(context.fetch(:shakaperf_record).fetch("shakaperf")).to eq(accepted_record.fetch("shakaperf"))
+    end
+
+    it "carries the promotion CI branch when accepted evidence originated on another branch" do
+      source_record = accepted_record.merge("release_branch" => "release/17.0.0-rc-source")
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        refresh_accepted_rc_ci_evidence_for_promotion!: successful_final_ci_snapshot,
+        reuse_accepted_rc_shakaperf_evidence!: true,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: source_record
+      )
+
+      context = run_accepted_rc_final_promotion_gates!(**gate_arguments.merge(record: source_record))
+
+      expect(context).to include(
+        candidate_sha: "e" * 40,
+        ci_branch: "release/17.0.0",
+        record: source_record
+      )
+      expect(self).to have_received(:refresh_accepted_rc_ci_evidence_for_promotion!).with(
+        hash_including(ci_branch: "release/17.0.0")
+      ).twice
+    end
+
+    it "carries a newly run strict ShakaPerf identity into final publication boundaries" do
+      ci_snapshot = {
+        status: "success",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: []
+      }
+      strict_run = {
+        "databaseId" => 654_321,
+        "attempt" => 1,
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/654321"
+      }
+      strict_snapshot = {
+        status: "success",
+        run_id: 654_321,
+        attempt: 1,
+        run_url: strict_run.fetch("url"),
+        candidate_sha: "e" * 40,
+        target_version: "17.0.0",
+        release_started_at: "2026-07-14T14:00:00Z"
+      }
+      allow(self).to receive_messages(
+        accelerated_rc_runtime_equivalent?: true,
+        github_repo_slug: "shakacode/react_on_rails",
+        refresh_accepted_rc_ci_evidence_for_promotion!: ci_snapshot,
+        reuse_accepted_rc_shakaperf_evidence!: false,
+        run_shakaperf_release_gate!: strict_run,
+        accelerated_shakaperf_snapshot: strict_snapshot,
+        accepted_accelerated_rc_record_for_release_branch_promotion!: accepted_record
+      )
+
+      context = run_accepted_rc_final_promotion_gates!(**gate_arguments)
+
+      aggregate_failures do
+        expect(context).to include(candidate_sha: "e" * 40, record: accepted_record)
+        expect(context.fetch(:ci_snapshot)).to eq(json_compatible_release_value(ci_snapshot))
+        expect(context.fetch(:shakaperf_record)).to include(
+          "release_branch" => "release/17.0.0",
+          "candidate_sha" => "e" * 40,
+          "target_version" => "17.0.0",
+          "shakaperf" => json_compatible_release_value(strict_snapshot)
+        )
+      end
+    end
+  end
+
+  describe "#create_release_tag_at_candidate_sha!" do
+    it "creates and verifies a release tag against the explicit candidate SHA" do
+      allow(self).to receive_messages(
+        current_git_sha!: "e" * 40,
+        peeled_git_tag_sha: "e" * 40
+      )
+      expect(self).to receive(:sh_args_in_dir_for_release).with(
+        "/tmp/repo", "git", "tag", "v17.0.0", "e" * 40
+      )
+
+      expect(
+        create_release_tag_at_candidate_sha!(
+          monorepo_root: "/tmp/repo", tag: "v17.0.0", candidate_sha: "e" * 40
+        )
+      ).to eq("e" * 40)
+    end
+
+    it "refuses explicit tag creation when local HEAD moved" do
+      allow(self).to receive(:current_git_sha!).and_return("d" * 40)
+      expect(self).not_to receive(:sh_args_in_dir_for_release)
+
+      expect do
+        create_release_tag_at_candidate_sha!(
+          monorepo_root: "/tmp/repo", tag: "v17.0.0", candidate_sha: "e" * 40
+        )
+      end.to raise_error(SystemExit, /local HEAD moved.*tag creation/i)
+    end
+  end
+
+  describe "#reuse_accepted_rc_shakaperf_evidence!" do
+    let(:record) do
+      {
+        "target_version" => "17.0.0.rc.10",
+        "candidate_sha" => "e" * 40,
+        "shakaperf" => {
+          "run_id" => 123_456,
+          "attempt" => 1,
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          "release_started_at" => "2026-07-14T13:00:00Z",
+          "candidate_sha" => "e" * 40,
+          "target_version" => "17.0.0.rc.10"
+        }
+      }
+    end
+
+    it "reuses only refreshed successful evidence bound to the accepted RC and runtime-equivalent final tip" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "e" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(run)
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection)
+        .with(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          ref: "release/17.0.0",
+          head_sha: "e" * 40,
+          target_version: "17.0.0.rc.10",
+          run:,
+          release_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+          require_prerun: false
+        ).and_return(nil)
+
+      expect do
+        expect(
+          reuse_accepted_rc_shakaperf_evidence!(
+            repo_slug: "shakacode/react_on_rails",
+            monorepo_root: "/tmp/repo",
+            ref: "release/17.0.0",
+            head_sha: "e" * 40,
+            record:
+          )
+        ).to be(true)
+      end.to output(/Reusing accepted RC ShakaPerf evidence/).to_stdout
+    end
+
+    it "declines stale or invalid accepted evidence so final promotion runs the strict gate" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "e" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive_messages(
+        refresh_shakaperf_release_gate_run!: run,
+        shakaperf_release_gate_run_evidence_rejection: "evidence is stale"
+      )
+
+      expect do
+        expect(
+          reuse_accepted_rc_shakaperf_evidence!(
+            repo_slug: "shakacode/react_on_rails",
+            monorepo_root: "/tmp/repo",
+            ref: "release/17.0.0",
+            head_sha: "e" * 40,
+            record:
+          )
+        ).to be(false)
+      end.to output(/not reusable.*evidence is stale/).to_stdout
+    end
+
+    it "declines a different run attempt so final promotion dispatches the strict gate" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 2,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "e" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(run)
+      expect(self).not_to receive(:shakaperf_release_gate_run_evidence_rejection)
+
+      expect do
+        expect(
+          reuse_accepted_rc_shakaperf_evidence!(
+            repo_slug: "shakacode/react_on_rails",
+            monorepo_root: "/tmp/repo",
+            ref: "release/17.0.0",
+            head_sha: "e" * 40,
+            record:
+          )
+        ).to be(false)
+      end.to output(/not reusable.*run identity changed/i).to_stdout
+    end
+  end
+
   describe "release task help" do
     it "does not advertise strict HEAD retry before the CI gate establishes healthy evidence" do
       rakefile = File.read(File.expand_path("../../../rakelib/release.rake", __dir__))
@@ -2469,6 +7303,629 @@ RSpec.describe "release.rake helper methods" do
       expect(help).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
       expect(help).to include("only after it has found complete healthy\n    CI evidence")
       expect(help).to include("Override prerelease CI gates only")
+    end
+
+    it "documents the explicit accelerated RC inputs and exposes the reconciliation task" do
+      rakefile = File.read(File.expand_path("../../../rakelib/release.rake", __dir__))
+      help = rakefile.match(/desc\("(.*?)"\)\ntask :release/m)[1]
+
+      expect(help).to include(
+        "RELEASE_ACCELERATED_RC=true",
+        "RELEASE_TRACKER=<issue>",
+        "RELEASE_ACCELERATED_RC_REASON=<reason>"
+      )
+      expect(Rake::Task.task_defined?("release:reconcile_accelerated_rc")).to be(true)
+    end
+
+    it "orders retry discovery and final evidence refresh before their irreversible boundaries" do
+      rakefile = File.read(File.expand_path("../../../rakelib/release.rake", __dir__))
+      release_task = rakefile.match(/task :release,.*?(?=\ndesc\("Creates or updates a GitHub release)/m)[0]
+      tag_push_helper = rakefile.match(/def push_release_tag_for_candidate!.*?^end$/m)[0]
+      tag_retry_index = release_task.index("release_tag_retry_state_for_current_head")
+      retry_mode_index = release_task.index("resolve_accelerated_rc_options_for_release!")
+      ci_gate_index = release_task.index("validate_main_ci_status!")
+      final_refresh_index = release_task.index("run_accepted_rc_final_promotion_gates!")
+      tag_push_index = release_task.index("push_release_tag_for_candidate!")
+      package_publish_index = release_task.index("Publishing PUBLIC packages to npmjs.org")
+      tag_handling_index = tag_push_helper.index('phase: "tag handling"')
+      tag_creation_index = tag_push_helper.index("ensure_release_tag_for_candidate!")
+      pre_push_boundary_index = tag_push_helper.index('phase: "git tag push"')
+      git_push_index = tag_push_helper.index('sh_in_dir_for_release(monorepo_root, "LEFTHOOK=0 git push --tags")')
+      package_boundary_index = tag_push_helper.index('phase: "package publication"')
+
+      expect(tag_retry_index).to be < retry_mode_index
+      expect(retry_mode_index).to be < ci_gate_index
+      expect(final_refresh_index).to be < tag_push_index
+      expect(tag_push_index).to be < package_publish_index
+      expect(tag_handling_index).to be < tag_creation_index
+      expect(tag_creation_index).to be < pre_push_boundary_index
+      expect(pre_push_boundary_index).to be < git_push_index
+      expect(git_push_index).to be < package_boundary_index
+      expect(release_task).to include(
+        "final_promotion_context = run_accepted_rc_final_promotion_gates!",
+        "validated_release_candidate_sha = final_promotion_context.fetch(:candidate_sha)",
+        "candidate_sha: validated_release_candidate_sha",
+        "accelerated_boundary_record: accelerated_publication_record || accepted_rc_record",
+        "accelerated_final_promotion_context: final_promotion_context",
+        "accelerated_rc_same_candidate_retry =",
+        "candidate_sha: accelerated_rc_same_candidate_retry ? current_git_sha!(release_root) : nil"
+      )
+      expect(release_task).not_to match(/sh_in_dir_for_release\(release_root, "git tag /)
+    end
+  end
+
+  describe "release task accelerated RC preflight" do
+    it "blocks a remote-only ordinary target tag before gates or release side effects from a mismatched checkout" do
+      release_task = Rake::Task["release"]
+      task_receiver = release_task.actions.first.binding.receiver
+      success_status = instance_double(Process::Status, success?: true)
+      events = []
+
+      allow(Open3).to receive(:capture2e)
+        .with("git", "-C", "/tmp/repo", "rev-parse", "--abbrev-ref", "HEAD")
+        .and_return(["release/17.0.0\n", success_status])
+      allow(ReactOnRails::GitUtils).to receive(:uncommitted_changes?)
+      allow(task_receiver).to receive(:with_release_checkout) { |**_, &block| block.call("/tmp/repo") }
+      allow(task_receiver).to receive_messages(
+        current_monorepo_root: "/tmp/repo",
+        verbose: nil,
+        resolve_release_version_before_auth!: "17.0.0.rc.10",
+        current_gem_version: "16.9.0",
+        github_repo_slug: "shakacode/react_on_rails",
+        local_release_tag_exists?: false,
+        remote_git_tag_exists?: true,
+        fetch_remote_release_tag!: nil,
+        accelerated_rc_tag_provenance_for_tag!: nil,
+        fetch_release_tracker_issue!: {},
+        current_release_approver!: "justin808"
+      )
+      allow(task_receiver).to receive(:sh_in_dir_for_release) do |_dir, command|
+        events << :push if command.include?("git push")
+        events << :version_mutation if command.include?("gem bump")
+      end
+      allow(task_receiver).to receive(:validate_main_ci_status!) do
+        events << :ci
+        abort "CI was reached before exact-target tag classification"
+      end
+      allow(task_receiver).to receive(:confirm_release!) { events << :confirmation }
+      allow(task_receiver).to receive(:append_accelerated_rc_tracker_record!) { events << :tracker_append }
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return("true")
+      allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return("3823")
+      allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil)
+                                   .and_return("Start published-artifact QA while exact-head checks finish")
+
+      failure = begin
+        release_task.reenable
+        release_task.invoke("17.0.0.rc.10", false, true, false)
+        nil
+      rescue SystemExit => error
+        error
+      ensure
+        release_task.reenable
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/ordinary lightweight.*v17\.0\.0\.rc\.10.*accelerated/i)
+        expect(events).to be_empty
+        expect(task_receiver).to have_received(:local_release_tag_exists?)
+          .with(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10")
+        expect(task_receiver).to have_received(:remote_git_tag_exists?)
+          .with(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10")
+        expect(task_receiver).to have_received(:fetch_remote_release_tag!)
+          .with(monorepo_root: "/tmp/repo", tag: "v17.0.0.rc.10", tag_type: "accelerated RC")
+        expect(task_receiver).not_to have_received(:confirm_release!)
+        expect(task_receiver).not_to have_received(:append_accelerated_rc_tracker_record!)
+      end
+    end
+  end
+
+  describe "#push_release_tag_for_candidate!" do
+    it "blocks candidate-accepted tag handling when final-promotion context is missing" do
+      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      tag_handled = false
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:validate_accelerated_tag_publication_boundary!)
+      allow(self).to receive(:ensure_release_tag_for_candidate!) { tag_handled = true }
+      allow(self).to receive(:validate_release_candidate_publication_boundary!)
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      failure = begin
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: accepted
+        )
+        package_publication_started = true
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/missing accelerated final-promotion context/i)
+        expect(tag_handled).to be(false)
+        expect(pushed).to be(false)
+        expect(package_publication_started).to be(false)
+      end
+    end
+
+    it "blocks newly failed live CI immediately before accelerated RC tag push" do
+      authorization = accelerated_rc_test_authorization
+      pending_ci = {
+        status: "pending",
+        sha: authorization.fetch("candidate_sha"),
+        checks_url: authorization.dig("ci", "checks_url"),
+        non_success: authorization.dig("ci", "non_success").map do |check|
+          check.transform_keys(&:to_sym)
+        end
+      }
+      failed_ci = {
+        status: "failed",
+        sha: "f" * 40,
+        checks_url: authorization.dig("ci", "checks_url"),
+        non_success: [{
+          name: "generator",
+          state: "failure",
+          url: authorization.dig("ci", "non_success", 0, "url")
+        }]
+      }
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        accelerated_rc_shakaperf_snapshot!: authorization.fetch("shakaperf"),
+        system: true,
+        validate_existing_accelerated_rc_tag!: nil,
+        validate_release_candidate_publication_boundary!: nil
+      )
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!)
+        .and_return(pending_ci, failed_ci)
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      failure = begin
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          accelerated_publication_record: authorization
+        )
+        package_publication_started = true
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/live.*exact-candidate CI.*failed|known failed.*CI/i)
+        expect(pushed).to be(false)
+        expect(package_publication_started).to be(false)
+      end
+    end
+
+    it "blocks unknown live ShakaPerf after tag push before accelerated package publication" do
+      authorization = accelerated_rc_test_authorization
+      pending_ci = {
+        status: "pending",
+        sha: authorization.fetch("candidate_sha"),
+        checks_url: authorization.dig("ci", "checks_url"),
+        non_success: authorization.dig("ci", "non_success").map do |check|
+          check.transform_keys(&:to_sym)
+        end
+      }
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_accelerated_rc_ci_snapshot!: pending_ci,
+        system: true,
+        validate_existing_accelerated_rc_tag!: nil,
+        validate_release_candidate_publication_boundary!: nil
+      )
+      allow(self).to receive(:accelerated_rc_shakaperf_snapshot!)
+        .and_return(authorization.fetch("shakaperf"), authorization.fetch("shakaperf"), { "status" => "unknown" })
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      failure = begin
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          accelerated_publication_record: authorization
+        )
+        package_publication_started = true
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/live ShakaPerf.*unknown/i)
+        expect(pushed).to be(true)
+        expect(package_publication_started).to be(false)
+      end
+    end
+
+    it "blocks a repository-wide tracker conflict that appears immediately before accelerated RC tag push" do
+      authorization = accelerated_rc_test_authorization
+      conflicting_authorization = accelerated_rc_test_authorization(tracker: 3824)
+      pending_ci = {
+        status: "pending",
+        sha: authorization.fetch("candidate_sha"),
+        checks_url: authorization.dig("ci", "checks_url"),
+        non_success: authorization.dig("ci", "non_success").map do |check|
+          check.transform_keys(&:to_sym)
+        end
+      }
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_accelerated_rc_ci_snapshot!: pending_ci,
+        accelerated_rc_shakaperf_snapshot!: authorization.fetch("shakaperf"),
+        system: true,
+        validate_existing_accelerated_rc_tag!: nil,
+        validate_release_candidate_publication_boundary!: nil
+      )
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!)
+        .and_return([authorization], [authorization, conflicting_authorization])
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      failure = begin
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0.rc.10",
+          candidate_sha: "f" * 40,
+          accelerated_publication_record: authorization
+        )
+        package_publication_started = true
+        nil
+      rescue SystemExit => e
+        e
+      end
+
+      aggregate_failures do
+        expect(failure).to be_a(SystemExit)
+        expect(failure&.message).to match(/repository-wide.*tracker|conflicting release trackers/i)
+        expect(pushed).to be(false)
+        expect(package_publication_started).to be(false)
+      end
+    end
+
+    it "blocks stable final package publication when rejection appears after tag push" do
+      authorization, publication, accepted = accelerated_rc_test_accepted_history
+      rejected_history = accelerated_rc_test_rejected_history
+      successful_ci = {
+        status: "success",
+        sha: accepted.fetch("candidate_sha"),
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      final_promotion_context = {
+        candidate_sha: "e" * 40,
+        ci_branch: "release/17.0.0",
+        record: accepted,
+        ci_snapshot: json_compatible_release_value(successful_ci),
+        shakaperf_record: {
+          "release_branch" => "release/17.0.0",
+          "candidate_sha" => "e" * 40,
+          "target_version" => accepted.fetch("target_version"),
+          "shakaperf" => accepted.fetch("shakaperf")
+        }
+      }
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_accelerated_rc_ci_snapshot!: successful_ci,
+        accelerated_rc_shakaperf_snapshot!: accepted.fetch("shakaperf"),
+        system: true,
+        validate_release_tag_candidate_sha!: "e" * 40,
+        validate_release_candidate_publication_boundary!: "e" * 40
+      )
+      allow(self).to receive(:fetch_repository_accelerated_rc_records_for_candidate!)
+        .and_return([authorization, publication, accepted], [authorization, publication, accepted], rejected_history)
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: final_promotion_context
+        )
+        package_publication_started = true
+      end.to raise_error(SystemExit, /permanently rejected|candidate-rejected.*absorbing/i)
+
+      expect(pushed).to be(true)
+      expect(package_publication_started).to be(false)
+    end
+
+    it "blocks stable final package publication when exact-candidate CI fails after tag push" do
+      authorization, publication, accepted = accelerated_rc_test_accepted_history
+      successful_ci = {
+        status: "success",
+        sha: accepted.fetch("candidate_sha"),
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      failed_ci = successful_ci.merge(
+        status: "failed",
+        non_success: [{
+          name: "generator",
+          state: "failure",
+          url: "https://github.com/shakacode/react_on_rails/actions/runs/999"
+        }]
+      )
+      final_promotion_context = {
+        candidate_sha: "e" * 40,
+        ci_branch: "release/17.0.0",
+        record: accepted,
+        ci_snapshot: json_compatible_release_value(successful_ci),
+        shakaperf_record: {
+          "release_branch" => "release/17.0.0",
+          "candidate_sha" => "e" * 40,
+          "target_version" => accepted.fetch("target_version"),
+          "shakaperf" => accepted.fetch("shakaperf")
+        }
+      }
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
+        accelerated_rc_shakaperf_snapshot!: accepted.fetch("shakaperf"),
+        system: true,
+        validate_release_tag_candidate_sha!: "e" * 40,
+        validate_release_candidate_publication_boundary!: "e" * 40
+      )
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!)
+        .and_return(successful_ci, successful_ci, failed_ci)
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: final_promotion_context
+        )
+        package_publication_started = true
+      end.to raise_error(SystemExit, /final promotion.*exact-candidate CI.*failed|exact-RC CI.*pending/i)
+
+      expect(pushed).to be(true)
+      expect(package_publication_started).to be(false)
+    end
+
+    it "blocks stable final package publication when the exact ShakaPerf run becomes unknown after tag push" do
+      authorization, publication, accepted = accelerated_rc_test_accepted_history
+      successful_ci = {
+        status: "success",
+        sha: accepted.fetch("candidate_sha"),
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      final_promotion_context = {
+        candidate_sha: "e" * 40,
+        ci_branch: "release/17.0.0",
+        record: accepted,
+        ci_snapshot: json_compatible_release_value(successful_ci),
+        shakaperf_record: {
+          "release_branch" => "release/17.0.0",
+          "candidate_sha" => "e" * 40,
+          "target_version" => accepted.fetch("target_version"),
+          "shakaperf" => accepted.fetch("shakaperf")
+        }
+      }
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
+        fetch_accelerated_rc_ci_snapshot!: successful_ci,
+        system: true,
+        validate_release_tag_candidate_sha!: "e" * 40,
+        validate_release_candidate_publication_boundary!: "e" * 40
+      )
+      allow(self).to receive(:accelerated_rc_shakaperf_snapshot!)
+        .and_return(accepted.fetch("shakaperf"), accepted.fetch("shakaperf"), { "status" => "unknown" })
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: final_promotion_context
+        )
+        package_publication_started = true
+      end.to raise_error(SystemExit, /final promotion.*ShakaPerf.*unknown/i)
+
+      expect(pushed).to be(true)
+      expect(package_publication_started).to be(false)
+    end
+
+    it "blocks stable final package publication when exact ShakaPerf evidence changes after tag push" do
+      authorization, publication, accepted = accelerated_rc_test_accepted_history
+      successful_ci = {
+        status: "success",
+        sha: accepted.fetch("candidate_sha"),
+        checks_url: accepted.dig("ci", "checks_url"),
+        non_success: []
+      }
+      final_promotion_context = {
+        candidate_sha: "e" * 40,
+        ci_branch: "release/17.0.0",
+        record: accepted,
+        ci_snapshot: json_compatible_release_value(successful_ci),
+        shakaperf_record: {
+          "release_branch" => "release/17.0.0",
+          "candidate_sha" => "e" * 40,
+          "target_version" => accepted.fetch("target_version"),
+          "shakaperf" => accepted.fetch("shakaperf")
+        }
+      }
+      changed_shakaperf = accepted.fetch("shakaperf").merge(
+        "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/654321"
+      )
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, publication, accepted],
+        fetch_accelerated_rc_ci_snapshot!: successful_ci,
+        system: true,
+        validate_release_tag_candidate_sha!: "e" * 40,
+        validate_release_candidate_publication_boundary!: "e" * 40
+      )
+      allow(self).to receive(:accelerated_rc_shakaperf_snapshot!)
+        .and_return(accepted.fetch("shakaperf"), accepted.fetch("shakaperf"), changed_shakaperf)
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: accepted,
+          accelerated_final_promotion_context: final_promotion_context
+        )
+        package_publication_started = true
+      end.to raise_error(SystemExit, /final promotion.*materially changed ShakaPerf/i)
+
+      expect(pushed).to be(true)
+      expect(package_publication_started).to be(false)
+    end
+
+    it "uses the promotion CI branch at all final boundaries and blocks its post-push failure" do
+      _authorization, _publication, accepted = accelerated_rc_test_accepted_history
+      source_record = accepted.merge("release_branch" => "release/17.0.0-rc-source")
+      promotion_branch = "release/17.0.0"
+      successful_ci = {
+        status: "success",
+        sha: source_record.fetch("candidate_sha"),
+        checks_url: source_record.dig("ci", "checks_url"),
+        non_success: []
+      }
+      failed_ci = successful_ci.merge(
+        status: "failed",
+        non_success: [{
+          name: "required-generator",
+          state: "failure",
+          url: "https://github.com/shakacode/react_on_rails/actions/runs/999"
+        }]
+      )
+      final_promotion_context = {
+        candidate_sha: "e" * 40,
+        ci_branch: promotion_branch,
+        record: source_record,
+        ci_snapshot: json_compatible_release_value(successful_ci),
+        shakaperf_record: {
+          "release_branch" => promotion_branch,
+          "candidate_sha" => "e" * 40,
+          "target_version" => source_record.fetch("target_version"),
+          "shakaperf" => source_record.fetch("shakaperf")
+        }
+      }
+      promotion_snapshots = [successful_ci, successful_ci, failed_ci]
+      fetched_branches = []
+      allow(self).to receive_messages(
+        github_repo_slug: "shakacode/react_on_rails",
+        validate_accelerated_repository_publication_boundary!: nil,
+        validate_final_promotion_shakaperf_publication_boundary!: nil,
+        system: true,
+        validate_release_tag_candidate_sha!: "e" * 40,
+        validate_release_candidate_publication_boundary!: "e" * 40
+      )
+      allow(self).to receive(:fetch_accelerated_rc_ci_snapshot!) do |**arguments|
+        ci_branch = arguments.fetch(:ci_branch)
+        fetched_branches << ci_branch
+        ci_branch == promotion_branch ? promotion_snapshots.shift : successful_ci
+      end
+      pushed = false
+      package_publication_started = false
+      allow(self).to receive(:sh_in_dir_for_release) { pushed = true }
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40,
+          accelerated_boundary_record: source_record,
+          accelerated_final_promotion_context: final_promotion_context
+        )
+        package_publication_started = true
+      end.to raise_error(SystemExit, /refreshed exact-RC CI is failed/)
+
+      aggregate_failures do
+        expect(fetched_branches).to eq([promotion_branch, promotion_branch, promotion_branch])
+        expect(pushed).to be(true)
+        expect(package_publication_started).to be(false)
+      end
+    end
+
+    it "blocks an existing stable tag before push when HEAD moved after final gates" do
+      allow(self).to receive(:system).and_return(true)
+      allow(self).to receive_messages(
+        validate_release_tag_candidate_sha!: "e" * 40,
+        current_git_sha!: "d" * 40
+      )
+      expect(self).not_to receive(:sh_in_dir_for_release)
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40
+        )
+      end.to raise_error(SystemExit, /HEAD moved.*before git tag push/i)
+    end
+
+    it "blocks a newly created stable tag before push when HEAD moves after tag creation" do
+      allow(self).to receive_messages(system: false, current_git_sha!: "d" * 40)
+      expect(self).to receive(:create_release_tag_at_candidate_sha!).with(
+        monorepo_root: "/tmp/repo",
+        tag: "v17.0.0",
+        candidate_sha: "e" * 40
+      )
+      expect(self).not_to receive(:sh_in_dir_for_release)
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40
+        )
+      end.to raise_error(SystemExit, /HEAD moved.*before git tag push/i)
+    end
+
+    it "revalidates HEAD after tag push before package publication" do
+      head_shas = ["e" * 40, "d" * 40]
+      allow(self).to receive_messages(
+        system: true,
+        validate_release_tag_candidate_sha!: "e" * 40
+      )
+      allow(self).to receive(:current_git_sha!) { head_shas.shift }
+      expect(self).to receive(:sh_in_dir_for_release).with("/tmp/repo", "LEFTHOOK=0 git push --tags")
+
+      expect do
+        push_release_tag_for_candidate!(
+          monorepo_root: "/tmp/repo",
+          tag: "v17.0.0",
+          candidate_sha: "e" * 40
+        )
+      end.to raise_error(SystemExit, /HEAD moved.*before package publication/i)
     end
   end
 
@@ -3136,6 +8593,40 @@ RSpec.describe "release.rake helper methods" do
             dry_run: false
           )
         end.to raise_error(SystemExit, /CI is still in progress.*Slow test/m)
+      end
+
+      it "allows only the explicit accelerated RC path to defer pending required checks" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha:, check_runs: [in_progress_run("Lint")])
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, ci_branch: "main").and_return(required_checks(checks: [required_check("Lint")]))
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            defer_pending: true
+          )
+        end.to output(/ACCELERATED RC.*deferring pending CI.*Lint/mi).to_stdout
+      end
+
+      it "never defers pending checks for stable or final promotion" do
+        allow(self).to receive(:fetch_main_ci_checks)
+          .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
+          .and_return(sha:, check_runs: [in_progress_run("Lint")])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: false,
+            allow_override: false,
+            dry_run: false,
+            defer_pending: true
+          )
+        end.to raise_error(SystemExit, /CI is still in progress.*Lint/m)
       end
     end
 
@@ -6487,6 +11978,20 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#latest_remote_rc_tag_for_version" do
+    %w[dotted-first dashed-first].each do |ordering|
+      it "rejects equivalent dotted and dashed RC tag names when #{ordering.tr('-', ' ')}" do
+        tags = %w[v17.0.0.rc.10 v17.0.0-rc.10]
+        tags.reverse! if ordering == "dashed-first"
+        allow(self).to receive(:remote_release_tags).and_return(tags)
+
+        expect do
+          latest_remote_rc_tag_for_version(monorepo_root: "/tmp/repo", target_gem_version: "17.0.0")
+        end.to raise_error(SystemExit, /ambiguous remote RC tags.*v17\.0\.0[.-]rc\.10/mi)
+      end
+    end
+  end
+
   describe "#ensure_release_branch_promotes_tagged_rc!" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:success_status) { instance_double(Process::Status, success?: true) }
@@ -6506,6 +12011,7 @@ RSpec.describe "release.rake helper methods" do
 
     before do
       allow(self).to receive(:remote_git_tag_exists?).and_call_original
+      allow(self).to receive(:remote_release_tags).and_return(["v17.0.0.rc.3"])
       allow(self)
         .to receive(:remote_git_tag_exists?)
         .with(monorepo_root:, tag: "v17.0.0.rc.3")
@@ -6528,6 +12034,63 @@ RSpec.describe "release.rake helper methods" do
           target_gem_version: "17.0.1"
         )
       ).to eq(stable_tag_retry: false, stable_tag_at_head: false)
+    end
+
+    %w[dotted-first dashed-first].product(%w[dotted dashed]).each do |ordering, provenance_alias|
+      it "blocks first promotion when #{ordering.tr('-', ' ')} and #{provenance_alias} carries provenance" do
+        tags = %w[v17.0.0.rc.10 v17.0.0-rc.10]
+        tags.reverse! if ordering == "dashed-first"
+        provenance_tag = provenance_alias == "dotted" ? "v17.0.0.rc.10" : "v17.0.0-rc.10"
+        allow(self).to receive(:remote_release_tags).and_return(tags)
+        allow(self).to receive(:remote_git_tag_exists?)
+          .with(monorepo_root:, tag: "v17.0.0.rc.10")
+          .and_return(true)
+        allow(self).to receive_messages(
+          fetch_remote_rc_tag!: nil,
+          peeled_git_tag_sha: "headsha",
+          current_git_sha!: "headsha"
+        )
+        allow(self).to receive(:accepted_accelerated_rc_record_for_release_branch_promotion!) do |rc_tag:, **|
+          { "status" => "candidate-accepted" } if rc_tag == provenance_tag
+        end
+
+        expect do
+          promotion = ensure_release_branch_promotes_tagged_rc!(
+            monorepo_root:,
+            current_branch: "release/17.0.0",
+            current_checkout_version: "17.0.0.rc.10",
+            target_gem_version: "17.0.0"
+          )
+          accepted_accelerated_rc_record_for_release_branch_promotion!(
+            monorepo_root:,
+            rc_tag: promotion.fetch(:rc_tag),
+            final_head_sha: "headsha",
+            tracker_input: "3823"
+          )
+        end.to raise_error(SystemExit, /ambiguous remote RC tags.*v17\.0\.0[.-]rc\.10/mi)
+        expect(self).not_to have_received(:accepted_accelerated_rc_record_for_release_branch_promotion!)
+      end
+    end
+
+    it "preserves a unique dashed RC tag identity through first final promotion" do
+      allow(self).to receive(:remote_release_tags).and_return(["v17.0.0-rc.10"])
+      allow(self).to receive(:remote_git_tag_exists?)
+        .with(monorepo_root:, tag: "v17.0.0-rc.10")
+        .and_return(true)
+      allow(self).to receive_messages(
+        fetch_remote_rc_tag!: nil,
+        peeled_git_tag_sha: "headsha",
+        current_git_sha!: "headsha"
+      )
+
+      expect(
+        ensure_release_branch_promotes_tagged_rc!(
+          monorepo_root:,
+          current_branch: "release/17.0.0",
+          current_checkout_version: "17.0.0.rc.10",
+          target_gem_version: "17.0.0"
+        )
+      ).to include(rc_tag: "v17.0.0-rc.10")
     end
 
     it "allows a matching release branch when HEAD is the current RC tag" do
@@ -6582,6 +12145,12 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive(:commit_non_runtime_only?)
         .with(monorepo_root:, sha: "notessha")
         .and_return(true)
+      allow(self).to receive(:release_finalization_metadata_touched)
+        .with(monorepo_root:, sha: "changelogsha")
+        .and_return(false)
+      allow(self).to receive(:release_finalization_metadata_touched)
+        .with(monorepo_root:, sha: "notessha")
+        .and_return(false)
 
       expect do
         ensure_release_branch_promotes_tagged_rc!(
@@ -6633,6 +12202,9 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive(:commit_non_runtime_only?)
         .with(monorepo_root:, sha: "versionbumpsha")
         .and_return(false)
+      allow(self).to receive(:release_finalization_metadata_touched)
+        .with(monorepo_root:, sha: "versionbumpsha")
+        .and_return(true)
       allow(self).to receive(:release_finalization_metadata_commit?)
         .with(monorepo_root:, sha: "versionbumpsha")
         .and_return(true)
@@ -6680,6 +12252,9 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive(:commit_non_runtime_only?)
         .with(monorepo_root:, sha: "changelogsha")
         .and_return(true)
+      allow(self).to receive(:release_finalization_metadata_touched)
+        .with(monorepo_root:, sha: "changelogsha")
+        .and_return(false)
 
       expect do
         ensure_release_branch_promotes_tagged_rc!(
@@ -6722,6 +12297,9 @@ RSpec.describe "release.rake helper methods" do
         .with("git", "-C", monorepo_root, "rev-list", "--reverse", "tagsha..headsha")
         .and_return(["runtimesha\n", success_status])
       allow(self).to receive(:commit_non_runtime_only?)
+        .with(monorepo_root:, sha: "runtimesha")
+        .and_return(false)
+      allow(self).to receive(:release_finalization_metadata_touched)
         .with(monorepo_root:, sha: "runtimesha")
         .and_return(false)
       allow(self).to receive(:release_finalization_metadata_commit?)
@@ -6775,6 +12353,9 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive(:commit_non_runtime_only?)
         .with(monorepo_root:, sha: "versionbumpsha")
         .and_return(false)
+      allow(self).to receive(:release_finalization_metadata_touched)
+        .with(monorepo_root:, sha: "versionbumpsha")
+        .and_return(true)
       allow(self).to receive(:release_finalization_metadata_commit?)
         .with(monorepo_root:, sha: "versionbumpsha")
         .and_return(true)
@@ -7014,6 +12595,9 @@ RSpec.describe "release.rake helper methods" do
         .with("git", "-C", monorepo_root, "rev-list", "--reverse", "tagsha..headsha")
         .and_return(["runtimesha\n", success_status])
       allow(self).to receive(:commit_non_runtime_only?)
+        .with(monorepo_root:, sha: "runtimesha")
+        .and_return(false)
+      allow(self).to receive(:release_finalization_metadata_touched)
         .with(monorepo_root:, sha: "runtimesha")
         .and_return(false)
       allow(self).to receive(:release_finalization_metadata_commit?)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -4293,25 +4293,89 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /write, maintain, or admin/)
     end
 
-    it "rejects tracker markers authored without maintainer repository permission" do
-      record = { "schema_version" => 1 }
-      marker = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 " \
-               "#{JSON.generate(record).unpack1('H*')} -->"
-      allow(self).to receive(:fetch_release_tracker_comments).and_return(
-        [{ "body" => marker, "user" => { "login" => "external-user" } }]
+    it "ignores a known non-maintainer marker at an idempotent tracker append boundary" do
+      authorization = build_accelerated_rc_publication_record(
+        options: accelerated_rc_options,
+        candidate_sha: "f" * 40,
+        runtime_tree_fingerprint: "a" * 64,
+        release_branch: "release/17.0.0",
+        ci_snapshot: accelerated_rc_ci_snapshot,
+        shakaperf: accelerated_rc_shakaperf_snapshot,
+        approved_by: "justin808",
+        recorded_at: Time.utc(2026, 7, 14, 13, 30)
       )
-      status = instance_double(Process::Status, success?: true)
+      untrusted_marker = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 " \
+                         "#{JSON.generate({ 'schema_version' => 1 }).unpack1('H*')} -->"
+      allow(self).to receive_messages(
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
+        fetch_release_tracker_comments: [
+          { "body" => untrusted_marker, "user" => { "login" => "external-user" } },
+          { "body" => accelerated_rc_tracker_comment(authorization), "user" => { "login" => "justin808" } }
+        ]
+      )
+      success = instance_double(Process::Status, success?: true)
       allow(self).to receive(:capture_gh_output)
         .with(
           "api",
           "repos/shakacode/react_on_rails/collaborators/external-user/permission",
           "--jq",
           ".permission"
-        ).and_return(["read\n", status])
+        ).and_return(["read\n", success])
+      allow(self).to receive(:capture_gh_output)
+        .with(
+          "api",
+          "repos/shakacode/react_on_rails/collaborators/justin808/permission",
+          "--jq",
+          ".permission"
+        ).and_return(["write\n", success])
+      expect(self).not_to receive(:post_release_tracker_comment!)
+
+      result = nil
+      failure = begin
+        result = append_accelerated_rc_tracker_record!(
+          repo_slug: "shakacode/react_on_rails", tracker: 3823, record: authorization
+        )
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure).to be_nil
+        expect(result).to eq(authorization)
+      end
+    end
+
+    it "fails closed when a tracker marker author permission lookup fails" do
+      marker = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 " \
+               "#{JSON.generate({ 'schema_version' => 1 }).unpack1('H*')} -->"
+      failure = instance_double(Process::Status, success?: false)
+      allow(self).to receive_messages(
+        fetch_release_tracker_comments: [
+          { "body" => marker, "user" => { "login" => "external-user" } }
+        ],
+        capture_gh_output: ["permission unavailable", failure]
+      )
 
       expect do
         fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
-      end.to raise_error(SystemExit, /write, maintain, or admin/)
+      end.to raise_error(SystemExit, /Unable to verify the repository permission/)
+    end
+
+    it "fails closed on an unknown successful tracker marker permission" do
+      marker = "<!-- #{ACCELERATED_RC_RECORD_MARKER} v1 " \
+               "#{JSON.generate({ 'schema_version' => 1 }).unpack1('H*')} -->"
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive_messages(
+        fetch_release_tracker_comments: [
+          { "body" => marker, "user" => { "login" => "external-user" } }
+        ],
+        capture_gh_output: ["future_permission\n", success]
+      )
+
+      expect do
+        fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /repository permission.*unknown/i)
     end
 
     it "loads repository issue-comment discovery incrementally and retains only marker comments" do
@@ -5828,18 +5892,17 @@ RSpec.describe "release.rake helper methods" do
       )
       expect(validate_accelerated_rc_tracker_record!(conflicting_authorization)).to eq(conflicting_authorization)
       allow(self).to receive_messages(
-        fetch_accelerated_rc_tracker_records!: [authorization, conflicting_authorization],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, conflicting_authorization],
         local_release_tag_exists?: false
       )
 
       expect do
-        accelerated_rc_publication_authorization_for_retry!(
+        accelerated_rc_authorization_for_same_candidate_retry!(
           repo_slug: "shakacode/react_on_rails",
-          tracker: 3823,
           target_version: "17.0.0.rc.10",
           candidate_sha: "f" * 40,
           monorepo_root: "/tmp/repo",
-          tag: "v17.0.0.rc.10"
+          accelerated_requested: false
         )
       end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
     end
@@ -5856,8 +5919,9 @@ RSpec.describe "release.rake helper methods" do
         recorded_at: Time.utc(2026, 7, 14, 13, 30)
       )
       allow(self).to receive_messages(
-        fetch_accelerated_rc_tracker_records!: [authorization],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization],
         local_release_tag_exists?: true,
+        fetch_release_tracker_issue!: {},
         accelerated_rc_tag_provenance_for_tag!: {
           "target_version" => "17.0.0.rc.10",
           "candidate_sha" => "e" * 40,
@@ -5867,13 +5931,12 @@ RSpec.describe "release.rake helper methods" do
       )
 
       expect do
-        accelerated_rc_publication_authorization_for_retry!(
+        accelerated_rc_authorization_for_same_candidate_retry!(
           repo_slug: "shakacode/react_on_rails",
-          tracker: 3823,
           target_version: "17.0.0.rc.10",
           candidate_sha: "f" * 40,
           monorepo_root: "/tmp/repo",
-          tag: "v17.0.0.rc.10"
+          accelerated_requested: false
         )
       end.to raise_error(SystemExit, /lacks matching canonical accelerated publication provenance/)
     end
@@ -5891,19 +5954,18 @@ RSpec.describe "release.rake helper methods" do
       )
       conflicting_authorization = authorization.merge("reason" => "Mutated authorization reason")
       allow(self).to receive_messages(
-        fetch_accelerated_rc_tracker_records!: [authorization, conflicting_authorization],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, conflicting_authorization],
         local_release_tag_exists?: true,
         accelerated_rc_tag_provenance_for_tag!: accelerated_rc_tag_provenance(authorization)
       )
 
       expect do
-        accelerated_rc_publication_authorization_for_retry!(
+        accelerated_rc_authorization_for_same_candidate_retry!(
           repo_slug: "shakacode/react_on_rails",
-          tracker: 3823,
           target_version: "17.0.0.rc.10",
           candidate_sha: "f" * 40,
           monorepo_root: "/tmp/repo",
-          tag: "v17.0.0.rc.10"
+          accelerated_requested: false
         )
       end.to raise_error(SystemExit, /conflicting canonical publication authorizations/i)
     end
@@ -5937,20 +5999,19 @@ RSpec.describe "release.rake helper methods" do
       )
       conflicting_accepted = accepted.merge("approved_by" => "other-maintainer")
       allow(self).to receive_messages(
-        fetch_accelerated_rc_tracker_records!: [
+        fetch_repository_accelerated_rc_records_for_candidate!: [
           authorization, publication, accepted, conflicting_accepted
         ],
         local_release_tag_exists?: false
       )
 
       expect do
-        accelerated_rc_publication_authorization_for_retry!(
+        accelerated_rc_authorization_for_same_candidate_retry!(
           repo_slug: "shakacode/react_on_rails",
-          tracker: 3823,
           target_version: "17.0.0.rc.10",
           candidate_sha: "f" * 40,
           monorepo_root: "/tmp/repo",
-          tag: "v17.0.0.rc.10"
+          accelerated_requested: false
         )
       end.to raise_error(SystemExit, /conflicting candidate-accepted terminal records/i)
     end
@@ -6305,18 +6366,17 @@ RSpec.describe "release.rake helper methods" do
         recorded_at: Time.utc(2026, 7, 14, 14)
       ).merge("required_follow_up" => "Skip reconciliation")
       allow(self).to receive_messages(
-        fetch_accelerated_rc_tracker_records!: [authorization, mutated_publication],
+        fetch_repository_accelerated_rc_records_for_candidate!: [authorization, mutated_publication],
         local_release_tag_exists?: false
       )
 
       expect do
-        accelerated_rc_publication_authorization_for_retry!(
+        accelerated_rc_authorization_for_same_candidate_retry!(
           repo_slug: "shakacode/react_on_rails",
-          tracker: 3823,
           target_version: "17.0.0.rc.10",
           candidate_sha: "f" * 40,
           monorepo_root: "/tmp/repo",
-          tag: "v17.0.0.rc.10"
+          accelerated_requested: false
         )
       end.to raise_error(SystemExit, /not the canonical authorized transition/)
     end

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7606,6 +7606,83 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    it "renders and reconfirms string-keyed refreshed pending evidence through the real prompt (V60)" do
+      changed_ci = accelerated_rc_ci_snapshot.merge(
+        non_success: accelerated_rc_ci_snapshot.fetch(:non_success) + [{
+          name: "docs",
+          state: "queued",
+          url: "https://github.com/shakacode/react_on_rails/actions/runs/124"
+        }]
+      )
+      changed_shakaperf = json_compatible_release_value(
+        accelerated_rc_shakaperf_snapshot.merge(
+          run_id: 654_321,
+          run_url: "https://github.com/shakacode/react_on_rails/actions/runs/654321"
+        )
+      )
+      refreshed = { ci: changed_ci, shakaperf: changed_shakaperf }
+      allow($stdin).to receive(:gets).and_return("y\n", "y\n")
+      allow(self).to receive(:refresh_accelerated_rc_live_evidence!).and_return(refreshed, refreshed)
+
+      result = nil
+      expect do
+        result = confirmed_fresh_accelerated_rc_evidence!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          target_version: "17.0.0.rc.10",
+          tracker: 3823,
+          reason: accelerated_rc_options.fetch(:reason),
+          ci_snapshot: accelerated_rc_ci_snapshot,
+          shakaperf: accelerated_rc_shakaperf_snapshot
+        )
+      end.to output(
+        %r{actions/runs/123456.*pending evidence changed.*docs.*actions/runs/654321}m
+      ).to_stdout
+
+      aggregate_failures do
+        expect(result).to eq(refreshed)
+        expect($stdin).to have_received(:gets).twice
+        expect(self).to have_received(:refresh_accelerated_rc_live_evidence!).twice
+      end
+    end
+
+    it "retains the three-confirmation instability cap with refreshed persisted evidence (V60)" do
+      refreshed_shakaperf = json_compatible_release_value(accelerated_rc_shakaperf_snapshot)
+      unstable_refreshes = 1.upto(3).map do |iteration|
+        changed_ci = accelerated_rc_ci_snapshot.merge(
+          non_success: accelerated_rc_ci_snapshot.fetch(:non_success) + [{
+            name: "changed-#{iteration}",
+            state: "queued",
+            url: "https://github.com/shakacode/react_on_rails/actions/runs/#{200 + iteration}"
+          }]
+        )
+        { ci: changed_ci, shakaperf: refreshed_shakaperf }
+      end
+      allow($stdin).to receive(:gets).and_return("y\n", "y\n", "y\n")
+      allow(self).to receive(:refresh_accelerated_rc_live_evidence!).and_return(*unstable_refreshes)
+
+      expect do
+        confirmed_fresh_accelerated_rc_evidence!(
+          repo_slug: "shakacode/react_on_rails",
+          monorepo_root: "/tmp/repo",
+          release_branch: "release/17.0.0",
+          candidate_sha: "f" * 40,
+          target_version: "17.0.0.rc.10",
+          tracker: 3823,
+          reason: accelerated_rc_options.fetch(:reason),
+          ci_snapshot: accelerated_rc_ci_snapshot,
+          shakaperf: accelerated_rc_shakaperf_snapshot
+        )
+      end.to raise_error(SystemExit, /pending evidence did not stabilize across confirmation/i)
+
+      aggregate_failures do
+        expect($stdin).to have_received(:gets).exactly(3).times
+        expect(self).to have_received(:refresh_accelerated_rc_live_evidence!).exactly(3).times
+      end
+    end
+
     it "does not reconfirm when pending CI checks only arrive in a different order" do
       check_runs = [
         {
@@ -8419,6 +8496,50 @@ RSpec.describe "release.rake helper methods" do
       end.to output(
         %r{17\.0\.0\.rc\.10.*#{'f' * 40}.*#3823.*generator-1.*actions/runs/1.*actions/runs/123456.*Start fleet QA now}m
       ).to_stdout
+    end
+
+    it "fails closed on missing, duplicate, or malformed confirmation display fields (V60)" do
+      ci = {
+        status: "pending",
+        sha: "f" * 40,
+        checks_url: "https://github.com/shakacode/react_on_rails/commit/#{'f' * 40}/checks",
+        non_success: [{
+          name: "generator",
+          state: "in_progress",
+          url: "https://github.com/shakacode/react_on_rails/actions/runs/123"
+        }]
+      }
+      shakaperf = {
+        status: "pending",
+        run_id: 123_456,
+        run_url: "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      malformed = {
+        "missing CI status" => [ci.except(:status), shakaperf],
+        "duplicate CI status key shape" => [ci.merge("status" => "pending"), shakaperf],
+        "non-Array CI checks" => [ci.merge(non_success: "unknown"), shakaperf],
+        "unknown CI check state" => [
+          ci.merge(non_success: [ci.fetch(:non_success).first.merge(state: "future_state")]),
+          shakaperf
+        ],
+        "missing ShakaPerf run URL" => [ci, shakaperf.except(:run_url)]
+      }
+      expect($stdin).not_to receive(:gets)
+
+      aggregate_failures do
+        malformed.each do |description, (malformed_ci, malformed_shakaperf)|
+          expect do
+            confirm_accelerated_rc_publication!(
+              version: "17.0.0.rc.10",
+              candidate_sha: "f" * 40,
+              tracker: 3823,
+              reason: "Start fleet QA now",
+              ci_snapshot: malformed_ci,
+              shakaperf: malformed_shakaperf
+            )
+          end.to raise_error(SystemExit, /confirmation evidence.*malformed or incomplete/i), description
+        end
+      end
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -2527,6 +2527,94 @@ RSpec.describe "release.rake helper methods" do
       expect(result).to include(status: "pending", run_id: 123_456)
     end
 
+    it "classifies a selected terminal pre-run before reusing an active exact-head run (V62)" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      active_exact_run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+        "headSha" => head_sha,
+        "status" => "in_progress",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      prerun = {
+        "databaseId" => 222_222,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref:, head_sha: "e" * 40, target_version:
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "failure",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/222222"
+      }
+      terminal_cases = {
+        "known failure" => [prerun, /known ShakaPerf failure/i],
+        "unknown terminal conclusion" => [prerun.merge("conclusion" => "future_failure"), /metadata|unknown/i]
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return("evidence is stale")
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      aggregate_failures do
+        terminal_cases.each do |label, (terminal_prerun, expected_error)|
+          [[active_exact_run, terminal_prerun], [terminal_prerun, active_exact_run]].each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, expected_error), "#{label}, order #{order}"
+          end
+        end
+
+        successful_prerun = prerun.merge("conclusion" => "success")
+        active_prerun = prerun.merge("status" => "in_progress", "conclusion" => nil)
+        unrelated_prerun = successful_prerun.merge(
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: "e" * 40, target_version: "17.0.0.rc.9"
+          )
+        )
+        control_sets = {
+          "absent pre-run" => [active_exact_run],
+          "successful or stale successful pre-run" => [active_exact_run, successful_prerun],
+          "active pre-run" => [active_exact_run, active_prerun],
+          "canonically unrelated pre-run" => [active_exact_run, unrelated_prerun]
+        }
+        control_sets.each do |label, records|
+          [records, records.reverse].uniq.each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            result = run_accelerated_shakaperf_release_gate!(
+              monorepo_root: "/tmp/repo",
+              ref:,
+              head_sha:,
+              target_version:,
+              release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+            )
+            expect(result).to include(status: "pending", run_id: 123_456), "#{label}, order #{order}"
+          end
+        end
+      end
+      expect(self).not_to have_received(:shakaperf_release_gate_run_evidence_rejection)
+    end
+
     it "blocks an existing active exact-head run that already has a terminal conclusion" do
       run = {
         "databaseId" => 123_456,

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7220,6 +7220,53 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#valid_accelerated_rc_non_runtime_classification?" do
+    let(:canonical_commit_sha) { "c" * 40 }
+
+    it "accepts only the exact positive shape with canonical git commit identities" do
+      malformed_classifications = {
+        "nil" => nil,
+        "non-Hash" => [],
+        "extra key" => { status: :non_runtime_only, commits: [canonical_commit_sha], future: true },
+        "missing status" => { commits: [canonical_commit_sha] },
+        "missing commits" => { status: :non_runtime_only },
+        "string keys" => { "status" => :non_runtime_only, "commits" => [canonical_commit_sha] },
+        "mixed future keys" => { status: :non_runtime_only, commits: [canonical_commit_sha], "future" => true },
+        "unknown status" => { status: :future, commits: [canonical_commit_sha] },
+        "none status" => { status: :none, commits: [canonical_commit_sha] },
+        "not-ancestor status" => { status: :not_ancestor, commits: [canonical_commit_sha] },
+        "runtime-bearing status" => { status: :runtime_bearing, commits: [canonical_commit_sha] },
+        "nil commits" => { status: :non_runtime_only, commits: nil },
+        "non-Array commits" => { status: :non_runtime_only, commits: canonical_commit_sha },
+        "empty commits" => { status: :non_runtime_only, commits: [] },
+        "empty identity" => { status: :non_runtime_only, commits: [""] },
+        "whitespace identity" => { status: :non_runtime_only, commits: [" \t"] },
+        "non-String identity" => { status: :non_runtime_only, commits: [123] },
+        "short identity" => { status: :non_runtime_only, commits: ["c" * 39] },
+        "long identity" => { status: :non_runtime_only, commits: ["c" * 41] },
+        "uppercase identity" => { status: :non_runtime_only, commits: ["C" * 40] },
+        "non-hex identity" => { status: :non_runtime_only, commits: ["g" * 40] }
+      }
+
+      aggregate_failures do
+        malformed_classifications.each do |description, classification|
+          result = nil
+          expect do
+            result = valid_accelerated_rc_non_runtime_classification?(classification)
+          end.not_to raise_error, description
+          expect(result).to be(false), description
+        end
+
+        expect(
+          valid_accelerated_rc_non_runtime_classification?(
+            status: :non_runtime_only,
+            commits: [canonical_commit_sha, "d" * 40]
+          )
+        ).to be(true)
+      end
+    end
+  end
+
   describe "#accepted_accelerated_rc_record_for_promotion!" do
     let(:authorization_record) do
       build_accelerated_rc_publication_record(
@@ -7511,41 +7558,7 @@ RSpec.describe "release.rake helper methods" do
       ).to eq(record)
     end
 
-    it "reuses accepted evidence for a mechanically runtime-equivalent final tip" do
-      record = authorization_record.merge(
-        "status" => "candidate-accepted",
-        "recorded_at" => "2026-07-14T15:00:00Z",
-        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
-        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
-        "evidence" => {
-          "demo_fleet" => "https://github.com/demo-fleet",
-          "behavioral" => "https://github.com/behavioral",
-          "artifacts" => "https://github.com/artifacts"
-        }
-      )
-      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
-        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
-      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
-        .with(monorepo_root: "/tmp/repo", sha: "e" * 40).and_return("a" * 64)
-      allow(self).to receive(:release_branch_commits_after_rc_tag).with(
-        monorepo_root: "/tmp/repo",
-        tag_sha: "f" * 40,
-        head_sha: "e" * 40
-      ).and_return(status: :non_runtime_only, commits: ["metadata-only-sha"])
-
-      expect(
-        accepted_accelerated_rc_record_for_promotion!(
-          records: [authorization_record, canonical_publication, record],
-          rc_version: "17.0.0.rc.10",
-          rc_sha: "f" * 40,
-          final_head_sha: "e" * 40,
-          monorepo_root: "/tmp/repo",
-          tag_provenance:
-        )
-      ).to eq(record)
-    end
-
-    it "blocks accepted evidence when the final tip changes the runtime tree" do
+    it "reuses accepted evidence for a non-runtime-only final tip despite a changed coarse fingerprint" do
       record = authorization_record.merge(
         "status" => "candidate-accepted",
         "recorded_at" => "2026-07-14T15:00:00Z",
@@ -7561,6 +7574,108 @@ RSpec.describe "release.rake helper methods" do
         .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
       allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
         .with(monorepo_root: "/tmp/repo", sha: "e" * 40).and_return("b" * 64)
+      allow(self).to receive(:release_branch_commits_after_rc_tag).with(
+        monorepo_root: "/tmp/repo",
+        tag_sha: "f" * 40,
+        head_sha: "e" * 40
+      ).and_return(status: :non_runtime_only, commits: ["c" * 40])
+
+      result = nil
+      expect do
+        result = accepted_accelerated_rc_record_for_promotion!(
+          records: [authorization_record, canonical_publication, record],
+          rc_version: "17.0.0.rc.10",
+          rc_sha: "f" * 40,
+          final_head_sha: "e" * 40,
+          monorepo_root: "/tmp/repo",
+          tag_provenance:
+        )
+      end.not_to raise_error
+      expect(result).to eq(record)
+    end
+
+    it "blocks every noncanonical final-tip classification even when coarse fingerprints match" do
+      record = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "recorded_at" => "2026-07-14T15:00:00Z",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint).and_return("a" * 64)
+      classifications = {
+        "extra key" => { status: :non_runtime_only, commits: ["c" * 40], future: true },
+        "string keys" => { "status" => :non_runtime_only, "commits" => ["c" * 40] },
+        "mixed future keys" => { status: :non_runtime_only, commits: ["c" * 40], "future" => true },
+        "runtime-bearing" => { status: :runtime_bearing, commits: ["c" * 40] },
+        "not-ancestor" => { status: :not_ancestor, commits: [] },
+        "none" => { status: :none, commits: [] },
+        "unknown status" => { status: :future, commits: ["c" * 40] },
+        "missing status" => { commits: ["c" * 40] },
+        "missing result" => nil,
+        "malformed non-runtime commits" => { status: :non_runtime_only, commits: nil },
+        "empty non-runtime commits" => { status: :non_runtime_only, commits: [] },
+        "whitespace identity" => { status: :non_runtime_only, commits: [" \t"] },
+        "uppercase identity" => { status: :non_runtime_only, commits: ["C" * 40] },
+        "short identity" => { status: :non_runtime_only, commits: ["c" * 39] }
+      }
+
+      aggregate_failures do
+        classifications.each do |description, classification|
+          allow(self).to receive(:release_branch_commits_after_rc_tag).and_return(classification)
+
+          expect do
+            accepted_accelerated_rc_record_for_promotion!(
+              records: [authorization_record, canonical_publication, record],
+              rc_version: "17.0.0.rc.10",
+              rc_sha: "f" * 40,
+              final_head_sha: "e" * 40,
+              monorepo_root: "/tmp/repo",
+              tag_provenance:
+            )
+          end.to raise_error(SystemExit, /not runtime-equivalent/), description
+        end
+      end
+    end
+
+    it "keeps same-SHA runtime equivalence bound to the exact recorded accepted fingerprint" do
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
+
+      aggregate_failures do
+        [nil, "malformed", "b" * 64].each do |stored_fingerprint|
+          record = { "runtime_tree_fingerprint" => stored_fingerprint }
+          expect(
+            accelerated_rc_runtime_equivalent?(
+              record:, rc_sha: "f" * 40, final_head_sha: "f" * 40, monorepo_root: "/tmp/repo"
+            )
+          ).to be(false), stored_fingerprint.inspect
+        end
+      end
+    end
+
+    it "blocks accepted evidence when the canonical classifier finds a runtime-bearing final tip" do
+      record = authorization_record.merge(
+        "status" => "candidate-accepted",
+        "recorded_at" => "2026-07-14T15:00:00Z",
+        "ci" => authorization_record.fetch("ci").merge("status" => "success", "non_success" => []),
+        "shakaperf" => authorization_record.fetch("shakaperf").merge("status" => "success"),
+        "evidence" => {
+          "demo_fleet" => "https://github.com/demo-fleet",
+          "behavioral" => "https://github.com/behavioral",
+          "artifacts" => "https://github.com/artifacts"
+        }
+      )
+      allow(self).to receive(:shakaperf_runtime_tree_fingerprint)
+        .with(monorepo_root: "/tmp/repo", sha: "f" * 40).and_return("a" * 64)
+      allow(self).to receive(:release_branch_commits_after_rc_tag).and_return(
+        status: :runtime_bearing,
+        commits: ["runtime-bearing-sha"]
+      )
 
       expect do
         accepted_accelerated_rc_record_for_promotion!(
@@ -7830,7 +7945,7 @@ RSpec.describe "release.rake helper methods" do
         monorepo_root: "/tmp/repo",
         tag_sha: "f" * 40,
         head_sha: "e" * 40
-      ).and_return(status: :non_runtime_only, commits: ["version-only-sha"])
+      ).and_return(status: :non_runtime_only, commits: ["c" * 40])
       allow(self).to receive_messages(
         refresh_accepted_rc_ci_evidence_for_promotion!: successful_final_ci_snapshot,
         reuse_accepted_rc_shakaperf_evidence!: true,

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -2344,6 +2344,7 @@ RSpec.describe "release.rake helper methods" do
         end
 
         results = {
+          "bundle_gemfile" => Bundler.default_gemfile.to_s,
           "array_many" => [].respond_to?(:many?),
           "empty" => capture_case.call([]),
           "single" => capture_case.call([queued_run]),
@@ -2351,26 +2352,44 @@ RSpec.describe "release.rake helper methods" do
         }
         puts "ROOT_RAKE_RESULT=#{JSON.generate(results)}"
       RUBY
-      root_bundle_environment = {
-        "BUNDLE_GEMFILE" => File.join(monorepo_root, "Gemfile"),
-        "BUNDLE_LOCKFILE" => File.join(monorepo_root, "Gemfile.lock")
-      }
-      stdout, stderr, status = Bundler.with_unbundled_env do
-        Open3.capture3(
-          root_bundle_environment,
+      Dir.mktmpdir("ror-v68-empty-root-bundle") do |empty_root_bundle|
+        unavailable_root_bundle_environment = {
+          "BUNDLE_GEMFILE" => File.join(monorepo_root, "Gemfile"),
+          "BUNDLE_LOCKFILE" => File.join(monorepo_root, "Gemfile.lock"),
+          "BUNDLE_PATH" => empty_root_bundle,
+          "BUNDLE_FROZEN" => "true"
+        }
+        unavailable_stdout, unavailable_stderr, unavailable_status = Bundler.with_unbundled_env do
+          Open3.capture3(
+            unavailable_root_bundle_environment,
+            "bundle", "exec", "ruby", "-e", 'puts "OLD_ROOT_BUNDLE_AVAILABLE"', chdir: monorepo_root
+          )
+        end
+        package_gemfile = File.join(monorepo_root, "react_on_rails", "Gemfile")
+        package_bundle_environment = {
+          "BUNDLE_GEMFILE" => package_gemfile,
+          "BUNDLE_LOCKFILE" => File.join(monorepo_root, "react_on_rails", "Gemfile.lock"),
+          "BUNDLE_FROZEN" => "true"
+        }
+        stdout, stderr, status = Open3.capture3(
+          package_bundle_environment,
           "bundle", "exec", "ruby", stdin_data: root_probe, chdir: monorepo_root
         )
-      end
-      result_line = stdout.lines.find { |line| line.start_with?("ROOT_RAKE_RESULT=") }
+        result_line = stdout.lines.find { |line| line.start_with?("ROOT_RAKE_RESULT=") }
 
-      expect(status).to be_success, "root Rake probe failed:\n#{stdout}\n#{stderr}"
-      expect(result_line).not_to be_nil, "root Rake probe produced no result:\n#{stdout}\n#{stderr}"
-      results = JSON.parse(result_line.delete_prefix("ROOT_RAKE_RESULT="))
-      expect(results.fetch("array_many")).to be(false)
-      expect(results.fetch("empty")).to eq("nil_result" => true, "run_id" => nil)
-      expect(results.fetch("single")).to eq("nil_result" => false, "run_id" => 980_001)
-      expect(results.fetch("ambiguous")).to eq("error_class" => "SystemExit", "status" => 1)
-      expect(stderr).to include("ambiguous concurrent fresh runs")
+        expect(unavailable_status).not_to be_success
+        expect(unavailable_stdout).not_to include("OLD_ROOT_BUNDLE_AVAILABLE")
+        expect(unavailable_stderr).to include("Bundler::GemNotFound")
+        expect(status).to be_success, "root Rake probe failed:\n#{stdout}\n#{stderr}"
+        expect(result_line).not_to be_nil, "root Rake probe produced no result:\n#{stdout}\n#{stderr}"
+        results = JSON.parse(result_line.delete_prefix("ROOT_RAKE_RESULT="))
+        expect(results.fetch("bundle_gemfile")).to eq(package_gemfile)
+        expect(results.fetch("array_many")).to be(false)
+        expect(results.fetch("empty")).to eq("nil_result" => true, "run_id" => nil)
+        expect(results.fetch("single")).to eq("nil_result" => false, "run_id" => 980_001)
+        expect(results.fetch("ambiguous")).to eq("error_class" => "SystemExit", "status" => 1)
+        expect(stderr).to include("ambiguous concurrent fresh runs")
+      end
     end
 
     it "rejects every active status when its conclusion is non-nil" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -208,12 +208,14 @@ RSpec.describe "release.rake helper methods" do
     snapshot["target_version"] = context.fetch(:final_target_version)
   end
 
-  def accelerated_rc_test_issue_comment(id:, body:, tracker: 3823, created_at: "2026-07-14T13:00:00Z", user: nil)
+  def accelerated_rc_test_issue_comment(id:, body:, tracker: 3823, created_at: "2026-07-14T13:00:00Z",
+                                        updated_at: created_at, user: nil)
     {
       "id" => id,
       "body" => body,
       "issue_url" => "https://api.github.com/repos/shakacode/react_on_rails/issues/#{tracker}",
       "created_at" => created_at,
+      "updated_at" => updated_at,
       "user" => user
     }
   end
@@ -2187,6 +2189,25 @@ RSpec.describe "release.rake helper methods" do
       ).to eq(matching_run)
     end
 
+    it "keeps ordinary polling permissive and preserves its missing-URL fallback" do
+      matching_run = {
+        "databaseId" => 2,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release-branch", head_sha:, target_version:
+        ),
+        "headSha" => head_sha
+      }
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug:, ref: "release-branch").and_return([matching_run])
+
+      expect(
+        wait_for_shakaperf_release_gate_run!(repo_slug:, ref: "release-branch", head_sha:, target_version:)
+      ).to eq(matching_run)
+      expect(shakaperf_release_gate_run_url(repo_slug:, run: matching_run))
+        .to eq("https://github.com/shakacode/react_on_rails/actions/runs/2")
+    end
+
     it "ignores stale workflow_dispatch runs for the same head SHA" do
       run_identity = {
         "attempt" => 1,
@@ -2281,6 +2302,77 @@ RSpec.describe "release.rake helper methods" do
   end
 
   describe "#run_accelerated_shakaperf_release_gate!" do
+    it "uses only Ruby core collection APIs when loaded by the real root Rake application" do
+      monorepo_root = File.expand_path("../../..", __dir__)
+      root_probe = <<~'RUBY'
+        require "json"
+        require "rake"
+
+        Rake.application.init
+        Rake.application.load_rakefile
+
+        repo_slug = "shakacode/react_on_rails"
+        ref = "release/17.0.0"
+        head_sha = "d" * 40
+        target_version = "17.0.0.rc.10"
+        earliest_created_at = Time.iso8601("2026-07-14T13:00:00Z")
+        queued_run = {
+          "databaseId" => 980_001,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+          "headSha" => head_sha,
+          "status" => "queued",
+          "conclusion" => nil,
+          "createdAt" => "2026-07-14T13:00:01Z",
+          "startedAt" => nil,
+          "updatedAt" => "2026-07-14T13:00:01Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/980001"
+        }
+        second_run = queued_run.merge(
+          "databaseId" => 980_002,
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/980002"
+        )
+        capture_case = lambda do |runs|
+          result = accelerated_shakaperf_fresh_polling_run!(
+            runs:, repo_slug:, ref:, head_sha:, target_version:, ignored_run_ids: [], earliest_created_at:
+          )
+          { "nil_result" => result.nil?, "run_id" => result&.fetch("databaseId") }
+        rescue SystemExit => error
+          { "error_class" => error.class.name, "status" => error.status }
+        rescue NoMethodError => error
+          { "error_class" => error.class.name, "missing_method" => error.name.to_s }
+        end
+
+        results = {
+          "array_many" => [].respond_to?(:many?),
+          "empty" => capture_case.call([]),
+          "single" => capture_case.call([queued_run]),
+          "ambiguous" => capture_case.call([queued_run, second_run])
+        }
+        puts "ROOT_RAKE_RESULT=#{JSON.generate(results)}"
+      RUBY
+      root_bundle_environment = {
+        "BUNDLE_GEMFILE" => File.join(monorepo_root, "Gemfile"),
+        "BUNDLE_LOCKFILE" => File.join(monorepo_root, "Gemfile.lock")
+      }
+      stdout, stderr, status = Bundler.with_unbundled_env do
+        Open3.capture3(
+          root_bundle_environment,
+          "bundle", "exec", "ruby", stdin_data: root_probe, chdir: monorepo_root
+        )
+      end
+      result_line = stdout.lines.find { |line| line.start_with?("ROOT_RAKE_RESULT=") }
+
+      expect(status).to be_success, "root Rake probe failed:\n#{stdout}\n#{stderr}"
+      expect(result_line).not_to be_nil, "root Rake probe produced no result:\n#{stdout}\n#{stderr}"
+      results = JSON.parse(result_line.delete_prefix("ROOT_RAKE_RESULT="))
+      expect(results.fetch("array_many")).to be(false)
+      expect(results.fetch("empty")).to eq("nil_result" => true, "run_id" => nil)
+      expect(results.fetch("single")).to eq("nil_result" => false, "run_id" => 980_001)
+      expect(results.fetch("ambiguous")).to eq("error_class" => "SystemExit", "status" => 1)
+      expect(stderr).to include("ambiguous concurrent fresh runs")
+    end
+
     it "rejects every active status when its conclusion is non-nil" do
       non_nil_conclusions = ["failure", ""]
       aggregate_failures do
@@ -2316,7 +2408,7 @@ RSpec.describe "release.rake helper methods" do
         shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
         dispatch_shakaperf_release_gate_workflow!: nil
       )
-      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(run)
+      allow(self).to receive(:wait_for_accelerated_shakaperf_release_gate_run!).and_return(run)
       expect(self).not_to receive(:watch_shakaperf_release_gate_run!)
 
       result = run_accelerated_shakaperf_release_gate!(
@@ -2356,7 +2448,7 @@ RSpec.describe "release.rake helper methods" do
         shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
         dispatch_shakaperf_release_gate_workflow!: nil
       )
-      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(run)
+      allow(self).to receive(:wait_for_accelerated_shakaperf_release_gate_run!).and_return(run)
 
       expect do
         run_accelerated_shakaperf_release_gate!(
@@ -2366,7 +2458,7 @@ RSpec.describe "release.rake helper methods" do
           target_version: "17.0.0.rc.10",
           release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
         )
-      end.to raise_error(SystemExit, /active ShakaPerf run.*terminal conclusion/i)
+      end.to raise_error(SystemExit, /ShakaPerf.*(?:contradictory|state|metadata|malformed)/i)
     end
 
     it "blocks a freshly dispatched run that is already known to have failed" do
@@ -2391,7 +2483,7 @@ RSpec.describe "release.rake helper methods" do
         shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
         dispatch_shakaperf_release_gate_workflow!: nil
       )
-      allow(self).to receive(:wait_for_shakaperf_release_gate_run!).and_return(run)
+      allow(self).to receive(:wait_for_accelerated_shakaperf_release_gate_run!).and_return(run)
 
       expect do
         run_accelerated_shakaperf_release_gate!(
@@ -2463,7 +2555,7 @@ RSpec.describe "release.rake helper methods" do
           target_version: "17.0.0.rc.10",
           release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
         )
-      end.to raise_error(SystemExit, /active ShakaPerf run.*terminal conclusion/i)
+      end.to raise_error(SystemExit, /ShakaPerf.*(?:contradictory|state|metadata|malformed)/i)
     end
 
     it "ignores a same-SHA run dispatched for another target version" do
@@ -2515,7 +2607,7 @@ RSpec.describe "release.rake helper methods" do
           target_version: "17.0.0.rc.10",
           release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
         )
-      end.to raise_error(SystemExit, /identity is unknown/)
+      end.to raise_error(SystemExit, /identity.*(?:unknown|malformed)/)
     end
 
     it "reuses a completed exact-head run only after verifying its evidence" do
@@ -2609,7 +2701,7 @@ RSpec.describe "release.rake helper methods" do
           target_version: "17.0.0.rc.10",
           release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
         )
-      end.to raise_error(SystemExit, /ShakaPerf.*unknown.*refusing unaudited publication/i)
+      end.to raise_error(SystemExit, /ShakaPerf.*(?:unknown|malformed).*refusing unaudited publication/i)
     end
 
     it "reuses a completed pre-run only when runtime-equivalent evidence verifies" do
@@ -2642,6 +2734,1290 @@ RSpec.describe "release.rake helper methods" do
       )
 
       expect(result).to include(status: "success", run_id: 222_222)
+    end
+
+    it "blocks the latest completed same-target failed or unknown pre-run before asynchronous dispatch" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      run_url = "https://github.com/shakacode/react_on_rails/actions/runs/222222"
+      base_prerun = {
+        "databaseId" => 222_222,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref:, head_sha: "e" * 40, target_version:
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => run_url
+      }
+      cases = {
+        "known failure" => ["failure", %r{known ShakaPerf failure.*actions/runs/222222}im],
+        "unknown conclusion" => ["future_conclusion", /ShakaPerf.*(?:unknown|malformed)/i]
+      }
+      queued_run = base_prerun.merge(
+        "databaseId" => 333_333,
+        "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+        "headSha" => head_sha,
+        "status" => "queued",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => nil,
+        "updatedAt" => "2026-07-14T13:00:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/333333"
+      )
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil,
+        wait_for_accelerated_shakaperf_release_gate_run!: queued_run
+      )
+
+      aggregate_failures do
+        cases.each do |label, (conclusion, message)|
+          prerun = base_prerun.merge("conclusion" => conclusion)
+          allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+            .with(repo_slug: "shakacode/react_on_rails", ref:).and_return([prerun])
+
+          expect do
+            run_accelerated_shakaperf_release_gate!(
+              monorepo_root: "/tmp/repo",
+              ref:,
+              head_sha:,
+              target_version:,
+              release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+            )
+          end.to raise_error(SystemExit, message), label
+        end
+      end
+      expect(self).not_to have_received(:dispatch_shakaperf_release_gate_workflow!)
+    end
+
+    it "blocks completed same-target failures and unknown conclusions across mixed unordered candidate sets" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_prerun = lambda do |candidate_sha:, run_id:, conclusion:, created_at:|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version:
+          ),
+          "headSha" => candidate_sha,
+          "status" => "completed",
+          "conclusion" => conclusion,
+          "createdAt" => created_at,
+          "startedAt" => "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      malformed_success = build_prerun.call(
+        candidate_sha: "f" * 40, run_id: 333_333, conclusion: "success", created_at: nil
+      )
+      ordered_success = build_prerun.call(
+        candidate_sha: "a" * 40, run_id: 444_444, conclusion: "success",
+        created_at: "2026-07-14T13:00:00Z"
+      )
+      queued_run = build_prerun.call(
+        candidate_sha: head_sha, run_id: 555_555, conclusion: nil,
+        created_at: "2026-07-14T14:00:00Z"
+      ).merge("status" => "queued", "startedAt" => nil)
+      blocking_conclusions = SHAKAPERF_RELEASE_GATE_TERMINAL_CONCLUSIONS - ["success"]
+      cases = blocking_conclusions.to_h do |conclusion|
+        [conclusion, /ShakaPerf.*(?:failure|unknown|malformed|metadata)/i]
+      end.merge("future_conclusion" => /ShakaPerf.*(?:unknown|malformed|metadata)/i)
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T14:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil,
+        wait_for_accelerated_shakaperf_release_gate_run!: queued_run,
+        shakaperf_release_gate_run_evidence_rejection: nil
+      )
+
+      aggregate_failures do
+        cases.each_with_index do |(conclusion, message), index|
+          ordered_blocker = build_prerun.call(
+            candidate_sha: "e" * 40,
+            run_id: 222_222 + index,
+            conclusion:,
+            created_at: "2026-07-14T12:00:00Z"
+          )
+          unordered_blocker = ordered_blocker.merge(
+            "databaseId" => 666_666 + index,
+            "headSha" => "b" * 40,
+            "displayTitle" => shakaperf_release_gate_display_title(
+              ref:, head_sha: "b" * 40, target_version:
+            ),
+            "createdAt" => nil,
+            "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{666_666 + index}"
+          )
+          candidate_sets = {
+            "ordered #{conclusion} with malformed success" => [ordered_blocker, malformed_success],
+            "unordered #{conclusion} with ordered success" => [unordered_blocker, ordered_success]
+          }
+
+          candidate_sets.each do |label, runs|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, message), label
+          end
+        end
+      end
+      expect(self).not_to have_received(:dispatch_shakaperf_release_gate_workflow!)
+    end
+
+    it "reuses a deterministically newer valid success despite an older ordered failure" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_prerun = lambda do |candidate_sha:, run_id:, conclusion:, created_at:|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version:
+          ),
+          "headSha" => candidate_sha,
+          "status" => "completed",
+          "conclusion" => conclusion,
+          "createdAt" => created_at,
+          "startedAt" => "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      older_failure = build_prerun.call(
+        candidate_sha: "e" * 40, run_id: 222_222, conclusion: "failure",
+        created_at: "2026-07-14T11:00:00Z"
+      )
+      newer_success = build_prerun.call(
+        candidate_sha: "f" * 40, run_id: 333_333, conclusion: "success",
+        created_at: "2026-07-14T12:00:00Z"
+      )
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref:)
+        .and_return([older_failure, newer_success])
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      result = run_accelerated_shakaperf_release_gate!(
+        monorepo_root: "/tmp/repo",
+        ref:,
+        head_sha:,
+        target_version:,
+        release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+      )
+
+      expect(result).to include(status: "success", run_id: 333_333, candidate_sha: "f" * 40)
+    end
+
+    it "fails closed on malformed exact-target identity instead of reusing or dispatching" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_run = lambda do |candidate_sha:, run_id:, conclusion: "success", created_at: "2026-07-14T12:00:00Z"|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version:
+          ),
+          "headSha" => candidate_sha,
+          "status" => "completed",
+          "conclusion" => conclusion,
+          "createdAt" => created_at,
+          "startedAt" => "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      reusable_success = build_run.call(candidate_sha: "f" * 40, run_id: 900_001)
+      pre_run_failure = build_run.call(candidate_sha: "e" * 40, run_id: 900_002, conclusion: "failure")
+      exact_head_failure = build_run.call(candidate_sha: head_sha, run_id: 900_003, conclusion: "failure")
+      malformed_head_success = build_run.call(candidate_sha: "malformed-sha", run_id: 900_004)
+      identity_cases = {
+        "pre-run missing attempt" => pre_run_failure.except("attempt"),
+        "pre-run zero attempt" => pre_run_failure.merge("attempt" => 0),
+        "pre-run non-integer attempt" => pre_run_failure.merge("attempt" => "1"),
+        "exact-head missing attempt" => exact_head_failure.except("attempt"),
+        "exact-head zero attempt" => exact_head_failure.merge("attempt" => 0),
+        "exact-head non-integer attempt" => exact_head_failure.merge("attempt" => "1"),
+        "missing title" => pre_run_failure.except("displayTitle"),
+        "non-String title" => pre_run_failure.merge("displayTitle" => 17),
+        "title and head mismatch" => pre_run_failure.merge(
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: "a" * 40, target_version:
+          )
+        ),
+        "missing head" => pre_run_failure.except("headSha"),
+        "malformed head success" => malformed_head_success
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      aggregate_failures do
+        identity_cases.each do |label, malformed_run|
+          [[malformed_run, reusable_success], [reusable_success, malformed_run]].each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, /ShakaPerf.*(?:identity|state|failure|unknown|malformed)/i),
+                   "#{label}, order #{order}"
+          end
+        end
+      end
+    end
+
+    it "totally classifies unordered same-target state before reusing ordered success" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_run = lambda do |candidate_sha:, run_id:, status:, conclusion:, created_at:|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version:
+          ),
+          "headSha" => candidate_sha,
+          "status" => status,
+          "conclusion" => conclusion,
+          "createdAt" => created_at,
+          "startedAt" => "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      ordered_success = build_run.call(
+        candidate_sha: "e" * 40,
+        run_id: 910_001,
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-07-14T12:00:00Z"
+      )
+      queued_run = build_run.call(
+        candidate_sha: head_sha,
+        run_id: 910_003,
+        status: "queued",
+        conclusion: nil,
+        created_at: "2026-07-14T14:00:00Z"
+      ).merge("startedAt" => nil)
+      cases = {
+        "completed success without ordering timestamps" => ["completed", "success", :block],
+        "completed known failure" => ["completed", "failure", :block],
+        "completed unknown conclusion" => ["completed", "future_conclusion", :block],
+        "completed nil conclusion" => ["completed", nil, :block],
+        "active nil conclusion without ordering timestamps" => ["in_progress", nil, :block],
+        "active terminal conclusion" => ["in_progress", "failure", :block],
+        "unknown status nil conclusion" => ["future_status", nil, :block],
+        "unknown status known conclusion" => ["future_status", "failure", :block],
+        "unknown status unknown conclusion" => ["future_status", "future_conclusion", :block],
+        "malformed status" => [17, nil, :block],
+        "malformed conclusion" => ["completed", ["success"], :block]
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_run_evidence_rejection: nil,
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T14:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil,
+        wait_for_accelerated_shakaperf_release_gate_run!: queued_run
+      )
+
+      aggregate_failures do
+        cases.each_with_index do |(label, (status, conclusion, expected)), index|
+          unordered_run = build_run.call(
+            candidate_sha: "f" * 40,
+            run_id: 920_000 + index,
+            status:,
+            conclusion:,
+            created_at: nil
+          )
+          [[unordered_run, ordered_success], [ordered_success, unordered_run]].each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            if expected == :block
+              expect do
+                run_accelerated_shakaperf_release_gate!(
+                  monorepo_root: "/tmp/repo",
+                  ref:,
+                  head_sha:,
+                  target_version:,
+                  release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+                )
+              end.to raise_error(SystemExit, /ShakaPerf.*(?:state|failure|unknown|contradictory|malformed)/i),
+                     "#{label}, order #{order}"
+            else
+              result = run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+              expected_status = expected == :reuse ? "success" : "pending"
+              expected_run_id = expected == :reuse ? 910_001 : 910_003
+              expect(result).to include(status: expected_status, run_id: expected_run_id),
+                                "#{label}, order #{order}"
+            end
+          end
+        end
+      end
+    end
+
+    it "lets blocking unordered and selected evidence outrank exact-head dispatch in every array order" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_run = lambda do |candidate_sha:, run_id:, status:, conclusion:, created_at:|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version:
+          ),
+          "headSha" => candidate_sha,
+          "status" => status,
+          "conclusion" => conclusion,
+          "createdAt" => created_at,
+          "startedAt" => status == "queued" ? nil : "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      unordered_active = build_run.call(
+        candidate_sha: "e" * 40, run_id: 925_001, status: "in_progress", conclusion: nil, created_at: nil
+      )
+      second_unordered_active = build_run.call(
+        candidate_sha: "f" * 40, run_id: 925_002, status: "queued", conclusion: nil, created_at: nil
+      )
+      unordered_failure = build_run.call(
+        candidate_sha: "a" * 40, run_id: 925_003, status: "completed", conclusion: "failure", created_at: nil
+      )
+      unordered_unknown = build_run.call(
+        candidate_sha: "b" * 40, run_id: 925_004, status: "future_status", conclusion: nil, created_at: nil
+      )
+      selected_prerun_failure = build_run.call(
+        candidate_sha: "c" * 40, run_id: 925_005, status: "completed", conclusion: "cancelled",
+        created_at: "2026-07-14T12:00:00Z"
+      )
+      selected_exact_failure = build_run.call(
+        candidate_sha: head_sha, run_id: 925_006, status: "completed", conclusion: "timed_out",
+        created_at: "2026-07-14T12:00:00Z"
+      )
+      queued_run = build_run.call(
+        candidate_sha: head_sha, run_id: 925_007, status: "queued", conclusion: nil,
+        created_at: "2026-07-14T13:00:00Z"
+      )
+      blocking_sets = {
+        "later unordered failure" => [unordered_active, second_unordered_active, unordered_failure],
+        "later unordered unknown state" => [unordered_active, second_unordered_active, unordered_unknown],
+        "selected ordered pre-run failure" => [unordered_active, selected_prerun_failure],
+        "selected exact-head failure" => [unordered_active, selected_exact_failure]
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil,
+        wait_for_accelerated_shakaperf_release_gate_run!: queued_run
+      )
+
+      aggregate_failures do
+        blocking_sets.each do |label, records|
+          [records, records.reverse].each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, /ShakaPerf.*(?:failure|state|unknown|contradictory|malformed)/i),
+                   "#{label}, order #{order}"
+          end
+        end
+      end
+      expect(self).not_to have_received(:dispatch_shakaperf_release_gate_workflow!)
+    end
+
+    it "validates complete accelerated run metadata before pending, dispatch, or unrelated filtering" do
+      target_version = "17.0.0.rc.10"
+      unrelated_version = "17.0.0.rc.9"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_run = lambda do |candidate_sha:, run_id:, target: target_version, status: "completed",
+                             conclusion: "success"|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version: target
+          ),
+          "headSha" => candidate_sha,
+          "status" => status,
+          "conclusion" => conclusion,
+          "createdAt" => "2026-07-14T12:00:00Z",
+          "startedAt" => status == "queued" ? nil : "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      target_success = build_run.call(candidate_sha: "e" * 40, run_id: 926_001)
+      exact_active = build_run.call(
+        candidate_sha: head_sha, run_id: 926_002, status: "queued", conclusion: nil
+      )
+      unordered_active = build_run.call(
+        candidate_sha: "f" * 40, run_id: 926_003, status: "in_progress", conclusion: nil
+      ).merge("createdAt" => nil)
+      unrelated = build_run.call(
+        candidate_sha: "a" * 40, run_id: 926_004, target: unrelated_version
+      )
+      malformed_cases = {
+        "exact active missing URL" => [exact_active.except("url")],
+        "exact active non-String URL" => [exact_active.merge("url" => 17)],
+        "unordered active empty URL" => [unordered_active.merge("url" => ""), target_success],
+        "unordered active malformed URL" => [unordered_active.merge("url" => "javascript:alert(1)"), target_success],
+        "unrelated missing run id" => [unrelated.except("databaseId"), target_success],
+        "unrelated missing attempt" => [unrelated.except("attempt"), target_success],
+        "unrelated missing URL" => [unrelated.except("url"), target_success],
+        "unrelated non-HTTPS URL" => [unrelated.merge("url" => "http://example.test/run"), target_success],
+        "unrelated malformed URL" => [unrelated.merge("url" => "https://[invalid"), target_success]
+      }
+      queued_run = exact_active.merge(
+        "databaseId" => 926_005,
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/926005"
+      )
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil,
+        wait_for_accelerated_shakaperf_release_gate_run!: queued_run
+      )
+
+      aggregate_failures do
+        malformed_cases.each do |label, records|
+          [records, records.reverse].uniq.each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, /ShakaPerf.*(?:identity|metadata|unknown|malformed)/i),
+                   "#{label}, order #{order}"
+          end
+        end
+      end
+      expect(self).not_to have_received(:dispatch_shakaperf_release_gate_workflow!)
+    end
+
+    it "totally validates state and timestamps before target filtering, ordering, reuse, or dispatch" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_run = lambda do |candidate_sha:, run_id:, target: target_version|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version: target
+          ),
+          "headSha" => candidate_sha,
+          "status" => "completed",
+          "conclusion" => "success",
+          "createdAt" => "2026-07-14T12:00:00Z",
+          "startedAt" => "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      reusable_success = build_run.call(candidate_sha: "e" * 40, run_id: 926_100)
+      unrelated = build_run.call(
+        candidate_sha: "a" * 40, run_id: 926_200, target: "17.0.0.rc.9"
+      )
+      malformed_cases = {
+        "unrelated missing createdAt" => unrelated.except("createdAt"),
+        "unrelated missing updatedAt" => unrelated.except("updatedAt"),
+        "unrelated completed missing startedAt" => unrelated.merge("startedAt" => nil),
+        "unrelated malformed createdAt" => unrelated.merge("createdAt" => "not-a-time"),
+        "unrelated created after started" => unrelated.merge("createdAt" => "2026-07-14T12:01:00Z"),
+        "unrelated started after updated" => unrelated.merge("startedAt" => "2026-07-14T13:00:00Z"),
+        "unrelated unknown status" => unrelated.merge("status" => "future_status", "conclusion" => nil),
+        "unrelated active terminal conclusion" => unrelated.merge(
+          "status" => "in_progress", "conclusion" => "failure"
+        ),
+        "same-target completed missing createdAt" => reusable_success.except("createdAt"),
+        "same-target completed missing updatedAt" => reusable_success.except("updatedAt"),
+        "same-target completed missing startedAt" => reusable_success.merge("startedAt" => nil),
+        "same-target completed nil conclusion" => reusable_success.merge("conclusion" => nil),
+        "same-target queued malformed timestamps" => reusable_success.merge(
+          "status" => "queued", "conclusion" => nil, "createdAt" => nil, "startedAt" => nil
+        ),
+        "same-target in-progress missing startedAt" => reusable_success.merge(
+          "status" => "in_progress", "conclusion" => nil, "startedAt" => nil
+        )
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil,
+        wait_for_accelerated_shakaperf_release_gate_run!: reusable_success.merge(
+          "databaseId" => 926_300,
+          "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+          "headSha" => head_sha,
+          "status" => "queued",
+          "conclusion" => nil,
+          "createdAt" => "2026-07-14T13:00:00Z",
+          "startedAt" => nil,
+          "updatedAt" => "2026-07-14T13:00:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/926300"
+        )
+      )
+
+      aggregate_failures do
+        malformed_cases.each do |label, malformed_run|
+          records = label.start_with?("unrelated") ? [malformed_run, reusable_success] : [malformed_run]
+          [records, records.reverse].uniq.each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, /ShakaPerf.*(?:metadata|state|unknown|malformed|timestamp)/i),
+                   "#{label}, order #{order}"
+          end
+        end
+      end
+      expect(self).not_to have_received(:dispatch_shakaperf_release_gate_workflow!)
+    end
+
+    it "requires the exact canonical accelerated Actions run URL before selection or pending dispatch" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      run_id = 926_400
+      canonical_run = {
+        "databaseId" => run_id,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+        "headSha" => head_sha,
+        "status" => "queued",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => nil,
+        "updatedAt" => "2026-07-14T13:00:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+      }
+      malformed_urls = {
+        "wrong host" => "https://example.com/shakacode/react_on_rails/actions/runs/#{run_id}",
+        "wrong repository" => "https://github.com/shakacode/other/actions/runs/#{run_id}",
+        "wrong path" => "https://github.com/shakacode/react_on_rails/actions/workflows/#{run_id}",
+        "wrong run ID" => "https://github.com/shakacode/react_on_rails/actions/runs/999999",
+        "query" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}?x=1",
+        "fragment" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}#summary",
+        "port" => "https://github.com:443/shakacode/react_on_rails/actions/runs/#{run_id}",
+        "missing" => nil,
+        "malformed" => "https://[invalid",
+        "non-String" => 17
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil,
+        shakaperf_release_gate_run_evidence_rejection: nil
+      )
+
+      aggregate_failures do
+        malformed_urls.each do |label, url|
+          malformed_run = canonical_run.merge("url" => url)
+          allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+            .with(repo_slug: "shakacode/react_on_rails", ref:).and_return([malformed_run])
+          expect do
+            run_accelerated_shakaperf_release_gate!(
+              monorepo_root: "/tmp/repo",
+              ref:,
+              head_sha:,
+              target_version:,
+              release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+            )
+          end.to raise_error(SystemExit, /ShakaPerf.*(?:URL|identity|metadata|malformed)/i), label
+
+          allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+            .with(repo_slug: "shakacode/react_on_rails", ref:).and_return([])
+          allow(self).to receive(:wait_for_accelerated_shakaperf_release_gate_run!).and_return(malformed_run)
+          expect do
+            run_accelerated_shakaperf_release_gate!(
+              monorepo_root: "/tmp/repo",
+              ref:,
+              head_sha:,
+              target_version:,
+              release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+            )
+          end.to raise_error(SystemExit, /ShakaPerf.*(?:URL|identity|metadata|malformed)/i),
+                 "fresh #{label}"
+        end
+      end
+    end
+
+    it "rejects incomplete state metadata returned by a fresh accelerated dispatch" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      fresh_run = {
+        "databaseId" => 926_500,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+        "headSha" => head_sha,
+        "status" => "queued",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => nil,
+        "updatedAt" => "2026-07-14T13:00:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/926500"
+      }
+      malformed_runs = {
+        "missing createdAt" => fresh_run.except("createdAt"),
+        "missing updatedAt" => fresh_run.except("updatedAt"),
+        "in-progress missing startedAt" => fresh_run.merge("status" => "in_progress"),
+        "completed missing startedAt" => fresh_run.merge("status" => "completed", "conclusion" => "success"),
+        "created after updated" => fresh_run.merge(
+          "createdAt" => "2026-07-14T13:01:00Z", "updatedAt" => "2026-07-14T13:00:00Z"
+        )
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref:).and_return([])
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil
+      )
+
+      aggregate_failures do
+        malformed_runs.each do |label, malformed_run|
+          allow(self).to receive(:wait_for_accelerated_shakaperf_release_gate_run!).and_return(malformed_run)
+          expect do
+            run_accelerated_shakaperf_release_gate!(
+              monorepo_root: "/tmp/repo",
+              ref:,
+              head_sha:,
+              target_version:,
+              release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+            )
+          end.to raise_error(SystemExit, /ShakaPerf.*(?:metadata|state|unknown|malformed|timestamp)/i), label
+        end
+      end
+    end
+
+    it "totally validates every accelerated polling response before filtering or returning a fresh run" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      release_started_at = Time.iso8601("2026-07-14T12:59:00Z")
+      dispatch_started_at = Time.iso8601("2026-07-14T13:00:00Z")
+      build_run = lambda do |run_id:, candidate_sha: head_sha, version: target_version, status: "queued",
+                             conclusion: nil, created_at: "2026-07-14T13:00:01Z",
+                             started_at: nil, updated_at: "2026-07-14T13:00:01Z"|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version: version
+          ),
+          "headSha" => candidate_sha,
+          "status" => status,
+          "conclusion" => conclusion,
+          "createdAt" => created_at,
+          "startedAt" => started_at,
+          "updatedAt" => updated_at,
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      fresh_run = build_run.call(run_id: 970_001)
+      malformed_run = build_run.call(run_id: 970_002)
+      malformed_identity = shakaperf_release_gate_display_title(
+        ref:, head_sha: "b" * 40, target_version:
+      )
+      malformed_cases = {
+        "non-Hash member" => 17,
+        "missing databaseId" => malformed_run.except("databaseId"),
+        "zero databaseId" => malformed_run.merge("databaseId" => 0),
+        "negative databaseId" => malformed_run.merge("databaseId" => -1),
+        "non-Integer databaseId" => malformed_run.merge("databaseId" => "970002"),
+        "missing attempt" => malformed_run.except("attempt"),
+        "zero attempt" => malformed_run.merge("attempt" => 0),
+        "negative attempt" => malformed_run.merge("attempt" => -1),
+        "non-Integer attempt" => malformed_run.merge("attempt" => "1"),
+        "missing title" => malformed_run.except("displayTitle"),
+        "empty title" => malformed_run.merge("displayTitle" => ""),
+        "non-String title" => malformed_run.merge("displayTitle" => 17),
+        "title and head mismatch" => malformed_run.merge("displayTitle" => malformed_identity),
+        "missing head" => malformed_run.except("headSha"),
+        "empty head" => malformed_run.merge("headSha" => ""),
+        "non-String head" => malformed_run.merge("headSha" => 17),
+        "unknown status" => malformed_run.merge("status" => "future_status"),
+        "non-String status" => malformed_run.merge("status" => :queued),
+        "active terminal conclusion" => malformed_run.merge("conclusion" => "failure"),
+        "completed nil conclusion" => malformed_run.merge(
+          "status" => "completed", "conclusion" => nil, "startedAt" => "2026-07-14T13:00:02Z",
+          "updatedAt" => "2026-07-14T13:00:03Z"
+        ),
+        "completed unknown conclusion" => malformed_run.merge(
+          "status" => "completed", "conclusion" => "future_conclusion",
+          "startedAt" => "2026-07-14T13:00:02Z", "updatedAt" => "2026-07-14T13:00:03Z"
+        ),
+        "missing createdAt" => malformed_run.except("createdAt"),
+        "malformed createdAt" => malformed_run.merge("createdAt" => "not-a-time"),
+        "missing updatedAt" => malformed_run.except("updatedAt"),
+        "malformed updatedAt" => malformed_run.merge("updatedAt" => "not-a-time"),
+        "created after updated" => malformed_run.merge(
+          "createdAt" => "2026-07-14T13:00:03Z", "updatedAt" => "2026-07-14T13:00:02Z"
+        ),
+        "in-progress nil startedAt" => malformed_run.merge(
+          "status" => "in_progress", "startedAt" => nil, "updatedAt" => "2026-07-14T13:00:03Z"
+        ),
+        "completed nil startedAt" => malformed_run.merge(
+          "status" => "completed", "conclusion" => "success", "startedAt" => nil,
+          "updatedAt" => "2026-07-14T13:00:03Z"
+        ),
+        "malformed startedAt" => malformed_run.merge(
+          "status" => "in_progress", "startedAt" => "not-a-time",
+          "updatedAt" => "2026-07-14T13:00:03Z"
+        ),
+        "started before creation" => malformed_run.merge(
+          "status" => "in_progress", "createdAt" => "2026-07-14T13:00:02Z",
+          "startedAt" => "2026-07-14T13:00:01Z", "updatedAt" => "2026-07-14T13:00:03Z"
+        ),
+        "started after update" => malformed_run.merge(
+          "status" => "in_progress", "startedAt" => "2026-07-14T13:00:04Z",
+          "updatedAt" => "2026-07-14T13:00:03Z"
+        )
+      }
+      url_mutations = {
+        "wrong host" => "https://example.com/shakacode/react_on_rails/actions/runs/970002",
+        "wrong owner" => "https://github.com/other/react_on_rails/actions/runs/970002",
+        "wrong repository" => "https://github.com/shakacode/other/actions/runs/970002",
+        "case variant" => "https://github.com/ShakaCode/react_on_rails/actions/runs/970002",
+        "repository suffix" => "https://github.com/shakacode/react_on_rails.evil/actions/runs/970002",
+        "wrong path" => "https://github.com/shakacode/react_on_rails/actions/workflows/970002",
+        "wrong run ID" => "https://github.com/shakacode/react_on_rails/actions/runs/999999",
+        "extra path segment" => "https://github.com/shakacode/react_on_rails/actions/runs/970002/attempts/1",
+        "port" => "https://github.com:443/shakacode/react_on_rails/actions/runs/970002",
+        "query" => "https://github.com/shakacode/react_on_rails/actions/runs/970002?attempt=1",
+        "fragment" => "https://github.com/shakacode/react_on_rails/actions/runs/970002#summary",
+        "userinfo" => "https://user@github.com/shakacode/react_on_rails/actions/runs/970002",
+        "missing" => nil,
+        "empty" => "",
+        "malformed" => "https://[invalid",
+        "HTTP" => "http://github.com/shakacode/react_on_rails/actions/runs/970002",
+        "non-String" => 17,
+        "generic HTTPS" => "https://example.org/run/970002"
+      }
+      dispatch_count = 0
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: dispatch_started_at,
+        shakaperf_release_gate_run_evidence_rejection: nil
+      )
+      allow(self).to receive(:dispatch_shakaperf_release_gate_workflow!) { dispatch_count += 1 }
+      run_with_poll = lambda do |poll_response, initial_runs: []|
+        responses = [initial_runs, poll_response]
+        allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+          .with(repo_slug: "shakacode/react_on_rails", ref:).and_wrap_original do
+            responses.empty? ? poll_response : responses.shift
+          end
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref:,
+          head_sha:,
+          target_version:,
+          release_started_at:
+        )
+      end
+      expected_dispatches = 0
+
+      aggregate_failures do
+        expect do
+          expected_dispatches += 1
+          run_with_poll.call({ "unexpected" => "collection" })
+        end.to raise_error(SystemExit, /collection.*(?:unknown|malformed)/i), "non-Array collection"
+
+        malformed_cases.each do |label, invalid_run|
+          [[fresh_run, invalid_run], [invalid_run, fresh_run]].each_with_index do |runs, order|
+            expect do
+              expected_dispatches += 1
+              run_with_poll.call(runs)
+            end.to raise_error(SystemExit, /ShakaPerf.*(?:identity|metadata|state|unknown|malformed|timestamp)/i),
+                   "#{label}, order #{order}"
+          end
+        end
+
+        url_mutations.each do |label, url|
+          same_target = malformed_run.merge("url" => url)
+          unrelated = same_target.merge(
+            "displayTitle" => shakaperf_release_gate_display_title(
+              ref:, head_sha: "a" * 40, target_version: "17.0.0.rc.9"
+            ),
+            "headSha" => "a" * 40
+          )
+          { "same target" => same_target, "canonical unrelated target" => unrelated }.each do |scope, invalid_run|
+            [[fresh_run, invalid_run], [invalid_run, fresh_run]].each_with_index do |runs, order|
+              expect do
+                expected_dispatches += 1
+                run_with_poll.call(runs)
+              end.to raise_error(SystemExit, /ShakaPerf.*(?:URL|identity|metadata|unknown|malformed)/i),
+                     "#{scope} #{label}, order #{order}"
+            end
+          end
+        end
+
+        valid_old_run = build_run.call(
+          run_id: 970_099,
+          candidate_sha: "a" * 40,
+          version: "17.0.0.rc.9",
+          status: "completed",
+          conclusion: "success",
+          started_at: "2026-07-14T12:00:01Z",
+          created_at: "2026-07-14T12:00:00Z",
+          updated_at: "2026-07-14T12:00:02Z"
+        )
+        malformed_ignored = malformed_run.merge(
+          "databaseId" => 970_099,
+          "url" => "https://example.com/shakacode/react_on_rails/actions/runs/970099"
+        )
+        [[fresh_run, malformed_ignored], [malformed_ignored, fresh_run]].each_with_index do |runs, order|
+          expect do
+            expected_dispatches += 1
+            run_with_poll.call(runs, initial_runs: [valid_old_run])
+          end.to raise_error(SystemExit, /ShakaPerf.*(?:URL|identity|metadata|unknown|malformed)/i),
+                 "malformed ignored old ID, order #{order}"
+        end
+
+        malformed_predispatch = malformed_run.merge("createdAt" => "not-a-time")
+        [[fresh_run, malformed_predispatch], [malformed_predispatch, fresh_run]].each_with_index do |runs, order|
+          expect do
+            expected_dispatches += 1
+            run_with_poll.call(runs)
+          end.to raise_error(SystemExit, /ShakaPerf.*(?:identity|metadata|unknown|malformed|timestamp)/i),
+                 "malformed pre-dispatch timestamp, order #{order}"
+        end
+      end
+
+      expect(dispatch_count).to eq(expected_dispatches)
+    end
+
+    it "rejects ambiguous or blocking concurrent accelerated fresh runs independent of polling order" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      release_started_at = Time.iso8601("2026-07-14T12:59:00Z")
+      build_run = lambda do |run_id:, status: "queued", conclusion: nil|
+        started_at = status == "queued" ? nil : "2026-07-14T13:00:02Z"
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+          "headSha" => head_sha,
+          "status" => status,
+          "conclusion" => conclusion,
+          "createdAt" => "2026-07-14T13:00:01Z",
+          "startedAt" => started_at,
+          "updatedAt" => "2026-07-14T13:00:03Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      pending_run = build_run.call(run_id: 971_001)
+      successful_run = build_run.call(run_id: 971_002, status: "completed", conclusion: "success")
+      failed_run = build_run.call(run_id: 971_003, status: "completed", conclusion: "failure")
+      unknown_run = build_run.call(run_id: 971_004, status: "future_status")
+      conflicting_duplicate = pending_run.merge(
+        "status" => "completed",
+        "conclusion" => "success",
+        "startedAt" => "2026-07-14T13:00:02Z"
+      )
+      active_terminal = build_run.call(run_id: 971_005, status: "in_progress", conclusion: "failure")
+      ambiguous_cases = {
+        "multiple eligible pending and success" => [pending_run, successful_run],
+        "pending beside known failure" => [pending_run, failed_run],
+        "success beside known failure" => [successful_run, failed_run],
+        "pending beside unknown state" => [pending_run, unknown_run],
+        "success beside contradictory active state" => [successful_run, active_terminal],
+        "conflicting duplicate and equal ordering identity" => [pending_run, conflicting_duplicate]
+      }
+      dispatch_count = 0
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        shakaperf_release_gate_run_evidence_rejection: nil
+      )
+      allow(self).to receive(:dispatch_shakaperf_release_gate_workflow!) { dispatch_count += 1 }
+      run_with_poll = lambda do |poll_response|
+        responses = [[], poll_response]
+        allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+          .with(repo_slug: "shakacode/react_on_rails", ref:).and_wrap_original do
+            responses.empty? ? poll_response : responses.shift
+          end
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref:,
+          head_sha:,
+          target_version:,
+          release_started_at:
+        )
+      end
+      expected_dispatches = 0
+
+      aggregate_failures do
+        ambiguous_cases.each do |label, runs|
+          [runs, runs.reverse].uniq.each_with_index do |ordered_runs, order|
+            expect do
+              expected_dispatches += 1
+              run_with_poll.call(ordered_runs)
+            end.to raise_error(SystemExit, /ShakaPerf.*(?:ambiguous|duplicate|conflicting|unknown|malformed)/i),
+                   "#{label}, order #{order}"
+          end
+        end
+
+        canonical_duplicate_result = begin
+          expected_dispatches += 1
+          run_with_poll.call([pending_run, pending_run.dup])
+        end
+        expect(canonical_duplicate_result).to include(status: "pending", run_id: 971_001)
+
+        queued_result = begin
+          expected_dispatches += 1
+          run_with_poll.call([pending_run])
+        end
+        expect(queued_result).to include(status: "pending", run_id: 971_001)
+
+        unrelated = pending_run.merge(
+          "databaseId" => 971_006,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: "a" * 40, target_version: "17.0.0.rc.9"
+          ),
+          "headSha" => "a" * 40,
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/971006"
+        )
+        unrelated_result = begin
+          expected_dispatches += 1
+          run_with_poll.call([unrelated, pending_run])
+        end
+        expect(unrelated_result).to include(status: "pending", run_id: 971_001)
+      end
+
+      expect(dispatch_count).to eq(expected_dispatches)
+    end
+
+    it "does not expose or synthesize a URL for a malformed known failure" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      malformed_failure = {
+        "databaseId" => 927_001,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+        "headSha" => head_sha,
+        "status" => "completed",
+        "conclusion" => "failure",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z"
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref:).and_return([malformed_failure])
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      expect do
+        run_accelerated_shakaperf_release_gate!(
+          monorepo_root: "/tmp/repo",
+          ref:,
+          head_sha:,
+          target_version:,
+          release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+        )
+      end.to raise_error(SystemExit) { |error|
+        expect(error.message).to match(/ShakaPerf.*(?:identity|metadata|unknown|malformed)/i)
+        expect(error.message).not_to include("https://github.com/shakacode/react_on_rails/actions/runs/927001")
+      }
+    end
+
+    it "rejects conflicting duplicate identities and equal ordering keys independent of array order" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      success = {
+        "databaseId" => 930_001,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref:, head_sha: "e" * 40, target_version:
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/930001"
+      }
+      equal_key_failure = success.merge("conclusion" => "failure")
+      conflicting_identity = success.merge(
+        "conclusion" => "failure",
+        "updatedAt" => "2026-07-14T12:45:00Z"
+      )
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      aggregate_failures do
+        {
+          "equal key" => equal_key_failure,
+          "same run identity with different ordering metadata" => conflicting_identity
+        }.each do |label, conflict|
+          [[success, conflict], [conflict, success]].each_with_index do |runs, order|
+            allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+              .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+
+            expect do
+              run_accelerated_shakaperf_release_gate!(
+                monorepo_root: "/tmp/repo",
+                ref:,
+                head_sha:,
+                target_version:,
+                release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+              )
+            end.to raise_error(SystemExit, /ShakaPerf.*(?:duplicate|conflicting|unknown)/i),
+                   "#{label}, order #{order}"
+          end
+        end
+      end
+    end
+
+    it "collapses canonically identical duplicates and preserves deterministic newer-run policy" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      build_run = lambda do |candidate_sha:, run_id:, conclusion:, created_at:|
+        {
+          "databaseId" => run_id,
+          "attempt" => 1,
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: candidate_sha, target_version:
+          ),
+          "headSha" => candidate_sha,
+          "status" => "completed",
+          "conclusion" => conclusion,
+          "createdAt" => created_at,
+          "startedAt" => "2026-07-14T12:00:05Z",
+          "updatedAt" => "2026-07-14T12:30:00Z",
+          "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{run_id}"
+        }
+      end
+      older_failure = build_run.call(
+        candidate_sha: "e" * 40,
+        run_id: 940_001,
+        conclusion: "failure",
+        created_at: "2026-07-14T11:00:00Z"
+      )
+      newer_success = build_run.call(
+        candidate_sha: "f" * 40,
+        run_id: 940_002,
+        conclusion: "success",
+        created_at: "2026-07-14T12:00:00Z"
+      )
+      newer_failure = newer_success.merge("conclusion" => "failure")
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+      allow(self).to receive(:reject_known_accelerated_shakaperf_failure!).and_call_original
+      expect(self).not_to receive(:dispatch_shakaperf_release_gate_workflow!)
+
+      aggregate_failures do
+        duplicate_cases = [
+          [older_failure, newer_success, newer_success.dup],
+          [newer_success.dup, newer_success, older_failure]
+        ]
+        duplicate_cases.each do |runs|
+          allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+            .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+          result = run_accelerated_shakaperf_release_gate!(
+            monorepo_root: "/tmp/repo",
+            ref:,
+            head_sha:,
+            target_version:,
+            release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+          )
+          expect(result).to include(status: "success", run_id: 940_002)
+        end
+
+        [[older_failure, newer_failure], [newer_failure, older_failure]].each_with_index do |runs, order|
+          allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+            .with(repo_slug: "shakacode/react_on_rails", ref:).and_return(runs)
+          expect do
+            run_accelerated_shakaperf_release_gate!(
+              monorepo_root: "/tmp/repo",
+              ref:,
+              head_sha:,
+              target_version:,
+              release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+            )
+          end.to raise_error(SystemExit, /known ShakaPerf failure/i), "newer failure, order #{order}"
+        end
+      end
+      expect(self).to have_received(:shakaperf_release_gate_run_evidence_rejection)
+        .with(hash_including(run: newer_success, require_prerun: true)).twice
+      expect(self).not_to have_received(:reject_known_accelerated_shakaperf_failure!)
+        .with(run: older_failure)
+    end
+
+    it "keeps an active same-target pre-run deferable" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      active_prerun = {
+        "databaseId" => 222_222,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref:, head_sha: "e" * 40, target_version:
+        ),
+        "headSha" => "e" * 40,
+        "status" => "in_progress",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/222222"
+      }
+      queued_run = active_prerun.merge(
+        "databaseId" => 333_333,
+        "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+        "headSha" => head_sha,
+        "status" => "queued",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => nil,
+        "updatedAt" => "2026-07-14T13:00:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/333333"
+      )
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+        .with(repo_slug: "shakacode/react_on_rails", ref:).and_return([active_prerun])
+      allow(self).to receive_messages(
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        wait_for_accelerated_shakaperf_release_gate_run!: queued_run
+      )
+      expect(self).to receive(:dispatch_shakaperf_release_gate_workflow!).once
+
+      result = run_accelerated_shakaperf_release_gate!(
+        monorepo_root: "/tmp/repo",
+        ref:,
+        head_sha:,
+        target_version:,
+        release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+      )
+
+      expect(result).to include(status: "pending", run_id: 333_333)
+    end
+
+    it "does not let stale or canonically unrelated pre-runs poison exact-head dispatch" do
+      target_version = "17.0.0.rc.10"
+      ref = "release/17.0.0"
+      head_sha = "d" * 40
+      base_prerun = {
+        "databaseId" => 222_222,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref:, head_sha: "e" * 40, target_version:
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/222222"
+      }
+      variants = {
+        "stale success" => base_prerun,
+        "unrelated target" => base_prerun.merge(
+          "displayTitle" => shakaperf_release_gate_display_title(
+            ref:, head_sha: "e" * 40, target_version: "17.0.0.rc.9"
+          )
+        )
+      }
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive_messages(
+        shakaperf_release_gate_run_evidence_rejection: "evidence is stale",
+        shakaperf_release_gate_dispatch_started_at: Time.iso8601("2026-07-14T13:00:00Z"),
+        dispatch_shakaperf_release_gate_workflow!: nil
+      )
+
+      aggregate_failures do
+        variants.each_with_index do |(label, prerun), index|
+          queued_run = base_prerun.merge(
+            "databaseId" => 333_333 + index,
+            "displayTitle" => shakaperf_release_gate_display_title(ref:, head_sha:, target_version:),
+            "headSha" => head_sha,
+            "status" => "queued",
+            "conclusion" => nil,
+            "createdAt" => "2026-07-14T13:00:00Z",
+            "startedAt" => nil,
+            "updatedAt" => "2026-07-14T13:00:00Z",
+            "url" => "https://github.com/shakacode/react_on_rails/actions/runs/#{333_333 + index}"
+          )
+          allow(self).to receive(:fetch_shakaperf_release_gate_runs)
+            .with(repo_slug: "shakacode/react_on_rails", ref:).and_return([prerun])
+          allow(self).to receive(:wait_for_accelerated_shakaperf_release_gate_run!).and_return(queued_run)
+
+          result = run_accelerated_shakaperf_release_gate!(
+            monorepo_root: "/tmp/repo",
+            ref:,
+            head_sha:,
+            target_version:,
+            release_started_at: Time.iso8601("2026-07-14T12:59:00Z")
+          )
+          expect(result).to include(status: "pending", run_id: 333_333 + index), label
+        end
+      end
+      expect(self).to have_received(:dispatch_shakaperf_release_gate_workflow!).exactly(2).times
     end
   end
 
@@ -4371,6 +5747,45 @@ RSpec.describe "release.rake helper methods" do
       expect(normalized_guide).to include(
         "Only an exactly present `user: nil` author is known deleted"
       )
+      expect(normalized_guide).to include(
+        "Missing, malformed, or unparseable creation or update timestamps block even on markerless API comments"
+      )
+      expect(normalized_guide).to include(
+        "Durable marker comments must remain unedited"
+      )
+      expect(normalized_guide).to include(
+        "completed known failure or unknown terminal conclusion blocks publication"
+      )
+      expect(normalized_guide).to include(
+        "only proven unrelated evidence is ignored"
+      )
+      expect(normalized_guide).to include(
+        "Before target filtering, duplicate collapse, ordering, reuse, or dispatch, every fetched accelerated"
+      )
+      expect(normalized_guide).to include(
+        "The API state is also total: active states permit only a null conclusion"
+      )
+      expect(normalized_guide).to include(
+        "Accelerated evidence never synthesizes a missing run URL"
+      )
+      expect(normalized_guide).to include(
+        "During accelerated post-dispatch polling, the complete fetched array and every member are validated"
+      )
+      expect(normalized_guide).to include(
+        "This accelerated-only polling seam does not change the ordinary blocking ShakaPerf waiter"
+      )
+      expect(normalized_guide).to include(
+        "positive integer run and attempt IDs and the literal URL"
+      )
+      expect(normalized_guide).to include(
+        "selected known failure or unknown state outranks pending dispatch independent of API order"
+      )
+      expect(normalized_guide).to include(
+        "only canonically identical duplicates collapse"
+      )
+      expect(normalized_guide).to include(
+        "deterministically newer ordered success may supersede older ordered failures"
+      )
     end
 
     it "rejects a closed release tracker" do
@@ -4621,6 +6036,126 @@ RSpec.describe "release.rake helper methods" do
       expect(
         fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
       ).to eq([])
+    end
+
+    it "accepts an unedited trusted marker when canonicalized creation and update instants match" do
+      authorization = accelerated_rc_test_authorization
+      comment = accelerated_rc_test_issue_comment(
+        id: 1,
+        body: accelerated_rc_tracker_comment(authorization),
+        created_at: "2026-07-14T13:00:00Z",
+        updated_at: "2026-07-14T03:00:00-10:00",
+        user: { "login" => "justin808" }
+      )
+      success = instance_double(Process::Status, success?: true)
+      tracker_issue = {
+        "number" => 3823,
+        "state" => "open",
+        "title" => "Release gate: React on Rails 17.0.0",
+        "labels" => [],
+        "pull_request" => nil
+      }
+      allow(self).to receive(:capture_gh_output) do |*args|
+        endpoint = args.fetch(1)
+        case endpoint
+        when /comments\?/
+          [JSON.generate([comment]), success]
+        when %r{collaborators/justin808/permission}
+          ["maintain\n", success]
+        when "repos/shakacode/react_on_rails/issues/3823"
+          [JSON.generate(tracker_issue), success]
+        else
+          raise "Unexpected gh API request: #{args.inspect}"
+        end
+      end
+
+      aggregate_failures do
+        expect(
+          fetch_accelerated_rc_tracker_records!(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+        ).to eq([authorization])
+        expect(
+          fetch_repository_accelerated_rc_records_for_candidate!(
+            repo_slug: "shakacode/react_on_rails",
+            target_version: authorization.fetch("target_version"),
+            candidate_sha: authorization.fetch("candidate_sha")
+          )
+        ).to eq([authorization])
+      end
+    end
+
+    it "blocks edited durable terminal and conflicting markers before trust or state use" do
+      accepted = accelerated_rc_test_accepted_history.last
+      rejected = accelerated_rc_test_rejected_history.last
+      conflicting = accepted.merge("reason" => "Conflicting edited acceptance")
+      success = instance_double(Process::Status, success?: true)
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+
+      aggregate_failures do
+        { "accepted" => accepted, "rejected" => rejected, "conflicting" => conflicting }.each do |label, record|
+          comment = accelerated_rc_test_issue_comment(
+            id: 1,
+            body: accelerated_rc_tracker_comment(record),
+            updated_at: "2026-07-14T13:00:01Z",
+            user: { "login" => "justin808" }
+          )
+          allow(self).to receive(:capture_gh_output).and_return([JSON.generate([comment]), success])
+
+          expect do
+            fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+          end.to raise_error(SystemExit, /edited.*accelerated RC.*comment|marker.*edited/i), label
+        end
+      end
+    end
+
+    it "fails closed on missing or malformed update timestamps even for markerless comments" do
+      success = instance_double(Process::Status, success?: true)
+      variants = {
+        "missing" => :missing,
+        "nil" => nil,
+        "non-String" => 123,
+        "unparseable" => "not-a-time"
+      }
+
+      aggregate_failures do
+        variants.each do |label, updated_at|
+          comment = accelerated_rc_test_issue_comment(id: 1, body: "ordinary repository discussion")
+          updated_at == :missing ? comment.delete("updated_at") : comment["updated_at"] = updated_at
+          allow(self).to receive(:capture_gh_output).and_return([JSON.generate([comment]), success])
+
+          expect do
+            fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+          end.to raise_error(SystemExit, /comment.*schema/i), "selected tracker: #{label}"
+          expect do
+            fetch_repository_issue_comments_for_accelerated_rc_retry!(repo_slug: "shakacode/react_on_rails")
+          end.to raise_error(SystemExit, /comment.*schema/i), "repository: #{label}"
+        end
+      end
+    end
+
+    it "does not let an edited acceptance rewrite an unedited absorbing rejection" do
+      rejected = accelerated_rc_test_rejected_history.last
+      accepted = accelerated_rc_test_accepted_history.last
+      comments = [
+        accelerated_rc_test_issue_comment(
+          id: 1,
+          body: accelerated_rc_tracker_comment(rejected),
+          user: { "login" => "justin808" }
+        ),
+        accelerated_rc_test_issue_comment(
+          id: 2,
+          body: accelerated_rc_tracker_comment(accepted),
+          created_at: "2026-07-14T13:01:00Z",
+          updated_at: "2026-07-14T13:02:00Z",
+          user: { "login" => "justin808" }
+        )
+      ]
+      success = instance_double(Process::Status, success?: true)
+      allow(self).to receive(:capture_gh_output).and_return([JSON.generate(comments), success])
+      expect(self).not_to receive(:accelerated_rc_repository_comment_permission!)
+
+      expect do
+        fetch_release_tracker_comments(repo_slug: "shakacode/react_on_rails", tracker: 3823)
+      end.to raise_error(SystemExit, /edited.*accelerated RC.*comment|marker.*edited/i)
     end
 
     it "fails closed when a repository comment page contains a malformed comment hash" do
@@ -6239,6 +7774,9 @@ RSpec.describe "release.rake helper methods" do
           "headSha" => "f" * 40,
           "status" => "in_progress",
           "conclusion" => "failure",
+          "createdAt" => "2026-07-14T13:00:00Z",
+          "startedAt" => "2026-07-14T13:00:05Z",
+          "updatedAt" => "2026-07-14T13:01:00Z",
           "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
         }
       )
@@ -6255,7 +7793,7 @@ RSpec.describe "release.rake helper methods" do
           release_started_at: Time.utc(2026, 7, 14, 14),
           tag: "v17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /active ShakaPerf run.*terminal conclusion/i)
+      end.to raise_error(SystemExit, /ShakaPerf.*(?:contradictory|state|metadata|malformed)/i)
     end
 
     it "blocks an untagged retry when a later valid authorization changes CI detail" do
@@ -6900,6 +8438,58 @@ RSpec.describe "release.rake helper methods" do
   end
 
   describe "#accelerated_rc_shakaperf_snapshot!" do
+    it "never synthesizes or accepts a noncanonical refreshed run URL" do
+      record = {
+        "candidate_sha" => "f" * 40,
+        "release_branch" => "release/17.0.0",
+        "shakaperf" => {
+          "status" => "pending",
+          "run_id" => 123_456,
+          "attempt" => 1,
+          "run_url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456",
+          "candidate_sha" => "f" * 40,
+          "target_version" => "17.0.0.rc.10",
+          "release_started_at" => "2026-07-14T13:00:00Z"
+        }
+      }
+      refreshed_run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "f" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "f" * 40,
+        "status" => "in_progress",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      malformed_urls = {
+        "missing" => nil,
+        "wrong host" => "https://example.com/shakacode/react_on_rails/actions/runs/123456",
+        "wrong repository" => "https://github.com/shakacode/other/actions/runs/123456",
+        "wrong run ID" => "https://github.com/shakacode/react_on_rails/actions/runs/999999",
+        "query" => "https://github.com/shakacode/react_on_rails/actions/runs/123456?attempt=1",
+        "fragment" => "https://github.com/shakacode/react_on_rails/actions/runs/123456#summary"
+      }
+
+      aggregate_failures do
+        malformed_urls.each do |label, url|
+          allow(self).to receive(:refresh_shakaperf_release_gate_run!)
+            .and_return(refreshed_run.merge("url" => url))
+          expect do
+            accelerated_rc_shakaperf_snapshot!(
+              repo_slug: "shakacode/react_on_rails",
+              monorepo_root: "/tmp/repo",
+              record:
+            )
+          end.to raise_error(SystemExit, /ShakaPerf.*(?:URL|identity|metadata|malformed)/i), label
+        end
+      end
+    end
+
     it "fails closed when the refreshed pending run no longer matches the recorded candidate" do
       record = {
         "candidate_sha" => "f" * 40,
@@ -6922,6 +8512,10 @@ RSpec.describe "release.rake helper methods" do
         ),
         "headSha" => "e" * 40,
         "status" => "in_progress",
+        "conclusion" => nil,
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       )
 
@@ -6957,6 +8551,9 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "f" * 40,
         "status" => "completed",
         "conclusion" => "unrecognized",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       )
 
@@ -6966,7 +8563,7 @@ RSpec.describe "release.rake helper methods" do
           monorepo_root: "/tmp/repo",
           record:
         )
-      end.to raise_error(SystemExit, /reconciliation is unknown.*refusing to accept or reject/i)
+      end.to raise_error(SystemExit, /ShakaPerf.*(?:unknown|malformed).*refusing unaudited publication/i)
     end
 
     it "fails closed when the refreshed run attempt differs from the authorized attempt" do
@@ -6992,6 +8589,9 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "f" * 40,
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T13:00:00Z",
+        "startedAt" => "2026-07-14T13:00:05Z",
+        "updatedAt" => "2026-07-14T13:01:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       )
 
@@ -8513,6 +10113,9 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "f" * 40,
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       }
       allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(refreshed_run)
@@ -8544,6 +10147,9 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => prerun_sha,
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
         "url" => record.dig("shakaperf", "run_url")
       }
       runtime_checks = []
@@ -8797,6 +10403,9 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "e" * 40,
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       }
       allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(run)
@@ -8825,6 +10434,46 @@ RSpec.describe "release.rake helper methods" do
       end.to output(/Reusing accepted RC ShakaPerf evidence/).to_stdout
     end
 
+    it "blocks accepted-record reuse when refreshed accelerated URL identity is missing or noncanonical" do
+      run = {
+        "databaseId" => 123_456,
+        "attempt" => 1,
+        "displayTitle" => shakaperf_release_gate_display_title(
+          ref: "release/17.0.0", head_sha: "e" * 40, target_version: "17.0.0.rc.10"
+        ),
+        "headSha" => "e" * 40,
+        "status" => "completed",
+        "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
+        "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
+      }
+      malformed_urls = {
+        "missing" => nil,
+        "wrong repository" => "https://github.com/shakacode/other/actions/runs/123456",
+        "wrong path" => "https://github.com/shakacode/react_on_rails/actions/workflows/123456",
+        "wrong run ID" => "https://github.com/shakacode/react_on_rails/actions/runs/999999",
+        "query" => "https://github.com/shakacode/react_on_rails/actions/runs/123456?attempt=1"
+      }
+      allow(self).to receive(:shakaperf_release_gate_run_evidence_rejection).and_return(nil)
+
+      aggregate_failures do
+        malformed_urls.each do |label, url|
+          allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(run.merge("url" => url))
+          expect do
+            reuse_accepted_rc_shakaperf_evidence!(
+              repo_slug: "shakacode/react_on_rails",
+              monorepo_root: "/tmp/repo",
+              ref: "release/17.0.0",
+              head_sha: "e" * 40,
+              record:
+            )
+          end.to raise_error(SystemExit, /ShakaPerf.*(?:URL|identity|metadata|malformed)/i), label
+        end
+      end
+    end
+
     it "declines stale or invalid accepted evidence so final promotion runs the strict gate" do
       run = {
         "databaseId" => 123_456,
@@ -8835,6 +10484,9 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "e" * 40,
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       }
       allow(self).to receive_messages(
@@ -8865,6 +10517,9 @@ RSpec.describe "release.rake helper methods" do
         "headSha" => "e" * 40,
         "status" => "completed",
         "conclusion" => "success",
+        "createdAt" => "2026-07-14T12:00:00Z",
+        "startedAt" => "2026-07-14T12:00:05Z",
+        "updatedAt" => "2026-07-14T12:30:00Z",
         "url" => "https://github.com/shakacode/react_on_rails/actions/runs/123456"
       }
       allow(self).to receive(:refresh_shakaperf_release_gate_run!).and_return(run)


### PR DESCRIPTION
## Why

Final promotion must never become weaker because release-candidate validation ran asynchronously. This change closes #4648 by making the accelerated path auditable, RC-only, and fail-closed while keeping the final stable-promotion boundary authoritative.

## What changed

- Records canonical RC authorization, tracker, CI, and ShakaPerf evidence with exact candidate/run/attempt/target/provenance binding.
- Allows pending ShakaPerf evidence only for the immutable RC candidate.
- Reuses a completed different-SHA pre-run only after live artifact, runtime-tree, ancestry, freshness, and metadata-only proof; active different-SHA evidence cannot persist, replay, or cross a publication boundary.
- Captures one exact source-RC annotated-tag object SHA for final promotion, reads type/provenance/peeled candidate by that object address, rebinds the local direct ref and a live remote direct/peeled snapshot, and revalidates the same identity at tag handling, before the stable push, and after the push before package publication.
- Rejects accelerated RC publication before version mutation or push unless the checkout is the matching `release/X.Y.Z` branch.
- Classifies canonical `test`, `beta`, `alpha`, and `pre` ShakaPerf history as unrelated without broadening the accelerated target beyond canonical RC versions.
- Persists publication completion immediately after package publication. If that append fails after all artifacts are public, reconciliation verifies the exact tag identity and all six registry artifacts, reconstructs the canonical `published-awaiting-gates` transition, and re-fetches it before evaluating deferred gates.
- Bounds repository evidence discovery and treats malformed, incomplete, conflicting, missing, or unknown evidence as a hard stop.
- Ignores selected-tracker marker comments only after a positive non-maintainer permission classification; lookup failures, unknown authors, edited trusted markers, and trusted malformed records remain blocking.
- Requires explicit positive retry counts and proves repository-wide publication completion before accepting an argument-less prerelease retry.
- Documents the RC-only acceleration path and the unchanged stable-promotion safety boundary.

No semantic `.github` files are changed.

## Verification

Current candidate: `73c39f66e94044473511fcaa08bc7746d6587fcf`

- Exact original-maker V86 `gpt-5.6-sol` / `xhigh` repair closed the final source-RC object-identity gap without weakening the ordinary lightweight-tag path.
- Fresh independent V87 `gpt-5.6-sol` / `xhigh` review reported `REVIEW_CLEAN`, zero findings, and zero unknowns across both the complete V86 delta and complete issue-base delta.
- New exact-object regressions: 6 examples, 0 failures.
- Publication reconciliation: 21 examples, 0 failures.
- Accepted-candidate selection: 9 examples, 0 failures.
- Final-promotion gates: 17 examples, 0 failures.
- Publication boundary: 51 examples, 0 failures.
- Full release-helper suite: 727 examples, 0 failures.
- Focused RuboCop: 2 files, 0 offenses; both Ruby syntax checks and Markdown formatting passed.
- Exact-path diff checks, clean-index/untracked checks, unchanged root/package lock hashes, and immutable canonical digests passed before and after commit.
- Pre-commit and pre-push hooks passed; pre-push also passed branch-wide Ruby lint and online Markdown link checks.
- Strict security preflight passed on the exact current issue/PR head and on release tracker #3823, with no untrusted or hidden participants, API-coverage gaps, suspicious text, or high-risk files.
- Current-head Claude review succeeded with no new feedback; all 34 review threads are resolved and the cutoff-safe review inventory found no untriaged item.

## Rollout and stale-base control

- Final merge remains gated on this exact head's full hosted CI, configured current-head reviews, resolved threads, strict merge ledger, and merge-queue aggregate checks.
- Dependencies #4645, #4646, and #4647 are merged and closed.
- Exact post-merge QA will replay retry, CI, ShakaPerf, tracker, idempotency, and stable fail-closed behavior before batch closeout.

## Merge qualification

Release-mode gate: tracker #3823 is open with `Mode: development`; this PR targets `main`, so the beta-phase standard merge gate applies. Accelerated-RC independent-finalizer scoring is not active.

Confidence note:

- Validated: exact V86 repair, fresh V87 independent review, focused reconciliation/selection/final-promotion/publication-boundary/full-helper tests, Ruby lint and syntax, Markdown formatting and links, diff/scope/lock integrity, hooks, strict security preflight, current-head Claude review, and review-thread closeout all passed on `73c39f66e94044473511fcaa08bc7746d6587fcf`.
- Evidence: current-head hosted checks and reviews are visible on this PR; the address-review summary links the final evidence-backed disposition and all threads are resolved.
- UNKNOWN: final current-head full hosted CI and the merge-queue aggregate are not yet terminal.
- Residual risk: release publication is safety-sensitive; merge remains blocked until current-head checks, reviews, threads, and the strict ledger are terminal and clean.

Closes #4648.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced an audited accelerated release-candidate publication workflow with environment-based configuration
  * Added a new rake task to reconcile accelerated RC workflows and confirm release state

* **Documentation**
  * Updated release guide with accelerated RC publication process, requirements, and workflow details

* **Tests**
  * Expanded test coverage for accelerated RC functionality and release gate validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
