### PR TITLE
Backport safe Pro attribution scanning to 17.0.0

### DIFF
--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -34,12 +34,11 @@ module ReactOnRailsProHelper
   SCRIPT_CLOSE_TAG_LENGTH = 8
   STATIC_RSC_PAYLOAD_SCRIPT_MARKER_ATTRIBUTE = "data-react-on-rails-rsc-payload"
   STATIC_RSC_ASSET_DIAGNOSTIC_CACHE_MUTEX = Mutex.new
+  HTML_COMMENT_OPEN = "<!--"
+  HTML_COMMENT_CLOSE = "-->"
   PRO_ATTRIBUTION_MARKER = "Powered by React on Rails Pro"
+  PRO_ATTRIBUTION_COMMENT_PREFIX = "Powered by React on Rails Pro (c) ShakaCode"
   RAILS_CONTEXT_MARKER = "js-react-on-rails-context"
-  LEADING_PRO_ATTRIBUTION_COMMENT_PATTERN =
-    /\A(?:\s*<!--\s*Powered by React on Rails Pro \(c\) ShakaCode(?:\s*\|(?:(?!-->).)*)?\s*-->\s*)+/m
-  LEADING_RAILS_CONTEXT_SCRIPT_PATTERN =
-    %r{\A\s*<script\b(?=[^>]*\bid=(?:"js-react-on-rails-context"|'js-react-on-rails-context'))[^>]*>.*?</script>\s*}mi
   @static_rsc_asset_diagnostic_cache = {}
 
   class << self
@@ -479,11 +478,58 @@ module ReactOnRailsProHelper
                    !html.include?(RAILS_CONTEXT_MARKER)
 
     was_html_safe = html.html_safe?
-    normalized_html = html.sub(LEADING_PRO_ATTRIBUTION_COMMENT_PATTERN, "")
-                          .sub(LEADING_RAILS_CONTEXT_SCRIPT_PATTERN, "")
+    normalized_html = strip_leading_pro_attribution_comments(html)
+    normalized_html = strip_leading_rails_context_script(normalized_html)
     normalized_html = prepend_render_rails_context(normalized_html)
 
     was_html_safe ? normalized_html : String.new(normalized_html)
+  end
+
+  def strip_leading_pro_attribution_comments(html)
+    cursor = 0
+    stripped_comment = false
+
+    loop do
+      comment_start = html_space_end_index(html, cursor)
+      break unless html[comment_start, HTML_COMMENT_OPEN.length] == HTML_COMMENT_OPEN
+
+      content_start = html_space_end_index(html, comment_start + HTML_COMMENT_OPEN.length)
+      prefix_end = content_start + PRO_ATTRIBUTION_COMMENT_PREFIX.length
+      break unless html[content_start, PRO_ATTRIBUTION_COMMENT_PREFIX.length] == PRO_ATTRIBUTION_COMMENT_PREFIX
+
+      comment_end = html.index(HTML_COMMENT_CLOSE, prefix_end)
+      break unless comment_end
+
+      separator_index = html_space_end_index(html, prefix_end)
+      break unless separator_index == comment_end || html[separator_index] == "|"
+
+      cursor = html_space_end_index(html, comment_end + HTML_COMMENT_CLOSE.length)
+      stripped_comment = true
+    end
+
+    stripped_comment ? (html[cursor..] || "") : html
+  end
+
+  def strip_leading_rails_context_script(html)
+    script_start = html_space_end_index(html, 0)
+    return html unless html_ascii_case_insensitive_match?(html, SCRIPT_OPEN_TAG, script_start)
+    return html unless html_tag_name_boundary?(html, script_start + SCRIPT_OPEN_TAG_LENGTH)
+
+    opening_tag_end = html_tag_end_index(html, script_start + SCRIPT_OPEN_TAG_LENGTH)
+    return html unless opening_tag_end
+
+    closing_tag_range = html_script_closing_tag_range(html, opening_tag_end + 1)
+    return html unless closing_tag_range
+
+    script_node = Nokogiri::HTML5.fragment(html[script_start..closing_tag_range.end]).at_css("script")
+    return html unless script_node && script_node["id"] == RAILS_CONTEXT_MARKER
+
+    html[html_space_end_index(html, closing_tag_range.end + 1)..] || ""
+  end
+
+  def html_space_end_index(html, cursor)
+    cursor += 1 while cursor < html.length && HTML_SPACE_CHARACTERS.include?(html[cursor])
+    cursor
   end
 
   def add_component_cache_metadata(result, cache_key, cache_hit)

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -163,6 +163,38 @@ describe ReactOnRailsProHelper do
           expect(Rails.cache.read(expected_cache_key)).to eq(cached_html)
         end
 
+        it "replaces stale cached context whose script closing tag contains HTML whitespace" do
+          cache_key = "stale-context-whitespace-cache-hit"
+          expected_cache_key = ReactOnRailsPro::Cache.react_component_cache_key("App", cache_key:)
+          stale_context =
+            '<script type="application/json" id="js-react-on-rails-context">{"railsEnv":"stale"}</script >'
+          cached_html = "#{stale_context}\n<div>cached component</div>".html_safe
+
+          Rails.cache.write(expected_cache_key, cached_html)
+
+          result = cached_react_component("App", cache_key:, auto_load_bundle: false) do
+            raise "props block should not run on cache hit"
+          end
+
+          expect(result.scan('id="js-react-on-rails-context"').length).to eq(1)
+          expect(result).not_to include('"railsEnv":"stale"')
+          expect(result).to include("<div>cached component</div>")
+        end
+
+        it "normalizes an incomplete attribution prefix in bounded time" do
+          original_regexp_timeout = Regexp.timeout
+          incomplete_comment =
+            "<!-- Powered by React on Rails Pro (c) ShakaCode |#{' ' * 200_000}not closed"
+          cached_html = "#{incomplete_comment}<div>cached component</div>".html_safe
+          Regexp.timeout = 0.001
+
+          expect do
+            send(:normalize_cached_pro_attribution, cached_html)
+          end.not_to raise_error
+        ensure
+          Regexp.timeout = original_regexp_timeout
+        end
+
         it "returns marker-free cached content unchanged after request context is emitted" do
           marker_free_html = "<div>cached component without provider metadata</div>".html_safe
           @rendered_rails_context = true


### PR DESCRIPTION
## Why

PR #4660 introduced cache-hit attribution normalization on `release/17.0.0`. During the forward-port in #4668, CodeQL found that its regular expressions both missed valid `</script >` closing tags and could time out on an incomplete attribution comment with repeated whitespace.

The deterministic scanner fix landed on `main`, but the release branch still contained the old regexes. That leaves the next 17.0.0 RC with a correctness and regex-denial-of-service risk unless the reviewed fix is backported.

## What changed

- replaces the two cached-attribution regexes with the deterministic HTML scanners already reviewed and merged in #4668
- recognizes HTML whitespace in Rails-context script closing tags
- avoids regexp timeout behavior on incomplete attribution comments
- adds the same two regression examples that protect `main`
- preserves the existing Pro source headers and does not change license metadata or EULA text

## Verification

- red phase on `658a63e1c`: 2 examples, 2 failures
  - `</script >` produced two Rails-context scripts
  - the incomplete 200,000-space attribution prefix raised `Regexp::TimeoutError`
- green phase on this head: 2 examples, 0 failures
- selected cache-attribution regression set: 5 examples, 0 failures
- full helper spec: 128 examples; the 23 failures all require generated SSR/RSC bundles absent from this fresh checkout, while the affected scanner/cache-attribution examples pass
- Pro RuboCop: 2 changed files, 0 offenses
- pre-push branch RuboCop: 27 Ruby files, 0 offenses
- Pro header enforcement: all 848 in-scope files have the current commercial-license header
- pinned Lychee 0.23.0 pre-push check: 1,399 links, 0 errors
- independent `gpt-5.6-sol` / xhigh `codex review --uncommitted`: no actionable defects
- `git diff --check`: clean
- CI detector: Pro Ruby core + Pro dummy app; selects lint, Pro lint/unit/dummy integration, and Pro benchmarks

## Changelog

No separate entry: this corrects the implementation of the existing unreleased #4660 license/attribution entry before the next RC and aligns the release branch with #4668 on `main`.
