### PR TITLE
Forward-port stable RSC 19.2.1 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Changed
 
+- **[Pro]** **RSC scaffolding now installs stable `react-on-rails-rsc@19.2.1`**: The Pro package,
+  node renderer, generator, dummy app, workspace overrides, and compatibility checks now use the stable
+  package and reject prereleases below the stable peer floor. This keeps React on Rails Pro 17 on the
+  coordinated React 19.2.7 runtime while including the 19.2.1 CSS/FOUC fix. The stable artifact uses the
+  React on Rails Pro commercial terms rather than MIT and reports `SEE LICENSE IN LICENSE.md` in npm metadata.
+  [Issue 4357](https://github.com/shakacode/react_on_rails/issues/4357).
+  [PR 4670](https://github.com/shakacode/react_on_rails/pull/4670) by
+  [justin808](https://github.com/justin808).
 - **[Pro]** **Published artifacts now identify the commercial license accurately**: The Pro gem reports
   `LicenseRef-LICENSE`, while the `react-on-rails-pro` and `react-on-rails-pro-node-renderer` npm packages
   report `SEE LICENSE IN LICENSE.md`. All three packed artifacts include React on Rails Pro EULA v2.3 instead

--- a/docs/oss/building-features/react-19-activity.md
+++ b/docs/oss/building-features/react-19-activity.md
@@ -21,11 +21,11 @@ This is the React-blessed replacement for the classic "keep the inactive tab ali
 
 ## Version requirements
 
-| Layer                              | Requirement                                                                                                                                                                                                                         |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `react` / `react-dom` in your app  | **19.2.0 or later** (`Activity` does not exist in earlier versions, including 19.0/19.1)                                                                                                                                            |
-| `react_on_rails` gem + npm package | Any current version — the package's peer dependency is `react >= 16`, so React on Rails does not constrain you; just upgrade `react`/`react-dom` in **your app's** bundle                                                           |
-| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and the supported `react-on-rails-rsc` 19.2.x line (`>= 19.2.1`; `19.2.1-rc.0` during the RC soak), so `<Activity>` is available on that coordinated set |
+| Layer                              | Requirement                                                                                                                                                                                   |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `react` / `react-dom` in your app  | **19.2.0 or later** (`Activity` does not exist in earlier versions, including 19.0/19.1)                                                                                                      |
+| `react_on_rails` gem + npm package | Any current version — the package's peer dependency is `react >= 16`, so React on Rails does not constrain you; just upgrade `react`/`react-dom` in **your app's** bundle                     |
+| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and stable `react-on-rails-rsc >= 19.2.1` on the 19.2.x line, so `<Activity>` is available on that coordinated set |
 
 `<Activity>` is a regular React feature inside your components. React on Rails needs no configuration for it — it works with the standard `react_component` helper in both client-side rendering and server-side rendering with hydration.
 

--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -190,7 +190,7 @@ Before starting any component migration, verify these items. Skipping them is th
 
 - [ ] **React 19.2 installed** -- both `react` and `react-dom` on 19.2.x with patch `>= 19.2.7`, with matching versions (`yarn why react` shows no duplicates)
 - [ ] **Node renderer configured** -- RSC requires `NodeRenderer`, not ExecJS. If `config.server_renderer` is not set to `"NodeRenderer"`, migrate first
-- [ ] **`react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- during the React on Rails Pro 17 RC soak, use `19.2.1-rc.0`; check with `yarn why react-on-rails-rsc`
+- [ ] **Stable `react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- install `19.2.1` or later on the 19.2.x line; check with `yarn why react-on-rails-rsc`
 - [ ] **Three webpack bundles building** -- client, server, and RSC bundles all compile without errors
 - [ ] **RSC manifests generated** -- `react-client-manifest.json` and `react-server-client-manifest.json` exist in your webpack output directory
 - [ ] **RSC payload route mounted** -- `rsc_payload_route` in `config/routes.rb`

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -49,7 +49,7 @@ yarn why react-on-rails-rsc
 
 If you're on React 18 or earlier, upgrade first -- RSC requires React 19.
 
-> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. During the 17.0 release-candidate soak, use `react-on-rails-rsc@19.2.1-rc.0` until the stable package is published. Older 19.0.x RSC packages no longer satisfy the Pro 17 runtime floor.
+> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. Older 19.0.x packages and 19.2.1 prereleases no longer satisfy the Pro 17 runtime floor.
 
 ## Step 2: Configure Rails for RSC
 
@@ -636,7 +636,7 @@ React on Rails Pro 17 RSC requires the coordinated React 19.2.x / `react-on-rail
 **Fix:** Upgrade React, React DOM, and `react-on-rails-rsc` together:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 ```
 
 ### Mistake 2: Forgetting the RSC bundle watcher in development

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -442,9 +442,8 @@ React on Rails Pro 17 RSC release set. Key constraints:
 
 - The fix landed in `react-on-rails-rsc` 19.2.0-rc.3 and is included in the 19.2.1 package line. Check the
   [react_on_rails_rsc releases](https://github.com/shakacode/react_on_rails_rsc/releases)
-  and the Pro release notes for the exact package to install. React on Rails Pro 17 RC packages use
-  `react-on-rails-rsc@19.2.1-rc.0`; the 17.0 final release requires `react-on-rails-rsc >= 19.2.1`
-  on the supported RSC 19.2.x package line.
+  and the Pro release notes for the exact package to install. React on Rails Pro 17 requires stable
+  `react-on-rails-rsc >= 19.2.1` on the supported RSC 19.2.x package line.
 - **Do not** bump `react-on-rails-rsc` on its own; it must be upgraded together with a compatible
   React, React DOM, and React on Rails Pro set, or the Pro node renderer's peer-compatibility check
   can fail at startup.

--- a/docs/pro/react-server-components/create-without-ssr.md
+++ b/docs/pro/react-server-components/create-without-ssr.md
@@ -26,16 +26,16 @@ bundle add react_on_rails_pro --version="= VERSION"
 Also, install React 19.2.x, React DOM 19.2.x, and the `react-on-rails-rsc` release currently used by the generator:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 ```
 
 > [!NOTE]
 > React on Rails Pro 17 RSC requires React 19.2.x with patch >= 19.2.7. React 19.0.x is no longer a supported Pro RSC runtime line in v17. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
 >
-> During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
+> The React on Rails Pro 17 generator pins stable `react-on-rails-rsc@19.2.1`. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
 
 2. Enable support for Server Components in React on Rails Pro configuration:
 

--- a/docs/pro/react-server-components/critical-resource-hints.md
+++ b/docs/pro/react-server-components/critical-resource-hints.md
@@ -48,7 +48,7 @@ The useful React DOM APIs for RSC resource hints are:
 
 > [!NOTE]
 > The generator currently installs the tested React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
-> line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak). Newer published
+> line (stable `19.2.1` or later). Newer published
 > `react-on-rails-rsc` releases may add automatic package-level hinting, but app-authored resource
 > hints should still use React DOM's public APIs rather than package-private helpers.
 

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -12,7 +12,7 @@ The generator supports Rspack — when `assets_bundler: rspack` is detected in `
 The RSC implementation depends on the `react-on-rails-rsc` npm package, which provides bundler-specific manifest plugins plus a shared loader:
 
 - **WebpackPlugin** (`react-on-rails-rsc/WebpackPlugin`) — generates client/server component manifest files under webpack.
-- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the `react-on-rails-rsc` 19.2.1 package line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak).
+- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by stable `react-on-rails-rsc` 19.2.1 and later on the 19.2.x package line.
 - **WebpackLoader** (`react-on-rails-rsc/WebpackLoader`) — transforms `'use client'` files into client reference proxies in the RSC bundle. Works under both webpack and rspack.
 
 ## React and Package Version Policy
@@ -23,10 +23,8 @@ line in v17 because the generator, peer metadata, and node-renderer startup chec
 now target the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
 line.
 
-During the React on Rails Pro 17 release-candidate soak, the generator pins
-`react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not
-published yet. For the 17.0 final release, use a stable `react-on-rails-rsc`
-19.2.x package with patch >= 19.2.1. Keep React, React DOM, and
+The React on Rails Pro 17 generator pins stable `react-on-rails-rsc@19.2.1`
+for both webpack and rspack projects. Keep React, React DOM, and
 `react-on-rails-rsc` upgraded as a coordinated set.
 
 ## Compatibility Matrix

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -23,15 +23,15 @@ Before running the generator, verify your environment:
 If React is outside the supported 19.2.x range or below 19.2.7, upgrade it first:
 
 ```bash
-pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 ```
 
 > **React 19.2.x with patch >= 19.2.7** is required for the React on Rails Pro 17 RSC path. React 19.0.x is no longer a supported Pro RSC runtime line in v17.
 
 > [!NOTE]
-> The RSC generator uses the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.x package line with patch >= 19.2.1. During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1.
+> The RSC generator uses the coordinated React 19.2.7 / stable `react-on-rails-rsc@19.2.1` package set. Later stable 19.2.x packages with patch >= 19.2.1 remain on the supported package line.
 
 > [!NOTE]
 > Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set. The RSC bundler APIs are version-coupled, so do not bump `react-on-rails-rsc` by itself.
@@ -39,7 +39,7 @@ pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
 The generator-managed RSC version is what goes in your app's `package.json`. Separately, the Pro package itself declares an optional peer range, which is broader on purpose:
 
 > [!NOTE]
-> The Pro package's optional `react-on-rails-rsc` peer range for the 17.0 final release is `>= 19.2.1 < 20.0.0`. Release candidates temporarily admit the matching prerelease tuple (`>= 19.2.1-rc.0 < 20.0.0`) so the RC package can be tested before the stable `19.2.1` package is published. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
+> The Pro package's optional `react-on-rails-rsc` peer range is `>= 19.2.1 < 20.0.0`; prereleases do not satisfy this stable floor. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
 
 ## Pre-Migration: Audit Components for Client API Usage
 
@@ -268,7 +268,7 @@ Then run `bundle install` before retrying the generator.
 
 If the RSC bundle build fails but server and client builds succeed, the issue is likely in `rscWebpackConfig.js`. Common causes:
 
-- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1-rc.0` / `yarn add react-on-rails-rsc@19.2.1-rc.0` / `pnpm add react-on-rails-rsc@19.2.1-rc.0` during the 17.0 RC soak, or install a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1 once it is published.
+- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1` / `yarn add react-on-rails-rsc@19.2.1` / `pnpm add react-on-rails-rsc@19.2.1`, or install a later stable 19.2.x package with patch >= 19.2.1.
 - **React or `react-on-rails-rsc` version mismatch**: RSC currently requires React 19.2.x with patch >= 19.2.7 and `react-on-rails-rsc` 19.2.x with patch >= 19.2.1. Check with `npm ls react react-dom react-on-rails-rsc`, `yarn why react` / `yarn why react-dom` / `yarn why react-on-rails-rsc`, or `pnpm list react react-dom react-on-rails-rsc`
 - **Custom webpack config incompatibility**: If your `serverWebpackConfig.js` was heavily customized, the generator's transforms may not apply cleanly. See [Preparing Your App: Step 4](../../oss/migrating/rsc-preparing-app.md#step-4-set-up-the-rsc-webpack-bundle) for the underlying intent of each webpack change
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -139,7 +139,7 @@ Ensure you're using the coordinated React 19.2.x line in your `package.json`:
 }
 ```
 
-> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1` (or `19.2.1-rc.0` during the 17.0 RC soak).
+> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with stable `react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`.
 
 ### 2. Prepare Your React Components
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1422,7 +1422,7 @@ The rake task accepts `FORMAT=json` for scripting. The output shape for an expir
   "organization": "Acme Corp",
   "plan": "paid",
   "expiration": "2024-01-01T00:00:00Z",
-  "attribution_required": false,
+  "attribution_required": true,
   "days_remaining": -2,
   "renewal_required": true
 }
@@ -2069,7 +2069,7 @@ Ensure you're using the coordinated React 19.2.x line in your `package.json`:
 }
 ```
 
-> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1` (or `19.2.1-rc.0` during the 17.0 RC soak).
+> Note: React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7`. Keep these versions coordinated with stable `react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`.
 
 ### 2. Prepare Your React Components
 
@@ -5683,7 +5683,7 @@ The useful React DOM APIs for RSC resource hints are:
 
 > [!NOTE]
 > The generator currently installs the tested React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
-> line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak). Newer published
+> line (stable `19.2.1` or later). Newer published
 > `react-on-rails-rsc` releases may add automatic package-level hinting, but app-authored resource
 > hints should still use React DOM's public APIs rather than package-private helpers.
 
@@ -7388,16 +7388,16 @@ bundle add react_on_rails_pro --version="= VERSION"
 Also, install React 19.2.x, React DOM 19.2.x, and the `react-on-rails-rsc` release currently used by the generator:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# bun add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 ```
 
 > [!NOTE]
 > React on Rails Pro 17 RSC requires React 19.2.x with patch >= 19.2.7. React 19.0.x is no longer a supported Pro RSC runtime line in v17. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
 >
-> During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
+> The React on Rails Pro 17 generator pins stable `react-on-rails-rsc@19.2.1`. Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
 
 2. Enable support for Server Components in React on Rails Pro configuration:
 
@@ -9255,15 +9255,15 @@ Before running the generator, verify your environment:
 If React is outside the supported 19.2.x range or below 19.2.7, upgrade it first:
 
 ```bash
-pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
-# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# or: yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
+# or: npm install react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 ```
 
 > **React 19.2.x with patch >= 19.2.7** is required for the React on Rails Pro 17 RSC path. React 19.0.x is no longer a supported Pro RSC runtime line in v17.
 
 > [!NOTE]
-> The RSC generator uses the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.x package line with patch >= 19.2.1. During the React on Rails Pro 17 release-candidate soak, the generator pins `react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not published yet. For the 17.0 final release, use a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1.
+> The RSC generator uses the coordinated React 19.2.7 / stable `react-on-rails-rsc@19.2.1` package set. Later stable 19.2.x packages with patch >= 19.2.1 remain on the supported package line.
 
 > [!NOTE]
 > Keep React, React DOM, and `react-on-rails-rsc` upgraded as a coordinated set. The RSC bundler APIs are version-coupled, so do not bump `react-on-rails-rsc` by itself.
@@ -9271,7 +9271,7 @@ pnpm add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
 The generator-managed RSC version is what goes in your app's `package.json`. Separately, the Pro package itself declares an optional peer range, which is broader on purpose:
 
 > [!NOTE]
-> The Pro package's optional `react-on-rails-rsc` peer range for the 17.0 final release is `>= 19.2.1 < 20.0.0`. Release candidates temporarily admit the matching prerelease tuple (`>= 19.2.1-rc.0 < 20.0.0`) so the RC package can be tested before the stable `19.2.1` package is published. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
+> The Pro package's optional `react-on-rails-rsc` peer range is `>= 19.2.1 < 20.0.0`; prereleases do not satisfy this stable floor. The Pro node renderer also checks the installed `react-on-rails-rsc`, React, and React DOM versions at startup and hard-errors on unsupported combinations. Set `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency rollout escape hatch; it downgrades that startup error to a warning.
 
 ## Pre-Migration: Audit Components for Client API Usage
 
@@ -9500,7 +9500,7 @@ Then run `bundle install` before retrying the generator.
 
 If the RSC bundle build fails but server and client builds succeed, the issue is likely in `rscWebpackConfig.js`. Common causes:
 
-- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1-rc.0` / `yarn add react-on-rails-rsc@19.2.1-rc.0` / `pnpm add react-on-rails-rsc@19.2.1-rc.0` during the 17.0 RC soak, or install a stable `react-on-rails-rsc` 19.2.x package with patch >= 19.2.1 once it is published.
+- **Missing `react-on-rails-rsc` package**: Run `npm install react-on-rails-rsc@19.2.1` / `yarn add react-on-rails-rsc@19.2.1` / `pnpm add react-on-rails-rsc@19.2.1`, or install a later stable 19.2.x package with patch >= 19.2.1.
 - **React or `react-on-rails-rsc` version mismatch**: RSC currently requires React 19.2.x with patch >= 19.2.7 and `react-on-rails-rsc` 19.2.x with patch >= 19.2.1. Check with `npm ls react react-dom react-on-rails-rsc`, `yarn why react` / `yarn why react-dom` / `yarn why react-on-rails-rsc`, or `pnpm list react react-dom react-on-rails-rsc`
 - **Custom webpack config incompatibility**: If your `serverWebpackConfig.js` was heavily customized, the generator's transforms may not apply cleanly. See [Preparing Your App: Step 4](../../oss/migrating/rsc-preparing-app.md#step-4-set-up-the-rsc-webpack-bundle) for the underlying intent of each webpack change
 
@@ -10360,7 +10360,7 @@ The generator supports Rspack — when `assets_bundler: rspack` is detected in `
 The RSC implementation depends on the `react-on-rails-rsc` npm package, which provides bundler-specific manifest plugins plus a shared loader:
 
 - **WebpackPlugin** (`react-on-rails-rsc/WebpackPlugin`) — generates client/server component manifest files under webpack.
-- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the `react-on-rails-rsc` 19.2.1 package line (`19.2.1-rc.0` during the React on Rails Pro 17 RC soak).
+- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by stable `react-on-rails-rsc` 19.2.1 and later on the 19.2.x package line.
 - **WebpackLoader** (`react-on-rails-rsc/WebpackLoader`) — transforms `'use client'` files into client reference proxies in the RSC bundle. Works under both webpack and rspack.
 
 ## React and Package Version Policy
@@ -10371,10 +10371,8 @@ line in v17 because the generator, peer metadata, and node-renderer startup chec
 now target the coordinated React 19.2.7 / `react-on-rails-rsc` 19.2.1 package
 line.
 
-During the React on Rails Pro 17 release-candidate soak, the generator pins
-`react-on-rails-rsc@19.2.1-rc.0` because the stable `19.2.1` package is not
-published yet. For the 17.0 final release, use a stable `react-on-rails-rsc`
-19.2.x package with patch >= 19.2.1. Keep React, React DOM, and
+The React on Rails Pro 17 generator pins stable `react-on-rails-rsc@19.2.1`
+for both webpack and rspack projects. Keep React, React DOM, and
 `react-on-rails-rsc` upgraded as a coordinated set.
 
 ## Compatibility Matrix

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6766,11 +6766,11 @@ This is the React-blessed replacement for the classic "keep the inactive tab ali
 
 ## Version requirements
 
-| Layer                              | Requirement                                                                                                                                                                                                                         |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `react` / `react-dom` in your app  | **19.2.0 or later** (`Activity` does not exist in earlier versions, including 19.0/19.1)                                                                                                                                            |
-| `react_on_rails` gem + npm package | Any current version — the package's peer dependency is `react >= 16`, so React on Rails does not constrain you; just upgrade `react`/`react-dom` in **your app's** bundle                                                           |
-| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and the supported `react-on-rails-rsc` 19.2.x line (`>= 19.2.1`; `19.2.1-rc.0` during the RC soak), so `<Activity>` is available on that coordinated set |
+| Layer                              | Requirement                                                                                                                                                                                   |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `react` / `react-dom` in your app  | **19.2.0 or later** (`Activity` does not exist in earlier versions, including 19.0/19.1)                                                                                                      |
+| `react_on_rails` gem + npm package | Any current version — the package's peer dependency is `react >= 16`, so React on Rails does not constrain you; just upgrade `react`/`react-dom` in **your app's** bundle                     |
+| RSC / Pro streaming path           | React on Rails Pro 17 RSC uses React/React DOM 19.2.x with patch >= 19.2.7 and stable `react-on-rails-rsc >= 19.2.1` on the 19.2.x line, so `<Activity>` is available on that coordinated set |
 
 `<Activity>` is a regular React feature inside your components. React on Rails needs no configuration for it — it works with the standard `react_component` helper in both client-side rendering and server-side rendering with hydration.
 
@@ -25509,7 +25509,7 @@ Before starting any component migration, verify these items. Skipping them is th
 
 - [ ] **React 19.2 installed** -- both `react` and `react-dom` on 19.2.x with patch `>= 19.2.7`, with matching versions (`yarn why react` shows no duplicates)
 - [ ] **Node renderer configured** -- RSC requires `NodeRenderer`, not ExecJS. If `config.server_renderer` is not set to `"NodeRenderer"`, migrate first
-- [ ] **`react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- during the React on Rails Pro 17 RC soak, use `19.2.1-rc.0`; check with `yarn why react-on-rails-rsc`
+- [ ] **Stable `react-on-rails-rsc` 19.2.x with patch `>= 19.2.1`** -- install `19.2.1` or later on the 19.2.x line; check with `yarn why react-on-rails-rsc`
 - [ ] **Three webpack bundles building** -- client, server, and RSC bundles all compile without errors
 - [ ] **RSC manifests generated** -- `react-client-manifest.json` and `react-server-client-manifest.json` exist in your webpack output directory
 - [ ] **RSC payload route mounted** -- `rsc_payload_route` in `config/routes.rb`
@@ -25610,7 +25610,7 @@ yarn why react-on-rails-rsc
 
 If you're on React 18 or earlier, upgrade first -- RSC requires React 19.
 
-> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. During the 17.0 release-candidate soak, use `react-on-rails-rsc@19.2.1-rc.0` until the stable package is published. Older 19.0.x RSC packages no longer satisfy the Pro 17 runtime floor.
+> **Version requirements:** React on Rails Pro 17 RSC requires React/React DOM 19.2.x with patch `>= 19.2.7` and a stable `react-on-rails-rsc` 19.2.x package with patch `>= 19.2.1`. Older 19.0.x packages and 19.2.1 prereleases no longer satisfy the Pro 17 runtime floor.
 
 ## Step 2: Configure Rails for RSC
 
@@ -26195,7 +26195,7 @@ React on Rails Pro 17 RSC requires the coordinated React 19.2.x / `react-on-rail
 **Fix:** Upgrade React, React DOM, and `react-on-rails-rsc` together:
 
 ```bash
-yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1-rc.0
+yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 ```
 
 ### Mistake 2: Forgetting the RSC bundle watcher in development
@@ -29853,9 +29853,8 @@ React on Rails Pro 17 RSC release set. Key constraints:
 
 - The fix landed in `react-on-rails-rsc` 19.2.0-rc.3 and is included in the 19.2.1 package line. Check the
   [react_on_rails_rsc releases](https://github.com/shakacode/react_on_rails_rsc/releases)
-  and the Pro release notes for the exact package to install. React on Rails Pro 17 RC packages use
-  `react-on-rails-rsc@19.2.1-rc.0`; the 17.0 final release requires `react-on-rails-rsc >= 19.2.1`
-  on the supported RSC 19.2.x package line.
+  and the Pro release notes for the exact package to install. React on Rails Pro 17 requires stable
+  `react-on-rails-rsc >= 19.2.1` on the supported RSC 19.2.x package line.
 - **Do not** bump `react-on-rails-rsc` on its own; it must be upgraded together with a compatible
   React, React DOM, and React on Rails Pro set, or the Pro node renderer's peer-compatibility check
   can fail at startup.

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       "These force patched versions of transitive dev dependencies. Remove when upstream packages update.",
       "ajv overrides were intentionally excluded: ajv v8 breaks webpack's schema-utils/ajv-keywords.",
       "The 2 moderate ajv alerts (ReDoS in $data option) are tolerable — ajv only validates our own config files.",
-      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react-on-rails-pro-node-renderer>react(-dom)/react-on-rails-rsc, react-on-rails-pro>react(-dom)/react-on-rails-rsc, and react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scope Pro RSC package tests and dummy validation to the React 19.2.7 + react-on-rails-rsc 19.2.1-rc.0 pair, the React on Rails 17 RSC floor (#3865; gate landed in #4026). The root workspace pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 only for legacy non-Pro fixture coverage."
+      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react-on-rails-pro-node-renderer>react(-dom)/react-on-rails-rsc, react-on-rails-pro>react(-dom)/react-on-rails-rsc, and react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scope Pro RSC package tests and dummy validation to the React 19.2.7 + react-on-rails-rsc 19.2.1 pair, the React on Rails 17 RSC floor (#3865; gate landed in #4026). The root workspace pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 only for legacy non-Pro fixture coverage."
     ],
     "overrides": {
       "react": "$react",
@@ -141,13 +141,13 @@
       "react_on_rails>react-dom": "^19.2.0",
       "react-on-rails-pro-node-renderer>react": "~19.2.7",
       "react-on-rails-pro-node-renderer>react-dom": "~19.2.7",
-      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1",
       "react-on-rails-pro>react": "~19.2.7",
       "react-on-rails-pro>react-dom": "~19.2.7",
-      "react-on-rails-pro>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro>react-on-rails-rsc": "19.2.1",
       "react_on_rails_pro_dummy>react": "~19.2.7",
       "react_on_rails_pro_dummy>react-dom": "~19.2.7",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1-rc.0",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1",
       "sentry-testkit>body-parser": "npm:empty-npm-package@1.0.0",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0",
       "lodash@>=4.0.0 <=4.17.22": ">=4.17.23 <5",

--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -73,7 +73,7 @@
     "react": "~19.2.7",
     "react-dom": "~19.2.7",
     "react-on-rails": "workspace:*",
-    "react-on-rails-rsc": "19.2.1-rc.0",
+    "react-on-rails-rsc": "19.2.1",
     "redis": "^5.0.1",
     "sentry-testkit": "^5.0.6",
     "touch": "^3.1.0",

--- a/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
@@ -20,11 +20,11 @@
 // Ruby Doctor/generator constants that install and diagnose the same Pro RSC
 // package line. The 19.2.1 line pairs with React/React DOM 19.2.7 and carries
 // the coordinated RSC fixes required by the Pro RSC renderer path.
-// `minimumPrereleaseVersion` keeps the 17.0 RC soak installable until the stable
-// 19.2.1 package is published without accepting older prereleases on the same
-// tuple. When it is set, keep its core tuple equal to `minimumVersion`.
+// Stable releases leave `minimumPrereleaseVersion` undefined so prereleases do
+// not satisfy the package floor. A future prerelease soak may set a matching
+// tuple temporarily.
 export const RSC_PEER_SUPPORT = {
-  reactOnRailsRsc: { minimumVersion: '19.2.1', minimumPrereleaseVersion: '19.2.1-rc.0', supportedMajor: 19 },
+  reactOnRailsRsc: { minimumVersion: '19.2.1', minimumPrereleaseVersion: undefined, supportedMajor: 19 },
   react: {
     supportedMajor: 19,
     supportedRanges: [

--- a/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
@@ -16,12 +16,7 @@
 import { checkRscPeerCompatibility } from '../src/shared/checkRscPeerCompatibility';
 import { RSC_PEER_SUPPORT } from '../src/shared/rscPeerSupport';
 
-const { minimumVersion } = RSC_PEER_SUPPORT.reactOnRailsRsc;
-type MutableRscSupport = {
-  minimumVersion: string;
-  minimumPrereleaseVersion?: string;
-  supportedMajor: number;
-};
+const { minimumPrereleaseVersion, minimumVersion } = RSC_PEER_SUPPORT.reactOnRailsRsc;
 
 const versionBelowMinimumVersion = (version: string) => {
   const [major, minor, patch] = version.split('.').map(Number);
@@ -30,24 +25,11 @@ const versionBelowMinimumVersion = (version: string) => {
   throw new Error('minimumVersion must allow a lower supported-major version for the floor test');
 };
 
-const coreTuple = (version: string) => {
-  const [core = ''] = version
-    .replace(/^[v=]+/, '')
-    .split('+')[0]
-    .split('-');
-  return core.split('.').map(Number);
-};
-
 const belowMinimumVersion = versionBelowMinimumVersion(minimumVersion);
 
 describe('checkRscPeerCompatibility', () => {
-  it('keeps the prerelease floor on the stable floor tuple when RC soak is configured', () => {
-    const { minimumPrereleaseVersion } = RSC_PEER_SUPPORT.reactOnRailsRsc;
-
-    expect(
-      minimumPrereleaseVersion === undefined ||
-        coreTuple(minimumPrereleaseVersion).join('.') === coreTuple(minimumVersion).join('.'),
-    ).toBe(true);
+  it('does not configure a prerelease exception for the stable package floor', () => {
+    expect(minimumPrereleaseVersion).toBeUndefined();
   });
 
   it('returns ok when react-on-rails-rsc is absent (optional peer not installed)', () => {
@@ -67,47 +49,25 @@ describe('checkRscPeerCompatibility', () => {
     expect(r.message).toContain(`>= ${minimumVersion}`);
   });
 
-  it('omits the RC soak clause when no prerelease floor is configured', () => {
-    const rscSupport = RSC_PEER_SUPPORT.reactOnRailsRsc as MutableRscSupport;
-    const originalMinimumPrereleaseVersion = rscSupport.minimumPrereleaseVersion;
-
-    try {
-      rscSupport.minimumPrereleaseVersion = undefined;
-      const r = checkRscPeerCompatibility({ rscVersion: belowMinimumVersion, reactVersion: '19.2.7' });
+  it.each(['19.2.1-beta.0', '19.2.1-rc.0', '19.2.1-rc.1', '19.2.1-rc.2', '19.2.1-rc-1', '19.2.2-alpha.0'])(
+    'errors for prerelease %s once the stable package floor is active',
+    (prerelease) => {
+      const r = checkRscPeerCompatibility({ rscVersion: prerelease, reactVersion: '19.2.7' });
 
       expect(r.level).toBe('error');
+      expect(r.message).toContain(prerelease);
       expect(r.message).toContain(`>= ${minimumVersion}`);
       expect(r.message).not.toContain('during the RC soak');
       expect(r.message).not.toContain('undefined');
-    } finally {
-      rscSupport.minimumPrereleaseVersion = originalMinimumPrereleaseVersion;
-    }
-  });
+    },
+  );
 
-  it('returns ok for the coordinated RC floor prerelease', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: '19.2.1-rc.0', reactVersion: '19.2.7' }).level).toBe('ok');
-  });
-
-  it('returns ok for a prerelease newer than the coordinated RC floor', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: '19.2.1-rc.1', reactVersion: '19.2.7' }).level).toBe('ok');
-  });
-
-  it('returns ok for a hyphenated prerelease newer than the coordinated RC floor', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: '19.2.1-rc-1', reactVersion: '19.2.7' }).level).toBe('ok');
-  });
-
-  it('errors for prereleases older than the coordinated RC floor', () => {
-    const r = checkRscPeerCompatibility({ rscVersion: '19.2.1-beta.0', reactVersion: '19.2.7' });
+  it('omits the RC soak clause when reporting the stable package floor', () => {
+    const r = checkRscPeerCompatibility({ rscVersion: belowMinimumVersion, reactVersion: '19.2.7' });
     expect(r.level).toBe('error');
-    expect(r.message).toContain('19.2.1-beta.0');
-    expect(r.message).toContain('19.2.1-rc.0');
-  });
-
-  it('errors for future prereleases outside the coordinated RC floor tuple', () => {
-    const r = checkRscPeerCompatibility({ rscVersion: '19.2.2-alpha.0', reactVersion: '19.2.7' });
-    expect(r.level).toBe('error');
-    expect(r.message).toContain('19.2.2-alpha.0');
-    expect(r.message).toContain('19.2.1-rc.0');
+    expect(r.message).toContain(`>= ${minimumVersion}`);
+    expect(r.message).not.toContain('during the RC soak');
+    expect(r.message).not.toContain('undefined');
   });
 
   it('returns ok for a version with a leading v (prefix stripped for comparison)', () => {
@@ -161,7 +121,7 @@ describe('checkRscPeerCompatibility', () => {
   });
 
   it('errors when React 19.0 is paired with the React 19.2 RSC package line', () => {
-    const r = checkRscPeerCompatibility({ rscVersion: '19.2.1-rc.0', reactVersion: '19.0.4' });
+    const r = checkRscPeerCompatibility({ rscVersion: minimumVersion, reactVersion: '19.0.4' });
     expect(r.level).toBe('error');
     expect(r.message).toContain('react');
     expect(r.message).toContain('19.0.4');

--- a/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
@@ -134,14 +134,17 @@ describe('runRscPeerCompatibilityCheck', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('does not warn for the coordinated RC package line', () => {
-    expect(() =>
-      runRscPeerCompatibilityCheck({
-        resolveVersion: resolveVersions('19.2.1-rc.0'),
-      }),
-    ).not.toThrow();
-    expect(warnSpy).not.toHaveBeenCalled();
-  });
+  it.each(['19.2.1-rc.0', '19.2.1-rc.1'])(
+    'throws for the superseded prerelease package line %s',
+    (prerelease) => {
+      expect(() =>
+        runRscPeerCompatibilityCheck({
+          resolveVersion: resolveVersions(prerelease),
+        }),
+      ).toThrow(new RegExp(`>= ${minimumVersion}`));
+      expect(warnSpy).not.toHaveBeenCalled();
+    },
+  );
 
   it('downgrades a hard error to a warning when the env hatch is set', () => {
     expect(() =>
@@ -176,7 +179,7 @@ describe('runRscPeerCompatibilityCheck', () => {
   it('throws when React 19.0 is paired with the React 19.2 RSC package line', () => {
     expect(() =>
       runRscPeerCompatibilityCheck({
-        resolveVersion: resolveVersions('19.2.1-rc.0', '19.0.4'),
+        resolveVersion: resolveVersions(minimumVersion, '19.0.4'),
       }),
     ).toThrow(/Incompatible react/);
     expect(warnSpy).not.toHaveBeenCalled();

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "react": ">= 16",
     "react-dom": ">= 16",
-    "react-on-rails-rsc": ">=19.2.1-rc.0 <20.0.0",
+    "react-on-rails-rsc": ">=19.2.1 <20.0.0",
     "@tanstack/react-router": ">=1.139.0 <2.0.0",
     "ioredis": ">= 5"
   },
@@ -118,7 +118,7 @@
     "mock-fs": "^5.5.0",
     "react": "~19.2.7",
     "react-dom": "~19.2.7",
-    "react-on-rails-rsc": "19.2.1-rc.0",
+    "react-on-rails-rsc": "19.2.1",
     "ioredis": "5.11.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ overrides:
   react_on_rails>react-dom: ^19.2.0
   react-on-rails-pro-node-renderer>react: ~19.2.7
   react-on-rails-pro-node-renderer>react-dom: ~19.2.7
-  react-on-rails-pro-node-renderer>react-on-rails-rsc: 19.2.1-rc.0
+  react-on-rails-pro-node-renderer>react-on-rails-rsc: 19.2.1
   react-on-rails-pro>react: ~19.2.7
   react-on-rails-pro>react-dom: ~19.2.7
-  react-on-rails-pro>react-on-rails-rsc: 19.2.1-rc.0
+  react-on-rails-pro>react-on-rails-rsc: 19.2.1
   react_on_rails_pro_dummy>react: ~19.2.7
   react_on_rails_pro_dummy>react-dom: ~19.2.7
-  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.1-rc.0
+  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.1
   sentry-testkit>body-parser: npm:empty-npm-package@1.0.0
   sentry-testkit>express: npm:empty-npm-package@1.0.0
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23 <5'
@@ -286,8 +286,8 @@ importers:
         specifier: ~19.2.7
         version: 19.2.7(react@19.2.7)
       react-on-rails-rsc:
-        specifier: 19.2.1-rc.0
-        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.2.1
+        version: 19.2.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
 
   packages/react-on-rails-pro-node-renderer:
     dependencies:
@@ -401,8 +401,8 @@ importers:
         specifier: workspace:*
         version: link:../react-on-rails
       react-on-rails-rsc:
-        specifier: 19.2.1-rc.0
-        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.2.1
+        version: 19.2.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
       redis:
         specifier: ^5.0.1
         version: 5.10.0
@@ -765,8 +765,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.2.1-rc.0
-        version: 19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
+        specifier: 19.2.1
+        version: 19.2.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8514,7 +8514,7 @@ packages:
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.2.7
+      react: ~19.0.4
 
   react-error-boundary@4.1.2:
     resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
@@ -8543,12 +8543,16 @@ packages:
       react-dom: ~19.0.4
       webpack: ^5.59.0
 
-  react-on-rails-rsc@19.2.1-rc.0:
-    resolution: {integrity: sha512-lWUQloOMYS2/Jio7M9pKaY84+gNJ1ZD2pMTj37HDZtf6GsJjb0CJfJlizvxbquUdMQawX+1h59c63syFZ7AWmQ==}
+  react-on-rails-rsc@19.2.1:
+    resolution: {integrity: sha512-PQ+Ly+cCA3flJ4EJMczSv0rD6boP0wcXCLmaSfj3HOt+7XxP7DkJyu5IiEGb86vIQjMwaTPs68XN9wlnnx+pUw==}
     peerDependencies:
-      react: ^19.2.7
-      react-dom: ^19.2.7
+      '@rspack/core': ^1.0.0 || ^2.0.0
+      react: ~19.0.4
+      react-dom: ~19.0.4
       webpack: ^5.59.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
 
   react-proptypes@1.0.0:
     resolution: {integrity: sha512-rIAUscBmSfPVEUkOc9wR66sMJolmCC6Bi88I7oNegkwoFkUFcqU2UhpBt8/AyFtSFxnk9zNMZ9cSZ9BQA433uA==}
@@ -8596,8 +8600,8 @@ packages:
     resolution: {integrity: sha512-bYfuvqPJnHB4CHo2Ze7fQyJAO77TUu1W/aKFt81ICXbLiOTg5jHaO/NPDlpvGWUALoEGaGb7Oi1uXAaO+Bw6jw==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: ^19.2.7
-      react-dom: ^19.2.7
+      react: ~19.0.4
+      react-dom: ~19.0.4
       webpack: ^5.59.0
 
   react@18.3.1:
@@ -19251,7 +19255,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
+  react-on-rails-rsc@19.2.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -19260,8 +19264,10 @@ snapshots:
       react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
       webpack: 5.104.1(@swc/core@1.15.3)(esbuild@0.28.0)(webpack-cli@7.0.3)
       webpack-sources: 3.3.3
+    optionalDependencies:
+      '@rspack/core': 2.0.5
 
-  react-on-rails-rsc@19.2.1-rc.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3)):
+  react-on-rails-rsc@19.2.1(@rspack/core@2.0.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -19270,6 +19276,8 @@ snapshots:
       react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(@swc/core@1.15.3))
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
+    optionalDependencies:
+      '@rspack/core': 2.0.5
 
   react-proptypes@1.0.0:
     dependencies:

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -156,13 +156,12 @@ module ReactOnRails
       # current on npm; React's RSC runtime and bundler integration can change between minors.
       #
       # This is intentionally distinct from RSC_PACKAGE_VERSION_PIN below, which pins
-      # `react-on-rails-rsc`. Coordination note for #3609: Pro package metadata accepts the
-      # prerelease RSC package broadly enough to keep `npm ls` healthy, while generated apps still
-      # install the tested React 19.2.x range and exact RSC package pin until stable 19.2.1 ships.
+      # `react-on-rails-rsc`. Coordination note for #3609: Pro package metadata and generated apps
+      # use the tested React 19.2.x range with the exact stable RSC package pin.
       RSC_REACT_VERSION_RANGE = "~19.2.7"
-      # Pinned to the 19.2.1 release candidate, which carries the coordinated React 19.2.7 RSC
-      # peer floor required by the React on Rails Pro 17 runtime check.
-      RSC_PACKAGE_VERSION_PIN = "19.2.1-rc.0"
+      # Pinned to the stable 19.2.1 package, which carries the coordinated React 19.2.7 RSC peer floor
+      # required by the React on Rails Pro 17 runtime check.
+      RSC_PACKAGE_VERSION_PIN = "19.2.1"
 
       private
 
@@ -256,7 +255,7 @@ module ReactOnRails
         say "Installing React dependencies..."
 
         # RSC requires the coordinated React 19.2.x patch line.
-        # Pin React to ~19.2.7 while using the matching RSC package release candidate.
+        # Pin React to ~19.2.7 while using the matching stable RSC package.
         react_deps = if respond_to?(:use_rsc?) && use_rsc?
                        ["react@#{RSC_REACT_VERSION_RANGE}", "react-dom@#{RSC_REACT_VERSION_RANGE}",
                         "prop-types@^15.0.0"]

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3501,8 +3501,8 @@ module ReactOnRails
       "#{RSC_SUPPORTED_PACKAGE_MAJOR}.#{minor}.x"
     end.join(" or ")
     RSC_PACKAGE_INSTALL_VERSION = ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN
-    # While the 17.0 RC soak accepts a prerelease package, the prerelease floor
-    # must share the same core tuple as RSC_MINIMUM_PACKAGE_VERSION.
+    # A temporary prerelease pin may define a matching exception during a future soak.
+    # Stable pins leave this nil so prereleases do not satisfy the package floor.
     RSC_MINIMUM_PACKAGE_PRERELEASE_VERSION =
       RSC_PACKAGE_INSTALL_VERSION.include?("-") ? RSC_PACKAGE_INSTALL_VERSION : nil
     RSC_MINIMUM_REACT_VERSION = "19.2.7"

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5242,7 +5242,7 @@ RSpec.describe ReactOnRails::Doctor do
             FileUtils.mkdir_p("config/webpack")
             File.write("config/routes.rb", "Rails.application.routes.draw do\n  rsc_payload_route\nend")
             File.write("config/webpack/rscWebpackConfig.js", "module.exports = {}")
-            File.write("package.json", '{"dependencies":{"react":"~19.2.7","react-on-rails-rsc":"19.2.1-rc.0"}}')
+            File.write("package.json", '{"dependencies":{"react":"~19.2.7","react-on-rails-rsc":"19.2.1"}}')
             File.write("Procfile.dev", "rsc-bundle: RSC_BUNDLE_ONLY=true bin/shakapacker --watch")
             example.run
           end
@@ -5283,7 +5283,7 @@ RSpec.describe ReactOnRails::Doctor do
             FileUtils.mkdir_p("config/webpack")
             File.write("config/routes.rb", "rsc_payload_route")
             File.write("config/webpack/rscWebpackConfig.js", "{}")
-            File.write("package.json", '{"dependencies":{"react":"~19.2.7","react-on-rails-rsc":"19.2.1-rc.0"}}')
+            File.write("package.json", '{"dependencies":{"react":"~19.2.7","react-on-rails-rsc":"19.2.1"}}')
             File.write("Procfile.dev", "rsc-bundle: RSC_BUNDLE_ONLY=true bin/shakapacker --watch")
             example.run
           end
@@ -5812,9 +5812,8 @@ RSpec.describe ReactOnRails::Doctor do
       expect(described_class::RSC_MINIMUM_PACKAGE_VERSION).to eq(
         rsc_support.match(/minimumVersion:\s*'(?<version>[^']+)'/)[:version]
       )
-      expect(described_class::RSC_MINIMUM_PACKAGE_PRERELEASE_VERSION).to eq(
-        rsc_support.match(/minimumPrereleaseVersion:\s*'(?<version>[^']+)'/)[:version]
-      )
+      prerelease_match = rsc_support.match(/minimumPrereleaseVersion:\s*'(?<version>[^']+)'/)
+      expect(described_class::RSC_MINIMUM_PACKAGE_PRERELEASE_VERSION).to eq(prerelease_match&.[](:version))
       expect(described_class::RSC_SUPPORTED_PACKAGE_MAJOR).to eq(
         rsc_support.match(/supportedMajor:\s*(?<major>\d+)/)[:major].to_i
       )
@@ -5994,7 +5993,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.0.7",
                   "react-dom" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6002,7 +6001,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.0.7")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => "19.2.1",
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             example.run
@@ -6019,7 +6018,7 @@ RSpec.describe ReactOnRails::Doctor do
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(error_msgs).to include(
           a_string_including(
-            "react-on-rails-rsc 19.2.1-rc.0 requires react ^19.2.7",
+            "react-on-rails-rsc 19.2.1 requires react ^19.2.7",
             "installed react is 19.0.7"
           )
         )
@@ -6029,7 +6028,7 @@ RSpec.describe ReactOnRails::Doctor do
 
       it "does not report peer compatibility success when peer checks are unexpectedly empty" do
         rsc_package = {
-          "version" => "19.2.1-rc.0",
+          "version" => "19.2.1",
           "peerDependencies" => { "react" => "^19.0.4" }
         }
         allow(doctor).to receive(:rsc_peer_check_results).and_return([])
@@ -6107,7 +6106,7 @@ RSpec.describe ReactOnRails::Doctor do
             expect(error_msgs).to include(
               a_string_including(
                 "react-on-rails-rsc 19.2.1-beta.0 is not supported by React on Rails Pro 17 RSC",
-                "or 19.2.1-rc.0 during the 17.0 RC soak"
+                "requires react-on-rails-rsc >= 19.2.1"
               )
             )
             expect(doctor).not_to have_received(:capture_rsc_dist_tags)
@@ -6144,7 +6143,7 @@ RSpec.describe ReactOnRails::Doctor do
             expect(error_msgs).to include(
               a_string_including(
                 "react-on-rails-rsc 19.2.2-alpha.0 is not supported by React on Rails Pro 17 RSC",
-                "or 19.2.1-rc.0 during the 17.0 RC soak"
+                "requires react-on-rails-rsc >= 19.2.1"
               )
             )
             expect(doctor).not_to have_received(:capture_rsc_dist_tags)
@@ -6197,7 +6196,7 @@ RSpec.describe ReactOnRails::Doctor do
               JSON.generate(
                 "dependencies" => {
                   "react" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6229,7 +6228,7 @@ RSpec.describe ReactOnRails::Doctor do
                   "react-dom" => "19.0.7"
                 },
                 "optionalDependencies" => {
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6254,7 +6253,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.0.7",
                   "react-dom" => "19.0.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6262,7 +6261,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.0.7")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => "19.2.1",
               "peerDependencies" => { "react" => "^19.0.0", "react-dom" => "^19.0.0" }
             )
             stub_package_root(Dir.pwd)
@@ -6274,7 +6273,7 @@ RSpec.describe ReactOnRails::Doctor do
             warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with unsupported React 19.0.7",
+                "react-on-rails-rsc 19.2.1 is installed with unsupported React 19.0.7",
                 "React/React DOM 19.2.x with patch >= 19.2.7"
               )
             )
@@ -6292,7 +6291,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.3.0",
                   "react-dom" => "19.3.0",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6300,7 +6299,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.3.0")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => "19.2.1",
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             stub_package_root(Dir.pwd)
@@ -6312,7 +6311,7 @@ RSpec.describe ReactOnRails::Doctor do
             warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with unsupported React 19.3.0",
+                "react-on-rails-rsc 19.2.1 is installed with unsupported React 19.3.0",
                 "React/React DOM 19.2.x with patch >= 19.2.7"
               )
             )
@@ -6330,7 +6329,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.2.7",
                   "react-dom" => "19.3.0",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6338,7 +6337,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.3.0")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => "19.2.1",
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             stub_package_root(Dir.pwd)
@@ -6349,7 +6348,7 @@ RSpec.describe ReactOnRails::Doctor do
             error_msgs = checker.messages.select { |m| m[:type] == :error }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with unsupported React DOM 19.3.0",
+                "react-on-rails-rsc 19.2.1 is installed with unsupported React DOM 19.3.0",
                 "React/React DOM 19.2.x with patch >= 19.2.7"
               )
             )
@@ -6366,7 +6365,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.2.7",
                   "react-dom" => "19.2.8",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6374,7 +6373,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.2.8")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => "19.2.1",
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             stub_package_root(Dir.pwd)
@@ -6385,7 +6384,7 @@ RSpec.describe ReactOnRails::Doctor do
             error_msgs = checker.messages.select { |m| m[:type] == :error }.map { |m| m[:content] }
             expect(error_msgs).to include(
               a_string_including(
-                "react-on-rails-rsc 19.2.1-rc.0 is installed with React 19.2.7 but React DOM 19.2.8",
+                "react-on-rails-rsc 19.2.1 is installed with React 19.2.7 but React DOM 19.2.8",
                 "react and react-dom to resolve to the same version"
               )
             )
@@ -6404,7 +6403,7 @@ RSpec.describe ReactOnRails::Doctor do
                 "dependencies" => {
                   "react" => "19.2.7",
                   "react-dom" => "19.2.7",
-                  "react-on-rails-rsc" => "19.2.1-rc.0"
+                  "react-on-rails-rsc" => "19.2.1"
                 }
               )
             )
@@ -6412,7 +6411,7 @@ RSpec.describe ReactOnRails::Doctor do
             install_package("react-dom", "version" => "19.2.7")
             install_package(
               "react-on-rails-rsc",
-              "version" => "19.2.1-rc.0",
+              "version" => "19.2.1",
               "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
             )
             example.run
@@ -6425,7 +6424,7 @@ RSpec.describe ReactOnRails::Doctor do
           .with(Dir.pwd)
           .and_return(
             [
-              JSON.generate("latest" => "19.0.5", "next" => "19.2.1-rc.1"),
+              JSON.generate("latest" => "19.2.1", "next" => "19.2.2-rc.1"),
               instance_double(Process::Status, success?: true)
             ]
           )
@@ -6435,7 +6434,7 @@ RSpec.describe ReactOnRails::Doctor do
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(warning_msgs).to include(
           a_string_including(
-            "react-on-rails-rsc 19.2.1-rc.0 is behind the npm next dist-tag 19.2.1-rc.1",
+            "react-on-rails-rsc 19.2.1 is behind the npm next dist-tag 19.2.2-rc.1",
             "React Server Components track React minor versions"
           )
         )
@@ -6724,7 +6723,7 @@ RSpec.describe ReactOnRails::Doctor do
               "dependencies" => {
                 "react" => "19.0.7",
                 "react-dom" => "19.0.7",
-                "react-on-rails-rsc" => "19.2.1-rc.0"
+                "react-on-rails-rsc" => "19.2.1"
               }
             )
           )
@@ -6732,7 +6731,7 @@ RSpec.describe ReactOnRails::Doctor do
           install_package("react-dom", "version" => "19.0.7")
           install_package(
             "react-on-rails-rsc",
-            "version" => "19.2.1-rc.0",
+            "version" => "19.2.1",
             "peerDependencies" => { "react" => "^19.2.7", "react-dom" => "^19.2.7" }
           )
           example.run
@@ -6767,7 +6766,7 @@ RSpec.describe ReactOnRails::Doctor do
       report = JSON.parse(output.join("\n"))
       rsc_check = report["checks"].find { |check| check["id"] == "react_server_components" }
       expect(rsc_check["status"]).to eq("fail")
-      expect(rsc_check["message"]).to include("react-on-rails-rsc 19.2.1-rc.0 requires react ^19.2.7")
+      expect(rsc_check["message"]).to include("react-on-rails-rsc 19.2.1 requires react ^19.2.7")
       expect(report["status"]).to eq("fail")
     end
   end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3681,20 +3681,19 @@ describe InstallGenerator, type: :generator do
       allow(install_generator).to receive(:fallback_package_manager).and_return("pnpm")
     end
 
-    it "explains why every RSC install is pinned during the RC soak" do
+    it "explains why every RSC install is pinned to the stable package" do
       allow(install_generator).to receive(:add_packages).and_return(true)
 
       install_generator.send(:add_rsc_dependencies)
 
       message_text = GeneratorMessages.messages.join("\n")
       expect(message_text).to include("all --rsc installs")
-      expect(message_text).to include("temporarily")
       expect(message_text).to include("react-on-rails-rsc@#{rsc_pin}")
       expect(message_text).to include("react-on-rails-rsc/RspackPlugin")
       expect(message_text).to include("Webpack")
-      expect(message_text).to include("prerelease")
-      expect(message_text).to include("until stable")
-      expect(message_text).to include("react-on-rails-rsc@19.2.1")
+      expect(message_text).not_to include("temporarily")
+      expect(message_text).not_to include("prerelease")
+      expect(message_text).not_to include("until stable")
     end
 
     it "keeps the version pin and uses the detected package manager when manual RSC recovery is needed" do

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -289,10 +289,10 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
       instance.add_npm_dependencies_result = false
       allow(instance).to receive(:existing_package_names).and_return(%w[react-on-rails-rsc])
 
-      result = instance.send(:add_packages, ["react-on-rails-rsc@19.2.1-rc.0"])
+      result = instance.send(:add_packages, ["react-on-rails-rsc@19.2.1"])
 
       expect(result).to be(true)
-      expect(instance.system_calls).to include(%w[npm install --save-exact react-on-rails-rsc@19.2.1-rc.0])
+      expect(instance.system_calls).to include(%w[npm install --save-exact react-on-rails-rsc@19.2.1])
     end
   end
 
@@ -803,7 +803,7 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
   describe "#rsc_packages_with_version" do
     it "defines an explicit RSC package version pin independent from the React semver range prefix" do
       expect(ReactOnRails::Generators::JsDependencyManager::RSC_REACT_VERSION_RANGE).to eq("~19.2.7")
-      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.2.1-rc.0")
+      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.2.1")
     end
 
     it "keeps the generated RSC React policy on the 19.2.x patch track" do
@@ -883,11 +883,11 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1-rc.0")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1")
       expect(warning_text).to include("left the version pin in package.json")
       expect(warning_text).to include("react-on-rails-rsc/WebpackPlugin")
       expect(warning_text).to include("react-on-rails-rsc/RspackPlugin")
-      manual_command = "npm install --save-exact react-on-rails-rsc@19.2.1-rc.0"
+      manual_command = "npm install --save-exact react-on-rails-rsc@19.2.1"
       expect(warning_text).to include(manual_command)
       expect(warning_text.scan(manual_command).size).to eq(1)
     end
@@ -895,9 +895,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
     it "keeps the pinned manual install instruction when the pinned install raises" do
       allow(instance)
         .to receive(:rsc_packages_with_version)
-        .and_return([["react-on-rails-rsc@19.2.1-rc.0"], true])
+        .and_return([["react-on-rails-rsc@19.2.1"], true])
 
-      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.2.1-rc.0"]).and_raise("network down")
+      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.2.1"]).and_raise("network down")
       allow(instance).to receive(:add_packages).with(["react-on-rails-rsc"]).and_return(true)
 
       instance.send(:add_rsc_dependencies)
@@ -906,9 +906,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1-rc.0")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.2.1")
       expect(warning_text).to include("Error adding React Server Components dependencies: network down")
-      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.2.1-rc.0")
+      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.2.1")
     end
 
     it "uses computed rsc packages for manual recovery when installation raises" do

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -56,7 +56,7 @@
     "react-intl": "^10",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "19.2.1-rc.0",
+    "react-on-rails-rsc": "19.2.1",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",

--- a/script/convert-test.bash
+++ b/script/convert-test.bash
@@ -105,13 +105,13 @@ write_fixture() {
       "react_on_rails>react-dom": "^19.2.0",
       "react-on-rails-pro>react": "~19.2.7",
       "react-on-rails-pro>react-dom": "~19.2.7",
-      "react-on-rails-pro>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro>react-on-rails-rsc": "19.2.1",
       "react-on-rails-pro-node-renderer>react": "~19.2.7",
       "react-on-rails-pro-node-renderer>react-dom": "~19.2.7",
-      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1-rc.0",
+      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.2.1",
       "react_on_rails_pro_dummy>react": "~19.2.7",
       "react_on_rails_pro_dummy>react-dom": "~19.2.7",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1-rc.0",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.1",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0"
     }
   }


### PR DESCRIPTION
## Why

Release PR #4670 moved React on Rails Pro 17 from the RSC 19.2.1 release candidate to the published stable package. This required forward-porting the merged release fix to main so the release branch and ongoing development do not diverge.

Closes #4357.

## What changed

- cherry-picked the merged #4670 squash commit with `git cherry-pick -x`
- resolved conflicts from current main, preserving its newer Pro 17 metadata, React 18 coverage, package scripts, documentation, and release history
- kept the stable `react-on-rails-rsc@19.2.1` pins, `>=19.2.1 <20` peer floor, prerelease rejection, lockfile integrity, and generated docs
- retained the July 9 production evidence as `19.2.1-rc.0`; current install guidance uses stable 19.2.1

The required flagship demo update is merged in shakacode/react-on-rails-demo-flagship#27.

## Changelog

The stable-adoption entry from #4670 is preserved under Unreleased / Changed and links the release PR. No duplicate entry was added for this mechanical forward-port.

## Validation

- `pnpm install --frozen-lockfile`
- node-renderer compatibility: 41 tests passed
- node-renderer type-check
- Doctor: 371 examples passed
- JavaScript dependency manager: 95 examples passed
- focused generator messaging: 3 examples passed
- full JavaScript lint
- focused RuboCop: 5 files clean
- Prettier and online/offline Markdown links
- docs sidebar and generated `llms-full` checks
- conversion fixture
- dependency graph: Pro paths resolve RSC 19.2.1 and RSDW 19.2.7; legacy root fixture remains RSC 19.0.5
- independent forward-port audit and final QA: zero Must-Fix findings

Release PR #4670 also passed the full hosted generator, integration, Pro, Playwright, node-renderer, lint, and documentation matrix before merge.

## Conflict-resolution notes

The 26-file cherry-pick conflicted because main had moved beyond the release branch. Each conflicted file was based on current main and received only the stable-RSC semantic delta. The lockfile and both generated LLM files were regenerated from the resolved main sources.

## Codex Decision Log

- preserved main package version `17.0.0-rc.6`; did not import release-only `17.0.0-rc.10` metadata
- kept historical RC changelog and dated RC verification statements unchanged
- classified stable adoption as Changed on main because the breaking RSC floor was already documented in the earlier RC entry
- process-gap disposition: not applicable; no recurring workflow miss was found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RSC setup now installs the stable `react-on-rails-rsc@19.2.1` package.

* **Bug Fixes**
  * Prerelease RSC versions below the stable compatibility floor are now rejected.
  * Compatibility checks and installation guidance now consistently require React/React DOM 19.2.7+ with stable RSC 19.2.1+.

* **Documentation**
  * Updated RSC, streaming SSR, migration, troubleshooting, and compatibility guidance to reflect stable package requirements and coordinated upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->