### PR TITLE
Update changelog for 17.0.0.rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
-### [17.0.0.rc.11] - 2026-07-14
+### [17.0.0.rc.11] - 2026-07-15
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.0.0.rc.11] - 2026-07-14
+
 #### Changed
 
 - **[Pro]** **RSC scaffolding now installs stable `react-on-rails-rsc@19.2.1`**: The Pro package,
@@ -2898,7 +2900,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.10...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.11...main
+[17.0.0.rc.11]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.10...v17.0.0.rc.11
 [17.0.0.rc.10]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.9...v17.0.0.rc.10
 [17.0.0.rc.9]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.8...v17.0.0.rc.9
 [17.0.0.rc.8]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.7...v17.0.0.rc.8


### PR DESCRIPTION
## Why

React on Rails `17.0.0.rc.11` needs focused release notes for the user-visible changes merged to `release/17.0.0` since `v17.0.0.rc.10`. Stamping the changelog before publishing lets the release task read the intended version and generate the corresponding GitHub release notes.

## What changed

- stamped `17.0.0.rc.11` immediately below `Unreleased`
- moved the existing Pro license/runtime and stable RSC 19.2.1 entries into the new RC section
- updated the compare links from `v17.0.0.rc.10` to `v17.0.0.rc.11`
- left every earlier RC section intact

## Classification sweep

| PR | Result | Category | Rationale |
| --- | --- | --- | --- |
| 4660 | entry-needed | Pro runtime | Changes published Pro license metadata, packaged terms, attribution behavior, and diagnostics; already represented in the changelog. |
| 4670 | entry-needed | Pro runtime | Changes the Pro/RSC package floor, generator output, compatibility checks, and shipped artifact license; already represented in the changelog. |
| 4671 | no-entry | perf-reliability | Corrects the still-unreleased 4660 implementation, including regex-timeout safety; the final user-visible behavior is already covered by the 4660 entry. |

The mechanical `v17.0.0.rc.10..origin/release/17.0.0` sweep returned no UNKNOWN commits.

## Verification

- `bundle exec rspec spec/react_on_rails/update_changelog_rake_helpers_spec.rb` from `react_on_rails/`: 33 examples, 0 failures
- repository pre-commit checks: trailing newlines, offline Markdown links, and Prettier passed
- `script/ci-changes-detector origin/release/17.0.0`: documentation-only; no hosted CI jobs recommended
- `git diff --check origin/release/17.0.0...HEAD`: passed
- structural checks: trailing newline, unique version headings, newest-first placement, and compare-link endpoints passed

## Review gate

- Sol/xhigh `codex review --base origin/release/17.0.0`: no actionable regressions; independently reproduced the stamp from the repository helpers
- Claude Opus/xhigh report-only review with tools disabled: no BLOCKING or DISCUSS findings
- `/simplify`: skipped as not applicable to a four-line machine-generated changelog header/link diff

## Review churn

- follow-up commits after first push: 0
- review-fix rounds before first push: 0
- residual risk: the release task must still bump version metadata and create the `v17.0.0.rc.11` tag after this PR merges; that is the normal release action, not part of this changelog-only PR
