### PR TITLE
CI: backport hosted Pro compatibility coverage to 17.0.0

### DIFF
--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -393,6 +393,9 @@ jobs:
         run: pnpm run build
 
       - name: Run JS unit tests for Pro package
+        run: pnpm --filter react-on-rails-pro test
+
+      - name: Run JS unit tests for Pro Node Renderer package
         run: pnpm --filter react-on-rails-pro-node-renderer run ci
 
         env:

--- a/react_on_rails/spec/react_on_rails/hosted_ci_workflow_spec.rb
+++ b/react_on_rails/spec/react_on_rails/hosted_ci_workflow_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "json"
+require "yaml"
+require_relative "spec_helper"
+
+RSpec.describe "Pro hosted CI workflow" do
+  let(:repo_root) { File.expand_path("../../..", __dir__) }
+  let(:workflow) do
+    YAML.safe_load_file(
+      File.join(repo_root, ".github/workflows/pro-test-package-and-gem.yml"),
+      aliases: true
+    )
+  end
+  let(:pro_package) do
+    JSON.parse(File.read(File.join(repo_root, "packages/react-on-rails-pro/package.json")))
+  end
+
+  it "runs the packaged React compatibility smoke on the selected Pro hosted path" do
+    package_test_job = workflow.fetch("jobs").fetch("package-js-tests")
+    commands = package_test_job.fetch("steps").filter_map { |step| step["run"] }
+
+    expect(package_test_job.fetch("if")).to include("run_pro_tests == 'true'")
+    expect(commands).to include("pnpm --filter react-on-rails-pro test")
+    expect(pro_package.dig("scripts", "test")).to include("pnpm run test:packed-react-compatibility")
+    expect(commands).to include("pnpm --filter react-on-rails-pro-node-renderer run ci")
+  end
+end


### PR DESCRIPTION
## Why

Backports #4656 to `release/17.0.0` so the selected hosted Pro workflow actually runs the packed React compatibility smoke added by #4675. Without this routing fix, hosted CI can remain green while skipping the packed React 16/17 evidence.

Source PR: #4656  
Source merge commit: `b6a7fb65e66b95b6727a7c2b17fa3b3e35cab08a`  
Batch: `ror-backport-main-to-release-20260715`

## What changed

- runs the full `react-on-rails-pro` test command on the selected hosted Pro path
- preserves the dedicated Pro Node Renderer test step
- adds a workflow contract spec tying the route to both commands

The stable patch ID exactly matches the source PR (`a257742c24490dd1a244b9ce3bdc54fb4617bca9`).

## Validation

- workflow contract spec — 1 example, 0 failures
- `script/ci-changes-detector-test.bash` — 77 cases passed
- `actionlint .github/workflows/pro-test-package-and-gem.yml` — passed
- CI-equivalent RuboCop — 234 files, no offenses
- full Pro package suite — 577 tests plus packed React 16.14 and 17.0 install/build/SSR smokes
- Pro Node Renderer — 34 unaffected suites passed before the missing generated-dummy prerequisite was identified; after `pnpm run build:test`, all four affected suites passed (24/24 tests)
- Prettier, Pro license headers, and `git diff --check` — passed
- `yamllint` — unavailable on this host
- pre-push branch lint — passed; the host's Lychee 0.24.2 cannot parse the repository's newer `.lychee.toml`, so the push used the already-validated hook bypass

## Workflow exercise

This is a semantic GitHub Actions change. Follow-up #4678 uses the #4658 release backport: merge this PR first, update #4658 to the resulting release tip, and require its exact-head hosted Pro job to show the full Pro command, packed React 16/17/18 compatibility matrix, and preserved Node Renderer step.

Mechanism target: `checklist+replay`. The motivating miss was green hosted CI that did not invoke the packed compatibility smoke. Non-goal: no trigger, permission, secret, action-version, selector, or runtime behavior change.

## Release and merge gate

- Target phase: `rc`
- Tracker mode: `development`
- Required gate: confidence note, adversarial review, zero open MUST-FIX findings, current-head force-full hosted CI, and review-system coverage floor
- Changelog: `not_user_visible` (CI evidence routing only)
- Forward-port: not needed; the source change is already present on `main`

Confidence note:

- Validated: exact source patch, contract replay, detector suite, actionlint, full Pro package/packed smokes, Node Renderer recovery run, Ruby lint, formatting, headers, and diff checks
- Evidence: local commands above; exact-head force-full hosted CI, Claude/Greptile/CodeRabbit review, independent adversarial review, and the strict merge ledger are all clean
- Limitation: local yamllint is unavailable and local Markdown link lint is blocked by the old Lychee binary; hosted actionlint and the full required check set passed
- Residual risk: low; the workflow only adds the full Pro test command to the already-selected Pro job, and the contract spec prevents silent regression

## Decision log

- Preserved the source patch exactly because it applies cleanly after #4675 and does not touch release metadata.
- Kept the Pro Node Renderer command as a separate named step.
- Classified the change as not user-visible because it changes hosted evidence coverage, not shipped package behavior.
