### PR TITLE
Release: forward-port post-pull prerelease guard

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -3360,7 +3360,7 @@ def resolve_version_input(version_input, monorepo_root, current_version: nil,
 
   if argumentless_prerelease_release_requires_explicit_version?(changelog_version:, current_version:,
                                                                 starting_version:)
-    abort argumentless_prerelease_release_message(changelog_version:, current_version: starting_version)
+    abort argumentless_prerelease_release_message(changelog_version:, current_version:)
   end
 
   if changelog_version && Gem::Version.new(changelog_version) > Gem::Version.new(current_version)

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1067,7 +1067,11 @@ def run_release_preflight_checks!(monorepo_root:, dry_run:)
 end
 
 def resolve_release_version_before_auth!(version_input:, monorepo_root:, dry_run:, current_version: nil)
-  resolved_version_input = resolve_version_input(version_input, monorepo_root, current_version:)
+  resolved_version_input = resolve_version_input(
+    version_input,
+    monorepo_root,
+    argumentless_starting_prerelease_version: current_version
+  )
   validate_requested_version_input!(resolved_version_input)
   run_release_preflight_checks!(monorepo_root:, dry_run:)
   resolved_version_input
@@ -3302,13 +3306,20 @@ def version_tagged?(monorepo_root, version)
   tagged_versions.include?(version)
 end
 
-def argumentless_prerelease_release_requires_explicit_version?(changelog_version:, current_version:)
-  return false unless release_prerelease_version?(current_version)
+def argumentless_prerelease_release_requires_explicit_version?(
+  changelog_version:,
+  current_version:,
+  starting_version: current_version
+)
+  return false unless release_prerelease_version?(starting_version)
   return true unless changelog_version
   return true unless release_prerelease_version?(changelog_version)
-  return true unless same_release_base?(changelog_version, current_version)
 
-  Gem::Version.new(changelog_version) <= Gem::Version.new(current_version)
+  versions_to_advance = [starting_version, current_version].uniq
+  return true unless versions_to_advance.all? { |version| same_release_base?(changelog_version, version) }
+
+  changelog_gem_version = Gem::Version.new(changelog_version)
+  versions_to_advance.any? { |version| changelog_gem_version <= Gem::Version.new(version) }
 end
 
 def argumentless_prerelease_release_message(changelog_version:, current_version:)
@@ -3338,15 +3349,18 @@ def untagged_changelog_current_version?(monorepo_root:, changelog_version:, curr
   !version_tagged?(monorepo_root, changelog_version)
 end
 
-def resolve_version_input(version_input, monorepo_root, current_version: nil)
+def resolve_version_input(version_input, monorepo_root, current_version: nil,
+                          argumentless_starting_prerelease_version: nil)
   stripped = version_input.to_s.strip
   return stripped unless stripped.empty?
 
   changelog_version = extract_latest_changelog_version(monorepo_root:)
   current_version ||= current_gem_version(monorepo_root)
+  starting_version = [argumentless_starting_prerelease_version, current_version].compact.first
 
-  if argumentless_prerelease_release_requires_explicit_version?(changelog_version:, current_version:)
-    abort argumentless_prerelease_release_message(changelog_version:, current_version:)
+  if argumentless_prerelease_release_requires_explicit_version?(changelog_version:, current_version:,
+                                                                starting_version:)
+    abort argumentless_prerelease_release_message(changelog_version:, current_version: starting_version)
   end
 
   if changelog_version && Gem::Version.new(changelog_version) > Gem::Version.new(current_version)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -327,7 +327,92 @@ RSpec.describe "release.rake helper methods" do
       allow(self).to receive(:extract_latest_changelog_version)
         .with(monorepo_root: "/tmp/repo")
         .and_return("17.0.0")
-      expect(self).not_to receive(:current_gem_version)
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0")
+      expect(self).not_to receive(:run_release_preflight_checks!)
+
+      expect do
+        resolve_release_version_before_auth!(
+          version_input: "",
+          monorepo_root: "/tmp/repo",
+          dry_run: false,
+          current_version: "17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+    end
+
+    it "refuses a changelog prerelease older than the post-pull checkout" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.11")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.12")
+      expect(self).not_to receive(:run_release_preflight_checks!)
+
+      expect do
+        resolve_release_version_before_auth!(
+          version_input: "",
+          monorepo_root: "/tmp/repo",
+          dry_run: false,
+          current_version: "17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+    end
+
+    it "refuses a changelog prerelease matching the post-pull checkout" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.11")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.11")
+      expect(self).not_to receive(:run_release_preflight_checks!)
+
+      expect do
+        resolve_release_version_before_auth!(
+          version_input: "",
+          monorepo_root: "/tmp/repo",
+          dry_run: false,
+          current_version: "17.0.0.rc.10"
+        )
+      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+    end
+
+    it "allows a changelog prerelease newer than an unchanged post-pull checkout" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.11")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.10")
+      expect(self).to receive(:run_release_preflight_checks!).with(monorepo_root: "/tmp/repo", dry_run: false)
+
+      result = resolve_release_version_before_auth!(
+        version_input: "",
+        monorepo_root: "/tmp/repo",
+        dry_run: false,
+        current_version: "17.0.0.rc.10"
+      )
+
+      expect(result).to eq("17.0.0.rc.11")
+    end
+
+    it "allows a changelog prerelease newer than an advanced post-pull checkout" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.12")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("17.0.0.rc.11")
+      expect(self).to receive(:run_release_preflight_checks!).with(monorepo_root: "/tmp/repo", dry_run: false)
+
+      result = resolve_release_version_before_auth!(
+        version_input: "",
+        monorepo_root: "/tmp/repo",
+        dry_run: false,
+        current_version: "17.0.0.rc.10"
+      )
+
+      expect(result).to eq("17.0.0.rc.12")
+    end
+
+    it "refuses a changelog prerelease on a different line than the post-pull checkout" do
+      allow(self).to receive(:extract_latest_changelog_version)
+        .with(monorepo_root: "/tmp/repo")
+        .and_return("17.0.0.rc.11")
+      allow(self).to receive(:current_gem_version).with("/tmp/repo").and_return("18.0.0.beta.1")
       expect(self).not_to receive(:run_release_preflight_checks!)
 
       expect do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
     end
 
-    it "uses the pre-pull prerelease version when a pull advances the checkout to stable" do
+    it "reports the post-pull stable version when a pull advances the checkout to stable" do
       allow(self).to receive(:extract_latest_changelog_version)
         .with(monorepo_root: "/tmp/repo")
         .and_return("17.0.0")
@@ -337,7 +337,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 17\.0\.0\n.*bundle exec rake "release\[17\.0\.0\]"/m
+      )
     end
 
     it "refuses a changelog prerelease older than the post-pull checkout" do
@@ -354,7 +357,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 17\.0\.0\.rc\.12\n.*bundle exec rake "release\[17\.0\.0\.rc\.12\]"/m
+      )
     end
 
     it "refuses a changelog prerelease matching the post-pull checkout" do
@@ -371,7 +377,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 17\.0\.0\.rc\.11\n.*bundle exec rake "release\[17\.0\.0\.rc\.11\]"/m
+      )
     end
 
     it "allows a changelog prerelease newer than an unchanged post-pull checkout" do
@@ -422,7 +431,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 18\.0\.0\.beta\.1\n.*bundle exec rake "release\[18\.0\.0\.beta\.1\]"/m
+      )
     end
   end
 


### PR DESCRIPTION
## Why

Forward-port the review fix from release PR #4676 so `main` has the same fail-closed behavior for argument-less prerelease releases.

The release command resolves its intended version before authentication, then runs inside a checkout that may advance after `git pull --rebase`. Without retaining both versions, a stale or matching changelog prerelease could be accepted relative to the pre-pull checkout and effectively downgrade or repeat the newer post-pull state.

## What changed

- carry the starting prerelease version through the post-pull version-resolution check
- require an argument-less changelog prerelease to be newer than both the starting and current checkout versions and on the same release line
- report and recommend the actual post-pull checkout version when that guard aborts
- cover older, matching, newer, and cross-line post-pull boundaries

The core guard is the exact patch from commit `ee710b304053f580a8c866984ee609636a9e1530` discovered and fixed during #4676 review. Current-head review then found and fixed a diagnostic bug: the abort used the stale pre-pull version in its `Current version` line and retry command. The PR intentionally has no changelog, docs, version, or lockfile changes.

## Validation

- TDD reproduction: rc.10 pre-pull → rc.12 post-pull with rc.11 changelog failed before this guard and passed after it
- review-fix TDD reproduction: the same boundary initially reported/recommended rc.10; it now reports/recommends the actual rc.12 post-pull checkout, with stable and cross-line cases covered too
- post-pull boundary group — 7 examples, 0 failures
- full release-helper spec — 380 examples, 0 failures
- representative #4661 exact-HEAD preservation coverage — 5 examples, 0 failures
- targeted RuboCop — 2 files, 0 offenses
- `ruby -c rakelib/release.rake` — syntax OK
- `git diff --check` and source patch equivalence passed
- broad validation passed setup, docs/sidebar, Ruby lint, benchmark lint, build, ESLint, Prettier, and TypeScript; one unrelated engine spec failed once and passed its immediate focused rerun (1 example, 0 failures), and the remaining broad generator sweep was stopped after the focused release evidence was complete
- exact-head optimized hosted CI passed at `0416c3d0aa40f98f905b3f424c3e3790d9089f09`, including the full selected Ruby generator suite
- CodeRabbit, Greptile, and Claude all produced current-head review artifacts; the one functional finding was fixed with TDD, the naming-only nit was auto-deferred, and all threads are resolved

## Classification

- Source: release PR #4676 review fix
- Target: `main`
- Release phase: beta/development
- Changelog: `not_user_visible` (release safety guard only)

Confidence note:

- Validated: core patch equivalence, post-review diagnostic correction, focused release boundaries, exact-head hosted CI, and current-head review coverage
- Pending: none
- Residual risk: low; the change is confined to argument-less prerelease inference and explicitly covers post-pull version ordering and diagnostics
