### PR TITLE
Release: handle optional required-check metadata

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1910,6 +1910,11 @@ CI_STATUSES_JSONL_QUERY = [
   ].join,
   'else error("expected status object with sha and statuses array") end'
 ].join(" ")
+REQUIRED_CHECKS_JQ_QUERY = [
+  "{contexts, checks: (if .checks == null then []",
+  'elif (.checks | type) == "array" then (.checks | map({context, app_id}))',
+  "else .checks end)}"
+].join(" ")
 REQUIRED_CHECK_DISCOVERY_UNKNOWN = Object.new.freeze
 
 # Upper bound on how many consecutive non-runtime-only commits the CI gate will
@@ -2516,12 +2521,11 @@ def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "
   # Keep legacy `contexts` separate from modern `checks` entries. Modern
   # required checks can be pinned to a GitHub App via `app_id`; legacy contexts
   # may be satisfied by either a Checks API run or a commit-status context.
-  jq_query = "{contexts, checks}"
   # Precondition: `fetch_main_ci_checks` already verified `gh` is installed
   # before `validate_main_ci_status!` calls this helper. The remaining failure
   # mode here is "branch protection unknown". Keep it distinct from a known
   # unprotected branch so exact-HEAD recovery can fail closed.
-  output, status = capture_gh_output("api", "--jq", jq_query, api_path)
+  output, status = capture_gh_output("api", "--jq", REQUIRED_CHECKS_JQ_QUERY, api_path)
   # Only a successful, structurally valid empty configuration means no required
   # checks. API errors and malformed payloads leave required gates unknown.
   return nil if !status.success? && known_branch_without_required_checks?(

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -2692,7 +2692,7 @@ RSpec.describe "release.rake helper methods" do
           .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
           .and_return(sha:, repo_slug: "shakacode/react_on_rails", check_runs: [passing_run("Lint")])
         allow(Open3).to receive(:capture2e)
-          .with("gh", "api", "--jq", "{contexts, checks}", api_path)
+          .with("gh", "api", "--jq", REQUIRED_CHECKS_JQ_QUERY, api_path)
           .and_return(["HTTP 404: Branch not protected", failure_status])
         allow(Open3).to receive(:capture3)
           .with("gh", "api", "--include", api_path)
@@ -2732,7 +2732,7 @@ RSpec.describe "release.rake helper methods" do
           .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
           .and_return(sha:, repo_slug: "shakacode/react_on_rails", check_runs: [passing_run("Lint")])
         allow(Open3).to receive(:capture2e)
-          .with("gh", "api", "--jq", "{contexts, checks}", api_path)
+          .with("gh", "api", "--jq", REQUIRED_CHECKS_JQ_QUERY, api_path)
           .and_return(["HTTP 404: Required status checks not enabled", failure_status])
         allow(Open3).to receive(:capture3)
           .with("gh", "api", "--include", api_path)
@@ -6011,11 +6011,38 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "required checks jq query" do
+    it "normalizes documented optional checks and app_id fields" do
+      cases = [
+        [
+          { "contexts" => ["Legacy CI"] },
+          { "contexts" => ["Legacy CI"], "checks" => [] }
+        ],
+        [
+          { "contexts" => [], "checks" => [{ "context" => "Lint" }] },
+          { "contexts" => [], "checks" => [{ "context" => "Lint", "app_id" => nil }] }
+        ],
+        [
+          { "contexts" => [], "checks" => {} },
+          { "contexts" => [], "checks" => {} }
+        ]
+      ]
+
+      cases.each do |payload, expected|
+        output, status = Open3.capture2e("jq", "-c", REQUIRED_CHECKS_JQ_QUERY, stdin_data: payload.to_json)
+        expect(status.success?).to be(true), output
+        expect(JSON.parse(output)).to eq(expected)
+      end
+    rescue Errno::ENOENT
+      raise "jq is required to verify required-check normalization"
+    end
+  end
+
   describe "#required_check_names_for_branch" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:success_status) { instance_double(Process::Status, success?: true) }
     let(:failure_status) { instance_double(Process::Status, success?: false) }
-    let(:expected_jq) { "{contexts, checks}" }
+    let(:expected_jq) { REQUIRED_CHECKS_JQ_QUERY }
 
     before do
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
@@ -6286,12 +6313,12 @@ RSpec.describe "release.rake helper methods" do
     end
 
     it "keeps nullable or missing branch protection fields visible to fail closed" do
-      # `{contexts, checks}` renders missing fields as null, which must remain
-      # distinguishable from a configured pair of empty arrays.
+      # The normalization deliberately preserves a missing `contexts` field as
+      # null, keeping it distinguishable from a configured empty array.
       allow(Open3).to receive(:capture2e)
-        .with("gh", "api", "--jq", "{contexts, checks}",
+        .with("gh", "api", "--jq", REQUIRED_CHECKS_JQ_QUERY,
               "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
-        .and_return([{ contexts: nil, checks: nil }.to_json, success_status])
+        .and_return([{ contexts: nil, checks: [] }.to_json, success_status])
 
       expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
     end
@@ -6314,6 +6341,18 @@ RSpec.describe "release.rake helper methods" do
       expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
     end
 
+    it "returns legacy contexts when the optional checks field is absent" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq,
+              "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
+        .and_return([{ contexts: ["Legacy CI"], checks: [] }.to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to eq(
+        contexts: ["Legacy CI"],
+        checks: []
+      )
+    end
+
     it "returns an unknown discovery state when a required check entry is malformed" do
       allow(Open3).to receive(:capture2e)
         .with("gh", "api", "--jq", expected_jq,
@@ -6323,13 +6362,16 @@ RSpec.describe "release.rake helper methods" do
       expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
     end
 
-    it "returns an unknown discovery state when a modern check omits app_id" do
+    it "accepts a modern check with an omitted optional app_id" do
       allow(Open3).to receive(:capture2e)
         .with("gh", "api", "--jq", expected_jq,
               "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks")
-        .and_return([{ contexts: [], checks: [{ context: "Lint" }] }.to_json, success_status])
+        .and_return([{ contexts: [], checks: [{ context: "Lint", app_id: nil }] }.to_json, success_status])
 
-      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+      expect(required_check_names_for_branch(monorepo_root:)).to eq(
+        contexts: [],
+        checks: [{ context: "Lint", app_id: nil }]
+      )
     end
 
     it "returns an unknown discovery state when a modern check has a nonpositive app_id" do


### PR DESCRIPTION
## Why

Forward-port the documented-schema compatibility fix found while reviewing release backport #4684. GitHub's required-status response may omit the optional `checks` field, and modern check entries may omit optional `app_id`. Treating either omission as unknown would incorrectly block a valid release configuration on `main`.

## What changed

- normalizes an absent or null `checks` field to an empty array
- projects a missing `app_id` as null
- preserves malformed non-array `checks` and missing/malformed `contexts` so Ruby validation still fails closed
- adds a real jq contract and helper regression coverage

This PR contains exactly the two-file review-fix commit from #4684; its stable patch-id matches the release candidate.

## Validation

- fresh base: `origin/main` at `f4a716fe0dbb9602b014b11398f688dfb93abe77`
- focused schema contracts: 3 examples, 0 failures
- release-helper + hosted-workflow specs: 383 examples, 0 failures
- targeted RuboCop: 2 files, no offenses
- Ruby syntax and `git diff --check`: clean
- pre-push branch lint: 2 files, no offenses
- seam doctor: PASS
- independent adversarial review on the source delta exercised malformed booleans, numbers, strings, objects, array entries, missing contexts, and optional `app_id`; no findings

## Classification

- Source: #4684 review fix `1d7f7a200835df5f472b9797a3ea3cf2fc1d273f`
- Target: `main`
- Tracker: #3823 (`development`, next-RC preparation)
- Changelog: `not_user_visible` (release-safety compatibility)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of branch protection required-status checks.
  * Preserved legacy checks while consistently processing modern check configurations.
  * Added support for missing, null, empty, and partially specified check data.
  * Improved CI status validation across varied GitHub protection-rule responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->