### PR TITLE
Release: report the checked-out retry version

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -2771,7 +2771,7 @@ def resolve_version_input(version_input, monorepo_root, current_version: nil,
 
   if argumentless_prerelease_release_requires_explicit_version?(changelog_version:, current_version:,
                                                                 starting_version:)
-    abort argumentless_prerelease_release_message(changelog_version:, current_version: starting_version)
+    abort argumentless_prerelease_release_message(changelog_version:, current_version:)
   end
 
   if changelog_version && Gem::Version.new(changelog_version) > Gem::Version.new(current_version)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "release.rake helper methods" do
       end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
     end
 
-    it "uses the pre-pull prerelease version when a pull advances the checkout to stable" do
+    it "reports the post-pull stable version when a pull advances the checkout to stable" do
       allow(self).to receive(:extract_latest_changelog_version)
         .with(monorepo_root: "/tmp/repo")
         .and_return("17.0.0")
@@ -337,7 +337,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 17\.0\.0\n.*bundle exec rake "release\[17\.0\.0\]"/m
+      )
     end
 
     it "refuses a changelog prerelease older than the post-pull checkout" do
@@ -354,7 +357,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 17\.0\.0\.rc\.12\n.*bundle exec rake "release\[17\.0\.0\.rc\.12\]"/m
+      )
     end
 
     it "refuses a changelog prerelease matching the post-pull checkout" do
@@ -371,7 +377,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 17\.0\.0\.rc\.11\n.*bundle exec rake "release\[17\.0\.0\.rc\.11\]"/m
+      )
     end
 
     it "allows a changelog prerelease newer than an unchanged post-pull checkout" do
@@ -422,7 +431,10 @@ RSpec.describe "release.rake helper methods" do
           dry_run: false,
           current_version: "17.0.0.rc.10"
         )
-      end.to raise_error(SystemExit, /bundle exec rake "release\[17\.0\.0\.rc\.10\]"/)
+      end.to raise_error(
+        SystemExit,
+        /Current version: 18\.0\.0\.beta\.1\n.*bundle exec rake "release\[18\.0\.0\.beta\.1\]"/m
+      )
     end
   end
 


### PR DESCRIPTION
## Why

Backport the diagnostic correction from #4680 to `release/17.0.0` after the strict retry-evidence backport in #4684.

The prerelease safety guard correctly compares both the pre-pull starting version and the post-pull checkout version, but its failure message was still displaying and recommending the stale pre-pull version. In cross-line or advanced-checkout cases, that guidance can point the release operator at the wrong candidate even though downstream policy would reject it.

## What changed

- pass the actual post-pull `current_version` to the retry-error formatter
- update focused specs so messages and suggested commands identify the checked-out version
- preserve the guard's comparisons against both starting and current versions

This is the stable-patch-ID-equivalent of main PR #4680 commit `0416c3d0aa40f98f905b3f424c3e3790d9089f09`, rebased as one commit onto release tip `8601d96357b61b9818055a41ead46ed26d51bcbe`.

## Validation

- full release-helper spec: 337 examples, 0 failures
- targeted RuboCop: 2 files, 0 offenses
- pre-push branch RuboCop: 33 files, 0 offenses
- Ruby syntax and `git diff --check`: clean
- stable patch ID matches the reviewed main fix
- delta is exactly `rakelib/release.rake` and `react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb`
- product metadata remains `17.0.0.rc.11` / `17.0.0-rc.11`

The local Markdown-link hook could not parse the repository's current `.lychee.toml` with this host's Lychee 0.24.2. This PR changes no Markdown; hosted link checks remain required.

## Classification

- Source: #4680 diagnostic correction
- Target: `release/17.0.0`, next RC
- Tracker: #3823 (`development`, RC phase)
- Changelog: `not_user_visible`

Confidence note:

- Validated: exact patch equivalence, focused release-helper behavior, lint, syntax, diff scope, and version preservation
- Pending: none; exact-head hosted CI and configured current-head review agents are complete
- Residual risk: low; this corrects operator-facing diagnostics without changing the guard decision


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerelease release guidance to display the correct current version after repository updates.
  * Updated release error messages and commands to accurately reflect the version available for release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->