### PR TITLE
Update changelog for 17.0.0.rc.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.0.0.rc.12] - 2026-07-15
+
 #### Added
 
 - **[Pro] React 18 support for non-RSC streaming SSR**: `stream_react_component` with synchronous
@@ -2910,7 +2912,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.11...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.12...main
+[17.0.0.rc.12]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.11...v17.0.0.rc.12
 [17.0.0.rc.11]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.10...v17.0.0.rc.11
 [17.0.0.rc.10]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.9...v17.0.0.rc.10
 [17.0.0.rc.9]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.8...v17.0.0.rc.9


### PR DESCRIPTION
## Why

Prepare the release/17.0.0 train for the 17.0.0.rc.12 release by stamping the existing Unreleased notes into a versioned changelog section.

## Classification

- Entry needed: PR 4679, already represented by its source PR 4658 under Unreleased.
- No entry: PRs 4675, 4676, 4677, 4684, and 4686 are CI or maintainer release-process changes.

## Verification

- git diff --check
- Confirmed CHANGELOG.md is the only changed file.
- Confirmed the rc.12 heading is unique and version headings remain newest-first.
- Confirmed compare links advance rc.11 to rc.12 and Unreleased starts at rc.12.
- Confirmed the file retains a trailing newline.
- Pre-commit Markdown link and trailing-newline checks passed.
- Prettier hook skipped because this worktree has no installed Prettier binary; the generated changelog-only diff was reviewed directly.
- No code tests were run because this changes only release-note Markdown.

Labels: none. Generated changelog-only change; hosted CI expansion is unnecessary.

Pre-push review: manual self-review complete; extra AI review and simplify skipped per the prerelease changelog fast path.

Babysit: off.
