### PR TITLE
[Pro] Cap the size of external source maps read by the node renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,9 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   larger than 50MB are no longer read into memory. Previously only inline (`data:`) source maps were
   size-capped, so a large external map was read and retained for the life of each pooled VM. Behavior change:
   stack frames for a bundle whose external map exceeds the cap keep their bundled locations instead of being
-  remapped to original sources, and the renderer logs a warning naming the map. The 50MB limit matches the
-  pre-existing cap for inline maps. Partially addresses
+  remapped to original sources, and the renderer logs a warning naming the map. An oversized map is terminal:
+  the renderer will not fall back to a differently-named map alongside the bundle, and will not retry the map
+  for that VM generation. The 50MB limit matches the pre-existing cap for inline maps. Partially addresses
   [Issue 4313](https://github.com/shakacode/react_on_rails/issues/4313).
   [PR 4688](https://github.com/shakacode/react_on_rails/pull/4688) by
   [AbanoubGhadban](https://github.com/AbanoubGhadban).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Capped the size of external source maps read by the Node renderer**: External `.map` files
+  larger than 50MB are no longer read into memory. Previously only inline (`data:`) source maps were
+  size-capped, so a large external map was read and retained for the life of each pooled VM. Behavior change:
+  stack frames for a bundle whose external map exceeds the cap keep their bundled locations instead of being
+  remapped to original sources, and the renderer logs a warning naming the map. The 50MB limit matches the
+  pre-existing cap for inline maps. Partially addresses
+  [Issue 4313](https://github.com/shakacode/react_on_rails/issues/4313).
+  [PR TBD](https://github.com/shakacode/react_on_rails/pull/TBD) by
+  [AbanoubGhadban](https://github.com/AbanoubGhadban).
+
 - **[Pro]** **Fixed webpack server-bundle builds for apps without `react-on-rails-rsc` (e.g. React 18 apps)**:
   17.0.0.rc.9 made webpack fail with `Module not found: Can't resolve 'react-on-rails-rsc/client.node'`
   (and `server.node`) unless the optional `react-on-rails-rsc` peer dependency was installed, because the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,11 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   larger than 50MB are no longer read into memory. Previously only inline (`data:`) source maps were
   size-capped, so a large external map was read and retained for the life of each pooled VM. Behavior change:
   stack frames for a bundle whose external map exceeds the cap keep their bundled locations instead of being
-  remapped to original sources, and the renderer logs a warning naming the map. An oversized map is terminal:
-  the renderer will not fall back to a differently-named map alongside the bundle, and will not retry the map
-  for that VM generation. The 50MB limit matches the pre-existing cap for inline maps. Partially addresses
+  remapped to original sources, and the renderer logs a warning naming the map. An oversized map is never
+  substituted: the renderer will not fall back to a differently-named map alongside the bundle. When the
+  oversized map is the one the bundle names, that result is final for the VM generation and is not retried;
+  a map that merely arrives late is still retried as before. The 50MB limit matches the pre-existing cap for
+  inline maps. Partially addresses
   [Issue 4313](https://github.com/shakacode/react_on_rails/issues/4313).
   [PR 4688](https://github.com/shakacode/react_on_rails/pull/4688) by
   [AbanoubGhadban](https://github.com/AbanoubGhadban).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   remapped to original sources, and the renderer logs a warning naming the map. The 50MB limit matches the
   pre-existing cap for inline maps. Partially addresses
   [Issue 4313](https://github.com/shakacode/react_on_rails/issues/4313).
-  [PR TBD](https://github.com/shakacode/react_on_rails/pull/TBD) by
+  [PR 4688](https://github.com/shakacode/react_on_rails/pull/4688) by
   [AbanoubGhadban](https://github.com/AbanoubGhadban).
 
 - **[Pro]** **Fixed webpack server-bundle builds for apps without `react-on-rails-rsc` (e.g. React 18 apps)**:

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -673,14 +673,20 @@ function loadSourceMapForBundle(
         ? extractSourceMappingUrl(readRegisteredBundleContentsForSourceMapLookup(bundleFilePath))
         : (registration.sourceMappingUrl ?? undefined);
 
+    // A registration's own null means "confirmed no usable map for this VM
+    // generation", which is terminal by definition. Say so here rather than
+    // letting `?? undefined` coerce it into the retryable `missing` path and
+    // relying on the caller's `shouldRetryMissingSourceMap` check to settle it.
+    if (registration.sourceMapJson === null) {
+      return { status: 'terminal' };
+    }
+
+    // The reader returns null only for an oversized map — also terminal.
     const sourceMapJson =
       registration.sourceMapJson === undefined
         ? readSourceMapJsonForBundle(bundleFilePath, sourceMappingUrl, registration.realBundleDirectory)
-        : (registration.sourceMapJson ?? undefined);
+        : registration.sourceMapJson;
 
-    // Only the reader returns null, and only for an oversized map. A
-    // registration's own null ("confirmed no usable map") is coerced to
-    // undefined above and settles through the `missing` path as before.
     if (sourceMapJson === null) {
       return { status: 'terminal' };
     }

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -107,6 +107,12 @@ const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
 // External `.map` files get the same ceiling as inline maps. This is a pre-read
 // size gate, not a hard memory bound: a map that grows between the `statSync` in
 // `resolveReadableSourceMapPath` and the read below still gets read in full.
+//
+// The two ceilings share a number but not a unit: this one is compared against
+// `stats.size` (bytes on disk), while `MAX_INLINE_SOURCE_MAP_BYTES` is compared
+// against a JS string length (UTF-16 code units), so a map with multi-byte
+// characters admits a different amount of data inline than externally. The
+// inline unit predates this constant and is left alone here.
 const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
 
 // Oversized maps are re-checked on every VM build and on error-path lookups, so
@@ -115,6 +121,12 @@ const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
 // than tied to registration lifetime: evicting the oldest entry only risks a
 // duplicate warning, while unregistering a bundle would re-warn on every VM
 // rebuild and defeat the throttle.
+//
+// A warned path is never re-armed, so if a path is reused (contrary to the
+// per-deploy assumption) and its map drops under the cap and later grows back
+// over it, that second regression warns only if the entry has since been
+// evicted. The map is still re-checked and skipped correctly either way; only
+// the warning is suppressed.
 const MAX_WARNED_OVERSIZED_SOURCE_MAP_PATHS = 256;
 const warnedOversizedSourceMapPaths = new Set<string>();
 
@@ -451,17 +463,20 @@ function readSourceMapJsonForBundle(
     // Fallback: the uploaded bundle is renamed to `<timestamp>.js`, so a map
     // uploaded alongside it under that name is also worth checking.
     const candidatePaths = candidateSourceMapPaths(bundleFilePath, sourceMappingUrl);
+    let higherPriorityCandidateMissing = false;
     for (const candidatePath of candidatePaths) {
       const sourceMapJson = readSourceMapFile(bundleFilePath, candidatePath, realBundleDirectory);
-      // An oversized map is terminal. Continuing to the next candidate would
-      // remap frames through a map the bundle never named, which is worse than
-      // keeping the bundled location.
       if (sourceMapJson === OVERSIZED_SOURCE_MAP) {
-        return null;
+        // Never fall through to a lower-priority candidate: remapping through a
+        // map the bundle does not name is worse than keeping bundled locations.
+        // Terminal only if nothing higher-priority was merely missing — if one
+        // was, it can still arrive, so leave the miss retryable.
+        return higherPriorityCandidateMissing ? undefined : null;
       }
       if (sourceMapJson) {
         return sourceMapJson;
       }
+      higherPriorityCandidateMissing = true;
     }
     return undefined;
   } catch (error) {
@@ -482,16 +497,18 @@ async function readSourceMapJsonForBundleAsync(
     }
 
     const candidatePaths = candidateSourceMapPaths(bundleFilePath, sourceMappingUrl);
+    let higherPriorityCandidateMissing = false;
     for (const candidatePath of candidatePaths) {
       // eslint-disable-next-line no-await-in-loop
       const sourceMapJson = await readSourceMapFileAsync(bundleFilePath, candidatePath, realBundleDirectory);
-      // Terminal — see the comment in the sync variant.
+      // See the comment in the sync variant.
       if (sourceMapJson === OVERSIZED_SOURCE_MAP) {
-        return null;
+        return higherPriorityCandidateMissing ? undefined : null;
       }
       if (sourceMapJson) {
         return sourceMapJson;
       }
+      higherPriorityCandidateMissing = true;
     }
     return undefined;
   } catch (error) {

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -110,7 +110,12 @@ const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
 const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
 
 // Oversized maps are re-checked on every VM build and on error-path lookups, so
-// warn once per map path to keep rolling deploys from flooding the log.
+// warn once per map path to keep rolling deploys from flooding the log. Bundle
+// paths are per-deploy, so this is bounded as an insertion-ordered FIFO rather
+// than tied to registration lifetime: evicting the oldest entry only risks a
+// duplicate warning, while unregistering a bundle would re-warn on every VM
+// rebuild and defeat the throttle.
+const MAX_WARNED_OVERSIZED_SOURCE_MAP_PATHS = 256;
 const warnedOversizedSourceMapPaths = new Set<string>();
 
 function warnOversizedSourceMap(sourceMapPath: string, sizeInBytes: number) {
@@ -118,9 +123,16 @@ function warnOversizedSourceMap(sourceMapPath: string, sizeInBytes: number) {
     return;
   }
 
+  if (warnedOversizedSourceMapPaths.size >= MAX_WARNED_OVERSIZED_SOURCE_MAP_PATHS) {
+    const oldestPath = warnedOversizedSourceMapPaths.values().next().value;
+    if (oldestPath !== undefined) {
+      warnedOversizedSourceMapPaths.delete(oldestPath);
+    }
+  }
+
   warnedOversizedSourceMapPaths.add(sourceMapPath);
   log.warn(
-    'Skipping source map %s: %d bytes exceeds the %d byte limit. Stack frames for this bundle will keep their bundled locations.',
+    'Skipping source map %s: size of %d bytes exceeds the %d byte limit. Stack frames for this bundle will keep their bundled locations.',
     sourceMapPath,
     sizeInBytes,
     MAX_EXTERNAL_SOURCE_MAP_BYTES,
@@ -349,69 +361,86 @@ function resolveReadableSourceMapPath(
 }
 
 /**
- * Resolves a readable, within-limit map path, warning once when the map is
- * oversized. Returns undefined for both "no usable map" and "map too large";
- * callers treat the two identically (frames keep their bundled locations).
+ * `unusable` means no readable map at this candidate path (missing, outside the
+ * bundle directory, not a file) and callers may try the next candidate.
+ * `oversized` means a real map is there but exceeds the cap — a terminal answer
+ * that must stop candidate resolution rather than look like a miss.
  */
+type ResolvedSourceMapCandidate =
+  | { status: 'usable'; sourceMapPath: string }
+  | { status: 'oversized' }
+  | { status: 'unusable' };
+
 function resolveSourceMapPathWithinSizeLimit(
   bundleFilePath: string,
   candidatePath: string,
   realBundleDirectory: string,
-) {
+): ResolvedSourceMapCandidate {
   const resolved = resolveReadableSourceMapPath(bundleFilePath, candidatePath, realBundleDirectory);
   if (!resolved) {
-    return undefined;
+    return { status: 'unusable' };
   }
 
   if (resolved.sizeInBytes > MAX_EXTERNAL_SOURCE_MAP_BYTES) {
     warnOversizedSourceMap(resolved.sourceMapPath, resolved.sizeInBytes);
-    return undefined;
+    return { status: 'oversized' };
   }
 
-  return resolved.sourceMapPath;
+  return { status: 'usable', sourceMapPath: resolved.sourceMapPath };
 }
 
-function readSourceMapFile(bundleFilePath: string, candidatePath: string, realBundleDirectory: string) {
-  const sourceMapPath = resolveSourceMapPathWithinSizeLimit(
-    bundleFilePath,
-    candidatePath,
-    realBundleDirectory,
-  );
-  if (!sourceMapPath) {
+/** Distinguishes "a map is here but too large" from "nothing readable here". */
+const OVERSIZED_SOURCE_MAP = Symbol('oversizedSourceMap');
+type SourceMapFileReadResult = string | typeof OVERSIZED_SOURCE_MAP | undefined;
+
+function readSourceMapFile(
+  bundleFilePath: string,
+  candidatePath: string,
+  realBundleDirectory: string,
+): SourceMapFileReadResult {
+  const candidate = resolveSourceMapPathWithinSizeLimit(bundleFilePath, candidatePath, realBundleDirectory);
+  if (candidate.status === 'oversized') {
+    return OVERSIZED_SOURCE_MAP;
+  }
+  if (candidate.status === 'unusable') {
     return undefined;
   }
 
   // `sourceMapPath` is filename-only and read through a final realpath that must
   // stay inside the real bundle directory, closing symlink-swap races.
   // codeql[js/path-injection]
-  return fs.readFileSync(sourceMapPath, 'utf8');
+  return fs.readFileSync(candidate.sourceMapPath, 'utf8');
 }
 
 async function readSourceMapFileAsync(
   bundleFilePath: string,
   candidatePath: string,
   realBundleDirectory: string,
-) {
-  const sourceMapPath = resolveSourceMapPathWithinSizeLimit(
-    bundleFilePath,
-    candidatePath,
-    realBundleDirectory,
-  );
-  if (!sourceMapPath) {
+): Promise<SourceMapFileReadResult> {
+  const candidate = resolveSourceMapPathWithinSizeLimit(bundleFilePath, candidatePath, realBundleDirectory);
+  if (candidate.status === 'oversized') {
+    return OVERSIZED_SOURCE_MAP;
+  }
+  if (candidate.status === 'unusable') {
     return undefined;
   }
 
   // `sourceMapPath` is filename-only and read through a final realpath that must
   // stay inside the real bundle directory, closing symlink-swap races.
   // codeql[js/path-injection]
-  return fs.promises.readFile(sourceMapPath, 'utf8');
+  return fs.promises.readFile(candidate.sourceMapPath, 'utf8');
 }
 
+/**
+ * Returns the source-map JSON for a bundle, `null` when a map was found but is
+ * unusable for good (oversized), or `undefined` when no map was found and one
+ * may still appear later.
+ */
 function readSourceMapJsonForBundle(
   bundleFilePath: string,
   sourceMappingUrl: string | undefined,
   realBundleDirectory: string,
-): string | undefined {
+): string | null | undefined {
   try {
     // Stack formatting is synchronous, so source-map discovery stays sync and
     // is cached per bundle registration.
@@ -424,6 +453,12 @@ function readSourceMapJsonForBundle(
     const candidatePaths = candidateSourceMapPaths(bundleFilePath, sourceMappingUrl);
     for (const candidatePath of candidatePaths) {
       const sourceMapJson = readSourceMapFile(bundleFilePath, candidatePath, realBundleDirectory);
+      // An oversized map is terminal. Continuing to the next candidate would
+      // remap frames through a map the bundle never named, which is worse than
+      // keeping the bundled location.
+      if (sourceMapJson === OVERSIZED_SOURCE_MAP) {
+        return null;
+      }
       if (sourceMapJson) {
         return sourceMapJson;
       }
@@ -435,11 +470,12 @@ function readSourceMapJsonForBundle(
   }
 }
 
+/** Async counterpart of {@link readSourceMapJsonForBundle}; same tri-state result. */
 async function readSourceMapJsonForBundleAsync(
   bundleFilePath: string,
   sourceMappingUrl: string | undefined,
   realBundleDirectory: string,
-): Promise<string | undefined> {
+): Promise<string | null | undefined> {
   try {
     if (sourceMappingUrl && sourceMappingUrl.startsWith('data:')) {
       return parseDataUrlSourceMap(sourceMappingUrl);
@@ -449,6 +485,10 @@ async function readSourceMapJsonForBundleAsync(
     for (const candidatePath of candidatePaths) {
       // eslint-disable-next-line no-await-in-loop
       const sourceMapJson = await readSourceMapFileAsync(bundleFilePath, candidatePath, realBundleDirectory);
+      // Terminal — see the comment in the sync variant.
+      if (sourceMapJson === OVERSIZED_SOURCE_MAP) {
+        return null;
+      }
       if (sourceMapJson) {
         return sourceMapJson;
       }
@@ -481,6 +521,12 @@ export async function preloadSourceMapJsonForBundle(bundleFilePath: string, bund
     sourceMappingUrl,
     realBundleDirectory,
   );
+  if (sourceMapJson === null) {
+    // A map is present but over the cap. Retrying cannot fix that, and leaving
+    // the miss retryable would let a later same-path map remap this VM
+    // generation, so settle it now.
+    return { retryMissingSourceMap: false, sourceMapJson: null };
+  }
   if (sourceMapJson !== undefined && !isValidJson(sourceMapJson)) {
     log.debug('Preloaded source map for bundle %s is not valid JSON yet; retrying lazily.', bundleFilePath);
     return { retryMissingSourceMap: true, sourceMapJson: undefined };

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -36,7 +36,10 @@
  * Performance: `prepareStackTrace` only runs when an error's `.stack` is first
  * accessed. External source map text is captured asynchronously while building
  * the VM so same-path rebuilds stay generation-isolated; SourceMap parsing and
- * position lookups stay lazy and cached per bundle registration.
+ * position lookups stay lazy and cached per bundle registration. Inline and
+ * external maps are both size-capped: an oversized map is skipped and its frames
+ * keep their bundled locations rather than paying its bytes for the life of the
+ * pooled VM.
  */
 
 import fs from 'fs';
@@ -101,6 +104,28 @@ let warnedMissingSourceMapConstructor = false;
 
 const MAX_MISSING_SOURCE_MAP_RETRIES = 5;
 const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
+// External `.map` files get the same ceiling as inline maps. This is a pre-read
+// size gate, not a hard memory bound: a map that grows between the `statSync` in
+// `resolveReadableSourceMapPath` and the read below still gets read in full.
+const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
+
+// Oversized maps are re-checked on every VM build and on error-path lookups, so
+// warn once per map path to keep rolling deploys from flooding the log.
+const warnedOversizedSourceMapPaths = new Set<string>();
+
+function warnOversizedSourceMap(sourceMapPath: string, sizeInBytes: number) {
+  if (warnedOversizedSourceMapPaths.has(sourceMapPath)) {
+    return;
+  }
+
+  warnedOversizedSourceMapPaths.add(sourceMapPath);
+  log.warn(
+    'Skipping source map %s: %d bytes exceeds the %d byte limit. Stack frames for this bundle will keep their bundled locations.',
+    sourceMapPath,
+    sizeInBytes,
+    MAX_EXTERNAL_SOURCE_MAP_BYTES,
+  );
+}
 
 function shouldRetryMissingSourceMap(registration: BundleSourceMapRegistration) {
   return registration.retryMissingSourceMap === true && !retiredMissingSourceMapRetries.has(registration);
@@ -290,11 +315,16 @@ function candidateSourceMapPaths(bundleFilePath: string, sourceMappingUrl: strin
   return Array.from(new Set(candidatePaths));
 }
 
+/**
+ * Resolves a candidate map path to a readable file inside the real bundle
+ * directory. Returns the size alongside the path so callers can apply
+ * {@link MAX_EXTERNAL_SOURCE_MAP_BYTES} without a second `stat`.
+ */
 function resolveReadableSourceMapPath(
   bundleFilePath: string,
   candidatePath: string,
   realBundleDirectory: string,
-) {
+): { sourceMapPath: string; sizeInBytes: number } | undefined {
   const bundleDirectory = path.dirname(bundleFilePath);
   try {
     const resolvedPath = path.resolve(candidatePath);
@@ -307,18 +337,46 @@ function resolveReadableSourceMapPath(
       return undefined;
     }
 
-    if (!fs.statSync(realSourceMapPath).isFile()) {
+    const stats = fs.statSync(realSourceMapPath);
+    if (!stats.isFile()) {
       return undefined;
     }
 
-    return realSourceMapPath;
+    return { sourceMapPath: realSourceMapPath, sizeInBytes: stats.size };
   } catch {
     return undefined;
   }
 }
 
+/**
+ * Resolves a readable, within-limit map path, warning once when the map is
+ * oversized. Returns undefined for both "no usable map" and "map too large";
+ * callers treat the two identically (frames keep their bundled locations).
+ */
+function resolveSourceMapPathWithinSizeLimit(
+  bundleFilePath: string,
+  candidatePath: string,
+  realBundleDirectory: string,
+) {
+  const resolved = resolveReadableSourceMapPath(bundleFilePath, candidatePath, realBundleDirectory);
+  if (!resolved) {
+    return undefined;
+  }
+
+  if (resolved.sizeInBytes > MAX_EXTERNAL_SOURCE_MAP_BYTES) {
+    warnOversizedSourceMap(resolved.sourceMapPath, resolved.sizeInBytes);
+    return undefined;
+  }
+
+  return resolved.sourceMapPath;
+}
+
 function readSourceMapFile(bundleFilePath: string, candidatePath: string, realBundleDirectory: string) {
-  const sourceMapPath = resolveReadableSourceMapPath(bundleFilePath, candidatePath, realBundleDirectory);
+  const sourceMapPath = resolveSourceMapPathWithinSizeLimit(
+    bundleFilePath,
+    candidatePath,
+    realBundleDirectory,
+  );
   if (!sourceMapPath) {
     return undefined;
   }
@@ -334,7 +392,11 @@ async function readSourceMapFileAsync(
   candidatePath: string,
   realBundleDirectory: string,
 ) {
-  const sourceMapPath = resolveReadableSourceMapPath(bundleFilePath, candidatePath, realBundleDirectory);
+  const sourceMapPath = resolveSourceMapPathWithinSizeLimit(
+    bundleFilePath,
+    candidatePath,
+    realBundleDirectory,
+  );
   if (!sourceMapPath) {
     return undefined;
   }
@@ -505,6 +567,7 @@ export function resetSourceMapSupport() {
   retiredMissingSourceMapRetries = new WeakSet<BundleSourceMapRegistration>();
   missingSourceMapRetryCounts = new WeakMap<BundleSourceMapRegistration, number>();
   warnedMissingSourceMapConstructor = false;
+  warnedOversizedSourceMapPaths.clear();
 }
 
 function createSourceMap(payload: ConstructorParameters<typeof SourceMap>[0]): SourceMap | null {

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -652,10 +652,21 @@ function readRegisteredBundleContentsForSourceMapLookup(bundleFilePath: string) 
   return fs.readFileSync(bundleFilePath, 'utf8');
 }
 
+/**
+ * `terminal` means a map was found but can never be used for this generation
+ * (oversized), so retrying is pointless and would risk remapping this generation
+ * with a different file. `missing` means nothing usable was found yet and a map
+ * may still appear, so the existing retry budget applies.
+ */
+type SourceMapLoadResult =
+  | { status: 'loaded'; sourceMap: LoadedSourceMap }
+  | { status: 'terminal' }
+  | { status: 'missing' };
+
 function loadSourceMapForBundle(
   bundleFilePath: string,
   registration: BundleSourceMapRegistration,
-): LoadedSourceMap | null {
+): SourceMapLoadResult {
   try {
     const sourceMappingUrl =
       registration.sourceMappingUrl === undefined
@@ -667,27 +678,38 @@ function loadSourceMapForBundle(
         ? readSourceMapJsonForBundle(bundleFilePath, sourceMappingUrl, registration.realBundleDirectory)
         : (registration.sourceMapJson ?? undefined);
 
+    // Only the reader returns null, and only for an oversized map. A
+    // registration's own null ("confirmed no usable map") is coerced to
+    // undefined above and settles through the `missing` path as before.
+    if (sourceMapJson === null) {
+      return { status: 'terminal' };
+    }
     if (!sourceMapJson) {
-      return null;
+      return { status: 'missing' };
     }
     const payload = JSON.parse(sourceMapJson) as ConstructorParameters<typeof SourceMap>[0];
     const sourceMap = createSourceMap(payload);
     if (!sourceMap) {
-      return null;
+      return { status: 'missing' };
     }
     const sourceRoot = typeof payload.sourceRoot === 'string' ? payload.sourceRoot : undefined;
     return {
-      sourceMap,
-      sourceRoot,
-      sources: Array.isArray(payload.sources)
-        ? payload.sources
-            .filter((source): source is string => typeof source === 'string')
-            .map((source) => applySourceRoot(sourceRoot, source))
-        : [],
+      status: 'loaded',
+      sourceMap: {
+        sourceMap,
+        sourceRoot,
+        sources: Array.isArray(payload.sources)
+          ? payload.sources
+              .filter((source): source is string => typeof source === 'string')
+              .map((source) => applySourceRoot(sourceRoot, source))
+          : [],
+      },
     };
   } catch (error) {
+    // Includes JSON.parse failures on a partially-written map, which stay
+    // retryable so the completed map can be picked up.
     log.debug('Failed to load source map for bundle %s: %s', bundleFilePath, error);
-    return null;
+    return { status: 'missing' };
   }
 }
 
@@ -701,17 +723,22 @@ function sourceMapForRegistration(
       return null;
     }
 
-    sourceMap = loadSourceMapForBundle(registration.bundleFilePath, registration);
-    if (sourceMap) {
+    const loadResult = loadSourceMapForBundle(registration.bundleFilePath, registration);
+    if (loadResult.status === 'loaded') {
+      sourceMap = loadResult.sourceMap;
       sourceMapCache.set(registration, sourceMap);
       missingSourceMapRetryCounts.delete(registration);
-    } else if (
-      !shouldRetryMissingSourceMap(registration) ||
-      (registration.sourceMappingUrl === null && !registration.retryMissingSourceMap)
-    ) {
-      sourceMapCache.set(registration, sourceMap);
     } else {
-      recordMissingSourceMapRetry(registration, lookupAttempt);
+      sourceMap = null;
+      if (
+        loadResult.status === 'terminal' ||
+        !shouldRetryMissingSourceMap(registration) ||
+        (registration.sourceMappingUrl === null && !registration.retryMissingSourceMap)
+      ) {
+        sourceMapCache.set(registration, sourceMap);
+      } else {
+        recordMissingSourceMapRetry(registration, lookupAttempt);
+      }
     }
   }
   return sourceMap;

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -115,9 +115,12 @@ const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
 // inline unit predates this constant and is left alone here.
 const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
 
-// Oversized maps are re-checked on every VM build and on error-path lookups, so
-// warn once per map path to keep rolling deploys from flooding the log. Bundle
-// paths are per-deploy, so this is bounded as an insertion-ordered FIFO rather
+// `preloadSourceMapJsonForBundle` re-checks the map on every VM build, and with
+// `maxVMPoolSize` defaulting to 2 an app with more bundles than that rebuilds
+// per request — so an unthrottled warning is a flood at request rate. (The
+// error-path lookup can also repeat, but only until the miss retires, bounded by
+// MAX_MISSING_SOURCE_MAP_RETRIES.) Warn once per map path instead. Bundle paths
+// are per-deploy, so this is bounded as an insertion-ordered FIFO rather
 // than tied to registration lifetime: evicting the oldest entry only risks a
 // duplicate warning, while unregistering a bundle would re-warn on every VM
 // rebuild and defeat the throttle.
@@ -340,15 +343,24 @@ function candidateSourceMapPaths(bundleFilePath: string, sourceMappingUrl: strin
 }
 
 /**
- * Resolves a candidate map path to a readable file inside the real bundle
- * directory. Returns the size alongside the path so callers can apply
- * {@link MAX_EXTERNAL_SOURCE_MAP_BYTES} without a second `stat`.
+ * Distinguishes "a map is here but too large" from "nothing readable here" — a
+ * distinction the candidate loops depend on, since an oversized candidate must
+ * stop resolution while an absent one may simply not have arrived yet.
+ */
+const OVERSIZED_SOURCE_MAP = Symbol('oversizedSourceMap');
+type SourceMapCandidateResult = string | typeof OVERSIZED_SOURCE_MAP | undefined;
+
+/**
+ * Resolves a candidate map path to a readable, within-cap file inside the real
+ * bundle directory, warning once when the map is oversized. The size check is
+ * last, so it only ever runs on a realpath already proven contained, and reuses
+ * the `stat` the `isFile` check already needs.
  */
 function resolveReadableSourceMapPath(
   bundleFilePath: string,
   candidatePath: string,
   realBundleDirectory: string,
-): { sourceMapPath: string; sizeInBytes: number } | undefined {
+): SourceMapCandidateResult {
   const bundleDirectory = path.dirname(bundleFilePath);
   try {
     const resolvedPath = path.resolve(candidatePath);
@@ -366,81 +378,47 @@ function resolveReadableSourceMapPath(
       return undefined;
     }
 
-    return { sourceMapPath: realSourceMapPath, sizeInBytes: stats.size };
+    if (stats.size > MAX_EXTERNAL_SOURCE_MAP_BYTES) {
+      warnOversizedSourceMap(realSourceMapPath, stats.size);
+      return OVERSIZED_SOURCE_MAP;
+    }
+
+    return realSourceMapPath;
   } catch {
     return undefined;
   }
 }
 
-/**
- * `unusable` means no readable map at this candidate path (missing, outside the
- * bundle directory, not a file) and callers may try the next candidate.
- * `oversized` means a real map is there but exceeds the cap — a terminal answer
- * that must stop candidate resolution rather than look like a miss.
- */
-type ResolvedSourceMapCandidate =
-  | { status: 'usable'; sourceMapPath: string }
-  | { status: 'oversized' }
-  | { status: 'unusable' };
-
-function resolveSourceMapPathWithinSizeLimit(
-  bundleFilePath: string,
-  candidatePath: string,
-  realBundleDirectory: string,
-): ResolvedSourceMapCandidate {
-  const resolved = resolveReadableSourceMapPath(bundleFilePath, candidatePath, realBundleDirectory);
-  if (!resolved) {
-    return { status: 'unusable' };
-  }
-
-  if (resolved.sizeInBytes > MAX_EXTERNAL_SOURCE_MAP_BYTES) {
-    warnOversizedSourceMap(resolved.sourceMapPath, resolved.sizeInBytes);
-    return { status: 'oversized' };
-  }
-
-  return { status: 'usable', sourceMapPath: resolved.sourceMapPath };
-}
-
-/** Distinguishes "a map is here but too large" from "nothing readable here". */
-const OVERSIZED_SOURCE_MAP = Symbol('oversizedSourceMap');
-type SourceMapFileReadResult = string | typeof OVERSIZED_SOURCE_MAP | undefined;
-
 function readSourceMapFile(
   bundleFilePath: string,
   candidatePath: string,
   realBundleDirectory: string,
-): SourceMapFileReadResult {
-  const candidate = resolveSourceMapPathWithinSizeLimit(bundleFilePath, candidatePath, realBundleDirectory);
-  if (candidate.status === 'oversized') {
-    return OVERSIZED_SOURCE_MAP;
-  }
-  if (candidate.status === 'unusable') {
-    return undefined;
+): SourceMapCandidateResult {
+  const sourceMapPath = resolveReadableSourceMapPath(bundleFilePath, candidatePath, realBundleDirectory);
+  if (sourceMapPath === OVERSIZED_SOURCE_MAP || sourceMapPath === undefined) {
+    return sourceMapPath;
   }
 
   // `sourceMapPath` is filename-only and read through a final realpath that must
   // stay inside the real bundle directory, closing symlink-swap races.
   // codeql[js/path-injection]
-  return fs.readFileSync(candidate.sourceMapPath, 'utf8');
+  return fs.readFileSync(sourceMapPath, 'utf8');
 }
 
 async function readSourceMapFileAsync(
   bundleFilePath: string,
   candidatePath: string,
   realBundleDirectory: string,
-): Promise<SourceMapFileReadResult> {
-  const candidate = resolveSourceMapPathWithinSizeLimit(bundleFilePath, candidatePath, realBundleDirectory);
-  if (candidate.status === 'oversized') {
-    return OVERSIZED_SOURCE_MAP;
-  }
-  if (candidate.status === 'unusable') {
-    return undefined;
+): Promise<SourceMapCandidateResult> {
+  const sourceMapPath = resolveReadableSourceMapPath(bundleFilePath, candidatePath, realBundleDirectory);
+  if (sourceMapPath === OVERSIZED_SOURCE_MAP || sourceMapPath === undefined) {
+    return sourceMapPath;
   }
 
   // `sourceMapPath` is filename-only and read through a final realpath that must
   // stay inside the real bundle directory, closing symlink-swap races.
   // codeql[js/path-injection]
-  return fs.promises.readFile(candidate.sourceMapPath, 'utf8');
+  return fs.promises.readFile(sourceMapPath, 'utf8');
 }
 
 /**
@@ -753,11 +731,7 @@ function sourceMapForRegistration(
       missingSourceMapRetryCounts.delete(registration);
     } else {
       sourceMap = null;
-      if (
-        loadResult.status === 'terminal' ||
-        !shouldRetryMissingSourceMap(registration) ||
-        (registration.sourceMappingUrl === null && !registration.retryMissingSourceMap)
-      ) {
+      if (loadResult.status === 'terminal' || !shouldRetryMissingSourceMap(registration)) {
         sourceMapCache.set(registration, sourceMap);
       } else {
         recordMissingSourceMapRetry(registration, lookupAttempt);

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -480,6 +480,40 @@ describe('source-mapped stack traces for VM errors', () => {
       }
     });
 
+    test('oversized map found on the lazy path is terminal and is not retried later', async () => {
+      // The retryable-miss path must not resurrect a generation: once this VM has
+      // seen an oversized map, a later under-cap map at the same path must not
+      // remap it.
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
+      await writeVmBundle(`${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`);
+
+      // Missing at build, so the registration stays lazy and retryable.
+      const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+
+      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
+      const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+
+      try {
+        await runInVM('global.triggerSsrError()', bundlePath);
+
+        // Map is now under the cap; the earlier oversized answer was terminal.
+        statSyncSpy.mockRestore();
+        const result = await runInVM('global.triggerSsrError()', bundlePath);
+        expect(isErrorRenderResult(result)).toBe(true);
+        if (!isErrorRenderResult(result)) {
+          throw new Error('expected exceptionMessage result');
+        }
+        expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
+        expect(result.exceptionMessage).toContain(`${bundlePath}:3:`);
+      } finally {
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+
     test('oversized external map warns once per map path across repeated lookups', async () => {
       const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
       const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -546,6 +546,48 @@ describe('source-mapped stack traces for VM errors', () => {
       }
     });
 
+    test('an oversized fallback map does not make a late-arriving named map terminal', async () => {
+      // The named map is missing at build and arrives shortly after — a supported
+      // flow. An oversized map sitting at the conventional fallback path must not
+      // be used, but it also must not retire the retry for the named map.
+      const bundlePath = vmBundlePath(testName);
+      const namedMapFileName = 'named.js.map';
+      const namedMapPath = path.join(path.dirname(bundlePath), namedMapFileName);
+      const fallbackMapPath = path.join(path.dirname(bundlePath), `${path.basename(bundlePath)}.map`);
+
+      await writeVmBundle(`${buildThrowingBundleSource()}\n//# sourceMappingURL=${namedMapFileName}\n`);
+      // Only the oversized fallback exists at build time.
+      await fsPromises.writeFile(
+        fallbackMapPath,
+        JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath), REBUILT_SOURCE)),
+      );
+      const statSyncSpy = mockReportedSourceMapSize(fallbackMapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+
+      try {
+        const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+
+        // The named map lands after the VM was built.
+        await fsPromises.writeFile(
+          namedMapPath,
+          JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))),
+        );
+
+        const result = await runInVM('global.triggerSsrError()', bundlePath);
+        expect(isErrorRenderResult(result)).toBe(true);
+        if (!isErrorRenderResult(result)) {
+          throw new Error('expected exceptionMessage result');
+        }
+        // The named map must win once it arrives...
+        expect(result.exceptionMessage).toContain(`${ORIGINAL_SOURCE}:2:3`);
+        // ...and the oversized fallback must never be substituted for it.
+        expect(result.exceptionMessage).not.toContain(REBUILT_SOURCE);
+      } finally {
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+
     test('oversized external map warns once per map path across repeated lookups', async () => {
       const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
       const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -309,12 +309,57 @@ describe('source-mapped stack traces for VM errors', () => {
       return { bundlePath, mapPath };
     }
 
+    test('oversized explicit map does not fall through to the conventional fallback map', async () => {
+      // An oversized map must be terminal, not a miss: falling through to
+      // `<bundle>.js.map` would remap frames with a map that is not the one the
+      // bundle names, which is worse than keeping the bundled location.
+      const bundlePath = vmBundlePath(testName);
+      const explicitMapFileName = 'explicit-oversized.js.map';
+      const explicitMapPath = path.join(path.dirname(bundlePath), explicitMapFileName);
+      const fallbackMapPath = path.join(path.dirname(bundlePath), `${path.basename(bundlePath)}.map`);
+
+      await writeVmBundle(`${buildThrowingBundleSource()}\n//# sourceMappingURL=${explicitMapFileName}\n`);
+      await fsPromises.writeFile(
+        explicitMapPath,
+        JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))),
+      );
+      // A stale map left at the conventional path, pointing at a different source.
+      await fsPromises.writeFile(
+        fallbackMapPath,
+        JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath), REBUILT_SOURCE)),
+      );
+
+      const statSyncSpy = mockReportedSourceMapSize(explicitMapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+
+      try {
+        const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+
+        const result = await runInVM('global.triggerSsrError()', bundlePath);
+        expect(isErrorRenderResult(result)).toBe(true);
+        if (!isErrorRenderResult(result)) {
+          throw new Error('expected exceptionMessage result');
+        }
+        // Must keep the bundled location, not silently remap through the stale map.
+        expect(result.exceptionMessage).not.toContain(REBUILT_SOURCE);
+        expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
+        expect(result.exceptionMessage).toContain(`${bundlePath}:3:`);
+      } finally {
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+
     test('oversized external map is skipped on the async preload path and warns', async () => {
       const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
       const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
       const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
       const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
       const readFileAsyncSpy = jest.spyOn(fsPromises, 'readFile');
+      // The readers read the realpath, not `mapPath`, so assert on the realpath —
+      // otherwise a regression that reads the map would slip past on platforms
+      // where the two differ (macOS /var -> /private/var).
+      const realMapPath = fs.realpathSync(mapPath);
 
       try {
         const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
@@ -328,8 +373,8 @@ describe('source-mapped stack traces for VM errors', () => {
         expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
         expect(result.exceptionMessage).toContain(`${bundlePath}:3:`);
         // The whole point of the cap: the bytes are never read.
-        expect(readFileSyncSpy).not.toHaveBeenCalledWith(mapPath, 'utf8');
-        expect(readFileAsyncSpy).not.toHaveBeenCalledWith(mapPath, 'utf8');
+        expect(readFileSyncSpy).not.toHaveBeenCalledWith(realMapPath, 'utf8');
+        expect(readFileAsyncSpy).not.toHaveBeenCalledWith(realMapPath, 'utf8');
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('exceeds the'),
           expect.stringContaining(path.basename(mapPath)),
@@ -358,6 +403,7 @@ describe('source-mapped stack traces for VM errors', () => {
       const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
       const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
       const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+      const realMapPath = fs.realpathSync(mapPath);
 
       try {
         const result = await runInVM('global.triggerSsrError()', bundlePath);
@@ -366,7 +412,7 @@ describe('source-mapped stack traces for VM errors', () => {
           throw new Error('expected exceptionMessage result');
         }
         expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
-        expect(readFileSyncSpy).not.toHaveBeenCalledWith(mapPath, 'utf8');
+        expect(readFileSyncSpy).not.toHaveBeenCalledWith(realMapPath, 'utf8');
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('exceeds the'),
           expect.stringContaining(path.basename(mapPath)),
@@ -401,6 +447,33 @@ describe('source-mapped stack traces for VM errors', () => {
           expect.anything(),
           expect.anything(),
         );
+      } finally {
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+
+    test('oversized map found at preload is terminal and is not retried later', async () => {
+      // Retrying cannot make a map smaller, and leaving the miss retryable would
+      // let a later same-path map remap this VM generation.
+      const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
+      const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+
+      try {
+        const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+        await runInVM('global.triggerSsrError()', bundlePath);
+
+        // The map is replaced with an under-cap one after the VM was built. The
+        // oversized answer was terminal, so this generation must not pick it up.
+        statSyncSpy.mockRestore();
+        const result = await runInVM('global.triggerSsrError()', bundlePath);
+        expect(isErrorRenderResult(result)).toBe(true);
+        if (!isErrorRenderResult(result)) {
+          throw new Error('expected exceptionMessage result');
+        }
+        expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
+        expect(result.exceptionMessage).toContain(`${bundlePath}:3:`);
       } finally {
         warnSpy.mockRestore();
         statSyncSpy.mockRestore();

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -276,6 +276,158 @@ describe('source-mapped stack traces for VM errors', () => {
     }
   });
 
+  describe('external source map size cap', () => {
+    // Mirrors MAX_EXTERNAL_SOURCE_MAP_BYTES in vmSourceMapSupport.ts, which is not
+    // exported. Reporting the size via a `statSync` spy keeps these tests fast:
+    // writing a genuinely oversized map would mean a 50MB+ disk write per test.
+    const MAX_EXTERNAL_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
+
+    function mockReportedSourceMapSize(mapPath: string, sizeInBytes: number) {
+      const realStatSync = fs.statSync.bind(fs);
+      // The production code stats the *realpath*, which differs from `mapPath` on
+      // macOS (/var -> /private/var), so compare against the resolved path.
+      const realMapPath = fs.realpathSync(mapPath);
+
+      return jest.spyOn(fs, 'statSync').mockImplementation(((target: fs.PathLike, options?: never) => {
+        const stats = realStatSync(target as string, options) as fs.Stats;
+        if (String(target) !== realMapPath) {
+          return stats;
+        }
+        // Preserve the prototype so `isFile()` keeps working.
+        return Object.assign(Object.create(Object.getPrototypeOf(stats) as object), stats, {
+          size: sizeInBytes,
+        }) as fs.Stats;
+      }) as typeof fs.statSync);
+    }
+
+    async function writeThrowingBundleWithExternalMap() {
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
+      await writeVmBundle(`${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`);
+      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
+      return { bundlePath, mapPath };
+    }
+
+    test('oversized external map is skipped on the async preload path and warns', async () => {
+      const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
+      const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+      const readFileAsyncSpy = jest.spyOn(fsPromises, 'readFile');
+
+      try {
+        const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+
+        const result = await runInVM('global.triggerSsrError()', bundlePath);
+        expect(isErrorRenderResult(result)).toBe(true);
+        if (!isErrorRenderResult(result)) {
+          throw new Error('expected exceptionMessage result');
+        }
+        // No remap: the frame keeps its bundled location instead of Boom.ts.
+        expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
+        expect(result.exceptionMessage).toContain(`${bundlePath}:3:`);
+        // The whole point of the cap: the bytes are never read.
+        expect(readFileSyncSpy).not.toHaveBeenCalledWith(mapPath, 'utf8');
+        expect(readFileAsyncSpy).not.toHaveBeenCalledWith(mapPath, 'utf8');
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('exceeds the'),
+          expect.stringContaining(path.basename(mapPath)),
+          MAX_EXTERNAL_SOURCE_MAP_BYTES + 1,
+          MAX_EXTERNAL_SOURCE_MAP_BYTES,
+        );
+      } finally {
+        readFileAsyncSpy.mockRestore();
+        readFileSyncSpy.mockRestore();
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+
+    test('oversized external map is skipped on the sync lazy path when the map lands after build', async () => {
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
+      await writeVmBundle(`${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`);
+
+      // No map at build time, so the preload misses and the registration stays
+      // lazy — the first error drives the synchronous read inside prepareStackTrace.
+      const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+
+      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
+      const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+      try {
+        const result = await runInVM('global.triggerSsrError()', bundlePath);
+        expect(isErrorRenderResult(result)).toBe(true);
+        if (!isErrorRenderResult(result)) {
+          throw new Error('expected exceptionMessage result');
+        }
+        expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
+        expect(readFileSyncSpy).not.toHaveBeenCalledWith(mapPath, 'utf8');
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('exceeds the'),
+          expect.stringContaining(path.basename(mapPath)),
+          MAX_EXTERNAL_SOURCE_MAP_BYTES + 1,
+          MAX_EXTERNAL_SOURCE_MAP_BYTES,
+        );
+      } finally {
+        readFileSyncSpy.mockRestore();
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+
+    test('external map exactly at the cap still remaps', async () => {
+      const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
+      // Boundary guard: the check is `size > cap`, so `size === cap` must be read.
+      const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+
+      try {
+        const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+
+        const result = await runInVM('global.triggerSsrError()', bundlePath);
+        expect(isErrorRenderResult(result)).toBe(true);
+        if (!isErrorRenderResult(result)) {
+          throw new Error('expected exceptionMessage result');
+        }
+        expect(result.exceptionMessage).toContain(`${ORIGINAL_SOURCE}:2:3`);
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('exceeds the'),
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+
+    test('oversized external map warns once per map path across repeated lookups', async () => {
+      const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
+      const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
+
+      try {
+        const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+        await runInVM('global.triggerSsrError()', bundlePath);
+        await runInVM('global.triggerSsrError()', bundlePath);
+
+        const oversizedWarnings = warnSpy.mock.calls.filter(
+          ([message]) => typeof message === 'string' && message.includes('exceeds the'),
+        );
+        expect(oversizedWarnings).toHaveLength(1);
+      } finally {
+        warnSpy.mockRestore();
+        statSyncSpy.mockRestore();
+      }
+    });
+  });
+
   test('external source map lookup retries when the map appears after VM build', async () => {
     const bundlePath = vmBundlePath(testName);
     const mapFileName = `${path.basename(bundlePath)}.map`;

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -514,6 +514,38 @@ describe('source-mapped stack traces for VM errors', () => {
       }
     });
 
+    test('a registration with a confirmed no-map result never reads, even if marked retryable', async () => {
+      // `sourceMapJson: null` means "confirmed no usable map for this generation".
+      // It is terminal on its own, not because preload happens to pair it with
+      // `retryMissingSourceMap: false` — this pins that invariant so a future
+      // preload change cannot silently fall back into retry churn.
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
+      const bundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`;
+      await writeVmBundle(bundleContents);
+      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
+
+      const registration = registerBundleForSourceMaps(
+        bundlePath,
+        0,
+        bundleContents,
+        /* preloadedSourceMapJson */ null,
+        /* retryMissingSourceMap */ true,
+      );
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+      try {
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+        // A usable map is sitting on disk; the confirmed-null registration must
+        // never consult it for this generation.
+        expect(readFileSyncSpy.mock.calls.map(([filePath]) => filePath)).not.toContain(mapPath);
+      } finally {
+        readFileSyncSpy.mockRestore();
+      }
+    });
+
     test('oversized external map warns once per map path across repeated lookups', async () => {
       const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
       const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -375,8 +375,10 @@ describe('source-mapped stack traces for VM errors', () => {
         // The whole point of the cap: the bytes are never read.
         expect(readFileSyncSpy).not.toHaveBeenCalledWith(realMapPath, 'utf8');
         expect(readFileAsyncSpy).not.toHaveBeenCalledWith(realMapPath, 'utf8');
+        // Assert what the warning must carry (which map, how big, the limit), not
+        // how it is worded.
         expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('exceeds the'),
+          expect.any(String),
           expect.stringContaining(path.basename(mapPath)),
           MAX_EXTERNAL_SOURCE_MAP_BYTES + 1,
           MAX_EXTERNAL_SOURCE_MAP_BYTES,
@@ -413,8 +415,10 @@ describe('source-mapped stack traces for VM errors', () => {
         }
         expect(result.exceptionMessage).not.toContain(ORIGINAL_SOURCE);
         expect(readFileSyncSpy).not.toHaveBeenCalledWith(realMapPath, 'utf8');
+        // Assert what the warning must carry (which map, how big, the limit), not
+        // how it is worded.
         expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('exceeds the'),
+          expect.any(String),
           expect.stringContaining(path.basename(mapPath)),
           MAX_EXTERNAL_SOURCE_MAP_BYTES + 1,
           MAX_EXTERNAL_SOURCE_MAP_BYTES,
@@ -441,9 +445,11 @@ describe('source-mapped stack traces for VM errors', () => {
           throw new Error('expected exceptionMessage result');
         }
         expect(result.exceptionMessage).toContain(`${ORIGINAL_SOURCE}:2:3`);
+        // No oversized warning for this map — matched by the map it names rather
+        // than by the message wording.
         expect(warnSpy).not.toHaveBeenCalledWith(
-          expect.stringContaining('exceeds the'),
-          expect.anything(),
+          expect.any(String),
+          expect.stringContaining(path.basename(mapPath)),
           expect.anything(),
           expect.anything(),
         );
@@ -514,38 +520,6 @@ describe('source-mapped stack traces for VM errors', () => {
       }
     });
 
-    test('a registration with a confirmed no-map result never reads, even if marked retryable', async () => {
-      // `sourceMapJson: null` means "confirmed no usable map for this generation".
-      // It is terminal on its own, not because preload happens to pair it with
-      // `retryMissingSourceMap: false` — this pins that invariant so a future
-      // preload change cannot silently fall back into retry churn.
-      const bundlePath = vmBundlePath(testName);
-      const mapFileName = `${path.basename(bundlePath)}.map`;
-      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
-      const bundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`;
-      await writeVmBundle(bundleContents);
-      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
-
-      const registration = registerBundleForSourceMaps(
-        bundlePath,
-        0,
-        bundleContents,
-        /* preloadedSourceMapJson */ null,
-        /* retryMissingSourceMap */ true,
-      );
-      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
-
-      try {
-        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
-        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
-        // A usable map is sitting on disk; the confirmed-null registration must
-        // never consult it for this generation.
-        expect(readFileSyncSpy.mock.calls.map(([filePath]) => filePath)).not.toContain(mapPath);
-      } finally {
-        readFileSyncSpy.mockRestore();
-      }
-    });
-
     test('an oversized fallback map does not make a late-arriving named map terminal', async () => {
       // The named map is missing at build and arrives shortly after — a supported
       // flow. An oversized map sitting at the conventional fallback path must not
@@ -588,18 +562,38 @@ describe('source-mapped stack traces for VM errors', () => {
       }
     });
 
-    test('oversized external map warns once per map path across repeated lookups', async () => {
+    test('oversized map warns once per path across VM rebuilds', async () => {
+      // The repeat that matters is the preload, which re-checks the map on every
+      // buildVM: an app with more bundles than maxVMPoolSize rebuilds per request,
+      // so without the throttle this warns at request rate. Repeated *errors* on
+      // one VM cannot show this — the registration caches the terminal answer and
+      // never re-checks.
+      buildConfig({
+        serverBundleCachePath: serverBundleCachePath(testName),
+        supportModules: true,
+        stubTimers: false,
+        maxVMPoolSize: 1,
+      });
+
       const { bundlePath, mapPath } = await writeThrowingBundleWithExternalMap();
+      const realMapPath = fs.realpathSync(mapPath);
+      const evictorBundlePath = path.join(serverBundleCachePath(testName), 'warn-once-evictor.js');
+      await writeBundleAt(evictorBundlePath, 'global.otherBundleLoaded = true;');
+
       const statSyncSpy = mockReportedSourceMapSize(mapPath, MAX_EXTERNAL_SOURCE_MAP_BYTES + 1);
       const warnSpy = jest.spyOn(log, 'warn').mockImplementation(() => undefined);
 
       try {
-        const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
-        await runInVM('global.triggerSsrError()', bundlePath);
-        await runInVM('global.triggerSsrError()', bundlePath);
+        // Build (preload warns), evict, then rebuild so preload runs a second time.
+        await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+        await buildExecutionContext([evictorBundlePath], /* buildVmsIfNeeded */ true);
+        expect(hasVMContextForBundle(bundlePath)).toBe(false);
+        await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
 
+        // Count by the data the warning carries, not its wording.
         const oversizedWarnings = warnSpy.mock.calls.filter(
-          ([message]) => typeof message === 'string' && message.includes('exceeds the'),
+          ([, warnedPath, warnedSize]) =>
+            warnedPath === realMapPath && warnedSize === MAX_EXTERNAL_SOURCE_MAP_BYTES + 1,
         );
         expect(oversizedWarnings).toHaveLength(1);
       } finally {


### PR DESCRIPTION
Partially addresses #4313.

## Scope — please read first

#4313 is labeled `parked`/`P3`. In [this comment](https://github.com/shakacode/react_on_rails/issues/4313#issuecomment-4863987564) @justin808 recommended no implementation PR for now, while allowing that a maintainer could "split a later narrow cap-only change with targeted source-map tests."

**This PR is exactly that narrow cap-only change, and nothing more.** It deliberately does **not** fix the issue's headline complaint. See "What this does not fix" below — that part is a product decision, not an oversight.

## Problem

`MAX_INLINE_SOURCE_MAP_BYTES` (50MB) is referenced only in `parseDataUrlSourceMap`, so it guards `data:` URL maps only. `readSourceMapFile` and `readSourceMapFileAsync` read external `.map` files with no size check at all. A large external map is read in full and retained for the life of each pooled VM.

## Change

External maps get the same 50MB ceiling as inline maps.

- The size comes from the `statSync` that `resolveReadableSourceMapPath` **already performs** for its `isFile()` check, so the cap costs no extra syscall. `resolveReadableSourceMapPath` now returns `{ sourceMapPath, sizeInBytes }`, and a new `resolveSourceMapPathWithinSizeLimit` applies the cap once for both the sync and async readers.
- Oversized maps are skipped on **both** the async preload path (used by every `buildVM`) and the synchronous lazy path (used when a map lands after the bundle).
- Warns **once per map path**. The async preload runs at every VM build and the sync path can run per error, so an unthrottled warning would flood the log on a rolling deploy.
- 50MB matches the pre-existing inline cap rather than a stricter unevidenced value: making external maps stricter than inline ones, with no override, would be an unjustified regression risk for anyone with legitimately large maps.

### Behavior change (intentional, called out in CHANGELOG)

Frames for a bundle whose external map exceeds 50MB keep their **bundled** locations instead of remapping to original sources, and the renderer logs a warning naming the map.

### Honest limitation

This is a **pre-read size gate, not a hard memory bound**. A map that grows between the `statSync` and the `readFileSync` is still read in full. Stated in the code comment and CHANGELOG too — it should not be oversold as absolute protection.

## What this does *not* fix

The issue's headline complaint is that a bundle which **never errors** still retains its full map size for the life of the pooled VM. **This PR does not address that**, and the obvious fix — dropping the eager preload so the existing lazy path runs — is provably wrong:

The existing test `same-path rebuild does not remap active old VM errors with the new source map` overwrites the `.map` on disk with a rebuilt map, then asserts that an old in-flight error **still** remaps to the *original* source. So the preload is not a cache — it retains **the only surviving copy** of that generation's map. A fingerprint (`{size, mtimeMs, ino}`) can *detect* staleness but cannot *recover* bytes that no longer exist on disk; it would return a raw stack and fail that assertion.

So removing the retention necessarily breaks a deliberately-encoded guarantee. The real tradeoff is:

- **today:** correct stacks for in-flight errors on a replaced bundle, paid for with steady-state map retention
- **alternative:** zero retention for zero-error bundles, paid for with un-remapped stacks in that window

That is a product call for @justin808, not one to make inside a cap PR. Left parked; I'll write it up on the issue.

Also deliberately excluded: drop-raw-JSON-after-parse (needs a "raw intentionally discarded" sentinel or a future parsed-map LRU would silently fall back to disk and reintroduce the stale-map risk the preload exists to prevent), the parsed-map LRU itself, and the `extractSourceMappingUrl` tail-scan.

## Testing

Four targeted tests added (`external source map size cap` describe block):

1. Oversized map on the **async preload** path → no remap, frame keeps bundle location, bytes never read (`readFile`/`readFileSync` asserted not called), warn logged.
2. Oversized map on the **sync lazy** path (map lands after VM build) → same.
3. Map **exactly at** the cap still remaps — boundary guard against a `>` / `>=` flip.
4. Warn emitted **once** per map path across repeated lookups.

**Verification performed:**

- **45/45 pass**, including the two tests most at risk: `external .map file next to the bundle is used` (asserts the preload path does no sync read) and `same-path rebuild does not remap active old VM errors with the new source map` (generation isolation).
- **Vacuity check:** with only the `src` change reverted and the tests intact, tests 1, 2 and 4 **fail**. Test 3 passes either way by design — it is a boundary guard, not a reproducer.
- `eslint` clean; `type-check` shows 4 pre-existing errors (opentelemetry version skew + an unbuilt workspace dep), identical with the change reverted, none in `vmSourceMapSupport.ts`.

Planning, implementation, and review were done in a loop with Codex CLI (GPT-5.2, xhigh reasoning) as an adversarial peer. Codex refuted my original fingerprint-based design by finding the `:895` test — that refutation is why this PR is cap-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capped **external `.map`** loading in the Node renderer to **50 MB** (matching inline limits). Oversized maps are skipped as **terminal**, no fallback/remap retries occur, and stack frames remain at bundled locations.
  * Logs a warning with cap/size details, **deduped once per map path** (bounded tracking).

* **Tests**
  * Added Jest coverage for oversized-map behavior across **preload (async)** and **lazy (sync)** paths, including retry prevention and warning de-duplication.

* **Documentation**
  * Updated the changelog to describe the **50 MB external source-map** limit and its effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- completed-batch-audit-summary:start -->
## Completed-batch audit

**Status:** Follow-ups remain — see the durable receipt. [Durable receipt](https://github.com/shakacode/react_on_rails/pull/4688#issuecomment-5164850472).
<!-- completed-batch-audit-summary:end -->
