### PR TITLE
Fix demo fleet verification metadata

### DIFF
--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -239,7 +239,7 @@ repos:
       - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     package_manager: yarn_berry
-    smoke: [/]
+    smoke: [/hello_world]
     verify: true
 
   - name: shakacode/react-on-rails-demo-v16-bundle-splitting
@@ -252,6 +252,7 @@ repos:
       - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     package_manager: npm
+    ruby_test: RAILS_ENV=test bin/rails db:test:prepare test test:system
     smoke: [/]
     verify: true
 


### PR DESCRIPTION
## Why

The demo-fleet verifier was probing the SSR/HMR tutorial at `/`, although its maintained rendered page is `/hello_world`. The Rails 8.1 bundle-splitting demo also lacked an explicit Minitest command, allowing the generic Ruby fallback to select an unsuitable test path.

Closes #4655.

## What changed

- use `/hello_world` as the SSR/HMR smoke route
- declare `RAILS_ENV=test bin/rails db:test:prepare test test:system` for the Rails 8.1 bundle-splitting demo
- preserve each demo's package manager, verification flag, and repository ownership

## Verification

- YAML contract assertions for both entries
- `pnpm prettier --check internal/contributor-info/demo-fleet.yml`
- `script/ci-changes-detector origin/main`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` — 237 files, 0 offenses
- `.agents/bin/validate --changed`
- `git diff --check origin/main...HEAD`
- bundle-splitting demo at `61d60be11b1010fbd7fd5f850f4189a05d376bfb`: `bundle install`, `npm ci`, packs/build, and the exact declared Minitest command passed (1 test, 1 assertion; 0 system tests)
- SSR/HMR demo at `12cbbe3c5e9de9163d2a31cc8036a022ffbbd0d8`: `bundle install`, immutable Yarn install, and Shakapacker build passed

## External replay note

The SSR/HMR RSpec/browser replay is environment-blocked on this Mac: after correcting the stale browser driver, both examples fail in the demo's existing ExecJS runtime with `ReferenceError: Can't find variable: MessageChannel`. A live Puma curl for the Rails 8.1 demo also timed out locally. These are recorded as external-runtime `UNKNOWN` for independent Linux/Chrome QA; no external demo files were changed.

## Review and risk

- independent Codex Sol/xhigh autoreview: clean
- scope: one internal YAML manifest; no runtime package or external-repository changes
- changelog: not user-visible

Confidence: high in the metadata correction and exact command contract; medium in cross-platform end-to-end replay until independent Linux/Chrome evidence is captured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the demo validation path for the SSR HMR application.
  * Added an explicit Ruby test command for the v16 bundle-splitting application to improve test execution consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->