### PR TITLE
Fix Pro performance mark fallback accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Bounded RSC browser performance fallback marks across soft navigations**: Browsers
+  that cannot preserve `PerformanceMark.detail` now retain only the 200 most recent fallback
+  entries, and React on Rails Pro clears the fallback queue during Turbo/Turbolinks page teardown.
+  The TypeScript runtime, generated inline helper, and Ruby streaming mirror share the same limit.
+  Fixes [Issue 4329](https://github.com/shakacode/react_on_rails/issues/4329).
+  [PR 4690](https://github.com/shakacode/react_on_rails/pull/4690) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Fixed webpack server-bundle builds for apps without `react-on-rails-rsc` (e.g. React 18 apps)**:
   17.0.0.rc.9 made webpack fail with `Module not found: Can't resolve 'react-on-rails-rsc/client.node'`
   (and `server.node`) unless the optional `react-on-rails-rsc` peer dependency was installed, because the

--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -653,7 +653,7 @@ export function unmountAll(): void {
   unmountAllComponents();
   unmountAllStores();
   // Keep this synchronous and after component/store unmounts. Mid-stream RSC payload/error
-  // scripts use `||=`, so moving or delaying cleanup could let previous-page writes recreate
+  // scripts use `||`/`||=`, so moving or delaying cleanup could let previous-page writes recreate
   // these globals and land in the next page's state.
   clearRSCPreloadedPayloadGlobals();
   clearBrowserPerformanceMarkFallbacks();

--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -37,6 +37,7 @@ import {
   buildRootErrorCallbackOptionsWithInternalRecoverableErrorReporting,
 } from 'react-on-rails/@internal/rootErrorHandlers';
 import { isThenable } from 'react-on-rails/@internal/isThenable';
+import { REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE } from './browserPerformanceMarks.ts';
 import { maybeWrapWithDefaultRSCProviderWithStatus } from './defaultRSCProviderRegistry.ts';
 import { chainRecoverableErrorHandlers } from './handleRecoverableError.client.ts';
 import type { RSCPreloadedPayloadGlobals } from './rscPayloadGlobals.ts';
@@ -644,6 +645,10 @@ function clearRSCPreloadedPayloadGlobals(): void {
   delete rscGlobal.REACT_ON_RAILS_RSC_ERRORS;
 }
 
+function clearBrowserPerformanceMarkFallbacks(): void {
+  Reflect.deleteProperty(globalThis, REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE);
+}
+
 export function unmountAll(): void {
   unmountAllComponents();
   unmountAllStores();
@@ -651,4 +656,5 @@ export function unmountAll(): void {
   // scripts use `||=`, so moving or delaying cleanup could let previous-page writes recreate
   // these globals and land in the next page's state.
   clearRSCPreloadedPayloadGlobals();
+  clearBrowserPerformanceMarkFallbacks();
 }

--- a/packages/react-on-rails-pro/src/browserPerformanceMarks.ts
+++ b/packages/react-on-rails-pro/src/browserPerformanceMarks.ts
@@ -16,6 +16,8 @@
 export const REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE = 'REACT_ON_RAILS_PERFORMANCE_MARKS';
 export const RSC_STREAM_PERFORMANCE_MARK_PREFIX = 'react-on-rails:rsc';
 
+const MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES = 200;
+
 export type BrowserPerformanceMarkDetail = Record<string, unknown>;
 export type BrowserPerformanceMarkFallback = 'mark-detail-unavailable' | 'performance-mark-unavailable';
 
@@ -91,8 +93,12 @@ export function markBrowserPerformance(markName: string, detail: BrowserPerforma
     entry.fallback = 'performance-mark-unavailable';
   }
 
-  (markGlobal[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE] =
-    markGlobal[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE] || []).push(entry);
+  const queue = markGlobal[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE] || [];
+  markGlobal[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE] = queue;
+  queue.push(entry);
+  if (queue.length > MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES) {
+    queue.splice(0, queue.length - MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES);
+  }
 }
 
 // Keep this inline script in sync with
@@ -116,6 +122,9 @@ export function createBrowserPerformanceMarkScript(
     `try{perf.mark(${markNameJson});entry.fallback="mark-detail-unavailable";}` +
     'catch(fallbackError){entry.fallback="performance-mark-unavailable";}' +
     '}else{entry.fallback="performance-mark-unavailable";}' +
-    `(self.${REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE}=self.${REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE}||[]).push(entry);})()`
+    `var queue=self.${REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE}=` +
+    `self.${REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE}||[];queue.push(entry);` +
+    `if(queue.length>${MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES}){` +
+    `queue.splice(0,queue.length-${MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES});}})()`
   );
 }

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -26,6 +26,7 @@ import * as ComponentRegistry from '../src/ComponentRegistry.ts';
 import * as StoreRegistry from '../src/StoreRegistry.ts';
 import { renderOrHydrateComponent, hydrateStore, unmountAll } from '../src/ClientSideRenderer.ts';
 import { PAGE_UNLOAD_REGISTRY_ERROR_NAME } from '../src/CallbackRegistry.ts';
+import { REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE } from '../src/browserPerformanceMarks.ts';
 import {
   clearDefaultRSCProviderFactory,
   setDefaultRSCProviderFactory,
@@ -795,6 +796,23 @@ describe('ClientSideRenderer', () => {
     expect(window.REACT_ON_RAILS_RSC_PAYLOADS[rscPayloadKey]).toEqual(['page2-chunk-a']);
     (window.REACT_ON_RAILS_RSC_ERRORS ||= {})[rscPayloadKey] = { hasErrors: true };
     expect(window.REACT_ON_RAILS_RSC_ERRORS[rscPayloadKey]).toEqual({ hasErrors: true });
+  });
+
+  it('clears queued browser performance mark fallbacks on page unload', () => {
+    const performanceMarksGlobal = globalThis as typeof globalThis &
+      Partial<Record<typeof REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE, unknown[]>>;
+
+    try {
+      performanceMarksGlobal[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE] = [
+        { name: 'react-on-rails:rsc:payload', detail: { source: 'react-on-rails-pro' } },
+      ];
+
+      unmountAll();
+
+      expect(performanceMarksGlobal[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE]).toBeUndefined();
+    } finally {
+      delete performanceMarksGlobal[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE];
+    }
   });
 
   it('runs a teardown returned asynchronously by a renderer on unmount', async () => {

--- a/packages/react-on-rails-pro/tests/browserPerformanceMarks.test.ts
+++ b/packages/react-on-rails-pro/tests/browserPerformanceMarks.test.ts
@@ -161,6 +161,23 @@ describe('browserPerformanceMarks runtime helper', () => {
     ]);
   });
 
+  it('keeps only the most recent 200 fallback entries', () => {
+    setPerformanceMarkDetailSupport(false);
+    setPerformanceMark(jest.fn() as Performance['mark']);
+
+    for (let index = 0; index < 205; index += 1) {
+      markBrowserPerformance(`react-on-rails:rsc:payload:${index}`, {
+        source: 'react-on-rails-pro',
+        index,
+      });
+    }
+
+    const queue = globalWithQueue[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE];
+    expect(queue).toHaveLength(200);
+    expect(queue?.[0]).toEqual(expect.objectContaining({ name: 'react-on-rails:rsc:payload:5' }));
+    expect(queue?.at(-1)).toEqual(expect.objectContaining({ name: 'react-on-rails:rsc:payload:204' }));
+  });
+
   it('uses the same fallback contract from generated inline mark scripts', () => {
     setPerformanceMarkDetailSupport(false);
     Object.defineProperty(globalThis, 'self', {
@@ -192,6 +209,29 @@ describe('browserPerformanceMarks runtime helper', () => {
     ]);
   });
 
+  it('caps fallback entries created by generated inline mark scripts', () => {
+    setPerformanceMarkDetailSupport(false);
+    Object.defineProperty(globalThis, 'self', {
+      configurable: true,
+      value: globalThis,
+      writable: true,
+    });
+    setPerformanceMark(jest.fn() as Performance['mark']);
+
+    for (let index = 0; index < 205; index += 1) {
+      const markScript = createBrowserPerformanceMarkScript(`react-on-rails:rsc:payload:${index}`, {
+        source: 'react-on-rails-pro',
+        index,
+      });
+      new Function(markScript)();
+    }
+
+    const queue = globalWithQueue[REACT_ON_RAILS_PERFORMANCE_MARKS_QUEUE];
+    expect(queue).toHaveLength(200);
+    expect(queue?.[0]).toEqual(expect.objectContaining({ name: 'react-on-rails:rsc:payload:5' }));
+    expect(queue?.at(-1)).toEqual(expect.objectContaining({ name: 'react-on-rails:rsc:payload:204' }));
+  });
+
   it('keeps the generated inline mark script body aligned with the Ruby stream script', () => {
     const markScript = createBrowserPerformanceMarkScript('react-on-rails:rsc:contract', {
       source: 'react-on-rails-pro',
@@ -211,7 +251,9 @@ describe('browserPerformanceMarks runtime helper', () => {
         'try{perf.mark("react-on-rails:rsc:contract");entry.fallback="mark-detail-unavailable";}' +
         'catch(fallbackError){entry.fallback="performance-mark-unavailable";}' +
         '}else{entry.fallback="performance-mark-unavailable";}' +
-        '(self.REACT_ON_RAILS_PERFORMANCE_MARKS=self.REACT_ON_RAILS_PERFORMANCE_MARKS||[]).push(entry);})()',
+        'var queue=self.REACT_ON_RAILS_PERFORMANCE_MARKS=' +
+        'self.REACT_ON_RAILS_PERFORMANCE_MARKS||[];queue.push(entry);' +
+        'if(queue.length>200){queue.splice(0,queue.length-200);}})()',
     );
   });
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -429,7 +429,8 @@ module ReactOnRailsPro
         try{perf.mark(#{mark_name_json});entry.fallback="mark-detail-unavailable";}
         catch(fallbackError){entry.fallback="performance-mark-unavailable";}}
         else{entry.fallback="performance-mark-unavailable";}
-        (self.REACT_ON_RAILS_PERFORMANCE_MARKS=self.REACT_ON_RAILS_PERFORMANCE_MARKS||[]).push(entry);
+        var queue=self.REACT_ON_RAILS_PERFORMANCE_MARKS=self.REACT_ON_RAILS_PERFORMANCE_MARKS||[];
+        queue.push(entry);if(queue.length>200){queue.splice(0,queue.length-200);}
         })()</script>
       HTML
     end

--- a/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb
@@ -66,8 +66,10 @@ module ReactOnRailsPro
     extend ActiveSupport::Concern
     RENDERER_SERVER_TIMING_COLLECTOR_KEY = :react_on_rails_pro_rsc_stream_renderer_server_timing_entries
     RENDERER_SERVER_TIMING_ATTEMPT_COLLECTOR_KEY = :react_on_rails_pro_rsc_stream_renderer_server_timing_attempt
+    MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES = 200
     private_constant :RENDERER_SERVER_TIMING_COLLECTOR_KEY
     private_constant :RENDERER_SERVER_TIMING_ATTEMPT_COLLECTOR_KEY
+    private_constant :MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES
 
     included do
       include ActionController::Live
@@ -430,7 +432,8 @@ module ReactOnRailsPro
         catch(fallbackError){entry.fallback="performance-mark-unavailable";}}
         else{entry.fallback="performance-mark-unavailable";}
         var queue=self.REACT_ON_RAILS_PERFORMANCE_MARKS=self.REACT_ON_RAILS_PERFORMANCE_MARKS||[];
-        queue.push(entry);if(queue.length>200){queue.splice(0,queue.length-200);}
+        queue.push(entry);if(queue.length>#{MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES}){
+        queue.splice(0,queue.length-#{MAX_BROWSER_PERFORMANCE_MARK_FALLBACK_ENTRIES});}
         })()</script>
       HTML
     end

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe ReactOnRailsPro::Stream do
       expect(written_chunks.second).to include(
         "self.REACT_ON_RAILS_PERFORMANCE_MARKS=self.REACT_ON_RAILS_PERFORMANCE_MARKS||[]"
       )
+      expect(written_chunks.second).to include("if(queue.length>200){queue.splice(0,queue.length-200);}")
       expect(written_chunks.second).not_to include("||=")
       expect(written_chunks.second).to include('perf.mark("react-on-rails:rsc:stream"')
       expect(written_chunks.second).to include('"phase":"stream-complete"')
@@ -410,7 +411,8 @@ RSpec.describe ReactOnRailsPro::Stream do
         try{perf.mark("react-on-rails:rsc:contract");entry.fallback="mark-detail-unavailable";}
         catch(fallbackError){entry.fallback="performance-mark-unavailable";}}
         else{entry.fallback="performance-mark-unavailable";}
-        (self.REACT_ON_RAILS_PERFORMANCE_MARKS=self.REACT_ON_RAILS_PERFORMANCE_MARKS||[]).push(entry);
+        var queue=self.REACT_ON_RAILS_PERFORMANCE_MARKS=self.REACT_ON_RAILS_PERFORMANCE_MARKS||[];
+        queue.push(entry);if(queue.length>200){queue.splice(0,queue.length-200);}
         })()
       JAVASCRIPT
 


### PR DESCRIPTION
## Why

Long-lived Turbo/Turbolinks sessions can accumulate React on Rails Pro browser-performance fallback entries when the browser cannot preserve `PerformanceMark.detail`. Unbounded growth makes the observability fallback itself a reliability risk.

Fixes #4329.

## What changed

- Keep only the 200 most recent fallback entries in the TypeScript runtime helper, generated inline helper, and Ruby streaming mirror.
- Clear the fallback queue during the existing synchronous page-unload teardown.
- Cover the cap direction, generated-helper parity, Ruby mirror parity, and teardown behavior.

## Design decisions

- Preserve the newest entries because they are the most useful for diagnosing the current page.
- Keep the TypeScript and Ruby emitters byte-aligned with a named limit in each language.
- Delete the queue after component/store teardown so stale page state cannot cross a soft navigation.

## Verification

- Pro Jest: 2 suites, 47 tests passed.
- Pro Ruby stream spec: 35 examples, 0 failures.
- Pro TypeScript type-check passed.
- Root JavaScript lint and formatting passed.
- Pro and OSS RuboCop passed.
- Pro license headers: 860 files passed.
- Changed-file builds and JavaScript test matrices passed.
- The broad validation run reached the OSS RBS suite and then hit a pre-existing Ruby 4/json activation conflict (`json` 2.19.9 active vs package lock 2.7.2); the same conflict reproduces outside this diff.

## Review and churn

- Codex review: clean.
- Claude ultra review: clean; one comment-only wording nit accepted.
- `/simplify`: accepted one behavior-preserving Ruby constant extraction; the generated JavaScript remains identical and the Ruby parity spec passes.
- Three local commits before first push: implementation, comment clarification, and named Ruby mirror limit.

## Changelog

Added a `[Pro]` entry under `Unreleased > Fixed` linking Issue #4329 and PR #4690.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited browser performance fallback data to the 200 most recent entries.
  * Cleared fallback performance data when navigating away from a page, preventing stale entries from carrying over.

* **Tests**
  * Added coverage for queue limits, cleanup during unmounting, and streamed observability behavior.

* **Documentation**
  * Updated the unreleased changelog with the performance fallback improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->\n\n## Agent Merge Qualification — post-merge reconciliation\n\nThis required PR-body evidence was added during the completed-batch audit after the protected merge queue landed the PR. It records the qualification used at the exact reviewed head; it does not retroactively change code or review state.\n\n- Release mode: development; target phase: beta; the standard beta merge gate was satisfied.\n- Merge authority: auto_merge_when_gates_pass, granted by batch ror-c-pro-rsc-20260715.\n- Qualified head: c3d32cc9ffa5456cc6e223f5c3e0b8884788c75b.\n- Changelog classification: changelog_present; the PR includes a user-visible Pro reliability entry.\n- Current-head CI: optimized hosted CI and required-pr-gate completed successfully before queue enrollment.\n- Review gate: Claude completed current-head review; CodeRabbit approved the exact head; Greptile completed; unresolved review threads were zero.\n- QA: exact-head cross-language queue-cap/teardown evidence is recorded at https://github.com/shakacode/react_on_rails/pull/4690#issuecomment-4991184117.\n- Merge queue: landed as 6325e108efbf1d2e6eeed8b9c9c4753fe6841d6f; linked Issue #4329 closed automatically.\n\nConfidence note:\n- Validated: Pro Jest 47/47; Ruby stream RSpec 35/35; Pro type-check; JS lint; Prettier; Pro RuboCop 242 files; Pro headers 860; executable base/head queue-bound comparison.\n- Evidence: hosted checks and reviews on this PR; QA evidence comment linked above; strict merge ledger replayed with changelog_present.\n- UNKNOWN: none affecting merge safety.\n- Residual risk: none identified for the bounded fallback queue behavior.\n