### PR TITLE
CI: route gem generator specs by changed paths

### DIFF
--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -51,6 +51,7 @@ jobs:
       run_lint: ${{ steps.detect.outputs.run_lint }}
       run_js_tests: ${{ steps.detect.outputs.run_js_tests }}
       run_ruby_tests: ${{ steps.detect.outputs.run_ruby_tests }}
+      run_gem_generator_specs: ${{ steps.detect.outputs.run_gem_generator_specs }}
       run_dummy_tests: ${{ steps.detect.outputs.run_dummy_tests }}
       run_generators: ${{ steps.detect.outputs.run_generators }}
       should_run_hosted_ci: ${{ steps.hosted-ci.outputs.should_run_hosted_ci }}
@@ -82,6 +83,7 @@ jobs:
               echo "run_lint=true"
               echo "run_js_tests=true"
               echo "run_ruby_tests=true"
+              echo "run_gem_generator_specs=true"
               echo "run_dummy_tests=true"
               echo "run_generators=true"
               echo "docs_only=false"
@@ -107,6 +109,7 @@ jobs:
           LATEST_RUBY_VERSION: ${{ steps.tool-versions.outputs.ruby-minor-version }}
           MINIMUM_RUBY_VERSION: ${{ steps.tool-versions.outputs.minimum-ruby-minor-version }}
           SHOULD_USE_FULL_MATRIX: ${{ steps.hosted-ci.outputs.should_use_full_matrix }}
+          RUN_GEM_GENERATOR_SPECS: ${{ steps.detect.outputs.run_gem_generator_specs }}
         run: |
           latest_ruby_version="$LATEST_RUBY_VERSION"
           minimum_ruby_version="$MINIMUM_RUBY_VERSION"
@@ -130,15 +133,26 @@ jobs:
                 ]
               }')"
           else
-            # PR matrix: test only latest versions for fast feedback × 2 shards
-            matrix="$(jq -nc \
-              --arg latest_ruby_version "$latest_ruby_version" \
-              '{
-                "include": [
-                  {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators"},
-                  {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "unit"}
-                ]
-              }')"
+            # PR matrix: always run the latest unit shard, and add generator
+            # specs only when their dedicated selector requires them.
+            if [[ "$RUN_GEM_GENERATOR_SPECS" == "true" ]]; then
+              matrix="$(jq -nc \
+                --arg latest_ruby_version "$latest_ruby_version" \
+                '{
+                  "include": [
+                    {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators"},
+                    {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "unit"}
+                  ]
+                }')"
+            else
+              matrix="$(jq -nc \
+                --arg latest_ruby_version "$latest_ruby_version" \
+                '{
+                  "include": [
+                    {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "unit"}
+                  ]
+                }')"
+            fi
           fi
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
       - name: Guard docs-only main pushes
@@ -153,10 +167,11 @@ jobs:
 
   rspec-package-tests:
     needs: detect-changes
-    # Run hosted gem tests only when hosted CI is allowed and Ruby paths changed.
+    # Run hosted gem tests only when hosted CI is allowed and Ruby or generator-spec coverage is required.
     if: |
       needs.detect-changes.outputs.should_run_hosted_ci == 'true' &&
-      needs.detect-changes.outputs.run_ruby_tests == 'true'
+      (needs.detect-changes.outputs.run_ruby_tests == 'true' ||
+       needs.detect-changes.outputs.run_gem_generator_specs == 'true')
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -1,5 +1,8 @@
 const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 function read(path) {
   return fs.readFileSync(path, 'utf8');
@@ -13,6 +16,55 @@ function assertDoesNotMatch(name, text, pattern) {
   assert.doesNotMatch(text, pattern, `${name} unexpectedly matches ${pattern}`);
 }
 
+function extractRunScript(workflow, stepName) {
+  const lines = workflow.split('\n');
+  const stepIndex = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
+  assert.notEqual(stepIndex, -1, `workflow is missing the ${stepName} step`);
+
+  const runIndex = lines.findIndex((line, index) => index > stepIndex && line.trim() === 'run: |');
+  assert.notEqual(runIndex, -1, `${stepName} is missing its run block`);
+
+  const blockIndent = lines[runIndex].match(/^\s*/)[0].length + 2;
+  const scriptLines = [];
+  for (const line of lines.slice(runIndex + 1)) {
+    if (line.trim() === '') {
+      scriptLines.push('');
+    } else if (line.match(/^\s*/)[0].length < blockIndent) {
+      break;
+    } else {
+      scriptLines.push(line.slice(blockIndent));
+    }
+  }
+
+  return scriptLines.join('\n');
+}
+
+function runGemMatrix(script, { full, generators }) {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'gem-tests-matrix-'));
+  const outputPath = path.join(temporaryDirectory, 'github-output');
+
+  try {
+    childProcess.execFileSync('bash', ['-c', script], {
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        LATEST_RUBY_VERSION: '3.4',
+        MINIMUM_RUBY_VERSION: '3.2',
+        SHOULD_USE_FULL_MATRIX: String(full),
+        RUN_GEM_GENERATOR_SPECS: String(generators),
+      },
+      stdio: 'pipe',
+    });
+    const matrixOutput = read(outputPath)
+      .split('\n')
+      .find((line) => line.startsWith('matrix='));
+    assert.ok(matrixOutput, 'gem matrix script did not write a matrix output');
+    return JSON.parse(matrixOutput.slice('matrix='.length));
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
 const labelDispatchWorkflow = read('.github/workflows/hosted-ci-label-dispatch.yml');
 const requiredWorkflow = read('.github/workflows/ci-required.yml');
 const hostedSelectorsAction = read('.github/actions/hosted-ci-selectors/action.yml');
@@ -20,6 +72,7 @@ const ciCommandsWorkflow = read('.github/workflows/ci-commands.yml');
 const claudeWorkflow = read('.github/workflows/claude.yml');
 const shakaperfReleaseGateWorkflow = read('.github/workflows/shakaperf-release-gates.yml');
 const rspackViteDxWorkflow = read('.github/workflows/rspack-vite-dx.yml');
+const gemTestsWorkflow = read('.github/workflows/gem-tests.yml');
 
 assertMatches(
   'hosted-ci-label-dispatch trigger',
@@ -117,6 +170,63 @@ assertMatches(
   /const isTrustedReleaseTarget = isReleaseTarget[\s\S]*!isDependabotPullRequest \|\| trustedDependabotHostedRequest/,
 );
 assertMatches('Dependabot trusted-dispatch retry', hostedSelectorsAction, /const maxAttempts = 4/);
+
+assertMatches(
+  'gem generator-spec detector output',
+  gemTestsWorkflow,
+  /run_gem_generator_specs: \$\{\{ steps\.detect\.outputs\.run_gem_generator_specs \}\}/,
+);
+assertMatches(
+  'gem generator-spec force-full override',
+  gemTestsWorkflow,
+  /echo "run_gem_generator_specs=true"/,
+);
+assertMatches(
+  'gem generator-spec matrix input',
+  gemTestsWorkflow,
+  /RUN_GEM_GENERATOR_SPECS: \$\{\{ steps\.detect\.outputs\.run_gem_generator_specs \}\}/,
+);
+assertMatches(
+  'gem generator-spec job gate',
+  gemTestsWorkflow,
+  /needs\.detect-changes\.outputs\.run_ruby_tests == 'true' \|\|\s+needs\.detect-changes\.outputs\.run_gem_generator_specs == 'true'/,
+);
+assertMatches('gem matrix keeps failure evidence', gemTestsWorkflow, /strategy:\n\s+fail-fast: false/);
+assertMatches(
+  'full matrix event policy',
+  hostedSelectorsAction,
+  /const shouldUseFullMatrix = shouldForceFullHostedCi \|\|\s+isPushToMain \|\|\s+isMergeGroup \|\|\s+isTrustedReleaseTarget/,
+);
+
+const gemMatrixScript = extractRunScript(gemTestsWorkflow, 'Set gem tests matrix');
+const latestUnit = { 'ruby-version': '3.4', 'dependency-level': 'latest', shard: 'unit' };
+const latestGenerators = {
+  'ruby-version': '3.4',
+  'dependency-level': 'latest',
+  shard: 'generators',
+};
+const minimumUnit = { 'ruby-version': '3.2', 'dependency-level': 'minimum', shard: 'unit' };
+const minimumGenerators = {
+  'ruby-version': '3.2',
+  'dependency-level': 'minimum',
+  shard: 'generators',
+};
+
+assert.deepEqual(
+  runGemMatrix(gemMatrixScript, { full: false, generators: false }).include,
+  [latestUnit],
+  'optimized non-generator PR matrix should keep only the latest unit shard',
+);
+assert.deepEqual(
+  runGemMatrix(gemMatrixScript, { full: false, generators: true }).include,
+  [latestGenerators, latestUnit],
+  'optimized generator PR matrix should keep the latest generator and unit shards',
+);
+assert.deepEqual(
+  runGemMatrix(gemMatrixScript, { full: true, generators: false }).include,
+  [latestGenerators, latestUnit, minimumGenerators, minimumUnit],
+  'main, merge-group, release-target, and force-full matrices should retain both dependency levels and shards',
+);
 
 assertMatches('ShakaPerf renderer h2c probe', shakaperfReleaseGateWorkflow, /require\('node:http2'\)/);
 assertMatches(

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -73,12 +73,12 @@ rules:
       - examples.yml:208
       - examples.yml:209
       - examples.yml:210
-      - gem-tests.yml:56
-      - gem-tests.yml:58
-      - gem-tests.yml:61
-      - gem-tests.yml:171
-      - gem-tests.yml:172
-      - gem-tests.yml:173
+      - gem-tests.yml:57
+      - gem-tests.yml:59
+      - gem-tests.yml:62
+      - gem-tests.yml:186
+      - gem-tests.yml:187
+      - gem-tests.yml:188
       - integration-tests.yml:55
       - integration-tests.yml:57
       - integration-tests.yml:60

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -70,6 +70,7 @@ BENCHMARKS_CHANGED=false
 SPEC_DUMMY_CHANGED=false
 JS_CHANGED=false
 GENERATORS_CHANGED=false
+GEM_GENERATOR_SPECS_INPUT_CHANGED=false
 PRO_RUBY_CORE_CHANGED=false
 PRO_RSPEC_CHANGED=false
 PRO_JS_CHANGED=false
@@ -578,6 +579,17 @@ while IFS= read -r file; do
         SOURCE_COMMENT_ONLY_CHANGED=true
       else
         RSPEC_CHANGED=true
+        case "$file" in
+          .github/workflows/gem-tests.yml|\
+          react_on_rails/spec/react_on_rails/simplecov_helper.rb|\
+          react_on_rails/spec/react_on_rails/spec_helper.rb|\
+          react_on_rails/spec/react_on_rails/support/generator_spec_helper.rb|\
+          react_on_rails/spec/react_on_rails/support/version_test_helpers.rb|\
+          react_on_rails/spec/react_on_rails/support/shared_examples/*|\
+          react_on_rails/spec/react_on_rails/support/shared_examples/**/*)
+            GEM_GENERATOR_SPECS_INPUT_CHANGED=true
+            ;;
+        esac
         # Spec-only changes set no BENCH_* flag: specs are never shipped in the
         # gem, so they cannot move runtime performance (e.g. #3854 changed only
         # CI-config specs yet ran the core+pro suites). Benchmarks are driven by
@@ -783,6 +795,7 @@ if [ "$DOCS_ONLY" = true ]; then
     "non_runtime_only:true"
     "run_lint:false"
     "run_ruby_tests:false"
+    "run_gem_generator_specs:false"
     "run_js_tests:false"
     "run_dummy_tests:false"
     "run_generators:false"
@@ -854,6 +867,7 @@ echo "Recommended CI jobs:"
 # Determine which jobs to run
 RUN_LINT=false
 RUN_RUBY_TESTS=false
+RUN_GEM_GENERATOR_SPECS=false
 RUN_JS_TESTS=false
 RUN_DUMMY_TESTS=false
 RUN_GENERATORS=false
@@ -873,6 +887,19 @@ fi
 
 if [ "$RUBY_CORE_CHANGED" = true ] || [ "$RSPEC_CHANGED" = true ] || [ "$GENERATORS_CHANGED" = true ]; then
   RUN_RUBY_TESTS=true
+fi
+
+# Gem generator specs are much slower than the unit shard, so select them
+# independently from generic RSpec coverage. Keep the selector conservative for
+# shared/core/JS/unknown CI inputs while excluding isolated specs and the
+# release-tooling paths classified above.
+if [ "$GENERATORS_CHANGED" = true ] ||
+  [ "$GEM_GENERATOR_SPECS_INPUT_CHANGED" = true ] ||
+  [ "$RUBY_CORE_CHANGED" = true ] ||
+  [ "$JS_CHANGED" = true ] ||
+  [ "$CI_INFRA_CHANGED" = true ] ||
+  [ "$UNCATEGORIZED_CHANGED" = true ]; then
+  RUN_GEM_GENERATOR_SPECS=true
 fi
 
 # Benchmark scripts live outside the gem: they're linted by rubocop and covered
@@ -994,6 +1021,7 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "non_runtime_only=$NON_RUNTIME_ONLY"
     echo "run_lint=$RUN_LINT"
     echo "run_ruby_tests=$RUN_RUBY_TESTS"
+    echo "run_gem_generator_specs=$RUN_GEM_GENERATOR_SPECS"
     echo "run_js_tests=$RUN_JS_TESTS"
     echo "run_dummy_tests=$RUN_DUMMY_TESTS"
     echo "run_generators=$RUN_GENERATORS"
@@ -1017,6 +1045,7 @@ if [ "${CI_JSON_OUTPUT:-}" = "1" ]; then
   "non_runtime_only": $NON_RUNTIME_ONLY,
   "run_lint": $RUN_LINT,
   "run_ruby_tests": $RUN_RUBY_TESTS,
+  "run_gem_generator_specs": $RUN_GEM_GENERATOR_SPECS,
   "run_js_tests": $RUN_JS_TESTS,
   "run_dummy_tests": $RUN_DUMMY_TESTS,
   "run_generators": $RUN_GENERATORS,

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -200,6 +200,7 @@ test_docs_changes_are_non_runtime_only() {
   assert_contains "$out" '"docs_only": true' "docs output"
   assert_contains "$out" '"non_runtime_only": true' "docs output"
   assert_contains "$out" '"run_lint": false' "docs output"
+  assert_contains "$out" '"run_gem_generator_specs": false' "docs output"
 }
 
 # Regression for PR #3597: an internal docs/planning YAML (e.g.
@@ -375,6 +376,7 @@ test_agent_bin_change_runs_ci_infrastructure_without_benchmarks() {
   assert_contains "$out" '"non_runtime_only": false' "agent bin output"
   assert_contains "$out" '"run_lint": true' "agent bin output"
   assert_contains "$out" '"run_ruby_tests": true' "agent bin output"
+  assert_contains "$out" '"run_gem_generator_specs": true' "agent bin output"
   assert_contains "$out" '"run_js_tests": true' "agent bin output"
   assert_contains "$out" '"run_dummy_tests": true' "agent bin output"
   assert_contains "$out" '"run_generators": true' "agent bin output"
@@ -480,6 +482,18 @@ test_suite_workflow_file_runs_its_tests_but_no_benchmark() {
   assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "workflow-only output"
 }
 
+test_gem_tests_workflow_change_keeps_generator_specs_fail_closed() {
+  setup_repo
+  mkdir -p .github/workflows
+  printf 'name: Gem tests\non: [pull_request]\n' > .github/workflows/gem-tests.yml
+  commit_change "tweak gem tests workflow"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_ruby_tests": true' "gem workflow output"
+  assert_contains "$out" '"run_gem_generator_specs": true' "gem workflow output"
+}
+
 # A CI-infra change mixed with a real runtime-source change DOES benchmark: the
 # genuine source edit sets the BENCH_* flags the workflow/script changes don't.
 test_ci_infra_plus_runtime_source_still_benchmarks() {
@@ -529,6 +543,7 @@ test_uncategorized_file_runs_tests_but_skips_benchmarks() {
   assert_contains "$out" '"non_runtime_only": false' "uncategorized output"
   # Full test suite still runs (the safety the catch-all is there for).
   assert_contains "$out" '"run_ruby_tests": true' "uncategorized output"
+  assert_contains "$out" '"run_gem_generator_specs": true' "uncategorized output"
   assert_contains "$out" '"run_pro_tests": true' "uncategorized output"
   # ... but no benchmark suite.
   assert_contains "$out" '"run_core_benchmarks": false' "uncategorized output"
@@ -885,8 +900,45 @@ test_rspec_only_changes_do_not_request_e2e() {
   local out
   out="$(detector_output)"
   assert_contains "$out" '"run_ruby_tests": true' "rspec-only output"
+  assert_contains "$out" '"run_gem_generator_specs": false' "rspec-only output"
   assert_contains "$out" '"run_dummy_tests": false' "rspec-only output"
   assert_contains "$out" '"run_e2e_tests": false' "rspec-only output"
+}
+
+assert_generator_spec_support_change_routes_generator_shard() {
+  local file="$1"
+  setup_repo
+  write_file_change "$file"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_ruby_tests": true' "$file output"
+  assert_contains "$out" '"run_gem_generator_specs": true' "$file output"
+}
+
+test_generator_spec_helper_change_routes_generator_shard() {
+  assert_generator_spec_support_change_routes_generator_shard \
+    "react_on_rails/spec/react_on_rails/support/generator_spec_helper.rb"
+}
+
+test_generator_shared_spec_helper_change_routes_generator_shard() {
+  assert_generator_spec_support_change_routes_generator_shard \
+    "react_on_rails/spec/react_on_rails/spec_helper.rb"
+}
+
+test_generator_simplecov_helper_change_routes_generator_shard() {
+  assert_generator_spec_support_change_routes_generator_shard \
+    "react_on_rails/spec/react_on_rails/simplecov_helper.rb"
+}
+
+test_generator_shared_example_change_routes_generator_shard() {
+  assert_generator_spec_support_change_routes_generator_shard \
+    "react_on_rails/spec/react_on_rails/support/shared_examples/base_generator_examples.rb"
+}
+
+test_generator_version_helper_change_routes_generator_shard() {
+  assert_generator_spec_support_change_routes_generator_shard \
+    "react_on_rails/spec/react_on_rails/support/version_test_helpers.rb"
 }
 
 test_generator_only_changes_do_not_request_e2e() {
@@ -896,6 +948,7 @@ test_generator_only_changes_do_not_request_e2e() {
   local out
   out="$(detector_output)"
   assert_contains "$out" '"run_ruby_tests": true' "generator-only output"
+  assert_contains "$out" '"run_gem_generator_specs": true' "generator-only output"
   assert_contains "$out" '"run_generators": true' "generator-only output"
   assert_contains "$out" '"run_dummy_tests": false' "generator-only output"
   assert_contains "$out" '"run_e2e_tests": false' "generator-only output"
@@ -916,6 +969,7 @@ test_core_ruby_changes_request_e2e() {
 
   local out
   out="$(detector_output)"
+  assert_contains "$out" '"run_gem_generator_specs": true' "core ruby output"
   assert_contains "$out" '"run_dummy_tests": true' "core ruby output"
   assert_contains "$out" '"run_e2e_tests": true' "core ruby output"
 }
@@ -926,6 +980,7 @@ test_core_js_changes_request_e2e() {
 
   local out
   out="$(detector_output)"
+  assert_contains "$out" '"run_gem_generator_specs": true' "core js output"
   assert_contains "$out" '"run_e2e_tests": true' "core js output"
 }
 
@@ -984,6 +1039,7 @@ assert_release_tooling_contract() {
   assert_contains "$out" '"run_ruby_tests": true' "$label"
   # Primary goal: NOT generator-sensitive, so required-pr-gate won't force hosted CI.
   assert_contains "$out" '"run_generators": false' "$label"
+  assert_contains "$out" '"run_gem_generator_specs": false' "$label"
   assert_contains "$out" '"run_js_tests": false' "$label"
   # Release tooling does not exercise the dummy app, E2E, or benchmarks. Assert
   # the FULL benchmark contract so a regression that flips any benchmark suite
@@ -1449,6 +1505,7 @@ test_empty_diff_skips_everything() {
   assert_contains "$out" '"non_runtime_only": true' "empty diff output"
   assert_contains "$out" '"run_lint": false' "empty diff output"
   assert_contains "$out" '"run_ruby_tests": false' "empty diff output"
+  assert_contains "$out" '"run_gem_generator_specs": false' "empty diff output"
   assert_contains "$out" '"benchmarks_changed": false' "empty diff output"
 }
 
@@ -1492,6 +1549,7 @@ run_test test_agent_bin_markdown_change_is_non_runtime_only
 run_test test_agent_workflow_config_change_runs_ci_infrastructure_without_benchmarks
 run_test test_ci_infrastructure_only_change_runs_tests_but_skips_benchmarks
 run_test test_suite_workflow_file_runs_its_tests_but_no_benchmark
+run_test test_gem_tests_workflow_change_keeps_generator_specs_fail_closed
 run_test test_ci_infra_plus_runtime_source_still_benchmarks
 run_test test_node_renderer_source_change_runs_node_renderer_benchmark
 run_test test_uncategorized_file_runs_tests_but_skips_benchmarks
@@ -1523,6 +1581,11 @@ run_test test_pure_annotation_remains_runtime_affecting
 run_test test_block_comment_with_trailing_code_remains_runtime_affecting
 run_test test_pro_only_changes_do_not_request_e2e
 run_test test_rspec_only_changes_do_not_request_e2e
+run_test test_generator_spec_helper_change_routes_generator_shard
+run_test test_generator_shared_spec_helper_change_routes_generator_shard
+run_test test_generator_simplecov_helper_change_routes_generator_shard
+run_test test_generator_shared_example_change_routes_generator_shard
+run_test test_generator_version_helper_change_routes_generator_shard
 run_test test_generator_only_changes_do_not_request_e2e
 run_test test_dummy_app_changes_request_e2e
 run_test test_core_ruby_changes_request_e2e


### PR DESCRIPTION
## Why

Optimized pull-request CI currently always runs both gem-spec shards, even when a change cannot affect generator specs. That spends the expensive generator shard on ordinary unit-spec and release-tooling changes.

## What changed

- adds a fail-closed `run_gem_generator_specs` detector output
- runs the latest Ruby unit shard alone for optimized non-generator changes
- adds the latest generator shard for generator, shared-helper, core, JavaScript, CI-infrastructure, and unknown inputs
- preserves the four-row latest/minimum generator/unit matrix for main, merge queue, release targets, and explicit force-full CI
- adds detector and hosted-CI contract coverage for the routing rules

## Workflow Change Audit

- Triggers: unchanged
- Permissions and secrets: unchanged
- Third-party actions and pins: unchanged
- Matrix/job behavior: optimized PR gem tests may omit the generator shard; full/release/merge/force-full paths remain the full four-row matrix
- Fail-closed behavior: CI-infrastructure and uncategorized paths require generator coverage
- Zizmor: base and head preserve the same two existing unsuppressed findings; suppression locations were updated mechanically

## Verification

- `bash script/ci-changes-detector-test.bash` — 83/83 passed
- `node .github/workflows/hosted-ci-safety.test.cjs`
- `actionlint .github/workflows/gem-tests.yml`
- `bash -n script/ci-changes-detector script/ci-changes-detector-test.bash`
- `shellcheck -x script/ci-changes-detector script/ci-changes-detector-test.bash` — existing informational `SC1091` only
- YAML safe-load, Prettier, ESLint, and `git diff --check`
- CI-equivalent OSS RuboCop — 237 files, 0 offenses
- shard dry-load — 1,254 generator examples and 2,090 unit examples, 0 failures
- independent `gpt-5.6-sol/xhigh` review — no blocking or discussion findings

The broad fast validation run passed through the OSS JavaScript suite (26 suites, 361 tests) and was externally terminated during the unrelated Pro node-renderer suite; no assertion failed before termination.

## Post-merge exercise

Issue #4683 remains open as the required semantic-workflow tracker. After merge, a disposable verification PR will exercise unit-only, generator+unit, fail-closed unknown/CI-input, and force-full four-row behavior. It will record current-head run links and be closed after evidence capture.

No changelog entry: this changes maintainer CI routing, not shipped product behavior.

Relates to #4683.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Gem generator tests now run selectively when relevant changes are detected, reducing unnecessary CI work.
  * Pull request checks default to the latest unit-test shard and add generator coverage only when needed.
  * Full hosted CI continues to include generator test coverage.
  * Gem test jobs now run whenever either Ruby tests or generator tests are required.

* **Tests**
  * Expanded validation confirms correct test selection, shard routing, and workflow safety across change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->