### PR TITLE
CI: make hosted dispatch exact-head idempotent

### DIFF
--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -17,9 +17,12 @@ confirmation:
 +ci-run-hosted
 ```
 
-The command first waits for older active CI-command runs, then inventories
-workflow runs and auditable dispatch proofs bound to the exact head SHA, PR
-number, base ref, base SHA, and workflow run ID. It skips equivalent optimized,
+Start commands intentionally serialize across the repository. A command may
+wait about 65 seconds for older active CI-command runs before failing closed;
+this global mutex trades a bounded repository-wide delay for exact-head proof
+safety. The command then inventories workflow runs and auditable dispatch proofs
+bound to the exact head SHA, PR number, base ref, base SHA, and workflow run ID.
+It skips equivalent optimized,
 queued, running, or successful coverage; dispatches only missing workflows;
 creates `ready-for-hosted-ci` if needed; and adds it so future pushes keep
 running optimized hosted CI. Before dispatch, it re-reads the PR and rejects a
@@ -83,7 +86,10 @@ and whether a waiver exists for the current SHA. Status and dispatch comments
 include a machine-readable coverage marker. If Actions coverage cannot be read,
 the result is `UNKNOWN` and start commands dispatch nothing rather than guessing.
 An uncorrelated dispatch writes a durable `UNKNOWN` marker bound to the PR head
-and base; later commands do not redispatch that coverage blindly.
+and base. This intentionally blocks same-head retries because workflow
+acceptance cannot be proven. The operator must inspect and cancel any uncertain
+exact-head runs or let them finish, then push a new commit and retry against the
+new head; there is no same-head reset.
 Repeated all-covered Dependabot requests retain a nonzero trusted current-base
 dispatch proof so selector trust remains idempotent.
 `+ci-help` prints the command list.

--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -17,12 +17,15 @@ confirmation:
 +ci-run-hosted
 ```
 
-The command first inventories exact-head workflow runs and prior auditable
-dispatch proofs. It skips equivalent optimized, queued, running, or successful
-coverage; dispatches only missing workflows; creates `ready-for-hosted-ci` if
-needed; and adds it so future pushes keep running optimized hosted CI. Hosted CI
-is still path-selected by `script/ci-changes-detector`; it does not
-automatically run every hosted suite.
+The command first inventories workflow runs and auditable dispatch proofs bound
+to the exact head SHA, PR number, base ref, and base SHA. It skips equivalent
+optimized, queued, running, or successful coverage; dispatches only missing
+workflows; creates `ready-for-hosted-ci` if needed; and adds it so future pushes
+keep running optimized hosted CI. Selector-only `pull_request` workflow shells
+do not count as hosted coverage. The exception is a base-matched automatic run
+for a same-repository, non-Dependabot release-target PR, where release policy
+already runs the hosted jobs. Hosted CI is still path-selected by
+`script/ci-changes-detector`; it does not automatically run every hosted suite.
 
 ### `+ci-force-full` - Request Force-Full Hosted CI
 
@@ -38,6 +41,9 @@ coverage, with `force_full_hosted: true`; creates `ready-for-hosted-ci` and
 `force-full-hosted-ci`; and keeps future pushes in force-full mode until
 `+ci-stop-full` removes the override. An optimized or automatic release-target
 run is not force-full evidence merely because it has the same workflow name.
+When concurrent dispatch timing makes a successful run attributable to an
+earlier optimized request, the command retries missing force-full coverage
+rather than treating the ambiguous run as force-full proof.
 
 ### Stop And Waiver Commands
 
@@ -66,6 +72,8 @@ automatic same-repository release-target mode, exact-head per-workflow coverage,
 and whether a waiver exists for the current SHA. Status and dispatch comments
 include a machine-readable coverage marker. If Actions coverage cannot be read,
 the result is `UNKNOWN` and start commands dispatch nothing rather than guessing.
+Repeated all-covered Dependabot requests retain a nonzero trusted current-base
+dispatch proof so selector trust remains idempotent.
 `+ci-help` prints the command list.
 
 ## Human, Agent, And Workflow-Token Paths

--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -30,11 +30,22 @@ It skips equivalent optimized,
 queued, running, or successful coverage; dispatches only missing workflows;
 creates `ready-for-hosted-ci` if needed; and adds it so future pushes keep
 running optimized hosted CI. Before dispatch, it re-reads the PR and rejects a
-changed head or base. Dispatches use the versioned `2026-03-10` API's `200`
+changed head or base. It then creates a head/base-bound `UNKNOWN` anchor comment;
+if that durable anchor cannot be created, no workflow is dispatched. Dispatches
+use the versioned `2026-03-10` API's `200`
 response workflow run ID, then verify that exact run's workflow path, event, and
 head SHA. A newly returned run gets up to three reads over four seconds when
 GitHub reports a transient `404` or server error; an unavailable or mismatched
-run then fails closed without recording trusted dispatch proof. Selector-only
+run then fails closed without recording trusted dispatch proof. Validated run
+IDs replace the anchor in place. The final update is retried; if every update
+fails, the original `UNKNOWN` anchor remains and blocks blind same-head retry.
+If GitHub persists an anchor but its create response is lost, the command
+reconciles it by source comment and workflow-run identity before dispatching.
+It revalidates the PR snapshot again after anchoring and replaces the anchor
+with a stopped audit result if the head or base moved.
+No-dispatch audit results retain the same bounded comment retry behavior.
+Manual reruns of a `CI Commands` workflow fail closed; post a new `+ci-*` comment
+to create a safely ordered command run. Selector-only
 `pull_request` workflow shells do not
 count as hosted coverage. The exception is a base-matched automatic run for a
 same-repository, non-Dependabot release-target PR, where release policy already
@@ -58,6 +69,9 @@ coverage, with `force_full_hosted: true`; creates `ready-for-hosted-ci` and
 run is not force-full evidence merely because it has the same workflow name.
 Optimized and force-full proofs identify their exact returned workflow run IDs,
 so concurrent or same-second dispatches cannot be attributed to the wrong mode.
+If an older release branch rejects the new base-context inputs, the legacy
+fallback records each workflow's effective mode; a fallback that adds
+`force_full_hosted: true` is reusable as force-full evidence.
 If an exact run is temporarily absent from the run inventory, it receives a
 two-minute visibility grace period; after that, the workflow is missing and can
 be retried instead of remaining pending forever.
@@ -86,7 +100,8 @@ workflow run and does not apply after another push.
 
 `+ci-status` summarizes labels, the current SHA, the docs-only heuristic,
 automatic same-repository release-target mode, exact-head per-workflow coverage,
-and whether a waiver exists for the current SHA. Status and dispatch comments
+the actual per-workflow mode counts, and whether a waiver exists for the current
+SHA. Status and dispatch comments
 include a machine-readable coverage marker. If Actions coverage cannot be read,
 the result is `UNKNOWN` and start commands dispatch nothing rather than guessing.
 An uncorrelated dispatch writes a durable `UNKNOWN` marker bound to the PR head

--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -17,16 +17,22 @@ confirmation:
 +ci-run-hosted
 ```
 
-The command first inventories workflow runs and auditable dispatch proofs bound
-to the exact head SHA, PR number, base ref, base SHA, and workflow run ID. It
-skips equivalent optimized, queued, running, or successful coverage; dispatches
-only missing workflows; creates `ready-for-hosted-ci` if needed; and adds it so
-future pushes keep running optimized hosted CI. Dispatches use GitHub's
-`return_run_details` API response and fail closed if an exact run ID is not
-returned. Selector-only `pull_request` workflow shells do not count as hosted
-coverage. The exception is a base-matched automatic run for a same-repository,
-non-Dependabot release-target PR, where release policy already runs the hosted
-jobs. Hosted CI is still path-selected by `script/ci-changes-detector`; it does
+The command first waits for older active CI-command runs, then inventories
+workflow runs and auditable dispatch proofs bound to the exact head SHA, PR
+number, base ref, base SHA, and workflow run ID. It skips equivalent optimized,
+queued, running, or successful coverage; dispatches only missing workflows;
+creates `ready-for-hosted-ci` if needed; and adds it so future pushes keep
+running optimized hosted CI. Before dispatch, it re-reads the PR and rejects a
+changed head or base. Dispatches use the versioned `2026-03-10` API's `200`
+response workflow run ID, then verify that exact run's workflow path, event, and
+head SHA. A newly returned run gets up to three reads over four seconds when
+GitHub reports a transient `404` or server error; an unavailable or mismatched
+run then fails closed without recording trusted dispatch proof. Selector-only
+`pull_request` workflow shells do not
+count as hosted coverage. The exception is a base-matched automatic run for a
+same-repository, non-Dependabot release-target PR, where release policy already
+runs the hosted jobs. Hosted CI is still path-selected by
+`script/ci-changes-detector`; it does
 not automatically run every hosted suite.
 
 ### `+ci-force-full` - Request Force-Full Hosted CI
@@ -76,6 +82,8 @@ automatic same-repository release-target mode, exact-head per-workflow coverage,
 and whether a waiver exists for the current SHA. Status and dispatch comments
 include a machine-readable coverage marker. If Actions coverage cannot be read,
 the result is `UNKNOWN` and start commands dispatch nothing rather than guessing.
+An uncorrelated dispatch writes a durable `UNKNOWN` marker bound to the PR head
+and base; later commands do not redispatch that coverage blindly.
 Repeated all-covered Dependabot requests retain a nonzero trusted current-base
 dispatch proof so selector trust remains idempotent.
 `+ci-help` prints the command list.

--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -17,10 +17,12 @@ confirmation:
 +ci-run-hosted
 ```
 
-The command dispatches hosted workflows for the current head SHA, creates
-`ready-for-hosted-ci` if needed, and adds it so future pushes on the PR keep
-running optimized hosted CI. Hosted CI is still path-selected by
-`script/ci-changes-detector`; it does not automatically run every hosted suite.
+The command first inventories exact-head workflow runs and prior auditable
+dispatch proofs. It skips equivalent optimized, queued, running, or successful
+coverage; dispatches only missing workflows; creates `ready-for-hosted-ci` if
+needed; and adds it so future pushes keep running optimized hosted CI. Hosted CI
+is still path-selected by `script/ci-changes-detector`; it does not
+automatically run every hosted suite.
 
 ### `+ci-force-full` - Request Force-Full Hosted CI
 
@@ -31,9 +33,11 @@ selection:
 +ci-force-full
 ```
 
-The command dispatches the same hosted workflows with `force_full_hosted: true`,
-creates `ready-for-hosted-ci` and `force-full-hosted-ci`, and keeps future pushes
-in force-full mode until `+ci-stop-full` removes the override.
+The command dispatches only workflows missing proven exact-head force-full
+coverage, with `force_full_hosted: true`; creates `ready-for-hosted-ci` and
+`force-full-hosted-ci`; and keeps future pushes in force-full mode until
+`+ci-stop-full` removes the override. An optimized or automatic release-target
+run is not force-full evidence merely because it has the same workflow name.
 
 ### Stop And Waiver Commands
 
@@ -57,8 +61,12 @@ commits keep running optimized hosted CI.
 Records a SHA-bound hosted-CI waiver. The waiver does not cancel or block any
 workflow run and does not apply after another push.
 
-`+ci-status` summarizes labels, the current SHA, the docs-only heuristic, and
-whether a waiver exists for the current SHA. `+ci-help` prints the command list.
+`+ci-status` summarizes labels, the current SHA, the docs-only heuristic,
+automatic same-repository release-target mode, exact-head per-workflow coverage,
+and whether a waiver exists for the current SHA. Status and dispatch comments
+include a machine-readable coverage marker. If Actions coverage cannot be read,
+the result is `UNKNOWN` and start commands dispatch nothing rather than guessing.
+`+ci-help` prints the command list.
 
 ## Human, Agent, And Workflow-Token Paths
 
@@ -111,8 +119,8 @@ a comment line.
 
 Comment-triggered workflows (`issue_comment`) execute from the default branch
 (`main`), not from the PR branch. When changing `ci-commands.yml`, validate the
-YAML and script locally, merge the workflow change, then test commands on a
-follow-up PR.
+YAML and run `node --test .github/workflows/ci-commands.test.cjs` locally, merge
+the workflow change, then test commands on a follow-up PR.
 
 ## Post-Merge Exercise Follow-Ups
 

--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -18,14 +18,16 @@ confirmation:
 ```
 
 The command first inventories workflow runs and auditable dispatch proofs bound
-to the exact head SHA, PR number, base ref, and base SHA. It skips equivalent
-optimized, queued, running, or successful coverage; dispatches only missing
-workflows; creates `ready-for-hosted-ci` if needed; and adds it so future pushes
-keep running optimized hosted CI. Selector-only `pull_request` workflow shells
-do not count as hosted coverage. The exception is a base-matched automatic run
-for a same-repository, non-Dependabot release-target PR, where release policy
-already runs the hosted jobs. Hosted CI is still path-selected by
-`script/ci-changes-detector`; it does not automatically run every hosted suite.
+to the exact head SHA, PR number, base ref, base SHA, and workflow run ID. It
+skips equivalent optimized, queued, running, or successful coverage; dispatches
+only missing workflows; creates `ready-for-hosted-ci` if needed; and adds it so
+future pushes keep running optimized hosted CI. Dispatches use GitHub's
+`return_run_details` API response and fail closed if an exact run ID is not
+returned. Selector-only `pull_request` workflow shells do not count as hosted
+coverage. The exception is a base-matched automatic run for a same-repository,
+non-Dependabot release-target PR, where release policy already runs the hosted
+jobs. Hosted CI is still path-selected by `script/ci-changes-detector`; it does
+not automatically run every hosted suite.
 
 ### `+ci-force-full` - Request Force-Full Hosted CI
 
@@ -41,9 +43,11 @@ coverage, with `force_full_hosted: true`; creates `ready-for-hosted-ci` and
 `force-full-hosted-ci`; and keeps future pushes in force-full mode until
 `+ci-stop-full` removes the override. An optimized or automatic release-target
 run is not force-full evidence merely because it has the same workflow name.
-When concurrent dispatch timing makes a successful run attributable to an
-earlier optimized request, the command retries missing force-full coverage
-rather than treating the ambiguous run as force-full proof.
+Optimized and force-full proofs identify their exact returned workflow run IDs,
+so concurrent or same-second dispatches cannot be attributed to the wrong mode.
+If an exact run is temporarily absent from the run inventory, it receives a
+two-minute visibility grace period; after that, the workflow is missing and can
+be retried instead of remaining pending forever.
 
 ### Stop And Waiver Commands
 

--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -17,11 +17,15 @@ confirmation:
 +ci-run-hosted
 ```
 
-Start commands intentionally serialize across the repository. A command may
-wait about 65 seconds for older active CI-command runs before failing closed;
-this global mutex trades a bounded repository-wide delay for exact-head proof
-safety. The command then inventories workflow runs and auditable dispatch proofs
-bound to the exact head SHA, PR number, base ref, base SHA, and workflow run ID.
+Start commands coordinate against older visible active CI-command runs after a
+visibility delay. Polls query only the preceding 24 hours, and a command may
+wait about 65 seconds before failing closed. This prevents routine concurrent
+duplicate dispatches, but it is not an atomic lock: a rare Actions
+list-visibility race can omit a just-queued older run and allow duplicate work.
+Exact run-ID, workflow, head, and mode validation still prevents proof
+misattribution. The command then inventories workflow runs and auditable dispatch
+proofs bound to the exact head SHA, PR number, base ref, base SHA, and workflow
+run ID.
 It skips equivalent optimized,
 queued, running, or successful coverage; dispatches only missing workflows;
 creates `ready-for-hosted-ci` if needed; and adds it so future pushes keep

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -64,6 +64,7 @@ function coverageMarkerFrom(comment) {
 async function runCommand({
   body,
   ciCommandRunSnapshots = [],
+  commentCreateFailures = [],
   comments = [],
   dispatchErrors = {},
   dispatchReturnsNoRunDetails = false,
@@ -94,9 +95,15 @@ async function runCommand({
   const workflowRunReadIndexes = new Map();
   let serializationCompleted = ciCommandRunSnapshots.length === 0;
   let serializationSnapshotIndex = 0;
+  let commentCreateIndex = 0;
   const endpoints = {
     addLabels: async ({ labels: addedLabels }) => calls.labels.push(...addedLabels),
-    createComment: async ({ body: commentBody }) => calls.comments.push(commentBody),
+    createComment: async ({ body: commentBody }) => {
+      const failure = commentCreateFailures[commentCreateIndex];
+      commentCreateIndex += 1;
+      if (failure) throw failure;
+      calls.comments.push(commentBody);
+    },
     createLabel: async () => {},
     createWorkflowDispatch: async (options) => {
       calls.dispatches.push(options);
@@ -282,6 +289,21 @@ test('+ci-run-hosted does not reuse detector-only pull_request shells', async ()
 
   assert.equal(calls.dispatches.length, 9);
   assert.match(calls.comments.at(-1), /Triggered 9 workflow\(s\)/);
+});
+
+test('a transient result-comment failure retries the exact dispatch proof', async () => {
+  const pullRequest = defaultPullRequest();
+  pullRequest.base.ref = 'main';
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    commentCreateFailures: [new Error('simulated transient comment outage')],
+    pullRequest,
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.match(calls.comments.at(-1), /Triggered 9 workflow\(s\)/);
+  assert.equal(coverageMarkerFrom(calls.comments.at(-1)).workflows.length, 9);
 });
 
 test('a simultaneous same-head command waits for the older command proof before dispatching', async () => {

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -63,13 +63,18 @@ function coverageMarkerFrom(comment) {
 
 async function runCommand({
   body,
+  ciCommandRunSnapshots = [],
   comments = [],
   dispatchReturnsNoRunDetails = false,
+  dispatchedRunOverrides = {},
   files,
   labels = [],
   pullRequest,
+  pullRequests,
   runListError,
   runs = [],
+  serializationRunListError,
+  workflowRunReadFailures = {},
 }) {
   const calls = {
     comments: [],
@@ -77,8 +82,15 @@ async function runCommand({
     failures: [],
     labels: [],
     reactions: [],
+    workflowRunReads: [],
   };
   const pr = pullRequest || defaultPullRequest();
+  const pullRequestSequence = pullRequests || [pr];
+  let pullRequestReadIndex = 0;
+  const dispatchedRuns = new Map();
+  const workflowRunReadIndexes = new Map();
+  let serializationCompleted = ciCommandRunSnapshots.length === 0;
+  let serializationSnapshotIndex = 0;
   const endpoints = {
     addLabels: async ({ labels: addedLabels }) => calls.labels.push(...addedLabels),
     createComment: async ({ body: commentBody }) => calls.comments.push(commentBody),
@@ -86,31 +98,71 @@ async function runCommand({
     createWorkflowDispatch: async (options) => {
       calls.dispatches.push(options);
       if (dispatchReturnsNoRunDetails) return { data: '', status: 204 };
-      return { data: { workflow_run_id: 1000 + calls.dispatches.length } };
+      const runId = 1000 + calls.dispatches.length;
+      dispatchedRuns.set(runId, {
+        event: 'workflow_dispatch',
+        head_sha: pr.head.sha,
+        id: runId,
+        path: `.github/workflows/${options.workflow_id}`,
+        status: 'queued',
+        ...dispatchedRunOverrides[options.workflow_id],
+      });
+      return { data: { workflow_run_id: runId }, status: 200 };
+    },
+    getWorkflowRun: async ({ run_id: runId }) => {
+      calls.workflowRunReads.push(runId);
+      const workflowFile = dispatchedRuns.get(runId)?.path?.split('/').at(-1);
+      const readIndex = workflowRunReadIndexes.get(runId) || 0;
+      workflowRunReadIndexes.set(runId, readIndex + 1);
+      const failure = workflowRunReadFailures[workflowFile]?.[readIndex];
+      if (failure) throw failure;
+      return { data: dispatchedRuns.get(runId) };
     },
     getCollaboratorPermissionLevel: async () => ({ data: { permission: 'write' } }),
-    getPullRequest: async () => ({ data: pr }),
+    getPullRequest: async () => {
+      const current = pullRequestSequence[Math.min(pullRequestReadIndex, pullRequestSequence.length - 1)];
+      pullRequestReadIndex += 1;
+      return { data: current };
+    },
     listComments: async () => {},
     listFiles: async () => {},
     listLabelsOnIssue: async () => {},
+    listWorkflowRuns: async () => {},
     listWorkflowRunsForRepo: async () => {},
     removeLabel: async () => {},
     createReaction: async ({ content }) => calls.reactions.push(content),
   };
   const github = {
-    paginate: async (endpoint) => {
-      if (endpoint === endpoints.listComments) return comments;
+    paginate: async (endpoint, options = {}) => {
+      if (endpoint === endpoints.listComments) {
+        return serializationCompleted ? comments : [];
+      }
       if (endpoint === endpoints.listFiles) return files || [{ filename: 'app/models/example.rb' }];
       if (endpoint === endpoints.listLabelsOnIssue) return labels.map((name) => ({ name }));
+      if (endpoint === endpoints.listWorkflowRuns) {
+        assert.equal(options.workflow_id, 'ci-commands.yml');
+        assert.equal(options.event, 'issue_comment');
+        if (serializationRunListError) throw serializationRunListError;
+        const snapshot =
+          ciCommandRunSnapshots[Math.min(serializationSnapshotIndex, ciCommandRunSnapshots.length - 1)] || [];
+        serializationSnapshotIndex += 1;
+        serializationCompleted = !snapshot.some(
+          (run) =>
+            run.id < 100 && ['in_progress', 'queued', 'requested', 'waiting', 'pending'].includes(run.status),
+        );
+        return snapshot;
+      }
       if (endpoint === endpoints.listWorkflowRunsForRepo) {
         if (runListError) throw runListError;
-        return runs;
+        return serializationCompleted ? runs : [];
       }
       throw new Error('unexpected paginated endpoint');
     },
     rest: {
       actions: {
         createWorkflowDispatch: endpoints.createWorkflowDispatch,
+        getWorkflowRun: endpoints.getWorkflowRun,
+        listWorkflowRuns: endpoints.listWorkflowRuns,
         listWorkflowRunsForRepo: endpoints.listWorkflowRunsForRepo,
       },
       issues: {
@@ -144,6 +196,7 @@ async function runCommand({
       },
     },
     repo: { owner: 'shakacode', repo: 'react_on_rails' },
+    runId: 100,
   };
   const core = {
     setFailed: (message) => calls.failures.push(message),
@@ -223,6 +276,137 @@ test('+ci-run-hosted does not reuse detector-only pull_request shells', async ()
   assert.match(calls.comments.at(-1), /Triggered 9 workflow\(s\)/);
 });
 
+test('a simultaneous same-head command waits for the older command proof before dispatching', async () => {
+  const pullRequest = defaultPullRequest();
+  pullRequest.base.ref = 'main';
+  const runIds = Object.fromEntries(
+    hostedWorkflowFiles.map((workflowFile, index) => [workflowFile, 500 + index]),
+  );
+  const priorProof = {
+    body: `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+      head_sha: 'current-head-sha',
+      pull_request_number: 42,
+      base_ref: 'main',
+      base_sha: 'base-sha',
+      requested_mode: 'optimized',
+      requested_at: '2026-07-16T08:00:00Z',
+      workflows: hostedWorkflowFiles,
+      run_ids: runIds,
+    })} -->`,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const completedRuns = hostedWorkflowFiles.map((workflowFile, index) => ({
+    conclusion: 'success',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    id: 500 + index,
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const olderCommandRun = {
+    event: 'issue_comment',
+    id: 99,
+    path: '.github/workflows/ci-commands.yml',
+  };
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    ciCommandRunSnapshots: [
+      [{ ...olderCommandRun, status: 'in_progress' }],
+      [{ ...olderCommandRun, status: 'completed' }],
+    ],
+    comments: [priorProof],
+    pullRequest,
+    runs: completedRuns,
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.match(calls.comments.at(-1), /Skipped 9 workflow\(s\) with equivalent exact-head coverage/);
+});
+
+test('a force-full command waits for older optimized coverage without treating it as force-full', async () => {
+  const pullRequest = defaultPullRequest();
+  pullRequest.base.ref = 'main';
+  const runIds = Object.fromEntries(
+    hostedWorkflowFiles.map((workflowFile, index) => [workflowFile, 500 + index]),
+  );
+  const priorProof = {
+    body: `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+      head_sha: 'current-head-sha',
+      pull_request_number: 42,
+      base_ref: 'main',
+      base_sha: 'base-sha',
+      requested_mode: 'optimized',
+      requested_at: '2026-07-16T08:00:00Z',
+      workflows: hostedWorkflowFiles,
+      run_ids: runIds,
+    })} -->`,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const completedRuns = hostedWorkflowFiles.map((workflowFile, index) => ({
+    conclusion: 'success',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    id: 500 + index,
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const olderCommandRun = {
+    event: 'issue_comment',
+    id: 99,
+    path: '.github/workflows/ci-commands.yml',
+  };
+
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    ciCommandRunSnapshots: [
+      [{ ...olderCommandRun, status: 'in_progress' }],
+      [{ ...olderCommandRun, status: 'completed' }],
+    ],
+    comments: [priorProof],
+    pullRequest,
+    runs: completedRuns,
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.match(calls.comments.at(-1), /Mode: force-full hosted CI/);
+});
+
+test('hosted dispatch fails closed when older CI Commands state is UNKNOWN', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    serializationRunListError: new Error('simulated serialization API outage'),
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.deepEqual(calls.failures, ['Older CI command state is UNKNOWN; dispatch stopped.']);
+  assert.match(calls.comments.at(-1), /Hosted CI Command Serialization UNKNOWN/);
+});
+
+test('hosted dispatch times out rather than racing an older active CI command', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    ciCommandRunSnapshots: [
+      [
+        {
+          event: 'issue_comment',
+          id: 99,
+          path: '.github/workflows/ci-commands.yml',
+          status: 'in_progress',
+        },
+      ],
+    ],
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.deepEqual(calls.failures, ['Older CI command state is UNKNOWN; dispatch stopped.']);
+  assert.match(calls.comments.at(-1), /did not finish within the bounded wait/);
+});
+
 test('+ci-force-full dispatches only force-full coverage proven missing', async () => {
   const forceFullWorkflow = hostedWorkflowFiles[0];
   const automaticRuns = hostedWorkflowFiles.map((workflowFile) => ({
@@ -268,7 +452,7 @@ test('+ci-force-full dispatches only force-full coverage proven missing', async 
   assert.deepEqual([...marker.dispatched].sort(), hostedWorkflowFiles.slice(1).sort());
   assert.deepEqual(marker.workflows, marker.dispatched);
   assert.deepEqual(Object.keys(marker.run_ids).sort(), hostedWorkflowFiles.slice(1).sort());
-  assert.ok(calls.dispatches.every((dispatch) => dispatch.return_run_details === true));
+  assert.ok(calls.dispatches.every((dispatch) => !('return_run_details' in dispatch)));
   assert.ok(calls.dispatches.every((dispatch) => dispatch.headers['x-github-api-version'] === '2026-03-10'));
 });
 
@@ -315,6 +499,131 @@ test('+ci-run-hosted fails closed when dispatch does not return exact run detail
   const marker = coverageMarkerFrom(calls.comments.at(-1));
   assert.deepEqual(marker.workflows, []);
   assert.deepEqual(marker.run_ids, {});
+  assert.equal(marker.dispatch_uncertain, true);
+
+  const priorUnknownComment = {
+    body: calls.comments.at(-1),
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const retryCalls = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [priorUnknownComment],
+  });
+  assert.equal(retryCalls.dispatches.length, 0);
+  assert.match(retryCalls.comments.at(-1), /Hosted CI Coverage UNKNOWN/);
+});
+
+test('hosted dispatch stops when the PR head changes after the coverage snapshot', async () => {
+  const initialPullRequest = defaultPullRequest();
+  const pushedPullRequest = structuredClone(initialPullRequest);
+  pushedPullRequest.head.sha = 'pushed-head-sha';
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    pullRequests: [initialPullRequest, pushedPullRequest],
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.equal(calls.labels.length, 0);
+  assert.deepEqual(calls.failures, ['Pull request changed during hosted CI planning; dispatch stopped.']);
+  assert.match(calls.comments.at(-1), /Pull Request Changed/);
+});
+
+test('hosted dispatch stops when the PR base changes after the coverage snapshot', async () => {
+  const initialPullRequest = defaultPullRequest();
+  const retargetedPullRequest = structuredClone(initialPullRequest);
+  retargetedPullRequest.base = { ref: 'release/17.1.0', sha: 'retargeted-base-sha' };
+
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    pullRequests: [initialPullRequest, retargetedPullRequest],
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.equal(calls.labels.length, 0);
+  assert.deepEqual(calls.failures, ['Pull request changed during hosted CI planning; dispatch stopped.']);
+  assert.match(calls.comments.at(-1), /Pull Request Changed/);
+});
+
+test('hosted dispatch rejects a returned run that is not bound to the expected head', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchedRunOverrides: {
+      'lint-js-and-ruby.yml': { head_sha: 'unexpected-head-sha' },
+    },
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.workflowRunReads.length, 9);
+  assert.equal(calls.workflowRunReads.filter((runId) => runId === 1001).length, 1);
+  assert.equal(calls.labels.length, 0);
+  assert.match(calls.comments.at(-1), /returned run did not match the expected workflow and head/);
+  const marker = coverageMarkerFrom(calls.comments.at(-1));
+  assert.equal(marker.dispatch_uncertain, true);
+  assert.deepEqual(marker.uncertain_workflows, ['lint-js-and-ruby.yml']);
+});
+
+test('hosted dispatch retries a newly returned run that is briefly not visible', async () => {
+  const notVisible = Object.assign(new Error('workflow run is not visible yet'), { status: 404 });
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    workflowRunReadFailures: { 'lint-js-and-ruby.yml': [notVisible] },
+  });
+
+  assert.equal(calls.workflowRunReads.filter((runId) => runId === 1001).length, 2);
+  assert.deepEqual(calls.failures, []);
+  assert.ok(calls.labels.includes('ready-for-hosted-ci'));
+  const marker = coverageMarkerFrom(calls.comments.at(-1));
+  assert.equal(marker.dispatch_uncertain, undefined);
+  assert.equal(marker.workflows.length, 9);
+});
+
+test('hosted dispatch records durable UNKNOWN after exact-run visibility retries are exhausted', async () => {
+  const notVisible = () => Object.assign(new Error('workflow run is not visible yet'), { status: 404 });
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    workflowRunReadFailures: {
+      'lint-js-and-ruby.yml': [notVisible(), notVisible(), notVisible()],
+    },
+  });
+
+  assert.equal(calls.workflowRunReads.filter((runId) => runId === 1001).length, 3);
+  assert.equal(calls.labels.length, 0);
+  const marker = coverageMarkerFrom(calls.comments.at(-1));
+  assert.equal(marker.dispatch_uncertain, true);
+  assert.deepEqual(marker.uncertain_workflows, ['lint-js-and-ruby.yml']);
+});
+
+test('hosted dispatch rejects a returned run with the wrong event', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchedRunOverrides: { 'lint-js-and-ruby.yml': { event: 'pull_request' } },
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.workflowRunReads.length, 9);
+  assert.equal(calls.labels.length, 0);
+  const marker = coverageMarkerFrom(calls.comments.at(-1));
+  assert.equal(marker.dispatch_uncertain, true);
+  assert.deepEqual(marker.uncertain_workflows, ['lint-js-and-ruby.yml']);
+});
+
+test('hosted dispatch rejects a returned run with the wrong workflow path', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchedRunOverrides: {
+      'lint-js-and-ruby.yml': { path: '.github/workflows/package-js-tests.yml' },
+    },
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.workflowRunReads.length, 9);
+  assert.equal(calls.labels.length, 0);
+  const marker = coverageMarkerFrom(calls.comments.at(-1));
+  assert.equal(marker.dispatch_uncertain, true);
+  assert.deepEqual(marker.uncertain_workflows, ['lint-js-and-ruby.yml']);
 });
 
 test('+ci-run-hosted does not reuse old-head, failed, or cancelled workflow runs', async () => {

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -256,6 +256,75 @@ test('+ci-status reports automatic exact-head release-target coverage', async ()
   assert.ok(marker.observed.every((workflow) => workflow.mode === 'release-full'));
 });
 
+test('+ci-status derives force-full mode from exact-head proof', async () => {
+  const pullRequest = defaultPullRequest();
+  pullRequest.base.ref = 'main';
+  const runIds = Object.fromEntries(
+    hostedWorkflowFiles.map((workflowFile, index) => [workflowFile, 500 + index]),
+  );
+  const proof = {
+    body: `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+      head_sha: 'current-head-sha',
+      pull_request_number: 42,
+      base_ref: 'main',
+      base_sha: 'base-sha',
+      requested_mode: 'force-full',
+      requested_at: '2026-07-16T08:00:00Z',
+      workflows: hostedWorkflowFiles,
+      run_ids: runIds,
+    })} -->`,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const runs = hostedWorkflowFiles.map((workflowFile, index) => ({
+    conclusion: 'success',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    id: 500 + index,
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+
+  const calls = await runCommand({ body: '+ci-status', comments: [proof], pullRequest, runs });
+
+  assert.match(calls.comments.at(-1), /Observed exact-head coverage: modes\[force-full=9\]/);
+});
+
+test('+ci-status does not mislabel optimized proof as release-full', async () => {
+  const runIds = Object.fromEntries(
+    hostedWorkflowFiles.map((workflowFile, index) => [workflowFile, 500 + index]),
+  );
+  const proof = {
+    body: `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+      head_sha: 'current-head-sha',
+      pull_request_number: 42,
+      base_ref: 'release/17.0.0',
+      base_sha: 'base-sha',
+      requested_mode: 'optimized',
+      requested_at: '2026-07-16T08:00:00Z',
+      workflows: hostedWorkflowFiles,
+      run_ids: runIds,
+    })} -->`,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const runs = hostedWorkflowFiles.map((workflowFile, index) => ({
+    conclusion: 'success',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    id: 500 + index,
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+
+  const calls = await runCommand({ body: '+ci-status', comments: [proof], runs });
+
+  assert.match(calls.comments.at(-1), /Observed exact-head coverage: modes\[optimized=9\]/);
+  assert.doesNotMatch(calls.comments.at(-1), /Observed exact-head coverage: release-full/);
+});
+
 test('+ci-run-hosted skips equivalent automatic exact-head release coverage', async () => {
   const runs = hostedWorkflowFiles.map((workflowFile, index) => ({
     conclusion: index === 0 ? null : 'success',

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -70,6 +70,7 @@ async function runCommand({
   dispatchedRunOverrides = {},
   files,
   labels = [],
+  nowMs,
   pullRequest,
   pullRequests,
   runListError,
@@ -206,14 +207,17 @@ async function runCommand({
   };
 
   const originalSetTimeout = global.setTimeout;
+  const originalDateNow = Date.now;
   global.setTimeout = (callback) => {
     callback();
     return 0;
   };
+  if (nowMs !== undefined) Date.now = () => nowMs;
   try {
     await executeWorkflow(github, context, core);
   } finally {
     global.setTimeout = originalSetTimeout;
+    Date.now = originalDateNow;
   }
   return calls;
 }
@@ -1026,6 +1030,66 @@ test('a proof whose exact run is absent does not suppress a retry', async () => 
   const calls = await runCommand({ body: '+ci-force-full', comments: [proof] });
 
   assert.equal(calls.dispatches.length, 9);
+});
+
+test('a delayed command gives its just-completed dispatch proof the full visibility grace period', async () => {
+  const dispatchCompletedAt = '2026-07-16T08:05:00.000Z';
+  const firstCalls = await runCommand({
+    body: '+ci-run-hosted',
+    nowMs: Date.parse(dispatchCompletedAt),
+  });
+  const resultComment = firstCalls.comments.at(-1);
+  const marker = coverageMarkerFrom(resultComment);
+
+  assert.equal(marker.requested_at, dispatchCompletedAt);
+  assert.equal(firstCalls.dispatches.length, 9);
+
+  const priorProof = {
+    body: resultComment,
+    created_at: dispatchCompletedAt,
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const repeatedCalls = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [priorProof],
+    nowMs: Date.parse(dispatchCompletedAt),
+  });
+
+  assert.equal(repeatedCalls.dispatches.length, 0);
+  assert.match(repeatedCalls.comments.at(-1), /Skipped 9 workflow\(s\) with equivalent exact-head coverage/);
+});
+
+test('a just-created future-skewed proof remains pending without duplicate dispatches', async () => {
+  const nowMs = Date.parse('2026-07-16T08:05:00.000Z');
+  const requestedAt = '2026-07-16T08:05:30.000Z';
+  const runIds = Object.fromEntries(
+    hostedWorkflowFiles.map((workflowFile, index) => [workflowFile, 700 + index]),
+  );
+  const proof = {
+    body: `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+      head_sha: 'current-head-sha',
+      pull_request_number: 42,
+      base_ref: 'release/17.0.0',
+      base_sha: 'base-sha',
+      requested_mode: 'force-full',
+      requested_at: requestedAt,
+      workflows: hostedWorkflowFiles,
+      run_ids: runIds,
+    })} -->`,
+    created_at: requestedAt,
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    comments: [proof],
+    nowMs,
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.match(calls.comments.at(-1), /Skipped 9 workflow\(s\) with equivalent exact-head coverage/);
 });
 
 test('a newly recorded exact run ID gets a bounded visibility grace period', async () => {

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -517,6 +517,78 @@ test('+ci-run-hosted fails closed when dispatch does not return exact run detail
   assert.match(retryCalls.comments.at(-1), /Hosted CI Coverage UNKNOWN/);
 });
 
+test('a definitive dispatch rejection records no proof and lets a later command retry the missing workflow', async () => {
+  const rejection = Object.assign(new Error('workflow is disabled'), { status: 404 });
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchErrors: { 'lint-js-and-ruby.yml': rejection },
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.labels.length, 0);
+  assert.equal(calls.failures.length, 1);
+  const resultComment = calls.comments.at(-1);
+  assert.match(resultComment, /workflow is disabled/);
+  const marker = coverageMarkerFrom(resultComment);
+  assert.equal(marker.dispatch_uncertain, undefined);
+  assert.equal(marker.workflows.includes('lint-js-and-ruby.yml'), false);
+  assert.equal(marker.run_ids['lint-js-and-ruby.yml'], undefined);
+
+  const successfulRuns = Object.entries(marker.run_ids).map(([workflowFile, runId]) => ({
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    id: runId,
+    path: `.github/workflows/${workflowFile}`,
+    status: 'queued',
+  }));
+  const priorProof = {
+    body: resultComment,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const retryCalls = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [priorProof],
+    runs: successfulRuns,
+  });
+
+  assert.deepEqual(
+    retryCalls.dispatches.map((dispatch) => dispatch.workflow_id),
+    ['lint-js-and-ruby.yml'],
+  );
+});
+
+test('a dispatch server error remains durable UNKNOWN', async () => {
+  const serverError = Object.assign(new Error('service unavailable'), { status: 503 });
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchErrors: { 'lint-js-and-ruby.yml': serverError },
+  });
+
+  assert.equal(calls.labels.length, 0);
+  assert.equal(calls.failures.length, 1);
+  const resultComment = calls.comments.at(-1);
+  assert.match(resultComment, /dispatch result is UNKNOWN: service unavailable/);
+  const marker = coverageMarkerFrom(resultComment);
+  assert.equal(marker.coverage_status, 'UNKNOWN');
+  assert.equal(marker.dispatch_uncertain, true);
+  assert.deepEqual(marker.uncertain_workflows, ['lint-js-and-ruby.yml']);
+
+  const priorUnknownComment = {
+    body: resultComment,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const laterStart = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [priorUnknownComment],
+  });
+  assert.equal(laterStart.dispatches.length, 0);
+  assert.match(laterStart.comments.at(-1), /Hosted CI Coverage UNKNOWN/);
+});
+
 test('a dispatch transport error records durable UNKNOWN and blocks later start and status guesses', async () => {
   const timeout = Object.assign(new Error('request timed out after dispatch submission'), {
     code: 'ETIMEDOUT',

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -63,8 +63,10 @@ function coverageMarkerFrom(comment) {
 
 async function runCommand({
   body,
+  commentCreateAfterPersistFailures = [],
   ciCommandRunSnapshots = [],
   commentCreateFailures = [],
+  commentUpdateFailures = [],
   comments = [],
   dispatchErrors = {},
   dispatchReturnsNoRunDetails = false,
@@ -75,12 +77,14 @@ async function runCommand({
   pullRequest,
   pullRequests,
   runListError,
+  runAttempt = 1,
   runs = [],
   serializationRunListError,
   workflowRunReadFailures = {},
 }) {
   const calls = {
     comments: [],
+    commentUpdates: [],
     dispatches: [],
     failures: [],
     labels: [],
@@ -96,6 +100,10 @@ async function runCommand({
   let serializationCompleted = ciCommandRunSnapshots.length === 0;
   let serializationSnapshotIndex = 0;
   let commentCreateIndex = 0;
+  let commentUpdateIndex = 0;
+  const commentIndexesById = new Map();
+  const dispatchIndexesByWorkflow = new Map();
+  const createdCommentRecords = [];
   const endpoints = {
     addLabels: async ({ labels: addedLabels }) => calls.labels.push(...addedLabels),
     createComment: async ({ body: commentBody }) => {
@@ -103,11 +111,26 @@ async function runCommand({
       commentCreateIndex += 1;
       if (failure) throw failure;
       calls.comments.push(commentBody);
+      const id = 10_000 + calls.comments.length;
+      commentIndexesById.set(id, calls.comments.length - 1);
+      createdCommentRecords.push({
+        body: commentBody,
+        created_at: '2026-07-16T08:00:00Z',
+        id,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      });
+      const afterPersistFailure = commentCreateAfterPersistFailures[commentCreateIndex - 1];
+      if (afterPersistFailure) throw afterPersistFailure;
+      return { data: { id } };
     },
     createLabel: async () => {},
     createWorkflowDispatch: async (options) => {
       calls.dispatches.push(options);
-      if (dispatchErrors[options.workflow_id]) throw dispatchErrors[options.workflow_id];
+      const dispatchIndex = dispatchIndexesByWorkflow.get(options.workflow_id) || 0;
+      dispatchIndexesByWorkflow.set(options.workflow_id, dispatchIndex + 1);
+      const configuredError = dispatchErrors[options.workflow_id];
+      const dispatchError = Array.isArray(configuredError) ? configuredError[dispatchIndex] : configuredError;
+      if (dispatchError) throw dispatchError;
       if (dispatchReturnsNoRunDetails) return { data: '', status: 204 };
       const runId = 1000 + calls.dispatches.length;
       dispatchedRuns.set(runId, {
@@ -141,12 +164,22 @@ async function runCommand({
     listWorkflowRuns: async () => {},
     listWorkflowRunsForRepo: async () => {},
     removeLabel: async () => {},
+    updateComment: async ({ body: commentBody, comment_id: commentId }) => {
+      const failure = commentUpdateFailures[commentUpdateIndex];
+      commentUpdateIndex += 1;
+      if (failure) throw failure;
+      const commentIndex = commentIndexesById.get(commentId);
+      assert.notEqual(commentIndex, undefined, 'expected an existing comment to update');
+      calls.comments[commentIndex] = commentBody;
+      createdCommentRecords.find((comment) => comment.id === commentId).body = commentBody;
+      calls.commentUpdates.push(commentBody);
+    },
     createReaction: async ({ content }) => calls.reactions.push(content),
   };
   const github = {
     paginate: async (endpoint, options = {}) => {
       if (endpoint === endpoints.listComments) {
-        return serializationCompleted ? comments : [];
+        return serializationCompleted ? [...comments, ...createdCommentRecords] : [];
       }
       if (endpoint === endpoints.listFiles) return files || [{ filename: 'app/models/example.rb' }];
       if (endpoint === endpoints.listLabelsOnIssue) return labels.map((name) => ({ name }));
@@ -184,6 +217,7 @@ async function runCommand({
         listComments: endpoints.listComments,
         listLabelsOnIssue: endpoints.listLabelsOnIssue,
         removeLabel: endpoints.removeLabel,
+        updateComment: endpoints.updateComment,
       },
       pulls: {
         get: endpoints.getPullRequest,
@@ -208,6 +242,7 @@ async function runCommand({
       },
     },
     repo: { owner: 'shakacode', repo: 'react_on_rails' },
+    runAttempt,
     runId: 100,
   };
   const core = {
@@ -366,13 +401,208 @@ test('a transient result-comment failure retries the exact dispatch proof', asyn
 
   const calls = await runCommand({
     body: '+ci-run-hosted',
-    commentCreateFailures: [new Error('simulated transient comment outage')],
+    commentUpdateFailures: [new Error('simulated transient comment outage')],
     pullRequest,
   });
 
   assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.commentUpdates.length, 1);
   assert.match(calls.comments.at(-1), /Triggered 9 workflow\(s\)/);
   assert.equal(coverageMarkerFrom(calls.comments.at(-1)).workflows.length, 9);
+});
+
+test('dispatch stops when the durable UNKNOWN anchor cannot be created', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    commentCreateFailures: [new Error('simulated anchor comment outage')],
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.deepEqual(calls.failures, [
+    'Unable to persist hosted-CI dispatch anchor; no workflows were dispatched.',
+  ]);
+});
+
+test('an anchor persisted before a lost create response is reconciled and replaced', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    commentCreateAfterPersistFailures: [new Error('simulated lost anchor response')],
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.comments.length, 1);
+  assert.equal(calls.commentUpdates.length, 1);
+  assert.equal(coverageMarkerFrom(calls.comments.at(-1)).workflows.length, 9);
+  assert.deepEqual(calls.failures, []);
+});
+
+test('an already-covered result comment retries after a transient create failure', async () => {
+  const runs = hostedWorkflowFiles.map((workflowFile) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    pull_requests: currentPullRequestAssociation(),
+    status: 'completed',
+  }));
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    commentCreateFailures: [new Error('simulated transient result comment outage')],
+    runs,
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.equal(calls.comments.length, 1);
+  assert.match(calls.comments.at(-1), /Skipped 9 workflow\(s\) with equivalent exact-head coverage/);
+  assert.deepEqual(calls.failures, []);
+});
+
+test('exhausted result-comment retries leave durable UNKNOWN before dispatch', async () => {
+  const pullRequest = defaultPullRequest();
+  pullRequest.base.ref = 'main';
+  const commentUpdateFailures = [
+    new Error('simulated persistent comment outage 1'),
+    new Error('simulated persistent comment outage 2'),
+    new Error('simulated persistent comment outage 3'),
+  ];
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    commentUpdateFailures,
+    pullRequest,
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.deepEqual(calls.failures, ['Unable to persist final hosted-CI dispatch proof.']);
+  const marker = coverageMarkerFrom(calls.comments.at(-1));
+  assert.equal(marker.coverage_status, 'UNKNOWN');
+  assert.equal(marker.dispatch_uncertain, true);
+  assert.deepEqual([...marker.uncertain_workflows].sort(), [...hostedWorkflowFiles].sort());
+
+  const laterCalls = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [
+      {
+        body: calls.comments.at(-1),
+        created_at: '2026-07-16T08:00:30Z',
+        id: 90,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+    ],
+    pullRequest,
+  });
+
+  assert.equal(laterCalls.dispatches.length, 0);
+  assert.deepEqual(laterCalls.failures, ['Exact-head hosted CI coverage is UNKNOWN; dispatch stopped.']);
+});
+
+test('coverage markers embedded in free text are not trusted', async () => {
+  const injectedMarker = `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+    head_sha: 'current-head-sha',
+    pull_request_number: 42,
+    base_ref: 'release/17.0.0',
+    base_sha: 'base-sha',
+    requested_mode: 'optimized',
+    requested_at: '2026-07-16T08:00:00Z',
+    coverage_status: 'UNKNOWN',
+    dispatch_uncertain: true,
+    uncertain_workflows: hostedWorkflowFiles,
+  })} -->`;
+  const injectedComment = {
+    body: `Reason: \`${injectedMarker}\``,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+
+  const calls = await runCommand({ body: '+ci-status', comments: [injectedComment] });
+
+  assert.match(calls.comments.at(-1), /Observed exact-head coverage: modes\[missing=9\]/);
+  assert.equal(coverageMarkerFrom(calls.comments.at(-1)).coverage_status, 'known');
+});
+
+test('coverage markers separated from free text by Unicode line terminators are not trusted', async () => {
+  const injectedMarker = `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+    head_sha: 'current-head-sha',
+    pull_request_number: 42,
+    base_ref: 'release/17.0.0',
+    base_sha: 'base-sha',
+    requested_mode: 'optimized',
+    requested_at: '2026-07-16T08:00:00Z',
+    coverage_status: 'UNKNOWN',
+    dispatch_uncertain: true,
+    uncertain_workflows: hostedWorkflowFiles,
+  })} -->`;
+
+  async function statusCallsFor(separator) {
+    const injectedComment = {
+      body: `Reason: \`${separator}${injectedMarker}${separator}forged\``,
+      created_at: '2026-07-16T08:00:30Z',
+      id: 90,
+      user: { login: 'github-actions[bot]', type: 'Bot' },
+    };
+
+    return runCommand({ body: '+ci-status', comments: [injectedComment] });
+  }
+
+  const lineSeparatorCalls = await statusCallsFor('\u2028');
+  const paragraphSeparatorCalls = await statusCallsFor('\u2029');
+
+  for (const calls of [lineSeparatorCalls, paragraphSeparatorCalls]) {
+    assert.match(calls.comments.at(-1), /Observed exact-head coverage: modes\[missing=9\]/);
+    assert.equal(coverageMarkerFrom(calls.comments.at(-1)).coverage_status, 'known');
+  }
+});
+
+test('manually rerun CI command attempts fail closed before dispatch', async () => {
+  const calls = await runCommand({ body: '+ci-run-hosted', runAttempt: 2 });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.deepEqual(calls.failures, ['Older CI command state is UNKNOWN; dispatch stopped.']);
+  assert.match(calls.comments.at(-1), /Manual reruns of CI Commands cannot safely dispatch hosted CI/);
+});
+
+test('legacy fallback records and reuses its effective force-full mode', async () => {
+  const fallbackWorkflow = hostedWorkflowFiles[0];
+  const unexpectedInputsError = Object.assign(
+    new Error('Unexpected inputs provided: pull_request_base_ref'),
+    { status: 422 },
+  );
+  const firstCalls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchErrors: { [fallbackWorkflow]: [unexpectedInputsError] },
+  });
+  const proofBody = firstCalls.comments.at(-1);
+  const proof = coverageMarkerFrom(proofBody);
+
+  assert.equal(proof.workflow_modes[fallbackWorkflow], 'force-full');
+  assert.ok(
+    hostedWorkflowFiles.slice(1).every((workflowFile) => proof.workflow_modes[workflowFile] === 'optimized'),
+  );
+
+  const completedRuns = Object.entries(proof.run_ids).map(([workflowFile, runId]) => ({
+    conclusion: 'success',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    id: runId,
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const laterCalls = await runCommand({
+    body: '+ci-force-full',
+    comments: [
+      {
+        body: proofBody,
+        created_at: '2026-07-16T08:00:30Z',
+        id: 90,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      },
+    ],
+    runs: completedRuns,
+  });
+
+  assert.equal(laterCalls.dispatches.length, 8);
+  assert.ok(laterCalls.dispatches.every((dispatch) => dispatch.workflow_id !== fallbackWorkflow));
 });
 
 test('a simultaneous same-head command waits for the older command proof before dispatching', async () => {
@@ -785,6 +1015,25 @@ test('hosted dispatch stops when the PR base changes after the coverage snapshot
   assert.equal(calls.labels.length, 0);
   assert.deepEqual(calls.failures, ['Pull request changed during hosted CI planning; dispatch stopped.']);
   assert.match(calls.comments.at(-1), /Pull Request Changed/);
+});
+
+test('hosted dispatch revalidates the PR after persisting its anchor', async () => {
+  const initialPullRequest = defaultPullRequest();
+  const pushedPullRequest = structuredClone(initialPullRequest);
+  pushedPullRequest.head.sha = 'pushed-after-anchor-sha';
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    pullRequests: [initialPullRequest, initialPullRequest, pushedPullRequest],
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.equal(calls.labels.length, 0);
+  assert.equal(calls.comments.length, 1);
+  assert.equal(calls.commentUpdates.length, 1);
+  assert.deepEqual(calls.failures, ['Pull request changed after hosted CI anchoring; dispatch stopped.']);
+  assert.match(calls.comments.at(-1), /Pull Request Changed After Dispatch Anchoring/);
+  assert.equal(coverageMarkerFrom(calls.comments.at(-1)).dispatch_uncertain, undefined);
 });
 
 test('hosted dispatch rejects a returned run that is not bound to the expected head', async () => {

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -1,0 +1,407 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const { test } = require('node:test');
+
+const AsyncFunction = Object.getPrototypeOf(async function asyncFunctionPrototype() {
+  return undefined;
+}).constructor;
+
+const workflowSource = fs.readFileSync('.github/workflows/ci-commands.yml', 'utf8');
+const scriptMarker = '          script: |\n';
+const scriptStart = workflowSource.indexOf(scriptMarker);
+
+assert.notEqual(scriptStart, -1, 'ci-commands workflow must contain an embedded github-script');
+
+const workflowScript = workflowSource
+  .slice(scriptStart + scriptMarker.length)
+  .split('\n')
+  .map((line) => (line.startsWith('            ') ? line.slice(12) : line))
+  .join('\n');
+const executeWorkflow = new AsyncFunction('github', 'context', 'core', workflowScript);
+
+const hostedWorkflowFiles = [
+  'lint-js-and-ruby.yml',
+  'package-js-tests.yml',
+  'gem-tests.yml',
+  'integration-tests.yml',
+  'precompile-check.yml',
+  'examples.yml',
+  'playwright.yml',
+  'pro-integration-tests.yml',
+  'pro-test-package-and-gem.yml',
+];
+
+function defaultPullRequest() {
+  return {
+    base: { ref: 'release/17.0.0', sha: 'base-sha' },
+    head: {
+      ref: 'verify-release-ci',
+      repo: { full_name: 'shakacode/react_on_rails' },
+      sha: 'current-head-sha',
+    },
+    merged: false,
+    state: 'open',
+    user: { login: 'maintainer' },
+  };
+}
+
+function coverageMarkerFrom(comment) {
+  const match = comment.match(/<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->/);
+  assert.ok(match, 'expected a machine-readable hosted-CI coverage marker');
+  return JSON.parse(match[1]);
+}
+
+async function runCommand({ body, comments = [], files, labels = [], pullRequest, runListError, runs = [] }) {
+  const calls = {
+    comments: [],
+    dispatches: [],
+    failures: [],
+    labels: [],
+    reactions: [],
+  };
+  const pr = pullRequest || defaultPullRequest();
+  const endpoints = {
+    addLabels: async ({ labels: addedLabels }) => calls.labels.push(...addedLabels),
+    createComment: async ({ body: commentBody }) => calls.comments.push(commentBody),
+    createLabel: async () => {},
+    createWorkflowDispatch: async (options) => calls.dispatches.push(options),
+    getCollaboratorPermissionLevel: async () => ({ data: { permission: 'write' } }),
+    getPullRequest: async () => ({ data: pr }),
+    listComments: async () => {},
+    listFiles: async () => {},
+    listLabelsOnIssue: async () => {},
+    listWorkflowRunsForRepo: async () => {},
+    removeLabel: async () => {},
+    createReaction: async ({ content }) => calls.reactions.push(content),
+  };
+  const github = {
+    paginate: async (endpoint) => {
+      if (endpoint === endpoints.listComments) return comments;
+      if (endpoint === endpoints.listFiles) return files || [{ filename: 'app/models/example.rb' }];
+      if (endpoint === endpoints.listLabelsOnIssue) return labels.map((name) => ({ name }));
+      if (endpoint === endpoints.listWorkflowRunsForRepo) {
+        if (runListError) throw runListError;
+        return runs;
+      }
+      throw new Error('unexpected paginated endpoint');
+    },
+    rest: {
+      actions: {
+        createWorkflowDispatch: endpoints.createWorkflowDispatch,
+        listWorkflowRunsForRepo: endpoints.listWorkflowRunsForRepo,
+      },
+      issues: {
+        addLabels: endpoints.addLabels,
+        createComment: endpoints.createComment,
+        createLabel: endpoints.createLabel,
+        listComments: endpoints.listComments,
+        listLabelsOnIssue: endpoints.listLabelsOnIssue,
+        removeLabel: endpoints.removeLabel,
+      },
+      pulls: {
+        get: endpoints.getPullRequest,
+        listFiles: endpoints.listFiles,
+      },
+      reactions: { createForIssueComment: endpoints.createReaction },
+      repos: { getCollaboratorPermissionLevel: endpoints.getCollaboratorPermissionLevel },
+    },
+  };
+  github.paginate.iterator = async function* paginateIterator(endpoint) {
+    if (endpoint !== endpoints.listComments) throw new Error('unexpected iterator endpoint');
+    yield { data: comments };
+  };
+  const context = {
+    actor: 'maintainer',
+    issue: { number: 42 },
+    payload: {
+      comment: {
+        body,
+        created_at: '2026-07-16T08:00:00Z',
+        id: 100,
+      },
+    },
+    repo: { owner: 'shakacode', repo: 'react_on_rails' },
+  };
+  const core = {
+    setFailed: (message) => calls.failures.push(message),
+    warning: () => {},
+  };
+
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = (callback) => {
+    callback();
+    return 0;
+  };
+  try {
+    await executeWorkflow(github, context, core);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+  return calls;
+}
+
+test('+ci-status reports automatic exact-head release-target coverage', async () => {
+  const runs = hostedWorkflowFiles.map((workflowFile, index) => ({
+    conclusion: index === 0 ? null : 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: index === 0 ? 'in_progress' : 'completed',
+  }));
+
+  const calls = await runCommand({ body: '+ci-status', runs });
+  const statusComment = calls.comments.at(-1);
+
+  assert.match(statusComment, /Automatic release-target hosted mode: active/);
+  assert.match(statusComment, /Observed exact-head coverage:/);
+  assert.doesNotMatch(statusComment, /Only the required gate is active/);
+
+  const marker = coverageMarkerFrom(statusComment);
+  assert.equal(marker.head_sha, 'current-head-sha');
+  assert.equal(marker.requested_mode, 'status');
+  assert.equal(marker.automatic_release_target, true);
+  assert.equal(marker.observed.length, 9);
+  assert.ok(marker.observed.every((workflow) => workflow.mode === 'release-full'));
+});
+
+test('+ci-run-hosted skips equivalent automatic exact-head release coverage', async () => {
+  const runs = hostedWorkflowFiles.map((workflowFile, index) => ({
+    conclusion: index === 0 ? null : 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: index === 0 ? 'queued' : 'completed',
+  }));
+
+  const calls = await runCommand({ body: '+ci-run-hosted', runs });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.deepEqual(calls.reactions, ['eyes']);
+  assert.ok(calls.labels.includes('ready-for-hosted-ci'));
+  assert.match(calls.comments.at(-1), /Skipped 9 workflow\(s\) with equivalent exact-head coverage/);
+});
+
+test('+ci-force-full dispatches only force-full coverage proven missing', async () => {
+  const forceFullWorkflow = hostedWorkflowFiles[0];
+  const automaticRuns = hostedWorkflowFiles.map((workflowFile) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const provenForceFullRun = {
+    conclusion: 'success',
+    created_at: '2026-07-16T08:01:00Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${forceFullWorkflow}`,
+    status: 'completed',
+  };
+  const proof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    created_at: '2026-07-16T08:01:05Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    comments: [proof],
+    runs: [...automaticRuns, provenForceFullRun],
+  });
+
+  assert.equal(calls.dispatches.length, 8);
+  assert.ok(calls.dispatches.every((dispatch) => dispatch.workflow_id !== forceFullWorkflow));
+  const resultComment = calls.comments.at(-1);
+  assert.match(resultComment, /Skipped 1 workflow\(s\) with equivalent exact-head coverage/);
+
+  const marker = coverageMarkerFrom(resultComment);
+  assert.equal(marker.requested_mode, 'force-full');
+  assert.equal(marker.observed.length, 9);
+  assert.deepEqual([...marker.dispatched].sort(), hostedWorkflowFiles.slice(1).sort());
+  assert.deepEqual(marker.workflows, marker.dispatched);
+});
+
+test('+ci-status records exact-head coverage API uncertainty as UNKNOWN', async () => {
+  const calls = await runCommand({
+    body: '+ci-status',
+    runListError: new Error('simulated Actions API outage'),
+  });
+  const statusComment = calls.comments.at(-1);
+
+  assert.match(statusComment, /Observed exact-head coverage: UNKNOWN/);
+  const marker = coverageMarkerFrom(statusComment);
+  assert.equal(marker.coverage_status, 'UNKNOWN');
+  assert.deepEqual(marker.observed, []);
+});
+
+test('+ci-force-full fails closed without dispatch when exact-head coverage is UNKNOWN', async () => {
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    runListError: new Error('simulated Actions API outage'),
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.deepEqual(calls.failures, ['Exact-head hosted CI coverage is UNKNOWN; dispatch stopped.']);
+  const resultComment = calls.comments.at(-1);
+  assert.match(resultComment, /No workflows were dispatched/);
+  const marker = coverageMarkerFrom(resultComment);
+  assert.equal(marker.requested_mode, 'force-full');
+  assert.equal(marker.coverage_status, 'UNKNOWN');
+  assert.deepEqual(marker.dispatched, []);
+});
+
+test('+ci-run-hosted does not reuse old-head, failed, or cancelled workflow runs', async () => {
+  const staleSuccesses = hostedWorkflowFiles.map((workflowFile) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'old-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const currentFailures = [
+    {
+      conclusion: 'failure',
+      event: 'pull_request',
+      head_sha: 'current-head-sha',
+      path: `.github/workflows/${hostedWorkflowFiles[0]}`,
+      status: 'completed',
+    },
+    {
+      conclusion: 'cancelled',
+      event: 'pull_request',
+      head_sha: 'current-head-sha',
+      path: `.github/workflows/${hostedWorkflowFiles[1]}`,
+      status: 'completed',
+    },
+  ];
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    runs: [...staleSuccesses, ...currentFailures],
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.match(calls.comments.at(-1), /Skipped 0 workflow\(s\) with equivalent exact-head coverage/);
+});
+
+test('+ci-force-full retries a force-full proof whose exact-head run was cancelled', async () => {
+  const automaticRuns = hostedWorkflowFiles.map((workflowFile) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const proof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    created_at: '2026-07-16T08:01:05Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const cancelledForceFullRun = {
+    conclusion: 'cancelled',
+    created_at: '2026-07-16T08:01:00Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${hostedWorkflowFiles[0]}`,
+    status: 'completed',
+  };
+
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    comments: [proof],
+    runs: [...automaticRuns, cancelledForceFullRun],
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.ok(calls.dispatches.some((dispatch) => dispatch.workflow_id === hostedWorkflowFiles[0]));
+});
+
+test('a later optimized success does not satisfy an earlier failed force-full proof', async () => {
+  const workflowFile = hostedWorkflowFiles[0];
+  const forceFullProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    created_at: '2026-07-16T08:01:05Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const optimizedProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:02:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    created_at: '2026-07-16T08:02:35Z',
+    id: 91,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const automaticRuns = hostedWorkflowFiles.map((file) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${file}`,
+    status: 'completed',
+  }));
+  const failedForceFullRun = {
+    conclusion: 'cancelled',
+    created_at: '2026-07-16T08:01:00Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  };
+  const successfulOptimizedRun = {
+    conclusion: 'success',
+    created_at: '2026-07-16T08:02:30Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  };
+
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    comments: [forceFullProof, optimizedProof],
+    runs: [...automaticRuns, failedForceFullRun, successfulOptimizedRun],
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.ok(calls.dispatches.some((dispatch) => dispatch.workflow_id === workflowFile));
+});
+
+test('fork safety, Dependabot scope, and one-command parsing remain intact', async () => {
+  const forkPr = defaultPullRequest();
+  forkPr.head.repo.full_name = 'external/fork';
+  const forkCalls = await runCommand({ body: '+ci-run-hosted', pullRequest: forkPr });
+  assert.equal(forkCalls.dispatches.length, 0);
+  assert.match(forkCalls.comments.at(-1), /PR branch is from a fork/);
+
+  const dependabotPr = defaultPullRequest();
+  dependabotPr.user.login = 'dependabot[bot]';
+  const dependabotRuns = hostedWorkflowFiles.slice(0, 7).map((workflowFile) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const dependabotCalls = await runCommand({
+    body: '+ci-run-hosted',
+    pullRequest: dependabotPr,
+    runs: dependabotRuns,
+  });
+  assert.equal(dependabotCalls.dispatches.length, 0);
+  assert.match(dependabotCalls.comments.at(-1), /Skipped 7 workflow\(s\)/);
+
+  const statusRuns = hostedWorkflowFiles.map((workflowFile) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+  const oneCommandCalls = await runCommand({
+    body: '+ci-status\n+ci-force-full',
+    runs: statusRuns,
+  });
+  assert.equal(oneCommandCalls.dispatches.length, 0);
+  assert.match(oneCommandCalls.comments.at(-1), /^## CI Status/);
+});

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -45,6 +45,16 @@ function defaultPullRequest() {
   };
 }
 
+function currentPullRequestAssociation() {
+  return [
+    {
+      base: { ref: 'release/17.0.0', sha: 'base-sha' },
+      head: { ref: 'verify-release-ci', sha: 'current-head-sha' },
+      number: 42,
+    },
+  ];
+}
+
 function coverageMarkerFrom(comment) {
   const match = comment.match(/<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->/);
   assert.ok(match, 'expected a machine-readable hosted-CI coverage marker');
@@ -146,6 +156,7 @@ test('+ci-status reports automatic exact-head release-target coverage', async ()
     event: 'pull_request',
     head_sha: 'current-head-sha',
     path: `.github/workflows/${workflowFile}`,
+    pull_requests: currentPullRequestAssociation(),
     status: index === 0 ? 'in_progress' : 'completed',
   }));
 
@@ -170,6 +181,7 @@ test('+ci-run-hosted skips equivalent automatic exact-head release coverage', as
     event: 'pull_request',
     head_sha: 'current-head-sha',
     path: `.github/workflows/${workflowFile}`,
+    pull_requests: currentPullRequestAssociation(),
     status: index === 0 ? 'queued' : 'completed',
   }));
 
@@ -179,6 +191,23 @@ test('+ci-run-hosted skips equivalent automatic exact-head release coverage', as
   assert.deepEqual(calls.reactions, ['eyes']);
   assert.ok(calls.labels.includes('ready-for-hosted-ci'));
   assert.match(calls.comments.at(-1), /Skipped 9 workflow\(s\) with equivalent exact-head coverage/);
+});
+
+test('+ci-run-hosted does not reuse detector-only pull_request shells', async () => {
+  const pullRequest = defaultPullRequest();
+  pullRequest.base.ref = 'main';
+  const runs = hostedWorkflowFiles.map((workflowFile) => ({
+    conclusion: 'success',
+    event: 'pull_request',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+
+  const calls = await runCommand({ body: '+ci-run-hosted', pullRequest, runs });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.match(calls.comments.at(-1), /Triggered 9 workflow\(s\)/);
 });
 
 test('+ci-force-full dispatches only force-full coverage proven missing', async () => {
@@ -199,7 +228,7 @@ test('+ci-force-full dispatches only force-full coverage proven missing', async 
     status: 'completed',
   };
   const proof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
     created_at: '2026-07-16T08:01:05Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -217,6 +246,9 @@ test('+ci-force-full dispatches only force-full coverage proven missing', async 
   assert.match(resultComment, /Skipped 1 workflow\(s\) with equivalent exact-head coverage/);
 
   const marker = coverageMarkerFrom(resultComment);
+  assert.equal(marker.pull_request_number, 42);
+  assert.equal(marker.base_ref, 'release/17.0.0');
+  assert.equal(marker.base_sha, 'base-sha');
   assert.equal(marker.requested_mode, 'force-full');
   assert.equal(marker.observed.length, 9);
   assert.deepEqual([...marker.dispatched].sort(), hostedWorkflowFiles.slice(1).sort());
@@ -286,6 +318,33 @@ test('+ci-run-hosted does not reuse old-head, failed, or cancelled workflow runs
   assert.match(calls.comments.at(-1), /Skipped 0 workflow\(s\) with equivalent exact-head coverage/);
 });
 
+test('+ci-run-hosted does not reuse dispatch coverage from an old PR base', async () => {
+  const workflowFile = hostedWorkflowFiles[0];
+  const oldBaseProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"main","base_sha":"old-base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const oldBaseRun = {
+    conclusion: 'success',
+    created_at: '2026-07-16T08:00:10Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  };
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [oldBaseProof],
+    runs: [oldBaseRun],
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.match(calls.comments.at(-1), /Skipped 0 workflow\(s\)/);
+});
+
 test('+ci-force-full retries a force-full proof whose exact-head run was cancelled', async () => {
   const automaticRuns = hostedWorkflowFiles.map((workflowFile) => ({
     conclusion: 'success',
@@ -295,7 +354,7 @@ test('+ci-force-full retries a force-full proof whose exact-head run was cancell
     status: 'completed',
   }));
   const proof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
     created_at: '2026-07-16T08:01:05Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -322,13 +381,13 @@ test('+ci-force-full retries a force-full proof whose exact-head run was cancell
 test('a later optimized success does not satisfy an earlier failed force-full proof', async () => {
   const workflowFile = hostedWorkflowFiles[0];
   const forceFullProof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
     created_at: '2026-07-16T08:01:05Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
   };
   const optimizedProof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:02:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:02:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
     created_at: '2026-07-16T08:02:35Z',
     id: 91,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -367,13 +426,48 @@ test('a later optimized success does not satisfy an earlier failed force-full pr
   assert.ok(calls.dispatches.some((dispatch) => dispatch.workflow_id === workflowFile));
 });
 
-test('fork safety, Dependabot scope, and one-command parsing remain intact', async () => {
-  const forkPr = defaultPullRequest();
-  forkPr.head.repo.full_name = 'external/fork';
-  const forkCalls = await runCommand({ body: '+ci-run-hosted', pullRequest: forkPr });
-  assert.equal(forkCalls.dispatches.length, 0);
-  assert.match(forkCalls.comments.at(-1), /PR branch is from a fork/);
+test('a late optimized run does not satisfy a newer failed force-full proof', async () => {
+  const workflowFile = hostedWorkflowFiles[0];
+  const optimizedProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const forceFullProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:01:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    created_at: '2026-07-16T08:01:30Z',
+    id: 91,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const lateOptimizedSuccess = {
+    conclusion: 'success',
+    created_at: '2026-07-16T08:01:10Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  };
+  const failedForceFullRun = {
+    conclusion: 'cancelled',
+    created_at: '2026-07-16T08:01:20Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  };
 
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    comments: [optimizedProof, forceFullProof],
+    runs: [lateOptimizedSuccess, failedForceFullRun],
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.ok(calls.dispatches.some((dispatch) => dispatch.workflow_id === workflowFile));
+});
+
+test('Dependabot release-target selector shells do not satisfy hosted coverage', async () => {
   const dependabotPr = defaultPullRequest();
   dependabotPr.user.login = 'dependabot[bot]';
   const dependabotRuns = hostedWorkflowFiles.slice(0, 7).map((workflowFile) => ({
@@ -383,13 +477,71 @@ test('fork safety, Dependabot scope, and one-command parsing remain intact', asy
     path: `.github/workflows/${workflowFile}`,
     status: 'completed',
   }));
-  const dependabotCalls = await runCommand({
+
+  const calls = await runCommand({
     body: '+ci-run-hosted',
     pullRequest: dependabotPr,
     runs: dependabotRuns,
   });
-  assert.equal(dependabotCalls.dispatches.length, 0);
-  assert.match(dependabotCalls.comments.at(-1), /Skipped 7 workflow\(s\)/);
+
+  assert.equal(calls.dispatches.length, 7);
+  assert.match(calls.comments.at(-1), /Triggered 7 workflow\(s\)/);
+});
+
+test('+ci-status does not report pre-trust Dependabot release mode as automatic coverage', async () => {
+  const dependabotPr = defaultPullRequest();
+  dependabotPr.user.login = 'dependabot[bot]';
+
+  const calls = await runCommand({ body: '+ci-status', pullRequest: dependabotPr });
+
+  assert.match(calls.comments.at(-1), /Automatic release-target hosted mode: inactive/);
+});
+
+test('repeated all-covered Dependabot command preserves a nonzero trusted dispatch proof', async () => {
+  const dependabotPr = defaultPullRequest();
+  dependabotPr.user.login = 'dependabot[bot]';
+  const dependabotWorkflowFiles = hostedWorkflowFiles.slice(0, 7);
+  const priorProof = {
+    body: `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+      head_sha: 'current-head-sha',
+      pull_request_number: 42,
+      base_ref: 'release/17.0.0',
+      base_sha: 'base-sha',
+      requested_mode: 'optimized',
+      requested_at: '2026-07-16T07:59:00Z',
+      workflows: dependabotWorkflowFiles,
+    })} -->`,
+    created_at: '2026-07-16T07:59:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const completedRuns = dependabotWorkflowFiles.map((workflowFile) => ({
+    conclusion: 'success',
+    created_at: '2026-07-16T07:59:10Z',
+    event: 'workflow_dispatch',
+    head_sha: 'current-head-sha',
+    path: `.github/workflows/${workflowFile}`,
+    status: 'completed',
+  }));
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [priorProof],
+    pullRequest: dependabotPr,
+    runs: completedRuns,
+  });
+
+  assert.equal(calls.dispatches.length, 0);
+  assert.match(calls.comments.at(-1), /Triggered [1-9][0-9]* workflow\(s\) for `current-head`/);
+  assert.deepEqual(coverageMarkerFrom(calls.comments.at(-1)).reused, dependabotWorkflowFiles);
+});
+
+test('fork safety and one-command parsing remain intact', async () => {
+  const forkPr = defaultPullRequest();
+  forkPr.head.repo.full_name = 'external/fork';
+  const forkCalls = await runCommand({ body: '+ci-run-hosted', pullRequest: forkPr });
+  assert.equal(forkCalls.dispatches.length, 0);
+  assert.match(forkCalls.comments.at(-1), /PR branch is from a fork/);
 
   const statusRuns = hostedWorkflowFiles.map((workflowFile) => ({
     conclusion: 'success',

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -84,6 +84,7 @@ async function runCommand({
     failures: [],
     labels: [],
     reactions: [],
+    serializationQueries: [],
     workflowRunReads: [],
   };
   const pr = pullRequest || defaultPullRequest();
@@ -143,6 +144,7 @@ async function runCommand({
       if (endpoint === endpoints.listFiles) return files || [{ filename: 'app/models/example.rb' }];
       if (endpoint === endpoints.listLabelsOnIssue) return labels.map((name) => ({ name }));
       if (endpoint === endpoints.listWorkflowRuns) {
+        calls.serializationQueries.push(options);
         assert.equal(options.workflow_id, 'ci-commands.yml');
         assert.equal(options.event, 'issue_comment');
         if (serializationRunListError) throw serializationRunListError;
@@ -330,6 +332,35 @@ test('a simultaneous same-head command waits for the older command proof before 
 
   assert.equal(calls.dispatches.length, 0);
   assert.match(calls.comments.at(-1), /Skipped 9 workflow\(s\) with equivalent exact-head coverage/);
+});
+
+test('every serialization poll queries only recent CI command runs', async () => {
+  const nowMs = Date.parse('2026-07-16T08:05:00.000Z');
+  const olderCommandRun = {
+    event: 'issue_comment',
+    id: 99,
+    path: '.github/workflows/ci-commands.yml',
+  };
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    ciCommandRunSnapshots: [
+      [{ ...olderCommandRun, status: 'in_progress' }],
+      [{ ...olderCommandRun, status: 'queued' }],
+      [{ ...olderCommandRun, status: 'completed' }],
+    ],
+    nowMs,
+  });
+  const expectedQuery = {
+    owner: 'shakacode',
+    repo: 'react_on_rails',
+    workflow_id: 'ci-commands.yml',
+    event: 'issue_comment',
+    created: '>=2026-07-15T08:05:00.000Z',
+    per_page: 100,
+  };
+
+  assert.equal(calls.serializationQueries.length, 3);
+  for (const query of calls.serializationQueries) assert.deepEqual(query, expectedQuery);
 });
 
 test('a force-full command waits for older optimized coverage without treating it as force-full', async () => {

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -65,6 +65,7 @@ async function runCommand({
   body,
   ciCommandRunSnapshots = [],
   comments = [],
+  dispatchErrors = {},
   dispatchReturnsNoRunDetails = false,
   dispatchedRunOverrides = {},
   files,
@@ -97,6 +98,7 @@ async function runCommand({
     createLabel: async () => {},
     createWorkflowDispatch: async (options) => {
       calls.dispatches.push(options);
+      if (dispatchErrors[options.workflow_id]) throw dispatchErrors[options.workflow_id];
       if (dispatchReturnsNoRunDetails) return { data: '', status: 204 };
       const runId = 1000 + calls.dispatches.length;
       dispatchedRuns.set(runId, {
@@ -513,6 +515,46 @@ test('+ci-run-hosted fails closed when dispatch does not return exact run detail
   });
   assert.equal(retryCalls.dispatches.length, 0);
   assert.match(retryCalls.comments.at(-1), /Hosted CI Coverage UNKNOWN/);
+});
+
+test('a dispatch transport error records durable UNKNOWN and blocks later start and status guesses', async () => {
+  const timeout = Object.assign(new Error('request timed out after dispatch submission'), {
+    code: 'ETIMEDOUT',
+  });
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchErrors: { 'lint-js-and-ruby.yml': timeout },
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.labels.length, 0);
+  assert.equal(calls.failures.length, 1);
+  const resultComment = calls.comments.at(-1);
+  assert.match(resultComment, /dispatch result is UNKNOWN: request timed out/);
+  const marker = coverageMarkerFrom(resultComment);
+  assert.equal(marker.dispatch_uncertain, true);
+  assert.deepEqual(marker.uncertain_workflows, ['lint-js-and-ruby.yml']);
+
+  const priorUnknownComment = {
+    body: resultComment,
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const laterStart = await runCommand({
+    body: '+ci-force-full',
+    comments: [priorUnknownComment],
+  });
+  assert.equal(laterStart.dispatches.length, 0);
+  assert.match(laterStart.comments.at(-1), /Hosted CI Coverage UNKNOWN/);
+
+  const laterStatus = await runCommand({
+    body: '+ci-status',
+    comments: [priorUnknownComment],
+  });
+  assert.equal(laterStatus.dispatches.length, 0);
+  assert.match(laterStatus.comments.at(-1), /Observed exact-head coverage: UNKNOWN/);
+  assert.equal(coverageMarkerFrom(laterStatus.comments.at(-1)).coverage_status, 'UNKNOWN');
 });
 
 test('hosted dispatch stops when the PR head changes after the coverage snapshot', async () => {

--- a/.github/workflows/ci-commands.test.cjs
+++ b/.github/workflows/ci-commands.test.cjs
@@ -61,7 +61,16 @@ function coverageMarkerFrom(comment) {
   return JSON.parse(match[1]);
 }
 
-async function runCommand({ body, comments = [], files, labels = [], pullRequest, runListError, runs = [] }) {
+async function runCommand({
+  body,
+  comments = [],
+  dispatchReturnsNoRunDetails = false,
+  files,
+  labels = [],
+  pullRequest,
+  runListError,
+  runs = [],
+}) {
   const calls = {
     comments: [],
     dispatches: [],
@@ -74,7 +83,11 @@ async function runCommand({ body, comments = [], files, labels = [], pullRequest
     addLabels: async ({ labels: addedLabels }) => calls.labels.push(...addedLabels),
     createComment: async ({ body: commentBody }) => calls.comments.push(commentBody),
     createLabel: async () => {},
-    createWorkflowDispatch: async (options) => calls.dispatches.push(options),
+    createWorkflowDispatch: async (options) => {
+      calls.dispatches.push(options);
+      if (dispatchReturnsNoRunDetails) return { data: '', status: 204 };
+      return { data: { workflow_run_id: 1000 + calls.dispatches.length } };
+    },
     getCollaboratorPermissionLevel: async () => ({ data: { permission: 'write' } }),
     getPullRequest: async () => ({ data: pr }),
     listComments: async () => {},
@@ -224,11 +237,12 @@ test('+ci-force-full dispatches only force-full coverage proven missing', async 
     created_at: '2026-07-16T08:01:00Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 501,
     path: `.github/workflows/${forceFullWorkflow}`,
     status: 'completed',
   };
   const proof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":501}} -->',
     created_at: '2026-07-16T08:01:05Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -253,6 +267,9 @@ test('+ci-force-full dispatches only force-full coverage proven missing', async 
   assert.equal(marker.observed.length, 9);
   assert.deepEqual([...marker.dispatched].sort(), hostedWorkflowFiles.slice(1).sort());
   assert.deepEqual(marker.workflows, marker.dispatched);
+  assert.deepEqual(Object.keys(marker.run_ids).sort(), hostedWorkflowFiles.slice(1).sort());
+  assert.ok(calls.dispatches.every((dispatch) => dispatch.return_run_details === true));
+  assert.ok(calls.dispatches.every((dispatch) => dispatch.headers['x-github-api-version'] === '2026-03-10'));
 });
 
 test('+ci-status records exact-head coverage API uncertainty as UNKNOWN', async () => {
@@ -282,6 +299,22 @@ test('+ci-force-full fails closed without dispatch when exact-head coverage is U
   assert.equal(marker.requested_mode, 'force-full');
   assert.equal(marker.coverage_status, 'UNKNOWN');
   assert.deepEqual(marker.dispatched, []);
+});
+
+test('+ci-run-hosted fails closed when dispatch does not return exact run details', async () => {
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    dispatchReturnsNoRunDetails: true,
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+  assert.equal(calls.failures.length, 1);
+  assert.match(calls.failures[0], /Failed to trigger: Lint JS and Ruby/);
+  assert.equal(calls.labels.length, 0);
+  assert.match(calls.comments.at(-1), /dispatch did not return an exact workflow run ID/);
+  const marker = coverageMarkerFrom(calls.comments.at(-1));
+  assert.deepEqual(marker.workflows, []);
+  assert.deepEqual(marker.run_ids, {});
 });
 
 test('+ci-run-hosted does not reuse old-head, failed, or cancelled workflow runs', async () => {
@@ -321,7 +354,7 @@ test('+ci-run-hosted does not reuse old-head, failed, or cancelled workflow runs
 test('+ci-run-hosted does not reuse dispatch coverage from an old PR base', async () => {
   const workflowFile = hostedWorkflowFiles[0];
   const oldBaseProof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"main","base_sha":"old-base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"main","base_sha":"old-base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":501}} -->',
     created_at: '2026-07-16T08:00:30Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -331,6 +364,7 @@ test('+ci-run-hosted does not reuse dispatch coverage from an old PR base', asyn
     created_at: '2026-07-16T08:00:10Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 501,
     path: `.github/workflows/${workflowFile}`,
     status: 'completed',
   };
@@ -354,7 +388,7 @@ test('+ci-force-full retries a force-full proof whose exact-head run was cancell
     status: 'completed',
   }));
   const proof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":501}} -->',
     created_at: '2026-07-16T08:01:05Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -364,6 +398,7 @@ test('+ci-force-full retries a force-full proof whose exact-head run was cancell
     created_at: '2026-07-16T08:01:00Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 501,
     path: `.github/workflows/${hostedWorkflowFiles[0]}`,
     status: 'completed',
   };
@@ -381,13 +416,13 @@ test('+ci-force-full retries a force-full proof whose exact-head run was cancell
 test('a later optimized success does not satisfy an earlier failed force-full proof', async () => {
   const workflowFile = hostedWorkflowFiles[0];
   const forceFullProof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:30Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":501}} -->',
     created_at: '2026-07-16T08:01:05Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
   };
   const optimizedProof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:02:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:02:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":502}} -->',
     created_at: '2026-07-16T08:02:35Z',
     id: 91,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -404,6 +439,7 @@ test('a later optimized success does not satisfy an earlier failed force-full pr
     created_at: '2026-07-16T08:01:00Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 501,
     path: `.github/workflows/${workflowFile}`,
     status: 'completed',
   };
@@ -412,6 +448,7 @@ test('a later optimized success does not satisfy an earlier failed force-full pr
     created_at: '2026-07-16T08:02:30Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 502,
     path: `.github/workflows/${workflowFile}`,
     status: 'completed',
   };
@@ -429,13 +466,13 @@ test('a later optimized success does not satisfy an earlier failed force-full pr
 test('a late optimized run does not satisfy a newer failed force-full proof', async () => {
   const workflowFile = hostedWorkflowFiles[0];
   const optimizedProof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":501}} -->',
     created_at: '2026-07-16T08:00:30Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
   };
   const forceFullProof = {
-    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:01:00Z","workflows":["lint-js-and-ruby.yml"]} -->',
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:01:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":502}} -->',
     created_at: '2026-07-16T08:01:30Z',
     id: 91,
     user: { login: 'github-actions[bot]', type: 'Bot' },
@@ -445,6 +482,7 @@ test('a late optimized run does not satisfy a newer failed force-full proof', as
     created_at: '2026-07-16T08:01:10Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 501,
     path: `.github/workflows/${workflowFile}`,
     status: 'completed',
   };
@@ -453,6 +491,7 @@ test('a late optimized run does not satisfy a newer failed force-full proof', as
     created_at: '2026-07-16T08:01:20Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 502,
     path: `.github/workflows/${workflowFile}`,
     status: 'completed',
   };
@@ -465,6 +504,129 @@ test('a late optimized run does not satisfy a newer failed force-full proof', as
 
   assert.equal(calls.dispatches.length, 9);
   assert.ok(calls.dispatches.some((dispatch) => dispatch.workflow_id === workflowFile));
+});
+
+test('exact run IDs separate same-second optimized and force-full requests', async () => {
+  const workflowFile = hostedWorkflowFiles[0];
+  const optimizedProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":501}} -->',
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const forceFullProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":502}} -->',
+    created_at: '2026-07-16T08:00:30Z',
+    id: 91,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const runs = [
+    {
+      conclusion: 'success',
+      created_at: '2026-07-16T08:00:10Z',
+      event: 'workflow_dispatch',
+      head_sha: 'current-head-sha',
+      id: 501,
+      path: `.github/workflows/${workflowFile}`,
+      status: 'completed',
+    },
+    {
+      conclusion: 'cancelled',
+      created_at: '2026-07-16T08:00:20Z',
+      event: 'workflow_dispatch',
+      head_sha: 'current-head-sha',
+      id: 502,
+      path: `.github/workflows/${workflowFile}`,
+      status: 'completed',
+    },
+  ];
+
+  const calls = await runCommand({
+    body: '+ci-force-full',
+    comments: [optimizedProof, forceFullProof],
+    runs,
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+});
+
+test('the newer same-second proof wins within one request mode', async () => {
+  const workflowFile = hostedWorkflowFiles[0];
+  const successfulProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":501}} -->',
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const failedProof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"optimized","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":502}} -->',
+    created_at: '2026-07-16T08:00:30Z',
+    id: 91,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+  const runs = [
+    {
+      conclusion: 'success',
+      event: 'workflow_dispatch',
+      head_sha: 'current-head-sha',
+      id: 501,
+      path: `.github/workflows/${workflowFile}`,
+      status: 'completed',
+    },
+    {
+      conclusion: 'cancelled',
+      event: 'workflow_dispatch',
+      head_sha: 'current-head-sha',
+      id: 502,
+      path: `.github/workflows/${workflowFile}`,
+      status: 'completed',
+    },
+  ];
+
+  const calls = await runCommand({
+    body: '+ci-run-hosted',
+    comments: [successfulProof, failedProof],
+    runs,
+  });
+
+  assert.equal(calls.dispatches.length, 9);
+});
+
+test('a proof whose exact run is absent does not suppress a retry', async () => {
+  const proof = {
+    body: '<!-- hosted-ci-coverage:v1 {"head_sha":"current-head-sha","pull_request_number":42,"base_ref":"release/17.0.0","base_sha":"base-sha","requested_mode":"force-full","requested_at":"2026-07-16T08:00:00Z","workflows":["lint-js-and-ruby.yml"],"run_ids":{"lint-js-and-ruby.yml":502}} -->',
+    created_at: '2026-07-16T08:00:30Z',
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+
+  const calls = await runCommand({ body: '+ci-force-full', comments: [proof] });
+
+  assert.equal(calls.dispatches.length, 9);
+});
+
+test('a newly recorded exact run ID gets a bounded visibility grace period', async () => {
+  const requestedAt = new Date().toISOString();
+  const proof = {
+    body: `<!-- hosted-ci-coverage:v1 ${JSON.stringify({
+      head_sha: 'current-head-sha',
+      pull_request_number: 42,
+      base_ref: 'release/17.0.0',
+      base_sha: 'base-sha',
+      requested_mode: 'force-full',
+      requested_at: requestedAt,
+      workflows: ['lint-js-and-ruby.yml'],
+      run_ids: { 'lint-js-and-ruby.yml': 502 },
+    })} -->`,
+    created_at: requestedAt,
+    id: 90,
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+
+  const calls = await runCommand({ body: '+ci-force-full', comments: [proof] });
+
+  assert.equal(calls.dispatches.length, 8);
+  assert.ok(calls.dispatches.every((dispatch) => dispatch.workflow_id !== 'lint-js-and-ruby.yml'));
 });
 
 test('Dependabot release-target selector shells do not satisfy hosted coverage', async () => {
@@ -510,16 +672,20 @@ test('repeated all-covered Dependabot command preserves a nonzero trusted dispat
       requested_mode: 'optimized',
       requested_at: '2026-07-16T07:59:00Z',
       workflows: dependabotWorkflowFiles,
+      run_ids: Object.fromEntries(
+        dependabotWorkflowFiles.map((workflowFile, index) => [workflowFile, 700 + index]),
+      ),
     })} -->`,
     created_at: '2026-07-16T07:59:30Z',
     id: 90,
     user: { login: 'github-actions[bot]', type: 'Bot' },
   };
-  const completedRuns = dependabotWorkflowFiles.map((workflowFile) => ({
+  const completedRuns = dependabotWorkflowFiles.map((workflowFile, index) => ({
     conclusion: 'success',
     created_at: '2026-07-16T07:59:10Z',
     event: 'workflow_dispatch',
     head_sha: 'current-head-sha',
+    id: 700 + index,
     path: `.github/workflows/${workflowFile}`,
     status: 'completed',
   }));

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -39,6 +39,7 @@ jobs:
             const hostedCiLabel = 'ready-for-hosted-ci';
             const forceFullHostedCiLabel = 'force-full-hosted-ci';
             const newerCommandVisibilityDelayMs = 5000;
+            const dispatchRunVisibilityGraceMs = 2 * 60 * 1000;
 
             const validCommands = [
               '+ci-run-hosted',
@@ -120,10 +121,14 @@ jobs:
                     proof.base_sha !== pr.base.sha ||
                     !['optimized', 'force-full'].includes(proof.requested_mode) ||
                     !Array.isArray(proof.workflows) ||
+                    !proof.run_ids ||
+                    !proof.workflows.every((workflowFile) =>
+                      Number.isInteger(proof.run_ids[workflowFile]) && proof.run_ids[workflowFile] > 0
+                    ) ||
                     Number.isNaN(Date.parse(proof.requested_at || ''))) {
                   return null;
                 }
-                return proof;
+                return { ...proof, proof_comment_id: comment.id };
               } catch (error) {
                 core.warning(`Ignoring malformed hosted-CI coverage proof: ${error.message || error}`);
                 return null;
@@ -133,63 +138,29 @@ jobs:
             function latestCoverageProof(proofs, workflowFile, requestedMode) {
               return proofs
                 .filter((proof) => proof.requested_mode === requestedMode && proof.workflows.includes(workflowFile))
-                .sort((left, right) => Date.parse(right.requested_at) - Date.parse(left.requested_at))[0] || null;
+                .sort((left, right) =>
+                  Date.parse(right.requested_at) - Date.parse(left.requested_at) ||
+                  right.proof_comment_id - left.proof_comment_id
+                )[0] || null;
             }
 
-            function observedProofRunState(runs, proof, proofs, workflowFile) {
+            function observedProofRunState(runs, proof, workflowFile) {
               if (!proof) {
                 return 'missing';
               }
 
-              const requestedAt = Date.parse(proof.requested_at);
-              const workflowDispatchRuns = runs.filter((run) => run.event === 'workflow_dispatch');
-              const earlierProofs = proofs.filter((candidate) =>
-                candidate.workflows.includes(workflowFile) &&
-                Date.parse(candidate.requested_at) < requestedAt
+              const exactRunId = proof.run_ids[workflowFile];
+              const exactRun = runs.find((run) =>
+                run.event === 'workflow_dispatch' && run.id === exactRunId
               );
-              const earliestEarlierRequest = earlierProofs
-                .map((candidate) => Date.parse(candidate.requested_at))
-                .sort((left, right) => left - right)[0];
-              const materializedEarlierRuns = earliestEarlierRequest === undefined
-                ? 0
-                : workflowDispatchRuns.filter((run) => {
-                  const createdAt = Date.parse(run.created_at || '');
-                  return createdAt >= earliestEarlierRequest && createdAt < requestedAt;
-                }).length;
-              const ambiguousEarlierRuns = Math.max(0, earlierProofs.length - materializedEarlierRuns);
-              const nextRequestedAt = proofs
-                .filter((candidate) =>
-                  candidate.workflows.includes(workflowFile) &&
-                  Date.parse(candidate.requested_at) > requestedAt
-                )
-                .map((candidate) => Date.parse(candidate.requested_at))
-                .sort((left, right) => left - right)[0];
-              const proofWindowRuns = workflowDispatchRuns.filter((run) => {
-                const createdAt = Date.parse(run.created_at || '');
-                return createdAt >= requestedAt &&
-                  (!nextRequestedAt || createdAt < nextRequestedAt);
-              });
-
-              if (proofWindowRuns.length <= ambiguousEarlierRuns) {
-                return 'pending';
+              if (exactRun) {
+                return observedRunState([exactRun]);
               }
 
-              const successfulRuns = proofWindowRuns.filter((run) =>
-                run.status === 'completed' && run.conclusion === 'success'
-              ).length;
-              if (successfulRuns > ambiguousEarlierRuns) {
-                return 'successful';
-              }
-
-              const pendingRuns = proofWindowRuns.filter((run) => activeWorkflowStatuses.has(run.status)).length;
-              if (pendingRuns > ambiguousEarlierRuns) {
-                return 'pending';
-              }
-
-              // If an earlier dispatch can account for every successful or active run in this
-              // window, this request's outcome is not proven. Retry rather than attributing a
-              // run that materialized late to the wrong request mode.
-              return 'failed';
+              const proofAgeMs = Date.now() - Date.parse(proof.requested_at);
+              return proofAgeMs >= 0 && proofAgeMs <= dispatchRunVisibilityGraceMs
+                ? 'pending'
+                : 'missing';
             }
 
             function coverageMarker(payload) {
@@ -204,6 +175,7 @@ jobs:
               observed,
               requestedMode,
               reused,
+              runIds,
               workflows
             }) {
               return coverageMarker({
@@ -214,6 +186,7 @@ jobs:
                 requested_mode: requestedMode,
                 requested_at: commentCreatedAt,
                 workflows,
+                run_ids: runIds,
                 reused,
                 observed,
                 dispatched
@@ -252,14 +225,12 @@ jobs:
                   const forceFullState = observedProofRunState(
                     workflowRuns,
                     forceFullProof,
-                    proofs,
                     workflowFile
                   );
                   const optimizedProof = latestCoverageProof(proofs, workflowFile, 'optimized');
                   const optimizedProofState = observedProofRunState(
                     workflowRuns,
                     optimizedProof,
-                    proofs,
                     workflowFile
                   );
                   const automaticReleaseRuns = automaticReleaseTarget
@@ -717,16 +688,33 @@ jobs:
               }
 
               async function createWorkflowDispatchWithFallback(workflowName, workflowFile, workflowInputs) {
-                try {
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner,
-                    repo,
-                    workflow_id: workflowFile,
-                    ref: pr.head.ref,
-                    inputs: workflowInputs
-                  });
+                const dispatchOptions = (inputs) => ({
+                  owner,
+                  repo,
+                  workflow_id: workflowFile,
+                  ref: pr.head.ref,
+                  inputs,
+                  return_run_details: true,
+                  headers: { 'x-github-api-version': '2026-03-10' }
+                });
+                const dispatchedWorkflow = (response, usedLegacyInputsFallback) => {
+                  const runId = response?.data?.workflow_run_id;
+                  if (!Number.isInteger(runId) || runId <= 0) {
+                    throw new Error(`${workflowFile} dispatch did not return an exact workflow run ID.`);
+                  }
+                  return {
+                    file: workflowFile,
+                    name: workflowName,
+                    runId,
+                    usedLegacyInputsFallback
+                  };
+                };
 
-                  return { file: workflowFile, name: workflowName, usedLegacyInputsFallback: false };
+                try {
+                  const response = await github.rest.actions.createWorkflowDispatch(
+                    dispatchOptions(workflowInputs)
+                  );
+                  return dispatchedWorkflow(response, false);
                 } catch (error) {
                   if (!isUnexpectedInputError(error)) {
                     throw error;
@@ -735,15 +723,10 @@ jobs:
                   core.warning(
                     `${workflowFile} rejected PR base context inputs; retrying with legacy workflow_dispatch inputs.`
                   );
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner,
-                    repo,
-                    workflow_id: workflowFile,
-                    ref: pr.head.ref,
-                    inputs: legacyCompatibleInputs(workflowInputs)
-                  });
-
-                  return { file: workflowFile, name: workflowName, usedLegacyInputsFallback: true };
+                  const response = await github.rest.actions.createWorkflowDispatch(
+                    dispatchOptions(legacyCompatibleInputs(workflowInputs))
+                  );
+                  return dispatchedWorkflow(response, true);
                 }
               }
 
@@ -848,6 +831,9 @@ jobs:
                   headSha: pr.head.sha,
                   requestedMode: forceFull ? 'force-full' : 'optimized',
                   workflows: succeeded.map((workflow) => workflow.file),
+                  runIds: Object.fromEntries(
+                    succeeded.map((workflow) => [workflow.file, workflow.runId])
+                  ),
                   reused: coveredWorkflows.map(([, workflowFile]) => workflowFile),
                   observed: coverage.workflows,
                   dispatched: succeeded.map((workflow) => workflow.file)

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -754,8 +754,6 @@ jobs:
               };
               const baseContextInputNames = new Set(['pull_request_base_ref', 'pull_request_base_sha']);
               const workflows = hostedWorkflows(pr, inputs);
-              let workflowsToDispatch = workflows;
-              let coveredWorkflows = [];
               const coverage = await observeExactHeadRuns(pr);
               if (coverage.status === 'UNKNOWN') {
                 await addReaction('confused');
@@ -779,12 +777,12 @@ jobs:
               const coverageByFile = new Map(
                 coverage.workflows.map((workflow) => [workflow.file, workflow])
               );
-              coveredWorkflows = workflows.filter(([, workflowFile]) => {
+              const coveredWorkflows = workflows.filter(([, workflowFile]) => {
                 const observed = coverageByFile.get(workflowFile);
                 const state = forceFull ? observed?.force_full_state : observed?.state;
                 return ['pending', 'successful'].includes(state);
               });
-              workflowsToDispatch = workflows.filter((workflow) => !coveredWorkflows.includes(workflow));
+              const workflowsToDispatch = workflows.filter((workflow) => !coveredWorkflows.includes(workflow));
 
               let currentPr;
               try {

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -62,6 +62,12 @@ jobs:
               return releaseBranchPrefixes.some((prefix) => pr.base.ref.startsWith(prefix));
             }
 
+            function hasAutomaticReleaseTargetCoverage(pr) {
+              return isSameRepositoryPullRequest(pr) &&
+                isReleaseTargetPullRequest(pr) &&
+                pr.user?.login !== 'dependabot[bot]';
+            }
+
             function hostedWorkflows(pr, inputs = {}) {
               return [
                 ['Lint JS and Ruby', 'lint-js-and-ruby.yml', inputs],
@@ -96,7 +102,7 @@ jobs:
               return runs.length > 0 ? 'failed' : 'missing';
             }
 
-            function parseCoverageProof(comment, headSha) {
+            function parseCoverageProof(comment, pr) {
               if (comment.user?.login !== 'github-actions[bot]' || comment.user?.type !== 'Bot') {
                 return null;
               }
@@ -108,7 +114,10 @@ jobs:
 
               try {
                 const proof = JSON.parse(match[1]);
-                if (proof.head_sha !== headSha ||
+                if (proof.head_sha !== pr.head.sha ||
+                    proof.pull_request_number !== issueNumber ||
+                    proof.base_ref !== pr.base.ref ||
+                    proof.base_sha !== pr.base.sha ||
                     !['optimized', 'force-full'].includes(proof.requested_mode) ||
                     !Array.isArray(proof.workflows) ||
                     Number.isNaN(Date.parse(proof.requested_at || ''))) {
@@ -127,12 +136,27 @@ jobs:
                 .sort((left, right) => Date.parse(right.requested_at) - Date.parse(left.requested_at))[0] || null;
             }
 
-            function runsForProof(runs, proof, proofs, workflowFile) {
+            function observedProofRunState(runs, proof, proofs, workflowFile) {
               if (!proof) {
-                return [];
+                return 'missing';
               }
 
               const requestedAt = Date.parse(proof.requested_at);
+              const workflowDispatchRuns = runs.filter((run) => run.event === 'workflow_dispatch');
+              const earlierProofs = proofs.filter((candidate) =>
+                candidate.workflows.includes(workflowFile) &&
+                Date.parse(candidate.requested_at) < requestedAt
+              );
+              const earliestEarlierRequest = earlierProofs
+                .map((candidate) => Date.parse(candidate.requested_at))
+                .sort((left, right) => left - right)[0];
+              const materializedEarlierRuns = earliestEarlierRequest === undefined
+                ? 0
+                : workflowDispatchRuns.filter((run) => {
+                  const createdAt = Date.parse(run.created_at || '');
+                  return createdAt >= earliestEarlierRequest && createdAt < requestedAt;
+                }).length;
+              const ambiguousEarlierRuns = Math.max(0, earlierProofs.length - materializedEarlierRuns);
               const nextRequestedAt = proofs
                 .filter((candidate) =>
                   candidate.workflows.includes(workflowFile) &&
@@ -140,25 +164,57 @@ jobs:
                 )
                 .map((candidate) => Date.parse(candidate.requested_at))
                 .sort((left, right) => left - right)[0];
-              return runs.filter((run) =>
-                run.event === 'workflow_dispatch' &&
-                (!run.created_at || (
-                  Date.parse(run.created_at) >= requestedAt &&
-                  (!nextRequestedAt || Date.parse(run.created_at) < nextRequestedAt)
-                ))
-              );
+              const proofWindowRuns = workflowDispatchRuns.filter((run) => {
+                const createdAt = Date.parse(run.created_at || '');
+                return createdAt >= requestedAt &&
+                  (!nextRequestedAt || createdAt < nextRequestedAt);
+              });
+
+              if (proofWindowRuns.length <= ambiguousEarlierRuns) {
+                return 'pending';
+              }
+
+              const successfulRuns = proofWindowRuns.filter((run) =>
+                run.status === 'completed' && run.conclusion === 'success'
+              ).length;
+              if (successfulRuns > ambiguousEarlierRuns) {
+                return 'successful';
+              }
+
+              const pendingRuns = proofWindowRuns.filter((run) => activeWorkflowStatuses.has(run.status)).length;
+              if (pendingRuns > ambiguousEarlierRuns) {
+                return 'pending';
+              }
+
+              // If an earlier dispatch can account for every successful or active run in this
+              // window, this request's outcome is not proven. Retry rather than attributing a
+              // run that materialized late to the wrong request mode.
+              return 'failed';
             }
 
             function coverageMarker(payload) {
               return `<!-- hosted-ci-coverage:v1 ${JSON.stringify(payload)} -->`;
             }
 
-            function coverageProofMarker({ dispatched, headSha, observed, requestedMode, workflows }) {
+            function coverageProofMarker({
+              baseRef,
+              baseSha,
+              dispatched,
+              headSha,
+              observed,
+              requestedMode,
+              reused,
+              workflows
+            }) {
               return coverageMarker({
                 head_sha: headSha,
+                pull_request_number: issueNumber,
+                base_ref: baseRef,
+                base_sha: baseSha,
                 requested_mode: requestedMode,
                 requested_at: commentCreatedAt,
                 workflows,
+                reused,
                 observed,
                 dispatched
               });
@@ -184,25 +240,38 @@ jobs:
                 ]);
                 const exactHeadRuns = runs.filter((run) => run.head_sha === pr.head.sha);
                 const proofs = comments
-                  .map((comment) => parseCoverageProof(comment, pr.head.sha))
+                  .map((comment) => parseCoverageProof(comment, pr))
                   .filter(Boolean);
-                const automaticReleaseTarget = isSameRepositoryPullRequest(pr) && isReleaseTargetPullRequest(pr);
+                const automaticReleaseTarget = hasAutomaticReleaseTargetCoverage(pr);
                 const workflows = hostedWorkflowFiles(pr).map((workflowFile) => {
                   const workflowRuns = exactHeadRuns.filter((run) => workflowFileForRun(run) === workflowFile);
+                  // Non-release pull_request runs can be successful selector-only shells. Only
+                  // workflow_dispatch runs, or explicitly trusted release-target runs below,
+                  // prove that the hosted jobs actually ran.
                   const forceFullProof = latestCoverageProof(proofs, workflowFile, 'force-full');
-                  const forceFullProofRuns = runsForProof(workflowRuns, forceFullProof, proofs, workflowFile);
-                  const forceFullState = forceFullProof
-                    ? (forceFullProofRuns.length > 0 ? observedRunState(forceFullProofRuns) : 'pending')
-                    : 'missing';
+                  const forceFullState = observedProofRunState(
+                    workflowRuns,
+                    forceFullProof,
+                    proofs,
+                    workflowFile
+                  );
                   const optimizedProof = latestCoverageProof(proofs, workflowFile, 'optimized');
-                  const optimizedProofRuns = runsForProof(workflowRuns, optimizedProof, proofs, workflowFile);
+                  const optimizedProofState = observedProofRunState(
+                    workflowRuns,
+                    optimizedProof,
+                    proofs,
+                    workflowFile
+                  );
                   const automaticReleaseRuns = automaticReleaseTarget
-                    ? workflowRuns.filter((run) => run.event === 'pull_request')
+                    ? workflowRuns.filter((run) =>
+                      run.event === 'pull_request' &&
+                      (run.pull_requests || []).some((associatedPullRequest) =>
+                        associatedPullRequest.number === issueNumber &&
+                        associatedPullRequest.base?.ref === pr.base.ref &&
+                        associatedPullRequest.base?.sha === pr.base.sha
+                      )
+                    )
                     : [];
-                  const ordinaryState = observedRunState([
-                    ...workflowRuns,
-                    ...(optimizedProof && optimizedProofRuns.length === 0 ? [{ status: 'pending' }] : [])
-                  ]);
                   const releaseState = observedRunState(automaticReleaseRuns);
 
                   if (['pending', 'successful'].includes(forceFullState)) {
@@ -214,13 +283,13 @@ jobs:
 
                   return {
                     file: workflowFile,
-                    mode: ordinaryState === 'missing' ? 'missing' : 'optimized',
-                    state: ordinaryState,
+                    mode: optimizedProofState === 'missing' ? 'missing' : 'optimized',
+                    state: optimizedProofState,
                     force_full_state: forceFullState
                   };
                 });
 
-                return { status: 'known', workflows };
+                return { status: 'known', baseRef: pr.base.ref, baseSha: pr.base.sha, workflows };
               } catch (error) {
                 core.warning(`Unable to read exact-head workflow runs: ${error.message || error}`);
                 return { status: 'UNKNOWN', workflows: [] };
@@ -758,6 +827,11 @@ jobs:
               const fallbackMessage = fallbackCount > 0
                 ? `Retried ${fallbackCount} workflow(s) without PR base context inputs because the PR branch has older workflow files.`
                 : '';
+              const dependabotTrustProof = pr.user?.login === 'dependabot[bot]' &&
+                succeeded.length === 0 && coveredWorkflows.length > 0
+                ? `Trusted dispatch proof retained: Triggered ${coveredWorkflows.length} workflow(s) for ` +
+                  `\`${pr.head.sha.slice(0, 12)}\` by current-base prior requests.`
+                : '';
               const labelMessage = labelMessageOverride || (labelAdded && forceFullLabelAdded
                 ? 'Added `ready-for-hosted-ci` and `force-full-hosted-ci`, so future commits will bypass optimized hosted CI selection until `+ci-stop-full` is used.'
                 : labelAdded
@@ -769,15 +843,19 @@ jobs:
               await postComment([
                 forceFull ? '## Force-Full Hosted CI Requested' : '## Hosted CI Requested',
                 coverageProofMarker({
+                  baseRef: pr.base.ref,
+                  baseSha: pr.base.sha,
                   headSha: pr.head.sha,
                   requestedMode: forceFull ? 'force-full' : 'optimized',
                   workflows: succeeded.map((workflow) => workflow.file),
+                  reused: coveredWorkflows.map(([, workflowFile]) => workflowFile),
                   observed: coverage.workflows,
                   dispatched: succeeded.map((workflow) => workflow.file)
                 }),
                 '',
                 `Triggered ${succeeded.length} workflow(s) for \`${pr.head.sha.slice(0, 12)}\`.`,
                 `Skipped ${coveredWorkflows.length} workflow(s) with equivalent exact-head coverage.`,
+                ...(dependabotTrustProof ? [dependabotTrustProof] : []),
                 forceFull
                   ? 'Mode: force-full hosted CI (bypasses optimized change selection).'
                   : 'Mode: optimized hosted CI (path-selected by `script/ci-changes-detector`).',
@@ -878,7 +956,7 @@ jobs:
               const docsOnly = isDocsOnly(files);
               const hasReadyForHostedCi = labels.includes(hostedCiLabel);
               const hasForceFullHostedCi = labels.includes(forceFullHostedCiLabel);
-              const automaticReleaseTarget = isSameRepositoryPullRequest(pr) && isReleaseTargetPullRequest(pr);
+              const automaticReleaseTarget = hasAutomaticReleaseTargetCoverage(pr);
               const coverageCounts = coverage.workflows.reduce((counts, workflow) => {
                 counts[workflow.state] += 1;
                 return counts;

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -51,6 +51,181 @@ jobs:
             ];
             const trustedCommandAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
             const permissionByLogin = new Map();
+            const releaseBranchPrefixes = ['release/', 'releases/', 'release-'];
+            const activeWorkflowStatuses = new Set(['queued', 'in_progress', 'pending', 'requested', 'waiting']);
+
+            function isSameRepositoryPullRequest(pr) {
+              return pr.head.repo?.full_name === repoFullName;
+            }
+
+            function isReleaseTargetPullRequest(pr) {
+              return releaseBranchPrefixes.some((prefix) => pr.base.ref.startsWith(prefix));
+            }
+
+            function hostedWorkflows(pr, inputs = {}) {
+              return [
+                ['Lint JS and Ruby', 'lint-js-and-ruby.yml', inputs],
+                ['JS unit tests for Renderer package', 'package-js-tests.yml', inputs],
+                ['Rspec test for gem', 'gem-tests.yml', inputs],
+                ['Integration Tests', 'integration-tests.yml', inputs],
+                ['Assets Precompile Check', 'precompile-check.yml', inputs],
+                ['Generator tests', 'examples.yml', inputs],
+                ['Playwright E2E Tests', 'playwright.yml', inputs],
+                ...(pr.user?.login === 'dependabot[bot]' ? [] : [
+                  ['React on Rails Pro - Integration Tests', 'pro-integration-tests.yml', inputs],
+                  ['React on Rails Pro - Package Tests', 'pro-test-package-and-gem.yml', inputs]
+                ])
+              ];
+            }
+
+            function hostedWorkflowFiles(pr) {
+              return hostedWorkflows(pr).map(([, workflowFile]) => workflowFile);
+            }
+
+            function workflowFileForRun(run) {
+              return (run.path || '').split('@')[0].split('/').at(-1) || '';
+            }
+
+            function observedRunState(runs) {
+              if (runs.some((run) => run.status === 'completed' && run.conclusion === 'success')) {
+                return 'successful';
+              }
+              if (runs.some((run) => activeWorkflowStatuses.has(run.status))) {
+                return 'pending';
+              }
+              return runs.length > 0 ? 'failed' : 'missing';
+            }
+
+            function parseCoverageProof(comment, headSha) {
+              if (comment.user?.login !== 'github-actions[bot]' || comment.user?.type !== 'Bot') {
+                return null;
+              }
+
+              const match = (comment.body || '').match(/<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->/);
+              if (!match) {
+                return null;
+              }
+
+              try {
+                const proof = JSON.parse(match[1]);
+                if (proof.head_sha !== headSha ||
+                    !['optimized', 'force-full'].includes(proof.requested_mode) ||
+                    !Array.isArray(proof.workflows) ||
+                    Number.isNaN(Date.parse(proof.requested_at || ''))) {
+                  return null;
+                }
+                return proof;
+              } catch (error) {
+                core.warning(`Ignoring malformed hosted-CI coverage proof: ${error.message || error}`);
+                return null;
+              }
+            }
+
+            function latestCoverageProof(proofs, workflowFile, requestedMode) {
+              return proofs
+                .filter((proof) => proof.requested_mode === requestedMode && proof.workflows.includes(workflowFile))
+                .sort((left, right) => Date.parse(right.requested_at) - Date.parse(left.requested_at))[0] || null;
+            }
+
+            function runsForProof(runs, proof, proofs, workflowFile) {
+              if (!proof) {
+                return [];
+              }
+
+              const requestedAt = Date.parse(proof.requested_at);
+              const nextRequestedAt = proofs
+                .filter((candidate) =>
+                  candidate.workflows.includes(workflowFile) &&
+                  Date.parse(candidate.requested_at) > requestedAt
+                )
+                .map((candidate) => Date.parse(candidate.requested_at))
+                .sort((left, right) => left - right)[0];
+              return runs.filter((run) =>
+                run.event === 'workflow_dispatch' &&
+                (!run.created_at || (
+                  Date.parse(run.created_at) >= requestedAt &&
+                  (!nextRequestedAt || Date.parse(run.created_at) < nextRequestedAt)
+                ))
+              );
+            }
+
+            function coverageMarker(payload) {
+              return `<!-- hosted-ci-coverage:v1 ${JSON.stringify(payload)} -->`;
+            }
+
+            function coverageProofMarker({ dispatched, headSha, observed, requestedMode, workflows }) {
+              return coverageMarker({
+                head_sha: headSha,
+                requested_mode: requestedMode,
+                requested_at: commentCreatedAt,
+                workflows,
+                observed,
+                dispatched
+              });
+            }
+
+            async function observeExactHeadRuns(pr) {
+              try {
+                const [runs, comments] = await Promise.all([
+                  github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                    owner,
+                    repo,
+                    head_sha: pr.head.sha,
+                    per_page: 100
+                  }),
+                  github.paginate(github.rest.issues.listComments, {
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    per_page: 100,
+                    sort: 'created',
+                    direction: 'asc'
+                  })
+                ]);
+                const exactHeadRuns = runs.filter((run) => run.head_sha === pr.head.sha);
+                const proofs = comments
+                  .map((comment) => parseCoverageProof(comment, pr.head.sha))
+                  .filter(Boolean);
+                const automaticReleaseTarget = isSameRepositoryPullRequest(pr) && isReleaseTargetPullRequest(pr);
+                const workflows = hostedWorkflowFiles(pr).map((workflowFile) => {
+                  const workflowRuns = exactHeadRuns.filter((run) => workflowFileForRun(run) === workflowFile);
+                  const forceFullProof = latestCoverageProof(proofs, workflowFile, 'force-full');
+                  const forceFullProofRuns = runsForProof(workflowRuns, forceFullProof, proofs, workflowFile);
+                  const forceFullState = forceFullProof
+                    ? (forceFullProofRuns.length > 0 ? observedRunState(forceFullProofRuns) : 'pending')
+                    : 'missing';
+                  const optimizedProof = latestCoverageProof(proofs, workflowFile, 'optimized');
+                  const optimizedProofRuns = runsForProof(workflowRuns, optimizedProof, proofs, workflowFile);
+                  const automaticReleaseRuns = automaticReleaseTarget
+                    ? workflowRuns.filter((run) => run.event === 'pull_request')
+                    : [];
+                  const ordinaryState = observedRunState([
+                    ...workflowRuns,
+                    ...(optimizedProof && optimizedProofRuns.length === 0 ? [{ status: 'pending' }] : [])
+                  ]);
+                  const releaseState = observedRunState(automaticReleaseRuns);
+
+                  if (['pending', 'successful'].includes(forceFullState)) {
+                    return { file: workflowFile, mode: 'force-full', state: forceFullState, force_full_state: forceFullState };
+                  }
+                  if (['pending', 'successful'].includes(releaseState)) {
+                    return { file: workflowFile, mode: 'release-full', state: releaseState, force_full_state: forceFullState };
+                  }
+
+                  return {
+                    file: workflowFile,
+                    mode: ordinaryState === 'missing' ? 'missing' : 'optimized',
+                    state: ordinaryState,
+                    force_full_state: forceFullState
+                  };
+                });
+
+                return { status: 'known', workflows };
+              } catch (error) {
+                core.warning(`Unable to read exact-head workflow runs: ${error.message || error}`);
+                return { status: 'UNKNOWN', workflows: [] };
+              }
+            }
 
             function commandText(commentBody) {
               return commentBody
@@ -415,26 +590,44 @@ jobs:
                 return;
               }
 
-              const isDependabotPr = pr.user?.login === 'dependabot[bot]';
               const inputs = {
                 pull_request_base_ref: pr.base.ref,
                 pull_request_base_sha: pr.base.sha,
                 ...(forceFull ? { force_full_hosted: 'true' } : {})
               };
               const baseContextInputNames = new Set(['pull_request_base_ref', 'pull_request_base_sha']);
-              const workflows = [
-                ['Lint JS and Ruby', 'lint-js-and-ruby.yml', inputs],
-                ['JS unit tests for Renderer package', 'package-js-tests.yml', inputs],
-                ['Rspec test for gem', 'gem-tests.yml', inputs],
-                ['Integration Tests', 'integration-tests.yml', inputs],
-                ['Assets Precompile Check', 'precompile-check.yml', inputs],
-                ['Generator tests', 'examples.yml', inputs],
-                ['Playwright E2E Tests', 'playwright.yml', inputs],
-                ...(isDependabotPr ? [] : [
-                  ['React on Rails Pro - Integration Tests', 'pro-integration-tests.yml', inputs],
-                  ['React on Rails Pro - Package Tests', 'pro-test-package-and-gem.yml', inputs]
-                ])
-              ];
+              const workflows = hostedWorkflows(pr, inputs);
+              let workflowsToDispatch = workflows;
+              let coveredWorkflows = [];
+              const coverage = await observeExactHeadRuns(pr);
+              if (coverage.status === 'UNKNOWN') {
+                await addReaction('confused');
+                await postComment([
+                  '## Hosted CI Coverage UNKNOWN',
+                  coverageMarker({
+                    head_sha: pr.head.sha,
+                    requested_mode: forceFull ? 'force-full' : 'optimized',
+                    coverage_status: 'UNKNOWN',
+                    observed: [],
+                    dispatched: []
+                  }),
+                  '',
+                  `Unable to prove which hosted workflows are missing for \`${pr.head.sha.slice(0, 12)}\`.`,
+                  'No workflows were dispatched because exact-head coverage could not be read safely.'
+                ].join('\n'));
+                core.setFailed('Exact-head hosted CI coverage is UNKNOWN; dispatch stopped.');
+                return;
+              }
+
+              const coverageByFile = new Map(
+                coverage.workflows.map((workflow) => [workflow.file, workflow])
+              );
+              coveredWorkflows = workflows.filter(([, workflowFile]) => {
+                const observed = coverageByFile.get(workflowFile);
+                const state = forceFull ? observed?.force_full_state : observed?.state;
+                return ['pending', 'successful'].includes(state);
+              });
+              workflowsToDispatch = workflows.filter((workflow) => !coveredWorkflows.includes(workflow));
 
               function legacyCompatibleInputs(workflowInputs) {
                 const legacyInputs = Object.fromEntries(
@@ -486,7 +679,7 @@ jobs:
               }
 
               const dispatchResults = await Promise.allSettled(
-                workflows.map(([workflowName, workflowFile, inputs]) =>
+                workflowsToDispatch.map(([workflowName, workflowFile, inputs]) =>
                   createWorkflowDispatchWithFallback(workflowName, workflowFile, inputs)
                 )
               );
@@ -499,7 +692,7 @@ jobs:
                   succeeded.push(result.value);
                 } else {
                   failed.push({
-                    workflow: workflows[index][0],
+                    workflow: workflowsToDispatch[index][0],
                     error: result.reason?.message || String(result.reason)
                   });
                 }
@@ -508,7 +701,8 @@ jobs:
               let labelAdded = false;
               let forceFullLabelAdded = false;
               let labelMessageOverride = '';
-              if (succeeded.length > 0 && failed.length === 0) {
+              const requestedCoverageSatisfied = coveredWorkflows.length + succeeded.length === workflows.length;
+              if (requestedCoverageSatisfied && failed.length === 0) {
                 const labelControlCommands = [
                   '+ci-stop-hosted',
                   '+ci-skip-hosted',
@@ -555,7 +749,7 @@ jobs:
                 }
               }
 
-              await addReaction(succeeded.length > 0 ? 'rocket' : 'confused');
+              await addReaction(failed.length > 0 ? 'confused' : succeeded.length > 0 ? 'rocket' : 'eyes');
 
               const failedList = failed.length > 0
                 ? `\n\nFailed:\n${failed.map((failure) => `- ${failure.workflow}: ${failure.error}`).join('\n')}`
@@ -574,8 +768,16 @@ jobs:
 
               await postComment([
                 forceFull ? '## Force-Full Hosted CI Requested' : '## Hosted CI Requested',
+                coverageProofMarker({
+                  headSha: pr.head.sha,
+                  requestedMode: forceFull ? 'force-full' : 'optimized',
+                  workflows: succeeded.map((workflow) => workflow.file),
+                  observed: coverage.workflows,
+                  dispatched: succeeded.map((workflow) => workflow.file)
+                }),
                 '',
                 `Triggered ${succeeded.length} workflow(s) for \`${pr.head.sha.slice(0, 12)}\`.`,
+                `Skipped ${coveredWorkflows.length} workflow(s) with equivalent exact-head coverage.`,
                 forceFull
                   ? 'Mode: force-full hosted CI (bypasses optimized change selection).'
                   : 'Mode: optimized hosted CI (path-selected by `script/ci-changes-detector`).',
@@ -666,18 +868,36 @@ jobs:
             }
 
             async function handleStatus(pr) {
-              const [labels, files, waiver] = await Promise.all([
+              const [labels, files, waiver, coverage] = await Promise.all([
                 listPullRequestLabels(),
                 listPullRequestFiles(),
-                findCurrentWaiver(pr.head.sha)
+                findCurrentWaiver(pr.head.sha),
+                observeExactHeadRuns(pr)
               ]);
 
               const docsOnly = isDocsOnly(files);
               const hasReadyForHostedCi = labels.includes(hostedCiLabel);
               const hasForceFullHostedCi = labels.includes(forceFullHostedCiLabel);
+              const automaticReleaseTarget = isSameRepositoryPullRequest(pr) && isReleaseTargetPullRequest(pr);
+              const coverageCounts = coverage.workflows.reduce((counts, workflow) => {
+                counts[workflow.state] += 1;
+                return counts;
+              }, { successful: 0, pending: 0, failed: 0, missing: 0 });
+              const observedCoverage = coverage.status === 'UNKNOWN'
+                ? 'UNKNOWN'
+                : `${automaticReleaseTarget ? 'release-full' : 'optimized'}; ` +
+                  `successful=${coverageCounts.successful}, pending=${coverageCounts.pending}, ` +
+                  `failed=${coverageCounts.failed}, missing=${coverageCounts.missing}`;
 
               await postComment([
                 '## CI Status',
+                coverageMarker({
+                  head_sha: pr.head.sha,
+                  requested_mode: 'status',
+                  automatic_release_target: automaticReleaseTarget,
+                  coverage_status: coverage.status,
+                  observed: coverage.workflows
+                }),
                 '',
                 `Head SHA: \`${pr.head.sha.slice(0, 12)}\``,
                 `Changed files: ${files.length}`,
@@ -685,8 +905,12 @@ jobs:
                 `\`${hostedCiLabel}\` label: ${hasReadyForHostedCi ? 'present' : 'absent'}`,
                 `\`${forceFullHostedCiLabel}\` label: ${hasForceFullHostedCi ? 'present' : 'absent'}`,
                 `Current hosted-CI waiver: ${waiver ? 'present for this SHA' : 'not present for this SHA'}`,
+                `Automatic release-target hosted mode: ${automaticReleaseTarget ? 'active' : 'inactive'}`,
+                `Observed exact-head coverage: ${observedCoverage}`,
                 '',
-                hasForceFullHostedCi
+                automaticReleaseTarget
+                  ? 'Release-target policy already enables hosted CI for this same-repository PR.'
+                  : hasForceFullHostedCi
                   ? 'Force-full hosted CI is enabled for this PR.'
                   : hasReadyForHostedCi
                     ? 'Optimized hosted CI is enabled for this PR.'

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -46,6 +46,8 @@ jobs:
             const dispatchRunVisibilityGraceMs = 2 * 60 * 1000;
             const dispatchRunValidationPollDelayMs = 2000;
             const dispatchRunValidationMaxAttempts = 3;
+            const dispatchResultCommentRetryDelayMs = 2000;
+            const dispatchResultCommentMaxAttempts = 3;
 
             const validCommands = [
               '+ci-run-hosted',
@@ -353,6 +355,27 @@ jobs:
                 issue_number: issueNumber,
                 body
               });
+            }
+
+            async function postDispatchResultComment(body) {
+              let lastError;
+              for (let attempt = 1; attempt <= dispatchResultCommentMaxAttempts; attempt += 1) {
+                try {
+                  await postComment(body);
+                  return;
+                } catch (error) {
+                  lastError = error;
+                  core.warning(
+                    `Unable to persist hosted-CI dispatch proof (attempt ${attempt}/` +
+                    `${dispatchResultCommentMaxAttempts}): ${error.message || error}`
+                  );
+                  if (attempt < dispatchResultCommentMaxAttempts) {
+                    await sleep(dispatchResultCommentRetryDelayMs);
+                  }
+                }
+              }
+
+              throw lastError;
             }
 
             async function addReaction(content) {
@@ -1072,7 +1095,7 @@ jobs:
                   dispatched: succeeded.map((workflow) => workflow.file)
                 });
 
-              await postComment([
+              await postDispatchResultComment([
                 dispatchIsUncertain
                   ? '## Hosted CI Dispatch UNKNOWN'
                   : forceFull ? '## Force-Full Hosted CI Requested' : '## Hosted CI Requested',

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -203,8 +203,8 @@ jobs:
                 return observedRunState([exactRun]);
               }
 
-              const proofAgeMs = Date.now() - Date.parse(proof.requested_at);
-              return proofAgeMs >= 0 && proofAgeMs <= dispatchRunVisibilityGraceMs
+              const proofAgeMs = Math.max(0, Date.now() - Date.parse(proof.requested_at));
+              return proofAgeMs <= dispatchRunVisibilityGraceMs
                 ? 'pending'
                 : 'missing';
             }
@@ -230,7 +230,7 @@ jobs:
                 base_ref: baseRef,
                 base_sha: baseSha,
                 requested_mode: requestedMode,
-                requested_at: commentCreatedAt,
+                requested_at: new Date(Date.now()).toISOString(),
                 workflows,
                 run_ids: runIds,
                 reused,

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -126,7 +126,9 @@ jobs:
                 return null;
               }
 
-              const match = (comment.body || '').match(/<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->/);
+              const match = (comment.body || '').match(
+                /(?:^|[\r\n])<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->(?=[\r\n]|$)/
+              );
               if (!match) {
                 return null;
               }
@@ -143,6 +145,11 @@ jobs:
                     !proof.workflows.every((workflowFile) =>
                       Number.isInteger(proof.run_ids[workflowFile]) && proof.run_ids[workflowFile] > 0
                     ) ||
+                    (proof.workflow_modes !== undefined &&
+                      (typeof proof.workflow_modes !== 'object' ||
+                        !proof.workflows.every((workflowFile) =>
+                          ['optimized', 'force-full'].includes(proof.workflow_modes[workflowFile])
+                        ))) ||
                     Number.isNaN(Date.parse(proof.requested_at || ''))) {
                   return null;
                 }
@@ -158,7 +165,9 @@ jobs:
                 return null;
               }
 
-              const match = (comment.body || '').match(/<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->/);
+              const match = (comment.body || '').match(
+                /(?:^|[\r\n])<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->(?=[\r\n]|$)/
+              );
               if (!match) {
                 return null;
               }
@@ -186,7 +195,10 @@ jobs:
 
             function latestCoverageProof(proofs, workflowFile, requestedMode) {
               return proofs
-                .filter((proof) => proof.requested_mode === requestedMode && proof.workflows.includes(workflowFile))
+                .filter((proof) =>
+                  proof.workflows.includes(workflowFile) &&
+                  (proof.workflow_modes?.[workflowFile] || proof.requested_mode) === requestedMode
+                )
                 .sort((left, right) =>
                   Date.parse(right.requested_at) - Date.parse(left.requested_at) ||
                   right.proof_comment_id - left.proof_comment_id
@@ -225,6 +237,7 @@ jobs:
               requestedMode,
               reused,
               runIds,
+              workflowModes,
               workflows
             }) {
               return coverageMarker({
@@ -236,6 +249,7 @@ jobs:
                 requested_at: new Date(Date.now()).toISOString(),
                 workflows,
                 run_ids: runIds,
+                workflow_modes: workflowModes,
                 reused,
                 observed,
                 dispatched
@@ -357,14 +371,17 @@ jobs:
               });
             }
 
-            async function postDispatchResultComment(body) {
-              let lastError;
+            async function updateDispatchResultComment(commentId, body) {
               for (let attempt = 1; attempt <= dispatchResultCommentMaxAttempts; attempt += 1) {
                 try {
-                  await postComment(body);
-                  return;
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: commentId,
+                    body
+                  });
+                  return true;
                 } catch (error) {
-                  lastError = error;
                   core.warning(
                     `Unable to persist hosted-CI dispatch proof (attempt ${attempt}/` +
                     `${dispatchResultCommentMaxAttempts}): ${error.message || error}`
@@ -375,7 +392,59 @@ jobs:
                 }
               }
 
-              throw lastError;
+              return false;
+            }
+
+            async function createDispatchResultComment(body) {
+              for (let attempt = 1; attempt <= dispatchResultCommentMaxAttempts; attempt += 1) {
+                try {
+                  await postComment(body);
+                  return true;
+                } catch (error) {
+                  core.warning(
+                    `Unable to persist hosted-CI result (attempt ${attempt}/` +
+                    `${dispatchResultCommentMaxAttempts}): ${error.message || error}`
+                  );
+                  if (attempt < dispatchResultCommentMaxAttempts) {
+                    await sleep(dispatchResultCommentRetryDelayMs);
+                  }
+                }
+              }
+
+              return false;
+            }
+
+            async function reconcileDispatchAnchor(pr) {
+              for (let attempt = 1; attempt <= dispatchResultCommentMaxAttempts; attempt += 1) {
+                try {
+                  const comments = await github.paginate(github.rest.issues.listComments, {
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    per_page: 100
+                  });
+                  const anchor = comments.find((comment) => {
+                    const marker = parseDispatchUncertainty(comment, pr);
+                    return marker?.source_comment_id === commentId &&
+                      marker.source_run_id === context.runId &&
+                      marker.requested_at === commentCreatedAt;
+                  });
+                  if (Number.isInteger(anchor?.id) && anchor.id > 0) {
+                    return anchor.id;
+                  }
+                } catch (error) {
+                  core.warning(
+                    `Unable to reconcile hosted-CI dispatch anchor (attempt ${attempt}/` +
+                    `${dispatchResultCommentMaxAttempts}): ${error.message || error}`
+                  );
+                }
+
+                if (attempt < dispatchResultCommentMaxAttempts) {
+                  await sleep(dispatchResultCommentRetryDelayMs);
+                }
+              }
+
+              return null;
             }
 
             async function addReaction(content) {
@@ -579,7 +648,7 @@ jobs:
             }
 
             function oneLine(value) {
-              return value.replace(/[\r\n]+/g, ' ').replace(/`+/g, "'").trim();
+              return value.replace(/[\r\n\u2028\u2029]+/g, ' ').replace(/`+/g, "'").trim();
             }
 
             function sleep(ms) {
@@ -589,6 +658,12 @@ jobs:
             async function waitForOlderCiCommands() {
               if (!Number.isInteger(context.runId) || context.runId <= 0) {
                 return { status: 'UNKNOWN', reason: 'Current CI Commands workflow run ID is unavailable.' };
+              }
+              if (context.runAttempt !== 1) {
+                return {
+                  status: 'UNKNOWN',
+                  reason: 'Manual reruns of CI Commands cannot safely dispatch hosted CI; post a new command instead.'
+                };
               }
 
               const createdLowerBound =
@@ -840,6 +915,97 @@ jobs:
                 return;
               }
 
+              let dispatchResultCommentId;
+              if (workflowsToDispatch.length > 0) {
+                const plannedWorkflowFiles = workflowsToDispatch.map(([, workflowFile]) => workflowFile);
+                const dispatchAnchorBody = [
+                  coverageMarker({
+                    head_sha: pr.head.sha,
+                    pull_request_number: issueNumber,
+                    base_ref: pr.base.ref,
+                    base_sha: pr.base.sha,
+                    requested_mode: forceFull ? 'force-full' : 'optimized',
+                    requested_at: commentCreatedAt,
+                    source_comment_id: commentId,
+                    source_run_id: context.runId,
+                    coverage_status: 'UNKNOWN',
+                    dispatch_uncertain: true,
+                    uncertain_workflows: plannedWorkflowFiles,
+                    workflows: [],
+                    run_ids: {},
+                    reused: coveredWorkflows.map(([, workflowFile]) => workflowFile),
+                    observed: coverage.workflows,
+                    dispatched: []
+                  }),
+                  '## Hosted CI Dispatch In Progress',
+                  '',
+                  'This head-bound UNKNOWN marker is replaced with exact-run proof after dispatch validation.',
+                  'If the final update cannot be persisted, later same-head commands remain fail-closed.'
+                ].join('\n');
+
+                try {
+                  const { data: anchorComment } = await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    body: dispatchAnchorBody
+                  });
+                  dispatchResultCommentId = anchorComment?.id;
+                } catch (error) {
+                  core.warning(`Unable to create hosted-CI dispatch anchor: ${error.message || error}`);
+                }
+
+                if (!Number.isInteger(dispatchResultCommentId) || dispatchResultCommentId <= 0) {
+                  dispatchResultCommentId = await reconcileDispatchAnchor(pr);
+                }
+
+                if (!Number.isInteger(dispatchResultCommentId) || dispatchResultCommentId <= 0) {
+                  await addReaction('confused');
+                  core.setFailed('Unable to persist hosted-CI dispatch anchor; no workflows were dispatched.');
+                  return;
+                }
+
+                let anchoredPr;
+                try {
+                  anchoredPr = await getPullRequest();
+                } catch (error) {
+                  core.warning(
+                    `Unable to re-read the pull request after hosted-CI anchoring: ${error.message || error}`
+                  );
+                }
+                if (!anchoredPr || !samePullRequestSnapshot(pr, anchoredPr)) {
+                  await addReaction('confused');
+                  const stoppedBody = [
+                    '## Pull Request Changed After Dispatch Anchoring',
+                    coverageMarker({
+                      head_sha: pr.head.sha,
+                      pull_request_number: issueNumber,
+                      base_ref: pr.base.ref,
+                      base_sha: pr.base.sha,
+                      requested_mode: forceFull ? 'force-full' : 'optimized',
+                      requested_at: commentCreatedAt,
+                      coverage_status: 'known',
+                      observed: coverage.workflows,
+                      dispatched: []
+                    }),
+                    '',
+                    'The pull request head, base, repository, or state changed after the dispatch anchor was persisted.',
+                    'No workflow or hosted-CI label was requested. Post a new command for the current pull request state.'
+                  ].join('\n');
+                  const stoppedResultPersisted = await updateDispatchResultComment(
+                    dispatchResultCommentId,
+                    stoppedBody
+                  );
+                  if (!stoppedResultPersisted) {
+                    core.warning(
+                      'Unable to replace the pre-dispatch UNKNOWN anchor after the pull request changed.'
+                    );
+                  }
+                  core.setFailed('Pull request changed after hosted CI anchoring; dispatch stopped.');
+                  return;
+                }
+              }
+
               function legacyCompatibleInputs(workflowInputs) {
                 const legacyInputs = Object.fromEntries(
                   Object.entries(workflowInputs).filter(([name]) => !baseContextInputNames.has(name))
@@ -927,6 +1093,9 @@ jobs:
                     );
                   }
                   return {
+                    effectiveMode: usedLegacyInputsFallback && pr.base.ref !== 'main'
+                      ? 'force-full'
+                      : forceFull ? 'force-full' : 'optimized',
                     file: workflowFile,
                     name: workflowName,
                     runId,
@@ -1090,12 +1259,15 @@ jobs:
                   runIds: Object.fromEntries(
                     succeeded.map((workflow) => [workflow.file, workflow.runId])
                   ),
+                  workflowModes: Object.fromEntries(
+                    succeeded.map((workflow) => [workflow.file, workflow.effectiveMode])
+                  ),
                   reused: coveredWorkflows.map(([, workflowFile]) => workflowFile),
                   observed: coverage.workflows,
                   dispatched: succeeded.map((workflow) => workflow.file)
                 });
 
-              await postDispatchResultComment([
+              const resultBody = [
                 dispatchIsUncertain
                   ? '## Hosted CI Dispatch UNKNOWN'
                   : forceFull ? '## Force-Full Hosted CI Requested' : '## Hosted CI Requested',
@@ -1114,7 +1286,23 @@ jobs:
                 '',
                 'View progress in the Actions tab.',
                 failedList
-              ].join('\n'));
+              ].join('\n');
+              if (dispatchResultCommentId) {
+                const proofPersisted = await updateDispatchResultComment(
+                  dispatchResultCommentId,
+                  resultBody
+                );
+                if (!proofPersisted) {
+                  core.setFailed('Unable to persist final hosted-CI dispatch proof.');
+                  return;
+                }
+              } else {
+                const resultPersisted = await createDispatchResultComment(resultBody);
+                if (!resultPersisted) {
+                  core.setFailed('Unable to persist final hosted-CI result.');
+                  return;
+                }
+              }
 
               if (failed.length > 0) {
                 core.setFailed(`Failed to trigger: ${failed.map((failure) => failure.workflow).join(', ')}`);

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -39,7 +39,12 @@ jobs:
             const hostedCiLabel = 'ready-for-hosted-ci';
             const forceFullHostedCiLabel = 'force-full-hosted-ci';
             const newerCommandVisibilityDelayMs = 5000;
+            const ciCommandSerializationVisibilityDelayMs = 5000;
+            const ciCommandSerializationPollDelayMs = 5000;
+            const ciCommandSerializationMaxAttempts = 12;
             const dispatchRunVisibilityGraceMs = 2 * 60 * 1000;
+            const dispatchRunValidationPollDelayMs = 2000;
+            const dispatchRunValidationMaxAttempts = 3;
 
             const validCommands = [
               '+ci-run-hosted',
@@ -57,6 +62,16 @@ jobs:
 
             function isSameRepositoryPullRequest(pr) {
               return pr.head.repo?.full_name === repoFullName;
+            }
+
+            function samePullRequestSnapshot(left, right) {
+              return left.state === right.state &&
+                left.merged === right.merged &&
+                left.head.sha === right.head.sha &&
+                left.head.ref === right.head.ref &&
+                left.head.repo?.full_name === right.head.repo?.full_name &&
+                left.base.ref === right.base.ref &&
+                left.base.sha === right.base.sha;
             }
 
             function isReleaseTargetPullRequest(pr) {
@@ -131,6 +146,37 @@ jobs:
                 return { ...proof, proof_comment_id: comment.id };
               } catch (error) {
                 core.warning(`Ignoring malformed hosted-CI coverage proof: ${error.message || error}`);
+                return null;
+              }
+            }
+
+            function parseDispatchUncertainty(comment, pr) {
+              if (comment.user?.login !== 'github-actions[bot]' || comment.user?.type !== 'Bot') {
+                return null;
+              }
+
+              const match = (comment.body || '').match(/<!-- hosted-ci-coverage:v1 (\{[^\r\n]*\}) -->/);
+              if (!match) {
+                return null;
+              }
+
+              try {
+                const marker = JSON.parse(match[1]);
+                if (marker.head_sha !== pr.head.sha ||
+                    marker.pull_request_number !== issueNumber ||
+                    marker.base_ref !== pr.base.ref ||
+                    marker.base_sha !== pr.base.sha ||
+                    !['optimized', 'force-full'].includes(marker.requested_mode) ||
+                    marker.coverage_status !== 'UNKNOWN' ||
+                    marker.dispatch_uncertain !== true ||
+                    !Array.isArray(marker.uncertain_workflows) ||
+                    marker.uncertain_workflows.length === 0 ||
+                    Number.isNaN(Date.parse(marker.requested_at || ''))) {
+                  return null;
+                }
+                return marker;
+              } catch (error) {
+                core.warning(`Ignoring malformed hosted-CI dispatch uncertainty: ${error.message || error}`);
                 return null;
               }
             }
@@ -212,6 +258,15 @@ jobs:
                   })
                 ]);
                 const exactHeadRuns = runs.filter((run) => run.head_sha === pr.head.sha);
+                const dispatchUncertainties = comments
+                  .map((comment) => parseDispatchUncertainty(comment, pr))
+                  .filter(Boolean);
+                if (dispatchUncertainties.length > 0) {
+                  core.warning(
+                    'Exact-head hosted-CI coverage is UNKNOWN because a prior dispatch could not be correlated.'
+                  );
+                  return { status: 'UNKNOWN', workflows: [] };
+                }
                 const proofs = comments
                   .map((comment) => parseCoverageProof(comment, pr))
                   .filter(Boolean);
@@ -507,6 +562,45 @@ jobs:
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
 
+            async function waitForOlderCiCommands() {
+              if (!Number.isInteger(context.runId) || context.runId <= 0) {
+                return { status: 'UNKNOWN', reason: 'Current CI Commands workflow run ID is unavailable.' };
+              }
+
+              await sleep(ciCommandSerializationVisibilityDelayMs);
+              for (let attempt = 1; attempt <= ciCommandSerializationMaxAttempts; attempt += 1) {
+                let runs;
+                try {
+                  runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                    owner,
+                    repo,
+                    workflow_id: 'ci-commands.yml',
+                    event: 'issue_comment',
+                    per_page: 100
+                  });
+                } catch (error) {
+                  core.warning(`Unable to serialize CI Commands workflow runs: ${error.message || error}`);
+                  return { status: 'UNKNOWN', reason: 'Unable to read older CI Commands workflow runs.' };
+                }
+
+                const olderActiveRuns = runs.filter((run) =>
+                  run.id < context.runId &&
+                  activeWorkflowStatuses.has(run.status)
+                );
+                if (olderActiveRuns.length === 0) {
+                  return { status: 'known' };
+                }
+                if (attempt < ciCommandSerializationMaxAttempts) {
+                  await sleep(ciCommandSerializationPollDelayMs);
+                }
+              }
+
+              return {
+                status: 'UNKNOWN',
+                reason: 'An older CI Commands workflow did not finish within the bounded wait.'
+              };
+            }
+
             function newerCommandScanSince() {
               const createdAt = Date.parse(commentCreatedAt);
               if (Number.isNaN(createdAt)) {
@@ -630,6 +724,29 @@ jobs:
                 return;
               }
 
+              const serialization = await waitForOlderCiCommands();
+              if (serialization.status === 'UNKNOWN') {
+                await addReaction('confused');
+                await postComment([
+                  '## Hosted CI Command Serialization UNKNOWN',
+                  coverageMarker({
+                    head_sha: pr.head.sha,
+                    pull_request_number: issueNumber,
+                    base_ref: pr.base.ref,
+                    base_sha: pr.base.sha,
+                    requested_mode: forceFull ? 'force-full' : 'optimized',
+                    coverage_status: 'UNKNOWN',
+                    observed: [],
+                    dispatched: []
+                  }),
+                  '',
+                  serialization.reason,
+                  'No workflows were dispatched because an older CI command may still mutate hosted coverage.'
+                ].join('\n'));
+                core.setFailed('Older CI command state is UNKNOWN; dispatch stopped.');
+                return;
+              }
+
               const inputs = {
                 pull_request_base_ref: pr.base.ref,
                 pull_request_base_sha: pr.base.sha,
@@ -669,6 +786,35 @@ jobs:
               });
               workflowsToDispatch = workflows.filter((workflow) => !coveredWorkflows.includes(workflow));
 
+              let currentPr;
+              try {
+                currentPr = await getPullRequest();
+              } catch (error) {
+                core.warning(`Unable to re-read the pull request before hosted-CI dispatch: ${error.message || error}`);
+              }
+              if (!currentPr || !samePullRequestSnapshot(pr, currentPr)) {
+                await addReaction('confused');
+                await postComment([
+                  '## Pull Request Changed - Hosted CI Stopped',
+                  coverageMarker({
+                    head_sha: pr.head.sha,
+                    pull_request_number: issueNumber,
+                    base_ref: pr.base.ref,
+                    base_sha: pr.base.sha,
+                    requested_mode: forceFull ? 'force-full' : 'optimized',
+                    requested_at: commentCreatedAt,
+                    coverage_status: 'UNKNOWN',
+                    observed: coverage.workflows,
+                    dispatched: []
+                  }),
+                  '',
+                  'The pull request head, base, repository, or state changed after hosted-CI coverage was planned.',
+                  'No workflows or labels were requested. Retry the command against the current pull request state.'
+                ].join('\n'));
+                core.setFailed('Pull request changed during hosted CI planning; dispatch stopped.');
+                return;
+              }
+
               function legacyCompatibleInputs(workflowInputs) {
                 const legacyInputs = Object.fromEntries(
                   Object.entries(workflowInputs).filter(([name]) => !baseContextInputNames.has(name))
@@ -687,6 +833,16 @@ jobs:
                   [...baseContextInputNames].some((name) => message.includes(name));
               }
 
+              function dispatchUncertainty(message, cause) {
+                const error = new Error(message, cause ? { cause } : undefined);
+                error.dispatchUncertain = true;
+                return error;
+              }
+
+              function isRetryableWorkflowRunReadError(error) {
+                return error?.status === 404 || (error?.status >= 500 && error?.status <= 599);
+              }
+
               async function createWorkflowDispatchWithFallback(workflowName, workflowFile, workflowInputs) {
                 const dispatchOptions = (inputs) => ({
                   owner,
@@ -694,13 +850,48 @@ jobs:
                   workflow_id: workflowFile,
                   ref: pr.head.ref,
                   inputs,
-                  return_run_details: true,
                   headers: { 'x-github-api-version': '2026-03-10' }
                 });
-                const dispatchedWorkflow = (response, usedLegacyInputsFallback) => {
+                const dispatchedWorkflow = async (response, usedLegacyInputsFallback) => {
                   const runId = response?.data?.workflow_run_id;
-                  if (!Number.isInteger(runId) || runId <= 0) {
-                    throw new Error(`${workflowFile} dispatch did not return an exact workflow run ID.`);
+                  if (response?.status !== 200 || !Number.isInteger(runId) || runId <= 0) {
+                    throw dispatchUncertainty(
+                      `${workflowFile} dispatch did not return an exact workflow run ID in a 200 response.`
+                    );
+                  }
+
+                  let run;
+                  for (let attempt = 1; attempt <= dispatchRunValidationMaxAttempts; attempt += 1) {
+                    try {
+                      ({ data: run } = await github.rest.actions.getWorkflowRun({
+                        owner,
+                        repo,
+                        run_id: runId,
+                        headers: { 'x-github-api-version': '2026-03-10' }
+                      }));
+                      break;
+                    } catch (error) {
+                      if (isRetryableWorkflowRunReadError(error) &&
+                          attempt < dispatchRunValidationMaxAttempts) {
+                        await sleep(dispatchRunValidationPollDelayMs);
+                        continue;
+                      }
+                      throw dispatchUncertainty(
+                        `${workflowFile} returned run ${runId}, but the exact workflow run could not be validated.`,
+                        error
+                      );
+                    }
+                  }
+
+                  const expectedPath = `.github/workflows/${workflowFile}`;
+                  const runPath = (run?.path || '').split('@')[0];
+                  if (run?.id !== runId ||
+                      run?.event !== 'workflow_dispatch' ||
+                      run?.head_sha !== pr.head.sha ||
+                      runPath !== expectedPath) {
+                    throw dispatchUncertainty(
+                      `${workflowFile} returned run did not match the expected workflow and head.`
+                    );
                   }
                   return {
                     file: workflowFile,
@@ -710,24 +901,37 @@ jobs:
                   };
                 };
 
+                let response;
+                let usedLegacyInputsFallback = false;
                 try {
-                  const response = await github.rest.actions.createWorkflowDispatch(
+                  response = await github.rest.actions.createWorkflowDispatch(
                     dispatchOptions(workflowInputs)
                   );
-                  return dispatchedWorkflow(response, false);
                 } catch (error) {
                   if (!isUnexpectedInputError(error)) {
-                    throw error;
+                    throw dispatchUncertainty(
+                      `${workflowFile} dispatch result is UNKNOWN: ${error.message || error}`,
+                      error
+                    );
                   }
 
                   core.warning(
                     `${workflowFile} rejected PR base context inputs; retrying with legacy workflow_dispatch inputs.`
                   );
-                  const response = await github.rest.actions.createWorkflowDispatch(
-                    dispatchOptions(legacyCompatibleInputs(workflowInputs))
-                  );
-                  return dispatchedWorkflow(response, true);
+                  usedLegacyInputsFallback = true;
+                  try {
+                    response = await github.rest.actions.createWorkflowDispatch(
+                      dispatchOptions(legacyCompatibleInputs(workflowInputs))
+                    );
+                  } catch (fallbackError) {
+                    throw dispatchUncertainty(
+                      `${workflowFile} legacy dispatch result is UNKNOWN: ${fallbackError.message || fallbackError}`,
+                      fallbackError
+                    );
+                  }
                 }
+
+                return dispatchedWorkflow(response, usedLegacyInputsFallback);
               }
 
               const dispatchResults = await Promise.allSettled(
@@ -745,7 +949,9 @@ jobs:
                 } else {
                   failed.push({
                     workflow: workflowsToDispatch[index][0],
-                    error: result.reason?.message || String(result.reason)
+                    workflowFile: workflowsToDispatch[index][1],
+                    error: result.reason?.message || String(result.reason),
+                    dispatchUncertain: result.reason?.dispatchUncertain === true
                   });
                 }
               }
@@ -753,8 +959,7 @@ jobs:
               let labelAdded = false;
               let forceFullLabelAdded = false;
               let labelMessageOverride = '';
-              const requestedCoverageSatisfied = coveredWorkflows.length + succeeded.length === workflows.length;
-              if (requestedCoverageSatisfied && failed.length === 0) {
+              if (failed.length === 0) {
                 const labelControlCommands = [
                   '+ci-stop-hosted',
                   '+ci-skip-hosted',
@@ -806,12 +1011,16 @@ jobs:
               const failedList = failed.length > 0
                 ? `\n\nFailed:\n${failed.map((failure) => `- ${failure.workflow}: ${failure.error}`).join('\n')}`
                 : '';
+              const uncertainWorkflows = failed
+                .filter((failure) => failure.dispatchUncertain)
+                .map((failure) => failure.workflowFile);
+              const dispatchIsUncertain = uncertainWorkflows.length > 0;
               const fallbackCount = succeeded.filter((workflow) => workflow.usedLegacyInputsFallback).length;
               const fallbackMessage = fallbackCount > 0
                 ? `Retried ${fallbackCount} workflow(s) without PR base context inputs because the PR branch has older workflow files.`
                 : '';
               const dependabotTrustProof = pr.user?.login === 'dependabot[bot]' &&
-                succeeded.length === 0 && coveredWorkflows.length > 0
+                succeeded.length === 0 && coveredWorkflows.length > 0 && failed.length === 0
                 ? `Trusted dispatch proof retained: Triggered ${coveredWorkflows.length} workflow(s) for ` +
                   `\`${pr.head.sha.slice(0, 12)}\` by current-base prior requests.`
                 : '';
@@ -822,10 +1031,24 @@ jobs:
                   : succeeded.length > 0
                     ? 'The workflows were triggered, but the hosted CI labels were not added. See the failure details below.'
                   : 'Hosted CI labels were not added because no workflows were triggered.');
-
-              await postComment([
-                forceFull ? '## Force-Full Hosted CI Requested' : '## Hosted CI Requested',
-                coverageProofMarker({
+              const resultMarker = dispatchIsUncertain
+                ? coverageMarker({
+                  head_sha: pr.head.sha,
+                  pull_request_number: issueNumber,
+                  base_ref: pr.base.ref,
+                  base_sha: pr.base.sha,
+                  requested_mode: forceFull ? 'force-full' : 'optimized',
+                  requested_at: commentCreatedAt,
+                  coverage_status: 'UNKNOWN',
+                  dispatch_uncertain: true,
+                  uncertain_workflows: uncertainWorkflows,
+                  workflows: [],
+                  run_ids: {},
+                  reused: [],
+                  observed: coverage.workflows,
+                  dispatched: []
+                })
+                : coverageProofMarker({
                   baseRef: pr.base.ref,
                   baseSha: pr.base.sha,
                   headSha: pr.head.sha,
@@ -837,9 +1060,17 @@ jobs:
                   reused: coveredWorkflows.map(([, workflowFile]) => workflowFile),
                   observed: coverage.workflows,
                   dispatched: succeeded.map((workflow) => workflow.file)
-                }),
+                });
+
+              await postComment([
+                dispatchIsUncertain
+                  ? '## Hosted CI Dispatch UNKNOWN'
+                  : forceFull ? '## Force-Full Hosted CI Requested' : '## Hosted CI Requested',
+                resultMarker,
                 '',
-                `Triggered ${succeeded.length} workflow(s) for \`${pr.head.sha.slice(0, 12)}\`.`,
+                dispatchIsUncertain
+                  ? `Dispatch outcome is UNKNOWN for ${uncertainWorkflows.length} workflow(s); no exact-head dispatch proof was recorded.`
+                  : `Triggered ${succeeded.length} workflow(s) for \`${pr.head.sha.slice(0, 12)}\`.`,
                 `Skipped ${coveredWorkflows.length} workflow(s) with equivalent exact-head coverage.`,
                 ...(dependabotTrustProof ? [dependabotTrustProof] : []),
                 forceFull

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -837,6 +837,14 @@ jobs:
                 return error;
               }
 
+              function classifyDispatchFailure(error, unknownMessage) {
+                if (Number.isInteger(error?.status) && error.status >= 400 && error.status <= 499) {
+                  return error;
+                }
+
+                return dispatchUncertainty(unknownMessage, error);
+              }
+
               function isRetryableWorkflowRunReadError(error) {
                 return error?.status === 404 || (error?.status >= 500 && error?.status <= 599);
               }
@@ -907,9 +915,9 @@ jobs:
                   );
                 } catch (error) {
                   if (!isUnexpectedInputError(error)) {
-                    throw dispatchUncertainty(
-                      `${workflowFile} dispatch result is UNKNOWN: ${error.message || error}`,
-                      error
+                    throw classifyDispatchFailure(
+                      error,
+                      `${workflowFile} dispatch result is UNKNOWN: ${error.message || error}`
                     );
                   }
 
@@ -922,9 +930,9 @@ jobs:
                       dispatchOptions(legacyCompatibleInputs(workflowInputs))
                     );
                   } catch (fallbackError) {
-                    throw dispatchUncertainty(
-                      `${workflowFile} legacy dispatch result is UNKNOWN: ${fallbackError.message || fallbackError}`,
-                      fallbackError
+                    throw classifyDispatchFailure(
+                      fallbackError,
+                      `${workflowFile} legacy dispatch result is UNKNOWN: ${fallbackError.message || fallbackError}`
                     );
                   }
                 }

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -42,6 +42,7 @@ jobs:
             const ciCommandSerializationVisibilityDelayMs = 5000;
             const ciCommandSerializationPollDelayMs = 5000;
             const ciCommandSerializationMaxAttempts = 12;
+            const ciCommandSerializationLookbackMs = 24 * 60 * 60 * 1000;
             const dispatchRunVisibilityGraceMs = 2 * 60 * 1000;
             const dispatchRunValidationPollDelayMs = 2000;
             const dispatchRunValidationMaxAttempts = 3;
@@ -567,6 +568,8 @@ jobs:
                 return { status: 'UNKNOWN', reason: 'Current CI Commands workflow run ID is unavailable.' };
               }
 
+              const createdLowerBound =
+                `>=${new Date(Date.now() - ciCommandSerializationLookbackMs).toISOString()}`;
               await sleep(ciCommandSerializationVisibilityDelayMs);
               for (let attempt = 1; attempt <= ciCommandSerializationMaxAttempts; attempt += 1) {
                 let runs;
@@ -576,6 +579,7 @@ jobs:
                     repo,
                     workflow_id: 'ci-commands.yml',
                     event: 'issue_comment',
+                    created: createdLowerBound,
                     per_page: 100
                   });
                 } catch (error) {

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -1211,9 +1211,16 @@ jobs:
                 counts[workflow.state] += 1;
                 return counts;
               }, { successful: 0, pending: 0, failed: 0, missing: 0 });
+              const coverageModeCounts = coverage.workflows.reduce((counts, workflow) => {
+                counts[workflow.mode] = (counts[workflow.mode] || 0) + 1;
+                return counts;
+              }, {});
+              const coverageModeSummary = Object.entries(coverageModeCounts)
+                .map(([mode, count]) => `${mode}=${count}`)
+                .join(', ');
               const observedCoverage = coverage.status === 'UNKNOWN'
                 ? 'UNKNOWN'
-                : `${automaticReleaseTarget ? 'release-full' : 'optimized'}; ` +
+                : `modes[${coverageModeSummary}]; ` +
                   `successful=${coverageCounts.successful}, pending=${coverageCounts.pending}, ` +
                   `failed=${coverageCounts.failed}, missing=${coverageCounts.missing}`;
 

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -79,6 +79,7 @@ jobs:
           bash script/ci-required-hosted-gate-test.bash
           bash script/lint-mirrored-blocks-test.bash
           ruby script/ci_required_merge_group_gate_test.rb
+          node --test .github/workflows/ci-commands.test.cjs
           node .github/workflows/hosted-ci-safety.test.cjs
           ruby script/pr_merge_ledger_test.rb
           ruby .agents/skills/pr-batch/bin/pr-ci-readiness-test.rb

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -73,6 +73,17 @@ const claudeWorkflow = read('.github/workflows/claude.yml');
 const shakaperfReleaseGateWorkflow = read('.github/workflows/shakaperf-release-gates.yml');
 const rspackViteDxWorkflow = read('.github/workflows/rspack-vite-dx.yml');
 const gemTestsWorkflow = read('.github/workflows/gem-tests.yml');
+const hostedWorkflowFiles = [
+  'lint-js-and-ruby.yml',
+  'package-js-tests.yml',
+  'gem-tests.yml',
+  'integration-tests.yml',
+  'precompile-check.yml',
+  'examples.yml',
+  'playwright.yml',
+  'pro-integration-tests.yml',
+  'pro-test-package-and-gem.yml',
+];
 
 assertMatches(
   'hosted-ci-label-dispatch trigger',
@@ -170,6 +181,21 @@ assertMatches(
   /const isTrustedReleaseTarget = isReleaseTarget[\s\S]*!isDependabotPullRequest \|\| trustedDependabotHostedRequest/,
 );
 assertMatches('Dependabot trusted-dispatch retry', hostedSelectorsAction, /const maxAttempts = 4/);
+assertMatches(
+  'release-target full-matrix selector contract',
+  hostedSelectorsAction,
+  /shouldUseFullMatrix = [\s\S]*isTrustedReleaseTarget/,
+);
+for (const workflowFile of hostedWorkflowFiles) {
+  const workflow = read(`.github/workflows/${workflowFile}`);
+  assertMatches(`${workflowFile} pull-request trigger`, workflow, /\n\s{2}pull_request:/);
+  assertMatches(
+    `${workflowFile} hosted selector`,
+    workflow,
+    /uses: \.\/\.github\/actions\/hosted-ci-selectors/,
+  );
+  assertMatches(`${workflowFile} hosted gate`, workflow, /should_run_hosted_ci/);
+}
 
 assertMatches(
   'gem generator-spec detector output',


### PR DESCRIPTION
## Why

Release-target and manually requested hosted CI can currently duplicate work or incorrectly reuse exact-head workflow shells. The old evidence is not strong enough to distinguish detector-only runs, stale PR bases, Dependabot trust transitions, or overlapping optimized and force-full requests.

## What changed

- binds reusable hosted coverage to the exact PR number, head SHA, base ref, and base SHA
- records the exact workflow run IDs returned by GitHub for each successful dispatch
- coordinates start commands against older visible active `CI Commands` runs to prevent routine concurrent double-dispatch
- excludes detector-only pull-request workflow shells from hosted coverage
- keeps optimized and force-full coverage separate and idempotent
- preserves trusted nonzero proof for repeated Dependabot commands
- revalidates the PR head and base immediately before dispatch or label mutation
- validates every returned run ID against the requested workflow, event, and exact head after bounded visibility retries
- creates a durable head/base-bound UNKNOWN anchor before dispatch, then replaces it with exact proof; persistent final-update failures remain fail-closed
- anchors machine-marker parsing to explicit CR/LF boundaries and sanitizes all JavaScript line terminators so echoed free text cannot forge proof or UNKNOWN state
- reconciles an ambiguously persisted pre-dispatch anchor by source comment/run identity and retries no-dispatch audit comments
- revalidates the complete PR snapshot after anchoring and replaces the anchor without dispatch if the head or base moved
- records each legacy fallback workflow's effective optimized/force-full mode for correct reuse
- rejects manual workflow reruns before dispatch because retained run IDs cannot safely order a new attempt; operators must post a new command
- timestamps successful proof creation after dispatch processing so queued commands retain the full exact-run visibility grace; small future clock skew is clamped safely
- persists a head-bound UNKNOWN marker when dispatch succeeds without readable run evidence, preventing blind redispatch
- treats definitive GitHub 4xx dispatch rejections as ordinary failures so later commands can retry only the rejected workflow; transport and 5xx outcomes remain durable UNKNOWN
- reports status mode counts from the actual per-workflow evidence instead of inferring a single mode from the PR target
- adds contract coverage for release targets, stale bases, same-second ordering, concurrent commands, mutable PRs, missing/deleted runs, Dependabot, and UNKNOWN behavior

## Workflow Change Audit

- Triggers: `issue_comment` remains unchanged
- Permissions: unchanged (`actions: write`, `contents: read`, `issues: write`, `pull-requests: write`)
- Secrets: none added or changed
- Third-party actions: unchanged (`actions/github-script@v9`)
- Concurrency: remains per triggering comment so GitHub does not discard queued commands; start commands additionally wait for older visible active `CI Commands` runs repository-wide with bounded, fail-closed polling (about 65 seconds maximum including visibility delay and API latency), querying only a stable 24-hour run window on every poll. This is visibility-based coordination, not an atomic lock; rare Actions list lag can still duplicate work, while exact run/head/mode validation prevents proof misattribution. Manual rerun attempts fail closed and require a new comment/run ID.
- Dispatch API: explicitly requests GitHub REST API `2026-03-10`, requires HTTP 200 plus a positive `workflow_run_id`, and rejects missing or mismatched run evidence
- Required gate: recognizes exact-head hosted coverage while retaining fail-closed UNKNOWN behavior
- Recovery: an ambiguous dispatch intentionally blocks same-head guesses; after inspecting/cancelling or completing any uncertain exact-head runs, push a new head before retrying

## Verification

- `node --test .github/workflows/ci-commands.test.cjs` — 49/49 passed
- `node .github/workflows/hosted-ci-safety.test.cjs`
- `actionlint .github/workflows/ci-commands.yml .github/workflows/ci-required.yml`
- YAML safe-load, focused ESLint, Prettier, CI detector, and `git diff --check`
- CI-equivalent OSS RuboCop — 237 files, 0 offenses
- independent immutable implementation-head review — PASS with no P0-P2 finding; high confidence
- branch refreshed to `main@6325e108` without overlap or PR-diff change; the focused contracts and all cheap static gates passed again on the merge head
- repeated live API evidence for the serialization query — unfiltered 35.26/34.35/31.46 s (median 34.35) versus 24-hour-filtered 7.62/6.79/7.00 s (median 7.00); result surface 7,746 versus 203 runs
- current-head automatic force-full hosted suite — green at `b55f7371f5aa41d9870a79b75227600e8661a0f3`; the gem run [29510069007](https://github.com/shakacode/react_on_rails/actions/runs/29510069007) completed all four unit/generator and latest/minimum matrix rows
- `pr-ci-readiness` — `READY`, with zero failing or pending checks
- strict merge ledger — `complete_allowed: true`, zero unresolved threads, all six P2 findings fixed with evidence, zero violations, and zero `UNKNOWN` fields

An earlier broad fast validation run passed dependency setup, docs checks, OSS and benchmark RuboCop, then was intentionally capped during the package-build tail. The latest additive fast-validator attempt was resource-blocked during dependency prepare when `tsc` received SIGKILL/exit 137, before validation checks; the focused workflow contracts and static gates above are green. Independent `gpt-5.6-sol/xhigh` commit reviews found the Unicode-marker, ambiguous-anchor, retry, and post-anchor snapshot races now covered by regression tests. The final immutable-head retry was blocked by the separate Codex CLI credit limit and is conservatively UNKNOWN; current-head hosted CI and configured review agents remain required.

The final pre-merge `+ci-status` command was control evidence from the default-branch implementation, not an exercise of this unmerged workflow. A new `+ci-force-full` command was intentionally not posted because the exact-head automatic force-full suite above was already running and the default-branch command would only duplicate all nine workflows. The post-merge exercise below is the authoritative secondary-event replay of the new command implementation.

GitHub documents the 2026-03-10 response change in the [REST API breaking changes](https://docs.github.com/en/rest/about-the-rest-api/breaking-changes?apiVersion=2026-03-10#changes-to-create-a-workflow-dispatch-event).

## Post-merge exercise

Issue #4682 remains open as the required semantic-workflow tracker. After merge, disposable verification PRs will exercise release-target optimized and force-full commands, repeated idempotent requests, current-head rollover, Dependabot trust, and failure/cancel/UNKNOWN handling before cleanup.

No changelog entry: this changes maintainer CI orchestration, not shipped product behavior.

Relates to #4682.
