### PR TITLE
Fix html_options hash mutation causing FrozenError and state leaks

### DIFF
--- a/react_on_rails/lib/react_on_rails/react_component/render_options.rb
+++ b/react_on_rails/lib/react_on_rails/react_component/render_options.rb
@@ -123,7 +123,7 @@ module ReactOnRails
       end
 
       def html_options
-        options[:html_options].to_h
+        options[:html_options].to_h.dup
       end
 
       def prerender

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -799,6 +799,7 @@ describe ReactOnRailsHelper do
     it "does not leak state into a reused html_options hash across calls" do
       shared_opts = { class: "widget", tag: "span" }
       react_component("App", html_options: shared_opts)
+      react_component("App", html_options: shared_opts)
       expect(shared_opts).to eq({ class: "widget", tag: "span" })
     end
 

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -788,6 +788,20 @@ describe ReactOnRailsHelper do
       it { is_expected.to include '<div id="App-react-component-0"></div>' }
     end
 
+    it "does not mutate a frozen html_options hash" do
+      frozen_opts = { class: "widget", tag: "span" }.freeze
+      expect do
+        react_component("App", html_options: frozen_opts)
+      end.not_to raise_error
+      expect(frozen_opts).to eq({ class: "widget", tag: "span" })
+    end
+
+    it "does not leak state into a reused html_options hash across calls" do
+      shared_opts = { class: "widget", tag: "span" }
+      react_component("App", html_options: shared_opts)
+      expect(shared_opts).to eq({ class: "widget", tag: "span" })
+    end
+
     describe "Pro inline hydration script" do
       let(:hydration_script) do
         %(typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('App-react-component-0');)
@@ -853,6 +867,14 @@ describe ReactOnRailsHelper do
       react_component_hash("App", props:, immediate_hydration: false)
 
       expect(Rails.logger).to have_received(:warn).once.with(include("immediate_hydration"))
+    end
+
+    it "does not mutate a frozen html_options hash" do
+      frozen_opts = { class: "widget" }.freeze
+      expect do
+        react_component_hash("App", props:, html_options: frozen_opts)
+      end.not_to raise_error
+      expect(frozen_opts).to eq({ class: "widget" })
     end
   end
 

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -877,6 +877,13 @@ describe ReactOnRailsHelper do
       end.not_to raise_error
       expect(frozen_opts).to eq({ class: "widget" })
     end
+
+    it "does not leak state into a reused html_options hash across calls" do
+      shared_opts = { class: "widget" }
+      react_component_hash("App", props:, html_options: shared_opts)
+      react_component_hash("App", props:, html_options: shared_opts)
+      expect(shared_opts).to eq({ class: "widget" })
+    end
   end
 
   describe "#create_render_options" do


### PR DESCRIPTION
## Summary

Fixes #4582.

- `RenderOptions#html_options` returned the caller's exact `Hash` instance (`Hash#to_h` returns `self` for plain Hashes). Callers in `helper.rb` then mutated it (`delete(:tag)`, `[:id]=`), which crashed on frozen hashes (`FrozenError`) and leaked state into reused ones.
- Return `.to_h.dup` so callers always get a safe, mutable copy.

## Test plan

- [x] Added regression test: `react_component` with a frozen `html_options` hash — no `FrozenError`
- [x] Added regression test: `react_component` with a reused `html_options` hash — no state leakage (`:tag` not deleted, `:id` not injected into the original)
- [x] Added regression test: `react_component_hash` with a frozen `html_options` hash — no `FrozenError`
- [x] All 3 new tests pass; all 32 `RenderOptions` unit tests pass; full helper spec suite shows no regressions from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented `html_options` passed to rendered React components from being unintentionally mutated.
  * Avoided state leakage when the same `html_options` hash is reused across multiple renders.
* **Tests**
  * Added regression coverage to confirm behavior with both mutable and frozen `html_options`, ensuring no errors and no cross-call side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->