### PR TITLE
Docs: make fleet validation parallel and repeatable

### DIFF
--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: run-fleet-validation
+description: Generate and coordinate parallel React on Rails release fleet validation from internal/contributor-info/demo-fleet.yml. Use when a maintainer wants to validate the latest RC or beta, split fleet work across machines or agent sessions, inspect fleet progress, or prepare repeatable per-lane prompts without hand-partitioning repositories.
+---
+
+# Run Fleet Validation
+
+Generate the prompt pack from the manifest instead of copying repository lists into ad hoc prompts.
+
+## Generate the lanes
+
+From the React on Rails repository root, run:
+
+```bash
+ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
+  --machines local,m1 \
+  --prompts 6 \
+  --output-dir tmp/fleet-validation-prompts
+```
+
+Keep the default release selector, `latest RC or beta`, for a new validation run. Pass
+`--release vX.Y.Z.rc.N` only for a rerun that must stay pinned to an older candidate.
+
+The generator reads only `tier: hard_gate` repositories, adds the monorepo generator/install
+gate required by `internal/contributor-info/rc-testing-plan.md`, balances weighted lanes across
+the named machines, and includes effective commands after manifest defaults are applied. It also
+creates a unique pack ID. Every replacement candidate needs a freshly generated pack and ID; pass
+`--pack-id ID` only when regenerating files for the same exact candidate run.
+
+## Launch and coordinate
+
+1. Read `tmp/fleet-validation-prompts/INDEX.md`.
+2. Start all prompt files simultaneously, three per machine for the default six-prompt/two-machine
+   layout. Prompt 1 publishes the exact candidate/RSC snapshot for the pack; the other five wait
+   for that marker before mutating anything. Each prompt is a separate top-level coordinator task
+   and must use its bounded subagents as written. Do not launch the six prompts as children of one
+   shared four-slot agent tree.
+3. Keep each lane in a separate checkout or worktree. Do not share mutable app checkouts between
+   lanes.
+4. Let lane coordinators create or update bump PRs and post idempotent evidence comments, but do
+   not let them merge or make the final release decision.
+5. Require an authoritative coordination claim for every mutable app target before its execution
+   subagent starts. A status read is not a lock. A refused claim or unknown claim outcome is
+   non-passing and must not produce a competing worktree or branch. Reuse live candidate ownership
+   first; generated fallback claim targets are only for genuinely fresh lanes and are stable by
+   resolved candidate plus repository so separately generated packs cannot race.
+6. Treat the release tracking issue plus its newest candidate-specific comments as the public
+   source of truth. The issue body can describe an earlier candidate in the same release cycle;
+   do not mistake that for the current candidate when a newer explicit RC section exists. A hard
+   gate remains pending until it has exact install, build, test, smoke, and required-CI evidence,
+   or an explicit waiver allowed by the RC plan.
+7. Generate a fresh pack for every replacement candidate, even when the manifest is unchanged.
+   Never reuse old prompt files or their snapshot marker for a new RC/beta. Within one exact
+   candidate run, re-run only affected lanes and preserve that pack ID.
+
+## Report status
+
+When asked what remains, inspect the current release-gate tracking issue and linked PRs before
+reporting. Classify every hard gate as `passed`, `blocked`, `pending`, or `unknown`:
+
+- `blocked`: a confirmed candidate regression or non-waivable failed gate
+- `pending`: work or required evidence is explicitly incomplete
+- `unknown`: evidence cannot be reached or is stale
+- `passed`: all required evidence is current for the resolved candidate
+
+Never infer a pass from an open PR or a green subset of checks. Keep private HiChee details out of
+public output; report only the high-level verdict, tester, date, and public issue link when one
+exists.
+
+## Validate changes to this skill
+
+Run both checks after changing the generator or prompt contract:
+
+```bash
+ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+python3 "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" \
+  .agents/skills/run-fleet-validation
+```

--- a/.agents/skills/run-fleet-validation/agents/openai.yaml
+++ b/.agents/skills/run-fleet-validation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run Fleet Validation"
+  short_description: "Generate parallel release fleet validation lanes"
+  default_prompt: "Use $run-fleet-validation to generate and coordinate the latest RC or beta fleet-validation prompts."

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -97,6 +97,8 @@ module FleetValidation
     def validate_options!
       raise ManifestError, "schema_version must be 1" unless @manifest["schema_version"] == 1
       raise ManifestError, "repos must be an array" unless @manifest["repos"].is_a?(Array)
+
+      validate_repo_entries!
       raise ManifestError, "--prompts must be positive" unless @prompt_count.positive?
       raise ManifestError, "--machines must name at least one machine" if @machines.empty?
       raise ManifestError, "--machines cannot exceed --prompts" if @machines.length > @prompt_count
@@ -115,6 +117,52 @@ module FleetValidation
       return if @prompt_count <= target_count
 
       raise ManifestError, "--prompts #{@prompt_count} exceeds #{target_count} available hard-gate targets"
+    end
+
+    def validate_repo_entries!
+      defaults = @manifest.fetch("defaults", {})
+      raise ManifestError, "defaults must be a mapping" unless defaults.is_a?(Hash)
+
+      @manifest.fetch("repos").each_with_index do |repo, index|
+        raise ManifestError, "repos[#{index}] must be a mapping" unless repo.is_a?(Hash)
+
+        next unless repo["tier"] == "hard_gate"
+
+        validate_hard_gate_repo!(defaults.merge(repo), index)
+      end
+    end
+
+    def validate_hard_gate_repo!(repo, index)
+      %w[name headline package_manager ruby_test build].each do |field|
+        value = repo[field]
+        if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          raise ManifestError, "repos[#{index}] hard gate is missing #{field}"
+        end
+        next if value.is_a?(String)
+
+        raise ManifestError, "repos[#{index}] hard gate #{field} must be a string"
+      end
+      unless [true, false].include?(repo["needs_pro"])
+        raise ManifestError, "repos[#{index}] hard gate needs_pro must be true or false"
+      end
+
+      validate_repo_collection!(repo, index, "packages")
+      validate_repo_collection!(repo, index, "smoke")
+      unless repo.fetch("smoke").all? { |path| path.is_a?(String) && !path.empty? }
+        raise ManifestError, "repos[#{index}] hard gate smoke entries must be non-empty strings"
+      end
+
+      repo.fetch("packages").each_with_index do |package, package_index|
+        unless package.is_a?(Hash) && package["ecosystem"].to_s != "" && package["name"].to_s != ""
+          raise ManifestError, "repos[#{index}].packages[#{package_index}] must name an ecosystem and package"
+        end
+      end
+    end
+
+    def validate_repo_collection!(repo, index, field)
+      return if repo[field].is_a?(Array)
+
+      raise ManifestError, "repos[#{index}] hard gate #{field} must be an array"
     end
 
     def build_targets
@@ -245,10 +293,11 @@ module FleetValidation
            template literally. Heartbeat successful claims at phase transitions.
         3. Concurrently spawn one execution subagent for the assigned monorepo generator/install gate,
            if present, plus one per successfully claimed app target (maximum #{targets.length} here). The
-           monorepo worker needs no app claim and runs the three exact commands in its own clean checkout
-           at the resolved tag. Every app worker uses its own scratch clone/worktree, validates or updates
-           the existing release bump, runs the effective install/build/test/smoke ladder, and prepares
-           exact public-safe evidence. Child agents must not spawn more agents.
+           monorepo worker needs no app claim and runs the local checkout commands plus the published
+           three-mode matrix in an isolated scratch directory. Every app worker uses its own scratch
+           clone/worktree, validates or updates the existing release bump, runs the effective
+           install/build/test/smoke ladder, and prepares exact public-safe evidence.
+           Child agents must not spawn more agents.
         4. As coordinator, reconcile their reports against live current-head state. Re-run cheap checks
            needed to resolve disagreement. Never convert missing evidence into a pass.
 
@@ -318,10 +367,19 @@ module FleetValidation
     def render_core_target(target)
       <<~TARGET.chomp
         - #{target.fetch('name')} — #{target.fetch('headline')}
-          In a clean checkout at the resolved tag, run exactly:
+          In a clean checkout at the resolved tag, run the local generator/build smoke:
           `(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)`
           `pnpm run build`
           `CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`
+          Then, in a separate scratch directory with no local package or gem overrides, replace
+          `RESOLVED_NPM_VERSION` with the exact normalized candidate version and run the published matrix:
+          `npx --yes create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-standard --standard`
+          `npx --yes create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-pro`
+          `npx --yes create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-rsc --rsc`
+          Never submit the placeholder literally. Install/build/smoke all three generated apps. Assert the
+          standard app is core-only, the default app has working Pro SSR without RSC, and the RSC app is
+          streamed and interactive. Verify exact candidate gem/npm locks in every applicable app and the
+          independently resolved RSC version only in the RSC app. Keep Pro/RSC logs private.
           This gate is validation-only. Do not create a branch or PR, and do not substitute fleet app CI.
       TARGET
     end

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -1,0 +1,469 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "optparse"
+require "securerandom"
+require "yaml"
+
+module FleetValidation
+  CORE_GATE = {
+    "name" => "react_on_rails generator/install smoke",
+    "headline" => "Monorepo generator and install smoke",
+    "kind" => "core",
+    "weight" => 5
+  }.freeze
+
+  class ManifestError < StandardError; end
+
+  class Generator
+    attr_reader :assignments
+
+    def initialize(manifest_path:, prompt_count:, machines:, release_selector:, pack_id: nil)
+      @manifest_path = manifest_path
+      @prompt_count = prompt_count
+      @machines = machines
+      @release_selector = release_selector
+      @pack_id = pack_id || default_pack_id
+      @manifest = load_manifest
+      validate_options!
+      @targets = build_targets
+      validate_target_ids!
+      @assignments = assign_machines(build_lanes)
+    end
+
+    def render_pack
+      sections = ordered_assignments.map.with_index(1) do |assignment, index|
+        <<~MARKDOWN
+          ## Prompt #{index} — #{assignment.fetch(:machine)}
+
+          ```text
+          #{render_prompt(assignment, index).rstrip}
+          ```
+        MARKDOWN
+      end
+
+      <<~MARKDOWN
+        # Fleet validation prompt pack
+
+        Pack ID: #{@pack_id}
+        Release selector: #{@release_selector}
+        Manifest: #{@manifest_path}
+        Layout: #{@prompt_count} simultaneous prompts across #{@machines.length} machines
+
+        #{machine_summary}
+
+        #{sections.join("\n")}
+      MARKDOWN
+    end
+
+    def write_pack(output_dir)
+      FileUtils.mkdir_p(output_dir)
+      clear_generated_prompts(output_dir)
+      rendered_prompts = []
+
+      ordered_assignments.each_with_index do |assignment, offset|
+        number = offset + 1
+        machine_slug = slug(assignment.fetch(:machine))
+        directory = File.join(output_dir, machine_slug)
+        FileUtils.mkdir_p(directory)
+        filename = format("%02d-fleet-lane.md", number)
+        relative_path = File.join(machine_slug, filename)
+        File.write(File.join(output_dir, relative_path), render_prompt(assignment, number))
+        rendered_prompts << [assignment.fetch(:machine), relative_path, assignment]
+      end
+
+      File.write(File.join(output_dir, "INDEX.md"), render_index(rendered_prompts))
+    end
+
+    private
+
+    def clear_generated_prompts(output_dir)
+      pattern = File.join(output_dir, "*", "*-fleet-lane.md")
+      FileUtils.rm_f(Dir.glob(pattern))
+    end
+
+    def load_manifest
+      manifest = YAML.safe_load_file(@manifest_path, permitted_classes: [], permitted_symbols: [], aliases: false)
+      raise ManifestError, "manifest root must be a mapping" unless manifest.is_a?(Hash)
+
+      manifest
+    rescue Errno::ENOENT
+      raise ManifestError, "manifest not found: #{@manifest_path}"
+    rescue Psych::Exception => e
+      raise ManifestError, "invalid manifest YAML: #{e.message}"
+    end
+
+    def validate_options!
+      raise ManifestError, "schema_version must be 1" unless @manifest["schema_version"] == 1
+      raise ManifestError, "repos must be an array" unless @manifest["repos"].is_a?(Array)
+      raise ManifestError, "--prompts must be positive" unless @prompt_count.positive?
+      raise ManifestError, "--machines must name at least one machine" if @machines.empty?
+      raise ManifestError, "--machines cannot exceed --prompts" if @machines.length > @prompt_count
+      raise ManifestError, "machine names must be unique" unless @machines.uniq.length == @machines.length
+      raise ManifestError, "machine names must have non-empty path slugs" if @machines.any? { |name| slug(name).empty? }
+      raise ManifestError, "machine names must have unique path slugs" unless @machines.map { |name| slug(name) }.uniq.length == @machines.length
+      unless @pack_id.match?(/\A[a-z0-9][a-z0-9._-]*\z/i)
+        raise ManifestError, "pack ID must contain only letters, digits, dots, underscores, and hyphens"
+      end
+
+      target_count = @manifest["repos"].count { |repo| repo["tier"] == "hard_gate" } + 1
+      minimum_prompts = (target_count.to_f / 2).ceil
+      if @prompt_count < minimum_prompts
+        raise ManifestError, "--prompts must be at least #{minimum_prompts} to keep at most two targets per lane"
+      end
+      return if @prompt_count <= target_count
+
+      raise ManifestError, "--prompts #{@prompt_count} exceeds #{target_count} available hard-gate targets"
+    end
+
+    def build_targets
+      defaults = @manifest.fetch("defaults", {})
+      repos = @manifest.fetch("repos").select { |repo| repo["tier"] == "hard_gate" }
+      [CORE_GATE] + repos.map { |repo| effective_repo(defaults, repo) }
+    end
+
+    def validate_target_ids!
+      ids = @targets.map { |target| stable_target_id(target) }
+      duplicates = ids.tally.select { |_id, count| count > 1 }.keys
+      return if duplicates.empty?
+
+      raise ManifestError, "target names must have unique stable IDs: #{duplicates.join(', ')}"
+    end
+
+    def effective_repo(defaults, repo)
+      effective = defaults.merge(repo)
+      effective["review_app"] = repo.fetch("review_app", defaults["review_app"])
+      effective["kind"] = "repo"
+      effective["weight"] = repo_weight(effective)
+      effective
+    end
+
+    def repo_weight(repo)
+      weight = 2
+      weight += 2 if repo["needs_pro"]
+      weight += 2 if repo.fetch("name").end_with?("/hichee")
+      weight += 1 if repo.fetch("packages", []).length >= 8
+      weight += 1 if repo["package_manager"].to_s.start_with?("yarn")
+      weight += 1 if repo.fetch("smoke", []).length > 1
+      weight
+    end
+
+    def build_lanes
+      lanes = Array.new(@prompt_count) { { targets: [], weight: 0 } }
+      @targets.sort_by { |target| [-target.fetch("weight"), target.fetch("name")] }.each do |target|
+        eligible_lanes = lanes.select { |item| item.fetch(:targets).length < 2 }
+        lane = eligible_lanes.min_by { |item| [item.fetch(:weight), item.fetch(:targets).length] }
+        lane.fetch(:targets) << target
+        lane[:weight] += target.fetch("weight")
+      end
+      lanes
+    end
+
+    def assign_machines(lanes)
+      capacity = (@prompt_count.to_f / @machines.length).ceil
+      machine_state = @machines.to_h { |machine| [machine, { count: 0, weight: 0 }] }
+
+      lanes.sort_by { |lane| -lane.fetch(:weight) }.map do |lane|
+        eligible = @machines.select { |machine| machine_state.fetch(machine).fetch(:count) < capacity }
+        machine = eligible.min_by do |candidate|
+          state = machine_state.fetch(candidate)
+          [state.fetch(:weight), state.fetch(:count), @machines.index(candidate)]
+        end
+        state = machine_state.fetch(machine)
+        state[:count] += 1
+        state[:weight] += lane.fetch(:weight)
+        lane.merge(machine:)
+      end
+    end
+
+    def ordered_assignments
+      assignments.sort_by do |assignment|
+        [@machines.index(assignment.fetch(:machine)), -assignment.fetch(:weight)]
+      end
+    end
+
+    def machine_summary
+      rows = ordered_assignments.group_by { |assignment| assignment.fetch(:machine) }.map do |machine, lanes|
+        targets = lanes.flat_map { |lane| lane.fetch(:targets).map { |target| target.fetch("name") } }
+        "- #{machine}: #{lanes.length} prompts; #{targets.join(', ')}"
+      end
+      (["## Machine allocation", ""] + rows).join("\n")
+    end
+
+    def render_index(rendered_prompts)
+      rows = rendered_prompts.map do |machine, path, assignment|
+        targets = assignment.fetch(:targets).map { |target| target.fetch("name") }.join("; ")
+        "| #{machine} | [#{File.basename(path)}](#{path}) | #{targets} |"
+      end
+
+      <<~MARKDOWN
+        # Fleet validation launch index
+
+        Start all #{@prompt_count} prompts simultaneously. This layout runs at most
+        #{(@prompt_count.to_f / @machines.length).ceil} prompts on one machine; use the exact allocation
+        below. Do not share mutable app checkouts between prompts.
+
+        Release selector: #{@release_selector}
+        Pack ID: #{@pack_id}
+
+        | Machine | Prompt | Targets |
+        | --- | --- | --- |
+        #{rows.join("\n")}
+      MARKDOWN
+    end
+
+    def render_prompt(assignment, number)
+      targets = assignment.fetch(:targets)
+      <<~PROMPT
+        You are fleet-validation coordinator #{number} running on #{assignment.fetch(:machine)}.
+        Pack ID: #{@pack_id}
+        Validate the assigned React on Rails release gates for #{@release_selector}. Work autonomously
+        through evidence collection and safe fixes; do not merge or make the final release decision.
+
+        Release resolution:
+        #{candidate_resolution_steps(number)}
+        #{tracker_resolution_steps(number)}
+        #{snapshot_resolution_steps(number)}
+
+        Assigned targets:
+        #{targets.map { |target| render_target(target) }.join("\n")}
+
+        Subagent plan (required):
+        1. Spawn one read-only evidence subagent covering all assigned targets. It must inspect the
+           tracker, targeted coordination state, existing bump PRs, required checks, and repo-local
+           instructions, then return a passed/blocked/pending/unknown matrix with links. It must not edit
+           or post.
+        2. Before starting a mutable app worker, acquire or resume its authoritative `agent-coord` claim
+           under the candidate-specific batch/target recorded in live coordination. If no lane exists for
+           a fresh target, use its generated fallback claim target shown below. Never use the fallback to
+           bypass an active/refused existing claim or completed handoff. Follow
+           `.agents/workflows/pr-processing.md`: targeted status is preflight only; the claim is the
+           compare-and-swap gate. Hard-stop that target on CLAIM_REFUSED. On claim timeout or unknown
+           outcome, report UNKNOWN and do not create a branch/worktree. Resume another owner's work only
+           through an explicit fenced handoff. Replace `RESOLVED_TAG` in a fallback template with the exact
+           tag before status/claim and use the displayed fallback claim repository; never submit the
+           template literally. Heartbeat successful claims at phase transitions.
+        3. Concurrently spawn one execution subagent for the assigned monorepo generator/install gate,
+           if present, plus one per successfully claimed app target (maximum #{targets.length} here). The
+           monorepo worker needs no app claim and runs the three exact commands in its own clean checkout
+           at the resolved tag. Every app worker uses its own scratch clone/worktree, validates or updates
+           the existing release bump, runs the effective install/build/test/smoke ladder, and prepares
+           exact public-safe evidence. Child agents must not spawn more agents.
+        4. As coordinator, reconcile their reports against live current-head state. Re-run cheap checks
+           needed to resolve disagreement. Never convert missing evidence into a pass.
+
+        Execution contract:
+        - Read AGENTS.md and repository-specific instructions before changing any target repo. Treat the
+          manifest commands as starting data; because `verify: true` entries are provisional, confirm
+          commands against the target before running or proposing a manifest correction.
+        - For app targets, reuse or update an existing bump PR for this candidate. If none exists, create
+          a feature branch and PR only after local install/build checks pass. Never push directly to a
+          default branch. The monorepo generator/install gate is read-only validation of published
+          artifacts: do not create a bump branch or PR for it.
+        - Capture dependency install, intentional lockfile diff, build/assets, target tests, required CI,
+          primary route smoke, SSR/hydration, and the target's headline Pro/RSC behavior where applicable.
+          When review-app metadata is null/unverified, derive a repo-owned local boot/smoke command from
+          target docs; do not invent a public deployment URL or claim hosted review-app smoke.
+        - A confirmed candidate regression is BLOCKED and needs a linked issue. Unrelated failures remain
+          PENDING until an allowed tracker waiver exists. Lane 4b artifact defects cannot be waived.
+        - For HiChee or Pro/private material, never paste private logs, URLs, screenshots, credentials, or
+          proprietary diffs. Public evidence is limited to high-level result, tester, date, and public issue.
+        - Post or update one tracker comment per target, using the exact resolved tag plus the stable
+          target ID shown below. The marker format is
+          `<!-- fleet-validation:<resolved-tag>:<stable-target-id> -->`; substitute the actual values and
+          never post the angle-bracket placeholders literally. Do not concurrently rewrite the tracker
+          body.
+
+        Stable evidence IDs:
+        #{targets.map { |target| "- #{target.fetch('name')}: #{stable_target_id(target)}" }.join("\n")}
+
+        Final response:
+        - Resolved release identifiers and tracking issue.
+        - One row per target: PASSED / BLOCKED / PENDING / UNKNOWN, PR, current-head CI, smoke evidence,
+          blocker/waiver link, and next owner/action.
+        - Any manifest fields proven stale, with an exact proposed YAML patch.
+        - A lane verdict. Say explicitly whether this lane blocks promotion; do not infer the whole-fleet
+          go/no-go decision.
+      PROMPT
+    end
+
+    def render_target(target)
+      return render_core_target(target) if target["kind"] == "core"
+
+      packages = target.fetch("packages", []).map do |package|
+        "#{package.fetch('ecosystem')}:#{package.fetch('name')}"
+      end.join(", ")
+      review_app = target["review_app"]
+      review_app_fields = if review_app.is_a?(Hash)
+                            "workflow=#{review_app['workflow'] || 'unverified'}, " \
+                              "status_check=#{review_app['status_check'] || 'unverified'}, " \
+                              "cpflow_app_name=#{review_app['cpflow_app_name'] || 'none/unverified'}"
+                          else
+                            "none/unverified"
+                          end
+
+      <<~TARGET.chomp
+        - #{target.fetch('name')} — #{target.fetch('headline')}
+          packages: #{packages}
+          needs_pro: #{target.fetch('needs_pro')}; package_manager: #{target.fetch('package_manager')}
+          fallback_claim_repo: shakacode/react_on_rails
+          fallback_claim_target_template: adhoc:fleet-RESOLVED_TAG-#{stable_target_id(target)}
+          install: #{install_command(target.fetch('package_manager'))}
+          ruby_test: #{target.fetch('ruby_test')}; js_test: #{target['js_test'] || 'none'}
+          build: #{target.fetch('build')}; smoke: #{target.fetch('smoke', []).join(', ')}
+          review_app: #{review_app_fields}; verify: #{target.fetch('verify', false)}
+      TARGET
+    end
+
+    def render_core_target(target)
+      <<~TARGET.chomp
+        - #{target.fetch('name')} — #{target.fetch('headline')}
+          In a clean checkout at the resolved tag, run exactly:
+          `(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)`
+          `pnpm run build`
+          `CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`
+          This gate is validation-only. Do not create a branch or PR, and do not substitute fleet app CI.
+      TARGET
+    end
+
+    def candidate_resolution_steps(number)
+      return "" unless number == 1
+
+      <<~STEPS.chomp
+        - You are the release-snapshot leader. Resolve #{@release_selector} once from authoritative
+          published `react_on_rails`, `react_on_rails_pro`, `react-on-rails`, `react-on-rails-pro`,
+          `react-on-rails-pro-node-renderer`, and `create-react-on-rails-app` packages plus the matching git
+          tag. Normalize RubyGems/npm RC or beta spelling before comparison and derive the release line from
+          that exact tag before selecting a tracker. Under `shakacode/react_on_rails`, acquire the
+          coordination snapshot claim `adhoc:fleet-snapshot-RESOLVED_TAG` after replacing `RESOLVED_TAG`
+          with the exact tag. Never submit the template literally; a refused claim is a hard stop.
+      STEPS
+    end
+
+    def snapshot_resolution_steps(number)
+      if number == 1
+        <<~STEPS.chomp
+          - Derive the independently released `react-on-rails-rsc` version separately from the tagged
+            product manifests and the release tracker, then verify that exact RSC artifact is published.
+            Never require it to share the React on Rails product version.
+          - Post one tracker snapshot comment marked `<!-- fleet-validation-snapshot:#{@pack_id} -->` with
+            the exact tag, normalized gem/npm product versions, RSC version, commit SHA, and resolution time.
+            Heartbeat/close the snapshot claim only after the public-safe comment is readable.
+        STEPS
+      else
+        <<~STEPS.chomp
+          - Do not select a candidate independently. Wait up to five minutes for the tracker comment marked
+            `<!-- fleet-validation-snapshot:#{@pack_id} -->` from coordinator 1, then use its exact tag,
+            product gem/npm versions, independently versioned RSC pin, and commit SHA for the whole lane.
+            Cross-check those artifacts and tag before mutation. If the snapshot is absent, malformed, or
+            inconsistent, report UNKNOWN and make no writes.
+        STEPS
+      end
+    end
+
+    def tracker_resolution_steps(number)
+      if number != 1
+        <<~STEPS.chomp
+          - Do not choose a release line first. Search the open `Release gate: react_on_rails X.Y.Z`
+            tracker issues for the exact `<!-- fleet-validation-snapshot:#{@pack_id} -->` marker. Wait up
+            to five minutes for one unique match; the issue containing it is this lane's tracker. If the
+            marker is absent or appears in multiple trackers, report UNKNOWN and make no writes.
+        STEPS
+      elsif @release_selector == "latest RC or beta"
+        <<~STEPS.chomp
+          - Find the open `Release gate: react_on_rails X.Y.Z` tracking issue for that release line. Do not
+            create a second tracker. A tracker spans multiple candidates: use its newest explicit RC section
+            or comment and targeted coordination status, not an older version still present in the issue body.
+            If the current candidate has no authoritative entry or live sources conflict, stop writes and
+            report UNKNOWN with evidence.
+        STEPS
+      else
+        <<~STEPS.chomp
+          - Find the open `Release gate: react_on_rails X.Y.Z` tracking issue for the release line containing
+            the pinned #{@release_selector} candidate. Do not create a second tracker. Use only the exact
+            candidate's section/comments plus targeted coordination state for candidate evidence. Newer
+            candidate entries are context and must not override the pinned selector. If authoritative
+            artifacts or the matching tag conflict with the pinned selector, stop writes and report UNKNOWN.
+        STEPS
+      end
+    end
+
+    def install_command(package_manager)
+      {
+        "npm" => "npm ci",
+        "pnpm" => "pnpm install --frozen-lockfile",
+        "yarn_classic" => "yarn install --frozen-lockfile",
+        "yarn_berry" => "yarn install --immutable"
+      }.fetch(package_manager, "derive from the target repo")
+    end
+
+    def stable_target_id(target)
+      slug(target.fetch("name"))
+    end
+
+    def default_pack_id
+      "fleet-#{Time.now.utc.strftime('%Y%m%dT%H%M%SZ')}-#{SecureRandom.hex(3)}"
+    end
+
+    def slug(value)
+      value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|\z/, "")
+    end
+  end
+
+  module CLI
+    module_function
+
+    def run(argv)
+      options = {
+        manifest_path: "internal/contributor-info/demo-fleet.yml",
+        prompt_count: 6,
+        machines: %w[local m1],
+        release_selector: "latest RC or beta",
+        pack_id: nil,
+        output_dir: nil
+      }
+      parser = option_parser(options)
+      parser.parse!(argv)
+
+      generator = Generator.new(
+        **options.slice(:manifest_path, :prompt_count, :machines, :release_selector, :pack_id)
+      )
+      if options[:output_dir]
+        generator.write_pack(options[:output_dir])
+        puts "Wrote #{options[:prompt_count]} prompts to #{options[:output_dir]}"
+      else
+        puts generator.render_pack
+      end
+      0
+    rescue ManifestError, OptionParser::ParseError => e
+      warn "ERROR: #{e.message}"
+      warn parser
+      1
+    end
+
+    def option_parser(options)
+      OptionParser.new do |parser|
+        parser.banner = "Usage: generate_prompts.rb [options]"
+        parser.on("--manifest PATH", "Fleet manifest path") { |value| options[:manifest_path] = value }
+        parser.on("--prompts COUNT", Integer, "Number of simultaneous prompts") do |value|
+          options[:prompt_count] = value
+        end
+        parser.on("--machines NAMES", "Comma-separated machine names") do |value|
+          options[:machines] = value.split(",").map(&:strip).reject(&:empty?)
+        end
+        parser.on("--release SELECTOR", "Release tag or dynamic selector") do |value|
+          options[:release_selector] = value
+        end
+        parser.on("--pack-id ID", "Reuse an existing generated pack ID") { |value| options[:pack_id] = value }
+        parser.on("--output-dir PATH", "Write prompt files and INDEX.md") { |value| options[:output_dir] = value }
+        parser.on("-h", "--help", "Show help") do
+          puts parser
+          exit 0
+        end
+      end
+    end
+  end
+end
+
+exit FleetValidation::CLI.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -173,6 +173,8 @@ module FleetValidation
 
     def validate_target_ids!
       ids = @targets.map { |target| stable_target_id(target) }
+      raise ManifestError, "target names must have non-empty stable IDs" if ids.any?(&:empty?)
+
       duplicates = ids.tally.select { |_id, count| count > 1 }.keys
       return if duplicates.empty?
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -133,7 +133,6 @@ module FleetValidation
 
     def effective_repo(defaults, repo)
       effective = defaults.merge(repo)
-      effective["review_app"] = repo.fetch("review_app", defaults["review_app"])
       effective["kind"] = "repo"
       effective["weight"] = repo_weight(effective)
       effective
@@ -407,7 +406,7 @@ module FleetValidation
     end
 
     def slug(value)
-      value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|\z/, "")
+      value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-\z/, "")
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -62,6 +62,10 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes pack, "workflow=cpflow-review-app.yml, status_check=cpflow/review-app"
     assert_includes pack, "one execution subagent for the assigned monorepo generator/install gate"
     assert_includes pack, "(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)"
+    assert_includes pack, "create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-standard --standard"
+    assert_includes pack, "create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-pro`"
+    assert_includes pack, "create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-rsc --rsc"
+    assert_includes pack, "independently resolved RSC version only in the RSC app"
     assert_includes pack, "verify: true"
   end
 
@@ -156,6 +160,37 @@ class FleetValidationGeneratorTest < Minitest::Test
         build_generator(manifest_path: manifest)
       end
       assert_equal "manifest root must be a mapping", error.message
+    end
+  end
+
+  def test_rejects_a_non_mapping_repo_entry
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      manifest.fetch("repos")[0] = "not-a-repo"
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      assert_equal "repos[0] must be a mapping", error.message
+    end
+  end
+
+  def test_rejects_a_hard_gate_missing_a_required_field
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      hard_gate = manifest.fetch("repos").find { |repo| repo["tier"] == "hard_gate" }
+      hard_gate.delete("name")
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      assert_equal "repos[0] hard gate is missing name", error.message
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -121,6 +121,20 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes pack, "fleet-validation:<resolved-tag>:<stable-target-id>"
   end
 
+  def test_strips_trailing_separators_from_stable_target_ids
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      manifest.fetch("repos").find { |repo| repo["tier"] == "hard_gate" }["name"] = "owner/example!"
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      pack = build_generator(manifest_path:).render_pack
+
+      assert_includes pack, "- owner/example!: owner-example"
+      refute_includes pack, "fallback_claim_target_template: adhoc:fleet-RESOLVED_TAG-owner-example-"
+    end
+  end
+
   def test_rejects_unsupported_schema
     Dir.mktmpdir do |directory|
       manifest = File.join(directory, "fleet.yml")

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "tmpdir"
+require_relative "generate_prompts"
+
+class FleetValidationGeneratorTest < Minitest::Test
+  MANIFEST = File.expand_path("../../../../internal/contributor-info/demo-fleet.yml", __dir__)
+
+  def build_generator(**overrides)
+    defaults = {
+      manifest_path: MANIFEST,
+      prompt_count: 6,
+      machines: %w[local m1],
+      release_selector: "latest RC or beta",
+      pack_id: "fleet-test-pack"
+    }
+    FleetValidation::Generator.new(**defaults.merge(overrides))
+  end
+
+  def test_balances_six_prompts_across_two_machines
+    generator = build_generator
+
+    assert_equal 6, generator.assignments.length
+    assert(generator.assignments.all? { |lane| lane.fetch(:targets).length <= 2 })
+    machine_counts = generator.assignments.map { |lane| lane.fetch(:machine) }.tally
+
+    assert_equal({ "local" => 3, "m1" => 3 }, machine_counts)
+  end
+
+  def test_assigns_every_hard_gate_and_core_gate_once
+    generator = build_generator
+    assigned_names = generator.assignments.flat_map do |lane|
+      lane.fetch(:targets).map { |target| target.fetch("name") }
+    end
+    manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+    expected_names = manifest.fetch("repos").filter_map do |repo|
+      repo.fetch("name") if repo["tier"] == "hard_gate"
+    end
+    expected_names << "react_on_rails generator/install smoke"
+
+    assert_equal expected_names.sort, assigned_names.sort
+    assert_equal assigned_names.length, assigned_names.uniq.length
+  end
+
+  def test_generated_prompts_are_dynamic_and_require_bounded_subagents
+    pack = build_generator.render_pack
+
+    assert_includes pack, "latest RC or beta"
+    assert_includes pack, "Spawn one read-only evidence subagent"
+    assert_match(/Child\s+agents must not spawn more agents/, pack)
+    assert_includes pack, "Do not select a candidate independently"
+    assert_includes pack, "independently released `react-on-rails-rsc`"
+    assert_includes pack, "the claim is the"
+    assert_includes pack,
+                    "fallback_claim_target_template: " \
+                    "adhoc:fleet-RESOLVED_TAG-shakacode-react-on-rails-demo-flagship"
+    assert_includes pack, "fallback_claim_repo: shakacode/react_on_rails"
+    assert_includes pack, "adhoc:fleet-snapshot-RESOLVED_TAG"
+    assert_includes pack, "Search the open `Release gate: react_on_rails X.Y.Z`"
+    assert_includes pack, "workflow=cpflow-review-app.yml, status_check=cpflow/review-app"
+    assert_includes pack, "one execution subagent for the assigned monorepo generator/install gate"
+    assert_includes pack, "(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)"
+    assert_includes pack, "verify: true"
+  end
+
+  def test_rejects_machine_names_that_collide_as_paths
+    error = assert_raises(FleetValidation::ManifestError) do
+      build_generator(machines: ["M 1", "m-1"])
+    end
+
+    assert_equal "machine names must have unique path slugs", error.message
+  end
+
+  def test_writes_machine_directories_and_index
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+
+      assert File.exist?(File.join(directory, "INDEX.md"))
+      assert_equal 3, Dir.glob(File.join(directory, "local", "*.md")).length
+      assert_equal 3, Dir.glob(File.join(directory, "m1", "*.md")).length
+    end
+  end
+
+  def test_index_describes_an_uneven_machine_allocation_as_a_maximum
+    Dir.mktmpdir do |directory|
+      build_generator(prompt_count: 5).write_pack(directory)
+      index = File.read(File.join(directory, "INDEX.md"))
+
+      assert_includes index, "runs at most\n3 prompts on one machine"
+      refute_includes index, "3 prompts per machine"
+    end
+  end
+
+  def test_removes_stale_lane_files_when_regenerating_an_output_directory
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      build_generator(prompt_count: 4, machines: ["local"], pack_id: "replacement-pack").write_pack(directory)
+
+      lane_files = Dir.glob(File.join(directory, "*", "*-fleet-lane.md"))
+
+      assert_equal 4, lane_files.length
+      assert_empty Dir.glob(File.join(directory, "m1", "*-fleet-lane.md"))
+      assert(lane_files.all? { |path| File.read(path).include?("replacement-pack") })
+    end
+  end
+
+  def test_rejects_prompt_count_that_exceeds_two_targets_per_lane
+    error = assert_raises(FleetValidation::ManifestError) do
+      build_generator(prompt_count: 3)
+    end
+
+    assert_equal "--prompts must be at least 4 to keep at most two targets per lane", error.message
+  end
+
+  def test_uses_stable_target_evidence_ids
+    pack = build_generator.render_pack
+
+    assert_includes pack, "shakacode-react-on-rails-demo-flagship"
+    assert_includes pack, "fleet-validation:<resolved-tag>:<stable-target-id>"
+  end
+
+  def test_rejects_unsupported_schema
+    Dir.mktmpdir do |directory|
+      manifest = File.join(directory, "fleet.yml")
+      File.write(manifest, "schema_version: 2\nrepos: []\n")
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path: manifest)
+      end
+      assert_equal "schema_version must be 1", error.message
+    end
+  end
+
+  def test_rejects_a_non_mapping_manifest
+    Dir.mktmpdir do |directory|
+      manifest = File.join(directory, "fleet.yml")
+      File.write(manifest, "- repo\n")
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path: manifest)
+      end
+      assert_equal "manifest root must be a mapping", error.message
+    end
+  end
+
+  def test_rejects_colliding_stable_target_ids
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      hard_gates = manifest.fetch("repos").select { |repo| repo["tier"] == "hard_gate" }
+      hard_gates[0]["name"] = "owner/foo.bar"
+      hard_gates[1]["name"] = "owner/foo-bar"
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      assert_equal "target names must have unique stable IDs: owner-foo-bar", error.message
+    end
+  end
+
+  def test_pinned_release_ignores_newer_tracker_candidates
+    pack = build_generator(release_selector: "v17.0.0.rc.12").render_pack
+
+    assert_match(/Newer\s+candidate entries are context and must not override the pinned selector/, pack)
+    refute_includes pack, "use its newest explicit RC section"
+  end
+
+  def test_dynamic_leader_resolves_the_release_before_selecting_a_tracker
+    prompt = build_generator.render_pack.match(/## Prompt 1.*?```text\n(.*?)```/m).captures.first
+
+    assert_operator prompt.index("derive the release line"), :<, prompt.index("Find the open `Release gate")
+  end
+end

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -211,6 +211,22 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_rejects_an_empty_stable_target_id
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      hard_gate = manifest.fetch("repos").find { |repo| repo["tier"] == "hard_gate" }
+      hard_gate["name"] = "!!!"
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      assert_equal "target names must have non-empty stable IDs", error.message
+    end
+  end
+
   def test_pinned_release_ignores_newer_tracker_candidates
     pack = build_generator(release_selector: "v17.0.0.rc.12").render_pack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,11 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
   `.agents/skills/react-on-rails-update-changelog/SKILL.md`; a short invocation
   is `$react-on-rails-update-changelog`. For ordinary mainline changelog updates
   on `main`, use the installed/shared `$update-changelog` skill.
+- When a maintainer wants to run or inspect RC/beta validation across the demo
+  fleet, use the repo-local `.agents/skills/run-fleet-validation/SKILL.md`; a
+  short invocation is `$run-fleet-validation`. Its Ruby generator reads
+  `internal/contributor-info/demo-fleet.yml` and emits balanced, subagent-driven
+  prompts for simultaneous execution across multiple machines.
 - Default simplify model: `claude-opus-4-8`
 
 ## External Flagship Demo Coordination

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -1,7 +1,7 @@
-# Demo fleet manifest — draft list of demo repos under cross-repo upgrade
-# automation. Read by future `rake demo_fleet:*` tasks. The canonical
-# release-gate policy lives in rc-testing-plan.md; reconcile this draft manifest
-# with that plan before implementing automation.
+# Demo fleet manifest — machine-readable input for release validation prompt
+# generation and the planned cross-repo upgrade automation. The canonical
+# release-gate policy lives in rc-testing-plan.md. Generate balanced validation
+# lanes with the repo-local run-fleet-validation skill.
 #
 # Schema version is bumped on breaking changes. Consumers must check it.
 #
@@ -34,9 +34,11 @@
 #   headline       — short name of the per-repo appendix in the RC plan.
 #                    The orchestrator uses this only for PR-body templating.
 #
-# Items marked `verify: true` have not been confirmed by inspecting the
-# demo repo. A one-time verification pass (per the RC plan's `*` convention)
-# must clear every verify flag before the manifest is treated as authoritative.
+# Items marked `verify: true` have not been confirmed by inspecting the demo
+# repo. Generated validation prompts include these values as provisional
+# starting data and require the worker to report exact YAML corrections. A
+# one-time verification pass must clear every flag before future orchestration
+# treats the commands as authoritative.
 
 schema_version: 1
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -483,6 +483,11 @@ pnpm run build
 CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
 ```
 
+Also run the published three-mode matrix from the candidate-specific section above in a separate
+scratch directory with no local overrides. The gate does not pass unless `--standard`, default Pro,
+and `--rsc` installs all build and smoke with the exact candidate locks and independently resolved RSC
+lock where applicable.
+
 If a command fails for an environmental reason, record the failure and file or link a follow-up
 issue. Do not silently mark the gate as passed.
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -77,6 +77,8 @@ candidate into six separate prompts. Its generator reads the hard gates from `de
 adds the monorepo generator/install gate, and emits six self-contained coordinator prompts
 balanced three-per-machine by default:
 
+From the repository root, run:
+
 ```bash
 ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
   --machines local,m1 \

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -70,6 +70,44 @@ The tracking issue is the single source of truth for:
 
 ## RC Validation Workflow
 
+### Fast parallel launch
+
+Use the repo-local `$run-fleet-validation` skill to avoid hand-copying the fleet or pinning a
+candidate into six separate prompts. Its generator reads the hard gates from `demo-fleet.yml`,
+adds the monorepo generator/install gate, and emits six self-contained coordinator prompts
+balanced three-per-machine by default:
+
+```bash
+ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
+  --machines local,m1 \
+  --prompts 6 \
+  --output-dir tmp/fleet-validation-prompts
+```
+
+The default prompt contract resolves the **latest RC or beta** when each lane starts. Use
+`--release vX.Y.Z.rc.N` only for a deliberately pinned rerun. Launch every prompt listed in
+`tmp/fleet-validation-prompts/INDEX.md` simultaneously. Each prompt coordinates bounded subagents:
+one read-only live-evidence pass plus one isolated execution worker per assigned target. With the
+default partition, no coordinator receives more than two execution targets. Run each prompt as a
+separate top-level task; do not place all six under one shared four-slot agent tree.
+
+Prompt 1 is the release-snapshot leader. It resolves the latest product RC/beta and the separately
+versioned `react-on-rails-rsc` pin once, then posts the pack's unique snapshot marker. The other
+five prompts may start simultaneously but must wait for that exact marker before mutation. This
+prevents a newly published candidate from splitting a staggered launch across versions.
+
+Each lane must acquire or resume an authoritative coordination claim before creating a mutable app
+checkout. It must reuse live candidate ownership first and use the pack's generated fallback claim
+target only when no lane exists. Fallback identity is stable by resolved candidate plus repository,
+not pack ID, so independently generated packs cannot race. Each lane then reuses or updates existing bump PRs and posts one
+idempotent marker comment per stable target identity to the tracking issue. Lanes must not
+concurrently rewrite the issue body. Generate a fresh pack and snapshot identity for every
+replacement candidate, even when the manifest is unchanged. Within one exact-candidate run, reuse
+that pack ID and rerun only the prompt files that own affected targets.
+
+The generated prompts accelerate the fleet hard gates; they do not replace the independent
+behavioral lanes in `release-verification-runbook.md` or the maintainer's final go/no-go decision.
+
 1. Cut the RC packages.
 2. Create or update the release-gate tracking issue from
    `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`.
@@ -438,7 +476,7 @@ For each hard-gate app PR:
 For the `react_on_rails` generator/install gate:
 
 ```bash
-bundle exec rspec react_on_rails/spec/react_on_rails/generators
+(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)
 pnpm run build
 CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
 ```

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -367,8 +367,12 @@ Check, with file/PR evidence for every claim:
 1. Every Lane 0 BREAKING CHANGE appears in the CHANGELOG release section AND in the upgrade
    guide, with the user-visible consequence stated (not just the internal change).
 2. Every DEBUT FEATURE has a CHANGELOG entry and documentation reachable from the docs site nav.
-3. Every issue labeled release:<X.Y.Z>-must-have is closed, and its fix is in
-   {{PREV_STABLE}}..{{RC_TAG}} (verify by commit, not by issue state).
+3. Every issue labeled release:<X.Y.Z>-must-have has a promotion-safe disposition. For a code or
+   docs defect, verify its fix is in `{{PREV_STABLE}}..{{RC_TAG}}` by commit; an open issue with a
+   landed fix is not automatically a gap, but stale acceptance criteria or remaining work is. For
+   a final-assembly/publish issue whose own lifecycle necessarily ends after promotion, require
+   its pre-publish dependencies and checklist to be satisfied; do not require the issue to close
+   before the publish steps it tracks can run.
 4. Version-stamp coherence: derive the expected gem/CHANGELOG and npm package versions from
    {{RC_TAG}} before comparing (for example, `v17.0.0.rc.7` -> gem/CHANGELOG `17.0.0.rc.7`,
    npm `17.0.0-rc.7`); gem version.rb files, every published package.json, and the CHANGELOG

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -372,7 +372,11 @@ Check, with file/PR evidence for every claim:
    landed fix is not automatically a gap, but stale acceptance criteria or remaining work is. For
    a final-assembly/publish issue whose own lifecycle necessarily ends after promotion, require
    its pre-publish dependencies and checklist to be satisfied; do not require the issue to close
-   before the publish steps it tracks can run.
+   before the publish steps it tracks can run. Example: an unchecked issue box is stale only when
+   linked commit evidence proves the tagged candidate already satisfies it and no implementation,
+   documentation, test, or rollout work remains. An unchecked box naming any such remaining work is
+   still a gap. A final-publish issue may remain open when its only remaining boxes are the publish
+   steps that promotion itself unlocks.
 4. Version-stamp coherence: derive the expected gem/CHANGELOG and npm package versions from
    {{RC_TAG}} before comparing (for example, `v17.0.0.rc.7` -> gem/CHANGELOG `17.0.0.rc.7`,
    npm `17.0.0-rc.7`); gem version.rb files, every published package.json, and the CHANGELOG


### PR DESCRIPTION
## Why

RC12 fleet validation exposed two recurring costs: release truth was fragmented across tracker comments and coordination state, and every run required hand-writing and balancing machine prompts. That made replacement-candidate launches slow and vulnerable to candidate drift, duplicate claims, and stale prompt reuse.

This change makes the fleet manifest an executable prompt source while keeping final promotion and independent release audits outside the generated worker lanes.

## What changed

- Add the repo-local `$run-fleet-validation` skill and a Ruby generator that emits six balanced, self-contained prompts across `local` and `m1` by default.
- Resolve the latest RC or beta once per pack, keep the independently versioned RSC artifact separate, and coordinate followers through a unique snapshot marker.
- Require bounded subagents, candidate/repository-stable coordination claims, isolated checkouts, privacy-safe reporting, and exact install/build/test/smoke evidence.
- Generate from `internal/contributor-info/demo-fleet.yml`, validate schema/IDs/layouts, clean stale output files, and support deliberately pinned reruns.
- Document the fast launch workflow and correct the generator-spec command to use the package Gemfile.
- Clarify that release must-have issues need a promotion-safe disposition; a landed fix or final-assembly issue is not blocked solely by remaining open.

## Verification

- `ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb` — 14 runs, 64 assertions
- `bundle exec rubocop --config .agents/.rubocop.yml .agents/skills/run-fleet-validation/scripts/generate_prompts.rb .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb`
- skill validator — valid
- generated a six-prompt `local,m1` pack and verified six lane files
- `pnpm exec prettier --check ...` on all changed Markdown/YAML files
- `bin/check-links` — 0 errors; pre-push online link hook — 18/18 OK
- `.agents/bin/agent-workflow-seam-doctor` — PASS
- `script/ci-changes-detector origin/main` — no hosted jobs recommended
- repeated `codex review --uncommitted` until clean; all actionable coordination and command findings fixed

The configured Claude simplify gate could not run because the account had reached its monthly spend limit. No files were changed by that command.

## Churn

- Initial push: one commit, no post-push fix commits.
- No changelog entry: this changes contributor release tooling and internal documentation, not product behavior.

Context: #3823


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fleet validation workflow that generates balanced release-validation prompt packs for parallel execution across multiple machines.
  - Introduced deterministic target/gate creation with configurable release selection, machine allocation, and stable evidence tracking.

- **Tests**
  - Added automated generator tests covering prompt assignment, pack rendering/output, manifest validation, and release-selection scenarios.

- **Documentation**
  - Documented the workflow, including “fast parallel launch” guidance, coordination/claiming rules, and provisional verification behavior.
  - Updated RC runbook and demo-fleet input guidance, plus tightened the generator/install gate checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->