### PR TITLE
Docs: document Pro ExecJS profiling prerequisites & missing cached helpers

### DIFF
--- a/docs/pro/fragment-caching.md
+++ b/docs/pro/fragment-caching.md
@@ -68,7 +68,7 @@ end %>
   { post: @post.to_props }
 end %>
 
-<%# Static RSC (strips hydration scripts for fully static pages) %>
+<%# Static RSC (strips RSC bootstrap scripts for fully static pages) %>
 <%= cached_static_rsc_component("StaticPage", cache_key: [@page]) do
   { page: @page.to_props }
 end %>
@@ -77,6 +77,8 @@ end %>
 <% card = cached_async_react_component("ProductCard", cache_key: [@product]) { @product.to_props } %>
 <%= card.value %>
 ```
+
+> **Note:** `cached_static_rsc_component` strips only the embedded RSC payload bootstrap scripts, not general component pack scripts. For fully static pages with no client interactivity, also pass `auto_load_bundle: false` and load your explicit sidecar pack separately.
 
 ### Rails Context And Render Order
 

--- a/docs/pro/fragment-caching.md
+++ b/docs/pro/fragment-caching.md
@@ -46,6 +46,38 @@ end %>
 
 A `cached_react_component_hash` variant is also available for cases where you need to extract metadata (like `<title>`) from the rendered output.
 
+### Additional Cached Helpers
+
+React on Rails Pro provides additional cached helpers for streaming, async, and RSC rendering. All share the same caching options (`cache_key`, `cache_tags`, `cache_options`, `:if`/`:unless`) as `cached_react_component`:
+
+| Helper                                   | Use case                                                                 | Prerequisites                                                        |
+| ---------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `cached_stream_react_component`          | Cache streamed React 18 components with Suspense                         | Requires `stream_view_containing_react_components`                   |
+| `cached_buffered_stream_react_component` | Cache streamed output as buffered HTML (no streaming setup needed)       | —                                                                    |
+| `cached_static_rsc_component`            | Cache static RSC pages with sidecar packs (strips RSC bootstrap scripts) | Requires `enable_rsc_support = true`                                 |
+| `cached_async_react_component`           | Cache async-rendered components                                          | Requires `AsyncRendering` concern and `enable_async_react_rendering` |
+
+```erb
+<%# Streaming with caching %>
+<%= cached_stream_react_component("StreamedApp", cache_key: [@user]) do
+  { user: @user.to_props }
+end %>
+
+<%# Buffered streaming (no ActionController::Live needed) %>
+<%= cached_buffered_stream_react_component("BufferedApp", cache_key: [@post]) do
+  { post: @post.to_props }
+end %>
+
+<%# Static RSC (strips hydration scripts for fully static pages) %>
+<%= cached_static_rsc_component("StaticPage", cache_key: [@page]) do
+  { page: @page.to_props }
+end %>
+
+<%# Async rendering with caching (cache hits return immediately) %>
+<% card = cached_async_react_component("ProductCard", cache_key: [@product]) { @product.to_props } %>
+<%= card.value %>
+```
+
 ### Rails Context And Render Order
 
 Fragment-cached helpers cache the final rendered HTML. That HTML includes the Rails context tag only when the helper call that populated the cache was the first component render in that request. If the same cached fragment is later served in a different view order, the page can either miss the Rails context tag or include a duplicate one.

--- a/docs/pro/profiling-server-side-rendering-code.md
+++ b/docs/pro/profiling-server-side-rendering-code.md
@@ -125,6 +125,11 @@ If you are using **v4.0.0** or later, enable the profiler by setting `profile_se
 config.profile_server_rendering_js_code = true
 ```
 
+> **Prerequisites:**
+>
+> - **ExecJS renderer only**: This setting only applies when `server_renderer == "ExecJS"` (the default). If you're using the Pro Node Renderer, this setting has no effect — use the [Chrome DevTools profiling method](#profiling-the-pro-node-renderer) above instead.
+> - **Node or V8 ExecJS runtime**: The ExecJS runtime must be Node or V8. Set this via the `EXECJS_RUNTIME` environment variable (e.g., `EXECJS_RUNTIME=Node`). Other runtimes will raise a configuration error.
+
 Then, run the app you are profiling and open some pages in it. You will find log files named `isolate-0x*.log` in the root of your app. Use the following command to analyze the log files:
 
 ```bash

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -4152,6 +4152,40 @@ end %>
 
 A `cached_react_component_hash` variant is also available for cases where you need to extract metadata (like `<title>`) from the rendered output.
 
+### Additional Cached Helpers
+
+React on Rails Pro provides additional cached helpers for streaming, async, and RSC rendering. All share the same caching options (`cache_key`, `cache_tags`, `cache_options`, `:if`/`:unless`) as `cached_react_component`:
+
+| Helper                                   | Use case                                                                 | Prerequisites                                                        |
+| ---------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `cached_stream_react_component`          | Cache streamed React 18 components with Suspense                         | Requires `stream_view_containing_react_components`                   |
+| `cached_buffered_stream_react_component` | Cache streamed output as buffered HTML (no streaming setup needed)       | —                                                                    |
+| `cached_static_rsc_component`            | Cache static RSC pages with sidecar packs (strips RSC bootstrap scripts) | Requires `enable_rsc_support = true`                                 |
+| `cached_async_react_component`           | Cache async-rendered components                                          | Requires `AsyncRendering` concern and `enable_async_react_rendering` |
+
+```erb
+<%# Streaming with caching %>
+<%= cached_stream_react_component("StreamedApp", cache_key: [@user]) do
+  { user: @user.to_props }
+end %>
+
+<%# Buffered streaming (no ActionController::Live needed) %>
+<%= cached_buffered_stream_react_component("BufferedApp", cache_key: [@post]) do
+  { post: @post.to_props }
+end %>
+
+<%# Static RSC (strips RSC bootstrap scripts for fully static pages) %>
+<%= cached_static_rsc_component("StaticPage", cache_key: [@page]) do
+  { page: @page.to_props }
+end %>
+
+<%# Async rendering with caching (cache hits return immediately) %>
+<% card = cached_async_react_component("ProductCard", cache_key: [@product]) { @product.to_props } %>
+<%= card.value %>
+```
+
+> **Note:** `cached_static_rsc_component` strips only the embedded RSC payload bootstrap scripts, not general component pack scripts. For fully static pages with no client interactivity, also pass `auto_load_bundle: false` and load your explicit sidecar pack separately.
+
 ### Rails Context And Render Order
 
 Fragment-cached helpers cache the final rendered HTML. That HTML includes the Rails context tag only when the helper call that populated the cache was the first component render in that request. If the same cached fragment is later served in a different view order, the page can either miss the Rails context tag or include a duplicate one.
@@ -4592,6 +4626,11 @@ If you are using **v4.0.0** or later, enable the profiler by setting `profile_se
 ```ruby
 config.profile_server_rendering_js_code = true
 ```
+
+> **Prerequisites:**
+>
+> - **ExecJS renderer only**: This setting only applies when `server_renderer == "ExecJS"` (the default). If you're using the Pro Node Renderer, this setting has no effect — use the [Chrome DevTools profiling method](#profiling-the-pro-node-renderer) above instead.
+> - **Node or V8 ExecJS runtime**: The ExecJS runtime must be Node or V8. Set this via the `EXECJS_RUNTIME` environment variable (e.g., `EXECJS_RUNTIME=Node`). Other runtimes will raise a configuration error.
 
 Then, run the app you are profiling and open some pages in it. You will find log files named `isolate-0x*.log` in the root of your app. Use the following command to analyze the log files:
 


### PR DESCRIPTION
## Summary

- Add prerequisites note to `profiling-server-side-rendering-code.md` explaining that the `profile_server_rendering_js_code` config only works with the ExecJS renderer (not NodeRenderer) and requires a Node or V8 ExecJS runtime (`EXECJS_RUNTIME=Node`)

- Add "Additional Cached Helpers" section to `fragment-caching.md` documenting the 4 missing cached helpers:
  - `cached_stream_react_component`
  - `cached_buffered_stream_react_component`
  - `cached_static_rsc_component`
  - `cached_async_react_component`

Fixes #4704

## Test plan

- [ ] Verify the markdown renders correctly on GitHub
- [ ] Verify the internal anchor link `#profiling-the-pro-node-renderer` works
- [ ] Review the cached helpers table formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Fragment Caching subsection covering additional Pro cached-helper variants for streaming, buffered streaming, static RSC, and async React rendering.
  * Documented shared caching options, prerequisites, and example usage for each helper.
  * Clarified prerequisites and runtime limitations for profiling server-side rendering with ExecJS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->