### PR TITLE
Docs: fix Shakapacker build & migration recipes (#4703)

### DIFF
--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -163,7 +163,7 @@ The default applies only to fresh installs. If `config/shakapacker.yml` already 
 
 - Rspack core packages (`@rspack/core`, `@rspack/cli`)
 - Rspack-specific plugins (`@rspack/plugin-react-refresh`, `rspack-manifest-plugin`)
-- Shakapacker configured with `assets_bundler: 'rspack'` and `webpack_loader: 'swc'`
+- Shakapacker configured with `assets_bundler: 'rspack'` and `javascript_transpiler: 'swc'`
 
 **Switching bundlers after installation:**
 

--- a/docs/oss/building-features/code-splitting.md
+++ b/docs/oss/building-features/code-splitting.md
@@ -202,7 +202,7 @@ const ServerApp = (props, railsContext) => {
   // __dirname is going to be the directory where the server-bundle.js exists
   // Note, React on Rails Pro automatically copies the loadable-stats.json to the same place as the
   // server-bundle.js. Thus, the __dirname of this code is where we can find loadable-stats.json.
-  // Be sure to configure ReactOnRailsPro.config.assets_top_copy to this file.
+  // Be sure to configure ReactOnRailsPro's `config.assets_to_copy` to this file.
   const statsFile = path.resolve(__dirname, 'loadable-stats.json');
 
   // This object is used to search filenames by corresponding chunk names.
@@ -235,7 +235,7 @@ ReactOnRails.register({
 
 ### React on Rails Pro
 
-You must set `config.assets_top_copy` so that the node-renderer will have access to the loadable-stats.json.
+You must set `config.assets_to_copy` so that the node-renderer will have access to the loadable-stats.json.
 
 ```ruby
   config.assets_to_copy = Rails.root.join("public", "webpack", Rails.env, "loadable-stats.json")

--- a/docs/oss/building-features/node-renderer/heroku.md
+++ b/docs/oss/building-features/node-renderer/heroku.md
@@ -68,7 +68,7 @@ To avoid the initial round trip to get a bundle on the renderer, you can pre-sta
 See [lib/tasks/assets.rake](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/lib/tasks/assets.rake) for a couple tasks that you can use.
 
 For same-dyno / same-filesystem deployments such as Heroku, the legacy
-`react_on_rails_pro:pre_stage_bundle_for_node_renderer` task is still appropriate. It pre-stages the same bundle-hash cache layout the renderer uses at runtime, but does so with symlinks instead of copies. Prefer `react_on_rails_pro:pre_seed_renderer_cache` for Docker/image-build workflows where the cache needs to be copied into an immutable artifact.
+`react_on_rails_pro:pre_stage_bundle_for_node_renderer` task is deprecated: it emits a deprecation warning and delegates to `react_on_rails_pro:pre_seed_renderer_cache` with `MODE=symlink`. That mode pre-stages the same bundle-hash cache layout the renderer uses at runtime, but does so with symlinks instead of copies. Use `MODE=copy` (the default) for Docker/image-build workflows where the cache needs to be copied into an immutable artifact.
 
 If you're not using the default cache location, set `RENDERER_SERVER_BUNDLE_CACHE_PATH` so the files stage into the right place. `RENDERER_BUNDLE_PATH` remains a deprecated compatibility alias.
 
@@ -77,10 +77,7 @@ Then you can use the rake task: `react_on_rails_pro:pre_seed_renderer_cache MODE
 You might do something like this:
 
 ```ruby
-Rake::Task["assets:precompile"]
-    .clear_prerequisites
-    .enhance([:environment, "react_on_rails:assets:compile_environment"])
-    .enhance do
+Rake::Task["assets:precompile"].enhance do
   ReactOnRailsPro::PreSeedRendererCache.call(mode: :symlink)
 end
 ```

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -1183,7 +1183,7 @@ When running tests in parallel (with `parallel_tests` gem):
 
 ```yaml
 - name: Compile test assets
-  run: RAILS_ENV=test bundle exec rake react_on_rails:assets:compile_environment
+  run: RAILS_ENV=test NODE_ENV=test bin/shakapacker
 
 - name: Run tests
   run: bundle exec rspec

--- a/docs/oss/core-concepts/webpack-configuration.md
+++ b/docs/oss/core-concepts/webpack-configuration.md
@@ -73,7 +73,7 @@ Rspack configuration is controlled via `config/shakapacker.yml`:
 ```yaml
 default: &default
   assets_bundler: 'rspack' # or 'webpack'
-  webpack_loader: 'swc' # Rspack works best with SWC
+  javascript_transpiler: 'swc' # Rspack works best with SWC
 ```
 
 The `bin/switch-bundler` script automatically updates this configuration when switching bundlers.

--- a/docs/oss/deployment/troubleshooting-build-errors.md
+++ b/docs/oss/deployment/troubleshooting-build-errors.md
@@ -175,9 +175,12 @@ Some operations require a working Rails environment:
 
 | react_on_rails | Shakapacker | Webpack | Node.js |
 | -------------- | ----------- | ------- | ------- |
+| v17.x          | >= 6.0      | v5      | 20-22   |
 | v16.x          | >= 6.0      | v5      | 20-22   |
 | v14.x          | >= 6.0      | v5      | 18-20   |
 | v13.x          | >= 6.0      | v5      | 16-18   |
+
+The Webpack column lists Webpack compatibility only. React on Rails v17 also supports Rspack as the assets bundler via Shakapacker's `assets_bundler: 'rspack'`.
 
 ### Common Upgrade Issues
 

--- a/docs/oss/migrating/babel-to-swc-migration.md
+++ b/docs/oss/migrating/babel-to-swc-migration.md
@@ -6,7 +6,7 @@ This document describes the migration from Babel to SWC for JavaScript/TypeScrip
 
 ## What is SWC?
 
-SWC (Speedy Web Compiler) is a Rust-based JavaScript/TypeScript compiler that is approximately 20x faster than Babel. Shakapacker 9.0+ uses SWC as the default transpiler.
+SWC (Speedy Web Compiler) is a Rust-based JavaScript/TypeScript compiler that is approximately 20x faster than Babel. SWC is available in Shakapacker 9.0+: Rspack projects use SWC by default, while Webpack projects default to Babel and opt in via `javascript_transpiler: swc` as shown below.
 
 ## Prerequisites
 

--- a/docs/oss/migrating/migrating-from-webpack-to-rspack.md
+++ b/docs/oss/migrating/migrating-from-webpack-to-rspack.md
@@ -273,7 +273,7 @@ Enable Rspack in `config/shakapacker.yml`:
 ```yaml
 default: &default
   assets_bundler: 'rspack' # or 'webpack'
-  webpack_loader: 'swc' # Rspack works best with SWC
+  javascript_transpiler: 'swc' # Rspack works best with SWC
 ```
 
 ## Troubleshooting

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4552,7 +4552,7 @@ Rspack configuration is controlled via `config/shakapacker.yml`:
 ```yaml
 default: &default
   assets_bundler: 'rspack' # or 'webpack'
-  webpack_loader: 'swc' # Rspack works best with SWC
+  javascript_transpiler: 'swc' # Rspack works best with SWC
 ```
 
 The `bin/switch-bundler` script automatically updates this configuration when switching bundlers.
@@ -6094,7 +6094,7 @@ const ServerApp = (props, railsContext) => {
   // __dirname is going to be the directory where the server-bundle.js exists
   // Note, React on Rails Pro automatically copies the loadable-stats.json to the same place as the
   // server-bundle.js. Thus, the __dirname of this code is where we can find loadable-stats.json.
-  // Be sure to configure ReactOnRailsPro.config.assets_top_copy to this file.
+  // Be sure to configure ReactOnRailsPro's `config.assets_to_copy` to this file.
   const statsFile = path.resolve(__dirname, 'loadable-stats.json');
 
   // This object is used to search filenames by corresponding chunk names.
@@ -6127,7 +6127,7 @@ ReactOnRails.register({
 
 ### React on Rails Pro
 
-You must set `config.assets_top_copy` so that the node-renderer will have access to the loadable-stats.json.
+You must set `config.assets_to_copy` so that the node-renderer will have access to the loadable-stats.json.
 
 ```ruby
   config.assets_to_copy = Rails.root.join("public", "webpack", Rails.env, "loadable-stats.json")
@@ -13445,7 +13445,7 @@ When running tests in parallel (with `parallel_tests` gem):
 
 ```yaml
 - name: Compile test assets
-  run: RAILS_ENV=test bundle exec rake react_on_rails:assets:compile_environment
+  run: RAILS_ENV=test NODE_ENV=test bin/shakapacker
 
 - name: Run tests
   run: bundle exec rspec
@@ -17667,7 +17667,7 @@ To avoid the initial round trip to get a bundle on the renderer, you can pre-sta
 See [lib/tasks/assets.rake](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/lib/tasks/assets.rake) for a couple tasks that you can use.
 
 For same-dyno / same-filesystem deployments such as Heroku, the legacy
-`react_on_rails_pro:pre_stage_bundle_for_node_renderer` task is still appropriate. It pre-stages the same bundle-hash cache layout the renderer uses at runtime, but does so with symlinks instead of copies. Prefer `react_on_rails_pro:pre_seed_renderer_cache` for Docker/image-build workflows where the cache needs to be copied into an immutable artifact.
+`react_on_rails_pro:pre_stage_bundle_for_node_renderer` task is deprecated: it emits a deprecation warning and delegates to `react_on_rails_pro:pre_seed_renderer_cache` with `MODE=symlink`. That mode pre-stages the same bundle-hash cache layout the renderer uses at runtime, but does so with symlinks instead of copies. Use `MODE=copy` (the default) for Docker/image-build workflows where the cache needs to be copied into an immutable artifact.
 
 If you're not using the default cache location, set `RENDERER_SERVER_BUNDLE_CACHE_PATH` so the files stage into the right place. `RENDERER_BUNDLE_PATH` remains a deprecated compatibility alias.
 
@@ -17676,10 +17676,7 @@ Then you can use the rake task: `react_on_rails_pro:pre_seed_renderer_cache MODE
 You might do something like this:
 
 ```ruby
-Rake::Task["assets:precompile"]
-    .clear_prerequisites
-    .enhance([:environment, "react_on_rails:assets:compile_environment"])
-    .enhance do
+Rake::Task["assets:precompile"].enhance do
   ReactOnRailsPro::PreSeedRendererCache.call(mode: :symlink)
 end
 ```
@@ -20415,7 +20412,7 @@ The default applies only to fresh installs. If `config/shakapacker.yml` already 
 
 - Rspack core packages (`@rspack/core`, `@rspack/cli`)
 - Rspack-specific plugins (`@rspack/plugin-react-refresh`, `rspack-manifest-plugin`)
-- Shakapacker configured with `assets_bundler: 'rspack'` and `webpack_loader: 'swc'`
+- Shakapacker configured with `assets_bundler: 'rspack'` and `javascript_transpiler: 'swc'`
 
 **Switching bundlers after installation:**
 
@@ -22658,9 +22655,12 @@ Some operations require a working Rails environment:
 
 | react_on_rails | Shakapacker | Webpack | Node.js |
 | -------------- | ----------- | ------- | ------- |
+| v17.x          | >= 6.0      | v5      | 20-22   |
 | v16.x          | >= 6.0      | v5      | 20-22   |
 | v14.x          | >= 6.0      | v5      | 18-20   |
 | v13.x          | >= 6.0      | v5      | 16-18   |
+
+The Webpack column lists Webpack compatibility only. React on Rails v17 also supports Rspack as the assets bundler via Shakapacker's `assets_bundler: 'rspack'`.
 
 ### Common Upgrade Issues
 
@@ -24949,7 +24949,7 @@ Enable Rspack in `config/shakapacker.yml`:
 ```yaml
 default: &default
   assets_bundler: 'rspack' # or 'webpack'
-  webpack_loader: 'swc' # Rspack works best with SWC
+  javascript_transpiler: 'swc' # Rspack works best with SWC
 ```
 
 ## Troubleshooting
@@ -25119,7 +25119,7 @@ This document describes the migration from Babel to SWC for JavaScript/TypeScrip
 
 ## What is SWC?
 
-SWC (Speedy Web Compiler) is a Rust-based JavaScript/TypeScript compiler that is approximately 20x faster than Babel. Shakapacker 9.0+ uses SWC as the default transpiler.
+SWC (Speedy Web Compiler) is a Rust-based JavaScript/TypeScript compiler that is approximately 20x faster than Babel. SWC is available in Shakapacker 9.0+: Rspack projects use SWC by default, while Webpack projects default to Babel and opt in via `javascript_transpiler: swc` as shown below.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes #4703.

Every claim in the issue was verified against source before being applied. Four of the issue's five diagnoses were correct as reported; the details below record where this PR deliberately departs from the issue, and the additional defects found while verifying.

## Where this PR departs from the issue

**The issue's proposed fix for the CI recipe was wrong.** It suggested replacing the nonexistent `react_on_rails:assets:compile_environment` with `react_on_rails:assets:webpack`. That task calls `exit!(1)` unless `config.build_production_command` is set ([`assets.rake#L26-L34`](https://github.com/shakacode/react_on_rails/blob/e9b1e35c980e07a96e06d9da4e0e737930b630dc/react_on_rails/lib/tasks/assets.rake#L26-L34)), so it would trade `Don't know how to build task` for a different hard CI failure — and it runs the *production* build command inside a `RAILS_ENV=test` recipe. This PR uses `RAILS_ENV=test NODE_ENV=test bin/shakapacker`, which is what this repo's own CI does (`dummy-app-bundler-tests.yml:103`, `pro-integration-tests.yml:924`).

**The issue's evidence for the compatibility matrix didn't support it.** It cited `required_ruby_version = ">= 3.3.0"`, but the matrix has no Ruby column. The v17 row here is sourced instead from the gemspec (`shakapacker >= 6.0`), the upgrade guide ("Shakapacker >= 6.0 is now required"), and `.minimum.tool-versions` / `.tool-versions` (Node 20.19.0 → 22.12.0).

## Defects the issue missed

- **`heroku.md:82`** used the same nonexistent rake task. It needed a *different* fix than the CI recipe: the snippet's `clear_prerequisites` pattern is stale. React on Rails always hooks `assets:precompile` with a **block action**, and Shakapacker does too whenever `assets:precompile` is already defined (the Sprockets case that this Heroku snippet targets) — and `clear_prerequisites` does not remove block actions. Shakapacker's other branch, taken only when `assets:precompile` is *not* already defined, does install `shakapacker:compile` as a real prerequisite, and there `clear_prerequisites` would have deleted the only thing compiling packs. Replaced with a plain `enhance` block, which is correct in **both** branches; the old snippet was correct in neither. (Evidence: `lib/tasks/shakapacker/compile.rake` is byte-identical in shakapacker 9.0.0 and 10.3.0.)
- **`heroku.md:70`** described `pre_stage_bundle_for_node_renderer` as "still appropriate". It is deprecated and delegates to `pre_seed_renderer_cache MODE=symlink` — the doc contradicted both the source and its own line 75.
- **`code-splitting.md:205`** had a second defect beyond the typo: `ReactOnRailsPro.config` is not a real API (only `ReactOnRailsPro.configuration` exists).
- **`webpack_loader` appears in three docs, not one** — `generator-details.md:164` and `webpack-configuration.md:76` were also affected.
- **`llms-full.txt` embeds `docs/oss/**`** and still contained the uncorrected recipes. Regenerated. Worth noting: CI would not have caught this — `check-llms-full.yml` only runs `--check` when the diff touches `llms-full.txt`/`llms.txt`/`sidebars.ts`/the generator, so a docs-only PR gets `--validate`, which passes against a stale file. Without this, the human-facing docs would be fixed while the LLM-facing copy kept serving the broken rake task.

## Wording note

`babel-to-swc-migration.md:9` is reworded to avoid asserting a version-specific default. `default_javascript_transpiler` is `rspack? ? "swc" : "babel"` — verified byte-identical in shakapacker 9.3.0, 9.6.1, and 10.3.0, with the method absent in 8.4.0. Only 9.0–9.2 were unavailable locally, so the new wording states SWC is *available* in 9.0+ and that Rspack defaults to it, which holds regardless.

## Verification

- `npx prettier --check .` (the repo's canonical gate, `package-scripts.yml:55-57`) — passes
- `node script/generate-llms-full.mjs --check` — passes (was `✗ stale` before regenerating; pristine `main` was `✓ current`, confirming this PR caused the staleness)
- pre-commit hooks (prettier, trailing-newlines, markdown-links) — pass
- No CHANGELOG entry: documentation fixes are excluded per `.claude/docs/changelog-guidelines.md`

Docs-only; no runtime code changed. Reviewed in an adversarial loop with Codex (gpt-5.5, xhigh reasoning), which caught the `ReactOnRailsPro.config` defect, the Heroku `clear_prerequisites` problem, and a stale verification claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples to use `javascript_transpiler: 'swc'` instead of the older `webpack_loader` key, clarifying Rspack defaults vs Webpack/SWC opt-in behavior.
  * Refreshed React on Rails Pro node-renderer setup to use `config.assets_to_copy` for `loadable-stats.json`.
  * Adjusted test asset precompilation guidance to run `bin/shakapacker` with `RAILS_ENV=test` and `NODE_ENV=test`.
  * Marked `react_on_rails_pro:pre_stage_bundle_for_node_renderer` as deprecated and documented the new cache preparation flow.
  * Extended the compatibility matrix with React on Rails v17 (including Rspack support) and updated deployment snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
