### PR TITLE
[Pro] Drop raw+parsed source-map double retention per pooled VM (#4313 Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,21 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Stopped retaining both raw and parsed source maps per pooled Node renderer VM**: Once a
+  bundle's source map is parsed on first use, the raw map JSON (up to 50MB under the cap) is released and
+  the parsed map becomes the VM generation's single retained copy. A registration whose raw JSON was
+  released never falls back to re-reading the map from disk, preserving the same-path rebuild guarantee:
+  old VM generations keep remapping through their own map even after the on-disk map is overwritten. Also
+  makes an unusable inline (`data:`) source map terminal on the lazy lookup path instead of retried,
+  matching registration-time behavior. Partially addresses
+  [Issue 4313](https://github.com/shakacode/react_on_rails/issues/4313).
+  [PR XXXX](https://github.com/shakacode/react_on_rails/pull/XXXX) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Capped the size of external source maps read by the Node renderer**: External `.map` files
-  larger than 50MB are no longer read into memory. Previously only inline (`data:`) source maps were
+  whose on-disk size exceeds 50MB are skipped by a pre-read size gate rather than read into memory (this is
+  not a hard memory bound: a map that grows between the size check and the read is still read in full).
+  Previously only inline (`data:`) source maps were
   size-capped, so a large external map was read and retained for the life of each pooled VM. Behavior change:
   stack frames for a bundle whose external map exceeds the cap keep their bundled locations instead of being
   remapped to original sources, and the renderer logs a warning naming the map. An oversized map is never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   makes an unusable inline (`data:`) source map terminal on the lazy lookup path instead of retried,
   matching registration-time behavior. Partially addresses
   [Issue 4313](https://github.com/shakacode/react_on_rails/issues/4313).
-  [PR XXXX](https://github.com/shakacode/react_on_rails/pull/XXXX) by
+  [PR 4711](https://github.com/shakacode/react_on_rails/pull/4711) by
   [justin808](https://github.com/justin808).
 
 - **[Pro]** **Capped the size of external source maps read by the Node renderer**: External `.map` files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **[Pro]** **Stopped retaining both raw and parsed source maps per pooled Node renderer VM**: Once a
   bundle's source map is parsed on first use, the raw map JSON (up to 50MB under the cap) is released and
-  the parsed map becomes the VM generation's single retained copy. A registration whose raw JSON was
-  released never falls back to re-reading the map from disk, preserving the same-path rebuild guarantee:
-  old VM generations keep remapping through their own map even after the on-disk map is overwritten. Also
-  makes an unusable inline (`data:`) source map terminal on the lazy lookup path instead of retried,
-  matching registration-time behavior. Partially addresses
+  the parsed map becomes the VM generation's single retained copy. For inline (`data:`) maps the encoded
+  URL payload (larger than the raw JSON) is released as well, so the single-copy reduction applies to both
+  external and inline maps. A registration whose raw map was released never falls back to re-reading the
+  map from disk, preserving the same-path rebuild guarantee: old VM generations keep remapping through
+  their own map even after the on-disk map is overwritten. Also makes an unusable inline (`data:`) source
+  map terminal on the lazy lookup path instead of retried, matching registration-time behavior. Partially
+  addresses
   [Issue 4313](https://github.com/shakacode/react_on_rails/issues/4313).
   [PR 4711](https://github.com/shakacode/react_on_rails/pull/4711) by
   [justin808](https://github.com/justin808).

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -50,14 +50,16 @@ import type { SourceMapping } from 'module';
 import log from '../shared/log.js';
 
 /**
- * Sentinel stored in {@link BundleSourceMapRegistration.sourceMapJson} once the
- * parsed source map has been cached: the raw JSON string is released so a
- * pooled VM generation does not retain both copies for its lifetime. It is
- * deliberately distinct from `null` ("confirmed no usable map") and `undefined`
- * ("check lazily on first error") so that a parsed-map eviction can never
- * silently fall through to a disk re-read — a re-read could remap this VM
- * generation with a newer same-path map, which is exactly what freezing the
- * JSON at registration time exists to prevent.
+ * Sentinel stored in {@link BundleSourceMapRegistration.sourceMapJson} once a
+ * lookup has settled — either the parsed map was cached (its raw JSON released
+ * so a pooled VM generation does not retain both copies for its lifetime) or the
+ * lookup ended terminal with no usable map. It is deliberately distinct from
+ * `null` ("confirmed no usable map") and `undefined` ("check lazily on first
+ * error") so that a parsed-map eviction can never silently fall through to a
+ * disk re-read — a re-read could remap this VM generation with a newer same-path
+ * map, which is exactly what freezing the JSON at registration time exists to
+ * prevent. A settled registration is therefore always the sentinel or `null`,
+ * never a live string and never a re-readable `undefined`.
  *
  * @internal Exported for tests.
  */
@@ -177,6 +179,40 @@ function shouldRetryMissingSourceMap(registration: BundleSourceMapRegistration) 
   return registration.retryMissingSourceMap === true && !retiredMissingSourceMapRetries.has(registration);
 }
 
+/**
+ * Releases the raw source-map data a settled registration no longer needs and
+ * makes the settle permanent, so a later parsed-cache eviction cannot re-read a
+ * newer same-path map (from disk, or from a retained inline `data:` payload) and
+ * remap this VM generation with it. It is the single point every settled
+ * transition funnels through, so no per-site path can leave data retained:
+ *  - a retained raw JSON string (released after a successful parse), or a lazy
+ *    `undefined` that has now settled, collapses to
+ *    {@link RAW_SOURCE_MAP_JSON_DISCARDED} — terminal, never re-read. A
+ *    registration already settled to `null` ("no usable map") keeps `null`.
+ *  - an inline `data:` `sourceMappingUrl` — the whole encoded payload, ≈1.33×
+ *    the JSON for base64 and dead once the map is parsed — is dropped. External
+ *    filenames are kept: the lazy read path legitimately uses them.
+ *
+ * Only call this on a settled lookup — a successful load, or a permanent
+ * terminal settle (including retry-cap retirement) — never while a registration
+ * is still retryable (a retrying registration must keep `undefined` so it can
+ * re-read until the map arrives). Mutating the shared registration object is
+ * intentional: every holder of the registration must observe the release.
+ */
+function releaseRetainedSourceMapData(registration: BundleSourceMapRegistration) {
+  if (registration.sourceMapJson === undefined || typeof registration.sourceMapJson === 'string') {
+    // eslint-disable-next-line no-param-reassign
+    registration.sourceMapJson = RAW_SOURCE_MAP_JSON_DISCARDED;
+  }
+  if (
+    typeof registration.sourceMappingUrl === 'string' &&
+    registration.sourceMappingUrl.startsWith('data:')
+  ) {
+    // eslint-disable-next-line no-param-reassign
+    registration.sourceMappingUrl = null;
+  }
+}
+
 export function retireMissingSourceMapRetry(registration: BundleSourceMapRegistration) {
   if (!shouldRetryMissingSourceMap(registration)) {
     return;
@@ -187,6 +223,13 @@ export function retireMissingSourceMapRetry(registration: BundleSourceMapRegistr
   if (sourceMapCache.get(registration) === undefined) {
     sourceMapCache.set(registration, null);
   }
+  // Retirement is a permanent settle — the registration will not retry again —
+  // so settle its JSON here too. Without this, a retired retryable registration
+  // keeps `sourceMapJson === undefined`, which a later parsed-cache eviction
+  // would re-read from disk (risking a newer same-path map). This is retirement,
+  // not the still-retrying `recordMissingSourceMapRetry` path, so releasing is
+  // safe. A successfully-loaded registration is a no-op here (already settled).
+  releaseRetainedSourceMapData(registration);
 }
 
 export function createSourceMapLookupAttempt(): SourceMapLookupAttempt {
@@ -454,11 +497,11 @@ function readSourceMapJsonForBundle(
     // Stack formatting is synchronous, so source-map discovery stays sync and
     // is cached per bundle registration.
     if (sourceMappingUrl && sourceMappingUrl.startsWith('data:')) {
-      // An unusable inline map (oversized, malformed, or non-JSON mime type) is
-      // terminal, matching registration-time normalization in
-      // `preloadSourceMapJsonForBundle` / `registerBundleForSourceMaps`: a
-      // usable map cannot "arrive later" for a data: URL, and retrying would
-      // re-extract from the on-disk bundle, risking a newer same-path map.
+      // An inline map that is unusable for good (oversized or non-JSON mime
+      // type) is terminal `null`; a decodable payload is returned as-is and
+      // validated lazily by the caller's `JSON.parse`. A usable inline map
+      // cannot "arrive later" for a data: URL, and re-reading the on-disk bundle
+      // to look would risk a newer same-path generation.
       return parseDataUrlSourceMap(sourceMappingUrl) ?? null;
     }
 
@@ -495,7 +538,8 @@ async function readSourceMapJsonForBundleAsync(
 ): Promise<string | null | undefined> {
   try {
     if (sourceMappingUrl && sourceMappingUrl.startsWith('data:')) {
-      // See the comment in the sync variant: unusable inline maps are terminal.
+      // See the comment in the sync variant: unusable inline maps are terminal,
+      // decodable ones are validated lazily by the caller's `JSON.parse`.
       return parseDataUrlSourceMap(sourceMappingUrl) ?? null;
     }
 
@@ -525,6 +569,13 @@ export async function preloadSourceMapJsonForBundle(bundleFilePath: string, bund
   const sourceMappingUrl = extractSourceMappingUrl(bundleContents);
   const realBundleDirectory = fs.realpathSync(path.dirname(bundleFilePath));
   if (sourceMappingUrl && sourceMappingUrl.startsWith('data:')) {
+    // Decode the inline map and freeze it for this generation (or terminal
+    // `null` when it is unusable for good — oversized or non-JSON mime type).
+    // Its JSON is validated lazily on the first stack remap, not eagerly here,
+    // so a VM build that never errors does not pay a full parse. Inline maps are
+    // never retryable: a decoded-but-invalid payload is settled and released on
+    // that first lookup rather than re-read (a re-read would risk a newer
+    // same-path generation).
     return {
       retryMissingSourceMap: false,
       sourceMapJson: parseDataUrlSourceMap(sourceMappingUrl) ?? null,
@@ -577,14 +628,19 @@ export function registerBundleForSourceMaps(
 ) {
   const sourceMappingUrl =
     bundleContents === undefined ? undefined : (extractSourceMappingUrl(bundleContents) ?? null);
+  // Decode an inline map here too, for direct registrations that skip preload.
+  // Skip it when a preload result is supplied: `preloadedSourceMapJson` already
+  // decoded the same payload and wins below, so decoding again would process a
+  // large inline map a second time at build. Its JSON is validated lazily on the
+  // first remap, not here.
   const inlineSourceMapJson =
-    sourceMappingUrl && sourceMappingUrl.startsWith('data:')
+    preloadedSourceMapJson === undefined && sourceMappingUrl && sourceMappingUrl.startsWith('data:')
       ? (parseDataUrlSourceMap(sourceMappingUrl) ?? null)
       : undefined;
   // sourceMapJson states: string = known JSON for this VM generation, null =
   // confirmed no usable source map, undefined = check lazily on first error.
-  // After the first successful parse the string is swapped for
-  // RAW_SOURCE_MAP_JSON_DISCARDED so only the parsed copy is retained.
+  // Once a lookup settles the string/undefined is swapped for
+  // RAW_SOURCE_MAP_JSON_DISCARDED so only the parsed copy (if any) is retained.
   const registration: BundleSourceMapRegistration = {
     bundleFilePath,
     firstLineColumnOffset,
@@ -768,35 +824,21 @@ function sourceMapForRegistration(
       sourceMap = loadResult.sourceMap;
       sourceMapCache.set(registration, sourceMap);
       missingSourceMapRetryCounts.delete(registration);
-      if (typeof registration.sourceMapJson === 'string') {
-        // The parsed map is now this generation's surviving copy; release the
-        // raw JSON so the pooled VM does not retain both for its lifetime.
-        // Lazy registrations (sourceMapJson === undefined) are left alone: the
-        // raw JSON never lived on the registration for those. Mutating the
-        // shared registration object is the point: every holder must see the
-        // release.
-        // eslint-disable-next-line no-param-reassign
-        registration.sourceMapJson = RAW_SOURCE_MAP_JSON_DISCARDED;
-
-        // For an inline map, `sourceMappingUrl` holds the entire encoded
-        // `data:application/json;...` payload (≈1.33× the JSON for base64) —
-        // dead weight once the parsed map is cached, since the sentinel guard
-        // above returns terminal before any code re-reads it. Release it too so
-        // single-copy retention actually applies to inline maps. External maps
-        // keep their `sourceMappingUrl`: it is a small relative filename the
-        // lazy read path legitimately uses, not a large payload.
-        if (
-          typeof registration.sourceMappingUrl === 'string' &&
-          registration.sourceMappingUrl.startsWith('data:')
-        ) {
-          // eslint-disable-next-line no-param-reassign
-          registration.sourceMappingUrl = null;
-        }
-      }
+      // Every successful load — including a lazy `undefined` registration —
+      // settles here: the parsed map is now this generation's surviving copy,
+      // so release the raw data and mark the JSON terminal. A later cache
+      // eviction then goes terminal instead of re-reading a newer same-path map.
+      releaseRetainedSourceMapData(registration);
     } else {
       sourceMap = null;
       if (loadResult.status === 'terminal' || !shouldRetryMissingSourceMap(registration)) {
         sourceMapCache.set(registration, sourceMap);
+        // Permanently settled with no usable parsed map (terminal, or a miss
+        // that will not be retried). Release any retained raw string — e.g. a
+        // frozen map that failed to parse — and settle the JSON so an eviction
+        // cannot re-read a newer same-path map. Not called on the retry branch
+        // below: a still-retrying registration must keep what it needs to retry.
+        releaseRetainedSourceMapData(registration);
       } else {
         recordMissingSourceMapRetry(registration, lookupAttempt);
       }

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -36,10 +36,11 @@
  * Performance: `prepareStackTrace` only runs when an error's `.stack` is first
  * accessed. External source map text is captured asynchronously while building
  * the VM so same-path rebuilds stay generation-isolated; SourceMap parsing and
- * position lookups stay lazy and cached per bundle registration. Inline and
- * external maps are both size-capped: an oversized map is skipped and its frames
- * keep their bundled locations rather than paying its bytes for the life of the
- * pooled VM.
+ * position lookups stay lazy and cached per bundle registration. Once the
+ * parsed `SourceMap` is cached, the raw map JSON is released so each pooled VM
+ * generation retains a single copy instead of both. Inline and external maps
+ * are both size-capped: an oversized map is skipped and its frames keep their
+ * bundled locations rather than paying its bytes for the life of the pooled VM.
  */
 
 import fs from 'fs';
@@ -47,6 +48,20 @@ import path from 'path';
 import { SourceMap } from 'module';
 import type { SourceMapping } from 'module';
 import log from '../shared/log.js';
+
+/**
+ * Sentinel stored in {@link BundleSourceMapRegistration.sourceMapJson} once the
+ * parsed source map has been cached: the raw JSON string is released so a
+ * pooled VM generation does not retain both copies for its lifetime. It is
+ * deliberately distinct from `null` ("confirmed no usable map") and `undefined`
+ * ("check lazily on first error") so that a parsed-map eviction can never
+ * silently fall through to a disk re-read — a re-read could remap this VM
+ * generation with a newer same-path map, which is exactly what freezing the
+ * JSON at registration time exists to prevent.
+ *
+ * @internal Exported for tests.
+ */
+export const RAW_SOURCE_MAP_JSON_DISCARDED = Symbol('rawSourceMapJsonDiscarded');
 
 export interface BundleSourceMapRegistration {
   bundleFilePath: string;
@@ -67,9 +82,11 @@ export interface BundleSourceMapRegistration {
    * `undefined` keeps lazy synchronous lookup behavior. `null` means registration
    * time lookup found no usable source map. A string freezes the source-map JSON
    * for this VM generation so same-path rebuilds cannot remap old bytecode with
-   * a newer map.
+   * a newer map. {@link RAW_SOURCE_MAP_JSON_DISCARDED} means the frozen JSON was
+   * parsed, cached, and released; the parsed map is this generation's surviving
+   * copy and lookups must never fall back to disk.
    */
-  sourceMapJson?: string | null;
+  sourceMapJson?: string | null | typeof RAW_SOURCE_MAP_JSON_DISCARDED;
   realBundleDirectory: string;
   /**
    * External source maps can arrive after a bundle first becomes visible. When
@@ -103,7 +120,8 @@ const sourceMapLookupAttempts = new WeakSet<SourceMapLookupAttempt>();
 let warnedMissingSourceMapConstructor = false;
 
 const MAX_MISSING_SOURCE_MAP_RETRIES = 5;
-const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
+/** @internal Exported for tests. */
+export const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
 // External `.map` files get the same ceiling as inline maps. This is a pre-read
 // size gate, not a hard memory bound: a map that grows between the `statSync` in
 // `resolveReadableSourceMapPath` and the read below still gets read in full.
@@ -113,7 +131,8 @@ const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
 // against a JS string length (UTF-16 code units), so a map with multi-byte
 // characters admits a different amount of data inline than externally. The
 // inline unit predates this constant and is left alone here.
-const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
+/** @internal Exported for tests. */
+export const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
 
 // `preloadSourceMapJsonForBundle` re-checks the map on every VM build, and with
 // `maxVMPoolSize` defaulting to 2 an app with more bundles than that rebuilds
@@ -423,8 +442,8 @@ async function readSourceMapFileAsync(
 
 /**
  * Returns the source-map JSON for a bundle, `null` when a map was found but is
- * unusable for good (oversized), or `undefined` when no map was found and one
- * may still appear later.
+ * unusable for good (oversized, or an unusable inline `data:` URL), or
+ * `undefined` when no map was found and one may still appear later.
  */
 function readSourceMapJsonForBundle(
   bundleFilePath: string,
@@ -435,7 +454,12 @@ function readSourceMapJsonForBundle(
     // Stack formatting is synchronous, so source-map discovery stays sync and
     // is cached per bundle registration.
     if (sourceMappingUrl && sourceMappingUrl.startsWith('data:')) {
-      return parseDataUrlSourceMap(sourceMappingUrl);
+      // An unusable inline map (oversized, malformed, or non-JSON mime type) is
+      // terminal, matching registration-time normalization in
+      // `preloadSourceMapJsonForBundle` / `registerBundleForSourceMaps`: a
+      // usable map cannot "arrive later" for a data: URL, and retrying would
+      // re-extract from the on-disk bundle, risking a newer same-path map.
+      return parseDataUrlSourceMap(sourceMappingUrl) ?? null;
     }
 
     // Fallback: the uploaded bundle is renamed to `<timestamp>.js`, so a map
@@ -471,7 +495,8 @@ async function readSourceMapJsonForBundleAsync(
 ): Promise<string | null | undefined> {
   try {
     if (sourceMappingUrl && sourceMappingUrl.startsWith('data:')) {
-      return parseDataUrlSourceMap(sourceMappingUrl);
+      // See the comment in the sync variant: unusable inline maps are terminal.
+      return parseDataUrlSourceMap(sourceMappingUrl) ?? null;
     }
 
     const candidatePaths = candidateSourceMapPaths(bundleFilePath, sourceMappingUrl);
@@ -558,7 +583,9 @@ export function registerBundleForSourceMaps(
       : undefined;
   // sourceMapJson states: string = known JSON for this VM generation, null =
   // confirmed no usable source map, undefined = check lazily on first error.
-  const registration = {
+  // After the first successful parse the string is swapped for
+  // RAW_SOURCE_MAP_JSON_DISCARDED so only the parsed copy is retained.
+  const registration: BundleSourceMapRegistration = {
     bundleFilePath,
     firstLineColumnOffset,
     realBundleDirectory: fs.realpathSync(path.dirname(bundleFilePath)),
@@ -663,20 +690,32 @@ function loadSourceMapForBundle(
   registration: BundleSourceMapRegistration,
 ): SourceMapLoadResult {
   try {
+    // A registration's own null means "confirmed no usable map for this VM
+    // generation", which is terminal by definition. Say so here rather than
+    // letting `?? undefined` coerce it into the retryable `missing` path and
+    // relying on the caller's `shouldRetryMissingSourceMap` check to settle it.
+    // Checked before the sourceMappingURL lookup below so a settled
+    // registration never re-reads the bundle from disk.
+    if (registration.sourceMapJson === null) {
+      return { status: 'terminal' };
+    }
+
+    // The raw JSON was released when the parsed map was cached. Reaching this
+    // point means the parsed map was evicted (for example, the registration was
+    // unregistered while an in-flight error still holds it). Do NOT fall back
+    // to a disk re-read: a newer same-path map could remap this generation.
+    // Keeping bundled frame locations is the safe terminal outcome.
+    if (registration.sourceMapJson === RAW_SOURCE_MAP_JSON_DISCARDED) {
+      return { status: 'terminal' };
+    }
+
     const sourceMappingUrl =
       registration.sourceMappingUrl === undefined
         ? extractSourceMappingUrl(readRegisteredBundleContentsForSourceMapLookup(bundleFilePath))
         : (registration.sourceMappingUrl ?? undefined);
 
-    // A registration's own null means "confirmed no usable map for this VM
-    // generation", which is terminal by definition. Say so here rather than
-    // letting `?? undefined` coerce it into the retryable `missing` path and
-    // relying on the caller's `shouldRetryMissingSourceMap` check to settle it.
-    if (registration.sourceMapJson === null) {
-      return { status: 'terminal' };
-    }
-
-    // The reader returns null only for an oversized map — also terminal.
+    // The reader returns null only for a map that is unusable for good
+    // (oversized, or an unusable inline map) — also terminal.
     const sourceMapJson =
       registration.sourceMapJson === undefined
         ? readSourceMapJsonForBundle(bundleFilePath, sourceMappingUrl, registration.realBundleDirectory)
@@ -729,6 +768,16 @@ function sourceMapForRegistration(
       sourceMap = loadResult.sourceMap;
       sourceMapCache.set(registration, sourceMap);
       missingSourceMapRetryCounts.delete(registration);
+      if (typeof registration.sourceMapJson === 'string') {
+        // The parsed map is now this generation's surviving copy; release the
+        // raw JSON so the pooled VM does not retain both for its lifetime.
+        // Lazy registrations (sourceMapJson === undefined) are left alone: the
+        // raw JSON never lived on the registration for those. Mutating the
+        // shared registration object is the point: every holder must see the
+        // release.
+        // eslint-disable-next-line no-param-reassign
+        registration.sourceMapJson = RAW_SOURCE_MAP_JSON_DISCARDED;
+      }
     } else {
       sourceMap = null;
       if (loadResult.status === 'terminal' || !shouldRetryMissingSourceMap(registration)) {

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -777,6 +777,21 @@ function sourceMapForRegistration(
         // release.
         // eslint-disable-next-line no-param-reassign
         registration.sourceMapJson = RAW_SOURCE_MAP_JSON_DISCARDED;
+
+        // For an inline map, `sourceMappingUrl` holds the entire encoded
+        // `data:application/json;...` payload (≈1.33× the JSON for base64) —
+        // dead weight once the parsed map is cached, since the sentinel guard
+        // above returns terminal before any code re-reads it. Release it too so
+        // single-copy retention actually applies to inline maps. External maps
+        // keep their `sourceMappingUrl`: it is a small relative filename the
+        // lazy read path legitimately uses, not a large payload.
+        if (
+          typeof registration.sourceMappingUrl === 'string' &&
+          registration.sourceMappingUrl.startsWith('data:')
+        ) {
+          // eslint-disable-next-line no-param-reassign
+          registration.sourceMappingUrl = null;
+        }
       }
     } else {
       sourceMap = null;

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -632,6 +632,63 @@ describe('source-mapped stack traces for VM errors', () => {
       });
     });
 
+    test('inline data: map encoded URL is released after first parse; external map filename is kept', async () => {
+      // Inline map: registration holds the whole encoded data: payload, which is
+      // dead weight once the parsed map is cached. Releasing only the raw JSON
+      // (but not this URL) would leave the larger base64 copy retained.
+      const inlineBundleContents = `${buildThrowingBundleSource()}\n${inlineSourceMapComment(
+        buildThrowingBundleMap('bundle.js'),
+      )}\n`;
+      const inlineBundlePath = await writeVmBundle(inlineBundleContents);
+      const inlineRegistration = registerBundleForSourceMaps(inlineBundlePath, 0, inlineBundleContents);
+      expect(typeof inlineRegistration.sourceMappingUrl).toBe('string');
+      expect(inlineRegistration.sourceMappingUrl).toEqual(expect.stringContaining('data:application/json'));
+
+      // (a) Remapping still works on first parse.
+      expect(resolveOriginalPositionForRegistration(inlineRegistration, inlineBundlePath, 3, 17)).toEqual({
+        source: ORIGINAL_SOURCE,
+        line: 2,
+        column: 3,
+      });
+
+      // (b) The encoded inline payload is released alongside the raw JSON.
+      expect(inlineRegistration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+      expect(inlineRegistration.sourceMappingUrl).toBeNull();
+
+      // External map: sourceMappingUrl is a small relative filename the lazy read
+      // path legitimately uses, so the release must leave it intact.
+      const externalBundlePath = path.join(serverBundleCachePath(testName), 'external', 'bundle.js');
+      const externalMapFileName = `${path.basename(externalBundlePath)}.map`;
+      const externalMapPath = path.join(path.dirname(externalBundlePath), externalMapFileName);
+      const externalBundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${externalMapFileName}\n`;
+      await writeBundleAt(externalBundlePath, externalBundleContents);
+      await fsPromises.writeFile(
+        externalMapPath,
+        JSON.stringify(buildThrowingBundleMap(path.basename(externalBundlePath))),
+      );
+      const externalPreload = await preloadSourceMapJsonForBundle(externalBundlePath, externalBundleContents);
+      const externalRegistration = registerBundleForSourceMaps(
+        externalBundlePath,
+        0,
+        externalBundleContents,
+        externalPreload.sourceMapJson,
+        externalPreload.retryMissingSourceMap,
+      );
+      expect(externalRegistration.sourceMappingUrl).toBe(externalMapFileName);
+
+      expect(resolveOriginalPositionForRegistration(externalRegistration, externalBundlePath, 3, 17)).toEqual(
+        {
+          source: ORIGINAL_SOURCE,
+          line: 2,
+          column: 3,
+        },
+      );
+
+      expect(externalRegistration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+      // Unchanged: only the inline data: payload is released, never the filename.
+      expect(externalRegistration.sourceMappingUrl).toBe(externalMapFileName);
+    });
+
     test('remap keeps working after the raw JSON is released and the on-disk map is overwritten', async () => {
       const bundlePath = vmBundlePath(testName);
       const mapFileName = `${path.basename(bundlePath)}.map`;

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -783,6 +783,109 @@ describe('source-mapped stack traces for VM errors', () => {
       }
     });
 
+    test('lazy registration settles to the sentinel after a successful load, so eviction cannot re-read disk', async () => {
+      // A lazy registration (external map, no preloaded JSON) keeps
+      // `sourceMapJson === undefined` until its first load. Without settling it
+      // on success, a later cache eviction would re-read a newer same-path map.
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
+      const bundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`;
+      await writeVmBundle(bundleContents);
+      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
+
+      const registration = registerBundleForSourceMaps(bundlePath, 0, bundleContents, undefined, true);
+      expect(registration.sourceMapJson).toBeUndefined();
+
+      // Successful load reads the external map from disk and settles the lazy
+      // registration to the sentinel (Finding A).
+      expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toEqual({
+        source: ORIGINAL_SOURCE,
+        line: 2,
+        column: 3,
+      });
+      expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+
+      // Evict the parsed cache while still holding the registration, then leave a
+      // different valid map on disk. A fall-through re-read would remap this
+      // generation through the newer map.
+      unregisterBundleForSourceMaps(registration);
+      await fsPromises.writeFile(
+        mapPath,
+        JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath), REBUILT_SOURCE)),
+      );
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+      try {
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+        const readPaths = readFileSyncSpy.mock.calls.map(([filePath]) => filePath);
+        expect(readPaths).not.toContain(mapPath);
+        expect(readPaths).not.toContain(bundlePath);
+        expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+      } finally {
+        readFileSyncSpy.mockRestore();
+      }
+    });
+
+    test('corrupt inline data: map is terminal on first lookup and releases its retained payload', async () => {
+      // A data: payload that passes mime + size but decodes to non-JSON. Its JSON
+      // is validated lazily (not eagerly at build), so it is frozen as a decoded
+      // string until the first remap. That lookup fails to parse and settles
+      // terminal — an inline map is never retryable (a re-read could pick up a
+      // newer same-path generation) — and the settle releases the retained data.
+      const corruptDataUrl = 'data:application/json;charset=utf-8,not-valid-json';
+      const bundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${corruptDataUrl}\n`;
+      const bundlePath = await writeVmBundle(bundleContents);
+
+      // Decoded and frozen, not eagerly validated, and not retryable.
+      const preloaded = await preloadSourceMapJsonForBundle(bundlePath, bundleContents);
+      expect(preloaded.sourceMapJson).toBe('not-valid-json');
+      expect(preloaded.retryMissingSourceMap).toBe(false);
+
+      const registration = registerBundleForSourceMaps(
+        bundlePath,
+        0,
+        bundleContents,
+        preloaded.sourceMapJson,
+        preloaded.retryMissingSourceMap,
+      );
+      expect(registration.sourceMapJson).toBe('not-valid-json');
+
+      // The invalid JSON never remaps; the terminal settle then releases both the
+      // frozen bad string and the retained encoded data: URL — nothing leaks for
+      // the pooled VM's life (Finding B), and it is not retried.
+      expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+      expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+      expect(registration.sourceMappingUrl).toBeNull();
+    });
+
+    test('retired retryable external map settles to the sentinel so eviction cannot re-read disk', async () => {
+      // A retryable external map that never arrives is retired at the retry cap.
+      // Retirement must settle sourceMapJson to the sentinel; otherwise a later
+      // parsed-cache eviction would re-read disk and could pick up a newer
+      // same-path map.
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const bundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`;
+      await writeVmBundle(bundleContents);
+
+      // No map on disk: registered retryable, sourceMappingUrl is a filename.
+      const registration = registerBundleForSourceMaps(bundlePath, 0, bundleContents, undefined, true);
+      expect(registration.sourceMapJson).toBeUndefined();
+      expect(registration.sourceMappingUrl).toBe(mapFileName);
+
+      // Exhaust the retry budget (MAX_MISSING_SOURCE_MAP_RETRIES = 5); the map
+      // never arrives, so each lookup misses and the retries retire.
+      for (let index = 0; index < 5; index += 1) {
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+      }
+
+      // Retirement settled the JSON to the sentinel; the external filename is
+      // kept (not a large payload).
+      expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+      expect(registration.sourceMappingUrl).toBe(mapFileName);
+    });
+
     test('oversized inline source map on the lazy lookup path is terminal, not retryable', async () => {
       // The lazy path re-reads the bundle from disk to find its
       // sourceMappingURL, so serve the oversized inline map via a readFileSync

--- a/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vmSourceMapSupport.test.ts
@@ -23,11 +23,16 @@ import { buildConfig } from '../src/shared/configBuilder';
 import { isErrorRenderResult } from '../src/shared/utils';
 import log from '../src/shared/log';
 import {
+  MAX_EXTERNAL_SOURCE_MAP_BYTES,
+  MAX_INLINE_SOURCE_MAP_BYTES,
+  preloadSourceMapJsonForBundle,
   PREPARE_STACK_TRACE_INSTALL_SCRIPT,
+  RAW_SOURCE_MAP_JSON_DISCARDED,
   registerBundleForSourceMaps,
   remapStackTrace,
   resolveOriginalPositionForRegistration,
   SOURCE_MAP_STACK_REMAPPER_CONTEXT_KEY,
+  unregisterBundleForSourceMaps,
 } from '../src/worker/vmSourceMapSupport';
 
 const testName = 'vmSourceMapSupport';
@@ -277,11 +282,11 @@ describe('source-mapped stack traces for VM errors', () => {
   });
 
   describe('external source map size cap', () => {
-    // Mirrors MAX_EXTERNAL_SOURCE_MAP_BYTES in vmSourceMapSupport.ts, which is not
-    // exported. Reporting the size via a `statSync` spy keeps these tests fast:
-    // writing a genuinely oversized map would mean a 50MB+ disk write per test.
-    const MAX_EXTERNAL_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
-
+    // These tests use the imported MAX_EXTERNAL_SOURCE_MAP_BYTES, so the at-cap
+    // and over-cap boundary assertions below verify the exported constant is the
+    // enforced limit. Reporting the size via a `statSync` spy keeps these tests
+    // fast: writing a genuinely oversized map would mean a 50MB+ disk write per
+    // test.
     function mockReportedSourceMapSize(mapPath: string, sizeInBytes: number) {
       const realStatSync = fs.statSync.bind(fs);
       // The production code stats the *realpath*, which differs from `mapPath` on
@@ -599,6 +604,171 @@ describe('source-mapped stack traces for VM errors', () => {
       } finally {
         warnSpy.mockRestore();
         statSyncSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('single-copy source map retention (raw JSON release)', () => {
+    test('raw source-map JSON is released from the registration after the first successful parse', async () => {
+      const bundleContents = `${buildThrowingBundleSource()}\n${inlineSourceMapComment(
+        buildThrowingBundleMap('bundle.js'),
+      )}\n`;
+      const bundlePath = await writeVmBundle(bundleContents);
+      const registration = registerBundleForSourceMaps(bundlePath, 0, bundleContents);
+      expect(typeof registration.sourceMapJson).toBe('string');
+
+      expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toEqual({
+        source: ORIGINAL_SOURCE,
+        line: 2,
+        column: 3,
+      });
+
+      expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+      // The parsed copy keeps serving lookups after the raw JSON is gone.
+      expect(resolveOriginalPositionForRegistration(registration, bundlePath, 4, 1)).toEqual({
+        source: ORIGINAL_SOURCE,
+        line: 4,
+        column: 1,
+      });
+    });
+
+    test('remap keeps working after the raw JSON is released and the on-disk map is overwritten', async () => {
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
+      const bundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`;
+      await writeVmBundle(bundleContents);
+      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
+
+      // Freeze the external map JSON at registration time, as the VM build does.
+      const preloadedSourceMap = await preloadSourceMapJsonForBundle(bundlePath, bundleContents);
+      expect(typeof preloadedSourceMap.sourceMapJson).toBe('string');
+      const registration = registerBundleForSourceMaps(
+        bundlePath,
+        0,
+        bundleContents,
+        preloadedSourceMap.sourceMapJson,
+        preloadedSourceMap.retryMissingSourceMap,
+      );
+
+      expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toEqual({
+        source: ORIGINAL_SOURCE,
+        line: 2,
+        column: 3,
+      });
+      expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+
+      // A same-path rewrite must not leak into this generation's remaps.
+      await fsPromises.writeFile(
+        mapPath,
+        JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath), REBUILT_SOURCE)),
+      );
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+      try {
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toEqual({
+          source: ORIGINAL_SOURCE,
+          line: 2,
+          column: 3,
+        });
+        const readPaths = readFileSyncSpy.mock.calls.map(([filePath]) => filePath);
+        expect(readPaths).not.toContain(mapPath);
+        expect(readPaths).not.toContain(bundlePath);
+      } finally {
+        readFileSyncSpy.mockRestore();
+      }
+    });
+
+    test('parsed-map eviction cannot fall through to a disk re-read once the raw JSON is released', async () => {
+      const bundlePath = vmBundlePath(testName);
+      const mapFileName = `${path.basename(bundlePath)}.map`;
+      const mapPath = path.join(path.dirname(bundlePath), mapFileName);
+      const bundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=${mapFileName}\n`;
+      await writeVmBundle(bundleContents);
+      await fsPromises.writeFile(mapPath, JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath))));
+
+      const preloadedSourceMap = await preloadSourceMapJsonForBundle(bundlePath, bundleContents);
+      const registration = registerBundleForSourceMaps(
+        bundlePath,
+        0,
+        bundleContents,
+        preloadedSourceMap.sourceMapJson,
+        preloadedSourceMap.retryMissingSourceMap,
+      );
+      expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toEqual({
+        source: ORIGINAL_SOURCE,
+        line: 2,
+        column: 3,
+      });
+      expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+
+      // Evict the parsed map while still holding the registration. The
+      // reachable production shape is a VM torn down (unregistered) while an
+      // in-flight error still holds its registration object.
+      unregisterBundleForSourceMaps(registration);
+      // Leave a valid, different map on disk: a fall-through re-read would
+      // remap this generation through it — the stale-map risk the frozen JSON
+      // exists to prevent.
+      await fsPromises.writeFile(
+        mapPath,
+        JSON.stringify(buildThrowingBundleMap(path.basename(bundlePath), REBUILT_SOURCE)),
+      );
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+      try {
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+        const readPaths = readFileSyncSpy.mock.calls.map(([filePath]) => filePath);
+        expect(readPaths).not.toContain(mapPath);
+        expect(readPaths).not.toContain(bundlePath);
+        expect(registration.sourceMapJson).toBe(RAW_SOURCE_MAP_JSON_DISCARDED);
+      } finally {
+        readFileSyncSpy.mockRestore();
+      }
+    });
+
+    test('oversized inline source map on the lazy lookup path is terminal, not retryable', async () => {
+      // The lazy path re-reads the bundle from disk to find its
+      // sourceMappingURL, so serve the oversized inline map via a readFileSync
+      // mock instead of writing a 50MB+ bundle to disk. The data: payload
+      // length gate fires before any decoding, so an opaque filler payload is
+      // enough.
+      const bundlePath = await writeVmBundle(`${buildThrowingBundleSource()}\n`);
+      const oversizedPayload = 'a'.repeat(MAX_INLINE_SOURCE_MAP_BYTES + 1);
+      const oversizedBundleContents = `${buildThrowingBundleSource()}\n//# sourceMappingURL=data:application/json;charset=utf-8,${oversizedPayload}\n`;
+      const validBundleContents = `${buildThrowingBundleSource()}\n${inlineSourceMapComment(
+        buildThrowingBundleMap('bundle.js'),
+      )}\n`;
+      const registration = registerBundleForSourceMaps(bundlePath, 0, undefined, undefined, true);
+
+      const realReadFileSync = fs.readFileSync.bind(fs);
+      let bundleContentsForLookup = oversizedBundleContents;
+      const readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(((
+        target: fs.PathLike | number,
+        options?: never,
+      ) => {
+        if (String(target) === bundlePath) {
+          return bundleContentsForLookup;
+        }
+        return realReadFileSync(target as string, options);
+      }) as typeof fs.readFileSync);
+
+      try {
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+        const bundleReadsAfterFirstLookup = readFileSyncSpy.mock.calls.filter(
+          ([target]) => String(target) === bundlePath,
+        ).length;
+        expect(bundleReadsAfterFirstLookup).toBeGreaterThan(0);
+
+        // Terminal means no retry churn: even when the bundle's inline map
+        // "shrinks" to a valid one (a same-path rewrite), this generation must
+        // neither re-read the bundle nor pick the new map up.
+        bundleContentsForLookup = validBundleContents;
+        expect(resolveOriginalPositionForRegistration(registration, bundlePath, 3, 17)).toBeNull();
+        expect(readFileSyncSpy.mock.calls.filter(([target]) => String(target) === bundlePath).length).toBe(
+          bundleReadsAfterFirstLookup,
+        );
+      } finally {
+        readFileSyncSpy.mockRestore();
       }
     });
   });


### PR DESCRIPTION
## Summary

Follow-up to #4688 (the external-map size cap) implementing the **retention half** of #4313. Once a bundle registration's source map is parsed on first use, the raw JSON string is released and replaced with a dedicated `RAW_SOURCE_MAP_JSON_DISCARDED` sentinel, so each pooled VM generation retains a single copy (the parsed `SourceMap`) instead of both the raw string and the parsed object.

## What this does NOT change

- The **eager preload** (`preloadSourceMapJsonForBundle`) is untouched — external maps are still captured asynchronously at VM build time.
- The **same-path-rebuild generation-safety guarantee** is preserved: old VM generations keep remapping through their own frozen map even after the on-disk map is overwritten. The regression tests `same-path rebuild does not remap active old VM errors with the new source map` and `...does not retry a missing old VM source map...` stay green.
- This is **not** the zero-retention / lazy-preload redesign discussed on #4313 — that remains a parked product decision.

## Sentinel / invalid-state design

`registration.sourceMapJson` is now `string | null | typeof RAW_SOURCE_MAP_JSON_DISCARDED | undefined` — four mutually-exclusive states: frozen raw JSON (not yet parsed) / confirmed-no-usable-map (`null`, terminal) / raw-released (sentinel, terminal) / check-lazily (`undefined`).

The load-bearing invariant: a registration whose raw JSON was released **never** falls back to re-reading the map from disk. If the parsed map is later evicted (e.g. the VM was unregistered while an in-flight error still references the registration), the lookup returns terminal (bundled frame locations) rather than re-reading a possibly-overwritten same-path map — the exact stale-map risk that freezing the JSON exists to prevent. The guard sits before the `sourceMappingURL` extraction that would otherwise trigger the disk read.

## Tests

New describe block `single-copy source map retention (raw JSON release)` (4 tests):
1. Raw JSON released from the registration after the first successful parse (state transitions `string` → sentinel; parsed copy keeps serving).
2. Remap keeps working after the raw JSON is released **and** the on-disk map is overwritten (no disk re-read).
3. Parsed-map eviction cannot fall through to a disk re-read once the raw JSON is released (terminal, bundled location).
4. Oversized inline (`data:`) source map on the lazy lookup path is terminal, not retryable (no retry churn).

`vmSourceMapSupport.test.ts`: 53/53. `type-check` (tsc --noEmit), `prettier --check`, and `eslint` on touched files all clean. Local adversarial review (`codex review --base origin/main`) returned no blocking findings.

## Carried-over items from #4688 review threads

Both were publicly deferred to this PR on resolved #4688 threads:

- **`data:`-branch tri-state normalization** — the lazy `data:`-URL branch (sync + async readers) now returns terminal `null` for an unusable inline map instead of the retryable `undefined`, matching registration-time `?? null` normalization.
- **`@internal` cap-constant export** — `MAX_INLINE_SOURCE_MAP_BYTES` / `MAX_EXTERNAL_SOURCE_MAP_BYTES` are now `@internal` test-only exports (precedent: `resetSourceMapSupport`); the test file imports them instead of hand-duplicating the 50MB literal.

## Changelog

Added a `[Pro]` Fixed entry under `[Unreleased]`, and qualified the existing #4688 entry so "no longer read into memory" now reads as a pre-read size gate, not a hard memory bound (a map that grows between the size check and the read is still read in full).

## Decision Log (non-blocking calls)

- **Eviction-after-discard → terminal, not disk re-read.** Intentional per #4313 Phase B scope: releasing the raw string accepts a terminal (bundled-location) result on the rare post-unregister-still-referenced re-lookup, in exchange for not retaining both copies. Review later: only if large-map memory evidence ever motivates the fuller retention redesign.
- **Reordered the `null`/sentinel checks before the `sourceMappingURL` extraction** in `loadSourceMapForBundle` — settled registrations skip a wasted bundle disk read; no result change.
- **`data:` normalization also covers malformed / non-JSON inline maps** (not only oversized) on the lazy path — consistent with registration-time behavior. That lazy `data:` branch is currently unreachable in production (`vm.ts` always preloads with bundle contents), so this is latent-consistency hardening.
- **Lazy (`undefined`) registrations are deliberately untouched** by the release logic — their raw JSON was never stored on the registration (already single-copy via the WeakMap cache).
- **`eslint no-param-reassign` disabled at the single mutation site** with an explanatory comment (repo precedent in `worker.ts`, `AsyncPropsManager.ts`) — the shared registration mutation is intentional so every holder observes the release.

Partially addresses #4313.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node-renderer source-map handling by discarding raw map JSON after a successful parse to reduce memory retention.
  * Ensures consistent stack-trace remapping for existing VM generations, without remapping to newer same-path maps.
  * Inline `data:` source maps now release their retained payload after parsing and are treated as terminal failures when unusable.
  * External `.map` files larger than the 50MB limit are skipped via an upfront size check, with clearer remapping/warning behavior.
* **Tests**
  * Added coverage for single-copy source-map retention, terminal failure scenarios, and non-retry behavior after raw data is released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->