### PR TITLE
Avoid duplicate Pro and RSC dependency installation

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -177,7 +177,7 @@ module ReactOnRails
       end
 
       def add_js_dependencies
-        using_pro = respond_to?(:use_pro?) && use_pro?
+        using_pro = respond_to?(:use_pro?, true) && use_pro?
         using_rsc = respond_to?(:use_rsc?) && use_rsc?
         # Pro package includes react-on-rails, so skip base package when using Pro
         add_react_on_rails_package unless using_pro

--- a/react_on_rails/lib/generators/react_on_rails/pro_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/pro_generator.rb
@@ -40,9 +40,11 @@ module ReactOnRails
           )
 
           setup_pro
-          add_pro_npm_dependencies
-          update_imports_to_pro_package unless options[:invoked_by_install]
-          print_success_message unless options[:invoked_by_install]
+          unless options[:invoked_by_install]
+            add_pro_npm_dependencies
+            update_imports_to_pro_package
+            print_success_message
+          end
         else
           GeneratorMessages.add_error(<<~MSG.strip)
             🚫 React on Rails Pro generator prerequisites not met!

--- a/react_on_rails/lib/generators/react_on_rails/rsc_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_generator.rb
@@ -53,7 +53,7 @@ module ReactOnRails
         if options[:invoked_by_install] || prerequisites_met?
           warn_about_react_version_for_rsc(force: true)
           setup_rsc
-          add_rsc_npm_dependencies
+          add_rsc_npm_dependencies unless options[:invoked_by_install]
           install_agent_guardrails
           print_success_message unless options[:invoked_by_install]
         else

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -58,6 +58,12 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       attr_writer :using_rspack
 
+      def use_pro?
+        @use_pro == true
+      end
+
+      attr_writer :use_pro
+
       def use_rsc?
         @use_rsc == true
       end
@@ -1008,6 +1014,22 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
   end
 
   describe "#add_js_dependencies" do
+    it "uses Pro dependencies when the host exposes Pro capability privately" do
+      test_class.send(:private, :use_pro?)
+      instance.use_pro = true
+      allow(instance).to receive_messages(
+        add_react_dependencies: nil,
+        add_css_dependencies: nil,
+        add_transpiler_dependencies: nil,
+        add_dev_dependencies: nil
+      )
+
+      expect(instance).not_to receive(:add_react_on_rails_package)
+      expect(instance).to receive(:add_pro_dependencies).once
+
+      instance.send(:add_js_dependencies)
+    end
+
     it "adds Babel React preset when SWC is not used" do
       instance.using_swc = false
 

--- a/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
@@ -113,6 +113,35 @@ describe ProGenerator, type: :generator do
       allow(generator).to receive(:print_generator_messages)
     end
 
+    context "when invoked by the install generator" do
+      let(:generator) { described_class.new([], { invoked_by_install: true }) }
+
+      it "runs Pro setup without adding dependencies again" do
+        expect(generator).to receive(:setup_pro).once
+        expect(generator).not_to receive(:add_pro_npm_dependencies)
+
+        generator.run_generator
+      end
+    end
+
+    context "when invoked standalone" do
+      before do
+        allow(generator).to receive_messages(
+          prerequisites_met?: true,
+          swap_base_gem_for_pro_in_gemfile: true,
+          update_imports_to_pro_package: nil,
+          print_success_message: nil
+        )
+      end
+
+      it "runs Pro setup and adds dependencies once" do
+        expect(generator).to receive(:setup_pro).once
+        expect(generator).to receive(:add_pro_npm_dependencies).once
+
+        generator.run_generator
+      end
+    end
+
     it "stops before setup when the Gemfile swap fails" do
       allow(generator).to receive_messages(prerequisites_met?: true, swap_base_gem_for_pro_in_gemfile: false)
       allow(generator).to receive(:setup_pro)

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -69,6 +69,41 @@ describe RscGenerator, type: :generator do
     end
   end
 
+  describe "#run_generator" do
+    let(:generator_options) { {} }
+    let(:generator) { described_class.new([], generator_options) }
+
+    before do
+      allow(generator).to receive(:print_generator_messages)
+      allow(generator).to receive(:warn_about_react_version_for_rsc)
+      allow(generator).to receive(:install_agent_guardrails)
+    end
+
+    context "when invoked by the install generator" do
+      let(:generator_options) { { invoked_by_install: true } }
+
+      it "runs RSC setup without adding dependencies again" do
+        expect(generator).to receive(:setup_rsc).once
+        expect(generator).not_to receive(:add_rsc_npm_dependencies)
+
+        generator.run_generator
+      end
+    end
+
+    context "when invoked standalone" do
+      before do
+        allow(generator).to receive_messages(prerequisites_met?: true, print_success_message: nil)
+      end
+
+      it "runs RSC setup and adds dependencies once" do
+        expect(generator).to receive(:setup_rsc).once
+        expect(generator).to receive(:add_rsc_npm_dependencies).once
+
+        generator.run_generator
+      end
+    end
+  end
+
   context "when standalone Tailwind flag is passed" do
     before do
       prepare_destination


### PR DESCRIPTION
## Why

A full `--rsc` installation lets the parent install generator select the complete Pro/RSC dependency stack, then invokes the standalone Pro and RSC generators for their setup work. Those child generators were also installing their npm dependencies, so the same dependency phases and RSC package-pin message appeared twice.

The investigation also found that the parent's Pro selection method is private. The dependency manager only checked public methods, so the parent did not recognize Pro mode; the duplicate child pass accidentally supplied the missing Pro packages.

## What changed

- Let the dependency manager recognize a private `use_pro?` capability on its host.
- Keep dependency ownership in the parent install generator when Pro/RSC child generators are invoked with `invoked_by_install`.
- Preserve standalone Pro and RSC generator behavior so each still installs its dependencies once.
- Add focused regression coverage for private Pro capability detection and parent-vs-standalone orchestration.

## Verification

- Reproduced the published failure before the fix: the Pro dependency heading, RSC dependency heading, and RSC package-pin message each appeared twice.
- Ran the same local-gem `create-react-on-rails-app --rsc --package-manager npm --no-agent-files` flow after the fix; it exited 0.
- Confirmed each affected output appears exactly once after the fix:
  - Pro dependency heading: 1
  - RSC dependency heading: 1
  - RSC package-pin message: 1
- Confirmed the generated app contains `react-on-rails-pro`, `react-on-rails-pro-node-renderer`, and `react-on-rails-rsc`, and does not retain the base `react-on-rails` package.
- `git diff --check origin/main...HEAD`
- Focused RuboCop over all six changed Ruby/spec files: 6 files inspected, no offenses.
- Pre-push hooks: branch RuboCop and Markdown link checks passed.

Automated specs were not completed locally under the repository's PR-work policy. Current-head hosted CI completed successfully, including the generator RSpec shards, unit specs, generated examples, CodeQL, and the required PR gate.

## QA evidence

Two independent read-only reviews covered the full branch diff and the install-generator ownership call site. Neither found a correctness, compatibility, security, architecture, or test-design blocker. The final manual reproduction used the committed branch head.

## Codex decision log

- **Changelog timing — `deferred_to_update_changelog`**
  - This user-visible fix should be included by the consolidated changelog workflow before the next release candidate.
  - Deferring avoids a placeholder PR reference and an extra review cycle before this PR number exists.

## Churn

- 1 commit
- 6 files
- One diagnostic smoke run exposed the private `use_pro?` ownership bug; the final smoke run passed with the expected package set and single output counts.

Fixes #4618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Pro capability hooks to ensure the correct Pro dependency setup is chosen even when the capability is implemented as a private method.
  * Updated Pro and RSC generators so dependency installation (and Pro success messaging) are skipped during the main install flow, preventing redundant steps.
* **Tests**
  * Expanded generator specs to verify distinct behavior for install-invoked versus standalone runs for both Pro and RSC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
