### PR TITLE
Fix knip duplicate-export failure breaking lint on main

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vmSourceMapSupport.ts
@@ -122,8 +122,12 @@ const sourceMapLookupAttempts = new WeakSet<SourceMapLookupAttempt>();
 let warnedMissingSourceMapConstructor = false;
 
 const MAX_MISSING_SOURCE_MAP_RETRIES = 5;
+// Shared ceiling for both source-map size gates below. Kept private so the two
+// exported caps stay distinct symbols (knip flags re-exporting one value under
+// two names as a duplicate export).
+const MAX_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
 /** @internal Exported for tests. */
-export const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
+export const MAX_INLINE_SOURCE_MAP_BYTES = MAX_SOURCE_MAP_BYTES;
 // External `.map` files get the same ceiling as inline maps. This is a pre-read
 // size gate, not a hard memory bound: a map that grows between the `statSync` in
 // `resolveReadableSourceMapPath` and the read below still gets read in full.
@@ -134,7 +138,7 @@ export const MAX_INLINE_SOURCE_MAP_BYTES = 50 * 1024 * 1024;
 // characters admits a different amount of data inline than externally. The
 // inline unit predates this constant and is left alone here.
 /** @internal Exported for tests. */
-export const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES;
+export const MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_SOURCE_MAP_BYTES;
 
 // `preloadSourceMapJsonForBundle` re-checks the map on every VM build, and with
 // `maxVMPoolSize` defaulting to 2 an app with more bundles than that rebuilds


### PR DESCRIPTION
## Why

Main is red: the `Lint JS and Ruby` workflow fails on `pnpm exec knip` since #4711 merged ([failing run](https://github.com/shakacode/react_on_rails/actions/runs/29615362951/job/87999199163)). knip's duplicate-exports rule flags `MAX_EXTERNAL_SOURCE_MAP_BYTES = MAX_INLINE_SOURCE_MAP_BYTES` in `vmSourceMapSupport.ts` as one value exported under two names. A red lint gate on main fails every PR branch, so this blocks the whole open-PR queue.

## What

Route both source-map size caps through a private shared constant (`MAX_SOURCE_MAP_BYTES`) so the two exports stay distinct symbols with the same value. No behavior change; the intentional unit difference (string length vs bytes-on-disk) documented in the surrounding comments is preserved.

## Test plan

- `pnpm exec knip` → exit 0 (was exit 1 with `Duplicate exports (1)`)
- `pnpm exec knip --production` → exit 0
- `pnpm exec jest tests/vmSourceMapSupport.test.ts` in `packages/react-on-rails-pro-node-renderer` → 57 passed
- Prettier + ESLint clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the maximum supported size for inline and external source maps.
  * Preserved separate limits for each source map type while ensuring they use the same size ceiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->