### PR TITLE
[Pro] Demote async-props closed-stream races from error to debug (fixes #4325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Stopped logging routine async-props stream-close races at error level**: When a client
+  disconnects mid-render, or a `stream_react_component_with_async_props` block keeps emitting after
+  `renderComplete` winds the connection down, writes to the already-closed renderer request stream are
+  now treated as routine disconnects: logged once at `debug` (no backtrace, gated on `logging_on_server`)
+  and short-circuited so the block's remaining props are skipped silently. Previously every remaining
+  prop produced an `error`-level entry with a 5-frame backtrace, so a single disconnect spammed logs in
+  proportion to the number of props still in flight and buried genuine emit failures in the noise.
+  Genuine write failures (for example a `JSON::GeneratorError`) still log at `error` with a backtrace.
+  This mirrors the sibling `ReactOnRailsPro::Stream#log_client_disconnect` convention. Fixes
+  [Issue 4325](https://github.com/shakacode/react_on_rails/issues/4325).
+  [PR XXXX](https://github.com/shakacode/react_on_rails/pull/XXXX) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Stopped retaining both raw and parsed source maps per pooled Node renderer VM**: Once a
   bundle's source map is parsed on first use, the raw map JSON (up to 50MB under the cap) is released and
   the parsed map becomes the VM generation's single retained copy. For inline (`data:`) maps the encoded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   Genuine write failures (for example a `JSON::GeneratorError`) still log at `error` with a backtrace.
   This mirrors the sibling `ReactOnRailsPro::Stream#log_client_disconnect` convention. Fixes
   [Issue 4325](https://github.com/shakacode/react_on_rails/issues/4325).
-  [PR XXXX](https://github.com/shakacode/react_on_rails/pull/XXXX) by
+  [PR 4719](https://github.com/shakacode/react_on_rails/pull/4719) by
   [justin808](https://github.com/justin808).
 
 - **[Pro]** **Stopped retaining both raw and parsed source maps per pooled Node renderer VM**: Once a

--- a/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
@@ -50,14 +50,42 @@ module ReactOnRailsPro
   class AsyncPropsEmitter
     SANITIZED_REJECTION_REASON = "Async prop rejected by server"
 
+    # Socket-level errors that mean the renderer request stream is already gone.
+    # These mirror the family that ReactOnRailsPro::Stream#log_client_disconnect
+    # (concerns/stream.rb) treats as a routine client disconnect, so the two files
+    # classify disconnect races the same way.
+    CLOSED_REQUEST_STREAM_SOCKET_ERRORS = [
+      IOError, Errno::EPIPE, Errno::ECONNRESET, Errno::ECONNABORTED
+    ].freeze
+
     attr_reader :pull_requests
 
     def initialize(bundle_timestamp, request_stream, pull_enabled: false)
       @bundle_timestamp = bundle_timestamp
       @request_stream = request_stream
       @pushed_props = Set.new
+      # Latched the first time a write hits a closed request stream, so the rest of
+      # the user's block (which runs in its own fiber and may keep emitting) is
+      # skipped silently instead of logging once per remaining prop.
+      @request_stream_closed = false
       @pull_enabled = pull_enabled
       @pull_requests = PullRequestQueue.new(@pushed_props) if pull_enabled
+    end
+
+    # Exception classes that indicate a write landed on an already-closed request
+    # stream. `@request_stream` is a Protocol::HTTP::Body::Writable::Output; writing
+    # after its queue closes raises Protocol::HTTP::Body::Writable::Closed on a clean
+    # close, or the stored socket error (Errno::*/IOError) that tore the stream down
+    # on an aborted one (see async-http Output#passthrough -> Writable#write).
+    #
+    # Resolved at rescue time rather than at load time on purpose: the protocol-http
+    # writable-body class is required lazily (only once streaming starts) and its
+    # Closed constant has moved namespaces across gem versions, so the defined? guard
+    # keeps this file loadable everywhere and picks the class up once it exists.
+    def self.closed_request_stream_errors
+      return CLOSED_REQUEST_STREAM_SOCKET_ERRORS unless defined?(Protocol::HTTP::Body::Writable::Closed)
+
+      CLOSED_REQUEST_STREAM_SOCKET_ERRORS + [Protocol::HTTP::Body::Writable::Closed]
     end
 
     # Sends an async prop to the Node renderer.
@@ -92,11 +120,22 @@ module ReactOnRailsPro
     private
 
     def write_settled_chunk(prop_name, action:)
+      # A closed request stream is routine (client disconnect, or the block still
+      # emitting after renderComplete winds the connection down). Once we have seen
+      # it close, skip the remaining writes entirely so a block emitting N more props
+      # does not generate N log lines or N wasted serializations.
+      return if @request_stream_closed
+
       chunk = yield
       @request_stream << "#{chunk.to_json}\n"
       # Once the chunk is written, Ruby treats the prop as settled too.
       # That keeps duplicate pull requests filtered even if the JS manager is recreated.
       @pushed_props.add(prop_name)
+    rescue *self.class.closed_request_stream_errors => e
+      # Routine disconnect race, not a genuine failure: keep it quiet, mirroring
+      # ReactOnRailsPro::Stream#log_client_disconnect. The prop is intentionally not
+      # marked pushed, matching the error path below.
+      handle_closed_request_stream(prop_name, action, e)
     rescue StandardError => e
       # Continue streaming: one failed async prop write should not abort the
       # entire render. The prop is not marked as pushed unless the write
@@ -105,6 +144,20 @@ module ReactOnRailsPro
         backtrace = e.backtrace&.first(5)&.join("\n")
         "[ReactOnRailsPro::AsyncProps] Failed to #{action} async prop '#{prop_name}': " \
           "#{e.class} - #{e.message}\n#{backtrace}"
+      end
+    end
+
+    # Handles a write to an already-closed request stream. Mirrors
+    # ReactOnRailsPro::Stream#log_client_disconnect: quiet (debug, no backtrace) and
+    # gated on logging_on_server. Latches @request_stream_closed so this logs at most
+    # once per stream and the block's remaining emits are skipped without noise.
+    def handle_closed_request_stream(prop_name, action, error)
+      @request_stream_closed = true
+      return unless ReactOnRails.configuration.logging_on_server
+
+      Rails.logger.debug do
+        "[ReactOnRailsPro::AsyncProps] Request stream closed while emitting async prop " \
+          "'#{prop_name}' (#{action}); skipping remaining props: #{error.class}"
       end
     end
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/async_props_emitter.rb
@@ -127,15 +127,25 @@ module ReactOnRailsPro
       return if @request_stream_closed
 
       chunk = yield
-      @request_stream << "#{chunk.to_json}\n"
+      serialized_chunk = "#{chunk.to_json}\n"
+
+      # Scope the closed-stream classification to the socket write itself. Building
+      # and serializing the chunk above (including a prop value's own #to_json) can
+      # raise IOError/Errno::* for reasons unrelated to a disconnect; letting those
+      # fall through to the genuine-failure path below keeps them at error level
+      # instead of latching the emitter shut and silently dropping later props.
+      begin
+        @request_stream << serialized_chunk
+      rescue *self.class.closed_request_stream_errors => e
+        # Routine disconnect race, not a genuine failure: keep it quiet, mirroring
+        # ReactOnRailsPro::Stream#log_client_disconnect. The prop is intentionally
+        # not marked pushed, matching the error path below.
+        return handle_closed_request_stream(prop_name, action, e)
+      end
+
       # Once the chunk is written, Ruby treats the prop as settled too.
       # That keeps duplicate pull requests filtered even if the JS manager is recreated.
       @pushed_props.add(prop_name)
-    rescue *self.class.closed_request_stream_errors => e
-      # Routine disconnect race, not a genuine failure: keep it quiet, mirroring
-      # ReactOnRailsPro::Stream#log_client_disconnect. The prop is intentionally not
-      # marked pushed, matching the error path below.
-      handle_closed_request_stream(prop_name, action, e)
     rescue StandardError => e
       # Continue streaming: one failed async prop write should not abort the
       # entire render. The prop is not marked as pushed unless the write

--- a/react_on_rails_pro/spec/react_on_rails_pro/async_props_emitter_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/async_props_emitter_spec.rb
@@ -212,6 +212,29 @@ RSpec.describe ReactOnRailsPro::AsyncPropsEmitter do
       expect(mock_logger).not_to have_received(:debug)
     end
 
+    it "treats a socket error raised while serializing a prop value as a genuine failure, not a disconnect" do
+      # Only the request-stream write is a disconnect race. A prop value whose own
+      # #to_json raises a socket-family error is a real bug: it must log at error
+      # (with a backtrace) and must NOT latch the emitter closed, so later props on
+      # a still-open stream keep flowing.
+      exploding = Object.new
+      def exploding.to_json(*)
+        raise Errno::EPIPE
+      end
+      written = []
+      allow(request_stream).to receive(:<<) { |chunk| written << chunk }
+
+      emitter.call("boom", exploding)
+      emitter.call("after", 1)
+
+      expect(mock_logger).to have_received(:error) do |&block|
+        expect(block.call).to include("Failed to send async prop 'boom'")
+      end
+      expect(mock_logger).not_to have_received(:debug)
+      # Not latched: the good prop after the raising one is still written.
+      expect(written).to contain_exactly(a_string_including("after"))
+    end
+
     it "does not mark a prop pushed when the write hits a closed stream" do
       pull_emitter = described_class.new(bundle_timestamp, request_stream, pull_enabled: true)
       allow(request_stream).to receive(:<<).and_raise(Protocol::HTTP::Body::Writable::Closed)

--- a/react_on_rails_pro/spec/react_on_rails_pro/async_props_emitter_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/async_props_emitter_spec.rb
@@ -15,6 +15,10 @@
 
 require_relative "spec_helper"
 require "react_on_rails_pro/async_props_emitter"
+# Ensures Protocol::HTTP::Body::Writable::Closed is loaded so the emitter's
+# closed-stream classification (and the tests that raise it) resolve the real
+# class rather than falling back to the socket-only error set.
+require "protocol/http/body/writable"
 
 RSpec.describe ReactOnRailsPro::AsyncPropsEmitter do
   let(:bundle_timestamp) { "bundle-12345" }
@@ -153,6 +157,134 @@ RSpec.describe ReactOnRailsPro::AsyncPropsEmitter do
       pull_emitter.pull_requests.close
 
       expect(pull_emitter.pull_requests.dequeue).to be_nil
+    end
+  end
+
+  describe "closed request stream handling" do
+    # The user's async-props block runs in its own fiber and can keep emitting
+    # after the client disconnects or the connection winds down post-renderComplete.
+    # Those writes hit an already-closed stream: a routine race, not a real failure.
+    let(:mock_logger) { instance_double(Logger) }
+
+    before do
+      allow(Rails).to receive(:logger).and_return(mock_logger)
+      allow(mock_logger).to receive(:debug)
+      allow(mock_logger).to receive(:error)
+      allow(ReactOnRails.configuration).to receive(:logging_on_server).and_return(true)
+    end
+
+    it "logs a closed-stream write at debug (not error) with no backtrace" do
+      allow(request_stream).to receive(:<<).and_raise(Protocol::HTTP::Body::Writable::Closed)
+
+      expect { emitter.call("books", []) }.not_to raise_error
+
+      expect(mock_logger).to have_received(:debug) do |&block|
+        message = block.call
+        expect(message).to include("Request stream closed")
+        expect(message).to include("books")
+        expect(message).to include("Protocol::HTTP::Body::Writable::Closed")
+        expect(message).not_to include("\n") # single line, no 5-frame backtrace
+      end
+      expect(mock_logger).not_to have_received(:error)
+    end
+
+    it "treats a socket disconnect (Errno::EPIPE) as a closed stream, not an error" do
+      allow(request_stream).to receive(:<<).and_raise(Errno::EPIPE)
+
+      expect { emitter.call("books", []) }.not_to raise_error
+
+      expect(mock_logger).to have_received(:debug)
+      expect(mock_logger).not_to have_received(:error)
+    end
+
+    it "still logs a genuine write failure at error with a backtrace" do
+      allow(request_stream).to receive(:<<).and_raise(RuntimeError.new("bad serialization"))
+
+      expect { emitter.call("books", []) }.not_to raise_error
+
+      expect(mock_logger).to have_received(:error) do |&block|
+        message = block.call
+        expect(message).to include("Failed to send async prop 'books'")
+        expect(message).to include("RuntimeError")
+        expect(message).to include("bad serialization")
+        expect(message).to match(/\.rb:\d+/) # backtrace frame present
+      end
+      expect(mock_logger).not_to have_received(:debug)
+    end
+
+    it "does not mark a prop pushed when the write hits a closed stream" do
+      pull_emitter = described_class.new(bundle_timestamp, request_stream, pull_enabled: true)
+      allow(request_stream).to receive(:<<).and_raise(Protocol::HTTP::Body::Writable::Closed)
+
+      Async do
+        pull_emitter.call("books", [])
+        pull_emitter.pull_requests.enqueue("books")
+        pull_emitter.pull_requests.close
+
+        # Prop is retryable via pull mode because it was never settled.
+        expect(pull_emitter.pull_requests.dequeue).to eq("books")
+        expect(pull_emitter.pull_requests.dequeue).to be_nil
+      end
+    end
+
+    it "logs once and skips remaining emits after the stream closes" do
+      write_attempts = 0
+      allow(request_stream).to receive(:<<) do
+        write_attempts += 1
+        raise Protocol::HTTP::Body::Writable::Closed
+      end
+
+      emitter.call("a", 1)
+      emitter.call("b", 2)
+      emitter.reject("c", "denied")
+
+      expect(write_attempts).to eq(1) # only the first emit is attempted after close
+      expect(mock_logger).to have_received(:debug).once
+      expect(mock_logger).not_to have_received(:error)
+    end
+
+    it "still short-circuits but stays silent when logging_on_server is false" do
+      allow(ReactOnRails.configuration).to receive(:logging_on_server).and_return(false)
+      write_attempts = 0
+      allow(request_stream).to receive(:<<) do
+        write_attempts += 1
+        raise Protocol::HTTP::Body::Writable::Closed
+      end
+
+      emitter.call("a", 1)
+      emitter.call("b", 2)
+
+      expect(write_attempts).to eq(1)
+      expect(mock_logger).not_to have_received(:debug)
+      expect(mock_logger).not_to have_received(:error)
+    end
+
+    it "demotes a closed-stream write in #reject to debug, not error" do
+      # #reject also emits a separate debug line (the redacted internal reason)
+      # while building the chunk, so capture every debug message and assert the
+      # closed-stream line is among them rather than picking the first call.
+      debug_messages = []
+      allow(mock_logger).to receive(:debug) { |*args, &block| debug_messages << (block ? block.call : args.first) }
+      allow(request_stream).to receive(:<<).and_raise(Protocol::HTTP::Body::Writable::Closed)
+
+      expect { emitter.reject("secretData", "forbidden") }.not_to raise_error
+
+      expect(debug_messages).to include(
+        a_string_including("Request stream closed").and(a_string_including("secretData"))
+      )
+      expect(mock_logger).not_to have_received(:error)
+    end
+  end
+
+  describe ".closed_request_stream_errors" do
+    it "pins the async-http writable-closed exception API alongside the socket family" do
+      # The emitter rescues these classes to demote disconnect races. Pin the API so
+      # a gem change fails here instead of silently reclassifying disconnects as
+      # error-level noise (mirrors the PullRequestQueue ClosedError pin below).
+      expect(defined?(Protocol::HTTP::Body::Writable::Closed)).to eq("constant")
+      expect(described_class.closed_request_stream_errors).to include(
+        Protocol::HTTP::Body::Writable::Closed, IOError, Errno::EPIPE, Errno::ECONNRESET, Errno::ECONNABORTED
+      )
     end
   end
 


### PR DESCRIPTION
### Summary

`ReactOnRailsPro::AsyncPropsEmitter#call` / `#reject` rescued **all** `StandardError`s from a
write to the renderer request stream and logged each at **error** level with a 5-frame backtrace —
including the routine case where the stream is already closed (client disconnected, or the user's
async-props block keeps emitting after `renderComplete` winds the connection down). Because that
block runs in its own fiber, a single disconnect produced **one error+backtrace entry per remaining
prop**, spamming logs in proportion to props still in flight and burying genuine emit failures in
the noise.

This PR classifies the closed-stream family separately and demotes it to a single quiet `debug`,
mirroring the sibling `ReactOnRailsPro::Stream#log_client_disconnect` convention that already models
the right behavior. Genuine write failures (e.g. a serialization error) still log at `error` with a
backtrace.

Fixes #4325.

### What changed

- Rescue the closed-stream family — `IOError`, `Errno::EPIPE`, `Errno::ECONNRESET`,
  `Errno::ECONNABORTED`, and (resolved lazily via `defined?`, since the constant has moved
  namespaces across gem versions) `Protocol::HTTP::Body::Writable::Closed` — **before** the generic
  `rescue StandardError`.
- Route it to `handle_closed_request_stream`, which logs once at `Rails.logger.debug` (no backtrace,
  gated on `logging_on_server`) and **latches** `@request_stream_closed`, so the block's remaining
  emits are skipped silently instead of re-logging and re-serializing per prop.
- The prop is still not marked pushed on a closed-stream write, matching the existing error path, so
  pull mode can re-request it.
- Scope the closed-stream classification to the `@request_stream << ...` write itself (second
  commit): chunk build/serialize — including a prop value's own `#to_json` — falls through to the
  error path, so a serialization error that happens to be `IOError`/`Errno::*` is **not**
  misclassified as a disconnect (which would latch the emitter shut and hide a genuine failure).
  This addressed a P2 from the pre-push AI review.

### Verification

- **RSpec** (`react_on_rails_pro/spec/react_on_rails_pro/async_props_emitter_spec.rb`): **32 examples,
  0 failures** — 9 new closed-stream cases (debug-not-error, socket disconnect, genuine-error still
  errors, prop-not-pushed/retryable, log-once-and-skip, silent when `logging_on_server` false, reject
  demotion, the socket-error-while-serializing regression, and an API-pin test).
- **RuboCop** (`--ignore-parent-exclusion`, both touched files): 0 offenses.
- **RBS**: no signature covers this file (N/A).
- **Pre-push AI review (codex, `--base origin/main`)**: one P2 (over-broad rescue) → fixed with a
  regression test → re-review clean ("No actionable correctness issues were identified").

### QA — real client-disconnect before/after

Drove the **real** `AsyncPropsEmitter` against a **real** closed
`Protocol::HTTP::Body::Writable::Output` (genuine `Protocol::HTTP::Body::Writable::Closed` from
protocol-http 0.62.2), emitting 4 props/reject after the disconnect, `logging_on_server=true`:

**BEFORE** (main `95d5575f9`) — 4× error + 5-frame backtrace, one per remaining prop (plus the
redacted reject reason still logged):

```
log entries: 5 total  (error=4, debug=1)
[1] ERROR: [ReactOnRailsPro::AsyncProps] Failed to send async prop 'users': Protocol::HTTP::Body::Writable::Closed - ...
    .../protocol/http/body/writable.rb:91:in 'Protocol::HTTP::Body::Writable#write'
    ...async_props_emitter.rb:96:in 'write_settled_chunk'  (+3 more frames)
[2] ERROR: ...'posts'...  [3] ERROR: ...'stats'...  [5] ERROR: Failed to reject async prop 'secret'...
```

**AFTER** (this PR) — single quiet debug, no backtrace, remaining props (incl. the reject and its
redacted reason) skipped:

```
log entries: 1 total  (error=0, debug=1)
[1] DEBUG: [ReactOnRailsPro::AsyncProps] Request stream closed while emitting async prop 'users' (send); skipping remaining props: Protocol::HTTP::Body::Writable::Closed
```

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~ (no user-facing docs; behavior is operator-log only)
- [x] Update CHANGELOG file

### Other Information

Pro-only change (`react_on_rails_pro/`). No API/behavior change beyond log severity/volume on
disconnect. Mirrors `ReactOnRailsPro::Stream#log_client_disconnect` (`concerns/stream.rb`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client disconnects during Pro async prop streaming.
  * Routine stream closures are now treated as normal disconnects, avoiding unnecessary error logs and backtraces.
  * Remaining async props are skipped after a disconnect, preventing repeated write attempts.
  * Genuine serialization and write failures continue to be reported as errors with diagnostic details.
  * Debug logging respects the server logging configuration and occurs only once per disconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Merge-authority evidence (batch ror-c-20260716-1543-pro-node-residuals)

**Release-mode gate:** development → target `main` = **beta** gate ("Confidence note + green required checks"). Satisfied.

**Confidence note:**
- **Validated:**
  - Local: `bundle exec rspec spec/react_on_rails_pro/async_props_emitter_spec.rb` → 32 examples, 0 failures.
  - Local: `bundle exec rubocop --ignore-parent-exclusion` on both touched files → 0 offenses. RBS: no signature covers this file (N/A).
  - Pre-push AI review (`codex review --base origin/main`): one P2 (over-broad rescue) → fixed in `5b361ac6e` with a regression test → re-review clean.
  - Hosted CI (`+ci-run-hosted`, head `5aba97d76`): **React on Rails Pro - Package Tests** (runs the emitter spec), **React on Rails Pro - Integration Tests**, **Integration Tests**, **Generator tests**, **Playwright E2E**, **JS unit tests for Renderer**, **Assets Precompile**, **Rspec test for gem** all green.
  - QA: real client-disconnect before/after on the actual emitter + a real closed `Protocol::HTTP::Body::Writable::Output` — BEFORE 4× error+backtrace/prop, AFTER 1 quiet debug, remainder skipped (see QA section above).
- **Evidence:** CI checks on this PR (head `5aba97d76`); QA/before-after inline above; codex re-review "No actionable correctness issues were identified."
- **UNKNOWN:** none.
- **Residual risk:** none for this change. The hosted **Lint JS and Ruby** `knip` "Detect dead code" step fails, but that failure is **pre-existing on `main`** (identical `Duplicate exports` in `vmSourceMapSupport.ts` from the merged source-map PRs) and this PR contains **zero JS/TS changes** — it is unrelated to this change and outside its scope. The `pull_request`-event "Lint JS and Ruby" check passed.

**Labels:** `ready-for-hosted-ci` (generator-sensitive gate; hosted CI requested and green). Benchmarks: not applicable (log-severity-only change).
