### PR TITLE
[Pro] Harden loadable-stats success-cache test; route worker tests through formAutoContent shim (partially addresses #4506)

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/tests/formAutoContent.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/formAutoContent.ts
@@ -38,6 +38,16 @@ type FormFields = Record<string, unknown>;
 type FormAutoContentResult = {
   payload: FormData | Readable;
   headers: Record<string, string>;
+  // The underlying `form-data` instance. Exposed so tests that need raw multipart
+  // bytes (`form.getBuffer()`) or byte-offset inspection can build their form
+  // through this one shim instead of importing `form-data` directly.
+  //
+  // NOTE: `form` equals the wire `payload` only for multipart requests (a
+  // file/Buffer/stream field is present). For a no-file request the wire `payload`
+  // is the urlencoded body below, so `form` is the multipart view of the same
+  // fields, not the bytes actually sent — do not read `form.getBuffer()` on a
+  // no-file result and expect the transmitted payload.
+  form: FormData;
 };
 
 function hasOwn(o: unknown, field: string): boolean {
@@ -104,6 +114,7 @@ export default function formAutoContent(json: FormFields): FormAutoContentResult
     return {
       payload: form,
       headers: form.getHeaders() as Record<string, string>,
+      form,
     };
   }
 
@@ -125,5 +136,6 @@ export default function formAutoContent(json: FormFields): FormAutoContentResult
   return {
     payload: Readable.from(stringify(urlencoded as Record<string, string>)),
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    form,
   };
 }

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -14,7 +14,6 @@
  */
 
 import fs from 'fs';
-import FormData from 'form-data';
 import path from 'path';
 import querystring from 'querystring';
 import { PassThrough, Readable } from 'stream';
@@ -155,18 +154,19 @@ describe('worker', () => {
     const httpErrorLogSpy = jest.spyOn(app.log, 'error');
 
     try {
-      const form = new FormData();
-      form.append('gemVersion', gemVersion);
-      form.append('protocolVersion', protocolVersion);
-      form.append('railsEnv', railsEnv);
-      form.append('renderingRequest', 'ReactOnRails.dummy');
-      form.append('bundle', fs.readFileSync(getFixtureBundle()), {
-        contentType: 'text/javascript',
-        filename: 'bundle.js',
-      });
-      form.append('asset1', Buffer.from('{}'), {
-        contentType: 'application/json',
-        filepath: '../../loadable-stats.json',
+      const { form } = formAutoContent({
+        gemVersion,
+        protocolVersion,
+        railsEnv,
+        renderingRequest: 'ReactOnRails.dummy',
+        bundle: {
+          value: fs.readFileSync(getFixtureBundle()),
+          options: { contentType: 'text/javascript', filename: 'bundle.js' },
+        },
+        asset1: {
+          value: Buffer.from('{}'),
+          options: { contentType: 'application/json', filepath: '../../loadable-stats.json' },
+        },
       });
 
       const res = await app
@@ -455,15 +455,16 @@ describe('worker', () => {
     const app = createWorker({
       password: 'password',
     });
-    const form = new FormData();
-    form.append('gemVersion', gemVersion);
-    form.append('protocolVersion', protocolVersion);
-    form.append('railsEnv', railsEnv);
-    form.append('renderingRequest', 'ReactOnRails.dummy');
-    form.append('password', 'wrong');
-    form.append('bundle', Buffer.from('untrusted bundle'), {
-      contentType: 'text/javascript',
-      filename: 'bundle.js',
+    const { form } = formAutoContent({
+      gemVersion,
+      protocolVersion,
+      railsEnv,
+      renderingRequest: 'ReactOnRails.dummy',
+      password: 'wrong',
+      bundle: {
+        value: Buffer.from('untrusted bundle'),
+        options: { contentType: 'text/javascript', filename: 'bundle.js' },
+      },
     });
 
     const res = await app
@@ -717,19 +718,20 @@ describe('worker', () => {
       uploadDirDuringResponse = req.uploadDir;
       done(null, payload);
     });
-    const form = new FormData();
-    form.append(`bundle_${bundleHash}`, fs.readFileSync(getFixtureBundle()), {
-      contentType: 'text/javascript',
-      filename: 'bundle.js',
+    const { form } = formAutoContent({
+      [`bundle_${bundleHash}`]: {
+        value: fs.readFileSync(getFixtureBundle()),
+        options: { contentType: 'text/javascript', filename: 'bundle.js' },
+      },
+      password: 'my_password',
+      'asset-after-password': {
+        value: fs.readFileSync(getFixtureAsset()),
+        options: { contentType: 'application/json', filename: 'asset-after-password.json' },
+      },
+      gemVersion,
+      protocolVersion,
+      railsEnv,
     });
-    form.append('password', 'my_password');
-    form.append('asset-after-password', fs.readFileSync(getFixtureAsset()), {
-      contentType: 'application/json',
-      filename: 'asset-after-password.json',
-    });
-    form.append('gemVersion', gemVersion);
-    form.append('protocolVersion', protocolVersion);
-    form.append('railsEnv', railsEnv);
 
     const payload = form.getBuffer();
     const passwordFieldOffset = payload.indexOf(Buffer.from('name="password"'));
@@ -764,21 +766,23 @@ describe('worker', () => {
     const app = createWorker({
       password: 'my_password',
     });
-    const form = new FormData();
-    form.append('gemVersion', gemVersion);
-    form.append('protocolVersion', protocolVersion);
-    form.append('railsEnv', railsEnv);
-    form.append('password', 'my_password');
-    form.append('bundle_too-many-files', Buffer.from('bundle'), {
-      contentType: 'text/javascript',
-      filename: 'bundle.js',
-    });
+    const fields: Record<string, unknown> = {
+      gemVersion,
+      protocolVersion,
+      railsEnv,
+      password: 'my_password',
+      'bundle_too-many-files': {
+        value: Buffer.from('bundle'),
+        options: { contentType: 'text/javascript', filename: 'bundle.js' },
+      },
+    };
     for (let index = 0; index < 996; index += 1) {
-      form.append(`asset${index}`, Buffer.from('{}'), {
-        contentType: 'application/json',
-        filename: `asset-${index}.json`,
-      });
+      fields[`asset${index}`] = {
+        value: Buffer.from('{}'),
+        options: { contentType: 'application/json', filename: `asset-${index}.json` },
+      };
     }
+    const { form } = formAutoContent(fields);
 
     const res = await app
       .inject()
@@ -799,18 +803,19 @@ describe('worker', () => {
     const httpErrorLogSpy = jest.spyOn(app.log, 'error');
 
     try {
-      const form = new FormData();
-      form.append('gemVersion', gemVersion);
-      form.append('protocolVersion', protocolVersion);
-      form.append('railsEnv', railsEnv);
-      form.append('password', 'my_password');
-      form.append(`bundle_${bundleHash}`, Buffer.from('bundle'), {
-        contentType: 'text/javascript',
-        filename: `${bundleHash}.js`,
-      });
-      form.append('asset1', Buffer.from('{}'), {
-        contentType: 'application/json',
-        filepath: '../../loadable-stats.json',
+      const { form } = formAutoContent({
+        gemVersion,
+        protocolVersion,
+        railsEnv,
+        password: 'my_password',
+        [`bundle_${bundleHash}`]: {
+          value: Buffer.from('bundle'),
+          options: { contentType: 'text/javascript', filename: `${bundleHash}.js` },
+        },
+        asset1: {
+          value: Buffer.from('{}'),
+          options: { contentType: 'application/json', filepath: '../../loadable-stats.json' },
+        },
       });
 
       const res = await app

--- a/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
+++ b/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
@@ -154,6 +154,16 @@ describe('loadRSCClientChunkStylesheetHrefsByChunkName', () => {
     );
     expect(readFileSync).toHaveBeenCalledTimes(2);
     expect(consoleWarn).toHaveBeenCalledTimes(1);
+
+    // Once the read succeeds, the success state is cached for the life of the
+    // process: later renders reuse it and must not re-read loadable-stats.json,
+    // even far past any retry window (issue #4371 no per-request re-read).
+    now += 30_000;
+    await expect(renderWithDefaultStylesheetInference(injectRSCPayload, flightData)).resolves.toContain(
+      '<link rel="stylesheet" href="/webpack/test/css/client1-12345678.css" data-precedence="rsc-css">',
+    );
+    expect(readFileSync).toHaveBeenCalledTimes(2);
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
   });
 
   it('does not repeat identical unexpected loadable-stats warnings on retry', async () => {


### PR DESCRIPTION
### Summary

Two **test-only** residuals from issue #4506 (post-merge audit of the loadable-stats fix wave
#4401/#4447 and the multipart consolidation #4435). Partially addresses #4506 (deliverables 2 and 3).
Deliverable 1 is intentionally deferred — see below.

2. **Success-cache regression test.** Extended the existing fail→retry→success test to render once more
   after success and assert `readFileSync` is **not** called again — locking in the
   success-permanent-cache guarantee (no per-request re-read, from #4371) against future refactors of
   the load-state machine.

3. **`worker.test.ts` no longer bypasses the `formAutoContent` shim.** #4285 (and a later commit) added
   5 direct `new FormData()` blocks alongside the `./formAutoContent` shim that #4435 standardized on.
   All 5 now build through the shim; the shim's return is extended with the raw `form` (documented as
   the multipart view — equal to the wire payload only for multipart requests) so the tests that need
   `getBuffer()`/byte-offset inspection keep working through one multipart pattern. The direct
   `import FormData from 'form-data'` is removed.

### Deliverable 1 deferred (ENOENT loadable-stats diagnostic)

The issue's first item asked for a one-time log note when `loadable-stats.json` is missing so a
misconfiguration is diagnosable. That code lives in `injectRSCPayload.ts`, which runs **inside the Pro
node-renderer VM**, where `console.*` is replaced (`worker/vm.ts`) by a `SharedConsoleHistory`
collector. That history reaches server logs only via `log.debug` **when the renderer log level is
`debug`** (default is `info`) and is otherwise replayed to the browser console (leaking the server
path). A `console.info` note therefore does **not** achieve the operator-diagnostic goal at default
config — confirmed by three independent reviewers (pre-push codex plus two PR review agents).

Making this reliable requires plumbing a renderer-side server-log channel into the VM context — a real
change beyond this "small residual" (and applicable to the sibling `console.warn` in the same
function). Deferred to a follow-up; **#4506 stays open** for it.

### Verification

- `loadClientChunkStylesheetHrefs.test.ts`: **9/9** (incl. the new no-re-read-after-success assertion).
- `worker.test.ts`: **59/59** (incl. the byte-offset file-first-password test and the >1000-parts test,
  proving field order and part count survive the shim).
- `injectRSCPayload.test.ts`: **76/76** (unchanged; no src change).
- `pnpm run type-check` clean; `pnpm run lint` clean; `knip` adds zero issues.
- Rebased onto current `main` (includes the knip lint fix #4718), so hosted **Lint JS and Ruby** is
  green rather than tripping the previously-pre-existing dead-code failure.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~ (test-only; no user-facing change)
- [x] ~Update CHANGELOG file~ (test-only; no user-visible behavior change)

### Other Information

Pro-only, test-only. No runtime/src change. `Labels: ready-for-hosted-ci` if the generator gate
applies. Benchmarks: not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Form content generation now exposes the underlying form data alongside the request payload and headers, supporting more flexible multipart request handling.

- **Bug Fixes**
  - Stylesheet metadata is now reused after a successful read, avoiding unnecessary repeated file access and warnings during subsequent renders.

- **Tests**
  - Expanded coverage for secure file uploads, authentication failures, multipart limits, unsafe filenames, and stylesheet metadata caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Merge-authority evidence (batch ror-c-20260716-1543-pro-node-residuals)

**Release-mode gate:** development → target `main` = **beta** gate ("Confidence note + green required checks"). Satisfied.

**Confidence note:**
- **Validated:**
  - Local: `loadClientChunkStylesheetHrefs.test.ts` 9/9, `worker.test.ts` 59/59, `injectRSCPayload.test.ts` 76/76; `pnpm run type-check` clean; `pnpm run lint` clean; `pnpm exec knip` adds zero issues.
  - Hosted CI on head `930c31a5b` (rebased onto current `main`, which includes knip fix #4718): all checks green, **zero failures** — incl. `React on Rails Pro - Package Tests`, `rspec-gem-specs`, `package-js-tests`, `Lint JS and Ruby` (knip now passes), Integration, Generator, Playwright.
  - Pre-push AI review (codex): the one P2 (ENOENT diagnostic ineffective from the VM) was resolved by **descoping deliverable 1**; all 4 PR review threads resolved.
- **Evidence:** CI checks on this PR (head `930c31a5b`, `mergeStateStatus = CLEAN`); resolved review threads; deferred-work follow-up #4731.
- **Scope:** test-only (no `src`/runtime change); `changelog_classification = not_user_visible`.
- **UNKNOWN:** none.
- **Residual risk:** none. Deliverable 1 of #4506 is intentionally deferred (#4731); #4506 remains open for it.

**Labels:** `ready-for-hosted-ci` (hosted CI requested and green). Benchmarks: not applicable (test-only).
