### PR TITLE
[Pro] Skip stream caches for error-containing renders (fixes #4581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Streaming caches no longer persist error-containing renders**: When a streamed render
+  emits a chunk with `hasErrors: true` (for example a Suspense boundary whose async data fetch hit a
+  transient failure on that one request), the resulting chunk set is no longer written to
+  `Rails.cache`. Under production defaults (`raise_non_shell_server_rendering_errors: false`), a stream
+  whose shell rendered but whose async boundary errored completes "normally", so both stream cache-write
+  paths (`ReactOnRailsPro::StreamCache` for prerender caching and `cached_stream_react_component`'s
+  view-level cache) previously persisted the broken fragment and served it from cache to every
+  subsequent visitor on that key until the entry expired — turning a single transient failure into a
+  persistent outage for that component. Both paths now detect the error chunk and skip the cache write;
+  clean renders are still cached. Fixes
+  [Issue 4581](https://github.com/shakacode/react_on_rails/issues/4581).
+  [PR 4722](https://github.com/shakacode/react_on_rails/pull/4722) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Stopped logging routine async-props stream-close races at error level**: When a client
   disconnects mid-render, or a `stream_react_component_with_async_props` block keeps emitting after
   `renderComplete` winds the connection down, writes to the already-closed renderer request stream are

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -158,8 +158,13 @@ module ReactOnRailsProHelper
     # Extract streaming-specific callback
     on_complete = options.delete(:on_complete)
 
+    # Optional per-chunk error callback (set by cached_stream_react_component) that
+    # is notified of each chunk's `hasErrors` flag so an error-containing render is
+    # not written to the cache. See https://github.com/shakacode/react_on_rails/issues/4581.
+    on_chunk_errors = options.delete(:on_chunk_errors)
+
     consumer_stream_async(on_complete:) do
-      internal_stream_react_component(component_name, options)
+      internal_stream_react_component(component_name, options, on_chunk_errors:)
     end
   end
 
@@ -1132,8 +1137,21 @@ module ReactOnRailsProHelper
   def handle_stream_cache_miss(component_name, raw_options, auto_load_bundle, view_cache_key, &)
     normalized_cache_tags = ReactOnRailsPro::Cache.normalize_tags(raw_options[:cache_tags])
     raw_cache_options = raw_options[:cache_options] || {}
+    # Shared between the per-chunk error callback and the on_complete cache write.
+    # Both run in the same async task/fiber, so by the time on_complete fires the
+    # stream is fully consumed and this flag reflects every chunk.
+    stream_has_errors = false
     cache_aware_options = raw_options.merge(
+      on_chunk_errors: ->(chunk_has_errors) { stream_has_errors ||= chunk_has_errors == true },
       on_complete: lambda { |chunks|
+        # Never persist a render that emitted an error chunk. With production
+        # defaults (`raise_non_shell_server_rendering_errors: false`), a stream
+        # whose shell succeeded but whose async boundary errored completes
+        # "normally", so without this guard the broken fragment would be cached
+        # and served to every subsequent visitor until the entry expires.
+        # See https://github.com/shakacode/react_on_rails/issues/4581.
+        next if stream_has_errors
+
         cache_write = ReactOnRailsPro::StreamCacheWrites.build(
           cache_key: view_cache_key,
           chunks:,
@@ -1332,13 +1350,14 @@ module ReactOnRailsProHelper
     true
   end
 
-  def internal_stream_react_component(component_name, options = {})
+  def internal_stream_react_component(component_name, options = {}, on_chunk_errors: nil)
     options = options.merge(render_mode: :html_streaming)
     result = internal_react_component(component_name, options)
     build_react_component_result_for_server_streamed_content(
       rendered_html_stream: result[:result],
       component_specification_tag: result[:tag],
-      render_options: result[:render_options]
+      render_options: result[:render_options],
+      on_chunk_errors:
     )
   end
 
@@ -1363,10 +1382,16 @@ module ReactOnRailsProHelper
   def build_react_component_result_for_server_streamed_content(
     rendered_html_stream:,
     component_specification_tag:,
-    render_options:
+    render_options:,
+    on_chunk_errors: nil
   )
     is_first_chunk = true
     rendered_html_stream.transform do |chunk_json_result|
+      # Surface the parsed `hasErrors` flag before the chunk is serialized to an
+      # HTML string. Downstream (the on_complete cache write) only sees strings,
+      # so this is the last point where the error flag is still available.
+      # See https://github.com/shakacode/react_on_rails/issues/4581.
+      on_chunk_errors&.call(chunk_json_result["hasErrors"])
       if is_first_chunk
         is_first_chunk = false
         build_react_component_result_for_server_rendered_string(

--- a/react_on_rails_pro/lib/react_on_rails_pro/stream_cache.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/stream_cache.rb
@@ -64,7 +64,9 @@ module ReactOnRailsPro
         return enum_for(:each_chunk) unless block
 
         buffered_chunks = []
+        stream_has_errors = false
         @upstream_stream.each_chunk do |chunk|
+          stream_has_errors ||= chunk_has_errors?(chunk)
           # Snapshot the chunk before handing it downstream. A downstream consumer
           # receives the same object we buffer here, and this buffered array is
           # persisted to Rails.cache after the stream completes. If a consumer
@@ -75,7 +77,23 @@ module ReactOnRailsPro
           buffered_chunks << chunk.dup
           yield(chunk)
         end
+        # Never persist a render that emitted an error chunk. With production
+        # defaults (`raise_non_shell_server_rendering_errors: false`), a stream
+        # whose shell succeeded but whose async boundary errored completes
+        # "normally", so without this guard the broken fragment would be cached
+        # and served to every subsequent visitor on this key until it expires.
+        # See https://github.com/shakacode/react_on_rails/issues/4581.
+        return if stream_has_errors
+
         Rails.cache.write(@cache_key, buffered_chunks, @cache_options || {})
+      end
+
+      private
+
+      # Chunks from the renderer are parsed JSON Hashes carrying a boolean
+      # `"hasErrors"` flag. Guard the type so a non-Hash chunk can never raise here.
+      def chunk_has_errors?(chunk)
+        chunk.is_a?(Hash) && chunk["hasErrors"] == true
       end
     end
   end

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -1479,6 +1479,59 @@ describe ReactOnRailsProHelper do
         expect(second_run_chunks).to eq(first_run_chunks)
       end
 
+      # Regression for https://github.com/shakacode/react_on_rails/issues/4581.
+      #
+      # A shell-ready render whose async boundary errors emits a chunk with
+      # hasErrors: true but still completes "normally" under production defaults
+      # (raise_non_shell_server_rendering_errors: false, set in the dummy app).
+      # The broken fragment must NOT be written to the view-level stream cache.
+      context "when a streamed chunk reports render errors" do # rubocop:disable RSpec/MultipleMemoizedHelpers
+        let(:error_chunks) do
+          [
+            { html: "<div>Chunk 1: shell ok</div>", consoleReplayScript: "",
+              hasErrors: false, isShellReady: true },
+            { html: "<div>Chunk 2: broken boundary</div>", consoleReplayScript: "",
+              hasErrors: true, isShellReady: true }
+          ]
+        end
+
+        it "does not write the error-containing stream to the cache" do
+          mock_request_and_response(error_chunks)
+          render_with_cached_stream
+
+          run_stream
+
+          # The whole stream was consumed (no exception aborted it) ...
+          expect(chunks_read.count).to eq(error_chunks.count)
+          # ... yet nothing was cached because a chunk reported hasErrors.
+          expect(cache_data).to be_empty
+        end
+
+        it "re-renders on the next request instead of serving a cached broken fragment" do
+          mock_request_and_response(error_chunks, count: 2)
+          render_with_cached_stream
+
+          run_stream
+          expect(chunks_read.count).to eq(error_chunks.count)
+
+          # Second request: because the first render was not cached, this is a
+          # MISS again and hits Node rather than replaying the broken fragment.
+          reset_stream_buffers
+          @rendered_rails_context = nil
+          run_stream
+          expect(chunks_read.count).to eq(error_chunks.count)
+        end
+
+        it "still caches a clean stream (control)" do
+          mock_request_and_response
+          render_with_cached_stream
+
+          run_stream
+
+          expect(cache_data).not_to be_empty
+        end
+      end
+
       it "serves a HIT on the second render when cache_options includes a namespace" do
         # The second mocked response only feeds a regression (second Node call),
         # letting the chunks_read assertion below fail legibly instead of erroring.

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_cache_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_cache_spec.rb
@@ -69,6 +69,50 @@ RSpec.describe ReactOnRailsPro::StreamCache, :caching do
     end
   end
 
+  # Regression for https://github.com/shakacode/react_on_rails/issues/4581.
+  #
+  # A stream whose shell renders but whose async boundary errors emits a chunk
+  # with "hasErrors" => true yet still completes "normally" under production
+  # defaults (raise_non_shell_server_rendering_errors: false). Such a broken
+  # render must never be persisted, or the errored fragment is served from cache
+  # to every subsequent visitor until the entry expires.
+  describe "error-containing streams" do
+    let(:clean_chunk) do
+      { "consoleReplayScript" => "", "hasErrors" => false, "isShellReady" => true, "html" => "ok" }
+    end
+    let(:error_chunk) do
+      { "consoleReplayScript" => "", "hasErrors" => true, "isShellReady" => true, "html" => "boom" }
+    end
+
+    it "does not cache a stream when any chunk reports hasErrors" do
+      described_class
+        .wrap_and_cache(cache_key, upstream_yielding([clean_chunk, error_chunk]))
+        .each_chunk { |_chunk| nil }
+
+      expect(Rails.cache.read(cache_key)).to be_nil
+    end
+
+    it "still yields every chunk downstream even when the render is not cached" do
+      yielded = []
+      described_class
+        .wrap_and_cache(cache_key, upstream_yielding([clean_chunk, error_chunk]))
+        .each_chunk { |chunk| yielded << chunk }
+
+      expect(yielded.length).to eq(2)
+      expect(Rails.cache.read(cache_key)).to be_nil
+    end
+
+    it "still caches a clean stream (no chunk reports hasErrors)" do
+      described_class
+        .wrap_and_cache(cache_key, upstream_yielding([clean_chunk]))
+        .each_chunk { |_chunk| nil }
+
+      cached = Rails.cache.read(cache_key)
+      expect(cached).to be_an(Array)
+      expect(cached.first).to include("html" => "ok")
+    end
+  end
+
   describe ".fetch_stream" do
     it "returns nil when nothing was cached" do
       expect(described_class.fetch_stream("missing-key")).to be_nil


### PR DESCRIPTION
## Summary

Fixes #4581 (P1, milestone **17.0.x**). **Candidate for 17.0.1 cherry-pick.**

React on Rails Pro streaming caches persisted chunk sets to `Rails.cache` even when a rendered chunk carried `hasErrors: true`. Under production defaults (`raise_non_shell_server_rendering_errors: false`), a stream whose shell renders (`isShellReady: true`) but whose async boundary errors (`hasErrors: true`) completes "normally" — so both cache-write paths wrote the broken fragment and served it from cache to **every subsequent visitor** on that key until `:expires_in` elapsed. A single transient failure became a persistent outage for that component.

This mirrors the empty-payload skip established in #4550.

## What changed

- **Prerender cache path** — `ReactOnRailsPro::StreamCache::CachingComponent#each_chunk` now inspects each raw chunk Hash's `"hasErrors"` flag while buffering and skips `Rails.cache.write` when any chunk errored. (`react_on_rails_pro/lib/react_on_rails_pro/stream_cache.rb`)
- **View-level cache path** — `cached_stream_react_component` → `handle_stream_cache_miss`. The parsed `hasErrors` flag is only visible before the chunk is serialized to an HTML string, so a per-chunk error signal (`on_chunk_errors`) is plumbed from `build_react_component_result_for_server_streamed_content` through `stream_react_component`/`internal_stream_react_component` to the `on_complete` cache-write closure, which now skips the deferred write for an error-containing render. The public `on_complete` callback arity is unchanged. (`react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb`)

Clean renders are still cached in both paths.

## Tests

- `react_on_rails_pro/spec/react_on_rails_pro/stream_cache_spec.rb` — path 1: error chunk not cached; clean chunk cached; downstream chunks still yielded.
- `react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb` — path 2: error-containing stream not cached, re-renders (MISS) on the next request; clean stream still cached (control).

## qa-evidence v1

```
issue: 4581
lane: batch-qa
method: temporarily disabled each guard (`return if stream_has_errors` / `next if stream_has_errors`),
        ran the new regression specs to show the pre-fix bug, then restored the guards and re-ran.

--- PATH 1  ReactOnRailsPro::StreamCache (spec/react_on_rails_pro/stream_cache_spec.rb) ---
BEFORE (guard disabled):
  error-containing streams
    does not cache a stream when any chunk reports hasErrors          FAILED
    still yields every chunk downstream even when the render is not cached  FAILED
    still caches a clean stream (no chunk reports hasErrors)          PASS (control)
  Failure/Error: expect(Rails.cache.read(cache_key)).to be_nil
    got: [{"hasErrors"=>false,"html"=>"ok"...}, {"hasErrors"=>true,"html"=>"boom"...}]
  => 3 examples, 2 failures

AFTER (fix in place):
  8 examples, 0 failures

--- PATH 2  cached_stream_react_component (spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb) ---
BEFORE (guard disabled):
  when a streamed chunk reports render errors
    does not write the error-containing stream to the cache          FAILED
    re-renders on the next request instead of serving a cached broken fragment  FAILED
    still caches a clean stream (control)                            PASS (control)
  Failure/Error: expect(cache_data).to be_empty
    got: {"ror_component/.../..." => ...<div>Chunk 2: broken boundary</div>...}
  => 3 examples, 2 failures

AFTER (fix in place):
  3 examples, 0 failures
```

## Validation

- RuboCop (Pro, CI-equivalent): `4 files inspected, no offenses detected`.
- RSpec path 1 (`stream_cache_spec.rb`): `8 examples, 0 failures`.
- RSpec path 2 (`react_on_rails_pro_helper_spec.rb`, error-chunk context): `3 examples, 0 failures`.
- Broader streaming helper describes run clean except 4 pre-existing `Errno::ENOENT` failures caused by a missing generated SSR bundle (`ssr-generated/server-bundle.js`) in this environment — verified identical failures on the unmodified base (stash + re-run), so they are unrelated to this change.

## Codex Decision Log

- **on_complete arity preserved**: `on_complete` is public API and existing tests call it with arity 1 (`on_complete.call(["chunk"])`). Rather than change its signature, the error signal travels on a separate `on_chunk_errors` closure channel; the two closures in `handle_stream_cache_miss` share a `stream_has_errors` local. Both run in the same cooperative async task/fiber, so the flag is fully populated before `on_complete` fires.
- **Where to detect errors**: path 1 sees raw chunk Hashes (`hasErrors` directly inspectable); path 2's cache stores transformed HTML strings, so detection is hoisted to the transform (`build_react_component_result_for_server_streamed_content`) — the last point the parsed flag exists.
- **Sibling buffered/static helpers out of scope**: `cached_buffered_stream_react_component` / `cached_static_rsc_component` (added after the issue was filed) share the same class of exposure but are outside the two paths named in #4581; flagged for a separate follow-up rather than widening this fix.

Do not merge — coordinator handles merge sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cached streamed renders from being persisted when any streamed chunk reports render errors.
  * Ensured subsequent requests re-render instead of serving error-containing cached fragments.
  * Clean streamed renders remain cacheable as before.

* **Tests**
  * Added regression coverage for error-containing vs. successful streamed renders, including view-level stream cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->