### PR TITLE
Remove false Doctor pack-tag pairing warnings (fixes #4619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4722](https://github.com/shakacode/react_on_rails/pull/4722) by
   [justin808](https://github.com/justin808).
 
+- **Stopped Doctor from warning when a layout uses only one pack helper**: `rake react_on_rails:doctor`
+  no longer emits `⚠️ <layout>: has javascript_pack_tag but missing stylesheet_pack_tag` (or its mirror)
+  based purely on helper asymmetry. A JavaScript-only Shakapacker entrypoint, a CSS-only pack, and a
+  hybrid layout that loads its CSS through Propshaft `stylesheet_link_tag` are all valid, so detected pack
+  helpers are now reported informationally instead of as warnings. A fresh create-react-on-rails Rails 8
+  RSC app no longer receives a spurious layout warning. Fixes
+  [Issue 4619](https://github.com/shakacode/react_on_rails/issues/4619).
+  [PR 4724](https://github.com/shakacode/react_on_rails/pull/4724) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Stopped logging routine async-props stream-close races at error level**: When a client
   disconnects mid-render, or a `stream_react_component_with_async_props` block keeps emitting after
   `renderComplete` winds the connection down, writes to the already-closed renderer request stream are

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1148,12 +1148,16 @@ module ReactOnRails
 
         layout_name = File.basename(layout_file, ".html.erb")
 
+        # Report detected pack helpers informationally. A JavaScript-only entrypoint
+        # (no emitted CSS), a CSS-only pack, or a hybrid layout that loads CSS via
+        # Propshaft `stylesheet_link_tag` are all valid, so helper asymmetry is not a
+        # warning. See https://github.com/shakacode/react_on_rails/issues/4619.
         if has_stylesheet && has_javascript
           checker.add_info("  ✅ #{layout_name}: has both stylesheet_pack_tag and javascript_pack_tag")
         elsif has_stylesheet
-          checker.add_warning("  ⚠️  #{layout_name}: has stylesheet_pack_tag but missing javascript_pack_tag")
+          checker.add_info("  ℹ️  #{layout_name}: has stylesheet_pack_tag")
         elsif has_javascript
-          checker.add_warning("  ⚠️  #{layout_name}: has javascript_pack_tag but missing stylesheet_pack_tag")
+          checker.add_info("  ℹ️  #{layout_name}: has javascript_pack_tag")
         else
           checker.add_info("  ℹ️  #{layout_name}: no pack tags found")
         end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1173,6 +1173,108 @@ RSpec.describe ReactOnRails::Doctor do
     end
   end
 
+  describe "#check_layout_files" do
+    let(:checker) { doctor.instance_variable_get(:@checker) }
+
+    def stub_layouts(layouts)
+      allow(Dir).to receive(:glob).with("app/views/layouts/**/*.erb").and_return(layouts.keys)
+      layouts.each do |path, content|
+        allow(File).to receive(:exist?).with(path).and_return(true)
+        allow(File).to receive(:read).with(path).and_return(content)
+      end
+    end
+
+    context "when a layout uses javascript_pack_tag with Propshaft stylesheet_link_tag (fresh RSC app)" do
+      before do
+        stub_layouts(
+          "app/views/layouts/application.html.erb" =>
+            %(<%= stylesheet_link_tag :app %>\n<%= javascript_pack_tag "application" %>)
+        )
+      end
+
+      it "does not warn about a missing stylesheet_pack_tag" do
+        doctor.send(:check_layout_files)
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ℹ️  application: has javascript_pack_tag")
+        )
+      end
+    end
+
+    context "when a layout is JavaScript-pack only" do
+      before do
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => %(<%= javascript_pack_tag "application" %>)
+        )
+      end
+
+      it "does not emit a symmetry warning" do
+        doctor.send(:check_layout_files)
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when a layout is stylesheet-pack only" do
+      before do
+        stub_layouts(
+          "app/views/layouts/marketing.html.erb" => %(<%= stylesheet_pack_tag "marketing" %>)
+        )
+      end
+
+      it "does not emit a symmetry warning" do
+        doctor.send(:check_layout_files)
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when a layout contains both flush helpers" do
+      before do
+        stub_layouts(
+          "app/views/layouts/react_on_rails_default.html.erb" =>
+            %(<%= stylesheet_pack_tag %>\n<%= javascript_pack_tag %>)
+        )
+      end
+
+      it "reports the layout as correctly configured without warning" do
+        doctor.send(:check_layout_files)
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(
+            type: :info,
+            content: "  ✅ react_on_rails_default: has both stylesheet_pack_tag and javascript_pack_tag"
+          )
+        )
+      end
+    end
+
+    context "with the fresh generated app's two layouts (Propshaft application + RoR default)" do
+      before do
+        stub_layouts(
+          "app/views/layouts/application.html.erb" =>
+            %(<%= stylesheet_link_tag :app %>\n<%= javascript_pack_tag "application" %>),
+          "app/views/layouts/react_on_rails_default.html.erb" =>
+            %(<%= stylesheet_pack_tag %>\n<%= javascript_pack_tag %>)
+        )
+      end
+
+      it "does not increase the Doctor warning count" do
+        doctor.send(:check_layout_files)
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when no layout files are present" do
+      before do
+        allow(Dir).to receive(:glob).with("app/views/layouts/**/*.erb").and_return([])
+      end
+
+      it "produces no messages" do
+        doctor.send(:check_layout_files)
+        expect(checker.messages).to be_empty
+      end
+    end
+  end
+
   describe "#scan_view_files_for_async_pack_tag" do
     before do
       allow(Dir).to receive(:glob).and_call_original


### PR DESCRIPTION
Fixes #4619

## Summary

`rake react_on_rails:doctor` emitted a false warning on a fresh, valid create-react-on-rails Rails 8 RSC app:

```
⚠️  application: has javascript_pack_tag but missing stylesheet_pack_tag
```

The warning came from `check_layout_files`, which scanned every ERB layout and warned whenever exactly one of the substrings `stylesheet_pack_tag` / `javascript_pack_tag` was present. That symmetric-pair invariant is wrong:

- A JavaScript-only Shakapacker entrypoint (no emitted CSS) needs no `stylesheet_pack_tag`.
- A CSS-only pack needs no `javascript_pack_tag`.
- Hybrid apps load application CSS via Propshaft `stylesheet_link_tag` while using Shakapacker only for JS.

## Behavior change

`check_layout_files` now reports detected pack helpers **informationally** instead of warning on helper asymmetry:

- Both helpers present → `✅ <layout>: has both stylesheet_pack_tag and javascript_pack_tag` (unchanged, still "correctly configured").
- Only `javascript_pack_tag` → `ℹ️  <layout>: has javascript_pack_tag` (was a warning).
- Only `stylesheet_pack_tag` → `ℹ️  <layout>: has stylesheet_pack_tag` (was a warning).
- Neither → `ℹ️  <layout>: no pack tags found` (unchanged).

No other Doctor check is affected. The full `doctor_spec.rb` suite (377 examples) passes.

## Codex Decision Log

- **Dropped the optional manifest-based CSS check.** The issue permits an evidence-backed targeted warning that fires only when a manifest proves a referenced JS entrypoint emits CSS the layout does not load. Per the issue's own guidance ("do not fabricate a half-baked manifest check"), and because Doctor's `check_layout_files` has no reliable, tested path to entrypoint→CSS manifest resolution at this seam, I dropped the symmetric warning entirely rather than add an unproven manifest read. This fully satisfies the acceptance criteria; the deeper check can be added later if a manifest seam is wired up.
- **Did not treat `stylesheet_link_tag` as equivalent to `stylesheet_pack_tag`.** As the issue requires, ordinary Propshaft CSS is not conflated with Shakapacker-emitted CSS; the fix simply stops warning on asymmetry rather than pattern-matching Propshaft helpers.

## QA evidence

```
qa-evidence v1
issue: 4619
fix: remove symmetric pack-tag pairing warnings from Doctor#check_layout_files
test: react_on_rails/spec/lib/react_on_rails/doctor_spec.rb -e "#check_layout_files"

BEFORE (source reverted to pre-fix check_layout_files, new specs run):
  6 examples, 4 failures
  FAILED - fresh RSC app (javascript_pack_tag + stylesheet_link_tag): expect(checker.warnings?).to be(false)
  FAILED - JavaScript-pack only: expect(checker.warnings?).to be(false)
  FAILED - stylesheet-pack only: expect(checker.warnings?).to be(false)
  FAILED - fresh generated app two layouts: expect(checker.warnings?).to be(false)
  (the "both flush helpers" and "no layout files" cases already passed)

AFTER (fix applied):
  6 examples, 0 failures

full suite: bundle exec rspec spec/lib/react_on_rails/doctor_spec.rb
  377 examples, 0 failures

rubocop (BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/doctor.rb spec/lib/react_on_rails/doctor_spec.rb):
  2 files inspected, no offenses detected
```

## Acceptance criteria coverage

- [x] Fixture: `javascript_pack_tag "application"` + `stylesheet_link_tag :app` + no `application` CSS → no warning.
- [x] One-sided JS-only and CSS-only pack fixtures → no symmetry warning.
- [x] Layout with both flush helpers → still reported as correctly configured.
- [x] Two-layout fresh-app case → layout analysis does not increase Doctor warning count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `rake react_on_rails:doctor` to stop reporting false-positive warnings for layouts that include only JavaScript or only CSS pack helpers, or that use hybrid CSS-loading approaches.
  * Reduced spurious layout warnings, including for Rails 8 applications using React Server Components.
  * Layouts containing both expected pack helpers continue to be recognized successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->