### PR TITLE
docs: mark 16.2.0 immediate_hydration override note as historical (fixes #4639)

### DIFF
--- a/docs/oss/upgrading/release-notes/16.2.0.md
+++ b/docs/oss/upgrading/release-notes/16.2.0.md
@@ -50,17 +50,19 @@ The `config.immediate_hydration` setting in `config/initializers/react_on_rails.
 2. **Pro users:** No action needed - immediate hydration is now enabled automatically
 3. **Non-Pro users:** No action needed - standard hydration behavior continues
 
-**Component-level overrides still work:**
+**Component-level overrides (historical — accurate for v16.2.0 only):**
+
+> **⚠️ No longer supported.** In v16.2.0 you could override immediate hydration per component or per store. This option was **completely removed in v16.6.0** ([PR 2834](https://github.com/shakacode/react_on_rails/pull/2834)). The helpers now log a warning and ignore `immediate_hydration:`. Immediate hydration is automatic (enabled for Pro users, disabled for non-Pro), with no per-component override. Remove any `immediate_hydration:` keys from your `react_component` / `react_component_hash` / `redux_store` calls. The example below is retained only as a record of the v16.2.0 behavior.
 
 ```ruby
-# Override for a specific component
-<%= react_component("MyComponent", props, immediate_hydration: false) %>
+# Override for a specific component (v16.2.0 only — removed in v16.6.0)
+<%= react_component("MyComponent", props: props, immediate_hydration: false) %>
 
-# Override for a specific store
+# Override for a specific store (v16.2.0 only — removed in v16.6.0)
 <%= redux_store("MyStore", props: store_props, immediate_hydration: true) %>
 ```
 
-**Note:** If a non-Pro user explicitly sets `immediate_hydration: true`, a warning will be logged and the value will be overridden to `false`.
+**Note:** In v16.2.0, if a non-Pro user explicitly set `immediate_hydration: true`, a warning was logged and the value was overridden to `false`. As of v16.6.0 the option is ignored entirely.
 
 [PR 1997](https://github.com/shakacode/react_on_rails/pull/1997) by [AbanoubGhadban](https://github.com/AbanoubGhadban).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -32164,17 +32164,19 @@ The `config.immediate_hydration` setting in `config/initializers/react_on_rails.
 2. **Pro users:** No action needed - immediate hydration is now enabled automatically
 3. **Non-Pro users:** No action needed - standard hydration behavior continues
 
-**Component-level overrides still work:**
+**Component-level overrides (historical — accurate for v16.2.0 only):**
+
+> **⚠️ No longer supported.** In v16.2.0 you could override immediate hydration per component or per store. This option was **completely removed in v16.6.0** ([PR 2834](https://github.com/shakacode/react_on_rails/pull/2834)). The helpers now log a warning and ignore `immediate_hydration:`. Immediate hydration is automatic (enabled for Pro users, disabled for non-Pro), with no per-component override. Remove any `immediate_hydration:` keys from your `react_component` / `react_component_hash` / `redux_store` calls. The example below is retained only as a record of the v16.2.0 behavior.
 
 ```ruby
-# Override for a specific component
-<%= react_component("MyComponent", props, immediate_hydration: false) %>
+# Override for a specific component (v16.2.0 only — removed in v16.6.0)
+<%= react_component("MyComponent", props: props, immediate_hydration: false) %>
 
-# Override for a specific store
+# Override for a specific store (v16.2.0 only — removed in v16.6.0)
 <%= redux_store("MyStore", props: store_props, immediate_hydration: true) %>
 ```
 
-**Note:** If a non-Pro user explicitly sets `immediate_hydration: true`, a warning will be logged and the value will be overridden to `false`.
+**Note:** In v16.2.0, if a non-Pro user explicitly set `immediate_hydration: true`, a warning was logged and the value was overridden to `false`. As of v16.6.0 the option is ignored entirely.
 
 [PR 1997](https://github.com/shakacode/react_on_rails/pull/1997) by [AbanoubGhadban](https://github.com/AbanoubGhadban).
 


### PR DESCRIPTION
Fixes #4639

## Problem

`docs/oss/upgrading/release-notes/16.2.0.md` documented per-component / per-store `immediate_hydration:` overrides under the heading **"Component-level overrides still work:"** as if they are current behavior. Two defects in `main`:

1. **The option no longer exists.** `immediate_hydration:` was completely removed in **v16.6.0** (commit `13e2b23e5`, [PR #2834](https://github.com/shakacode/react_on_rails/pull/2834)). The helpers now log a warning and drop it, so the "still work" claim is false.
2. **3-positional-arg bug.** `react_component("MyComponent", props, immediate_hydration: false)` passes `props` positionally plus a trailing keyword, which raises `ArgumentError: wrong number of arguments (given 3, expected 1..2)`. It must use the `props:` keyword.

## Fix (historical-record reconciliation)

The 16.2.0 note is a historical record that **was** accurate for v16.2.0 (component-level overrides did work then). Rather than delete the block or pretend the option still works, this PR:

- Retitles the block to **"Component-level overrides (historical — accurate for v16.2.0 only)"**.
- Adds a callout that the option was **completely removed in v16.6.0 (#2834)**, that the helpers now warn and ignore it, and that immediate hydration is now automatic (Pro on / non-Pro off) with no per-component override.
- Fixes the `react_component` example to use `props:` so the retained illustration is at least syntactically valid.
- Annotates both example lines as "v16.2.0 only — removed in v16.6.0".

### Where the removal note lives

The removal shipped in **v16.6.0** (verified via `git tag --contains 13e2b23e5` → first tag `v16.6.0`), but the release-notes directory only contains files through `16.4.0.md` — there is **no** `16.5.0.md` / `16.6.0.md` file to edit. Per the issue's fallback ("if you cannot confidently determine the removing version's release-notes file, add a forward-pointer in 16.2.0.md instead of guessing"), the removal note is added inline in `16.2.0.md`. The removal is also already recorded in `CHANGELOG.md` (#2834), and `immediate_hydration` deprecation is documented in `docs/oss/configuration/configuration-deprecated.md` and `docs/oss/configuration/README.md`.

## Scope

- Intentionally **scoped out of #4637** (issue #4634) because it needed more than a syntax fix — this documents the removal, not just a `props:` correction.
- Docs-only + regenerated `llms-full.txt`. No CHANGELOG entry (pure historical-doc correction; the removal is already in the changelog).

## Docs validation gates

- **Prettier (pinned 3.6.2):** `npx prettier@3.6.2 --write docs/oss/upgrading/release-notes/16.2.0.md` → unchanged (already formatted).
- **llms-full regen:** `node script/generate-llms-full.mjs` → regenerated; `--check` mode confirms current. Only `llms-full.txt` changed (`llms.txt` / `llms-full-pro.txt` unchanged).
- **Sidebar:** `script/check-docs-sidebar` → pass (no new published doc files; editing an existing file).

## Codex Decision Log

- **Keep-vs-remove the example → keep, marked historical.** The block is a historical record that was accurate for v16.2.0. Deleting it loses the migration context; leaving it unqualified is false for current main. Marking it historical + fixing the syntax preserves the record while making the removal unambiguous.
- **Which removing-version release-note to edit → none exists; forward-pointer inline in 16.2.0.md.** The removal (#2834 / `13e2b23e5`) first shipped in tag `v16.6.0`, but no `16.5.0.md`/`16.6.0.md` release-notes file exists (dir stops at 16.4.0). Used the issue's documented fallback rather than guessing or creating a new release-notes file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
