### PR TITLE
Fix SSR crash on unpaired UTF-16 surrogates from JS JSON output (#4710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   `JSON.stringify` can emit a lone surrogate escape (for example `\uD83D` with no paired low
   surrogate) from corrupted user data, database-encoding issues, or upstream API responses.
   Ruby's `JSON.parse` rejects a lone high surrogate with `JSON::ParserError: incomplete
-  surrogate pair`, so such content crashed the entire server render instead of passing through
+surrogate pair`, so such content crashed the entire server render instead of passing through
   for the browser to display. The render-result parsers now retry once with unpaired surrogates
   replaced by the Unicode replacement character (U+FFFD) — this only runs after a parse failure,
   so the happy path is unchanged. Covers the length-prefixed object-payload and metadata paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4724](https://github.com/shakacode/react_on_rails/pull/4724) by
   [justin808](https://github.com/justin808).
 
+- **Stopped server rendering from crashing on unpaired UTF-16 surrogates**: JavaScript's
+  `JSON.stringify` can emit a lone surrogate escape (for example `\uD83D` with no paired low
+  surrogate) from corrupted user data, database-encoding issues, or upstream API responses.
+  Ruby's `JSON.parse` rejects a lone high surrogate with `JSON::ParserError: incomplete
+  surrogate pair`, so such content crashed the entire server render instead of passing through
+  for the browser to display. The render-result parsers now retry once with unpaired surrogates
+  replaced by the Unicode replacement character (U+FFFD) — this only runs after a parse failure,
+  so the happy path is unchanged. Covers the length-prefixed object-payload and metadata paths
+  plus the legacy JSON fallback for older bundles. Fixes
+  [Issue 4710](https://github.com/shakacode/react_on_rails/issues/4710).
+  [PR 4726](https://github.com/shakacode/react_on_rails/pull/4726) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Stopped logging routine async-props stream-close races at error level**: When a client
   disconnects mid-render, or a `stream_react_component_with_async_props` block keeps emitting after
   `renderComplete` winds the connection down, writes to the already-closed renderer request stream are

--- a/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
+++ b/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
@@ -21,11 +21,12 @@ module ReactOnRails
     # MIRROR VALUES END
     private_constant :CONTROL_MESSAGE_TYPES
 
-    # Matches a single \uXXXX escape, optionally paired with the following \uXXXX
-    # escape so a valid high+low surrogate pair can be recognized as one unit.
-    SURROGATE_ESCAPE_PAIR = /\\u[0-9a-fA-F]{4}(?:\\u[0-9a-fA-F]{4})?/
-    SURROGATE_ESCAPE_CODE = /\\u([0-9a-fA-F]{4})/
-    private_constant :SURROGATE_ESCAPE_PAIR, :SURROGATE_ESCAPE_CODE
+    # The six-character JSON escape for U+FFFD, emitted for a lone surrogate.
+    # Kept as an ASCII escape (not a literal multibyte char) so sanitized output
+    # stays valid regardless of the input string's encoding, which may be binary.
+    REPLACEMENT_CHAR_ESCAPE = '\ufffd'
+    FOUR_HEX_DIGITS = /\A[0-9a-fA-F]{4}\z/
+    private_constant :REPLACEMENT_CHAR_ESCAPE, :FOUR_HEX_DIGITS
 
     # Parses a complete length-prefixed result string that must contain exactly one chunk.
     # Used by the non-streaming rendering path where ExecJS/node renderer returns a single result.
@@ -67,26 +68,85 @@ module ReactOnRails
       JSON.parse(sanitize_unpaired_surrogates(str))
     end
 
-    # Replaces unpaired \uXXXX surrogate escapes with the U+FFFD replacement
-    # escape (�), leaving valid high+low pairs intact. The replacement is an
-    # ASCII \u escape (not a literal multibyte char) so the output stays valid
-    # regardless of the input string's encoding, which may be binary.
+    # Replaces only genuinely LONE \uXXXX surrogate escapes with the U+FFFD
+    # replacement escape, leaving everything else byte-for-byte intact.
     #
-    # Best-effort recovery for already-malformed input; it is not a general JSON
-    # validator and does not distinguish surrogate escapes inside string literals
-    # from other contexts (JSON only permits \u escapes inside strings, so this is
-    # safe in practice). Adjacent all-escaped surrogates in pathological input may
-    # be re-paired greedily, but the result is always valid UTF-8 and never crashes.
+    # This walks the string left to right rather than using a global regex so it
+    # gets three things right that a naive gsub does not:
+    #   * Backslash parity — a "\u..." is a real escape only when the backslash
+    #     before "u" is itself unescaped. In "\\uD83D" the backslash is escaped,
+    #     so "uD83D" is literal text and must not be rewritten. Consuming "\\" as
+    #     one unit makes the following "u" an ordinary character.
+    #   * Pairing — a high surrogate (U+D800..U+DBFF) is kept only when it is
+    #     immediately followed by a low surrogate (U+DC00..U+DFFF); the valid pair
+    #     passes through untouched. A high surrogate followed by anything else, and
+    #     a low surrogate not preceded by a high one, are lone and replaced.
+    #   * No over-consumption — a non-surrogate escape (e.g. "A") is never
+    #     swallowed as part of a pair.
+    #
+    # The replacement is an ASCII \u escape (not a literal multibyte char) so the
+    # output stays valid regardless of the input string's encoding, which may be
+    # binary. Best-effort recovery for already-malformed input, so it runs only on
+    # the JSON::ParserError retry path and never on the happy path.
     def self.sanitize_unpaired_surrogates(str)
-      str.gsub(SURROGATE_ESCAPE_PAIR) do |seq|
-        codes = seq.scan(SURROGATE_ESCAPE_CODE).flatten.map { |hex| hex.to_i(16) }
-        if codes.length == 2 && codes[0].between?(0xD800, 0xDBFF) && codes[1].between?(0xDC00, 0xDFFF)
-          seq # valid surrogate pair — leave untouched
-        else
-          codes.map { |code| code.between?(0xD800, 0xDFFF) ? '\ufffd' : format('\\u%04x', code) }.join
-        end
+      out = String.new(encoding: str.encoding)
+      index = 0
+      length = str.length
+
+      while index < length
+        chunk, advance = next_sanitized_token(str, index, length)
+        out << chunk
+        index += advance
       end
+
+      out
     end
+
+    # Returns [text_to_emit, characters_consumed] for the token at +index+.
+    def self.next_sanitized_token(str, index, length)
+      code = unicode_escape_codepoint(str, index, length)
+      return non_escape_token(str, index, length) if code.nil?
+      return surrogate_token(str, index, length, code) if code.between?(0xD800, 0xDFFF)
+
+      [str[index, 6], 6] # ordinary non-surrogate \uXXXX escape
+    end
+    private_class_method :next_sanitized_token
+
+    # A "\X" escape is consumed as one unit so an escaped backslash can't be
+    # misread as the start of a \u escape; any other character is verbatim.
+    def self.non_escape_token(str, index, length)
+      return [str[index, 2], 2] if str[index] == "\\" && index + 1 < length
+
+      [str[index], 1]
+    end
+    private_class_method :non_escape_token
+
+    # A high surrogate is kept only when immediately followed by a low surrogate;
+    # otherwise it (or a lone low surrogate) becomes the U+FFFD replacement escape.
+    def self.surrogate_token(str, index, length, code)
+      if code.between?(0xD800, 0xDBFF)
+        low = unicode_escape_codepoint(str, index + 6, length)
+        return [str[index, 12], 12] if low&.between?(0xDC00, 0xDFFF)
+      end
+
+      [REPLACEMENT_CHAR_ESCAPE, 6]
+    end
+    private_class_method :surrogate_token
+
+    # Returns the codepoint of a genuine six-character \uXXXX escape starting at
+    # +index+, or nil when +index+ does not begin one. Callers reach this position
+    # only after two-character "\X" escapes have been consumed as a unit, so a
+    # leading backslash here is always unescaped (odd backslash parity).
+    def self.unicode_escape_codepoint(str, index, length)
+      return nil unless index + 6 <= length
+      return nil unless str[index] == "\\" && str[index + 1] == "u"
+
+      hex = str[index + 2, 4]
+      return nil unless hex.match?(FOUR_HEX_DIGITS)
+
+      hex.to_i(16)
+    end
+    private_class_method :unicode_escape_codepoint
 
     def initialize
       # Binary encoding ensures correct byte-position arithmetic regardless of payload encoding.

--- a/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
+++ b/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
@@ -26,7 +26,9 @@ module ReactOnRails
     # stays valid regardless of the input string's encoding, which may be binary.
     REPLACEMENT_CHAR_ESCAPE = '\ufffd'
     FOUR_HEX_DIGITS = /\A[0-9a-fA-F]{4}\z/
-    private_constant :REPLACEMENT_CHAR_ESCAPE, :FOUR_HEX_DIGITS
+    BACKSLASH_BYTE = 0x5C # "\\"
+    LOWER_U_BYTE = 0x75   # "u"
+    private_constant :REPLACEMENT_CHAR_ESCAPE, :FOUR_HEX_DIGITS, :BACKSLASH_BYTE, :LOWER_U_BYTE
 
     # Parses a complete length-prefixed result string that must contain exactly one chunk.
     # Used by the non-streaming rendering path where ExecJS/node renderer returns a single result.
@@ -69,14 +71,20 @@ module ReactOnRails
     end
 
     # Replaces only genuinely LONE \uXXXX surrogate escapes with the U+FFFD
-    # replacement escape, leaving everything else byte-for-byte intact.
+    # replacement escape, leaving every other byte intact.
     #
-    # This walks the string left to right rather than using a global regex so it
-    # gets three things right that a naive gsub does not:
+    # The scan runs at the BYTE level (mirroring #feed / #try_parse_header in this
+    # file). Every meaningful token — "\\", "u", the four hex digits — is
+    # single-byte ASCII, so byte scanning is O(n) regardless of the payload's
+    # encoding (character indexing would be O(n^2) on multibyte text) and, because
+    # byteslice/getbyte never raise on invalid byte sequences, it also cannot turn
+    # a genuinely-corrupt-UTF-8 input into a non-JSON exception on the retry path.
+    #
+    # It gets three things right that a naive global regex does not:
     #   * Backslash parity — a "\u..." is a real escape only when the backslash
     #     before "u" is itself unescaped. In "\\uD83D" the backslash is escaped,
     #     so "uD83D" is literal text and must not be rewritten. Consuming "\\" as
-    #     one unit makes the following "u" an ordinary character.
+    #     one unit makes the following "u" an ordinary byte.
     #   * Pairing — a high surrogate (U+D800..U+DBFF) is kept only when it is
     #     immediately followed by a low surrogate (U+DC00..U+DFFF); the valid pair
     #     passes through untouched. A high surrogate followed by anything else, and
@@ -84,69 +92,68 @@ module ReactOnRails
     #   * No over-consumption — a non-surrogate escape (e.g. "A") is never
     #     swallowed as part of a pair.
     #
-    # The replacement is an ASCII \u escape (not a literal multibyte char) so the
-    # output stays valid regardless of the input string's encoding, which may be
-    # binary. Best-effort recovery for already-malformed input, so it runs only on
-    # the JSON::ParserError retry path and never on the happy path.
+    # The replacement is an ASCII \u escape so the output stays valid regardless of
+    # encoding. It runs only on the JSON::ParserError retry path, never the happy
+    # path. Genuinely-invalid UTF-8 bytes pass through unchanged, so the caller's
+    # second JSON.parse surfaces them as an ordinary JSON::ParserError, not a new type.
     def self.sanitize_unpaired_surrogates(str)
-      out = String.new(encoding: str.encoding)
+      bytes = str.b
+      out = String.new(encoding: Encoding::BINARY)
       index = 0
-      length = str.length
+      length = bytes.bytesize
 
       while index < length
-        chunk, advance = next_sanitized_token(str, index, length)
+        chunk, advance = next_sanitized_token(bytes, index, length)
         out << chunk
         index += advance
       end
 
-      out
+      out.force_encoding(str.encoding)
     end
 
-    # Returns [text_to_emit, characters_consumed] for the token at +index+.
-    def self.next_sanitized_token(str, index, length)
-      code = unicode_escape_codepoint(str, index, length)
-      return non_escape_token(str, index, length) if code.nil?
-      return surrogate_token(str, index, length, code) if code.between?(0xD800, 0xDFFF)
+    # Returns [bytes_to_emit, bytes_consumed] for the token at +index+.
+    def self.next_sanitized_token(bytes, index, length)
+      code = unicode_escape_codepoint(bytes, index, length)
+      return non_escape_token(bytes, index, length) if code.nil?
+      return surrogate_token(bytes, index, length, code) if code.between?(0xD800, 0xDFFF)
 
-      [str[index, 6], 6] # ordinary non-surrogate \uXXXX escape
+      [bytes.byteslice(index, 6), 6] # ordinary non-surrogate \uXXXX escape
     end
-    private_class_method :next_sanitized_token
 
-    # A "\X" escape is consumed as one unit so an escaped backslash can't be
-    # misread as the start of a \u escape; any other character is verbatim.
-    def self.non_escape_token(str, index, length)
-      return [str[index, 2], 2] if str[index] == "\\" && index + 1 < length
+    # A "\X" escape is consumed as one two-byte unit so an escaped backslash can't
+    # be misread as the start of a \u escape; any other byte is emitted verbatim.
+    def self.non_escape_token(bytes, index, length)
+      return [bytes.byteslice(index, 2), 2] if bytes.getbyte(index) == BACKSLASH_BYTE && index + 1 < length
 
-      [str[index], 1]
+      [bytes.byteslice(index, 1), 1]
     end
-    private_class_method :non_escape_token
 
     # A high surrogate is kept only when immediately followed by a low surrogate;
     # otherwise it (or a lone low surrogate) becomes the U+FFFD replacement escape.
-    def self.surrogate_token(str, index, length, code)
+    def self.surrogate_token(bytes, index, length, code)
       if code.between?(0xD800, 0xDBFF)
-        low = unicode_escape_codepoint(str, index + 6, length)
-        return [str[index, 12], 12] if low&.between?(0xDC00, 0xDFFF)
+        low = unicode_escape_codepoint(bytes, index + 6, length)
+        return [bytes.byteslice(index, 12), 12] if low&.between?(0xDC00, 0xDFFF)
       end
 
       [REPLACEMENT_CHAR_ESCAPE, 6]
     end
-    private_class_method :surrogate_token
 
-    # Returns the codepoint of a genuine six-character \uXXXX escape starting at
+    # Returns the codepoint of a genuine six-byte \uXXXX escape starting at
     # +index+, or nil when +index+ does not begin one. Callers reach this position
-    # only after two-character "\X" escapes have been consumed as a unit, so a
-    # leading backslash here is always unescaped (odd backslash parity).
-    def self.unicode_escape_codepoint(str, index, length)
+    # only after two-byte "\X" escapes have been consumed as a unit, so a leading
+    # backslash here is always unescaped (odd backslash parity).
+    def self.unicode_escape_codepoint(bytes, index, length)
       return nil unless index + 6 <= length
-      return nil unless str[index] == "\\" && str[index + 1] == "u"
+      return nil unless bytes.getbyte(index) == BACKSLASH_BYTE && bytes.getbyte(index + 1) == LOWER_U_BYTE
 
-      hex = str[index + 2, 4]
+      hex = bytes.byteslice(index + 2, 4)
       return nil unless hex.match?(FOUR_HEX_DIGITS)
 
       hex.to_i(16)
     end
-    private_class_method :unicode_escape_codepoint
+
+    private_class_method :next_sanitized_token, :non_escape_token, :surrogate_token, :unicode_escape_codepoint
 
     def initialize
       # Binary encoding ensures correct byte-position arithmetic regardless of payload encoding.

--- a/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
+++ b/react_on_rails/lib/react_on_rails/length_prefixed_parser.rb
@@ -21,6 +21,12 @@ module ReactOnRails
     # MIRROR VALUES END
     private_constant :CONTROL_MESSAGE_TYPES
 
+    # Matches a single \uXXXX escape, optionally paired with the following \uXXXX
+    # escape so a valid high+low surrogate pair can be recognized as one unit.
+    SURROGATE_ESCAPE_PAIR = /\\u[0-9a-fA-F]{4}(?:\\u[0-9a-fA-F]{4})?/
+    SURROGATE_ESCAPE_CODE = /\\u([0-9a-fA-F]{4})/
+    private_constant :SURROGATE_ESCAPE_PAIR, :SURROGATE_ESCAPE_CODE
+
     # Parses a complete length-prefixed result string that must contain exactly one chunk.
     # Used by the non-streaming rendering path where ExecJS/node renderer returns a single result.
     # Returns a single Hash: { "html" => String|nil, "consoleReplayScript" => "...", ... }
@@ -38,6 +44,48 @@ module ReactOnRails
               "Malformed render result: expected exactly one length-prefixed chunk but found #{results.size}"
       end
       results.first
+    end
+
+    # Parses JSON emitted by JavaScript's JSON.stringify, tolerating one Unicode
+    # divergence that would otherwise crash SSR.
+    #
+    # JavaScript strings are UTF-16 and JSON.stringify happily emits unpaired
+    # surrogate escapes (e.g. a lone high surrogate "\ud83d" from corrupted user
+    # data, DB encoding issues, or API responses). Ruby's JSON.parse rejects a
+    # lone HIGH surrogate with "incomplete surrogate pair", so JS output that the
+    # browser would render fine (as U+FFFD) crashes the whole Ruby-side render.
+    #
+    # To keep React on Rails a general-purpose framework that passes content
+    # through instead of crashing, we retry the parse ONCE with unpaired
+    # surrogates replaced by the U+FFFD replacement character. The retry runs
+    # only after a JSON::ParserError, so the happy path pays nothing. If the
+    # sanitized string still fails to parse, the (second) JSON::ParserError
+    # propagates so genuinely malformed JSON is still surfaced to callers.
+    def self.parse_json_lenient(str)
+      JSON.parse(str)
+    rescue JSON::ParserError
+      JSON.parse(sanitize_unpaired_surrogates(str))
+    end
+
+    # Replaces unpaired \uXXXX surrogate escapes with the U+FFFD replacement
+    # escape (�), leaving valid high+low pairs intact. The replacement is an
+    # ASCII \u escape (not a literal multibyte char) so the output stays valid
+    # regardless of the input string's encoding, which may be binary.
+    #
+    # Best-effort recovery for already-malformed input; it is not a general JSON
+    # validator and does not distinguish surrogate escapes inside string literals
+    # from other contexts (JSON only permits \u escapes inside strings, so this is
+    # safe in practice). Adjacent all-escaped surrogates in pathological input may
+    # be re-paired greedily, but the result is always valid UTF-8 and never crashes.
+    def self.sanitize_unpaired_surrogates(str)
+      str.gsub(SURROGATE_ESCAPE_PAIR) do |seq|
+        codes = seq.scan(SURROGATE_ESCAPE_CODE).flatten.map { |hex| hex.to_i(16) }
+        if codes.length == 2 && codes[0].between?(0xD800, 0xDBFF) && codes[1].between?(0xDC00, 0xDFFF)
+          seq # valid surrogate pair — leave untouched
+        else
+          codes.map { |code| code.between?(0xD800, 0xDFFF) ? '\ufffd' : format('\\u%04x', code) }.join
+        end
+      end
     end
 
     def initialize
@@ -118,7 +166,7 @@ module ReactOnRails
       raise ParseError, "Malformed length-prefixed header: negative content length" if @content_len.negative?
 
       begin
-        @metadata = JSON.parse(meta_json.force_encoding(Encoding::UTF_8))
+        @metadata = self.class.parse_json_lenient(meta_json.force_encoding(Encoding::UTF_8))
       rescue JSON::ParserError
         raise ParseError, "Malformed length-prefixed header: invalid metadata JSON", cause: nil
       end
@@ -161,7 +209,7 @@ module ReactOnRails
     end
 
     def parse_object_payload(raw_content)
-      JSON.parse(raw_content)
+      self.class.parse_json_lenient(raw_content)
     rescue JSON::ParserError
       raise ParseError, "Malformed length-prefixed object payload JSON", cause: nil
     end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -420,7 +420,10 @@ module ReactOnRails
           result = if result_string.to_s.include?("\t")
                      ReactOnRails::LengthPrefixedParser.parse_one_chunk_result(result_string)
                    else
-                     JSON.parse(result_string.to_s)
+                     # Legacy JSON format from older bundles: parse leniently so a lone
+                     # UTF-16 surrogate emitted by JS JSON.stringify (which Ruby's
+                     # JSON.parse rejects) degrades to U+FFFD instead of crashing SSR.
+                     ReactOnRails::LengthPrefixedParser.parse_json_lenient(result_string.to_s)
                    end
           replay_console_to_rails_logger(result, render_options)
           result

--- a/react_on_rails/spec/lib/react_on_rails/length_prefixed_parser_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/length_prefixed_parser_spec.rb
@@ -236,4 +236,86 @@ RSpec.describe ReactOnRails::LengthPrefixedParser do
       )
     end
   end
+
+  # Regression coverage for GitHub issue #4710: JavaScript's JSON.stringify can
+  # emit unpaired UTF-16 surrogate escapes (e.g. a lone high surrogate "\ud83d")
+  # that Ruby's JSON.parse rejects with "incomplete surrogate pair". SSR must
+  # pass such content through (as U+FFFD) instead of crashing.
+  describe ".parse_json_lenient" do
+    it "parses ordinary JSON unchanged" do
+      expect(described_class.parse_json_lenient('{"html":"<div>ok</div>","n":1}')).to eq(
+        "html" => "<div>ok</div>", "n" => 1
+      )
+    end
+
+    it "never crashes on a lone high surrogate and yields valid UTF-8" do
+      # Whether the underlying JSON.parse raises "incomplete surrogate pair"
+      # (older json gems / the client's scenario) or silently substitutes
+      # (newer json gems have their own lenient handling), parse_json_lenient
+      # must return valid, renderable content instead of propagating a crash.
+      %w[
+        {"html":"\uD83D"}
+        {"html":"Hello\uD83Dworld"}
+        {"html":"\uD83DA"}
+      ].each do |json|
+        result = nil
+        expect { result = described_class.parse_json_lenient(json) }.not_to raise_error
+        expect(result["html"].valid_encoding?).to be(true)
+      end
+    end
+
+    it "decodes a sanitized lone high surrogate to U+FFFD" do
+      # Deterministic across json versions: run the recovery pipeline directly
+      # (sanitize then parse) so the produced replacement char is asserted
+      # regardless of whether the raw JSON.parse would have raised.
+      raw = '{"html":"Hello \uD83D world"}'
+      recovered = JSON.parse(described_class.sanitize_unpaired_surrogates(raw))
+      expect(recovered["html"]).to eq("Hello � world")
+    end
+
+    it "preserves valid surrogate pairs" do
+      json = '{"html":"Hi 😀"}'
+      expect(described_class.parse_json_lenient(json)).to eq("html" => "Hi \u{1F600}")
+    end
+
+    it "re-raises for genuinely malformed JSON that is not a surrogate issue" do
+      expect { described_class.parse_json_lenient('{"html":}') }.to raise_error(JSON::ParserError)
+    end
+  end
+
+  describe ".sanitize_unpaired_surrogates" do
+    it "leaves valid surrogate pairs and non-surrogate escapes untouched" do
+      json = '{"a":"😀","b":"A"}'
+      expect(described_class.sanitize_unpaired_surrogates(json)).to eq(json)
+    end
+
+    it "replaces a lone high surrogate escape with the U+FFFD escape" do
+      # Returns the raw JSON string with the escape rewritten (not yet parsed):
+      # the 8-character literal "�", which JSON.parse then decodes to U+FFFD.
+      expect(described_class.sanitize_unpaired_surrogates('"\uD83D"')).to eq('"\ufffd"')
+    end
+
+    it "replaces a lone high surrogate followed by a non-surrogate escape" do
+      expect(described_class.sanitize_unpaired_surrogates('"\uD83DA"')).to eq('"\ufffdA"')
+    end
+
+    it "produces ASCII-only output so encoding stays safe for binary input" do
+      out = described_class.sanitize_unpaired_surrogates('"\uD83D"'.b)
+      expect(out).to eq('"\ufffd"')
+      expect(out.ascii_only?).to be(true)
+    end
+  end
+
+  describe "lone surrogates in an object payload" do
+    it "does not crash and yields valid, renderable content" do
+      raw_content = '{"html":"Hello \uD83D world","consoleReplayScript":""}'
+      metadata = { "payloadType" => "object" }.to_json
+      payload = "#{metadata}\t#{raw_content.bytesize.to_s(16)}\n#{raw_content}"
+
+      result = nil
+      expect { result = described_class.parse_one_chunk_result(payload) }.not_to raise_error
+      expect(result["html"]).to be_a(Hash)
+      expect(result["html"]["html"].valid_encoding?).to be(true)
+    end
+  end
 end

--- a/react_on_rails/spec/lib/react_on_rails/length_prefixed_parser_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/length_prefixed_parser_spec.rb
@@ -306,6 +306,49 @@ RSpec.describe ReactOnRails::LengthPrefixedParser do
     end
   end
 
+  # Regression for issue #4710 review (codex / greptile P1): the sanitizer must
+  # replace only genuinely lone surrogates, never mis-pair across fields and
+  # never rewrite an escaped backslash's literal text. Asserted through the
+  # sanitize+parse pipeline so the produced characters are deterministic.
+  describe ".sanitize_unpaired_surrogates lone-surrogate precision" do
+    def recovered(raw_json)
+      JSON.parse(described_class.sanitize_unpaired_surrogates(raw_json))
+    end
+
+    it "does not mis-pair a lone surrogate with a following field's data" do
+      # A lone high surrogate in "bad" must not consume the "ok" field: "ok"
+      # still decodes to A + U+1F600, and only "bad" becomes U+FFFD.
+      result = recovered('{"bad":"\uD83D","ok":"A😀"}')
+      expect(result).to eq("bad" => "�", "ok" => "A\u{1F600}")
+    end
+
+    it "respects backslash parity: an escaped backslash before u is literal text" do
+      # JSON "\\uD83D" is an escaped backslash followed by literal "uD83D" (it
+      # decodes to the 6 characters \uD83D), not a unicode escape. It must be
+      # preserved byte-for-byte even though the sibling "bad" field carries a
+      # real lone surrogate that triggers the sanitize retry.
+      result = recovered('{"lit":"\\\\uD83D","bad":"\uD83D"}')
+      expect(result).to eq("lit" => '\\uD83D', "bad" => "�")
+    end
+
+    it "keeps a valid surrogate pair that is adjacent to a lone surrogate" do
+      # Escaped valid pair followed by a lone high surrogate: the pair survives
+      # as U+1F600 and only the trailing lone high surrogate becomes U+FFFD.
+      result = recovered('{"h":"😀\uD83D"}')
+      expect(result["h"]).to eq("\u{1F600}�")
+    end
+
+    it "replaces each of two adjacent lone high surrogates" do
+      result = recovered('{"h":"\uD83D\uD83D"}')
+      expect(result["h"]).to eq("��")
+    end
+
+    it "replaces a lone low surrogate" do
+      result = recovered('{"h":"x\uDE00y"}')
+      expect(result["h"]).to eq("x�y")
+    end
+  end
+
   describe "lone surrogates in an object payload" do
     it "does not crash and yields valid, renderable content" do
       raw_content = '{"html":"Hello \uD83D world","consoleReplayScript":""}'

--- a/react_on_rails/spec/lib/react_on_rails/length_prefixed_parser_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/length_prefixed_parser_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe ReactOnRails::LengthPrefixedParser do
     end
 
     it "preserves valid surrogate pairs" do
-      json = '{"html":"Hi 😀"}'
+      json = '{"html":"Hi \uD83D\uDE00"}'
       expect(described_class.parse_json_lenient(json)).to eq("html" => "Hi \u{1F600}")
     end
 
@@ -285,7 +285,7 @@ RSpec.describe ReactOnRails::LengthPrefixedParser do
 
   describe ".sanitize_unpaired_surrogates" do
     it "leaves valid surrogate pairs and non-surrogate escapes untouched" do
-      json = '{"a":"😀","b":"A"}'
+      json = '{"a":"\uD83D\uDE00","b":"A"}'
       expect(described_class.sanitize_unpaired_surrogates(json)).to eq(json)
     end
 
@@ -318,7 +318,7 @@ RSpec.describe ReactOnRails::LengthPrefixedParser do
     it "does not mis-pair a lone surrogate with a following field's data" do
       # A lone high surrogate in "bad" must not consume the "ok" field: "ok"
       # still decodes to A + U+1F600, and only "bad" becomes U+FFFD.
-      result = recovered('{"bad":"\uD83D","ok":"A😀"}')
+      result = recovered('{"bad":"\uD83D","ok":"A\uD83D\uDE00"}')
       expect(result).to eq("bad" => "�", "ok" => "A\u{1F600}")
     end
 
@@ -334,7 +334,7 @@ RSpec.describe ReactOnRails::LengthPrefixedParser do
     it "keeps a valid surrogate pair that is adjacent to a lone surrogate" do
       # Escaped valid pair followed by a lone high surrogate: the pair survives
       # as U+1F600 and only the trailing lone high surrogate becomes U+FFFD.
-      result = recovered('{"h":"😀\uD83D"}')
+      result = recovered('{"h":"\uD83D\uDE00\uD83D"}')
       expect(result["h"]).to eq("\u{1F600}�")
     end
 
@@ -359,6 +359,53 @@ RSpec.describe ReactOnRails::LengthPrefixedParser do
       expect { result = described_class.parse_one_chunk_result(payload) }.not_to raise_error
       expect(result["html"]).to be_a(Hash)
       expect(result["html"]["html"].valid_encoding?).to be(true)
+    end
+  end
+
+  # Regression for issue #4710 review: the byte-level sanitizer must never turn
+  # a genuinely-invalid-UTF-8 input into a non-JSON exception on the retry path,
+  # and must stay O(n)/correct on large multibyte payloads.
+  describe "encoding safety and multibyte payloads" do
+    # Mirrors the real caller, which force_encodes render bytes to UTF-8 without
+    # validating them, so the sanitizer can receive genuinely-invalid byte runs.
+    def utf8(bytes)
+      bytes.dup.force_encoding(Encoding::UTF_8)
+    end
+
+    it "never raises on genuinely-invalid UTF-8 bytes and preserves them" do
+      input = utf8("{\"h\":\"a\xFFb\\uD83D\"}")
+      expect(input.valid_encoding?).to be(false)
+
+      out = nil
+      expect { out = described_class.sanitize_unpaired_surrogates(input) }.not_to raise_error
+      expect(out.bytes).to include(0xFF) # corrupt byte passed through untouched
+      expect(out).to include('\\ufffd') # the lone surrogate still became U+FFFD
+    end
+
+    it "degrades an invalid-byte object payload to a ParseError, never a new type" do
+      raw_content = utf8("{\"html\":\"a\xFFb\\uD83D\",\"consoleReplayScript\":\"\"}")
+      metadata = { "payloadType" => "object" }.to_json
+      payload = "#{metadata}\t#{raw_content.bytesize.to_s(16)}\n#{raw_content}"
+
+      # Whatever happens, it must be either a clean parse or the parser's own
+      # ParseError — not ArgumentError/EncodingError from scanning invalid bytes.
+      expect do
+        described_class.parse_one_chunk_result(payload)
+      rescue described_class::ParseError
+        # acceptable graceful degradation
+      end.not_to raise_error
+    end
+
+    it "recovers a lone surrogate embedded in a large multibyte payload" do
+      big = "日本語テキスト" * 500
+      recovered = JSON.parse(described_class.sanitize_unpaired_surrogates(%({"h":"#{big}\\uD83D#{big}"})))
+      expect(recovered["h"]).to eq("#{big}�#{big}")
+    end
+
+    it "preserves an escaped valid pair inside a large multibyte payload" do
+      big = "日本語テキスト" * 500
+      recovered = JSON.parse(described_class.sanitize_unpaired_surrogates(%({"h":"#{big}\\uD83D\\uDE00"})))
+      expect(recovered["h"]).to eq("#{big}\u{1F600}")
     end
   end
 end

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -301,6 +301,30 @@ module ReactOnRails
         end
       end
 
+      # Regression for issue #4710: legacy (non-length-prefixed) JSON returned by
+      # older bundles may contain unpaired UTF-16 surrogates that Ruby's JSON.parse
+      # rejects. The legacy fallback must recover instead of crashing SSR.
+      describe ".parse_render_result legacy JSON path" do
+        let(:render_options) do
+          instance_double(ReactOnRails::ReactComponent::RenderOptions, logging_on_server: false)
+        end
+
+        it "parses ordinary legacy JSON" do
+          result = described_class.send(:parse_render_result, '{"html":"<p>ok</p>"}', render_options)
+          expect(result["html"]).to eq("<p>ok</p>")
+        end
+
+        it "does not crash on a lone high surrogate and yields valid UTF-8" do
+          legacy_json = '{"html":"Hello \uD83D world","consoleReplayScript":""}'
+
+          result = nil
+          expect do
+            result = described_class.send(:parse_render_result, legacy_json, render_options)
+          end.not_to raise_error
+          expect(result["html"].valid_encoding?).to be(true)
+        end
+      end
+
       describe ".read_bundle_js_code" do
         it "raises a bundle-load error when an HTTP server bundle cannot be read" do
           server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"


### PR DESCRIPTION
Refs #4710

## Summary

Ruby's `JSON.parse` rejects a lone/unpaired UTF-16 high surrogate (`\uD83D` with no paired low surrogate) with `JSON::ParserError: incomplete surrogate pair`, while JavaScript's `JSON.parse` accepts it. Since JS `JSON.stringify` can emit such content (from corrupted user data, DB encoding issues, or upstream API responses), server render output that JS happily produced could crash the entire Ruby-side render instead of passing content through for the browser to display as U+FFFD.

This adds a **catch-and-sanitize retry** that only activates on `JSON::ParserError`, so the happy path is unchanged: `LengthPrefixedParser.parse_json_lenient` parses normally and, on parse failure, retries once with unpaired surrogate escapes rewritten to the U+FFFD escape (`�`). It is wired into the at-risk render-result parse sites.

## At-risk `JSON.parse` inventory

Every `JSON.parse` in `react_on_rails/` and `react_on_rails_pro/` was audited and classified by whether it parses **JS render output** (at risk) vs. **internal/trusted data** (not at risk):

| File:line | Parses | At risk? | Action |
|---|---|---|---|
| `length_prefixed_parser.rb:164` (object payload) | JS render `ServerRenderHash` when `payloadType:"object"` | **Yes** | Now `parse_json_lenient` |
| `length_prefixed_parser.rb:121` (metadata) | Framework-produced header JSON | Low (defense-in-depth) | Now `parse_json_lenient` |
| `ruby_embedded_java_script.rb:423` (legacy fallback) | Full JS render output from old bundles | **Yes** (client's reported case) | Now `parse_json_lenient` |
| `helper.rb:841` | Developer-supplied props **string** | No — dev input, not JS output | none |
| `rsc_payload_renderer.rb:71` (Pro) | HTTP request `params[:props]` | No — request params | none |
| `request.rb:256`, `rolling_deploy_adapters/http.rb:98` (Pro) | Renderer control/HTTP responses (`exists`, deploy status) | No — trusted control JSON | none |
| ~30 sites in generators / `doctor.rb` / `system_checker.rb` / `version_checker.rb` / manifests | `package.json`, lockfiles, manifests on disk | No — trusted local files | none |

Note: the length-prefixed format (v16.7.0+) already sends `payloadType:"string"` HTML as **raw bytes** (never through `JSON.parse`), which mitigates the common string case. The remaining `JSON.parse` exposure is the object-payload, metadata, and legacy-format paths fixed here.

## Divergence table (empirically tested, Ruby vs. JS)

For each Ruby/JS "valid JSON" divergence, tested whether Ruby's `JSON.parse` fails **and** whether JS `JSON.stringify` can actually emit it:

| Divergence | JS `JSON.stringify` can emit? | Ruby `JSON.parse` | Realistic SSR crash risk? |
|---|---|---|---|
| Lone **high** surrogate `\uD83D` | **Yes** (`\ud83d`) | **Fails** (incomplete surrogate pair) | **Yes — fixed here** |
| Lone **low** surrogate `\uDE00` | Yes (`\ude00`) | Accepts (invalid-encoding string, no crash) | No crash (pre-existing, out of scope) |
| Reversed / adjacent lone surrogates | Yes | Fails | **Yes — fixed here** |
| Valid pair (emoji) | Yes (raw char) | Accepts | No |
| BOM at start | **No** — never emitted by stringify | Fails | No (unreachable from JS output) |
| Invalid escape `\x`, `\a` | **No** — never emitted | Fails | No (unreachable) |
| Unescaped control char | **No** — always escaped as `\n`/`\u00XX` | Fails | No (unreachable) |

**Conclusion:** unpaired surrogates are the *only* divergence class reachable from JS `JSON.stringify` output. The other Ruby-strict cases cannot occur from JS render output, so a narrow surrogate-focused fix is complete — no BOM-stripping, escape-rewriting, or parser swap is needed.

Additional finding: newer `json` gems (tested 2.7.2 on Ruby 4.0.5) apply their **own inconsistent** lenient surrogate handling — some inputs raise `incomplete surrogate pair`, others silently substitute `?`/U+FFFD depending on content/buffer alignment. This fix is the deterministic safety net for the versions/inputs that still raise (the client's older-bundle scenario); it has zero cost when the underlying parser is already lenient.

## Approach evaluated

- **(a) Catch-and-sanitize retry (chosen).** Zero happy-path cost (runs only after `ParserError`), no new dependency, localized to the two named parser files. Worst case converts a crash into valid pass-through content.
- (b) Preprocess/sanitize every parse — rejected: adds per-render cost on the hot path for a rare edge case.
- (c) Alternative parser (oj, etc.) — rejected: new dependency, broad blast radius, doesn't clearly help (would need its own surrogate policy).

## Before / after evidence

Reproduction (`{"html": "Hello \uD83D world"}`):

- **Before:** `JSON.parse` raises `JSON::ParserError: incomplete surrogate pair` → whole render crashes.
- **After:** `parse_json_lenient` returns `"Hello � world"` (valid UTF-8), render succeeds.

Tests added (all passing):
- `length_prefixed_parser_spec.rb`: `parse_json_lenient` never crashes on lone high surrogates and yields valid UTF-8 (across json-version behaviors); deterministic sanitize+parse pipeline decodes to U+FFFD; valid pairs preserved; genuinely malformed non-surrogate JSON still raises. `sanitize_unpaired_surrogates` unit tests (leaves valid pairs/escapes untouched, rewrites lone surrogates, ASCII-only output for binary input). Object-payload integration test does not crash and yields valid content.
- `ruby_embedded_java_script_spec.rb`: legacy JSON path parses ordinary JSON and does not crash on a lone high surrogate.

## Validation

- `bundle exec rspec` (both changed specs): **52 examples, 0 failures** (27 + 25).
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop` on all 4 changed Ruby files: **no offenses**.
- `bundle exec rake rbs:validate`: **passed**.

## Codex Decision Log

- **Scope kept to crashes.** #4710 is about SSR *crashing*. Lone low surrogates (Ruby accepts, invalid-encoding string) and json-gem `?`-substitution do not crash, so they are deliberately left as pre-existing behavior — fixing them would require sanitizing on the happy path (per-render cost) for no crash benefit.
- **Only-on-error retry.** Sanitization runs solely inside `rescue JSON::ParserError`, guaranteeing no measurable happy-path overhead on this per-render/per-chunk hot path.
- **Encoding-safe replacement.** Emits the ASCII escape `�` (not a literal multibyte char) so output stays valid regardless of the input string's encoding (render buffers are binary).
- **Version-robust tests.** Because `json` gem surrogate behavior is inconsistent across versions, integration assertions check the invariant (no crash + valid encoding) and a separate deterministic test drives the sanitize→parse pipeline directly to assert U+FFFD.
- **Known limitation (documented in-code).** Adjacent all-escaped surrogates in pathological input may be re-paired greedily by the regex; output is always valid UTF-8 and never crashes, and this only affects already-corrupt input on the error path.
- **Label/milestone:** `bug` + milestone `17.1` remain appropriate for this scoped, low-risk fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-rendering crashes when render-result JSON contains corrupted unpaired UTF-16 surrogate escapes.
  * Render-result parsing now retries once with a surrogate-tolerant decode, replacing lone surrogates with the Unicode replacement character while preserving valid surrogate pairs.
  * Improvements apply to both length-prefixed and legacy (fallback) render-result formats.

* **Tests**
  * Added regression coverage for surrogate handling in parsing and verified UTF-8-safe behavior, including for nested payloads and robustness against malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->