### PR TITLE
Docs: node-renderer default setup requires Node.js 20+ (Fastify 5)

### DIFF
--- a/docs/oss/building-features/node-renderer/basics.md
+++ b/docs/oss/building-features/node-renderer/basics.md
@@ -58,7 +58,7 @@ For the most control over the setup, create a JavaScript file to start the NodeR
    mkdir renderer-app
    cd renderer-app
    ```
-2. Make sure you have **Node.js 18+** and a JavaScript package manager such as **npm**, **pnpm**, **Yarn**, or **bun**.
+2. Make sure you have **Node.js 20+** and a JavaScript package manager such as **npm**, **pnpm**, **Yarn**, or **bun**. The default setup bundles Fastify 5, which requires Node.js 20+ — on Node.js 18 the renderer exits at startup unless you pin Fastify 4 via your package manager's dependency-override mechanism (npm [`overrides`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides), Yarn/Bun [`resolutions`](https://yarnpkg.com/configuration/manifest#resolutions), or pnpm [`pnpm.overrides`](https://pnpm.io/package_json#pnpmoverrides)). (The package's `engines.node` floor is `>=18.19.0`, which applies only to that Fastify 4 path.)
 3. Initialize a Node application and install the `react-on-rails-pro-node-renderer` package.
    ```sh
    npm init -y


### PR DESCRIPTION
## Summary
Corrects the node-renderer setup prerequisite to state **Node.js 18.19.0+**, matching the `react-on-rails-pro-node-renderer` package's `engines.node` `>=18.19.0`. Previously the doc said only "Node.js 18+", so an install on Node 18.0–18.18 followed the documented floor but could be rejected by npm/pnpm against the package's `engines` constraint.

## Scope
Deliberately narrow: only the node-renderer prerequisite ([basics.md](docs/oss/building-features/node-renderer/basics.md)). The general framework/CLI "Node 18+" statements elsewhere are **left unchanged because they are accurate** — `create-react-on-rails-app` declares `engines.node` `>=18.0.0`, and the core `react-on-rails` packages set no Node floor. Only the node-renderer package carries the `.19` patch requirement.

## Provenance
Surfaced by automated review on the llms-full regen PR #4728; tracked in #4730. The companion jwt/base64 finding from that issue was investigated and needs no change (base64 is guaranteed via `activesupport` 7.1+ on every Ruby-3.4-capable Rails; the jwt floor was intentionally relaxed in #3320 and should not be raised).

## Validation
- Prettier: clean.
- Docs-only, single-line prose correction; no sidebar/link impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Node.js requirement guidance for the `react-on-rails-pro-node-renderer` package: the default setup now requires **Node.js 20+**.
  * Added clarification that **Node.js 18** can work only when using a **Fastify 4** pin, with the Node floor documented as **`>=18.19.0`** for that path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->