### PR TITLE
[Pro] Backport production RSC diagnostic redaction

### DIFF
--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -100,14 +100,17 @@ function hasRenderingErrorSignal(renderingError: unknown) {
 function createRSCDiagnosticScript(
   metadata: Record<string, unknown>,
   cacheKey: string,
+  railsEnv: string | undefined,
   sanitizedNonce?: string,
 ) {
   const { hasErrors, renderingError } = metadata;
   // `hasErrors` is a boolean per the server wire contract; renderingError only carries
   // a useful diagnostic when the server provided a non-blank message or stack.
   if (hasErrors !== true && !hasRenderingErrorSignal(renderingError)) return undefined;
+  const diagnostic =
+    railsEnv === 'development' || railsEnv === 'test' ? { hasErrors, renderingError } : { hasErrors: true };
   return createScriptTag(
-    `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify({ hasErrors, renderingError })}`,
+    `${cacheKeyDiagnosticObject(cacheKey)}||=${JSON.stringify(diagnostic)}`,
     sanitizedNonce,
     true,
   );
@@ -1594,6 +1597,7 @@ function applyStreamedStylesheetPreloadGating(
 }
 
 type InjectRSCPayloadOptions = {
+  railsEnv?: string;
   rscClientManifestStylesheetHrefs?: ReadonlySet<string>;
   rscClientChunkStylesheetHrefsByChunkName?: RSCClientChunkStylesheetHrefsByChunkName;
   rscStreamObservability?: boolean;
@@ -1633,6 +1637,7 @@ export default function injectRSCPayload(
   options: InjectRSCPayloadOptions = {},
 ) {
   const {
+    railsEnv,
     rscClientManifestStylesheetHrefs = new Set<string>(),
     rscClientChunkStylesheetHrefsByChunkName = loadRSCClientChunkStylesheetHrefsByChunkName(),
     rscStreamObservability = false,
@@ -2011,7 +2016,12 @@ export default function injectRSCPayload(
             const handleParsedChunk = (content: Uint8Array, metadata: Record<string, unknown>) => {
               const flightData = textDecoder.decode(content);
               if (!hasEmittedDiagnosticScript) {
-                const diagnosticScript = createRSCDiagnosticScript(metadata, rscPayloadKey, sanitizedNonce);
+                const diagnosticScript = createRSCDiagnosticScript(
+                  metadata,
+                  rscPayloadKey,
+                  railsEnv,
+                  sanitizedNonce,
+                );
                 if (diagnosticScript) {
                   rscPayloadBuffers.push(Buffer.from(diagnosticScript));
                   hasEmittedDiagnosticScript = true;

--- a/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
@@ -231,6 +231,7 @@ const streamRenderReactComponent = (
                 domNodeId,
                 railsContext.cspNonce,
                 {
+                  railsEnv: railsContext.railsEnv,
                   rscClientManifestStylesheetHrefs,
                   ...(reactClientManifestFileName
                     ? {}

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -34,6 +34,8 @@ const toLengthPrefixedWithMetadata = (content: string, metadata: Record<string, 
 const rscPayloadKey = 'test-fun4a7ngv9-test-node';
 const rscPayloadKeyReference = `[${JSON.stringify(rscPayloadKey)}]`;
 const rscPayloadScriptMarker = 'data-react-on-rails-rsc-payload="true"';
+const secretRenderingErrorMessage = 'ROR_DIAGNOSTIC_SECRET_MESSAGE_7f9c2e';
+const secretRenderingErrorStack = 'ROR_DIAGNOSTIC_SECRET_STACK_4b1a8d';
 const expectedInitializationScript = `<script ${rscPayloadScriptMarker}>delete (self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference};(self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]</script>`;
 const expectedPayloadPushScript = (chunk: string) =>
   `<script ${rscPayloadScriptMarker}>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]).push(${JSON.stringify(
@@ -385,33 +387,67 @@ describe('injectRSCPayload', () => {
     }
   });
 
-  it('injects RSC diagnostic metadata without exposing unrelated stream metadata', async () => {
+  it.each(['development', 'test'])(
+    'injects RSC diagnostic metadata in the explicit %s environment without exposing unrelated stream metadata',
+    async (railsEnv) => {
+      const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+        hasErrors: true,
+        renderingError: {
+          message: secretRenderingErrorMessage,
+          stack: secretRenderingErrorStack,
+        },
+        consoleReplayScript: '<script>console.log("replay")</script>',
+        serializedProps: { token: 'do-not-serialize' },
+      });
+      const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+      const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+      const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+        railsEnv,
+        rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      });
+      const resultStr = await collectStreamData(result);
+
+      expect(resultStr).toContain(
+        `<script ${rscPayloadScriptMarker}>(self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference}||=`,
+      );
+      expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
+      expect(resultStr).toContain('["test-fun4a7ngv9-test-node"]||=');
+      expect(resultStr).toContain(secretRenderingErrorMessage);
+      expect(resultStr).toContain(secretRenderingErrorStack);
+      expect(resultStr).toContain('REACT_ON_RAILS_RSC_PAYLOADS');
+      expect(resultStr).not.toContain('serializedProps');
+      expect(resultStr).not.toContain('do-not-serialize');
+      expect(resultStr).not.toContain('consoleReplayScript');
+    },
+  );
+
+  it.each([
+    ['production', 'production'],
+    ['missing', undefined],
+  ])('redacts RSC rendering error details when railsEnv is %s', async (_name, railsEnv) => {
     const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
       hasErrors: true,
       renderingError: {
-        message: 'useState is not a function',
-        stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
+        message: secretRenderingErrorMessage,
+        stack: secretRenderingErrorStack,
       },
-      consoleReplayScript: '<script>console.log("replay")</script>',
-      serializedProps: { token: 'do-not-serialize' },
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      railsEnv,
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain(
-      `<script ${rscPayloadScriptMarker}>(self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference}||=`,
+      `<script ${rscPayloadScriptMarker}>(self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference}||={"hasErrors":true}</script>`,
     );
-    expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
-    expect(resultStr).toContain('["test-fun4a7ngv9-test-node"]||=');
-    expect(resultStr).toContain('useState is not a function');
-    expect(resultStr).toContain('/app/components/Broken.server.tsx');
-    expect(resultStr).toContain('REACT_ON_RAILS_RSC_PAYLOADS');
-    expect(resultStr).not.toContain('serializedProps');
-    expect(resultStr).not.toContain('do-not-serialize');
-    expect(resultStr).not.toContain('consoleReplayScript');
+    expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain(secretRenderingErrorMessage);
+    expect(resultStr).not.toContain(secretRenderingErrorStack);
   });
 
   it('keeps the first RSC diagnostic metadata for a payload key', async () => {
@@ -440,7 +476,10 @@ describe('injectRSCPayload', () => {
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      railsEnv: 'development',
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+    });
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain('First error');


### PR DESCRIPTION
## Why

Issue #4629 identified that streamed React Server Component diagnostics could serialize a server render error's message and source-mapped stack into browser-visible HTML outside development. The mainline fix landed in #4631; the closed v17 release tracker designated this as lead 17.0.1 patch-train work.

This PR is the smallest release-branch backport that closes the client-visible disclosure without importing #4631's broader node-renderer reporting changes.

## What changed

- Pass `railsContext.railsEnv` to the internal RSC payload injector.
- Include full `renderingError` metadata only for explicit `development` and `test`.
- Fail closed for production, custom environments, and missing environment values by emitting only `{ hasErrors: true }`.
- Keep the existing server rendering/reporting path unchanged.

## Reporter-path preservation

- `reportError`, `emitError`, `buildRenderMetadata`, `streamingUtils.ts`, and the node-renderer handlers are unchanged.
- The existing `streamServerRenderedReactComponent` regression suite remains green.
- This deliberately does not backport #4631's separate custom `renderingError` event, which is outside this security backport's authorized paths and behavior.

## Verification

- `pnpm --filter react-on-rails-pro exec jest tests/injectRSCPayload.test.ts --runInBand` — 79 tests passed.
- `pnpm --filter react-on-rails-pro exec jest tests/streamServerRenderedReactComponent.test.jsx --runInBand` — 39 tests passed.
- Pro TypeScript type-check — passed.
- Focused ESLint and Prettier — passed.
- Mandatory OSS RuboCop — 234 files, no offenses.
- `script/check-pro-license-headers` — 851 files passed.
- `git diff --check` — passed.
- Pre-commit hooks — passed.

The pre-push branch RuboCop gate also passed. Its Markdown link phase could not run because release-branch divergence selected unrelated Markdown files and the installed Lychee version cannot parse the current `.lychee.toml`; no Markdown or configuration file changes in this PR.

## Release context

- Base: `release/17.0.0`
- Release tracker #3823: closed as released; repository mode returned to `development`.
- Release-branch phase gate: `rc`.
- Intended train: 17.0.1 patch work.
- No tag, package publication, version bump, or release action is included.

## Codex Decision Log

- **Non-blocking:** Keep this backport smaller than merged main PR #4631.
  - **Decision:** Backport only client-boundary redaction and its focused tests.
  - **Why:** The production disclosure is removed without changing reporter semantics or touching node-renderer paths excluded by the batch.
  - **Review later:** The broader reporter-delivery improvement remains on `main`.
- **Non-blocking:** Do not edit `CHANGELOG.md` in this lane.
  - **Decision:** Preserve the batch's exact three-path ownership boundary.
  - **Why:** #4631 already carries the mainline changelog entry; release-note stamping is separate patch-train assembly work.
  - **Review later:** Ensure the 17.0.1 changelog assembly includes the #4629 entry before publication.

Addresses #4629.
