### PR TITLE
CI: split generator specs into setup-safe subshards

### DIFF
--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -226,10 +226,12 @@ jobs:
           cd react_on_rails
           if [[ "$SHARD" == generators-* ]]; then
             shard_number="${SHARD#generators-}"
+            # Keep this aligned with the generators-1/2/3 rows in both matrix branches above.
             shard_count=3
             shard_index="$((shard_number - 1))"
             manifest_path="${RUNNER_TEMP}/generator-shard-${shard_number}.opts"
 
+            # Rebuild from each job's exact checkout; never share a manifest across jobs or heads.
             bundle exec ruby -rrspec/core -rdigest -e '
               shard_index = Integer(ARGV.fetch(0))
               shard_count = Integer(ARGV.fetch(1))
@@ -261,6 +263,7 @@ jobs:
               visit_group = lambda do |group|
                 hooks = group.hooks
                 owns_context_hook = %i[before after].any? do |position|
+                  # RSpec has no public hook-enumeration API; fail loudly if this private seam changes.
                   !hooks.send(:all_hooks_for, position, :context).empty?
                 end
 

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -246,17 +246,20 @@ jobs:
               )
               abort "generator manifest dry run failed with status #{status}" unless status.zero?
 
+              id_for = lambda do |item|
+                metadata = item.metadata
+                "#{metadata.fetch(:rerun_file_path)}[#{metadata.fetch(:scoped_id)}]"
+              end
               examples = RSpec.world.all_examples.map do |example|
                 metadata = example.metadata
                 file = metadata.fetch(:rerun_file_path)
                 scoped_id = metadata.fetch(:scoped_id)
-                { id: "#{file}[#{scoped_id}]", file:, scoped_id:, example: }
+                { id: id_for.call(example), file:, scoped_id: }
               end
               ids = examples.map { |row| row.fetch(:id) }
               abort "generator manifest is empty" if ids.empty?
               abort "generator manifest has duplicate scoped IDs" unless ids.uniq.length == ids.length
 
-              rows_by_example = examples.to_h { |row| [row.fetch(:example), row] }
               atomic_unit_by_id = {}
               setup_count_by_unit = Hash.new(0)
 
@@ -270,17 +273,14 @@ jobs:
                 if owns_context_hook
                   descendants = group.descendant_filtered_examples
                   existing_units = descendants.filter_map do |example|
-                    row = rows_by_example.fetch(example)
-                    atomic_unit_by_id[row.fetch(:id)]
+                    atomic_unit_by_id[id_for.call(example)]
                   end.uniq
                   abort "nested generator setup spans multiple atomic units" if existing_units.length > 1
 
-                  metadata = group.metadata
-                  own_unit_id = "#{metadata.fetch(:rerun_file_path)}[#{metadata.fetch(:scoped_id)}]"
+                  own_unit_id = id_for.call(group)
                   unit_id = existing_units.first || own_unit_id
                   descendants.each do |example|
-                    row = rows_by_example.fetch(example)
-                    atomic_unit_by_id[row.fetch(:id)] = unit_id
+                    atomic_unit_by_id[id_for.call(example)] = unit_id
                   end
                   setup_count_by_unit[unit_id] += 1
                 end
@@ -293,15 +293,17 @@ jobs:
                 id = row.fetch(:id)
                 atomic_unit_by_id.fetch(id, id)
               end.to_a
+              weight_by_unit = units.to_h do |unit_id, rows|
+                [unit_id, rows.length + setup_count_by_unit.fetch(unit_id, 0)]
+              end
               shards = Array.new(shard_count) { [] }
               shard_loads = Array.new(shard_count, 0)
               shard_example_counts = Array.new(shard_count, 0)
 
               units.sort_by do |unit_id, rows|
-                unit_weight = rows.length + setup_count_by_unit.fetch(unit_id, 0)
-                [-unit_weight, Digest::SHA256.hexdigest(unit_id), unit_id]
+                [-weight_by_unit.fetch(unit_id), Digest::SHA256.hexdigest(unit_id), unit_id]
               end.each do |unit_id, rows|
-                unit_weight = rows.length + setup_count_by_unit.fetch(unit_id, 0)
+                unit_weight = weight_by_unit.fetch(unit_id)
                 target = (0...shard_count).min_by do |index|
                   [shard_loads[index], shard_example_counts[index], shards[index].length, index]
                 end

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -116,19 +116,23 @@ jobs:
 
           # Full matrices run only on main, merge queue, release targets, or
           # explicit force-full hosted CI. Normal hosted PR CI stays optimized.
-          # Each Ruby version / dependency level is split into two shards:
-          #   generators – spec/react_on_rails/generators (heavy filesystem I/O)
-          #   unit       – everything else under spec/react_on_rails
+          # Each Ruby version / dependency level keeps one unit shard and splits
+          # spec/react_on_rails/generators across three deterministic subshards
+          # while keeping context-hook setup atomic.
           if [[ "$SHOULD_USE_FULL_MATRIX" == "true" ]]; then
-            # Full matrix: test both latest and minimum supported versions × 2 shards
+            # Full matrix: test both latest and minimum supported versions.
             matrix="$(jq -nc \
               --arg latest_ruby_version "$latest_ruby_version" \
               --arg minimum_ruby_version "$minimum_ruby_version" \
               '{
                 "include": [
-                  {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators"},
+                  {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators-1"},
+                  {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators-2"},
+                  {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators-3"},
                   {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "unit"},
-                  {"ruby-version": $minimum_ruby_version, "dependency-level": "minimum", "shard": "generators"},
+                  {"ruby-version": $minimum_ruby_version, "dependency-level": "minimum", "shard": "generators-1"},
+                  {"ruby-version": $minimum_ruby_version, "dependency-level": "minimum", "shard": "generators-2"},
+                  {"ruby-version": $minimum_ruby_version, "dependency-level": "minimum", "shard": "generators-3"},
                   {"ruby-version": $minimum_ruby_version, "dependency-level": "minimum", "shard": "unit"}
                 ]
               }')"
@@ -140,7 +144,9 @@ jobs:
                 --arg latest_ruby_version "$latest_ruby_version" \
                 '{
                   "include": [
-                    {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators"},
+                    {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators-1"},
+                    {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators-2"},
+                    {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "generators-3"},
                     {"ruby-version": $latest_ruby_version, "dependency-level": "latest", "shard": "unit"}
                   ]
                 }')"
@@ -218,8 +224,113 @@ jobs:
           SHARD: ${{ matrix.shard }}
         run: |
           cd react_on_rails
-          if [[ "$SHARD" = "generators" ]]; then
-            bundle exec rspec spec/react_on_rails/generators
+          if [[ "$SHARD" == generators-* ]]; then
+            shard_number="${SHARD#generators-}"
+            shard_count=3
+            shard_index="$((shard_number - 1))"
+            manifest_path="${RUNNER_TEMP}/generator-shard-${shard_number}.opts"
+
+            bundle exec ruby -rrspec/core -rdigest -e '
+              shard_index = Integer(ARGV.fetch(0))
+              shard_count = Integer(ARGV.fetch(1))
+              manifest_path = ARGV.fetch(2)
+              abort "invalid generator shard index" unless shard_index.between?(0, shard_count - 1)
+
+              sink = File.open(File::NULL, "w")
+              status = RSpec::Core::Runner.run(
+                ["spec/react_on_rails/generators", "--dry-run", "--format", "progress"],
+                sink,
+                sink
+              )
+              abort "generator manifest dry run failed with status #{status}" unless status.zero?
+
+              examples = RSpec.world.all_examples.map do |example|
+                metadata = example.metadata
+                file = metadata.fetch(:rerun_file_path)
+                scoped_id = metadata.fetch(:scoped_id)
+                { id: "#{file}[#{scoped_id}]", file:, scoped_id:, example: }
+              end
+              ids = examples.map { |row| row.fetch(:id) }
+              abort "generator manifest is empty" if ids.empty?
+              abort "generator manifest has duplicate scoped IDs" unless ids.uniq.length == ids.length
+
+              rows_by_example = examples.to_h { |row| [row.fetch(:example), row] }
+              atomic_unit_by_id = {}
+              setup_count_by_unit = Hash.new(0)
+
+              visit_group = lambda do |group|
+                hooks = group.hooks
+                owns_context_hook = %i[before after].any? do |position|
+                  !hooks.send(:all_hooks_for, position, :context).empty?
+                end
+
+                if owns_context_hook
+                  descendants = group.descendant_filtered_examples
+                  existing_units = descendants.filter_map do |example|
+                    row = rows_by_example.fetch(example)
+                    atomic_unit_by_id[row.fetch(:id)]
+                  end.uniq
+                  abort "nested generator setup spans multiple atomic units" if existing_units.length > 1
+
+                  metadata = group.metadata
+                  own_unit_id = "#{metadata.fetch(:rerun_file_path)}[#{metadata.fetch(:scoped_id)}]"
+                  unit_id = existing_units.first || own_unit_id
+                  descendants.each do |example|
+                    row = rows_by_example.fetch(example)
+                    atomic_unit_by_id[row.fetch(:id)] = unit_id
+                  end
+                  setup_count_by_unit[unit_id] += 1
+                end
+
+                group.children.each { |child| visit_group.call(child) }
+              end
+              RSpec.world.example_groups.each { |group| visit_group.call(group) }
+
+              units = examples.group_by do |row|
+                id = row.fetch(:id)
+                atomic_unit_by_id.fetch(id, id)
+              end.to_a
+              shards = Array.new(shard_count) { [] }
+              shard_loads = Array.new(shard_count, 0)
+              shard_example_counts = Array.new(shard_count, 0)
+
+              units.sort_by do |unit_id, rows|
+                unit_weight = rows.length + setup_count_by_unit.fetch(unit_id, 0)
+                [-unit_weight, Digest::SHA256.hexdigest(unit_id), unit_id]
+              end.each do |unit_id, rows|
+                unit_weight = rows.length + setup_count_by_unit.fetch(unit_id, 0)
+                target = (0...shard_count).min_by do |index|
+                  [shard_loads[index], shard_example_counts[index], shards[index].length, index]
+                end
+                shards.fetch(target) << [unit_id, rows]
+                shard_loads[target] += unit_weight
+                shard_example_counts[target] += rows.length
+              end
+
+              assigned_ids = shards.flat_map do |shard_units|
+                shard_units.flat_map { |_, rows| rows.map { |row| row.fetch(:id) } }
+              end
+              abort "generator partition lost or duplicated examples" unless assigned_ids.sort == ids.sort
+
+              selected_units = shards.fetch(shard_index)
+              selected = selected_units.flat_map(&:last)
+              abort "generator shard #{shard_index + 1} is empty" if selected.empty?
+
+              arguments = selected.group_by { |row| row.fetch(:file) }.map do |file, rows|
+                scoped_ids = rows.map { |row| row.fetch(:scoped_id) }
+                "#{file}[#{scoped_ids.join(",")}]"
+              end
+              File.write(manifest_path, arguments.join("\n") << "\n")
+              puts "generator shard #{shard_index + 1}/#{shard_count}: " \
+                   "#{selected.length}/#{ids.length} examples in #{selected_units.length} setup-safe units " \
+                   "across #{arguments.length} files"
+            ' "$shard_index" "$shard_count" "$manifest_path"
+
+            specs=()
+            while IFS= read -r spec; do
+              specs+=("$spec")
+            done < "$manifest_path"
+            bundle exec rspec "${specs[@]}"
           else
             bundle exec rspec spec/react_on_rails --exclude-pattern "**/generators/**"
           fi

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -273,7 +273,7 @@ assertMatches(
 assertMatches(
   'generator subshards balance examples and shared setup units',
   gemRspecScript,
-  /unit_weight = rows\.length \+ setup_count_by_unit\.fetch\(unit_id, 0\)/,
+  /weight_by_unit = units\.to_h[\s\S]*rows\.length \+ setup_count_by_unit\.fetch\(unit_id, 0\)/,
 );
 assertMatches(
   'generator subshards reject duplicate scoped IDs',

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -226,17 +226,17 @@ assertMatches(
 
 const gemMatrixScript = extractRunScript(gemTestsWorkflow, 'Set gem tests matrix');
 const latestUnit = { 'ruby-version': '3.4', 'dependency-level': 'latest', shard: 'unit' };
-const latestGenerators = {
+const latestGenerators = ['generators-1', 'generators-2', 'generators-3'].map((shard) => ({
   'ruby-version': '3.4',
   'dependency-level': 'latest',
-  shard: 'generators',
-};
+  shard,
+}));
 const minimumUnit = { 'ruby-version': '3.2', 'dependency-level': 'minimum', shard: 'unit' };
-const minimumGenerators = {
+const minimumGenerators = ['generators-1', 'generators-2', 'generators-3'].map((shard) => ({
   'ruby-version': '3.2',
   'dependency-level': 'minimum',
-  shard: 'generators',
-};
+  shard,
+}));
 
 assert.deepEqual(
   runGemMatrix(gemMatrixScript, { full: false, generators: false }).include,
@@ -245,13 +245,51 @@ assert.deepEqual(
 );
 assert.deepEqual(
   runGemMatrix(gemMatrixScript, { full: false, generators: true }).include,
-  [latestGenerators, latestUnit],
-  'optimized generator PR matrix should keep the latest generator and unit shards',
+  [...latestGenerators, latestUnit],
+  'optimized generator PR matrix should keep three latest generator subshards and the latest unit shard',
 );
 assert.deepEqual(
   runGemMatrix(gemMatrixScript, { full: true, generators: false }).include,
-  [latestGenerators, latestUnit, minimumGenerators, minimumUnit],
-  'main, merge-group, release-target, and force-full matrices should retain both dependency levels and shards',
+  [...latestGenerators, latestUnit, ...minimumGenerators, minimumUnit],
+  'main, merge-group, release-target, and force-full matrices should retain both unit rows and three generator subshards per dependency level',
+);
+
+const gemRspecScript = extractRunScript(gemTestsWorkflow, 'Run rspec tests');
+assertMatches(
+  'generator subshards use stable RSpec scoped IDs',
+  gemRspecScript,
+  /metadata\.fetch\(:rerun_file_path\)[\s\S]*metadata\.fetch\(:scoped_id\)/,
+);
+assertMatches(
+  'generator subshards keep context-hook setup atomic',
+  gemRspecScript,
+  /all_hooks_for, position, :context[\s\S]*atomic_unit_by_id/,
+);
+assertMatches(
+  'generator subshards use a deterministic head-local tie break',
+  gemRspecScript,
+  /Digest::SHA256\.hexdigest\(unit_id\)/,
+);
+assertMatches(
+  'generator subshards balance examples and shared setup units',
+  gemRspecScript,
+  /unit_weight = rows\.length \+ setup_count_by_unit\.fetch\(unit_id, 0\)/,
+);
+assertMatches(
+  'generator subshards reject duplicate scoped IDs',
+  gemRspecScript,
+  /ids\.uniq\.length == ids\.length/,
+);
+assertMatches(
+  'unit shard retains generator exclusion',
+  gemRspecScript,
+  /bundle exec rspec spec\/react_on_rails --exclude-pattern "\*\*\/generators\/\*\*"/,
+);
+assertDoesNotMatch('generator subshards avoid brittle line-number selection', gemRspecScript, /line_number/);
+assertDoesNotMatch(
+  'generator subshards do not split shared setup by leaf-example hash',
+  gemRspecScript,
+  /Digest::SHA256\.hexdigest\(id\)\.to_i\(16\) % shard_count/,
 );
 
 assertMatches('ShakaPerf renderer h2c probe', shakaperfReleaseGateWorkflow, /require\('node:http2'\)/);


### PR DESCRIPTION
## Why

Generator specs dominate the gem workflow's full-matrix critical path. Six post-merge full-matrix runs established a 2,427-second median critical path and a 4,660-second paired runner-sum, while unit jobs remained near two minutes.

## What

- Preserve the optimized and full-matrix selector contracts from #4691.
- Split generator coverage into three deterministic subshards per dependency level.
- Build each manifest from the current head's stable RSpec scoped IDs.
- Keep context-hook setup groups atomic and balance examples plus shared setup weight.
- Fail closed on empty, duplicate, lost, or duplicated selections.
- Avoid line numbers, caches, secrets, timing databases, and cross-head state.

## Verification

- Exact reviewed head: `27d81b4beadad20b74301f17ee53c7f2000ad773`.
- Hosted-CI safety contract passed.
- `actionlint` passed.
- Relaxed `yamllint` passed with only the repository's existing line-length warnings.
- CI change-detector suite passed: 83/83.
- CI-equivalent OSS RuboCop passed: 241 files, no offenses.
- Exact-head manifest contained 1,277 unique examples.
- Shard counts: 426 / 425 / 426.
- Setup-safe units: 297 / 298 / 297.
- Modeled work: 469 / 470 / 469.
- All three grouped RSpec dry-runs completed with zero failures.
- Fresh Sol/xhigh exact-head adversarial review regenerated and invoked every selector and found no actionable correctness regressions.
- Fresh hosted review cutoff has zero unresolved threads and zero must-fix findings.

The review sandbox's attempted full shard execution could not write its home/cache and hit npm registry DNS `ENOTFOUND`; no full local shard pass is claimed. `.agents/bin/validate --changed` was intentionally stopped during the long generator surface and is not claimed green.

## Hosted benchmark

Two exact-head force-full attempts passed all 16 matrix rows with zero flakes:

- Median critical generator path: 14m34s, down 25m53s (64.0%) from the 2,427s baseline median.
- Critical-path attempt-to-attempt spread: 32s (3.7%).
- Mean generator runner-sum: 80m58s, up 4.2% from the paired baseline.
- Runner-sum attempt-to-attempt spread: 1.8%.

The repeated evidence supports retaining the three-way split. Full job links and calculations are recorded on #4683.

## Workflow change audit

- Triggers, permissions, action versions, and secret usage are unchanged.
- Both dependency levels and both unit rows remain covered.
- `fail-fast: false` remains.
- No cache or artifact reuse was added.
- The partition is computed from the exact checked-out head, so stale-base or cross-head results cannot be reused.
- Changelog: not user-visible; no entry required.

## Review churn

The first review rejected leaf-example hashing because it would repeat expensive `before(:all)`/`after(:all)` setup across shards. The final design uses setup-safe atomic units and was revalidated after rebasing over the latest `main`.

The final simplify pass consolidated scoped-ID construction and precomputed unit weights. The portable manifest-read loop was retained deliberately. Those behavior-preserving changes were committed separately and re-reviewed at the exact head above.

Part of #4683. Keep the issue open pending exact-head force-full timing evidence and the required post-merge secondary-event replay.
