### PR TITLE
Agents: add fleet validation lifecycle closeout

### DIFF
--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -62,8 +62,8 @@ policy/inventory manifest fails closed.
    If an owned release-wide blocker makes the barrier impossible to open, use the terminal blocked
    preflight path instead: retain its durable `blocker_id` and public-safe `blocker_evidence`, keep
    `APP_WORK_ALLOWED` false, leave every app target untouched while preserving any read-only
-   package-lock probes, audit with an empty maker list, and keep aggregate merge/reachability and
-   tracker promotion blocked.
+   package-lock probes, keep `preflight.public_marker` pristine and unpublished, audit with an empty
+   maker list, and keep aggregate merge/reachability and tracker promotion blocked.
 3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.
    Its terminal report must retain the package versions/sources and exact-head evidence for every
    check; those are observed target versions and need not equal the release snapshot. `pending` and
@@ -147,7 +147,8 @@ required path records its lane, failure evidence, and `blocker_id`. Waived or de
 retain a durable owner and record a structured disposition with the gate, authority, evidence URL,
 and public-safe reason.
 Unrelated baseline defects require the same structured waiver before promotion. Each mutable target
-records its maker identity so the independent audit can prove complete maker coverage. The
+records a canonical nonblank maker identity so the independent audit can prove complete maker
+coverage and compare the checker against every maker without whitespace aliases. The
 validation-only core gate retains the OSS, Pro, node-renderer, RSC, and generator CLI package
 versions it exercises and binds all evidence to the pack's exact candidate commit, but does not
 fabricate per-target merge or reachability evidence.

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -120,11 +120,13 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --expected-pack-id PACK_ID \
   --expected-release-selector "GENERATED_RELEASE_SELECTOR" \
   --expected-candidate vX.Y.Z.rc.N \
+  --expected-candidate-commit CANDIDATE_COMMIT_SHA \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
-The expected pack ID and generated release selector come from the checker-held launch record, not
-from the ledger under review. The validator fails closed on stale pack IDs, selectors, or candidates,
+The expected pack ID, generated release selector, candidate tag, and candidate source commit come
+from the checker-held launch record, not from the ledger under review. The validator fails closed
+on stale pack IDs, selectors, candidates, or candidate commits,
 missing/duplicate/mismatched public
 preflight markers, product package versions that do not normalize to
 the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -118,11 +118,14 @@ that same file:
 ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --ledger tmp/fleet-validation-prompts/result-ledger.json \
   --expected-pack-id PACK_ID \
+  --expected-release-selector "GENERATED_RELEASE_SELECTOR" \
   --expected-candidate vX.Y.Z.rc.N \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
-The validator fails closed on stale pack IDs or candidates, missing/duplicate/mismatched public
+The expected pack ID and generated release selector come from the checker-held launch record, not
+from the ledger under review. The validator fails closed on stale pack IDs, selectors, or candidates,
+missing/duplicate/mismatched public
 preflight markers, product package versions that do not normalize to
 the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or
 review-app state, candidate-managed hard-gate package versions that differ from the resolved release

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -38,7 +38,8 @@ ledger only when a pinned release selector matches the ledger's resolved candida
 manifest fingerprint still matches. Once a dynamic `latest RC or beta` pack has resolved its
 candidate, reuse its existing generated files or create a fresh pack; regeneration cannot safely
 prove that the dynamic selector still resolves to the same candidate. A changed candidate or
-policy/inventory manifest fails closed.
+policy/inventory manifest fails closed. Generate a fresh pack in a fresh output directory; one pack
+must never replace another pack's durable result ledger.
 
 ## Launch and coordinate
 

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-fleet-validation
-description: Generate and coordinate parallel React on Rails release fleet validation from internal/contributor-info/demo-fleet.yml. Use when a maintainer wants to validate the latest RC or beta, split fleet work across machines or agent sessions, inspect fleet progress, or prepare repeatable per-lane prompts without hand-partitioning repositories.
+description: Generate and coordinate the complete React on Rails release fleet lifecycle from internal/contributor-info/demo-fleet.yml. Use when a maintainer wants to validate the latest RC or beta, split fleet work across machines or agent sessions, inspect fleet progress, or run fail-closed release closeout from a durable result ledger.
 ---
 
 # Run Fleet Validation
@@ -21,35 +21,45 @@ ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
 Keep the default release selector, `latest RC or beta`, for a new validation run. Pass
 `--release vX.Y.Z.rc.N` only for a rerun that must stay pinned to an older candidate.
 
-The generator reads only `tier: hard_gate` repositories, adds the monorepo generator/install
-gate required by `internal/contributor-info/rc-testing-plan.md`, balances weighted lanes across
-the named machines, and includes effective commands after manifest defaults are applied. It also
-creates a unique pack ID. Every replacement candidate needs a freshly generated pack and ID; pass
-`--pack-id ID` only when regenerating files for the same exact candidate run.
+The generator assigns only `tier: hard_gate` repositories to mutable maker prompts, adds the
+monorepo generator/install gate required by `internal/contributor-info/rc-testing-plan.md`, and
+balances weighted lanes across the named machines. The same pack also inventories every
+`soft_track` repository as report-only and generates:
+
+- `LIFECYCLE.md` — ordered snapshot-through-closeout phases and required release-path coverage;
+- `PREFLIGHT.md` — the release-wide CI/artifact/generator and machine-capability barrier;
+- `REPORT-ONLY.md` — the complete non-mutating soft-track pass;
+- `CLOSEOUT.md` — independent audit, authority/freeze reconciliation, merge, reachability, tree parity, and tracker closeout;
+- `result-ledger.json` and `result-ledger.schema.json` — the durable public-safe evidence contract.
+
+Every replacement candidate needs a freshly generated pack and ID; pass `--pack-id ID` only when
+regenerating files for the same exact candidate run.
 
 ## Launch and coordinate
 
-1. Read `tmp/fleet-validation-prompts/INDEX.md`.
-2. Start all prompt files simultaneously, three per machine for the default six-prompt/two-machine
-   layout. Prompt 1 publishes the exact candidate/RSC snapshot for the pack; the other five wait
-   for that marker before mutating anything. Each prompt is a separate top-level coordinator task
-   and must use its bounded subagents as written. Do not launch the six prompts as children of one
-   shared four-slot agent tree.
-3. Keep each lane in a separate checkout or worktree. Do not share mutable app checkouts between
+1. Read `tmp/fleet-validation-prompts/INDEX.md` and run `PREFLIGHT.md`.
+2. Start the prompt coordinators, three per machine for the default six-prompt/two-machine layout.
+   Prompt 1 publishes the exact candidate/RSC snapshot. No app mutation worker may start before the
+   pack ledger has `APP_WORK_ALLOWED`, backed by terminal-green exact-commit CI, artifacts, and the
+   standard/Pro/Pro+RSC generator matrix, or an explicit policy-allowed public-safe waiver.
+3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.
+4. Each prompt is a separate top-level coordinator task and must use its bounded subagents as
+   written. Do not launch the six prompts as children of one shared four-slot agent tree.
+5. Keep each lane in a separate checkout or worktree. Do not share mutable app checkouts between
    lanes.
-4. Let lane coordinators create or update bump PRs and post idempotent evidence comments, but do
-   not let them merge or make the final release decision.
-5. Require an authoritative coordination claim for every mutable app target before its execution
+6. Let lane coordinators create or update bump PRs and post idempotent evidence comments. Merge
+   remains a generated closeout task and requires explicit authority plus a fresh mode/freeze read.
+7. Require an authoritative coordination claim for every mutable app target before its execution
    subagent starts. A status read is not a lock. A refused claim or unknown claim outcome is
    non-passing and must not produce a competing worktree or branch. Reuse live candidate ownership
    first; generated fallback claim targets are only for genuinely fresh lanes and are stable by
    resolved candidate plus repository so separately generated packs cannot race.
-6. Treat the release tracking issue plus its newest candidate-specific comments as the public
+8. Treat the release tracking issue plus its newest candidate-specific comments as the public
    source of truth. The issue body can describe an earlier candidate in the same release cycle;
    do not mistake that for the current candidate when a newer explicit RC section exists. A hard
    gate remains pending until it has exact install, build, test, smoke, and required-CI evidence,
    or an explicit waiver allowed by the RC plan.
-7. Generate a fresh pack for every replacement candidate, even when the manifest is unchanged.
+9. Generate a fresh pack for every replacement candidate, even when the manifest is unchanged.
    Never reuse old prompt files or their snapshot marker for a new RC/beta. Within one exact
    candidate run, re-run only affected lanes and preserve that pack ID.
 
@@ -67,12 +77,36 @@ Never infer a pass from an open PR or a green subset of checks. Keep private HiC
 public output; report only the high-level verdict, tester, date, and public issue link when one
 exists.
 
+## Validate and render closeout
+
+The independent checker validates the exact ledger and renders the append-only tracker matrix from
+that same file:
+
+```bash
+ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
+  --ledger tmp/fleet-validation-prompts/result-ledger.json \
+  --expected-candidate vX.Y.Z.rc.N \
+  --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
+```
+
+The validator fails closed on stale candidates, incomplete inventory, premature app work,
+`UNKNOWN` capabilities or review-app state, missing package/check/baseline evidence, unowned
+blockers, private-only fields, missing required paths, non-independent audit, base movement,
+authority/freeze conflict, and missing default reachability/tree parity.
+
+For the checked-in sanitized RC12 regression corpus:
+
+```bash
+ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+```
+
 ## Validate changes to this skill
 
 Run both checks after changing the generator or prompt contract:
 
 ```bash
 ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
 python3 "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" \
   .agents/skills/run-fleet-validation
 ```

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -37,9 +37,11 @@ regenerating files for the same exact candidate run.
 
 ## Launch and coordinate
 
-1. Read `tmp/fleet-validation-prompts/INDEX.md` and run `PREFLIGHT.md`.
-2. Start the prompt coordinators, three per machine for the default six-prompt/two-machine layout.
-   Prompt 1 publishes the exact candidate/RSC snapshot. No app mutation worker may start before the
+1. Read `tmp/fleet-validation-prompts/INDEX.md` and start prompt 1 in snapshot/read-only mode.
+   It publishes the exact candidate/RSC snapshot and generator-matrix evidence without starting its
+   assigned app mutation.
+2. Run `PREFLIGHT.md` against that snapshot, then start the remaining prompt coordinators.
+   No app mutation worker may start before the
    pack ledger has `APP_WORK_ALLOWED`, backed by terminal-green exact-commit CI, artifacts, and the
    standard/Pro/Pro+RSC generator matrix, or an explicit policy-allowed public-safe waiver.
 3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -44,7 +44,8 @@ candidate or policy/inventory manifest fails closed.
    assigned app mutation.
 2. Run `PREFLIGHT.md` against that snapshot, then start the remaining prompt coordinators.
    No app mutation worker may start before the
-   pack ledger has `APP_WORK_ALLOWED`, backed by terminal-green exact-commit CI, artifacts, and the
+   pack ledger has `preflight.app_work_allowed: true` (the explicit `APP_WORK_ALLOWED` marker),
+   backed by terminal-green exact-commit CI, artifacts, and the
    standard/Pro/Pro+RSC generator matrix, or an explicit policy-allowed public-safe waiver.
 3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.
 4. Each prompt is a separate top-level coordinator task and must use its bounded subagents as

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -110,6 +110,10 @@ hard-gate app repositories. A blocker-owned terminal `BLOCKED` run can close wit
 merge or post-merge reachability evidence; merge-eligible runs still require both. A blocked
 required path records its lane, failure evidence, and `blocker_id`. Waived or deferred blockers
 record a structured disposition with the gate, authority, evidence URL, and public-safe reason.
+Unrelated baseline defects require the same structured waiver before promotion. Each mutable target
+records its maker identity so the independent audit can prove complete maker coverage. The
+validation-only core gate retains the OSS, Pro, node-renderer, RSC, and generator CLI package
+versions it exercises, but does not fabricate per-target merge or reachability evidence.
 
 For the checked-in sanitized RC12 regression corpus:
 

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -59,8 +59,9 @@ policy/inventory manifest fails closed.
    monorepo generator gate may run before the mutation barrier.
    If an owned release-wide blocker makes the barrier impossible to open, use the terminal blocked
    preflight path instead: retain its durable `blocker_id` and public-safe `blocker_evidence`, keep
-   `APP_WORK_ALLOWED` false, leave every app target untouched, audit with an empty maker list, and
-   keep aggregate merge/reachability and tracker promotion blocked.
+   `APP_WORK_ALLOWED` false, leave every app target untouched while preserving any read-only
+   package-lock probes, audit with an empty maker list, and keep aggregate merge/reachability and
+   tracker promotion blocked.
 3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.
    Its terminal report must retain the package versions/sources and exact-head evidence for every
    check; those are observed target versions and need not equal the release snapshot. `pending` and
@@ -137,7 +138,8 @@ and public-safe reason.
 Unrelated baseline defects require the same structured waiver before promotion. Each mutable target
 records its maker identity so the independent audit can prove complete maker coverage. The
 validation-only core gate retains the OSS, Pro, node-renderer, RSC, and generator CLI package
-versions it exercises, but does not fabricate per-target merge or reachability evidence.
+versions it exercises and binds all evidence to the pack's exact candidate commit, but does not
+fabricate per-target merge or reachability evidence.
 Hard-gate snapshot comparison covers those candidate-managed product packages and the separately
 resolved RSC package; independently versioned Shakapacker or Control Plane Flow dependencies retain
 their target-observed versions. Report-only package locks are evidence of the inspected target, not

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -62,23 +62,28 @@ policy/inventory manifest fails closed.
    check; `pending` and `unknown` do not count as report-only closeout.
 4. Each prompt is a separate top-level coordinator task and must use its bounded subagents as
    written. Do not launch the six prompts as children of one shared four-slot agent tree.
-5. Keep each lane in a separate checkout or worktree. Do not share mutable app checkouts between
+5. Require each lane to write its complete schema-valid inventory fragment to its generated
+   `lane-result-N.json` path and return the exact JSON in its final response when it cannot access
+   the shared pack checkout. Only the explicitly designated single ledger writer may merge those
+   fragments into `result-ledger.json`, under the pack lock and with an atomic file replacement.
+   Prose summaries are not ledger evidence.
+6. Keep each lane in a separate checkout or worktree. Do not share mutable app checkouts between
    lanes.
-6. Let lane coordinators create or update bump PRs and post idempotent evidence comments. Merge
+7. Let lane coordinators create or update bump PRs and post idempotent evidence comments. Merge
    remains a generated closeout task and requires explicit authority plus a fresh mode/freeze read.
-7. Require an authoritative coordination claim for every mutable app target before its execution
+8. Require an authoritative coordination claim for every mutable app target before its execution
    subagent starts. A status read is not a lock. A refused claim or unknown claim outcome is
    non-passing and must not produce a competing worktree or branch. Reuse live candidate ownership
    first; generated fallback claim targets are only for genuinely fresh lanes and are stable by
    resolved candidate plus repository so separately generated packs cannot race.
-8. Treat the release tracking issue plus its newest candidate-specific comments as the public
+9. Treat the release tracking issue plus its newest candidate-specific comments as the public
    source of truth. The issue body can describe an earlier candidate in the same release cycle;
    do not mistake that for the current candidate when a newer explicit RC section exists. A hard
    gate remains pending until it has exact install, build, test, smoke, and required-CI evidence,
    or an explicit waiver allowed by the RC plan.
-9. Generate a fresh pack for every replacement candidate, even when the manifest is unchanged.
-   Never reuse old prompt files or their snapshot marker for a new RC/beta. Within one exact
-   candidate run, re-run only affected lanes and preserve that pack ID.
+10. Generate a fresh pack for every replacement candidate, even when the manifest is unchanged.
+    Never reuse old prompt files or their snapshot marker for a new RC/beta. Within one exact
+    candidate run, re-run only affected lanes and preserve that pack ID.
 
 ## Report status
 
@@ -110,8 +115,10 @@ The validator fails closed on stale candidates, product package versions that do
 the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or
 review-app state, retained package versions that differ from the resolved release snapshot,
 check/review evidence that does not match the immutable audited/reviewed/current target revision,
+mutable-app check evidence that does not match the reconciled current base revision,
 missing package/check/baseline evidence, unowned
-blockers, private-only fields, missing required paths, non-independent audit, base movement,
+blockers, blockers whose status remains `UNKNOWN`, private-only fields, missing required paths,
+non-independent audit, base movement,
 authority/freeze conflict, and missing default reachability/tree parity.
 The monorepo generator/install smoke is a first-class hard-gate ledger row in addition to the seven
 hard-gate app repositories. A blocker-owned terminal `BLOCKED` run can close without inventing a

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -100,9 +100,11 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
-The validator fails closed on stale candidates, incomplete inventory, premature app work,
-`UNKNOWN` capabilities or review-app state, retained package versions that differ from the resolved
-release snapshot, missing package/check/baseline evidence, unowned
+The validator fails closed on stale candidates, product package versions that do not normalize to
+the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or
+review-app state, retained package versions that differ from the resolved release snapshot,
+check/review evidence that does not match the immutable audited/reviewed/current target revision,
+missing package/check/baseline evidence, unowned
 blockers, private-only fields, missing required paths, non-independent audit, base movement,
 authority/freeze conflict, and missing default reachability/tree parity.
 The monorepo generator/install smoke is a first-class hard-gate ledger row in addition to the seven
@@ -115,8 +117,10 @@ Unrelated baseline defects require the same structured waiver before promotion. 
 records its maker identity so the independent audit can prove complete maker coverage. The
 validation-only core gate retains the OSS, Pro, node-renderer, RSC, and generator CLI package
 versions it exercises, but does not fabricate per-target merge or reachability evidence.
-Any merge already recorded retains its base, authority/freeze, reachability, and tree-parity proofs
-even when another lane leaves the overall release blocked.
+Every mutable target records its own merge authority, freeze state, merge commit, and evidence.
+The aggregate merge/reachability state is derived from those rows, so a partial fleet closeout
+retains proofs for every landed lane without fabricating them for blocked lanes. The independent
+audit also records replayable public-safe evidence.
 
 For the checked-in sanitized RC12 regression corpus:
 

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -63,7 +63,10 @@ policy/inventory manifest fails closed.
    keep aggregate merge/reachability and tracker promotion blocked.
 3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.
    Its terminal report must retain the package versions/sources and exact-head evidence for every
-   check; `pending` and `unknown` do not count as report-only closeout.
+   check; those are observed target versions and need not equal the release snapshot. `pending` and
+   `unknown` do not count as report-only closeout. An owned blocker referenced exclusively by soft
+   tracks makes the verdict `PARTIAL` but does not block promotion; the same blocker becomes
+   release-gating when preflight, a hard gate, or a required path references it.
 4. Each prompt is a separate top-level coordinator task and must use its bounded subagents as
    written. Do not launch the six prompts as children of one shared four-slot agent tree.
 5. Require each lane to write its complete schema-valid inventory fragment to its generated
@@ -117,7 +120,8 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
 
 The validator fails closed on stale candidates, product package versions that do not normalize to
 the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or
-review-app state, retained package versions that differ from the resolved release snapshot,
+review-app state, candidate-managed hard-gate package versions that differ from the resolved release
+snapshot,
 check/review evidence that does not match the immutable audited/reviewed/current target revision,
 mutable-app check evidence that does not match the reconciled current base revision,
 missing package/check/baseline evidence, unowned
@@ -134,6 +138,10 @@ Unrelated baseline defects require the same structured waiver before promotion. 
 records its maker identity so the independent audit can prove complete maker coverage. The
 validation-only core gate retains the OSS, Pro, node-renderer, RSC, and generator CLI package
 versions it exercises, but does not fabricate per-target merge or reachability evidence.
+Hard-gate snapshot comparison covers those candidate-managed product packages and the separately
+resolved RSC package; independently versioned Shakapacker or Control Plane Flow dependencies retain
+their target-observed versions. Report-only package locks are evidence of the inspected target, not
+a requirement to adopt the candidate.
 Every mutable target records its own merge authority, freeze state, merge commit, and evidence.
 The validator rejects a merged row when that same target retains a blocked result/check, candidate
 regression, or broken/blocked review app; another lane's blocker does not erase a landed lane's

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -47,6 +47,9 @@ candidate or policy/inventory manifest fails closed.
    pack ledger has `preflight.app_work_allowed: true` (the explicit `APP_WORK_ALLOWED` marker),
    backed by terminal-green exact-commit CI, artifacts, and the
    standard/Pro/Pro+RSC generator matrix, or an explicit policy-allowed public-safe waiver.
+   Record `preflight.opened_at` when opening the barrier and each mutable target's
+   `work_started_at`; closeout rejects missing or reversed ordering evidence. The validation-only
+   monorepo generator gate may run before the mutation barrier.
 3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.
 4. Each prompt is a separate top-level coordinator task and must use its bounded subagents as
    written. Do not launch the six prompts as children of one shared four-slot agent tree.

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -136,7 +136,8 @@ check/review evidence that does not match the immutable audited/reviewed/current
 mutable-app check evidence that does not match the reconciled current base revision,
 missing package/check/baseline evidence, unowned
 blockers, inactive blockers still referenced by blocked outcomes, blockers whose status remains
-`UNKNOWN`, contradictory tracker promotion, private-only fields, missing required paths,
+`UNKNOWN`, release blockers paired with `hold` or `recommend` promotion, `blocked` promotion without
+a release blocker, private-only fields, missing required paths,
 non-independent audit, base movement,
 authority/freeze conflict, and missing default reachability/tree parity.
 The monorepo generator/install smoke is a first-class hard-gate ledger row in addition to the seven

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -34,8 +34,11 @@ balances weighted lanes across the named machines. The same pack also inventorie
 
 Every replacement candidate needs a freshly generated pack and ID; pass `--pack-id ID` only when
 regenerating files for the same exact candidate run. Same-pack regeneration preserves the result
-ledger only when both the release selector and complete manifest fingerprint still match; a changed
-candidate or policy/inventory manifest fails closed.
+ledger only when a pinned release selector matches the ledger's resolved candidate and the complete
+manifest fingerprint still matches. Once a dynamic `latest RC or beta` pack has resolved its
+candidate, reuse its existing generated files or create a fresh pack; regeneration cannot safely
+prove that the dynamic selector still resolves to the same candidate. A changed candidate or
+policy/inventory manifest fails closed.
 
 ## Launch and coordinate
 
@@ -104,7 +107,9 @@ blockers, private-only fields, missing required paths, non-independent audit, ba
 authority/freeze conflict, and missing default reachability/tree parity.
 The monorepo generator/install smoke is a first-class hard-gate ledger row in addition to the seven
 hard-gate app repositories. A blocker-owned terminal `BLOCKED` run can close without inventing a
-merge or post-merge reachability evidence; merge-eligible runs still require both.
+merge or post-merge reachability evidence; merge-eligible runs still require both. A blocked
+required path records its lane, failure evidence, and `blocker_id`. Waived or deferred blockers
+record a structured disposition with the gate, authority, evidence URL, and public-safe reason.
 
 For the checked-in sanitized RC12 regression corpus:
 

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -109,11 +109,14 @@ The monorepo generator/install smoke is a first-class hard-gate ledger row in ad
 hard-gate app repositories. A blocker-owned terminal `BLOCKED` run can close without inventing a
 merge or post-merge reachability evidence; merge-eligible runs still require both. A blocked
 required path records its lane, failure evidence, and `blocker_id`. Waived or deferred blockers
-record a structured disposition with the gate, authority, evidence URL, and public-safe reason.
+retain a durable owner and record a structured disposition with the gate, authority, evidence URL,
+and public-safe reason.
 Unrelated baseline defects require the same structured waiver before promotion. Each mutable target
 records its maker identity so the independent audit can prove complete maker coverage. The
 validation-only core gate retains the OSS, Pro, node-renderer, RSC, and generator CLI package
 versions it exercises, but does not fabricate per-target merge or reachability evidence.
+Any merge already recorded retains its base, authority/freeze, reachability, and tree-parity proofs
+even when another lane leaves the overall release blocked.
 
 For the checked-in sanitized RC12 regression corpus:
 

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -131,11 +131,12 @@ missing/duplicate/mismatched public
 preflight markers, product package versions that do not normalize to
 the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or
 review-app state, candidate-managed hard-gate package versions that differ from the resolved release
-snapshot,
+snapshot, resolved snapshots that name unpublished package sources,
 check/review evidence that does not match the immutable audited/reviewed/current target revision,
 mutable-app check evidence that does not match the reconciled current base revision,
 missing package/check/baseline evidence, unowned
-blockers, blockers whose status remains `UNKNOWN`, private-only fields, missing required paths,
+blockers, inactive blockers still referenced by blocked outcomes, blockers whose status remains
+`UNKNOWN`, contradictory tracker promotion, private-only fields, missing required paths,
 non-independent audit, base movement,
 authority/freeze conflict, and missing default reachability/tree parity.
 The monorepo generator/install smoke is a first-class hard-gate ledger row in addition to the seven

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -53,7 +53,13 @@ policy/inventory manifest fails closed.
    Record `preflight.opened_at` when opening the barrier and each mutable target's
    `work_started_at`; closeout rejects missing or reversed ordering evidence. The validation-only
    monorepo generator gate may run before the mutation barrier.
+   If an owned release-wide blocker makes the barrier impossible to open, use the terminal blocked
+   preflight path instead: retain its durable `blocker_id` and public-safe `blocker_evidence`, keep
+   `APP_WORK_ALLOWED` false, leave every app target untouched, audit with an empty maker list, and
+   keep aggregate merge/reachability and tracker promotion blocked.
 3. Run `REPORT-ONLY.md` so every soft track receives a disposition without a bump or merge.
+   Its terminal report must retain the package versions/sources and exact-head evidence for every
+   check; `pending` and `unknown` do not count as report-only closeout.
 4. Each prompt is a separate top-level coordinator task and must use its bounded subagents as
    written. Do not launch the six prompts as children of one shared four-slot agent tree.
 5. Keep each lane in a separate checkout or worktree. Do not share mutable app checkouts between

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -33,7 +33,9 @@ balances weighted lanes across the named machines. The same pack also inventorie
 - `result-ledger.json` and `result-ledger.schema.json` — the durable public-safe evidence contract.
 
 Every replacement candidate needs a freshly generated pack and ID; pass `--pack-id ID` only when
-regenerating files for the same exact candidate run.
+regenerating files for the same exact candidate run. Same-pack regeneration preserves the result
+ledger only when both the release selector and complete manifest fingerprint still match; a changed
+candidate or policy/inventory manifest fails closed.
 
 ## Launch and coordinate
 
@@ -92,9 +94,13 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
 ```
 
 The validator fails closed on stale candidates, incomplete inventory, premature app work,
-`UNKNOWN` capabilities or review-app state, missing package/check/baseline evidence, unowned
+`UNKNOWN` capabilities or review-app state, retained package versions that differ from the resolved
+release snapshot, missing package/check/baseline evidence, unowned
 blockers, private-only fields, missing required paths, non-independent audit, base movement,
 authority/freeze conflict, and missing default reachability/tree parity.
+The monorepo generator/install smoke is a first-class hard-gate ledger row in addition to the seven
+hard-gate app repositories. A blocker-owned terminal `BLOCKED` run can close without inventing a
+merge or post-merge reachability evidence; merge-eligible runs still require both.
 
 For the checked-in sanitized RC12 regression corpus:
 

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -50,6 +50,10 @@ policy/inventory manifest fails closed.
    pack ledger has `preflight.app_work_allowed: true` (the explicit `APP_WORK_ALLOWED` marker),
    backed by terminal-green exact-commit CI, artifacts, and the
    standard/Pro/Pro+RSC generator matrix, or an explicit policy-allowed public-safe waiver.
+   Before any remote maker starts, publish the generated pack-bound preflight marker on the release
+   tracker with the exact candidate tag/commit, manifest snapshot fingerprint, barrier timestamp,
+   and public-safe terminal gate evidence. Every remote coordinator must read and cross-check that
+   unique marker; launch timing alone never proves `APP_WORK_ALLOWED`.
    Record `preflight.opened_at` when opening the barrier and each mutable target's
    `work_started_at`; closeout rejects missing or reversed ordering evidence. The validation-only
    monorepo generator gate may run before the mutation barrier.
@@ -131,6 +135,9 @@ records its maker identity so the independent audit can prove complete maker cov
 validation-only core gate retains the OSS, Pro, node-renderer, RSC, and generator CLI package
 versions it exercises, but does not fabricate per-target merge or reachability evidence.
 Every mutable target records its own merge authority, freeze state, merge commit, and evidence.
+The validator rejects a merged row when that same target retains a blocked result/check, candidate
+regression, or broken/blocked review app; another lane's blocker does not erase a landed lane's
+evidence, but a target's own failed gate can never authorize its merge.
 The aggregate merge/reachability state is derived from those rows, so a partial fleet closeout
 retains proofs for every landed lane without fabricating them for blocked lanes. The independent
 audit also records replayable public-safe evidence.

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -53,7 +53,9 @@ policy/inventory manifest fails closed.
    Before any remote maker starts, publish the generated pack-bound preflight marker on the release
    tracker with the exact candidate tag/commit, manifest snapshot fingerprint, barrier timestamp,
    and public-safe terminal gate evidence. Every remote coordinator must read and cross-check that
-   unique marker; launch timing alone never proves `APP_WORK_ALLOWED`.
+   unique marker; launch timing alone never proves `APP_WORK_ALLOWED`. Record the verified marker
+   in `preflight.public_marker` with `status: unique`, the exact pack/candidate/commit/fingerprint/
+   opened-at fields, and replayable public-safe evidence.
    Record `preflight.opened_at` when opening the barrier and each mutable target's
    `work_started_at`; closeout rejects missing or reversed ordering evidence. The validation-only
    monorepo generator gate may run before the mutation barrier.
@@ -115,11 +117,13 @@ that same file:
 ```bash
 ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --ledger tmp/fleet-validation-prompts/result-ledger.json \
+  --expected-pack-id PACK_ID \
   --expected-candidate vX.Y.Z.rc.N \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
-The validator fails closed on stale candidates, product package versions that do not normalize to
+The validator fails closed on stale pack IDs or candidates, missing/duplicate/mismatched public
+preflight markers, product package versions that do not normalize to
 the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or
 review-app state, candidate-managed hard-gate package versions that differ from the resolved release
 snapshot,

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -122,12 +122,15 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --expected-release-selector "GENERATED_RELEASE_SELECTOR" \
   --expected-candidate vX.Y.Z.rc.N \
   --expected-candidate-commit CANDIDATE_COMMIT_SHA \
+  --expected-policy-commit POLICY_COMMIT_SHA \
+  --expected-tracker-mode TRACKER_MODE \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
-The expected pack ID, generated release selector, candidate tag, and candidate source commit come
-from the checker-held launch record, not from the ledger under review. The validator fails closed
-on stale pack IDs, selectors, candidates, or candidate commits,
+The expected pack ID, generated release selector, candidate tag, candidate source commit, policy
+commit, and tracker mode come from the checker-held launch record, not from the ledger under review.
+The tracker output path must be distinct from the ledger path. The validator fails closed on stale
+pack IDs, selectors, candidates, candidate commits, policy commits, or tracker modes,
 missing/duplicate/mismatched public
 preflight markers, product package versions that do not normalize to
 the selected candidate, incomplete inventory, premature app work, `UNKNOWN` capabilities or

--- a/.agents/skills/run-fleet-validation/agents/openai.yaml
+++ b/.agents/skills/run-fleet-validation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Run Fleet Validation"
-  short_description: "Generate parallel release fleet validation lanes"
-  default_prompt: "Use $run-fleet-validation to generate and coordinate the latest RC or beta fleet-validation prompts."
+  short_description: "Run release fleet validation through durable closeout"
+  default_prompt: "Use $run-fleet-validation to generate and coordinate the latest RC or beta through preflight, fleet evidence, independent audit, and ledger-driven closeout."

--- a/.agents/skills/run-fleet-validation/fixtures/rc12-sanitized.yml
+++ b/.agents/skills/run-fleet-validation/fixtures/rc12-sanitized.yml
@@ -1,0 +1,90 @@
+schema_version: 1
+
+lifecycle:
+  required_paths:
+    - id: standard-generator
+      evidence_source: core_generator
+    - id: pro-ssr
+      evidence_source: core_generator
+    - id: pro-rsc
+      evidence_source: core_generator
+    - id: rspack
+      evidence_source: fleet
+    - id: webpack-rsc-production
+      evidence_source: release_must_have
+    - id: ssr-rsc-html
+      evidence_source: fleet
+    - id: client-navigation-interaction
+      evidence_source: fleet
+
+defaults:
+  package_manager: pnpm
+  ruby_test: bundle exec rspec
+  build: bin/build
+  review_app: null
+
+repos:
+  - name: sanitized/hard-01
+    headline: Sanitized hard gate 01
+    tier: hard_gate
+    needs_pro: false
+    packages: [{ ecosystem: gem, name: example-package }]
+    smoke: [/]
+    verify: false
+  - name: sanitized/hard-02
+    headline: Sanitized hard gate 02
+    tier: hard_gate
+    needs_pro: false
+    packages: [{ ecosystem: gem, name: example-package }]
+    smoke: [/]
+    verify: false
+  - name: sanitized/hard-03
+    headline: Sanitized hard gate 03
+    tier: hard_gate
+    needs_pro: false
+    packages: [{ ecosystem: npm, name: example-package }]
+    smoke: [/]
+    verify: false
+  - name: sanitized/hard-04
+    headline: Sanitized hard gate 04
+    tier: hard_gate
+    needs_pro: false
+    packages: [{ ecosystem: npm, name: example-package }]
+    smoke: [/]
+    verify: false
+  - name: sanitized/hard-05
+    headline: Sanitized hard gate 05
+    tier: hard_gate
+    needs_pro: false
+    packages: [{ ecosystem: gem, name: example-package }]
+    smoke: [/]
+    verify: false
+  - name: sanitized/hard-06
+    headline: Sanitized hard gate 06
+    tier: hard_gate
+    needs_pro: false
+    packages: [{ ecosystem: npm, name: example-package }]
+    smoke: [/]
+    verify: false
+  - name: sanitized/hard-07
+    headline: Sanitized hard gate 07
+    tier: hard_gate
+    needs_pro: false
+    packages: [{ ecosystem: gem, name: example-package }]
+    smoke: [/]
+    verify: false
+  - name: sanitized/soft-01
+    headline: Sanitized soft track 01
+    tier: soft_track
+  - name: sanitized/soft-02
+    headline: Sanitized soft track 02
+    tier: soft_track
+  - name: sanitized/soft-03
+    headline: Sanitized soft track 03
+    tier: soft_track
+  - name: sanitized/soft-04
+    headline: Sanitized soft track 04
+    tier: soft_track
+  - name: sanitized/soft-05
+    headline: Sanitized soft track 05
+    tier: soft_track

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -769,6 +769,7 @@ module FleetValidation
         result.concat(preflight_errors)
         result.concat(pack_identity_errors)
         result.concat(blocked_preflight_state_errors)
+        result.concat(waiver_evidence_errors)
         result.concat(independent_audit_errors)
         result << "independent audit is not passed" unless @ledger.dig("audit", "status") == "passed"
         result.concat(tracker_errors)
@@ -990,7 +991,12 @@ module FleetValidation
     end
 
     def blocked_preflight_state_errors
-      errors = Array(@ledger["inventory"]).filter_map do |item|
+      errors = Array(@ledger["inventory"]).flat_map do |item|
+        if item["work_mode"] == "validation_only" && item["work_state"] != "not_started"
+          next validation_only_preflight_evidence_errors(item)
+        end
+
+        item_errors = []
         expected_merge_status = item["work_mode"] == "mutation" ? "not_started" : "not_applicable"
         untouched_checks = item.fetch("checks", {}).values.all? do |check|
           check["status"] == "pending" && !present?(check["head_commit"]) && !present?(check["evidence"]) &&
@@ -998,9 +1004,21 @@ module FleetValidation
         end
         untouched = item["work_state"] == "not_started" && !present?(item["work_started_at"]) &&
                     !present?(item["maker_id"]) && item["result"] == "pending" &&
-                    Array(item["package_locks"]).empty? && untouched_checks &&
-                    item.dig("merge", "status") == expected_merge_status && !present?(item["evidence"])
-        "blocked preflight target #{item['id']} contains app-work state" unless untouched
+                    Array(item["package_locks"]).empty? && untouched_checks && !present?(item["evidence"])
+        unless untouched
+          item_errors << "blocked preflight target #{item['id']} contains app-work state"
+        end
+        merge = item.fetch("merge", {})
+        pristine_merge = merge["status"] == expected_merge_status && merge["authority"] == "none" &&
+                         !present?(merge["authority_evidence"]) && merge["freeze_state"] == "unknown" &&
+                         !present?(merge["merge_commit"]) && !present?(merge["evidence"])
+        unless pristine_merge
+          item_errors << "blocked preflight target #{item['id']} contains nested merge state"
+        end
+        unless pristine_reachability?(item.fetch("reachability", {}))
+          item_errors << "blocked preflight target #{item['id']} contains reachability state"
+        end
+        item_errors
       end
       errors << "blocked preflight aggregate merge status must be blocked" unless @ledger.dig("merge", "status") == "blocked"
       %w[default_branch tree_parity].each do |field|
@@ -1009,6 +1027,88 @@ module FleetValidation
         end
       end
       errors
+    end
+
+    def validation_only_preflight_evidence_errors(item)
+      errors = []
+      allowed = { "finished" => %w[passed waived], "blocked" => ["blocked"] }
+      unless Array(allowed[item["work_state"]]).include?(item["result"]) && present?(item["evidence"])
+        errors << "blocked preflight validation-only target #{item['id']} is not terminal"
+      end
+      errors << "blocked preflight validation-only target #{item['id']} has a maker" if present?(item["maker_id"])
+
+      revisions = item.fetch("revisions", {})
+      current_head = revisions["current"]
+      unless %w[audit reviewed current].all? { |field| commit_identity?(revisions[field]) } &&
+             revisions["audit"] == revisions["reviewed"] && revisions["reviewed"] == current_head &&
+             revisions["reconciliation"] == "passed"
+        errors << "blocked preflight validation-only target #{item['id']} has incomplete revision evidence"
+      end
+
+      expected = @inventory.find { |target| target["id"] == item["id"] }
+      expected_packages = Array(expected&.fetch("packages", [])).map do |package|
+        [package["ecosystem"], package["name"]]
+      end
+      locks = Array(item["package_locks"])
+      actual_packages = locks.map { |lock| [lock["ecosystem"], lock["name"]] }
+      resolved = Array(@ledger.dig("pack", "resolved_packages")).to_h do |package|
+        [[package["ecosystem"], package["name"]], [package["version"], package["source"]]]
+      end
+      invalid_locks = locks.any? do |lock|
+        !%w[ecosystem name version source].all? { |field| present?(lock[field]) } ||
+          resolved[[lock["ecosystem"], lock["name"]]] != [lock["version"], lock["source"]]
+      end
+      if (expected_packages - actual_packages).any? || actual_packages.tally.any? { |_identity, count| count > 1 } ||
+         invalid_locks
+        errors << "blocked preflight validation-only target #{item['id']} has incomplete package evidence"
+      end
+
+      checks_terminal = item.fetch("checks", {}).values.all? do |check|
+        %w[passed blocked waived].include?(check["status"]) && present?(check["evidence"]) &&
+          commit_identity?(check["head_commit"]) && check["head_commit"] == current_head
+      end
+      unless checks_terminal
+        errors << "blocked preflight validation-only target #{item['id']} has incomplete check evidence"
+      end
+
+      baseline = item.fetch("baseline", {})
+      baseline_terminal = !%w[pending unknown].include?(baseline["classification"]) &&
+                          baseline["head_commit"] == current_head && present?(baseline["evidence"])
+      unless baseline_terminal
+        errors << "blocked preflight validation-only target #{item['id']} has incomplete baseline evidence"
+      end
+      review_app = item.fetch("review_app", {})
+      review_terminal = review_app["head_commit"] == current_head && present?(review_app["evidence"]) &&
+                        validation_only_review_terminal?(item, review_app)
+      unless review_terminal
+        errors << "blocked preflight validation-only target #{item['id']} has incomplete review-app evidence"
+      end
+
+      merge = item.fetch("merge", {})
+      unless merge["status"] == "not_applicable" && merge["authority"] == "none" &&
+             !present?(merge["authority_evidence"]) && !present?(merge["merge_commit"])
+        errors << "blocked preflight validation-only target #{item['id']} contains mutation merge state"
+      end
+      unless pristine_reachability?(item.fetch("reachability", {}))
+        errors << "blocked preflight validation-only target #{item['id']} contains reachability state"
+      end
+      errors
+    end
+
+    def validation_only_review_terminal?(item, review_app)
+      case review_app["state"]
+      when "not_configured"
+        review_app["deployed_smoke"] == "waived"
+      when "configured_runnable"
+        review_app["deployed_smoke"] == "passed" ||
+          (review_app["deployed_smoke"] == "blocked") ||
+          (review_app["deployed_smoke"] == "waived" &&
+            valid_waiver?(review_app["waiver"], "#{item['id']}:review_app"))
+      when "configured_broken"
+        review_app["deployed_smoke"] == "blocked"
+      else
+        false
+      end
     end
 
     def barrier_order_errors
@@ -1456,6 +1556,9 @@ module FleetValidation
              present?(merge["merge_commit"])
             errors << "target #{item['id']} not-applicable merge retains mutation state"
           end
+          unless pristine_reachability?(item.fetch("reachability", {}))
+            errors << "target #{item['id']} non-mutation target retains reachability state"
+          end
           next errors
         end
 
@@ -1539,6 +1642,12 @@ module FleetValidation
 
     def present?(value)
       !value.nil? && !value.to_s.strip.empty?
+    end
+
+    def pristine_reachability?(reachability)
+      reachability["default_branch"] == "pending" && !present?(reachability["default_commit"]) &&
+        !present?(reachability["default_evidence"]) && reachability["tree_parity"] == "pending" &&
+        !present?(reachability["tree"]) && !present?(reachability["tree_evidence"])
     end
 
     def commit_identity?(value)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -58,9 +58,10 @@ module FleetValidation
           target.slice("id", "tier", "work_mode").merge(
             "work_state" => "not_started",
             "result" => "pending",
+            "waiver" => nil,
             "package_locks" => [],
             "checks" => %w[install build test local_smoke hosted_ci review].to_h do |check|
-              [check, { "status" => "pending", "evidence" => nil }]
+              [check, { "status" => "pending", "evidence" => nil, "waiver" => nil }]
             end,
             "review_app" => { "state" => "unknown", "evidence" => nil, "deployed_smoke" => "pending" },
             "baseline" => { "classification" => "pending", "evidence" => nil },
@@ -201,7 +202,7 @@ module FleetValidation
     def inventory_item_schema
       object_schema(
         %w[
-          id tier work_mode work_state result package_locks checks review_app baseline evidence
+          id tier work_mode work_state result waiver package_locks checks review_app baseline evidence
         ],
         {
           "id" => nonempty_string,
@@ -209,6 +210,7 @@ module FleetValidation
           "work_mode" => { "enum" => %w[mutation report_only] },
           "work_state" => { "enum" => %w[not_started running finished blocked unknown] },
           "result" => { "enum" => %w[pending passed reported blocked waived unknown] },
+          "waiver" => waiver_schema,
           "package_locks" => {
             "type" => "array",
             "items" => object_schema(
@@ -289,8 +291,9 @@ module FleetValidation
       {
         "type" => %w[object null],
         "additionalProperties" => false,
-        "required" => %w[authority evidence_url reason],
+        "required" => %w[gate authority evidence_url reason],
         "properties" => {
+          "gate" => nonempty_string,
           "authority" => nonempty_string,
           "evidence_url" => nonempty_string,
           "reason" => nonempty_string
@@ -339,10 +342,11 @@ module FleetValidation
 
     def evidence_status_schema
       object_schema(
-        %w[status evidence],
+        %w[status evidence waiver],
         {
           "status" => status_string,
-          "evidence" => nullable_string
+          "evidence" => nullable_string,
+          "waiver" => waiver_schema
         }
       )
     end
@@ -500,8 +504,10 @@ module FleetValidation
       result << inventory_completion_error if @closeout && inventory_completion_error
       result << package_lock_error if @closeout && package_lock_error
       result << check_evidence_error if @closeout && check_evidence_error
+      result.concat(waiver_evidence_errors) if @closeout
+      result.concat(base_identity_errors) if @closeout
       result << base_movement_error if @closeout && base_movement_error
-      result << independent_audit_error if @closeout && independent_audit_error
+      result.concat(independent_audit_errors) if @closeout
       result << "independent audit is not passed" if @closeout && @ledger.dig("audit", "status") != "passed"
       if @closeout && !present?(@ledger.dig("preflight", "capabilities", "restart_handoff"))
         result << "capability restart_handoff is missing"
@@ -541,10 +547,26 @@ module FleetValidation
     end
 
     def inventory_errors
-      actual_ids = Array(@ledger["inventory"]).filter_map { |item| item["id"] }
-      @inventory.filter_map do |target|
-        "inventory missing target #{target.fetch('id')}" unless actual_ids.include?(target.fetch("id"))
+      actual = Array(@ledger["inventory"])
+      expected_by_id = @inventory.to_h { |target| [target.fetch("id"), target] }
+      actual_ids = actual.filter_map { |item| item["id"] }
+      errors = expected_by_id.filter_map do |id, _target|
+        "inventory missing target #{id}" unless actual_ids.include?(id)
       end
+      actual_ids.tally.each do |id, count|
+        errors << "inventory has duplicate target #{id}" if count > 1
+      end
+      (actual_ids - expected_by_id.keys).uniq.each do |id|
+        errors << "inventory has unexpected target #{id}"
+      end
+      actual.each do |item|
+        expected = expected_by_id[item["id"]]
+        next unless expected
+        next if item["tier"] == expected["tier"] && item["work_mode"] == expected["work_mode"]
+
+        errors << "inventory target #{item['id']} classification does not match manifest"
+      end
+      errors
     end
 
     def private_field_errors
@@ -599,15 +621,23 @@ module FleetValidation
 
     def preflight_errors
       preflight = @ledger.fetch("preflight", {})
-      waived = preflight["status"] == "waived" && valid_waiver?(preflight["waiver"])
-      errors = %w[release_ci artifacts generator_matrix].filter_map do |field|
-        next if preflight[field] == "passed" || waived
+      waiver = preflight["status"] == "waived" ? preflight["waiver"] : nil
+      errors = %w[release_ci generator_matrix].filter_map do |field|
+        next if preflight[field] == "passed" || valid_waiver?(waiver, field)
 
         "release-wide preflight #{field} is not passed or explicitly waived"
       end
+      unless preflight["artifacts"] == "passed"
+        message = if valid_waiver?(waiver, "artifacts")
+                    "release-wide preflight artifacts must pass and cannot be waived"
+                  else
+                    "release-wide preflight artifacts is not passed or explicitly waived"
+                  end
+        errors << message
+      end
       capabilities = preflight.fetch("capabilities", {})
       %w[status permissions git_auth github_auth registry_network toolchains host_capacity coordination].each do |field|
-        next if capabilities[field] == "passed" || waived
+        next if capabilities[field] == "passed" || valid_waiver?(waiver, "capabilities.#{field}")
 
         errors << "capability #{field} is not passed or explicitly waived"
       end
@@ -662,11 +692,42 @@ module FleetValidation
       "#{count} hard-gate target(s) have unknown or nonterminal check evidence"
     end
 
-    def independent_audit_error
+    def independent_audit_errors
       audit = @ledger.fetch("audit", {})
-      return unless Array(audit["maker_ids"]).include?(audit["checker"])
+      errors = []
+      errors << "independent audit checker is missing" unless present?(audit["checker"])
+      errors << "independent audit maker identities are missing" if Array(audit["maker_ids"]).empty?
+      if present?(audit["checker"]) && Array(audit["maker_ids"]).include?(audit["checker"])
+        errors << "independent audit checker is also a maker"
+      end
+      errors
+    end
 
-      "independent audit checker is also a maker"
+    def base_identity_errors
+      audit = @ledger.fetch("audit", {})
+      merge = @ledger.fetch("merge", {})
+      errors = []
+      errors << "audit base_commit is missing" unless present?(audit["base_commit"])
+      %w[reviewed_base_commit current_base_commit].each do |field|
+        errors << "merge #{field} is missing" unless present?(merge[field])
+      end
+      errors
+    end
+
+    def waiver_evidence_errors
+      Array(@ledger["inventory"]).flat_map do |item|
+        errors = []
+        if item["result"] == "waived" && !valid_waiver?(item["waiver"], item["id"])
+          errors << "target #{item['id']} waived result is missing structured waiver evidence"
+        end
+        item.fetch("checks", {}).each do |name, check|
+          next unless check["status"] == "waived"
+          next if valid_waiver?(check["waiver"], "#{item['id']}:#{name}")
+
+          errors << "target #{item['id']} waived check #{name} is missing structured waiver evidence"
+        end
+        errors
+      end
     end
 
     def reachability_errors
@@ -704,7 +765,7 @@ module FleetValidation
       return false unless path
       return true if path["status"] == "passed" && present?(path["lane"]) && present?(path["evidence"])
 
-      path["status"] == "waived" && valid_waiver?(path["waiver"])
+      path["status"] == "waived" && valid_waiver?(path["waiver"], path["id"])
     end
 
     def present?(value)
@@ -713,16 +774,22 @@ module FleetValidation
 
     def app_work_allowed?
       preflight = @ledger.fetch("preflight", {})
-      preflight["status"] == "passed" || (preflight["status"] == "waived" && valid_waiver?(preflight["waiver"]))
+      %w[passed waived].include?(preflight["status"]) && preflight_errors.empty?
     end
 
-    def valid_waiver?(waiver)
-      waiver.is_a?(Hash) && %w[authority evidence_url reason].all? { |field| present?(waiver[field]) }
+    def valid_waiver?(waiver, expected_gate)
+      waiver.is_a?(Hash) && waiver["gate"] == expected_gate &&
+        %w[authority evidence_url reason].all? { |field| present?(waiver[field]) }
     end
 
     def release_blocked?
       hard_gate_blocked = Array(@ledger["inventory"]).any? do |item|
-        item["tier"] == "hard_gate" && !%w[passed waived].include?(item["result"])
+        next false unless item["tier"] == "hard_gate"
+
+        top_level_blocked = !%w[passed waived].include?(item["result"])
+        check_blocked = item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" }
+        candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
+        top_level_blocked || check_blocked || candidate_regression
       end
       required_path_blocked = @required_paths.any? do |required|
         path = Array(@ledger["required_paths"]).find { |item| item["id"] == required.fetch("id") }
@@ -868,7 +935,12 @@ module FleetValidation
       blockers = Array(@ledger["blockers"])
       paths = Array(@ledger["required_paths"])
       blocked = inventory.any? do |item|
-        item["tier"] == "hard_gate" && !%w[passed waived].include?(item["result"])
+        next false unless item["tier"] == "hard_gate"
+
+        top_level_blocked = !%w[passed waived].include?(item["result"])
+        check_blocked = item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" }
+        candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
+        top_level_blocked || check_blocked || candidate_regression
       end
       blocked ||= paths.any? { |path| !%w[passed waived].include?(path["status"]) }
       blocked ||= blockers.any? { |blocker| !%w[resolved waived deferred].include?(blocker["status"]) }

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -122,7 +122,8 @@ module FleetValidation
             "status" => "pending",
             "lane" => nil,
             "evidence" => nil,
-            "waiver" => nil
+            "waiver" => nil,
+            "blocker_id" => nil
           )
         end,
         "blockers" => [],
@@ -214,8 +215,16 @@ module FleetValidation
       existing = JSON.parse(File.read(path))
       existing_pack = existing.fetch("pack", {})
       return unless existing_pack["pack_id"] == @pack_id
-      return if existing_pack["release_selector"] == @release_selector &&
-                existing_pack["snapshot_fingerprint"] == snapshot_fingerprint
+
+      same_snapshot = existing_pack["release_selector"] == @release_selector &&
+                      existing_pack["snapshot_fingerprint"] == snapshot_fingerprint
+      if same_snapshot && resolved_candidate_reusable?(existing)
+        return
+      elsif same_snapshot
+        raise ManifestError,
+              "existing result ledger's resolved dynamic candidate cannot be safely reused; " \
+              "pin the exact candidate or generate a fresh pack"
+      end
 
       raise ManifestError, "existing result ledger belongs to a different release snapshot"
     rescue JSON::ParserError => e
@@ -367,21 +376,22 @@ module FleetValidation
 
     def required_path_schema
       object_schema(
-        %w[id evidence_source status lane evidence waiver],
+        %w[id evidence_source status lane evidence waiver blocker_id],
         {
           "id" => nonempty_string,
           "evidence_source" => nonempty_string,
           "status" => status_string,
           "lane" => nullable_string,
           "evidence" => nullable_string,
-          "waiver" => waiver_schema
+          "waiver" => waiver_schema,
+          "blocker_id" => nullable_string
         }
       )
     end
 
     def blocker_schema
       object_schema(
-        %w[id status public_summary owner],
+        %w[id status public_summary owner disposition],
         {
           "id" => nonempty_string,
           "status" => { "enum" => %w[open pending blocked unknown resolved waived deferred] },
@@ -394,7 +404,8 @@ module FleetValidation
               "waiver_url" => nonempty_string,
               "public_tracker_reason" => nonempty_string
             }
-          }
+          },
+          "disposition" => waiver_schema
         }
       )
     end
@@ -601,7 +612,9 @@ module FleetValidation
         Validate the final ledger, regenerate the append-only tracker matrix from that exact file, and
         post it without hand-copying worker prose. End with exact `PASS`, `PARTIAL`, or `BLOCKED`
         semantics. A promotion recommendation is allowed only when every required release path is green
-        or explicitly waived and no `UNKNOWN` remains.
+        or explicitly waived and no `UNKNOWN` remains. A failed required path closes as `BLOCKED` only
+        when it records its lane, failure evidence, and an owned `blocker_id`. Waived or deferred
+        blockers require structured gate, authority, evidence URL, and reason fields.
       MARKDOWN
     end
 
@@ -633,6 +646,13 @@ module FleetValidation
 
     def slug(value)
       value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-\z/, "")
+    end
+
+    def resolved_candidate_reusable?(ledger)
+      candidate = ledger.dig("pack", "candidate")
+      return !ledger.dig("preflight", "app_work_allowed") if candidate.nil?
+
+      candidate == @release_selector
     end
   end
 
@@ -813,8 +833,8 @@ module FleetValidation
         if path && path["evidence_source"] != required["evidence_source"]
           errors << "required path #{required.fetch('id')} evidence_source does not match manifest"
         end
-        unless path_evidenced?(path)
-          errors << "required path #{required.fetch('id')} has no passing evidence or waiver"
+        unless path_terminally_evidenced?(path)
+          errors << "required path #{required.fetch('id')} has no passing, blocked, or waived evidence"
         end
 
         errors
@@ -823,7 +843,13 @@ module FleetValidation
 
     def blocker_owner_errors
       Array(@ledger["blockers"]).filter_map do |blocker|
-        next if %w[resolved waived deferred].include?(blocker["status"])
+        status = blocker["status"]
+        if %w[waived deferred].include?(status)
+          next if valid_waiver?(blocker["disposition"], blocker["id"])
+
+          next "blocker #{blocker['id'] || 'missing-id'} is missing structured #{status} disposition evidence"
+        end
+        next if status == "resolved"
         next if durable_owner?(blocker["owner"])
 
         "blocker #{blocker['id'] || 'missing-id'} has no durable owner"
@@ -1025,7 +1051,7 @@ module FleetValidation
 
     def blocker_reference_errors
       blockers = Array(@ledger["blockers"]).to_h { |blocker| [blocker["id"], blocker] }
-      Array(@ledger["inventory"]).flat_map do |item|
+      inventory_errors = Array(@ledger["inventory"]).flat_map do |item|
         references = []
         if item["result"] == "blocked" || item.dig("baseline", "classification") == "candidate_regression"
           references << ["result", item["blocker_id"]]
@@ -1044,6 +1070,15 @@ module FleetValidation
           "target #{item['id']} blocked #{label} has no owned blocker reference"
         end
       end
+      path_errors = Array(@ledger["required_paths"]).filter_map do |path|
+        next unless path["status"] == "blocked"
+
+        blocker = blockers[path["blocker_id"]]
+        next if blocker && durable_owner?(blocker["owner"])
+
+        "required path #{path['id']} blocked result has no owned blocker reference"
+      end
+      inventory_errors + path_errors
     end
 
     def waiver_evidence_errors
@@ -1125,9 +1160,10 @@ module FleetValidation
       %w[issue_url waiver_url public_tracker_reason].any? { |key| present?(owner[key]) }
     end
 
-    def path_evidenced?(path)
+    def path_terminally_evidenced?(path)
       return false unless path
       return true if path["status"] == "passed" && present?(path["lane"]) && present?(path["evidence"])
+      return true if path["status"] == "blocked" && present?(path["lane"]) && present?(path["evidence"])
 
       path["status"] == "waived" && valid_waiver?(path["waiver"], path["id"])
     end
@@ -1176,7 +1212,7 @@ module FleetValidation
       end
       required_path_blocked = @required_paths.any? do |required|
         path = Array(@ledger["required_paths"]).find { |item| item["id"] == required.fetch("id") }
-        !path_evidenced?(path)
+        !%w[passed waived].include?(path&.fetch("status", nil))
       end
       active_blocker = Array(@ledger["blockers"]).any? do |blocker|
         !%w[resolved waived deferred].include?(blocker["status"])

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -1710,7 +1710,11 @@ module FleetValidation
       if tracker["status"] == "posted" && !present?(tracker["comment_url"])
         errors << "posted tracker closeout is missing comment_url"
       end
-      if tracker["promotion"] == "blocked" && !release_blocked?
+      if release_blocked?
+        unless tracker["promotion"] == "blocked"
+          errors << "tracker promotion must be blocked while a release blocker remains"
+        end
+      elsif tracker["promotion"] == "blocked"
         errors << "tracker promotion is blocked without a release blocker"
       end
       errors

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -15,16 +15,20 @@ module FleetValidation
       "work_mode" => "mutation",
       "packages" => [
         { "ecosystem" => "gem", "name" => "react_on_rails" },
-        { "ecosystem" => "npm", "name" => "react-on-rails" }
+        { "ecosystem" => "npm", "name" => "react-on-rails" },
+        { "ecosystem" => "npm", "name" => "create-react-on-rails-app" }
       ]
     }.freeze
 
-    attr_reader :inventory, :required_paths
+    attr_reader :inventory, :required_paths, :snapshot_fingerprint
 
     def initialize(manifest:, pack_id:, release_selector:)
       @manifest = manifest
       @pack_id = pack_id
       @release_selector = release_selector
+      @snapshot_fingerprint = Digest::SHA256.hexdigest(
+        JSON.generate("release_selector" => @release_selector, "manifest" => @manifest)
+      )
       @inventory = build_inventory
       @required_paths = build_required_paths
     end
@@ -53,6 +57,7 @@ module FleetValidation
         },
         "preflight" => {
           "status" => "pending",
+          "app_work_allowed" => false,
           "waiver" => nil,
           "release_ci" => { "status" => "pending", "evidence" => nil },
           "artifacts" => { "status" => "pending", "evidence" => nil },
@@ -189,19 +194,27 @@ module FleetValidation
       }
     end
 
+    def validate_existing_ledger(path)
+      return unless File.exist?(path)
+
+      existing = JSON.parse(File.read(path))
+      existing_pack = existing.fetch("pack", {})
+      return unless existing_pack["pack_id"] == @pack_id
+      return if existing_pack["release_selector"] == @release_selector &&
+                existing_pack["snapshot_fingerprint"] == snapshot_fingerprint
+
+      raise ManifestError, "existing result ledger belongs to a different release snapshot"
+    rescue JSON::ParserError => e
+      raise ManifestError, "existing result ledger is invalid JSON: #{e.message}"
+    end
+
     private
 
     def write_ledger(path)
+      validate_existing_ledger(path)
       if File.exist?(path)
         existing = JSON.parse(File.read(path))
-        existing_pack = existing.fetch("pack", {})
-        if existing_pack["pack_id"] == @pack_id
-          same_snapshot = existing_pack["release_selector"] == @release_selector &&
-                          existing_pack["snapshot_fingerprint"] == snapshot_fingerprint
-          return if same_snapshot
-
-          raise ManifestError, "existing result ledger belongs to a different release snapshot"
-        end
+        return if existing.dig("pack", "pack_id") == @pack_id
       end
 
       File.write(path, "#{JSON.pretty_generate(ledger_template)}\n")
@@ -225,12 +238,13 @@ module FleetValidation
 
     def preflight_schema
       fields = %w[
-        status waiver release_ci artifacts generator_matrix capabilities
+        status app_work_allowed waiver release_ci artifacts generator_matrix capabilities
       ]
       object_schema(
         fields,
         {
           "status" => { "enum" => %w[pending passed waived blocked unknown] },
+          "app_work_allowed" => { "type" => "boolean" },
           "waiver" => waiver_schema,
           "release_ci" => preflight_gate_schema,
           "artifacts" => preflight_gate_schema,
@@ -514,6 +528,8 @@ module FleetValidation
         An explicit public-safe waiver may replace a failed gate only when the release policy allows
         it and the ledger records the authority and evidence URL. Missing, pending, conflicting, stale,
         or `UNKNOWN` evidence does not open the barrier.
+        After validating those gates and capabilities, set `preflight.app_work_allowed` to `true`;
+        that schema-validated boolean is the ledger's explicit `APP_WORK_ALLOWED` marker.
 
         Before worker launch, record a machine/session capability attestation covering
         nonblocking permissions, Git and GitHub authentication, registry/network access, required toolchains,
@@ -581,23 +597,22 @@ module FleetValidation
     def slug(value)
       value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-\z/, "")
     end
-
-    def snapshot_fingerprint
-      @snapshot_fingerprint ||= Digest::SHA256.hexdigest(
-        JSON.generate(
-          "release_selector" => @release_selector,
-          "manifest" => @manifest
-        )
-      )
-    end
   end
 
   class LedgerValidator
-    def initialize(ledger, inventory:, required_paths:, expected_candidate: nil, closeout: false)
+    def initialize(
+      ledger,
+      inventory:,
+      required_paths:,
+      expected_candidate: nil,
+      expected_snapshot_fingerprint: nil,
+      closeout: false
+    )
       @ledger = ledger
       @inventory = inventory
       @required_paths = required_paths
       @expected_candidate = expected_candidate
+      @expected_snapshot_fingerprint = expected_snapshot_fingerprint
       @closeout = closeout
     end
 
@@ -709,11 +724,17 @@ module FleetValidation
 
     def required_path_errors
       paths = Array(@ledger["required_paths"])
-      @required_paths.filter_map do |required|
+      @required_paths.flat_map do |required|
         path = paths.find { |item| item["id"] == required.fetch("id") }
-        next if path_evidenced?(path)
+        errors = []
+        if path && path["evidence_source"] != required["evidence_source"]
+          errors << "required path #{required.fetch('id')} evidence_source does not match manifest"
+        end
+        unless path_evidenced?(path)
+          errors << "required path #{required.fetch('id')} has no passing evidence or waiver"
+        end
 
-        "required path #{required.fetch('id')} has no passing evidence or waiver"
+        errors
       end
     end
 
@@ -778,6 +799,9 @@ module FleetValidation
       end
       allowed_modes = %w[development accelerated-rc strict-rc final-release]
       errors << "pack tracker_mode is not allowed" unless allowed_modes.include?(pack["tracker_mode"])
+      if @expected_snapshot_fingerprint && pack["snapshot_fingerprint"] != @expected_snapshot_fingerprint
+        errors << "pack snapshot_fingerprint does not match the current manifest"
+      end
       errors
     end
 
@@ -1012,12 +1036,13 @@ module FleetValidation
     end
 
     def commit_identity?(value)
-      value.to_s.match?(/\A[0-9a-f]{7,40}\z/i)
+      value.to_s.match?(/\A[0-9a-f]{40}\z/i)
     end
 
     def app_work_allowed?
       preflight = @ledger.fetch("preflight", {})
-      %w[passed waived].include?(preflight["status"]) && preflight_errors.empty?
+      preflight["app_work_allowed"] == true &&
+        %w[passed waived].include?(preflight["status"]) && preflight_errors.empty?
     end
 
     def valid_waiver?(waiver, expected_gate)
@@ -1092,11 +1117,12 @@ module FleetValidation
     def type_matches?(value, type)
       {
         "array" => Array,
+        "boolean" => [TrueClass, FalseClass],
         "integer" => Integer,
         "null" => NilClass,
         "object" => Hash,
         "string" => String
-      }.fetch(type).then { |klass| value.is_a?(klass) }
+      }.fetch(type).then { |klass| Array(klass).any? { |candidate| value.is_a?(candidate) } }
     end
 
     def validate_object(value, schema, path)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -695,6 +695,7 @@ module FleetValidation
       result.concat(review_app_errors)
       result.concat(barrier_order_errors)
       result.concat(required_path_errors) if @closeout
+      result.concat(blocker_identity_errors) if @closeout
       result.concat(blocker_owner_errors) if @closeout
       result.concat(blocker_reference_errors) if @closeout
       result.concat(preflight_errors) if @closeout
@@ -870,6 +871,14 @@ module FleetValidation
 
         errors
       end
+    end
+
+    def blocker_identity_errors
+      ids = Array(@ledger["blockers"]).map { |blocker| blocker["id"] }
+      duplicates = ids.tally.select { |_id, count| count > 1 }.keys
+      return [] if duplicates.empty?
+
+      ["blocker IDs must be unique: #{duplicates.join(', ')}"]
     end
 
     def base_movement_error
@@ -1197,7 +1206,7 @@ module FleetValidation
     end
 
     def present?(value)
-      !value.nil? && !value.to_s.empty?
+      !value.nil? && !value.to_s.strip.empty?
     end
 
     def commit_identity?(value)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -7,6 +7,29 @@ require "time"
 module FleetValidation
   class ManifestError < StandardError; end
 
+  module BlockerScope
+    module_function
+
+    def soft_only_ids(ledger)
+      soft_items = Array(ledger["inventory"]).select { |item| item["tier"] == "soft_track" }
+      soft_ids = soft_items.flat_map { |item| target_ids(item) }
+      gating_ids = [ledger.dig("preflight", "blocker_id")]
+      gating_ids.concat(
+        Array(ledger["inventory"]).select { |item| item["tier"] == "hard_gate" }
+                                  .flat_map { |item| target_ids(item) }
+      )
+      gating_ids.concat(Array(ledger["required_paths"]).filter_map { |path| path["blocker_id"] })
+
+      (soft_ids - gating_ids.compact).uniq
+    end
+
+    def target_ids(item)
+      ids = [item["blocker_id"], item.dig("review_app", "blocker_id")]
+      ids.concat(item.fetch("checks", {}).values.filter_map { |check| check["blocker_id"] })
+      ids.compact.reject { |id| id.to_s.strip.empty? }
+    end
+  end
+
   class Lifecycle
     REQUIRED_PATH_IDS = %w[
       standard-generator pro-ssr pro-rsc rspack webpack-rsc-production ssr-rsc-html
@@ -654,9 +677,10 @@ module FleetValidation
         <<~ROW.chomp
           - `#{target.fetch('id')}` — Report only; do not mutate.
             Inspect the fresh default, current package locks, standing CI/smoke metadata, and archived or deferred disposition.
-            Retain the inspected package versions/sources and exact-head check evidence. Record
-            `reported`, `blocked`, or `waived` plus public-safe evidence in the shared ledger;
-            `pending` or `unknown` cannot close the pack.
+            Retain the inspected package versions/sources and exact-head check evidence; these
+            observed versions need not equal the release snapshot. Record `reported`, `blocked`, or
+            `waived` plus public-safe evidence in the shared ledger; `pending` or `unknown` cannot
+            close the pack.
         ROW
       end
 
@@ -665,6 +689,9 @@ module FleetValidation
 
         Run after the release-wide preflight barrier opens. These tracks complete the release inventory
         but never become candidate bump/merge lanes unless a maintainer separately changes their tier.
+        An owned blocker referenced only by these soft tracks produces `PARTIAL` follow-up state but
+        does not block promotion. A preflight, hard-gate, or required-path reference makes that blocker
+        release-gating.
 
         #{rows.join("\n")}
       MARKDOWN
@@ -698,7 +725,10 @@ module FleetValidation
         or explicitly waived and no `UNKNOWN` remains. A failed required path closes as `BLOCKED` only
         when it records its lane, failure evidence, and an owned `blocker_id`. Waived or deferred
         blockers retain a durable owner and require structured gate, authority, evidence URL, and
-        reason fields. The aggregate merge/reachability state is derived from the per-target rows. If
+        reason fields. Candidate-snapshot package matching applies to candidate-managed packages on
+        hard gates, including the separately resolved RSC package; report-only and independently
+        versioned dependency locks retain the versions observed in their target. The aggregate
+        merge/reachability state is derived from the per-target rows. If
         any lane has already merged, its base, authority/freeze, merge-commit, reachability, and
         tree-parity proofs remain required even when another lane blocks overall promotion.
       MARKDOWN
@@ -1037,6 +1067,9 @@ module FleetValidation
         item_errors
       end
       errors << "blocked preflight aggregate merge status must be blocked" unless @ledger.dig("merge", "status") == "blocked"
+      unless @ledger.dig("tracker", "promotion") == "blocked"
+        errors << "blocked preflight tracker promotion must be blocked"
+      end
       %w[default_branch tree_parity].each do |field|
         unless @ledger.dig("reachability", field) == "blocked"
           errors << "blocked preflight aggregate reachability #{field} must be blocked"
@@ -1369,18 +1402,22 @@ module FleetValidation
         [[package["ecosystem"], package["name"]], [package["version"], package["source"]]]
       end
       invalid_items = Array(@ledger["inventory"]).select do |item|
+        next false unless item["tier"] == "hard_gate"
+
         Array(item["package_locks"]).any? do |lock|
+          next false unless candidate_managed_package?(lock["ecosystem"], lock["name"])
+
           resolved[[lock["ecosystem"], lock["name"]]] != [lock["version"], lock["source"]]
         end
       end
       return if invalid_items.empty?
 
-      hard_gate_count = invalid_items.count { |item| item["tier"] == "hard_gate" }
-      if hard_gate_count.positive?
-        "#{hard_gate_count} hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
-      else
-        "#{invalid_items.length} report-only target(s) retain package versions or sources outside the resolved release snapshot"
-      end
+      "#{invalid_items.length} hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
+    end
+
+    def candidate_managed_package?(ecosystem, name)
+      PRODUCT_PACKAGES.fetch(ecosystem, []).include?(name) ||
+        (ecosystem == "npm" && name == "react-on-rails-rsc")
     end
 
     def check_evidence_errors
@@ -1784,8 +1821,10 @@ module FleetValidation
         path = Array(@ledger["required_paths"]).find { |item| item["id"] == required.fetch("id") }
         !%w[passed waived].include?(path&.fetch("status", nil))
       end
+      soft_only_blockers = BlockerScope.soft_only_ids(@ledger)
       active_blocker = Array(@ledger["blockers"]).any? do |blocker|
-        !%w[resolved waived deferred].include?(blocker["status"])
+        !%w[resolved waived deferred].include?(blocker["status"]) &&
+          !soft_only_blockers.include?(blocker["id"])
       end
 
       hard_gate_blocked || required_path_blocked || active_blocker
@@ -1939,7 +1978,11 @@ module FleetValidation
           review_app_blocked
       end
       blocked ||= paths.any? { |path| !%w[passed waived].include?(path["status"]) }
-      blocked ||= blockers.any? { |blocker| !%w[resolved waived deferred].include?(blocker["status"]) }
+      soft_only_blockers = BlockerScope.soft_only_ids(@ledger)
+      blocked ||= blockers.any? do |blocker|
+        !%w[resolved waived deferred].include?(blocker["status"]) &&
+          !soft_only_blockers.include?(blocker["id"])
+      end
       blocked ||= @ledger.dig("tracker", "promotion") == "blocked"
       return "BLOCKED" if blocked
 

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -275,7 +275,12 @@ module FleetValidation
 
       existing = JSON.parse(File.read(path))
       existing_pack = existing.fetch("pack", {})
-      return unless existing_pack["pack_id"] == @pack_id
+      existing_pack_id = existing_pack["pack_id"]
+      unless existing_pack_id == @pack_id
+        raise ManifestError,
+              "existing result ledger belongs to pack #{existing_pack_id || '<missing>'}; " \
+              "refusing to overwrite it with pack #{@pack_id}"
+      end
 
       schema_errors = SchemaValidator.new(schema).errors(existing)
       unless schema_errors.empty?
@@ -774,6 +779,7 @@ module FleetValidation
     end
 
     def build_required_paths
+      paths = nil
       lifecycle = @manifest["lifecycle"]
       paths = lifecycle["required_paths"] if lifecycle.is_a?(Hash)
       unless paths.is_a?(Array) && !paths.empty?
@@ -1946,6 +1952,7 @@ module FleetValidation
     end
 
     def terminal_preflight_waiver?(preflight, waiver)
+      gate = nil
       gate = waiver["gate"] if waiver.is_a?(Hash)
       if %w[release_ci generator_matrix].include?(gate)
         valid_preflight_waiver?(waiver, gate, preflight[gate])
@@ -2175,7 +2182,11 @@ module FleetValidation
     end
 
     def escape(value)
-      value.to_s.gsub(/\s+/, " ").strip.gsub("|", "\\|").gsub("<!--", "&lt;!--").gsub("-->", "--&gt;")
+      value.to_s.gsub(/\s+/, " ").strip
+           .gsub("\\") { "\\\\" }
+           .gsub("|", "\\|")
+           .gsub("<!--", "&lt;!--")
+           .gsub("-->", "--&gt;")
     end
 
     def structured_waiver?(waiver, gate)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -770,11 +770,12 @@ module FleetValidation
         merge/reachability state is derived from the per-target rows. If
         any lane has already merged, its base, authority/freeze, merge-commit, reachability, and
         tree-parity proofs remain required even when another lane blocks overall promotion. An
-        unmerged blocked lane retains pristine pending reachability with no stale proof fields, while
-        a non-mutation lane records an evidenced, freeze-clear `not_applicable` merge disposition.
-        Supply the expected pack ID, generated release selector, candidate tag, and candidate source
-        commit from the independent launch record when validating; never derive the expected snapshot
-        identity from the ledger itself.
+        unmerged blocked lane retains pristine pending reachability with no stale proof fields and
+        records the terminal freeze reread as `clear`, `frozen`, or `conflict`, never `unknown`.
+        A non-mutation lane records an evidenced, freeze-clear `not_applicable` merge disposition.
+        Supply the expected pack ID, generated release selector, candidate tag, candidate source
+        commit, policy commit, and tracker mode from the independent launch record when validating;
+        never derive the expected snapshot identity from the ledger itself.
       MARKDOWN
     end
 
@@ -835,8 +836,10 @@ module FleetValidation
       expected_candidate: nil,
       expected_candidate_commit: nil,
       expected_pack_id: nil,
+      expected_policy_commit: nil,
       expected_release_selector: nil,
       expected_snapshot_fingerprint: nil,
+      expected_tracker_mode: nil,
       closeout: false
     )
       @ledger = ledger
@@ -845,8 +848,10 @@ module FleetValidation
       @expected_candidate = expected_candidate
       @expected_candidate_commit = expected_candidate_commit
       @expected_pack_id = expected_pack_id
+      @expected_policy_commit = expected_policy_commit
       @expected_release_selector = expected_release_selector
       @expected_snapshot_fingerprint = expected_snapshot_fingerprint
+      @expected_tracker_mode = expected_tracker_mode
       @closeout = closeout
     end
 
@@ -1408,6 +1413,13 @@ module FleetValidation
         errors << "pack candidate commit mismatch: expected #{@expected_candidate_commit}, " \
                   "got #{pack['candidate_commit']}"
       end
+      if @expected_policy_commit && pack["policy_commit"] != @expected_policy_commit
+        errors << "pack policy commit mismatch: expected #{@expected_policy_commit}, " \
+                  "got #{pack['policy_commit']}"
+      end
+      if @expected_tracker_mode && pack["tracker_mode"] != @expected_tracker_mode
+        errors << "pack tracker mode mismatch: expected #{@expected_tracker_mode}, got #{pack['tracker_mode']}"
+      end
       errors
     end
 
@@ -1781,7 +1793,7 @@ module FleetValidation
           if merge["authority"] != "none" || present?(merge["authority_evidence"])
             errors << "target #{item['id']} blocked merge retains mutation authority"
           end
-          unless merge["freeze_state"] == "clear"
+          unless %w[clear frozen conflict].include?(merge["freeze_state"])
             errors << "target #{item['id']} blocked merge freeze state is unresolved"
           end
           if present?(merge["merge_commit"])

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -2,17 +2,23 @@
 
 require "json"
 require "digest"
+require "time"
 
 module FleetValidation
   class ManifestError < StandardError; end
 
   class Lifecycle
+    REQUIRED_PATH_IDS = %w[
+      standard-generator pro-ssr pro-rsc rspack webpack-rsc-production ssr-rsc-html
+      client-navigation-interaction
+    ].freeze
+
     CORE_INVENTORY_TARGET = {
       "id" => "react-on-rails-generator-install-smoke",
       "name" => "react_on_rails generator/install smoke",
       "headline" => "Monorepo generator and install smoke",
       "tier" => "hard_gate",
-      "work_mode" => "mutation",
+      "work_mode" => "validation_only",
       "packages" => [
         { "ecosystem" => "gem", "name" => "react_on_rails" },
         { "ecosystem" => "npm", "name" => "react-on-rails" },
@@ -58,6 +64,7 @@ module FleetValidation
         "preflight" => {
           "status" => "pending",
           "app_work_allowed" => false,
+          "opened_at" => nil,
           "waiver" => nil,
           "release_ci" => { "status" => "pending", "evidence" => nil },
           "artifacts" => { "status" => "pending", "evidence" => nil },
@@ -77,6 +84,7 @@ module FleetValidation
         "inventory" => inventory.map do |target|
           target.slice("id", "tier", "work_mode").merge(
             "work_state" => "not_started",
+            "work_started_at" => nil,
             "result" => "pending",
             "waiver" => nil,
             "blocker_id" => nil,
@@ -84,7 +92,13 @@ module FleetValidation
             "checks" => %w[install build test local_smoke hosted_ci review].to_h do |check|
               [check, { "status" => "pending", "evidence" => nil, "waiver" => nil, "blocker_id" => nil }]
             end,
-            "review_app" => { "state" => "unknown", "evidence" => nil, "deployed_smoke" => "pending" },
+            "review_app" => {
+              "state" => "unknown",
+              "evidence" => nil,
+              "deployed_smoke" => "pending",
+              "waiver" => nil,
+              "blocker_id" => nil
+            },
             "baseline" => { "classification" => "pending", "evidence" => nil, "waiver" => nil },
             "bases" => {
               "audit" => nil,
@@ -238,13 +252,14 @@ module FleetValidation
 
     def preflight_schema
       fields = %w[
-        status app_work_allowed waiver release_ci artifacts generator_matrix capabilities
+        status app_work_allowed opened_at waiver release_ci artifacts generator_matrix capabilities
       ]
       object_schema(
         fields,
         {
           "status" => { "enum" => %w[pending passed waived blocked unknown] },
           "app_work_allowed" => { "type" => "boolean" },
+          "opened_at" => nullable_string,
           "waiver" => waiver_schema,
           "release_ci" => preflight_gate_schema,
           "artifacts" => preflight_gate_schema,
@@ -273,13 +288,15 @@ module FleetValidation
     def inventory_item_schema
       object_schema(
         %w[
-          id tier work_mode work_state result waiver blocker_id package_locks checks review_app baseline bases reachability evidence
+          id tier work_mode work_state work_started_at result waiver blocker_id package_locks checks
+          review_app baseline bases reachability evidence
         ],
         {
           "id" => nonempty_string,
           "tier" => { "enum" => %w[hard_gate soft_track] },
-          "work_mode" => { "enum" => %w[mutation report_only] },
+          "work_mode" => { "enum" => %w[mutation validation_only report_only] },
           "work_state" => { "enum" => %w[not_started running finished blocked unknown] },
+          "work_started_at" => nullable_string,
           "result" => { "enum" => %w[pending passed reported blocked waived unknown] },
           "waiver" => waiver_schema,
           "blocker_id" => nullable_string,
@@ -302,13 +319,15 @@ module FleetValidation
             end
           ),
           "review_app" => object_schema(
-            %w[state evidence deployed_smoke],
+            %w[state evidence deployed_smoke waiver blocker_id],
             {
               "state" => {
                 "enum" => %w[configured_runnable configured_broken not_configured unknown]
               },
               "evidence" => nullable_string,
-              "deployed_smoke" => status_string
+              "deployed_smoke" => status_string,
+              "waiver" => waiver_schema,
+              "blocker_id" => nullable_string
             }
           ),
           "baseline" => object_schema(
@@ -528,8 +547,10 @@ module FleetValidation
         An explicit public-safe waiver may replace a failed gate only when the release policy allows
         it and the ledger records the authority and evidence URL. Missing, pending, conflicting, stale,
         or `UNKNOWN` evidence does not open the barrier.
-        After validating those gates and capabilities, set `preflight.app_work_allowed` to `true`;
-        that schema-validated boolean is the ledger's explicit `APP_WORK_ALLOWED` marker.
+        After validating those gates and capabilities, record `preflight.opened_at` and set
+        `preflight.app_work_allowed` to `true`; that schema-validated state is the ledger's explicit
+        `APP_WORK_ALLOWED` marker. Every mutable target records `work_started_at`, which must be later
+        than the barrier time. The validation-only monorepo generator gate may run before this marker.
 
         Before worker launch, record a machine/session capability attestation covering
         nonblocking permissions, Git and GitHub authentication, registry/network access, required toolchains,
@@ -585,10 +606,26 @@ module FleetValidation
     end
 
     def build_required_paths
-      lifecycle = @manifest.fetch("lifecycle", {})
-      paths = lifecycle.fetch("required_paths", [])
-      unless paths.is_a?(Array) && paths.all? { |path| path.is_a?(Hash) && path["id"].to_s != "" }
-        raise ManifestError, "lifecycle.required_paths must contain mappings with IDs"
+      lifecycle = @manifest["lifecycle"]
+      paths = lifecycle["required_paths"] if lifecycle.is_a?(Hash)
+      unless paths.is_a?(Array) && !paths.empty?
+        raise ManifestError, "lifecycle.required_paths must be a nonempty array"
+      end
+
+      unless paths.all? do |path|
+        path.is_a?(Hash) && path["id"].to_s != "" && path["evidence_source"].to_s != ""
+      end
+        raise ManifestError, "lifecycle.required_paths must contain mappings with IDs and evidence sources"
+      end
+
+      duplicates = paths.map { |path| path.fetch("id") }.tally.select { |_id, count| count > 1 }.keys
+      unless duplicates.empty?
+        raise ManifestError, "lifecycle.required_paths IDs must be unique: #{duplicates.join(', ')}"
+      end
+
+      missing = REQUIRED_PATH_IDS - paths.map { |path| path.fetch("id") }
+      unless missing.empty?
+        raise ManifestError, "lifecycle.required_paths is missing required IDs: #{missing.join(', ')}"
       end
 
       paths.map(&:dup)
@@ -624,7 +661,8 @@ module FleetValidation
       result.concat(inventory_errors)
       result.concat(private_field_errors)
       result << "app work started before APP_WORK_ALLOWED" if app_work_started? && !app_work_allowed?
-      result << review_app_error if review_app_error
+      result.concat(review_app_errors)
+      result.concat(barrier_order_errors)
       result.concat(required_path_errors) if @closeout
       result.concat(blocker_owner_errors) if @closeout
       result.concat(blocker_reference_errors) if @closeout
@@ -663,12 +701,15 @@ module FleetValidation
     end
 
     def candidate_error
-      return unless @expected_candidate
+      expected = @expected_candidate
+      release_selector = @ledger.dig("pack", "release_selector")
+      expected ||= release_selector unless release_selector == "latest RC or beta"
+      return unless expected
 
       actual = @ledger.fetch("pack", {})["candidate"]
-      return if actual == @expected_candidate
+      return if actual == expected
 
-      "candidate mismatch: expected #{@expected_candidate}, got #{actual || 'missing'}"
+      "candidate mismatch: expected #{expected}, got #{actual || 'missing'}"
     end
 
     def capability_errors
@@ -713,18 +754,60 @@ module FleetValidation
       end
     end
 
-    def review_app_error
+    def review_app_errors
+      errors = []
       count = Array(@ledger["inventory"]).count do |item|
         item["work_state"] != "not_started" && item.dig("review_app", "state").to_s.casecmp("unknown").zero?
       end
-      return if count.zero?
+      errors << "review app capability UNKNOWN for #{count} started target(s)" unless count.zero?
+      return errors unless @closeout
 
-      "review app capability UNKNOWN for #{count} started target(s)"
+      Array(@ledger["inventory"]).each do |item|
+        review_app = item.fetch("review_app", {})
+        state = review_app["state"]
+        evidence = present?(review_app["evidence"])
+        passed = review_app["deployed_smoke"] == "passed" && evidence
+        blocked = review_app["deployed_smoke"] == "blocked" && evidence
+        waived = review_app["deployed_smoke"] == "waived" &&
+                 valid_waiver?(review_app["waiver"], "#{item['id']}:review_app")
+        terminal = case state
+                   when "not_configured"
+                     review_app["deployed_smoke"] == "waived" && evidence
+                   when "configured_runnable"
+                     passed || blocked || waived
+                   when "configured_broken"
+                     blocked
+                   end
+        errors << "target #{item['id']} review-app smoke is not terminal" unless terminal
+      end
+      errors
+    end
+
+    def barrier_order_errors
+      opened_at = timestamp(@ledger.dig("preflight", "opened_at"))
+      Array(@ledger["inventory"]).filter_map do |item|
+        next unless item["work_mode"] == "mutation" && item["work_state"] != "not_started"
+
+        started_at = timestamp(item["work_started_at"])
+        if !opened_at || !started_at
+          "target #{item['id']} is missing replayable barrier/work-start ordering evidence"
+        elsif started_at <= opened_at
+          "target #{item['id']} started before the preflight barrier opened"
+        end
+      end
     end
 
     def required_path_errors
       paths = Array(@ledger["required_paths"])
-      @required_paths.flat_map do |required|
+      errors = []
+      paths.filter_map { |path| path["id"] }.tally.each do |id, count|
+        errors << "required paths contain duplicate ID #{id}" if count > 1
+      end
+      expected_ids = @required_paths.map { |path| path.fetch("id") }
+      (paths.filter_map { |path| path["id"] } - expected_ids).uniq.each do |id|
+        errors << "required paths contain unexpected ID #{id}"
+      end
+      errors + @required_paths.flat_map do |required|
         path = paths.find { |item| item["id"] == required.fetch("id") }
         errors = []
         if path && path["evidence_source"] != required["evidence_source"]
@@ -786,12 +869,13 @@ module FleetValidation
 
         errors << "capability #{field} is not passed or explicitly waived"
       end
+      errors << "capability restart_handoff is missing" unless present?(capabilities["restart_handoff"])
       errors
     end
 
     def pack_identity_errors
       pack = @ledger.fetch("pack", {})
-      errors = %w[candidate candidate_commit policy_commit tracker_mode].filter_map do |field|
+      errors = %w[candidate candidate_commit policy_commit tracker_mode snapshot_fingerprint].filter_map do |field|
         "pack #{field} is missing" unless present?(pack[field])
       end
       %w[candidate_commit policy_commit].each do |field|
@@ -799,6 +883,19 @@ module FleetValidation
       end
       allowed_modes = %w[development accelerated-rc strict-rc final-release]
       errors << "pack tracker_mode is not allowed" unless allowed_modes.include?(pack["tracker_mode"])
+      expected_packages = @inventory.select { |target| target["tier"] == "hard_gate" }
+                                    .flat_map { |target| Array(target["packages"]) }
+                                    .map { |package| [package["ecosystem"], package["name"]] }
+                                    .uniq
+      resolved_packages = Array(pack["resolved_packages"])
+      actual_packages = resolved_packages.map { |package| [package["ecosystem"], package["name"]] }
+      if (expected_packages - actual_packages).any? ||
+         resolved_packages.any? { |package| !present?(package["version"]) || !present?(package["source"]) }
+        errors << "pack resolved package snapshot is incomplete"
+      end
+      if actual_packages.tally.any? { |_identity, count| count > 1 }
+        errors << "pack resolved package snapshot contains duplicate identities"
+      end
       if @expected_snapshot_fingerprint && pack["snapshot_fingerprint"] != @expected_snapshot_fingerprint
         errors << "pack snapshot_fingerprint does not match the current manifest"
       end
@@ -845,7 +942,7 @@ module FleetValidation
 
         actual = locks.map { |lock| [lock["ecosystem"], lock["name"]] }
         expected = expected_by_id.fetch(item["id"], []).map { |package| [package["ecosystem"], package["name"]] }
-        (expected - actual).any?
+        (expected - actual).any? || actual.tally.any? { |_identity, total| total > 1 }
       end
       return if count.zero?
 
@@ -854,18 +951,18 @@ module FleetValidation
 
     def package_version_error
       resolved = Array(@ledger.dig("pack", "resolved_packages")).to_h do |package|
-        [[package["ecosystem"], package["name"]], package["version"]]
+        [[package["ecosystem"], package["name"]], [package["version"], package["source"]]]
       end
       count = Array(@ledger["inventory"]).count do |item|
         next false unless item["tier"] == "hard_gate"
 
         Array(item["package_locks"]).any? do |lock|
-          resolved[[lock["ecosystem"], lock["name"]]] != lock["version"]
+          resolved[[lock["ecosystem"], lock["name"]]] != [lock["version"], lock["source"]]
         end
       end
       return if count.zero?
 
-      "#{count} hard-gate target(s) retain package versions outside the resolved release snapshot"
+      "#{count} hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
     end
 
     def check_evidence_error
@@ -935,6 +1032,10 @@ module FleetValidation
         end
         item.fetch("checks", {}).each do |name, check|
           references << ["check #{name}", check["blocker_id"]] if check["status"] == "blocked"
+        end
+        review_app = item.fetch("review_app", {})
+        if review_app["state"] == "configured_broken" || review_app["deployed_smoke"] == "blocked"
+          references << ["review app", review_app["blocker_id"]]
         end
         references.filter_map do |label, blocker_id|
           blocker = blockers[blocker_id]
@@ -1042,7 +1143,9 @@ module FleetValidation
     def app_work_allowed?
       preflight = @ledger.fetch("preflight", {})
       preflight["app_work_allowed"] == true &&
-        %w[passed waived].include?(preflight["status"]) && preflight_errors.empty?
+        timestamp(preflight["opened_at"]) &&
+        %w[passed waived].include?(preflight["status"]) &&
+        preflight_errors.empty? && pack_identity_errors.empty? && candidate_error.nil?
     end
 
     def valid_waiver?(waiver, expected_gate)
@@ -1054,6 +1157,12 @@ module FleetValidation
       gate.is_a?(Hash) && gate["status"] == "passed" && present?(gate["evidence"])
     end
 
+    def timestamp(value)
+      Time.iso8601(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+
     def release_blocked?
       hard_gate_blocked = Array(@ledger["inventory"]).any? do |item|
         next false unless item["tier"] == "hard_gate"
@@ -1061,7 +1170,9 @@ module FleetValidation
         top_level_blocked = !%w[passed waived].include?(item["result"]) || item["work_state"] == "blocked"
         check_blocked = item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" }
         candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
-        top_level_blocked || check_blocked || candidate_regression
+        review_app_blocked = item.dig("review_app", "state") == "configured_broken" ||
+                             item.dig("review_app", "deployed_smoke") == "blocked"
+        top_level_blocked || check_blocked || candidate_regression || review_app_blocked
       end
       required_path_blocked = @required_paths.any? do |required|
         path = Array(@ledger["required_paths"]).find { |item| item["id"] == required.fetch("id") }
@@ -1213,7 +1324,9 @@ module FleetValidation
         top_level_blocked = !%w[passed waived].include?(item["result"]) || item["work_state"] == "blocked"
         check_blocked = item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" }
         candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
-        top_level_blocked || check_blocked || candidate_regression
+        review_app_blocked = item.dig("review_app", "state") == "configured_broken" ||
+                             item.dig("review_app", "deployed_smoke") == "blocked"
+        top_level_blocked || check_blocked || candidate_regression || review_app_blocked
       end
       blocked ||= paths.any? { |path| !%w[passed waived].include?(path["status"]) }
       blocked ||= blockers.any? { |blocker| !%w[resolved waived deferred].include?(blocker["status"]) }
@@ -1224,7 +1337,9 @@ module FleetValidation
         target_waived = item["result"] == "waived"
         check_waived = item.fetch("checks", {}).values.any? { |check| check["status"] == "waived" }
         baseline_waived = item.dig("baseline", "classification") == "waived"
-        target_waived || check_waived || baseline_waived ||
+        review_app_waived = item.dig("review_app", "deployed_smoke") == "waived" &&
+                            item.dig("review_app", "state") != "not_configured"
+        target_waived || check_waived || baseline_waived || review_app_waived ||
           (item["tier"] == "soft_track" && item["result"] == "blocked")
       end
       partial ||= @ledger.dig("preflight", "status") == "waived"

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -758,6 +758,7 @@ module FleetValidation
       result.concat(capability_errors)
       result.concat(inventory_errors)
       result.concat(private_field_errors)
+      result.concat(disposition_state_errors)
       result << "app work started before APP_WORK_ALLOWED" if app_work_started? && !app_work_allowed?
       result.concat(review_app_errors)
       result.concat(barrier_order_errors)
@@ -868,6 +869,94 @@ module FleetValidation
           "blocker #{blocker['id'] || 'missing-id'} contains forbidden private field #{field}"
         end
       end
+    end
+
+    def disposition_state_errors
+      preflight = @ledger.fetch("preflight", {})
+      errors = []
+      preflight_conflict = case preflight["status"]
+                           when "waived"
+                             present?(preflight["blocker_id"]) || present?(preflight["blocker_evidence"])
+                           when "blocked"
+                             !preflight["waiver"].nil?
+                           else
+                             [
+                               !preflight["waiver"].nil?,
+                               present?(preflight["blocker_id"]),
+                               present?(preflight["blocker_evidence"])
+                             ].any?
+                           end
+      if preflight_conflict
+        errors << "#{preflight['status']} preflight retains disposition fields from another state"
+      end
+
+      Array(@ledger["inventory"]).each do |item|
+        result_blocker_allowed = item["result"] == "blocked" ||
+                                 item.dig("baseline", "classification") == "candidate_regression"
+        result_conflict = if item["result"] == "waived"
+                            present?(item["blocker_id"])
+                          elsif item["result"] == "blocked"
+                            !item["waiver"].nil?
+                          else
+                            !item["waiver"].nil? || (present?(item["blocker_id"]) && !result_blocker_allowed)
+                          end
+        if result_conflict
+          errors << "target result #{item['result']} retains disposition fields from another state"
+        end
+
+        baseline = item.fetch("baseline", {})
+        unless %w[waived baseline_defect].include?(baseline["classification"]) || baseline["waiver"].nil?
+          errors << "target baseline #{baseline['classification']} retains a waiver from another state"
+        end
+
+        item.fetch("checks", {}).each do |name, check|
+          conflict = case check["status"]
+                     when "waived"
+                       present?(check["blocker_id"])
+                     when "blocked"
+                       !check["waiver"].nil?
+                     else
+                       !check["waiver"].nil? || present?(check["blocker_id"])
+                     end
+          if conflict
+            errors << "target check #{name} #{check['status']} retains disposition fields from another state"
+          end
+        end
+
+        review_app = item.fetch("review_app", {})
+        review_conflict = case review_app["deployed_smoke"]
+                          when "waived"
+                            present?(review_app["blocker_id"])
+                          when "blocked"
+                            !review_app["waiver"].nil?
+                          else
+                            !review_app["waiver"].nil? || present?(review_app["blocker_id"])
+                          end
+        if review_conflict
+          errors << "target review-app #{review_app['deployed_smoke']} retains disposition fields from another state"
+        end
+      end
+
+      Array(@ledger["required_paths"]).each do |path|
+        conflict = case path["status"]
+                   when "waived"
+                     present?(path["blocker_id"])
+                   when "blocked"
+                     !path["waiver"].nil?
+                   else
+                     !path["waiver"].nil? || present?(path["blocker_id"])
+                   end
+        if conflict
+          errors << "required path #{path['status']} retains disposition fields from another state"
+        end
+      end
+
+      Array(@ledger["blockers"]).each do |blocker|
+        next if %w[waived deferred].include?(blocker["status"]) || blocker["disposition"].nil?
+
+        errors << "blocker #{blocker['id']} #{blocker['status']} status retains a waiver disposition"
+      end
+      errors
     end
 
     def review_app_errors
@@ -1139,16 +1228,19 @@ module FleetValidation
       resolved = Array(@ledger.dig("pack", "resolved_packages")).to_h do |package|
         [[package["ecosystem"], package["name"]], [package["version"], package["source"]]]
       end
-      count = Array(@ledger["inventory"]).count do |item|
-        next false unless item["tier"] == "hard_gate"
-
+      invalid_items = Array(@ledger["inventory"]).select do |item|
         Array(item["package_locks"]).any? do |lock|
           resolved[[lock["ecosystem"], lock["name"]]] != [lock["version"], lock["source"]]
         end
       end
-      return if count.zero?
+      return if invalid_items.empty?
 
-      "#{count} hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
+      hard_gate_count = invalid_items.count { |item| item["tier"] == "hard_gate" }
+      if hard_gate_count.positive?
+        "#{hard_gate_count} hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
+      else
+        "#{invalid_items.length} report-only target(s) retain package versions or sources outside the resolved release snapshot"
+      end
     end
 
     def check_evidence_errors
@@ -1223,6 +1315,9 @@ module FleetValidation
         end
       else
         errors << "independent audit maker identities are missing" if audit_maker_ids.empty?
+        if audit_maker_ids.length != audit_maker_ids.uniq.length
+          errors << "independent audit maker identities must be unique"
+        end
         if raw_mutable_maker_ids.any? { |maker_id| !present?(maker_id) } ||
            audit_maker_ids.any? { |maker_id| !present?(maker_id) }
           errors << "independent audit maker identities contain blank values"
@@ -1252,6 +1347,9 @@ module FleetValidation
         if commit_identity?(bases["audit"]) && commit_identity?(bases["reviewed"]) &&
            bases["audit"] != bases["reviewed"]
           errors << "target #{item['id']} audit base does not match reviewed base"
+        end
+        unless bases["reconciliation"] == "passed"
+          errors << "target #{item['id']} base reconciliation is not passed"
         end
       end
       errors
@@ -1352,9 +1450,13 @@ module FleetValidation
       Array(@ledger["inventory"]).flat_map do |item|
         merge = item.fetch("merge", {})
         if item["work_mode"] != "mutation"
-          next [] if merge["status"] == "not_applicable"
-
-          next ["target #{item['id']} must mark merge not_applicable"]
+          errors = []
+          errors << "target #{item['id']} must mark merge not_applicable" unless merge["status"] == "not_applicable"
+          if merge["authority"] != "none" || present?(merge["authority_evidence"]) ||
+             present?(merge["merge_commit"])
+            errors << "target #{item['id']} not-applicable merge retains mutation state"
+          end
+          next errors
         end
 
         errors = []
@@ -1370,6 +1472,13 @@ module FleetValidation
           errors << "target #{item['id']} merge evidence is missing" unless present?(merge["evidence"])
         elsif merge["status"] == "blocked"
           errors << "target #{item['id']} blocked merge disposition has no evidence" unless present?(merge["evidence"])
+          if present?(merge["merge_commit"])
+            errors << "target #{item['id']} blocked merge retains a merge commit"
+          end
+          reachability = item.fetch("reachability", {})
+          if reachability["default_branch"] == "passed" || reachability["tree_parity"] == "passed"
+            errors << "target #{item['id']} blocked merge retains successful reachability"
+          end
         end
         if !release_blocked? && merge["status"] != "merged"
           errors << "target #{item['id']} merge is incomplete for a promotable release"

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -39,9 +39,9 @@ module FleetValidation
         "preflight" => {
           "status" => "pending",
           "waiver" => nil,
-          "release_ci" => "pending",
-          "artifacts" => "pending",
-          "generator_matrix" => "pending",
+          "release_ci" => { "status" => "pending", "evidence" => nil },
+          "artifacts" => { "status" => "pending", "evidence" => nil },
+          "generator_matrix" => { "status" => "pending", "evidence" => nil },
           "capabilities" => {
             "status" => "pending",
             "permissions" => "pending",
@@ -59,12 +59,19 @@ module FleetValidation
             "work_state" => "not_started",
             "result" => "pending",
             "waiver" => nil,
+            "blocker_id" => nil,
             "package_locks" => [],
             "checks" => %w[install build test local_smoke hosted_ci review].to_h do |check|
-              [check, { "status" => "pending", "evidence" => nil, "waiver" => nil }]
+              [check, { "status" => "pending", "evidence" => nil, "waiver" => nil, "blocker_id" => nil }]
             end,
             "review_app" => { "state" => "unknown", "evidence" => nil, "deployed_smoke" => "pending" },
             "baseline" => { "classification" => "pending", "evidence" => nil },
+            "bases" => {
+              "audit" => nil,
+              "reviewed" => nil,
+              "current" => nil,
+              "reconciliation" => "pending"
+            },
             "evidence" => nil
           )
         end,
@@ -161,7 +168,8 @@ module FleetValidation
           "name" => repo.fetch("name"),
           "headline" => repo.fetch("headline"),
           "tier" => tier,
-          "work_mode" => tier == "soft_track" ? "report_only" : "mutation"
+          "work_mode" => tier == "soft_track" ? "report_only" : "mutation",
+          "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
         }
       end
     end
@@ -175,9 +183,9 @@ module FleetValidation
         {
           "status" => { "enum" => %w[pending passed waived blocked unknown] },
           "waiver" => waiver_schema,
-          "release_ci" => status_string,
-          "artifacts" => status_string,
-          "generator_matrix" => status_string,
+          "release_ci" => preflight_gate_schema,
+          "artifacts" => preflight_gate_schema,
+          "generator_matrix" => preflight_gate_schema,
           "capabilities" => object_schema(
             %w[
               status permissions git_auth github_auth registry_network toolchains host_capacity
@@ -202,7 +210,7 @@ module FleetValidation
     def inventory_item_schema
       object_schema(
         %w[
-          id tier work_mode work_state result waiver package_locks checks review_app baseline evidence
+          id tier work_mode work_state result waiver blocker_id package_locks checks review_app baseline bases evidence
         ],
         {
           "id" => nonempty_string,
@@ -211,6 +219,7 @@ module FleetValidation
           "work_state" => { "enum" => %w[not_started running finished blocked unknown] },
           "result" => { "enum" => %w[pending passed reported blocked waived unknown] },
           "waiver" => waiver_schema,
+          "blocker_id" => nullable_string,
           "package_locks" => {
             "type" => "array",
             "items" => object_schema(
@@ -246,6 +255,15 @@ module FleetValidation
                 "enum" => %w[pending clean baseline_defect candidate_regression waived unknown]
               },
               "evidence" => nullable_string
+            }
+          ),
+          "bases" => object_schema(
+            %w[audit reviewed current reconciliation],
+            {
+              "audit" => nullable_string,
+              "reviewed" => nullable_string,
+              "current" => nullable_string,
+              "reconciliation" => status_string
             }
           ),
           "evidence" => nullable_string
@@ -342,11 +360,22 @@ module FleetValidation
 
     def evidence_status_schema
       object_schema(
-        %w[status evidence waiver],
+        %w[status evidence waiver blocker_id],
         {
           "status" => status_string,
           "evidence" => nullable_string,
-          "waiver" => waiver_schema
+          "waiver" => waiver_schema,
+          "blocker_id" => nullable_string
+        }
+      )
+    end
+
+    def preflight_gate_schema
+      object_schema(
+        %w[status evidence],
+        {
+          "status" => status_string,
+          "evidence" => nullable_string
         }
       )
     end
@@ -407,6 +436,8 @@ module FleetValidation
         - registry and tarball artifacts are coherent with that commit; and
         - the published standard / Pro / Pro+RSC generator matrix is green.
 
+        Each gate records both a terminal status and public-safe replayable evidence. A bare `passed`
+        status never opens the barrier. Published-artifact defects are non-waivable and must be republished.
         An explicit public-safe waiver may replace a failed gate only when the release policy allows
         it and the ledger records the authority and evidence URL. Missing, pending, conflicting, stale,
         or `UNKNOWN` evidence does not open the barrier.
@@ -499,6 +530,7 @@ module FleetValidation
       result << review_app_error if review_app_error
       result.concat(required_path_errors) if @closeout
       result.concat(blocker_owner_errors) if @closeout
+      result.concat(blocker_reference_errors) if @closeout
       result.concat(preflight_errors) if @closeout
       result.concat(pack_identity_errors) if @closeout
       result << inventory_completion_error if @closeout && inventory_completion_error
@@ -611,10 +643,17 @@ module FleetValidation
 
     def base_movement_error
       merge = @ledger.fetch("merge", {})
-      reviewed = merge["reviewed_base_commit"]
-      current = merge["current_base_commit"]
-      return unless present?(reviewed) && present?(current) && reviewed != current
-      return if merge["base_reconciliation"] == "passed"
+      moved = Array(@ledger["inventory"]).any? do |item|
+        next false unless item["tier"] == "hard_gate"
+
+        bases = item.fetch("bases", {})
+        present?(bases["reviewed"]) && present?(bases["current"]) &&
+          bases["reviewed"] != bases["current"] && bases["reconciliation"] != "passed"
+      end
+      moved ||= present?(merge["reviewed_base_commit"]) && present?(merge["current_base_commit"]) &&
+                merge["reviewed_base_commit"] != merge["current_base_commit"] &&
+                merge["base_reconciliation"] != "passed"
+      return unless moved
 
       "base moved after audit without passing reconciliation"
     end
@@ -623,11 +662,11 @@ module FleetValidation
       preflight = @ledger.fetch("preflight", {})
       waiver = preflight["status"] == "waived" ? preflight["waiver"] : nil
       errors = %w[release_ci generator_matrix].filter_map do |field|
-        next if preflight[field] == "passed" || valid_waiver?(waiver, field)
+        next if preflight_gate_passed?(preflight[field]) || valid_waiver?(waiver, field)
 
         "release-wide preflight #{field} is not passed or explicitly waived"
       end
-      unless preflight["artifacts"] == "passed"
+      unless preflight_gate_passed?(preflight["artifacts"])
         message = if valid_waiver?(waiver, "artifacts")
                     "release-wide preflight artifacts must pass and cannot be waived"
                   else
@@ -655,7 +694,9 @@ module FleetValidation
       count = Array(@ledger["inventory"]).count do |item|
         terminal_results = item["tier"] == "hard_gate" ? %w[passed blocked waived] : %w[reported blocked waived]
         baseline = item.dig("baseline", "classification")
-        !terminal_results.include?(item["result"]) || %w[pending unknown].include?(baseline)
+        !terminal_results.include?(item["result"]) || %w[pending unknown].include?(baseline) ||
+          !%w[finished blocked].include?(item["work_state"]) || !present?(item["evidence"]) ||
+          !present?(item.dig("baseline", "evidence"))
       end
       return if count.zero?
 
@@ -663,13 +704,19 @@ module FleetValidation
     end
 
     def package_lock_error
+      expected_by_id = @inventory.to_h { |target| [target.fetch("id"), Array(target["packages"])] }
       count = Array(@ledger["inventory"]).count do |item|
         next false unless item["tier"] == "hard_gate"
 
         locks = item["package_locks"]
-        !locks.is_a?(Array) || locks.empty? || locks.any? do |lock|
+        malformed = !locks.is_a?(Array) || locks.empty? || locks.any? do |lock|
           %w[ecosystem name version source].any? { |field| !present?(lock[field]) }
         end
+        next true if malformed
+
+        actual = locks.map { |lock| [lock["ecosystem"], lock["name"]] }
+        expected = expected_by_id.fetch(item["id"], []).map { |package| [package["ecosystem"], package["name"]] }
+        (expected - actual).any?
       end
       return if count.zero?
 
@@ -711,7 +758,34 @@ module FleetValidation
       %w[reviewed_base_commit current_base_commit].each do |field|
         errors << "merge #{field} is missing" unless present?(merge[field])
       end
+      Array(@ledger["inventory"]).each do |item|
+        next unless item["tier"] == "hard_gate"
+
+        bases = item.fetch("bases", {})
+        %w[audit reviewed current].each do |field|
+          errors << "target #{item['id']} #{field} base is missing" unless present?(bases[field])
+        end
+      end
       errors
+    end
+
+    def blocker_reference_errors
+      blockers = Array(@ledger["blockers"]).to_h { |blocker| [blocker["id"], blocker] }
+      Array(@ledger["inventory"]).flat_map do |item|
+        references = []
+        if item["result"] == "blocked" || item.dig("baseline", "classification") == "candidate_regression"
+          references << ["result", item["blocker_id"]]
+        end
+        item.fetch("checks", {}).each do |name, check|
+          references << ["check #{name}", check["blocker_id"]] if check["status"] == "blocked"
+        end
+        references.filter_map do |label, blocker_id|
+          blocker = blockers[blocker_id]
+          next if blocker && durable_owner?(blocker["owner"])
+
+          "target #{item['id']} blocked #{label} has no owned blocker reference"
+        end
+      end
     end
 
     def waiver_evidence_errors
@@ -739,7 +813,7 @@ module FleetValidation
 
     def merge_authority_error
       merge = @ledger.fetch("merge", {})
-      return unless merge["status"] == "merged"
+      return "closeout merge status is not merged" unless merge["status"] == "merged"
 
       authorized = %w[ask auto_merge_when_gates_pass].include?(merge["authority"])
       conflict = merge["freeze_state"] != "clear" || @ledger.dig("pack", "tracker_mode") == "conflict"
@@ -780,6 +854,10 @@ module FleetValidation
     def valid_waiver?(waiver, expected_gate)
       waiver.is_a?(Hash) && waiver["gate"] == expected_gate &&
         %w[authority evidence_url reason].all? { |field| present?(waiver[field]) }
+    end
+
+    def preflight_gate_passed?(gate)
+      gate.is_a?(Hash) && gate["status"] == "passed" && present?(gate["evidence"])
     end
 
     def release_blocked?

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -623,7 +623,9 @@ module FleetValidation
         semantics. A promotion recommendation is allowed only when every required release path is green
         or explicitly waived and no `UNKNOWN` remains. A failed required path closes as `BLOCKED` only
         when it records its lane, failure evidence, and an owned `blocker_id`. Waived or deferred
-        blockers require structured gate, authority, evidence URL, and reason fields.
+        blockers retain a durable owner and require structured gate, authority, evidence URL, and
+        reason fields. If any lane has already merged, its base, authority/freeze, reachability, and
+        tree-parity proofs remain required even when another lane blocks overall promotion.
       MARKDOWN
     end
 
@@ -703,16 +705,17 @@ module FleetValidation
       result << package_version_error if @closeout && package_version_error
       result << check_evidence_error if @closeout && check_evidence_error
       result.concat(waiver_evidence_errors) if @closeout
-      result.concat(base_identity_errors) if @closeout && merge_eligible?
-      result << base_movement_error if @closeout && merge_eligible? && base_movement_error
+      recorded_merge = @ledger.dig("merge", "status") == "merged"
+      merge_proofs_required = merge_eligible? || recorded_merge
+      result.concat(base_identity_errors) if @closeout && merge_proofs_required
+      result << base_movement_error if @closeout && merge_proofs_required && base_movement_error
       result.concat(independent_audit_errors) if @closeout
       result << "independent audit is not passed" if @closeout && @ledger.dig("audit", "status") != "passed"
       if @closeout && !present?(@ledger.dig("preflight", "capabilities", "restart_handoff"))
         result << "capability restart_handoff is missing"
       end
-      result.concat(reachability_errors) if @closeout && merge_eligible?
+      result.concat(reachability_errors) if @closeout && merge_proofs_required
       result.concat(tracker_errors) if @closeout
-      recorded_merge = @ledger.dig("merge", "status") == "merged"
       if @closeout && (merge_eligible? || recorded_merge) && merge_authority_error
         result << merge_authority_error
       end
@@ -732,15 +735,15 @@ module FleetValidation
     end
 
     def candidate_error
-      expected = @expected_candidate
       release_selector = @ledger.dig("pack", "release_selector")
-      expected ||= release_selector unless release_selector == "latest RC or beta"
-      return unless expected
-
       actual = @ledger.fetch("pack", {})["candidate"]
-      return if actual == expected
+      if release_selector != "latest RC or beta" && actual != release_selector
+        return "candidate mismatch: pinned selector #{release_selector}, got #{actual || 'missing'}"
+      end
+      return unless @expected_candidate
+      return if actual == @expected_candidate
 
-      "candidate mismatch: expected #{expected}, got #{actual || 'missing'}"
+      "candidate mismatch: expected #{@expected_candidate}, got #{actual || 'missing'}"
     end
 
     def capability_errors
@@ -817,7 +820,7 @@ module FleetValidation
     def barrier_order_errors
       opened_at = timestamp(@ledger.dig("preflight", "opened_at"))
       Array(@ledger["inventory"]).filter_map do |item|
-        next unless item["work_mode"] == "mutation" && item["work_state"] != "not_started"
+        next if item["work_mode"] == "validation_only" || item["work_state"] == "not_started"
 
         started_at = timestamp(item["work_started_at"])
         if !opened_at || !started_at
@@ -853,17 +856,19 @@ module FleetValidation
     end
 
     def blocker_owner_errors
-      Array(@ledger["blockers"]).filter_map do |blocker|
+      Array(@ledger["blockers"]).flat_map do |blocker|
         status = blocker["status"]
-        if %w[waived deferred].include?(status)
-          next if valid_waiver?(blocker["disposition"], blocker["id"])
-
-          next "blocker #{blocker['id'] || 'missing-id'} is missing structured #{status} disposition evidence"
+        errors = []
+        if %w[waived deferred].include?(status) &&
+           !valid_waiver?(blocker["disposition"], blocker["id"])
+          errors << "blocker #{blocker['id'] || 'missing-id'} " \
+                    "is missing structured #{status} disposition evidence"
         end
-        next if status == "resolved"
-        next if durable_owner?(blocker["owner"])
+        if status != "resolved" && !durable_owner?(blocker["owner"])
+          errors << "blocker #{blocker['id'] || 'missing-id'} has no durable owner"
+        end
 
-        "blocker #{blocker['id'] || 'missing-id'} has no durable owner"
+        errors
       end
     end
 

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -21,7 +21,7 @@ module FleetValidation
       File.write(File.join(output_dir, "PREFLIGHT.md"), render_preflight)
       File.write(File.join(output_dir, "REPORT-ONLY.md"), render_report_only)
       File.write(File.join(output_dir, "CLOSEOUT.md"), render_closeout)
-      File.write(File.join(output_dir, "result-ledger.json"), "#{JSON.pretty_generate(ledger_template)}\n")
+      write_ledger(File.join(output_dir, "result-ledger.json"))
       File.write(File.join(output_dir, "result-ledger.schema.json"), "#{JSON.pretty_generate(schema)}\n")
     end
 
@@ -71,6 +71,14 @@ module FleetValidation
               "reviewed" => nil,
               "current" => nil,
               "reconciliation" => "pending"
+            },
+            "reachability" => {
+              "default_branch" => "pending",
+              "default_commit" => nil,
+              "default_evidence" => nil,
+              "tree_parity" => "pending",
+              "tree" => nil,
+              "tree_evidence" => nil
             },
             "evidence" => nil
           )
@@ -130,7 +138,10 @@ module FleetValidation
               "candidate" => nullable_string,
               "candidate_commit" => nullable_string,
               "policy_commit" => nullable_string,
-              "tracker_mode" => nullable_string
+              "tracker_mode" => {
+                "type" => %w[string null],
+                "enum" => [nil, "development", "accelerated-rc", "strict-rc", "final-release"]
+              }
             }
           ),
           "preflight" => preflight_schema,
@@ -159,6 +170,17 @@ module FleetValidation
     end
 
     private
+
+    def write_ledger(path)
+      if File.exist?(path)
+        existing = JSON.parse(File.read(path))
+        return if existing.dig("pack", "pack_id") == @pack_id
+      end
+
+      File.write(path, "#{JSON.pretty_generate(ledger_template)}\n")
+    rescue JSON::ParserError => e
+      raise ManifestError, "existing result ledger is invalid JSON: #{e.message}"
+    end
 
     def build_inventory
       @manifest.fetch("repos").map do |repo|
@@ -210,7 +232,7 @@ module FleetValidation
     def inventory_item_schema
       object_schema(
         %w[
-          id tier work_mode work_state result waiver blocker_id package_locks checks review_app baseline bases evidence
+          id tier work_mode work_state result waiver blocker_id package_locks checks review_app baseline bases reachability evidence
         ],
         {
           "id" => nonempty_string,
@@ -264,6 +286,17 @@ module FleetValidation
               "reviewed" => nullable_string,
               "current" => nullable_string,
               "reconciliation" => status_string
+            }
+          ),
+          "reachability" => object_schema(
+            %w[default_branch default_commit default_evidence tree_parity tree tree_evidence],
+            {
+              "default_branch" => status_string,
+              "default_commit" => nullable_string,
+              "default_evidence" => nullable_string,
+              "tree_parity" => status_string,
+              "tree" => nullable_string,
+              "tree_evidence" => nullable_string
             }
           ),
           "evidence" => nullable_string
@@ -545,6 +578,7 @@ module FleetValidation
         result << "capability restart_handoff is missing"
       end
       result.concat(reachability_errors) if @closeout
+      result.concat(tracker_errors) if @closeout
       result << merge_authority_error if @closeout && merge_authority_error
       result << promotion_error if @closeout && promotion_error
       if @closeout && @ledger.dig("merge", "status") == "merged" &&
@@ -685,9 +719,15 @@ module FleetValidation
 
     def pack_identity_errors
       pack = @ledger.fetch("pack", {})
-      %w[candidate candidate_commit policy_commit tracker_mode].filter_map do |field|
+      errors = %w[candidate candidate_commit policy_commit tracker_mode].filter_map do |field|
         "pack #{field} is missing" unless present?(pack[field])
       end
+      %w[candidate_commit policy_commit].each do |field|
+        errors << "pack #{field} is not an exact commit identity" unless commit_identity?(pack[field])
+      end
+      allowed_modes = %w[development accelerated-rc strict-rc final-release]
+      errors << "pack tracker_mode is not allowed" unless allowed_modes.include?(pack["tracker_mode"])
+      errors
     end
 
     def inventory_completion_error
@@ -806,9 +846,33 @@ module FleetValidation
 
     def reachability_errors
       reachability = @ledger.fetch("reachability", {})
-      %w[default_branch tree_parity].filter_map do |field|
+      errors = %w[default_branch tree_parity].filter_map do |field|
         "reachability #{field} is not passed" unless reachability[field] == "passed"
       end
+      Array(@ledger["inventory"]).each do |item|
+        next unless item["tier"] == "hard_gate"
+
+        target = item.fetch("reachability", {})
+        unless target["default_branch"] == "passed" && commit_identity?(target["default_commit"]) &&
+               present?(target["default_evidence"])
+          errors << "target #{item['id']} default-branch reachability evidence is incomplete"
+        end
+        unless target["tree_parity"] == "passed" && commit_identity?(target["tree"]) &&
+               present?(target["tree_evidence"])
+          errors << "target #{item['id']} tree-parity evidence is incomplete"
+        end
+      end
+      errors
+    end
+
+    def tracker_errors
+      tracker = @ledger.fetch("tracker", {})
+      errors = []
+      errors << "tracker closeout status is not ready or posted" unless %w[ready posted].include?(tracker["status"])
+      if tracker["status"] == "posted" && !present?(tracker["comment_url"])
+        errors << "posted tracker closeout is missing comment_url"
+      end
+      errors
     end
 
     def merge_authority_error
@@ -844,6 +908,10 @@ module FleetValidation
 
     def present?(value)
       !value.nil? && !value.to_s.empty?
+    end
+
+    def commit_identity?(value)
+      value.to_s.match?(/\A[0-9a-f]{7,40}\z/i)
     end
 
     def app_work_allowed?
@@ -1026,7 +1094,13 @@ module FleetValidation
       return "BLOCKED" if blocked
 
       partial = inventory.any? do |item|
-        item["result"] == "waived" || (item["tier"] == "soft_track" && item["result"] == "blocked")
+        target_waived = item["result"] == "waived"
+        check_waived = item.fetch("checks", {}).values.any? { |check| check["status"] == "waived" }
+        target_waived || check_waived || (item["tier"] == "soft_track" && item["result"] == "blocked")
+      end
+      partial ||= @ledger.dig("preflight", "status") == "waived"
+      partial ||= %w[release_ci artifacts generator_matrix].any? do |gate|
+        @ledger.dig("preflight", gate, "status") == "waived"
       end
       partial ||= paths.any? { |path| path["status"] == "waived" }
       partial ||= blockers.any? { |blocker| %w[waived deferred].include?(blocker["status"]) }

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -627,6 +627,12 @@ module FleetValidation
         `preflight.app_work_allowed` to `true`; that schema-validated state is the ledger's explicit
         `APP_WORK_ALLOWED` marker. Every mutable target records `work_started_at`, which must be later
         than the barrier time. The validation-only monorepo generator gate may run before this marker.
+        Before any remote maker starts, publish a public-safe tracker comment marked
+        `<!-- fleet-validation-preflight:#{@pack_id} -->`. It must bind `APP_WORK_ALLOWED` to the exact
+        candidate tag and commit, snapshot fingerprint `#{snapshot_fingerprint}`, `preflight.opened_at`,
+        and terminal status plus replayable evidence for release CI, artifacts, and generator matrix.
+        Remote coordinators cross-check that unique marker against the published pack snapshot; an
+        absent, duplicate, stale, malformed, or mismatched marker leaves the barrier `UNKNOWN`.
         If an owned release-wide blocker makes opening the barrier impossible, close the pack with
         `preflight.status: blocked`, a durable `preflight.blocker_id`, public-safe
         `preflight.blocker_evidence`, and `APP_WORK_ALLOWED` still false. In that terminal path every
@@ -772,6 +778,7 @@ module FleetValidation
       result << "app work started before APP_WORK_ALLOWED" if app_work_started? && !app_work_allowed?
       result.concat(review_app_errors)
       result.concat(barrier_order_errors)
+      result << product_candidate_version_error if @closeout && product_candidate_version_error
       if @closeout && preflight_blocked?
         result.concat(blocker_identity_errors)
         result.concat(blocker_owner_errors)
@@ -793,7 +800,6 @@ module FleetValidation
       result.concat(blocker_reference_errors) if @closeout
       result.concat(preflight_errors) if @closeout
       result.concat(pack_identity_errors) if @closeout
-      result << product_candidate_version_error if @closeout && product_candidate_version_error
       result << inventory_completion_error if @closeout && inventory_completion_error
       result << work_state_result_error if @closeout && work_state_result_error
       result << package_lock_error if @closeout && package_lock_error
@@ -1616,6 +1622,9 @@ module FleetValidation
         end
         if merge["status"] == "merged"
           authorized = %w[ask auto_merge_when_gates_pass].include?(merge["authority"])
+          if target_blocked_gate?(item)
+            errors << "target #{item['id']} merged despite its own blocked gate outcome"
+          end
           errors << "target #{item['id']} merged without explicit authority" unless authorized
           errors << "target #{item['id']} merged without authority evidence" unless present?(merge["authority_evidence"])
           errors << "target #{item['id']} merged during a freeze or phase conflict" unless merge["freeze_state"] == "clear"
@@ -1636,6 +1645,15 @@ module FleetValidation
         end
         errors
       end
+    end
+
+    def target_blocked_gate?(item)
+      review_app = item.fetch("review_app", {})
+      item["result"] == "blocked" ||
+        item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" } ||
+        item.dig("baseline", "classification") == "candidate_regression" ||
+        review_app["state"] == "configured_broken" ||
+        review_app["deployed_smoke"] == "blocked"
     end
 
     def aggregate_state_errors

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -659,8 +659,9 @@ module FleetValidation
         If an owned release-wide blocker makes opening the barrier impossible, close the pack with
         `preflight.status: blocked`, a durable `preflight.blocker_id`, public-safe
         `preflight.blocker_evidence`, and `APP_WORK_ALLOWED` still false. In that terminal path every
-        app target remains untouched, the independent audit records no maker IDs, and aggregate
-        merge/reachability plus tracker promotion remain blocked.
+        app target remains untouched, although it may retain read-only package-lock probe evidence.
+        The independent audit records no maker IDs, and aggregate merge/reachability plus tracker
+        promotion remain blocked.
 
         Before worker launch, record a machine/session capability attestation covering
         nonblocking permissions, Git and GitHub authentication, registry/network access, required toolchains,
@@ -717,7 +718,8 @@ module FleetValidation
         default, then prove default-branch reachability and tree parity against the audited result.
         A squash merge need not retain the maker head commit, but its resulting tree must contain the
         audited patch. The validation-only generator/install gate creates no branch and is therefore
-        excluded from per-target merge-base, reachability, and tree-parity evidence.
+        excluded from per-target merge-base, reachability, and tree-parity evidence, but its exact
+        audited revision must equal the pack's candidate commit.
 
         Validate the final ledger, regenerate the append-only tracker matrix from that exact file, and
         post it without hand-copying worker prose. End with exact `PASS`, `PARTIAL`, or `BLOCKED`
@@ -742,9 +744,12 @@ module FleetValidation
       end
 
       unless paths.all? do |path|
-        path.is_a?(Hash) && path["id"].to_s != "" && path["evidence_source"].to_s != ""
+        path.is_a?(Hash) && %w[id evidence_source].all? do |field|
+          path[field].is_a?(String) && !path[field].strip.empty?
+        end
       end
-        raise ManifestError, "lifecycle.required_paths must contain mappings with IDs and evidence sources"
+        raise ManifestError,
+              "lifecycle.required_paths must contain mappings with string IDs and evidence sources"
       end
 
       duplicates = paths.map { |path| path.fetch("id") }.tally.select { |_id, count| count > 1 }.keys
@@ -1050,7 +1055,7 @@ module FleetValidation
         end
         untouched = item["work_state"] == "not_started" && !present?(item["work_started_at"]) &&
                     !present?(item["maker_id"]) && item["result"] == "pending" &&
-                    Array(item["package_locks"]).empty? && untouched_checks && !present?(item["evidence"])
+                    untouched_checks && !present?(item["evidence"])
         unless untouched
           item_errors << "blocked preflight target #{item['id']} contains app-work state"
         end
@@ -1093,6 +1098,8 @@ module FleetValidation
              revisions["reconciliation"] == "passed"
         errors << "blocked preflight validation-only target #{item['id']} has incomplete revision evidence"
       end
+      candidate_revision_error = validation_only_candidate_revision_error(item, current_head)
+      errors << candidate_revision_error if candidate_revision_error
 
       expected = @inventory.find { |target| target["id"] == item["id"] }
       expected_packages = Array(expected&.fetch("packages", [])).map do |package|
@@ -1472,6 +1479,8 @@ module FleetValidation
           errors << "target #{item['id']} current revision does not match reviewed revision"
         end
         errors << "target #{item['id']} revision reconciliation is not passed" unless revisions["reconciliation"] == "passed"
+        candidate_revision_error = validation_only_candidate_revision_error(item, revisions["current"])
+        errors << candidate_revision_error if candidate_revision_error
 
         review_app = item.fetch("review_app", {})
         if !commit_identity?(review_app["head_commit"]) || review_app["head_commit"] != revisions["current"]
@@ -1755,6 +1764,15 @@ module FleetValidation
 
     def commit_identity?(value)
       value.to_s.match?(/\A[0-9a-f]{40}\z/i)
+    end
+
+    def validation_only_candidate_revision_error(item, revision)
+      candidate_commit = @ledger.dig("pack", "candidate_commit")
+      return unless item["work_mode"] == "validation_only"
+      return unless commit_identity?(revision) && commit_identity?(candidate_commit)
+      return if revision == candidate_commit
+
+      "validation-only target revision does not match the candidate commit"
     end
 
     def app_work_allowed?

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
 require "json"
+require "digest"
 
 module FleetValidation
   class ManifestError < StandardError; end
 
   class Lifecycle
+    CORE_INVENTORY_TARGET = {
+      "id" => "react-on-rails-generator-install-smoke",
+      "name" => "react_on_rails generator/install smoke",
+      "headline" => "Monorepo generator and install smoke",
+      "tier" => "hard_gate",
+      "work_mode" => "mutation",
+      "packages" => [
+        { "ecosystem" => "gem", "name" => "react_on_rails" },
+        { "ecosystem" => "npm", "name" => "react-on-rails" }
+      ]
+    }.freeze
+
     attr_reader :inventory, :required_paths
 
     def initialize(manifest:, pack_id:, release_selector:)
@@ -31,10 +44,12 @@ module FleetValidation
         "pack" => {
           "pack_id" => @pack_id,
           "release_selector" => @release_selector,
+          "snapshot_fingerprint" => snapshot_fingerprint,
           "candidate" => nil,
           "candidate_commit" => nil,
           "policy_commit" => nil,
-          "tracker_mode" => nil
+          "tracker_mode" => nil,
+          "resolved_packages" => []
         },
         "preflight" => {
           "status" => "pending",
@@ -65,7 +80,7 @@ module FleetValidation
               [check, { "status" => "pending", "evidence" => nil, "waiver" => nil, "blocker_id" => nil }]
             end,
             "review_app" => { "state" => "unknown", "evidence" => nil, "deployed_smoke" => "pending" },
-            "baseline" => { "classification" => "pending", "evidence" => nil },
+            "baseline" => { "classification" => "pending", "evidence" => nil, "waiver" => nil },
             "bases" => {
               "audit" => nil,
               "reviewed" => nil,
@@ -131,17 +146,22 @@ module FleetValidation
         "properties" => {
           "schema_version" => { "const" => 1 },
           "pack" => object_schema(
-            %w[pack_id release_selector candidate candidate_commit policy_commit tracker_mode],
+            %w[
+              pack_id release_selector snapshot_fingerprint candidate candidate_commit policy_commit
+              tracker_mode resolved_packages
+            ],
             {
               "pack_id" => nonempty_string,
               "release_selector" => nonempty_string,
+              "snapshot_fingerprint" => nonempty_string,
               "candidate" => nullable_string,
               "candidate_commit" => nullable_string,
               "policy_commit" => nullable_string,
               "tracker_mode" => {
                 "type" => %w[string null],
                 "enum" => [nil, "development", "accelerated-rc", "strict-rc", "final-release"]
-              }
+              },
+              "resolved_packages" => { "type" => "array", "items" => package_lock_schema }
             }
           ),
           "preflight" => preflight_schema,
@@ -174,7 +194,14 @@ module FleetValidation
     def write_ledger(path)
       if File.exist?(path)
         existing = JSON.parse(File.read(path))
-        return if existing.dig("pack", "pack_id") == @pack_id
+        existing_pack = existing.fetch("pack", {})
+        if existing_pack["pack_id"] == @pack_id
+          same_snapshot = existing_pack["release_selector"] == @release_selector &&
+                          existing_pack["snapshot_fingerprint"] == snapshot_fingerprint
+          return if same_snapshot
+
+          raise ManifestError, "existing result ledger belongs to a different release snapshot"
+        end
       end
 
       File.write(path, "#{JSON.pretty_generate(ledger_template)}\n")
@@ -183,7 +210,7 @@ module FleetValidation
     end
 
     def build_inventory
-      @manifest.fetch("repos").map do |repo|
+      [CORE_INVENTORY_TARGET] + @manifest.fetch("repos").map do |repo|
         tier = repo.fetch("tier")
         {
           "id" => slug(repo.fetch("name")),
@@ -271,12 +298,13 @@ module FleetValidation
             }
           ),
           "baseline" => object_schema(
-            %w[classification evidence],
+            %w[classification evidence waiver],
             {
               "classification" => {
                 "enum" => %w[pending clean baseline_defect candidate_regression waived unknown]
               },
-              "evidence" => nullable_string
+              "evidence" => nullable_string,
+              "waiver" => waiver_schema
             }
           ),
           "bases" => object_schema(
@@ -417,6 +445,18 @@ module FleetValidation
       { "type" => "string", "minLength" => 1 }
     end
 
+    def package_lock_schema
+      object_schema(
+        %w[ecosystem name version source],
+        {
+          "ecosystem" => { "enum" => %w[gem npm] },
+          "name" => nonempty_string,
+          "version" => nonempty_string,
+          "source" => nonempty_string
+        }
+      )
+    end
+
     def nullable_string
       { "type" => %w[string null] }
     end
@@ -541,6 +581,15 @@ module FleetValidation
     def slug(value)
       value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-\z/, "")
     end
+
+    def snapshot_fingerprint
+      @snapshot_fingerprint ||= Digest::SHA256.hexdigest(
+        JSON.generate(
+          "release_selector" => @release_selector,
+          "manifest" => @manifest
+        )
+      )
+    end
   end
 
   class LedgerValidator
@@ -567,21 +616,23 @@ module FleetValidation
       result.concat(preflight_errors) if @closeout
       result.concat(pack_identity_errors) if @closeout
       result << inventory_completion_error if @closeout && inventory_completion_error
+      result << work_state_result_error if @closeout && work_state_result_error
       result << package_lock_error if @closeout && package_lock_error
+      result << package_version_error if @closeout && package_version_error
       result << check_evidence_error if @closeout && check_evidence_error
       result.concat(waiver_evidence_errors) if @closeout
-      result.concat(base_identity_errors) if @closeout
-      result << base_movement_error if @closeout && base_movement_error
+      result.concat(base_identity_errors) if @closeout && merge_eligible?
+      result << base_movement_error if @closeout && merge_eligible? && base_movement_error
       result.concat(independent_audit_errors) if @closeout
       result << "independent audit is not passed" if @closeout && @ledger.dig("audit", "status") != "passed"
       if @closeout && !present?(@ledger.dig("preflight", "capabilities", "restart_handoff"))
         result << "capability restart_handoff is missing"
       end
-      result.concat(reachability_errors) if @closeout
+      result.concat(reachability_errors) if @closeout && merge_eligible?
       result.concat(tracker_errors) if @closeout
-      result << merge_authority_error if @closeout && merge_authority_error
+      result << merge_authority_error if @closeout && merge_eligible? && merge_authority_error
       result << promotion_error if @closeout && promotion_error
-      if @closeout && @ledger.dig("merge", "status") == "merged" &&
+      if @closeout && merge_eligible? && @ledger.dig("merge", "status") == "merged" &&
          !present?(@ledger.dig("merge", "authority_evidence"))
         result << "merged result is missing explicit authority evidence"
       end
@@ -743,6 +794,20 @@ module FleetValidation
       "#{count} inventory target(s) are unknown or nonterminal"
     end
 
+    def work_state_result_error
+      count = Array(@ledger["inventory"]).count do |item|
+        allowed = if item["tier"] == "hard_gate"
+                    { "finished" => %w[passed waived], "blocked" => ["blocked"] }
+                  else
+                    { "finished" => %w[reported waived], "blocked" => ["blocked"] }
+                  end
+        !Array(allowed[item["work_state"]]).include?(item["result"])
+      end
+      return if count.zero?
+
+      "#{count} inventory target(s) have inconsistent work-state/result combinations"
+    end
+
     def package_lock_error
       expected_by_id = @inventory.to_h { |target| [target.fetch("id"), Array(target["packages"])] }
       count = Array(@ledger["inventory"]).count do |item|
@@ -761,6 +826,22 @@ module FleetValidation
       return if count.zero?
 
       "#{count} hard-gate target(s) are missing retained package lock evidence"
+    end
+
+    def package_version_error
+      resolved = Array(@ledger.dig("pack", "resolved_packages")).to_h do |package|
+        [[package["ecosystem"], package["name"]], package["version"]]
+      end
+      count = Array(@ledger["inventory"]).count do |item|
+        next false unless item["tier"] == "hard_gate"
+
+        Array(item["package_locks"]).any? do |lock|
+          resolved[[lock["ecosystem"], lock["name"]]] != lock["version"]
+        end
+      end
+      return if count.zero?
+
+      "#{count} hard-gate target(s) retain package versions outside the resolved release snapshot"
     end
 
     def check_evidence_error
@@ -794,16 +875,28 @@ module FleetValidation
       audit = @ledger.fetch("audit", {})
       merge = @ledger.fetch("merge", {})
       errors = []
-      errors << "audit base_commit is missing" unless present?(audit["base_commit"])
+      unless commit_identity?(audit["base_commit"])
+        errors << "audit base_commit is missing or not an exact commit identity"
+      end
       %w[reviewed_base_commit current_base_commit].each do |field|
-        errors << "merge #{field} is missing" unless present?(merge[field])
+        errors << "merge #{field} is missing or not an exact commit identity" unless commit_identity?(merge[field])
+      end
+      if commit_identity?(audit["base_commit"]) && commit_identity?(merge["reviewed_base_commit"]) &&
+         audit["base_commit"] != merge["reviewed_base_commit"]
+        errors << "audit base_commit does not match merge reviewed_base_commit"
       end
       Array(@ledger["inventory"]).each do |item|
         next unless item["tier"] == "hard_gate"
 
         bases = item.fetch("bases", {})
         %w[audit reviewed current].each do |field|
-          errors << "target #{item['id']} #{field} base is missing" unless present?(bases[field])
+          unless commit_identity?(bases[field])
+            errors << "target #{item['id']} #{field} base is missing or not an exact commit identity"
+          end
+        end
+        if commit_identity?(bases["audit"]) && commit_identity?(bases["reviewed"]) &&
+           bases["audit"] != bases["reviewed"]
+          errors << "target #{item['id']} audit base does not match reviewed base"
         end
       end
       errors
@@ -833,6 +926,10 @@ module FleetValidation
         errors = []
         if item["result"] == "waived" && !valid_waiver?(item["waiver"], item["id"])
           errors << "target #{item['id']} waived result is missing structured waiver evidence"
+        end
+        if item.dig("baseline", "classification") == "waived" &&
+           !valid_waiver?(item.dig("baseline", "waiver"), "#{item['id']}:baseline")
+          errors << "target #{item['id']} waived baseline is missing structured waiver evidence"
         end
         item.fetch("checks", {}).each do |name, check|
           next unless check["status"] == "waived"
@@ -893,6 +990,10 @@ module FleetValidation
       "promotion cannot be recommended while release blockers remain"
     end
 
+    def merge_eligible?
+      !release_blocked?
+    end
+
     def durable_owner?(owner)
       return false unless owner.is_a?(Hash)
 
@@ -932,7 +1033,7 @@ module FleetValidation
       hard_gate_blocked = Array(@ledger["inventory"]).any? do |item|
         next false unless item["tier"] == "hard_gate"
 
-        top_level_blocked = !%w[passed waived].include?(item["result"])
+        top_level_blocked = !%w[passed waived].include?(item["result"]) || item["work_state"] == "blocked"
         check_blocked = item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" }
         candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
         top_level_blocked || check_blocked || candidate_regression
@@ -1083,7 +1184,7 @@ module FleetValidation
       blocked = inventory.any? do |item|
         next false unless item["tier"] == "hard_gate"
 
-        top_level_blocked = !%w[passed waived].include?(item["result"])
+        top_level_blocked = !%w[passed waived].include?(item["result"]) || item["work_state"] == "blocked"
         check_blocked = item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" }
         candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
         top_level_blocked || check_blocked || candidate_regression
@@ -1096,7 +1197,9 @@ module FleetValidation
       partial = inventory.any? do |item|
         target_waived = item["result"] == "waived"
         check_waived = item.fetch("checks", {}).values.any? { |check| check["status"] == "waived" }
-        target_waived || check_waived || (item["tier"] == "soft_track" && item["result"] == "blocked")
+        baseline_waived = item.dig("baseline", "classification") == "waived"
+        target_waived || check_waived || baseline_waived ||
+          (item["tier"] == "soft_track" && item["result"] == "blocked")
       end
       partial ||= @ledger.dig("preflight", "status") == "waived"
       partial ||= %w[release_ci artifacts generator_matrix].any? do |gate|

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -244,6 +244,11 @@ module FleetValidation
       existing_pack = existing.fetch("pack", {})
       return unless existing_pack["pack_id"] == @pack_id
 
+      schema_errors = SchemaValidator.new(schema).errors(existing)
+      unless schema_errors.empty?
+        raise ManifestError, "existing result ledger does not match the current schema: #{schema_errors.join('; ')}"
+      end
+
       same_snapshot = existing_pack["release_selector"] == @release_selector &&
                       existing_pack["snapshot_fingerprint"] == snapshot_fingerprint
       if same_snapshot && resolved_candidate_reusable?(existing)
@@ -274,15 +279,17 @@ module FleetValidation
     end
 
     def build_inventory
+      defaults = @manifest.fetch("defaults", {})
       [CORE_INVENTORY_TARGET] + @manifest.fetch("repos").map do |repo|
         tier = repo.fetch("tier")
+        effective = tier == "hard_gate" ? defaults.merge(repo) : repo
         {
           "id" => slug(repo.fetch("name")),
           "name" => repo.fetch("name"),
           "headline" => repo.fetch("headline"),
           "tier" => tier,
           "work_mode" => tier == "soft_track" ? "report_only" : "mutation",
-          "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
+          "packages" => Array(effective["packages"]).map { |package| package.slice("ecosystem", "name") }
         }
       end
     end
@@ -759,6 +766,7 @@ module FleetValidation
       result.concat(inventory_errors)
       result.concat(private_field_errors)
       result.concat(disposition_state_errors)
+      result.concat(timestamp_errors)
       result << "app work started before APP_WORK_ALLOWED" if app_work_started? && !app_work_allowed?
       result.concat(review_app_errors)
       result.concat(barrier_order_errors)
@@ -1187,6 +1195,21 @@ module FleetValidation
       "base moved after audit without passing reconciliation"
     end
 
+    def timestamp_errors
+      errors = []
+      opened_at = @ledger.dig("preflight", "opened_at")
+      if present?(opened_at) && !timestamp(opened_at)
+        errors << "preflight opened_at must be an ISO8601 timestamp with an explicit offset"
+      end
+      Array(@ledger["inventory"]).each do |item|
+        work_started_at = item["work_started_at"]
+        next unless present?(work_started_at) && !timestamp(work_started_at)
+
+        errors << "target #{item['id']} work_started_at must be an ISO8601 timestamp with an explicit offset"
+      end
+      errors
+    end
+
     def preflight_errors
       preflight = @ledger.fetch("preflight", {})
       if preflight["status"] == "blocked"
@@ -1205,11 +1228,16 @@ module FleetValidation
       end
 
       waiver = preflight["status"] == "waived" ? preflight["waiver"] : nil
-      errors = %w[release_ci generator_matrix].filter_map do |field|
-        next if preflight_gate_passed?(preflight[field]) || valid_waiver?(waiver, field)
+      errors = if preflight["status"] == "waived" && !terminal_preflight_waiver?(preflight, waiver)
+                 ["waived preflight has no terminal failed gate with replayable evidence"]
+               else
+                 []
+               end
+      errors.concat(%w[release_ci generator_matrix].filter_map do |field|
+        next if preflight_gate_passed?(preflight[field]) || valid_preflight_waiver?(waiver, field, preflight[field])
 
         "release-wide preflight #{field} is not passed or explicitly waived"
-      end
+      end)
       unless preflight_gate_passed?(preflight["artifacts"])
         message = if valid_waiver?(waiver, "artifacts")
                     "release-wide preflight artifacts must pass and cannot be waived"
@@ -1220,7 +1248,8 @@ module FleetValidation
       end
       capabilities = preflight.fetch("capabilities", {})
       %w[status permissions git_auth github_auth registry_network toolchains host_capacity coordination].each do |field|
-        next if capabilities[field] == "passed" || valid_waiver?(waiver, "capabilities.#{field}")
+        next if capabilities[field] == "passed" ||
+                valid_preflight_capability_waiver?(waiver, field, capabilities[field])
 
         errors << "capability #{field} is not passed or explicitly waived"
       end
@@ -1672,9 +1701,32 @@ module FleetValidation
     end
 
     def timestamp(value)
+      return unless value.to_s.match?(/(?:Z|[+-]\d{2}:\d{2})\z/)
+
       Time.iso8601(value.to_s)
     rescue ArgumentError
       nil
+    end
+
+    def terminal_preflight_waiver?(preflight, waiver)
+      gate = waiver["gate"] if waiver.is_a?(Hash)
+      if %w[release_ci generator_matrix].include?(gate)
+        valid_preflight_waiver?(waiver, gate, preflight[gate])
+      elsif gate.to_s.start_with?("capabilities.")
+        field = gate.delete_prefix("capabilities.")
+        valid_preflight_capability_waiver?(waiver, field, preflight.dig("capabilities", field))
+      else
+        false
+      end
+    end
+
+    def valid_preflight_waiver?(waiver, field, gate)
+      valid_waiver?(waiver, field) && gate.is_a?(Hash) &&
+        %w[blocked waived].include?(gate["status"]) && present?(gate["evidence"])
+    end
+
+    def valid_preflight_capability_waiver?(waiver, field, status)
+      valid_waiver?(waiver, "capabilities.#{field}") && %w[blocked waived].include?(status)
     end
 
     def release_blocked?

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -95,21 +95,50 @@ module FleetValidation
             "blocker_id" => nil,
             "package_locks" => [],
             "checks" => %w[install build test local_smoke hosted_ci review].to_h do |check|
-              [check, { "status" => "pending", "evidence" => nil, "waiver" => nil, "blocker_id" => nil }]
+              [
+                check,
+                {
+                  "status" => "pending",
+                  "head_commit" => nil,
+                  "evidence" => nil,
+                  "waiver" => nil,
+                  "blocker_id" => nil
+                }
+              ]
             end,
             "review_app" => {
               "state" => "unknown",
+              "head_commit" => nil,
               "evidence" => nil,
               "deployed_smoke" => "pending",
               "waiver" => nil,
               "blocker_id" => nil
             },
-            "baseline" => { "classification" => "pending", "evidence" => nil, "waiver" => nil },
+            "baseline" => {
+              "classification" => "pending",
+              "head_commit" => nil,
+              "evidence" => nil,
+              "waiver" => nil
+            },
+            "revisions" => {
+              "audit" => nil,
+              "reviewed" => nil,
+              "current" => nil,
+              "reconciliation" => "pending"
+            },
             "bases" => {
               "audit" => nil,
               "reviewed" => nil,
               "current" => nil,
               "reconciliation" => "pending"
+            },
+            "merge" => {
+              "status" => target["work_mode"] == "mutation" ? "not_started" : "not_applicable",
+              "authority" => "none",
+              "authority_evidence" => nil,
+              "freeze_state" => "unknown",
+              "merge_commit" => nil,
+              "evidence" => nil
             },
             "reachability" => {
               "default_branch" => "pending",
@@ -136,17 +165,9 @@ module FleetValidation
           "status" => "pending",
           "checker" => nil,
           "maker_ids" => [],
-          "base_commit" => nil
+          "evidence" => nil
         },
-        "merge" => {
-          "authority" => "none",
-          "authority_evidence" => nil,
-          "freeze_state" => "unknown",
-          "status" => "not_started",
-          "reviewed_base_commit" => nil,
-          "current_base_commit" => nil,
-          "base_reconciliation" => "pending"
-        },
+        "merge" => { "status" => "not_started" },
         "reachability" => {
           "default_branch" => "pending",
           "tree_parity" => "pending"
@@ -198,8 +219,8 @@ module FleetValidation
           "reachability" => object_schema(
             %w[default_branch tree_parity],
             {
-              "default_branch" => status_string,
-              "tree_parity" => status_string
+              "default_branch" => aggregate_status_schema,
+              "tree_parity" => aggregate_status_schema
             }
           ),
           "tracker" => object_schema(
@@ -303,7 +324,7 @@ module FleetValidation
       object_schema(
         %w[
           id tier work_mode maker_id work_state work_started_at result waiver blocker_id package_locks checks
-          review_app baseline bases reachability evidence
+          review_app baseline revisions bases merge reachability evidence
         ],
         {
           "id" => nonempty_string,
@@ -334,11 +355,12 @@ module FleetValidation
             end
           ),
           "review_app" => object_schema(
-            %w[state evidence deployed_smoke waiver blocker_id],
+            %w[state head_commit evidence deployed_smoke waiver blocker_id],
             {
               "state" => {
                 "enum" => %w[configured_runnable configured_broken not_configured unknown]
               },
+              "head_commit" => nullable_string,
               "evidence" => nullable_string,
               "deployed_smoke" => status_string,
               "waiver" => waiver_schema,
@@ -346,15 +368,17 @@ module FleetValidation
             }
           ),
           "baseline" => object_schema(
-            %w[classification evidence waiver],
+            %w[classification head_commit evidence waiver],
             {
               "classification" => {
                 "enum" => %w[pending clean baseline_defect candidate_regression waived unknown]
               },
+              "head_commit" => nullable_string,
               "evidence" => nullable_string,
               "waiver" => waiver_schema
             }
           ),
+          "revisions" => revision_schema,
           "bases" => object_schema(
             %w[audit reviewed current reconciliation],
             {
@@ -364,6 +388,7 @@ module FleetValidation
               "reconciliation" => status_string
             }
           ),
+          "merge" => target_merge_schema,
           "reachability" => object_schema(
             %w[default_branch default_commit default_evidence tree_parity tree tree_evidence],
             {
@@ -432,30 +457,45 @@ module FleetValidation
 
     def audit_schema
       object_schema(
-        %w[status checker maker_ids base_commit],
+        %w[status checker maker_ids evidence],
         {
           "status" => status_string,
           "checker" => nullable_string,
           "maker_ids" => { "type" => "array", "items" => nonempty_string },
-          "base_commit" => nullable_string
+          "evidence" => nullable_string
         }
       )
     end
 
     def merge_schema
       object_schema(
-        %w[
-          authority authority_evidence freeze_state status reviewed_base_commit current_base_commit
-          base_reconciliation
-        ],
+        %w[status],
+        { "status" => { "enum" => %w[not_started merged partial blocked unknown] } }
+      )
+    end
+
+    def revision_schema
+      object_schema(
+        %w[audit reviewed current reconciliation],
         {
+          "audit" => nullable_string,
+          "reviewed" => nullable_string,
+          "current" => nullable_string,
+          "reconciliation" => status_string
+        }
+      )
+    end
+
+    def target_merge_schema
+      object_schema(
+        %w[status authority authority_evidence freeze_state merge_commit evidence],
+        {
+          "status" => { "enum" => %w[not_applicable not_started authorized merged blocked unknown] },
           "authority" => { "enum" => %w[none ask auto_merge_when_gates_pass] },
           "authority_evidence" => nullable_string,
           "freeze_state" => { "enum" => %w[clear frozen conflict unknown] },
-          "status" => { "enum" => %w[not_started authorized merged blocked unknown] },
-          "reviewed_base_commit" => nullable_string,
-          "current_base_commit" => nullable_string,
-          "base_reconciliation" => status_string
+          "merge_commit" => nullable_string,
+          "evidence" => nullable_string
         }
       )
     end
@@ -471,9 +511,10 @@ module FleetValidation
 
     def evidence_status_schema
       object_schema(
-        %w[status evidence waiver blocker_id],
+        %w[status head_commit evidence waiver blocker_id],
         {
           "status" => status_string,
+          "head_commit" => nullable_string,
           "evidence" => nullable_string,
           "waiver" => waiver_schema,
           "blocker_id" => nullable_string
@@ -513,6 +554,10 @@ module FleetValidation
 
     def status_string
       { "enum" => %w[pending passed reported blocked waived unknown] }
+    end
+
+    def aggregate_status_schema
+      { "enum" => %w[pending passed partial blocked unknown] }
     end
 
     def render_lifecycle
@@ -606,11 +651,13 @@ module FleetValidation
         ledger. The checker audits every hard-gate diff, all report-only dispositions, required-path
         coverage, baseline classifications, exact-head CI/review evidence, and blocker ownership.
         Every mutable target records its maker identity; `audit.maker_ids` must exactly cover those
-        identities before independence can pass.
+        identities before independence can pass. The audit records replayable public-safe evidence,
+        and every check head must match the target's exact audited, reviewed, and current revision.
 
-        Immediately before any merge or tracker write, re-read tracker mode and freeze state. Merge only
-        with explicit merge authority and no phase/freeze conflict. Reconcile default-base movement,
-        refresh affected checks, and record the audited base in the ledger.
+        Immediately before each merge or tracker write, re-read tracker mode and freeze state. Record
+        authority, freeze state, merge commit, and evidence on that mutable target. Merge only with
+        explicit merge authority and no phase/freeze conflict. Reconcile default-base movement, refresh
+        affected checks, and record the audited base in the ledger.
 
         For each authorized lane, merge through the repository's normal reviewed path, fetch the new
         default, then prove default-branch reachability and tree parity against the audited result.
@@ -624,7 +671,8 @@ module FleetValidation
         or explicitly waived and no `UNKNOWN` remains. A failed required path closes as `BLOCKED` only
         when it records its lane, failure evidence, and an owned `blocker_id`. Waived or deferred
         blockers retain a durable owner and require structured gate, authority, evidence URL, and
-        reason fields. If any lane has already merged, its base, authority/freeze, reachability, and
+        reason fields. The aggregate merge/reachability state is derived from the per-target rows. If
+        any lane has already merged, its base, authority/freeze, merge-commit, reachability, and
         tree-parity proofs remain required even when another lane blocks overall promotion.
       MARKDOWN
     end
@@ -668,6 +716,13 @@ module FleetValidation
   end
 
   class LedgerValidator
+    PRODUCT_PACKAGES = {
+      "gem" => %w[react_on_rails react_on_rails_pro],
+      "npm" => %w[
+        react-on-rails create-react-on-rails-app react-on-rails-pro react-on-rails-pro-node-renderer
+      ]
+    }.freeze
+
     def initialize(
       ledger,
       inventory:,
@@ -700,30 +755,26 @@ module FleetValidation
       result.concat(blocker_reference_errors) if @closeout
       result.concat(preflight_errors) if @closeout
       result.concat(pack_identity_errors) if @closeout
+      result << product_candidate_version_error if @closeout && product_candidate_version_error
       result << inventory_completion_error if @closeout && inventory_completion_error
       result << work_state_result_error if @closeout && work_state_result_error
       result << package_lock_error if @closeout && package_lock_error
       result << package_version_error if @closeout && package_version_error
       result << check_evidence_error if @closeout && check_evidence_error
+      result.concat(revision_evidence_errors) if @closeout
       result.concat(waiver_evidence_errors) if @closeout
-      recorded_merge = @ledger.dig("merge", "status") == "merged"
-      merge_proofs_required = merge_eligible? || recorded_merge
-      result.concat(base_identity_errors) if @closeout && merge_proofs_required
-      result << base_movement_error if @closeout && merge_proofs_required && base_movement_error
+      result.concat(base_identity_errors) if @closeout
+      result << base_movement_error if @closeout && base_movement_error
       result.concat(independent_audit_errors) if @closeout
       result << "independent audit is not passed" if @closeout && @ledger.dig("audit", "status") != "passed"
       if @closeout && !present?(@ledger.dig("preflight", "capabilities", "restart_handoff"))
         result << "capability restart_handoff is missing"
       end
-      result.concat(reachability_errors) if @closeout && merge_proofs_required
+      result.concat(target_merge_errors) if @closeout
+      result.concat(reachability_errors) if @closeout
+      result.concat(aggregate_state_errors) if @closeout
       result.concat(tracker_errors) if @closeout
-      if @closeout && (merge_eligible? || recorded_merge) && merge_authority_error
-        result << merge_authority_error
-      end
       result << promotion_error if @closeout && promotion_error
-      if @closeout && recorded_merge && !present?(@ledger.dig("merge", "authority_evidence"))
-        result << "merged result is missing explicit authority evidence"
-      end
       result
     end
 
@@ -882,7 +933,6 @@ module FleetValidation
     end
 
     def base_movement_error
-      merge = @ledger.fetch("merge", {})
       moved = Array(@ledger["inventory"]).any? do |item|
         next false unless item["work_mode"] == "mutation"
 
@@ -890,9 +940,6 @@ module FleetValidation
         present?(bases["reviewed"]) && present?(bases["current"]) &&
           bases["reviewed"] != bases["current"] && bases["reconciliation"] != "passed"
       end
-      moved ||= present?(merge["reviewed_base_commit"]) && present?(merge["current_base_commit"]) &&
-                merge["reviewed_base_commit"] != merge["current_base_commit"] &&
-                merge["base_reconciliation"] != "passed"
       return unless moved
 
       "base moved after audit without passing reconciliation"
@@ -951,6 +998,23 @@ module FleetValidation
         errors << "pack snapshot_fingerprint does not match the current manifest"
       end
       errors
+    end
+
+    def product_candidate_version_error
+      candidate = @ledger.dig("pack", "candidate").to_s
+      match = candidate.match(/\Av?(\d+\.\d+\.\d+)(?:\.(rc|beta)\.(\d+))?\z/)
+      return "candidate #{candidate} cannot be normalized to product package versions" unless match
+
+      gem_version = candidate.delete_prefix("v")
+      npm_version = match[2] ? "#{match[1]}-#{match[2]}.#{match[3]}" : match[1]
+      expected = { "gem" => gem_version, "npm" => npm_version }
+      mismatched = Array(@ledger.dig("pack", "resolved_packages")).any? do |package|
+        names = PRODUCT_PACKAGES.fetch(package["ecosystem"], [])
+        names.include?(package["name"]) && package["version"] != expected.fetch(package["ecosystem"])
+      end
+      return unless mismatched
+
+      "resolved product package versions do not match candidate #{candidate}"
     end
 
     def inventory_completion_error
@@ -1021,15 +1085,49 @@ module FleetValidation
         next false unless item["tier"] == "hard_gate"
 
         checks = item["checks"]
+        current_head = item.dig("revisions", "current")
         !checks.is_a?(Hash) || %w[install build test local_smoke hosted_ci review].any? do |name|
           check = checks[name]
           !check.is_a?(Hash) || !%w[passed blocked waived].include?(check["status"]) ||
-            !present?(check["evidence"])
+            !present?(check["evidence"]) || !commit_identity?(check["head_commit"]) ||
+            check["head_commit"] != current_head
         end
       end
       return if count.zero?
 
-      "#{count} hard-gate target(s) have unknown or nonterminal check evidence"
+      "#{count} hard-gate target(s) check evidence is not bound to its immutable current head"
+    end
+
+    def revision_evidence_errors
+      Array(@ledger["inventory"]).flat_map do |item|
+        revisions = item.fetch("revisions", {})
+        errors = []
+        %w[audit reviewed current].each do |field|
+          errors << "target #{item['id']} #{field} revision is missing" unless commit_identity?(revisions[field])
+        end
+        if commit_identity?(revisions["audit"]) && revisions["audit"] != revisions["reviewed"]
+          errors << "target #{item['id']} audit revision does not match reviewed revision"
+        end
+        if commit_identity?(revisions["current"]) && revisions["current"] != revisions["reviewed"]
+          errors << "target #{item['id']} current revision does not match reviewed revision"
+        end
+        errors << "target #{item['id']} revision reconciliation is not passed" unless revisions["reconciliation"] == "passed"
+
+        review_app = item.fetch("review_app", {})
+        if !commit_identity?(review_app["head_commit"]) || review_app["head_commit"] != revisions["current"]
+          errors << "target #{item['id']} review-app evidence is not bound to its immutable current head"
+        end
+        baseline = item.fetch("baseline", {})
+        expected_baseline_head = if item["work_mode"] == "mutation"
+                                   item.dig("bases", "current")
+                                 else
+                                   revisions["current"]
+                                 end
+        if !commit_identity?(baseline["head_commit"]) || baseline["head_commit"] != expected_baseline_head
+          errors << "target #{item['id']} baseline evidence is not bound to its fresh-default head"
+        end
+        errors
+      end
     end
 
     def independent_audit_errors
@@ -1042,6 +1140,7 @@ module FleetValidation
       mutable_count = Array(@ledger["inventory"]).count { |item| item["work_mode"] == "mutation" }
       errors << "independent audit checker is missing" unless present?(audit["checker"])
       errors << "independent audit maker identities are missing" if audit_maker_ids.empty?
+      errors << "independent audit evidence is missing" unless present?(audit["evidence"])
       if mutable_maker_ids.length != mutable_count || mutable_maker_ids.uniq.sort != audit_maker_ids.uniq.sort
         errors << "independent audit maker identities do not cover every mutable target"
       end
@@ -1052,19 +1151,7 @@ module FleetValidation
     end
 
     def base_identity_errors
-      audit = @ledger.fetch("audit", {})
-      merge = @ledger.fetch("merge", {})
       errors = []
-      unless commit_identity?(audit["base_commit"])
-        errors << "audit base_commit is missing or not an exact commit identity"
-      end
-      %w[reviewed_base_commit current_base_commit].each do |field|
-        errors << "merge #{field} is missing or not an exact commit identity" unless commit_identity?(merge[field])
-      end
-      if commit_identity?(audit["base_commit"]) && commit_identity?(merge["reviewed_base_commit"]) &&
-         audit["base_commit"] != merge["reviewed_base_commit"]
-        errors << "audit base_commit does not match merge reviewed_base_commit"
-      end
       Array(@ledger["inventory"]).each do |item|
         next unless item["work_mode"] == "mutation"
 
@@ -1139,14 +1226,11 @@ module FleetValidation
     end
 
     def reachability_errors
-      reachability = @ledger.fetch("reachability", {})
-      errors = %w[default_branch tree_parity].filter_map do |field|
-        "reachability #{field} is not passed" unless reachability[field] == "passed"
-      end
-      Array(@ledger["inventory"]).each do |item|
-        next unless item["work_mode"] == "mutation"
+      Array(@ledger["inventory"]).flat_map do |item|
+        next [] unless item["work_mode"] == "mutation" && item.dig("merge", "status") == "merged"
 
         target = item.fetch("reachability", {})
+        errors = []
         unless target["default_branch"] == "passed" && commit_identity?(target["default_commit"]) &&
                present?(target["default_evidence"])
           errors << "target #{item['id']} default-branch reachability evidence is incomplete"
@@ -1155,8 +1239,8 @@ module FleetValidation
                present?(target["tree_evidence"])
           errors << "target #{item['id']} tree-parity evidence is incomplete"
         end
+        errors
       end
-      errors
     end
 
     def tracker_errors
@@ -1169,15 +1253,63 @@ module FleetValidation
       errors
     end
 
-    def merge_authority_error
-      merge = @ledger.fetch("merge", {})
-      return "closeout merge status is not merged" unless merge["status"] == "merged"
+    def target_merge_errors
+      Array(@ledger["inventory"]).flat_map do |item|
+        merge = item.fetch("merge", {})
+        if item["work_mode"] != "mutation"
+          next [] if merge["status"] == "not_applicable"
 
-      authorized = %w[ask auto_merge_when_gates_pass].include?(merge["authority"])
-      conflict = merge["freeze_state"] != "clear" || @ledger.dig("pack", "tracker_mode") == "conflict"
-      return if authorized && !conflict
+          next ["target #{item['id']} must mark merge not_applicable"]
+        end
 
-      "merge is not allowed while tracker mode or freeze state conflicts"
+        errors = []
+        unless %w[merged blocked].include?(merge["status"])
+          errors << "target #{item['id']} merge disposition is not terminal"
+        end
+        if merge["status"] == "merged"
+          authorized = %w[ask auto_merge_when_gates_pass].include?(merge["authority"])
+          errors << "target #{item['id']} merged without explicit authority" unless authorized
+          errors << "target #{item['id']} merged without authority evidence" unless present?(merge["authority_evidence"])
+          errors << "target #{item['id']} merged during a freeze or phase conflict" unless merge["freeze_state"] == "clear"
+          errors << "target #{item['id']} merge commit is missing" unless commit_identity?(merge["merge_commit"])
+          errors << "target #{item['id']} merge evidence is missing" unless present?(merge["evidence"])
+        elsif merge["status"] == "blocked"
+          errors << "target #{item['id']} blocked merge disposition has no evidence" unless present?(merge["evidence"])
+        end
+        if !release_blocked? && merge["status"] != "merged"
+          errors << "target #{item['id']} merge is incomplete for a promotable release"
+        end
+        errors
+      end
+    end
+
+    def aggregate_state_errors
+      mutation_items = Array(@ledger["inventory"]).select { |item| item["work_mode"] == "mutation" }
+      merged_count = mutation_items.count { |item| item.dig("merge", "status") == "merged" }
+      expected_merge = if merged_count == mutation_items.length
+                         "merged"
+                       elsif merged_count.positive?
+                         "partial"
+                       else
+                         "blocked"
+                       end
+      expected_reachability = if expected_merge == "merged"
+                                "passed"
+                              elsif expected_merge == "partial"
+                                "partial"
+                              else
+                                "blocked"
+                              end
+      errors = []
+      unless @ledger.dig("merge", "status") == expected_merge
+        errors << "aggregate merge status does not match per-target merge states"
+      end
+      %w[default_branch tree_parity].each do |field|
+        unless @ledger.dig("reachability", field) == expected_reachability
+          errors << "aggregate reachability #{field} does not match per-target merge states"
+        end
+      end
+      errors
     end
 
     def promotion_error
@@ -1185,10 +1317,6 @@ module FleetValidation
       return unless release_blocked?
 
       "promotion cannot be recommended while release blockers remain"
-    end
-
-    def merge_eligible?
-      !release_blocked?
     end
 
     def durable_owner?(owner)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -756,7 +756,10 @@ module FleetValidation
         blockers retain a durable owner and require structured gate, authority, evidence URL, and
         reason fields. Candidate-snapshot package matching applies to candidate-managed packages on
         hard gates, including the separately resolved RSC package; report-only and independently
-        versioned dependency locks retain the versions observed in their target. The aggregate
+        versioned dependency locks retain the versions observed in their target. The resolved release
+        snapshot uses the canonical `registry` source; local workspace or path overrides cannot prove
+        published-artifact readiness. Blocked outcomes reference active owned blockers, and tracker
+        promotion cannot claim `BLOCKED` when no release blocker remains. The aggregate
         merge/reachability state is derived from the per-target rows. If
         any lane has already merged, its base, authority/freeze, merge-commit, reachability, and
         tree-parity proofs remain required even when another lane blocks overall promotion. An
@@ -1371,6 +1374,9 @@ module FleetValidation
       if actual_packages.tally.any? { |_identity, count| count > 1 }
         errors << "pack resolved package snapshot contains duplicate identities"
       end
+      if resolved_packages.any? { |package| package["source"] != "registry" }
+        errors << "pack resolved package snapshot contains unpublished sources"
+      end
       if @expected_snapshot_fingerprint && pack["snapshot_fingerprint"] != @expected_snapshot_fingerprint
         errors << "pack snapshot_fingerprint does not match the current manifest"
       end
@@ -1611,7 +1617,9 @@ module FleetValidation
       preflight_errors = []
       if preflight_blocked?
         blocker = blockers[@ledger.dig("preflight", "blocker_id")]
-        unless blocker && durable_owner?(blocker["owner"])
+        if blocker && durable_owner?(blocker["owner"])
+          preflight_errors << inactive_blocker_error("blocked preflight", blocker) unless active_blocker?(blocker)
+        else
           preflight_errors << "blocked preflight has no owned blocker reference"
         end
       end
@@ -1629,7 +1637,11 @@ module FleetValidation
         end
         references.filter_map do |label, blocker_id|
           blocker = blockers[blocker_id]
-          next if blocker && durable_owner?(blocker["owner"])
+          if blocker && durable_owner?(blocker["owner"])
+            next if active_blocker?(blocker)
+
+            next inactive_blocker_error("target #{item['id']} blocked #{label}", blocker)
+          end
 
           "target #{item['id']} blocked #{label} has no owned blocker reference"
         end
@@ -1638,7 +1650,11 @@ module FleetValidation
         next unless path["status"] == "blocked"
 
         blocker = blockers[path["blocker_id"]]
-        next if blocker && durable_owner?(blocker["owner"])
+        if blocker && durable_owner?(blocker["owner"])
+          next if active_blocker?(blocker)
+
+          next inactive_blocker_error("required path #{path['id']} blocked result", blocker)
+        end
 
         "required path #{path['id']} blocked result has no owned blocker reference"
       end
@@ -1693,6 +1709,9 @@ module FleetValidation
       errors << "tracker closeout status is not ready or posted" unless %w[ready posted].include?(tracker["status"])
       if tracker["status"] == "posted" && !present?(tracker["comment_url"])
         errors << "posted tracker closeout is missing comment_url"
+      end
+      if tracker["promotion"] == "blocked" && !release_blocked?
+        errors << "tracker promotion is blocked without a release blocker"
       end
       errors
     end
@@ -1805,6 +1824,14 @@ module FleetValidation
       return false unless owner.is_a?(Hash)
 
       %w[issue_url waiver_url public_tracker_reason].any? { |key| present?(owner[key]) }
+    end
+
+    def active_blocker?(blocker)
+      %w[open pending blocked unknown].include?(blocker["status"])
+    end
+
+    def inactive_blocker_error(subject, blocker)
+      "#{subject} references inactive blocker #{blocker['id']}"
     end
 
     def path_terminally_evidenced?(path)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -102,6 +102,7 @@ module FleetValidation
                 {
                   "status" => "pending",
                   "head_commit" => nil,
+                  "base_commit" => nil,
                   "evidence" => nil,
                   "waiver" => nil,
                   "blocker_id" => nil
@@ -523,10 +524,11 @@ module FleetValidation
 
     def evidence_status_schema
       object_schema(
-        %w[status head_commit evidence waiver blocker_id],
+        %w[status head_commit base_commit evidence waiver blocker_id],
         {
           "status" => status_string,
           "head_commit" => nullable_string,
+          "base_commit" => nullable_string,
           "evidence" => nullable_string,
           "waiver" => waiver_schema,
           "blocker_id" => nullable_string
@@ -1007,8 +1009,8 @@ module FleetValidation
         item_errors = []
         expected_merge_status = item["work_mode"] == "mutation" ? "not_started" : "not_applicable"
         untouched_checks = item.fetch("checks", {}).values.all? do |check|
-          check["status"] == "pending" && !present?(check["head_commit"]) && !present?(check["evidence"]) &&
-            check["waiver"].nil? && !present?(check["blocker_id"])
+          check["status"] == "pending" && !present?(check["head_commit"]) && !present?(check["base_commit"]) &&
+            !present?(check["evidence"]) && check["waiver"].nil? && !present?(check["blocker_id"])
         end
         untouched = item["work_state"] == "not_started" && !present?(item["work_started_at"]) &&
                     !present?(item["maker_id"]) && item["result"] == "pending" &&
@@ -1161,6 +1163,9 @@ module FleetValidation
       Array(@ledger["blockers"]).flat_map do |blocker|
         status = blocker["status"]
         errors = []
+        if status == "unknown"
+          errors << "blocker #{blocker['id'] || 'missing-id'} remains UNKNOWN at closeout"
+        end
         if %w[waived deferred].include?(status) &&
            !valid_waiver?(blocker["disposition"], blocker["id"])
           errors << "blocker #{blocker['id'] || 'missing-id'} " \
@@ -1373,25 +1378,39 @@ module FleetValidation
     end
 
     def check_evidence_errors
-      invalid_items = Array(@ledger["inventory"]).select do |item|
+      invalid_head_items = []
+      invalid_base_items = []
+      Array(@ledger["inventory"]).each do |item|
         checks = item["checks"]
         current_head = item.dig("revisions", "current")
+        current_base = item.dig("bases", "current")
         allowed_statuses = item["tier"] == "hard_gate" ? %w[passed blocked waived] : %w[passed reported blocked waived]
-        !checks.is_a?(Hash) || %w[install build test local_smoke hosted_ci review].any? do |name|
+        invalid_head = !checks.is_a?(Hash) || %w[install build test local_smoke hosted_ci review].any? do |name|
           check = checks[name]
           !check.is_a?(Hash) || !allowed_statuses.include?(check["status"]) ||
             !present?(check["evidence"]) || !commit_identity?(check["head_commit"]) ||
             check["head_commit"] != current_head
         end
+        invalid_base = item["work_mode"] == "mutation" &&
+                       (!checks.is_a?(Hash) || %w[install build test local_smoke hosted_ci review].any? do |name|
+                         check = checks[name]
+                         !check.is_a?(Hash) || !commit_identity?(check["base_commit"]) ||
+                           check["base_commit"] != current_base
+                       end)
+        invalid_head_items << item if invalid_head
+        invalid_base_items << item if invalid_base
       end
-      hard_gate_count = invalid_items.count { |item| item["tier"] == "hard_gate" }
-      report_only_count = invalid_items.count { |item| item["work_mode"] == "report_only" }
+      hard_gate_count = invalid_head_items.count { |item| item["tier"] == "hard_gate" }
+      report_only_count = invalid_head_items.count { |item| item["work_mode"] == "report_only" }
       errors = []
       if hard_gate_count.positive?
         errors << "#{hard_gate_count} hard-gate target(s) check evidence is not bound to its immutable current head"
       end
       if report_only_count.positive?
         errors << "#{report_only_count} report-only target(s) have unknown or stale check evidence"
+      end
+      invalid_base_items.each do |item|
+        errors << "target #{item['id']} check evidence is not bound to its reconciled current base"
       end
       errors
     end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -70,6 +70,8 @@ module FleetValidation
           "app_work_allowed" => false,
           "opened_at" => nil,
           "waiver" => nil,
+          "blocker_id" => nil,
+          "blocker_evidence" => nil,
           "release_ci" => { "status" => "pending", "evidence" => nil },
           "artifacts" => { "status" => "pending", "evidence" => nil },
           "generator_matrix" => { "status" => "pending", "evidence" => nil },
@@ -287,7 +289,8 @@ module FleetValidation
 
     def preflight_schema
       fields = %w[
-        status app_work_allowed opened_at waiver release_ci artifacts generator_matrix capabilities
+        status app_work_allowed opened_at waiver blocker_id blocker_evidence release_ci artifacts
+        generator_matrix capabilities
       ]
       object_schema(
         fields,
@@ -296,6 +299,8 @@ module FleetValidation
           "app_work_allowed" => { "type" => "boolean" },
           "opened_at" => nullable_string,
           "waiver" => waiver_schema,
+          "blocker_id" => nullable_string,
+          "blocker_evidence" => nullable_string,
           "release_ci" => preflight_gate_schema,
           "artifacts" => preflight_gate_schema,
           "generator_matrix" => preflight_gate_schema,
@@ -613,6 +618,11 @@ module FleetValidation
         `preflight.app_work_allowed` to `true`; that schema-validated state is the ledger's explicit
         `APP_WORK_ALLOWED` marker. Every mutable target records `work_started_at`, which must be later
         than the barrier time. The validation-only monorepo generator gate may run before this marker.
+        If an owned release-wide blocker makes opening the barrier impossible, close the pack with
+        `preflight.status: blocked`, a durable `preflight.blocker_id`, public-safe
+        `preflight.blocker_evidence`, and `APP_WORK_ALLOWED` still false. In that terminal path every
+        app target remains untouched, the independent audit records no maker IDs, and aggregate
+        merge/reachability plus tracker promotion remain blocked.
 
         Before worker launch, record a machine/session capability attestation covering
         nonblocking permissions, Git and GitHub authentication, registry/network access, required toolchains,
@@ -629,7 +639,9 @@ module FleetValidation
         <<~ROW.chomp
           - `#{target.fetch('id')}` — Report only; do not mutate.
             Inspect the fresh default, current package locks, standing CI/smoke metadata, and archived or deferred disposition.
-            Record `reported`, `blocked`, `waived`, or `unknown` plus public-safe evidence in the shared ledger.
+            Retain the inspected package versions/sources and exact-head check evidence. Record
+            `reported`, `blocked`, or `waived` plus public-safe evidence in the shared ledger;
+            `pending` or `unknown` cannot close the pack.
         ROW
       end
 
@@ -749,6 +761,20 @@ module FleetValidation
       result << "app work started before APP_WORK_ALLOWED" if app_work_started? && !app_work_allowed?
       result.concat(review_app_errors)
       result.concat(barrier_order_errors)
+      if @closeout && preflight_blocked?
+        result.concat(blocker_identity_errors)
+        result.concat(blocker_owner_errors)
+        result.concat(blocker_reference_errors)
+        result.concat(preflight_errors)
+        result.concat(pack_identity_errors)
+        result.concat(blocked_preflight_state_errors)
+        result.concat(independent_audit_errors)
+        result << "independent audit is not passed" unless @ledger.dig("audit", "status") == "passed"
+        result.concat(tracker_errors)
+        result << promotion_error if promotion_error
+        return result
+      end
+
       result.concat(required_path_errors) if @closeout
       result.concat(blocker_identity_errors) if @closeout
       result.concat(blocker_owner_errors) if @closeout
@@ -760,7 +786,7 @@ module FleetValidation
       result << work_state_result_error if @closeout && work_state_result_error
       result << package_lock_error if @closeout && package_lock_error
       result << package_version_error if @closeout && package_version_error
-      result << check_evidence_error if @closeout && check_evidence_error
+      result.concat(check_evidence_errors) if @closeout
       result.concat(revision_evidence_errors) if @closeout
       result.concat(waiver_evidence_errors) if @closeout
       result.concat(base_identity_errors) if @closeout
@@ -784,6 +810,10 @@ module FleetValidation
       Array(@ledger["inventory"]).any? do |item|
         item["work_mode"] == "mutation" && item["work_state"] != "not_started"
       end
+    end
+
+    def preflight_blocked?
+      @ledger.dig("preflight", "status") == "blocked"
     end
 
     def candidate_error
@@ -847,6 +877,7 @@ module FleetValidation
       end
       errors << "review app capability UNKNOWN for #{count} started target(s)" unless count.zero?
       return errors unless @closeout
+      return errors if preflight_blocked?
 
       Array(@ledger["inventory"]).each do |item|
         review_app = item.fetch("review_app", {})
@@ -865,6 +896,28 @@ module FleetValidation
                      blocked
                    end
         errors << "target #{item['id']} review-app smoke is not terminal" unless terminal
+      end
+      errors
+    end
+
+    def blocked_preflight_state_errors
+      errors = Array(@ledger["inventory"]).filter_map do |item|
+        expected_merge_status = item["work_mode"] == "mutation" ? "not_started" : "not_applicable"
+        untouched_checks = item.fetch("checks", {}).values.all? do |check|
+          check["status"] == "pending" && !present?(check["head_commit"]) && !present?(check["evidence"]) &&
+            check["waiver"].nil? && !present?(check["blocker_id"])
+        end
+        untouched = item["work_state"] == "not_started" && !present?(item["work_started_at"]) &&
+                    !present?(item["maker_id"]) && item["result"] == "pending" &&
+                    Array(item["package_locks"]).empty? && untouched_checks &&
+                    item.dig("merge", "status") == expected_merge_status && !present?(item["evidence"])
+        "blocked preflight target #{item['id']} contains app-work state" unless untouched
+      end
+      errors << "blocked preflight aggregate merge status must be blocked" unless @ledger.dig("merge", "status") == "blocked"
+      %w[default_branch tree_parity].each do |field|
+        unless @ledger.dig("reachability", field) == "blocked"
+          errors << "blocked preflight aggregate reachability #{field} must be blocked"
+        end
       end
       errors
     end
@@ -947,6 +1000,21 @@ module FleetValidation
 
     def preflight_errors
       preflight = @ledger.fetch("preflight", {})
+      if preflight["status"] == "blocked"
+        errors = []
+        errors << "blocked preflight must keep APP_WORK_ALLOWED closed" unless preflight["app_work_allowed"] == false
+        errors << "blocked preflight must not record an opened barrier" if present?(preflight["opened_at"])
+        errors << "blocked preflight is missing public-safe blocker evidence" unless present?(preflight["blocker_evidence"])
+        blocked_gate = %w[release_ci artifacts generator_matrix].any? do |field|
+          preflight.dig(field, "status") == "blocked" && present?(preflight.dig(field, "evidence"))
+        end
+        blocked_capability = preflight.fetch("capabilities", {}).any? do |field, status|
+          field != "restart_handoff" && status == "blocked"
+        end
+        errors << "blocked preflight has no explicitly blocked gate or capability" unless blocked_gate || blocked_capability
+        return errors
+      end
+
       waiver = preflight["status"] == "waived" ? preflight["waiver"] : nil
       errors = %w[release_ci generator_matrix].filter_map do |field|
         next if preflight_gate_passed?(preflight[field]) || valid_waiver?(waiver, field)
@@ -1046,22 +1114,25 @@ module FleetValidation
 
     def package_lock_error
       expected_by_id = @inventory.to_h { |target| [target.fetch("id"), Array(target["packages"])] }
-      count = Array(@ledger["inventory"]).count do |item|
-        next false unless item["tier"] == "hard_gate"
-
+      invalid_items = Array(@ledger["inventory"]).select do |item|
         locks = item["package_locks"]
-        malformed = !locks.is_a?(Array) || locks.empty? || locks.any? do |lock|
+        expected = expected_by_id.fetch(item["id"], []).map { |package| [package["ecosystem"], package["name"]] }
+        malformed = !locks.is_a?(Array) || (expected.any? && locks.empty?) || Array(locks).any? do |lock|
           %w[ecosystem name version source].any? { |field| !present?(lock[field]) }
         end
         next true if malformed
 
         actual = locks.map { |lock| [lock["ecosystem"], lock["name"]] }
-        expected = expected_by_id.fetch(item["id"], []).map { |package| [package["ecosystem"], package["name"]] }
         (expected - actual).any? || actual.tally.any? { |_identity, total| total > 1 }
       end
-      return if count.zero?
+      return if invalid_items.empty?
 
-      "#{count} hard-gate target(s) are missing retained package lock evidence"
+      hard_gate_count = invalid_items.count { |item| item["tier"] == "hard_gate" }
+      if hard_gate_count.positive?
+        "#{hard_gate_count} hard-gate target(s) are missing retained package lock evidence"
+      else
+        "#{invalid_items.length} inventory target(s) are missing retained package lock evidence"
+      end
     end
 
     def package_version_error
@@ -1080,22 +1151,28 @@ module FleetValidation
       "#{count} hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
     end
 
-    def check_evidence_error
-      count = Array(@ledger["inventory"]).count do |item|
-        next false unless item["tier"] == "hard_gate"
-
+    def check_evidence_errors
+      invalid_items = Array(@ledger["inventory"]).select do |item|
         checks = item["checks"]
         current_head = item.dig("revisions", "current")
+        allowed_statuses = item["tier"] == "hard_gate" ? %w[passed blocked waived] : %w[passed reported blocked waived]
         !checks.is_a?(Hash) || %w[install build test local_smoke hosted_ci review].any? do |name|
           check = checks[name]
-          !check.is_a?(Hash) || !%w[passed blocked waived].include?(check["status"]) ||
+          !check.is_a?(Hash) || !allowed_statuses.include?(check["status"]) ||
             !present?(check["evidence"]) || !commit_identity?(check["head_commit"]) ||
             check["head_commit"] != current_head
         end
       end
-      return if count.zero?
-
-      "#{count} hard-gate target(s) check evidence is not bound to its immutable current head"
+      hard_gate_count = invalid_items.count { |item| item["tier"] == "hard_gate" }
+      report_only_count = invalid_items.count { |item| item["work_mode"] == "report_only" }
+      errors = []
+      if hard_gate_count.positive?
+        errors << "#{hard_gate_count} hard-gate target(s) check evidence is not bound to its immutable current head"
+      end
+      if report_only_count.positive?
+        errors << "#{report_only_count} report-only target(s) have unknown or stale check evidence"
+      end
+      errors
     end
 
     def revision_evidence_errors
@@ -1134,15 +1211,26 @@ module FleetValidation
       audit = @ledger.fetch("audit", {})
       errors = []
       audit_maker_ids = Array(audit["maker_ids"])
-      mutable_maker_ids = Array(@ledger["inventory"]).filter_map do |item|
+      raw_mutable_maker_ids = Array(@ledger["inventory"]).filter_map do |item|
         item["maker_id"] if item["work_mode"] == "mutation"
       end
       mutable_count = Array(@ledger["inventory"]).count { |item| item["work_mode"] == "mutation" }
       errors << "independent audit checker is missing" unless present?(audit["checker"])
-      errors << "independent audit maker identities are missing" if audit_maker_ids.empty?
       errors << "independent audit evidence is missing" unless present?(audit["evidence"])
-      if mutable_maker_ids.length != mutable_count || mutable_maker_ids.uniq.sort != audit_maker_ids.uniq.sort
-        errors << "independent audit maker identities do not cover every mutable target"
+      if preflight_blocked?
+        unless raw_mutable_maker_ids.none? { |maker_id| present?(maker_id) } && audit_maker_ids.empty?
+          errors << "blocked preflight audit must not claim maker identities"
+        end
+      else
+        errors << "independent audit maker identities are missing" if audit_maker_ids.empty?
+        if raw_mutable_maker_ids.any? { |maker_id| !present?(maker_id) } ||
+           audit_maker_ids.any? { |maker_id| !present?(maker_id) }
+          errors << "independent audit maker identities contain blank values"
+        end
+        mutable_maker_ids = raw_mutable_maker_ids.select { |maker_id| present?(maker_id) }
+        if mutable_maker_ids.length != mutable_count || mutable_maker_ids.uniq.sort != audit_maker_ids.uniq.sort
+          errors << "independent audit maker identities do not cover every mutable target"
+        end
       end
       if present?(audit["checker"]) && audit_maker_ids.include?(audit["checker"])
         errors << "independent audit checker is also a maker"
@@ -1171,6 +1259,13 @@ module FleetValidation
 
     def blocker_reference_errors
       blockers = Array(@ledger["blockers"]).to_h { |blocker| [blocker["id"], blocker] }
+      preflight_errors = []
+      if preflight_blocked?
+        blocker = blockers[@ledger.dig("preflight", "blocker_id")]
+        unless blocker && durable_owner?(blocker["owner"])
+          preflight_errors << "blocked preflight has no owned blocker reference"
+        end
+      end
       inventory_errors = Array(@ledger["inventory"]).flat_map do |item|
         references = []
         if item["result"] == "blocked" || item.dig("baseline", "classification") == "candidate_regression"
@@ -1198,7 +1293,7 @@ module FleetValidation
 
         "required path #{path['id']} blocked result has no owned blocker reference"
       end
-      inventory_errors + path_errors
+      preflight_errors + inventory_errors + path_errors
     end
 
     def waiver_evidence_errors

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -92,6 +92,15 @@ module FleetValidation
           "status" => "pending",
           "app_work_allowed" => false,
           "opened_at" => nil,
+          "public_marker" => {
+            "status" => "pending",
+            "pack_id" => nil,
+            "candidate" => nil,
+            "candidate_commit" => nil,
+            "snapshot_fingerprint" => nil,
+            "opened_at" => nil,
+            "evidence" => nil
+          },
           "waiver" => nil,
           "blocker_id" => nil,
           "blocker_evidence" => nil,
@@ -320,8 +329,8 @@ module FleetValidation
 
     def preflight_schema
       fields = %w[
-        status app_work_allowed opened_at waiver blocker_id blocker_evidence release_ci artifacts
-        generator_matrix capabilities
+        status app_work_allowed opened_at public_marker waiver blocker_id blocker_evidence release_ci
+        artifacts generator_matrix capabilities
       ]
       object_schema(
         fields,
@@ -329,6 +338,7 @@ module FleetValidation
           "status" => { "enum" => %w[pending passed waived blocked unknown] },
           "app_work_allowed" => { "type" => "boolean" },
           "opened_at" => nullable_string,
+          "public_marker" => public_marker_schema,
           "waiver" => waiver_schema,
           "blocker_id" => nullable_string,
           "blocker_evidence" => nullable_string,
@@ -436,6 +446,21 @@ module FleetValidation
               "tree_evidence" => nullable_string
             }
           ),
+          "evidence" => nullable_string
+        }
+      )
+    end
+
+    def public_marker_schema
+      object_schema(
+        %w[status pack_id candidate candidate_commit snapshot_fingerprint opened_at evidence],
+        {
+          "status" => { "enum" => %w[pending unique absent duplicate mismatched unknown] },
+          "pack_id" => nullable_string,
+          "candidate" => nullable_string,
+          "candidate_commit" => nullable_string,
+          "snapshot_fingerprint" => nullable_string,
+          "opened_at" => nullable_string,
           "evidence" => nullable_string
         }
       )
@@ -656,6 +681,8 @@ module FleetValidation
         and terminal status plus replayable evidence for release CI, artifacts, and generator matrix.
         Remote coordinators cross-check that unique marker against the published pack snapshot; an
         absent, duplicate, stale, malformed, or mismatched marker leaves the barrier `UNKNOWN`.
+        Record that cross-check in `preflight.public_marker` with `status: unique`, the exact
+        pack/candidate/commit/fingerprint/opened-at fields, and replayable public-safe evidence.
         If an owned release-wide blocker makes opening the barrier impossible, close the pack with
         `preflight.status: blocked`, a durable `preflight.blocker_id`, public-safe
         `preflight.blocker_evidence`, and `APP_WORK_ALLOWED` still false. In that terminal path every
@@ -790,6 +817,7 @@ module FleetValidation
       inventory:,
       required_paths:,
       expected_candidate: nil,
+      expected_pack_id: nil,
       expected_snapshot_fingerprint: nil,
       closeout: false
     )
@@ -797,6 +825,7 @@ module FleetValidation
       @inventory = inventory
       @required_paths = required_paths
       @expected_candidate = expected_candidate
+      @expected_pack_id = expected_pack_id
       @expected_snapshot_fingerprint = expected_snapshot_fingerprint
       @closeout = closeout
     end
@@ -810,6 +839,8 @@ module FleetValidation
       result.concat(private_field_errors)
       result.concat(disposition_state_errors)
       result.concat(timestamp_errors)
+      marker_error = public_preflight_marker_error
+      result << marker_error if public_preflight_marker_required? && marker_error
       result << "app work started before APP_WORK_ALLOWED" if app_work_started? && !app_work_allowed?
       result.concat(review_app_errors)
       result.concat(barrier_order_errors)
@@ -1334,6 +1365,9 @@ module FleetValidation
       if @expected_snapshot_fingerprint && pack["snapshot_fingerprint"] != @expected_snapshot_fingerprint
         errors << "pack snapshot_fingerprint does not match the current manifest"
       end
+      if @expected_pack_id && pack["pack_id"] != @expected_pack_id
+        errors << "pack ID mismatch: expected #{@expected_pack_id}, got #{pack['pack_id']}"
+      end
       errors
     end
 
@@ -1780,7 +1814,29 @@ module FleetValidation
       preflight["app_work_allowed"] == true &&
         timestamp(preflight["opened_at"]) &&
         %w[passed waived].include?(preflight["status"]) &&
-        preflight_errors.empty? && pack_identity_errors.empty? && candidate_error.nil?
+        preflight_errors.empty? && pack_identity_errors.empty? && candidate_error.nil? &&
+        public_preflight_marker_error.nil?
+    end
+
+    def public_preflight_marker_required?
+      app_work_started? || @ledger.dig("preflight", "app_work_allowed") == true ||
+        (@closeout && !preflight_blocked?)
+    end
+
+    def public_preflight_marker_error
+      marker = @ledger.dig("preflight", "public_marker")
+      pack = @ledger.fetch("pack", {})
+      preflight = @ledger.fetch("preflight", {})
+      valid = marker.is_a?(Hash) && marker["status"] == "unique" &&
+              marker["pack_id"] == pack["pack_id"] &&
+              marker["candidate"] == pack["candidate"] &&
+              marker["candidate_commit"] == pack["candidate_commit"] &&
+              marker["snapshot_fingerprint"] == pack["snapshot_fingerprint"] &&
+              marker["opened_at"] == preflight["opened_at"] &&
+              present?(marker["evidence"])
+      return if valid
+
+      "public preflight marker is not unique and snapshot-bound"
     end
 
     def valid_waiver?(waiver, expected_gate)
@@ -2019,7 +2075,11 @@ module FleetValidation
         @ledger.dig("preflight", gate, "status") == "waived"
       end
       partial ||= paths.any? { |path| path["status"] == "waived" }
-      partial ||= blockers.any? { |blocker| %w[waived deferred].include?(blocker["status"]) }
+      partial ||= blockers.any? do |blocker|
+        %w[waived deferred].include?(blocker["status"]) ||
+          (soft_only_blockers.include?(blocker["id"]) &&
+            !%w[resolved waived deferred].include?(blocker["status"]))
+      end
       partial ||= @ledger.dig("tracker", "promotion") == "hold"
 
       partial ? "PARTIAL" : "PASS"

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -1,0 +1,892 @@
+# frozen_string_literal: true
+
+require "json"
+
+module FleetValidation
+  class ManifestError < StandardError; end
+
+  class Lifecycle
+    attr_reader :inventory, :required_paths
+
+    def initialize(manifest:, pack_id:, release_selector:)
+      @manifest = manifest
+      @pack_id = pack_id
+      @release_selector = release_selector
+      @inventory = build_inventory
+      @required_paths = build_required_paths
+    end
+
+    def write_artifacts(output_dir)
+      File.write(File.join(output_dir, "LIFECYCLE.md"), render_lifecycle)
+      File.write(File.join(output_dir, "PREFLIGHT.md"), render_preflight)
+      File.write(File.join(output_dir, "REPORT-ONLY.md"), render_report_only)
+      File.write(File.join(output_dir, "CLOSEOUT.md"), render_closeout)
+      File.write(File.join(output_dir, "result-ledger.json"), "#{JSON.pretty_generate(ledger_template)}\n")
+      File.write(File.join(output_dir, "result-ledger.schema.json"), "#{JSON.pretty_generate(schema)}\n")
+    end
+
+    def ledger_template
+      {
+        "schema_version" => 1,
+        "pack" => {
+          "pack_id" => @pack_id,
+          "release_selector" => @release_selector,
+          "candidate" => nil,
+          "candidate_commit" => nil,
+          "policy_commit" => nil,
+          "tracker_mode" => nil
+        },
+        "preflight" => {
+          "status" => "pending",
+          "waiver" => nil,
+          "release_ci" => "pending",
+          "artifacts" => "pending",
+          "generator_matrix" => "pending",
+          "capabilities" => {
+            "status" => "pending",
+            "permissions" => "pending",
+            "git_auth" => "pending",
+            "github_auth" => "pending",
+            "registry_network" => "pending",
+            "toolchains" => "pending",
+            "host_capacity" => "pending",
+            "coordination" => "pending",
+            "restart_handoff" => nil
+          }
+        },
+        "inventory" => inventory.map do |target|
+          target.slice("id", "tier", "work_mode").merge(
+            "work_state" => "not_started",
+            "result" => "pending",
+            "package_locks" => [],
+            "checks" => %w[install build test local_smoke hosted_ci review].to_h do |check|
+              [check, { "status" => "pending", "evidence" => nil }]
+            end,
+            "review_app" => { "state" => "unknown", "evidence" => nil, "deployed_smoke" => "pending" },
+            "baseline" => { "classification" => "pending", "evidence" => nil },
+            "evidence" => nil
+          )
+        end,
+        "required_paths" => required_paths.map do |path|
+          path.slice("id", "evidence_source").merge(
+            "status" => "pending",
+            "lane" => nil,
+            "evidence" => nil,
+            "waiver" => nil
+          )
+        end,
+        "blockers" => [],
+        "audit" => {
+          "status" => "pending",
+          "checker" => nil,
+          "maker_ids" => [],
+          "base_commit" => nil
+        },
+        "merge" => {
+          "authority" => "none",
+          "authority_evidence" => nil,
+          "freeze_state" => "unknown",
+          "status" => "not_started",
+          "reviewed_base_commit" => nil,
+          "current_base_commit" => nil,
+          "base_reconciliation" => "pending"
+        },
+        "reachability" => {
+          "default_branch" => "pending",
+          "tree_parity" => "pending"
+        },
+        "tracker" => {
+          "status" => "pending",
+          "comment_url" => nil,
+          "promotion" => "blocked"
+        }
+      }
+    end
+
+    def schema
+      {
+        "$schema" => "https://json-schema.org/draft/2020-12/schema",
+        "title" => "React on Rails fleet validation result ledger",
+        "type" => "object",
+        "additionalProperties" => false,
+        "required" => %w[
+          schema_version pack preflight inventory required_paths blockers audit merge reachability tracker
+        ],
+        "properties" => {
+          "schema_version" => { "const" => 1 },
+          "pack" => object_schema(
+            %w[pack_id release_selector candidate candidate_commit policy_commit tracker_mode],
+            {
+              "pack_id" => nonempty_string,
+              "release_selector" => nonempty_string,
+              "candidate" => nullable_string,
+              "candidate_commit" => nullable_string,
+              "policy_commit" => nullable_string,
+              "tracker_mode" => nullable_string
+            }
+          ),
+          "preflight" => preflight_schema,
+          "inventory" => { "type" => "array", "items" => inventory_item_schema },
+          "required_paths" => { "type" => "array", "items" => required_path_schema },
+          "blockers" => { "type" => "array", "items" => blocker_schema },
+          "audit" => audit_schema,
+          "merge" => merge_schema,
+          "reachability" => object_schema(
+            %w[default_branch tree_parity],
+            {
+              "default_branch" => status_string,
+              "tree_parity" => status_string
+            }
+          ),
+          "tracker" => object_schema(
+            %w[status comment_url promotion],
+            {
+              "status" => { "enum" => %w[pending ready posted blocked unknown] },
+              "comment_url" => nullable_string,
+              "promotion" => { "enum" => %w[recommend hold blocked] }
+            }
+          )
+        }
+      }
+    end
+
+    private
+
+    def build_inventory
+      @manifest.fetch("repos").map do |repo|
+        tier = repo.fetch("tier")
+        {
+          "id" => slug(repo.fetch("name")),
+          "name" => repo.fetch("name"),
+          "headline" => repo.fetch("headline"),
+          "tier" => tier,
+          "work_mode" => tier == "soft_track" ? "report_only" : "mutation"
+        }
+      end
+    end
+
+    def preflight_schema
+      fields = %w[
+        status waiver release_ci artifacts generator_matrix capabilities
+      ]
+      object_schema(
+        fields,
+        {
+          "status" => { "enum" => %w[pending passed waived blocked unknown] },
+          "waiver" => waiver_schema,
+          "release_ci" => status_string,
+          "artifacts" => status_string,
+          "generator_matrix" => status_string,
+          "capabilities" => object_schema(
+            %w[
+              status permissions git_auth github_auth registry_network toolchains host_capacity
+              coordination restart_handoff
+            ],
+            {
+              "status" => status_string,
+              "permissions" => status_string,
+              "git_auth" => status_string,
+              "github_auth" => status_string,
+              "registry_network" => status_string,
+              "toolchains" => status_string,
+              "host_capacity" => status_string,
+              "coordination" => status_string,
+              "restart_handoff" => nullable_string
+            }
+          )
+        }
+      )
+    end
+
+    def inventory_item_schema
+      object_schema(
+        %w[
+          id tier work_mode work_state result package_locks checks review_app baseline evidence
+        ],
+        {
+          "id" => nonempty_string,
+          "tier" => { "enum" => %w[hard_gate soft_track] },
+          "work_mode" => { "enum" => %w[mutation report_only] },
+          "work_state" => { "enum" => %w[not_started running finished blocked unknown] },
+          "result" => { "enum" => %w[pending passed reported blocked waived unknown] },
+          "package_locks" => {
+            "type" => "array",
+            "items" => object_schema(
+              %w[ecosystem name version source],
+              {
+                "ecosystem" => { "enum" => %w[gem npm] },
+                "name" => nonempty_string,
+                "version" => nonempty_string,
+                "source" => nonempty_string
+              }
+            )
+          },
+          "checks" => object_schema(
+            %w[install build test local_smoke hosted_ci review],
+            %w[install build test local_smoke hosted_ci review].to_h do |check|
+              [check, evidence_status_schema]
+            end
+          ),
+          "review_app" => object_schema(
+            %w[state evidence deployed_smoke],
+            {
+              "state" => {
+                "enum" => %w[configured_runnable configured_broken not_configured unknown]
+              },
+              "evidence" => nullable_string,
+              "deployed_smoke" => status_string
+            }
+          ),
+          "baseline" => object_schema(
+            %w[classification evidence],
+            {
+              "classification" => {
+                "enum" => %w[pending clean baseline_defect candidate_regression waived unknown]
+              },
+              "evidence" => nullable_string
+            }
+          ),
+          "evidence" => nullable_string
+        }
+      )
+    end
+
+    def required_path_schema
+      object_schema(
+        %w[id evidence_source status lane evidence waiver],
+        {
+          "id" => nonempty_string,
+          "evidence_source" => nonempty_string,
+          "status" => status_string,
+          "lane" => nullable_string,
+          "evidence" => nullable_string,
+          "waiver" => waiver_schema
+        }
+      )
+    end
+
+    def blocker_schema
+      object_schema(
+        %w[id status public_summary owner],
+        {
+          "id" => nonempty_string,
+          "status" => { "enum" => %w[open pending blocked unknown resolved waived deferred] },
+          "public_summary" => nonempty_string,
+          "owner" => {
+            "type" => %w[object null],
+            "additionalProperties" => false,
+            "properties" => {
+              "issue_url" => nonempty_string,
+              "waiver_url" => nonempty_string,
+              "public_tracker_reason" => nonempty_string
+            }
+          }
+        }
+      )
+    end
+
+    def waiver_schema
+      {
+        "type" => %w[object null],
+        "additionalProperties" => false,
+        "required" => %w[authority evidence_url reason],
+        "properties" => {
+          "authority" => nonempty_string,
+          "evidence_url" => nonempty_string,
+          "reason" => nonempty_string
+        }
+      }
+    end
+
+    def audit_schema
+      object_schema(
+        %w[status checker maker_ids base_commit],
+        {
+          "status" => status_string,
+          "checker" => nullable_string,
+          "maker_ids" => { "type" => "array", "items" => nonempty_string },
+          "base_commit" => nullable_string
+        }
+      )
+    end
+
+    def merge_schema
+      object_schema(
+        %w[
+          authority authority_evidence freeze_state status reviewed_base_commit current_base_commit
+          base_reconciliation
+        ],
+        {
+          "authority" => { "enum" => %w[none ask auto_merge_when_gates_pass] },
+          "authority_evidence" => nullable_string,
+          "freeze_state" => { "enum" => %w[clear frozen conflict unknown] },
+          "status" => { "enum" => %w[not_started authorized merged blocked unknown] },
+          "reviewed_base_commit" => nullable_string,
+          "current_base_commit" => nullable_string,
+          "base_reconciliation" => status_string
+        }
+      )
+    end
+
+    def object_schema(required, properties)
+      {
+        "type" => "object",
+        "additionalProperties" => false,
+        "required" => required,
+        "properties" => properties
+      }
+    end
+
+    def evidence_status_schema
+      object_schema(
+        %w[status evidence],
+        {
+          "status" => status_string,
+          "evidence" => nullable_string
+        }
+      )
+    end
+
+    def nonempty_string
+      { "type" => "string", "minLength" => 1 }
+    end
+
+    def nullable_string
+      { "type" => %w[string null] }
+    end
+
+    def status_string
+      { "enum" => %w[pending passed reported blocked waived unknown] }
+    end
+
+    def render_lifecycle
+      coverage = required_paths.map do |path|
+        "| `#{path.fetch('id')}` | #{path.fetch('evidence_source')} | required |"
+      end
+      <<~MARKDOWN
+        # Fleet validation lifecycle
+
+        Pack ID: #{@pack_id}
+        Release selector: #{@release_selector}
+
+        This pack covers #{inventory.count { |item| item['tier'] == 'hard_gate' }} hard gates and
+        #{inventory.count { |item| item['tier'] == 'soft_track' }} report-only soft tracks.
+
+        1. Phase 0 — snapshot: resolve candidate, exact release commit, policy/default commit, tracker mode, and target defaults once.
+        2. Phase 1 — capability preflight: attest machines/sessions and probe target defaults, commands, locks, baseline, and review-app capability.
+        3. Phase 2 — release-wide barrier: prove exact-commit CI, artifacts, and the published generator matrix before app mutation.
+        4. Phase 3 — fleet execution: run claimed hard gates and inspect every report-only soft track.
+        5. Phase 4 — independent audit: reserve a checker that made none of the changes and audit combined evidence.
+        6. Phase 5 — authorized merge: re-read tracker mode/freeze and merge only within explicit authority.
+        7. Phase 6 — reachability and tree parity: fetch each new default and prove the audited patch landed.
+        8. Phase 7 — tracker closeout: validate the ledger and render the append-only disposition matrix.
+
+        `APP_WORK_ALLOWED` is the barrier between phases 2 and 3. Missing, stale, pending, conflicting,
+        or `UNKNOWN` evidence never advances the lifecycle.
+
+        ## Required release-path coverage
+
+        | Path | Evidence source | Contract |
+        | --- | --- | --- |
+        #{coverage.join("\n")}
+      MARKDOWN
+    end
+
+    def render_preflight
+      <<~MARKDOWN
+        # Release-wide preflight
+
+        No app mutation coordinator may emit or consume `APP_WORK_ALLOWED` until all release-wide
+        gates are terminal:
+
+        - release commit CI is green for the exact candidate commit;
+        - registry and tarball artifacts are coherent with that commit; and
+        - the published standard / Pro / Pro+RSC generator matrix is green.
+
+        An explicit public-safe waiver may replace a failed gate only when the release policy allows
+        it and the ledger records the authority and evidence URL. Missing, pending, conflicting, stale,
+        or `UNKNOWN` evidence does not open the barrier.
+
+        Before worker launch, record a machine/session capability attestation covering
+        nonblocking permissions, Git and GitHub authentication, registry/network access, required toolchains,
+        host capacity, coordination availability, and a restart-safe handoff. Probe each target's fresh
+        default branch, repo instructions, package manager/lock, commands, smoke metadata, and review-app
+        capability. Classify review apps as
+        configured/runnable, configured/broken, not configured, or `UNKNOWN`;
+        never wait for an invented review app.
+      MARKDOWN
+    end
+
+    def render_report_only
+      rows = inventory.select { |target| target["tier"] == "soft_track" }.map do |target|
+        <<~ROW.chomp
+          - `#{target.fetch('id')}` — Report only; do not mutate.
+            Inspect the fresh default, current package locks, standing CI/smoke metadata, and archived or deferred disposition.
+            Record `reported`, `blocked`, `waived`, or `unknown` plus public-safe evidence in the shared ledger.
+        ROW
+      end
+
+      <<~MARKDOWN
+        # Report-only soft tracks
+
+        Run after the release-wide preflight barrier opens. These tracks complete the release inventory
+        but never become candidate bump/merge lanes unless a maintainer separately changes their tier.
+
+        #{rows.join("\n")}
+      MARKDOWN
+    end
+
+    def render_closeout
+      <<~MARKDOWN
+        # Independent closeout
+
+        Reserve an independent checker whose identity is absent from every maker ID in the result
+        ledger. The checker audits every hard-gate diff, all report-only dispositions, required-path
+        coverage, baseline classifications, exact-head CI/review evidence, and blocker ownership.
+
+        Immediately before any merge or tracker write, re-read tracker mode and freeze state. Merge only
+        with explicit merge authority and no phase/freeze conflict. Reconcile default-base movement,
+        refresh affected checks, and record the audited base in the ledger.
+
+        For each authorized lane, merge through the repository's normal reviewed path, fetch the new
+        default, then prove default-branch reachability and tree parity against the audited result.
+        A squash merge need not retain the maker head commit, but its resulting tree must contain the
+        audited patch.
+
+        Validate the final ledger, regenerate the append-only tracker matrix from that exact file, and
+        post it without hand-copying worker prose. End with exact `PASS`, `PARTIAL`, or `BLOCKED`
+        semantics. A promotion recommendation is allowed only when every required release path is green
+        or explicitly waived and no `UNKNOWN` remains.
+      MARKDOWN
+    end
+
+    def build_required_paths
+      lifecycle = @manifest.fetch("lifecycle", {})
+      paths = lifecycle.fetch("required_paths", [])
+      unless paths.is_a?(Array) && paths.all? { |path| path.is_a?(Hash) && path["id"].to_s != "" }
+        raise ManifestError, "lifecycle.required_paths must contain mappings with IDs"
+      end
+
+      paths.map(&:dup)
+    end
+
+    def slug(value)
+      value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-\z/, "")
+    end
+  end
+
+  class LedgerValidator
+    def initialize(ledger, inventory:, required_paths:, expected_candidate: nil, closeout: false)
+      @ledger = ledger
+      @inventory = inventory
+      @required_paths = required_paths
+      @expected_candidate = expected_candidate
+      @closeout = closeout
+    end
+
+    def errors
+      result = []
+      result << "schema_version must be 1" unless @ledger["schema_version"] == 1
+      result << candidate_error if candidate_error
+      result.concat(capability_errors)
+      result.concat(inventory_errors)
+      result.concat(private_field_errors)
+      result << "app work started before APP_WORK_ALLOWED" if app_work_started? && !app_work_allowed?
+      result << review_app_error if review_app_error
+      result.concat(required_path_errors) if @closeout
+      result.concat(blocker_owner_errors) if @closeout
+      result.concat(preflight_errors) if @closeout
+      result.concat(pack_identity_errors) if @closeout
+      result << inventory_completion_error if @closeout && inventory_completion_error
+      result << package_lock_error if @closeout && package_lock_error
+      result << check_evidence_error if @closeout && check_evidence_error
+      result << base_movement_error if @closeout && base_movement_error
+      result << independent_audit_error if @closeout && independent_audit_error
+      result << "independent audit is not passed" if @closeout && @ledger.dig("audit", "status") != "passed"
+      if @closeout && !present?(@ledger.dig("preflight", "capabilities", "restart_handoff"))
+        result << "capability restart_handoff is missing"
+      end
+      result.concat(reachability_errors) if @closeout
+      result << merge_authority_error if @closeout && merge_authority_error
+      result << promotion_error if @closeout && promotion_error
+      if @closeout && @ledger.dig("merge", "status") == "merged" &&
+         !present?(@ledger.dig("merge", "authority_evidence"))
+        result << "merged result is missing explicit authority evidence"
+      end
+      result
+    end
+
+    private
+
+    def app_work_started?
+      Array(@ledger["inventory"]).any? do |item|
+        item["work_mode"] == "mutation" && item["work_state"] != "not_started"
+      end
+    end
+
+    def candidate_error
+      return unless @expected_candidate
+
+      actual = @ledger.fetch("pack", {})["candidate"]
+      return if actual == @expected_candidate
+
+      "candidate mismatch: expected #{@expected_candidate}, got #{actual || 'missing'}"
+    end
+
+    def capability_errors
+      capabilities = @ledger.fetch("preflight", {}).fetch("capabilities", {})
+      capabilities.filter_map do |name, value|
+        "capability #{name} is UNKNOWN" if value.to_s.casecmp("unknown").zero?
+      end
+    end
+
+    def inventory_errors
+      actual_ids = Array(@ledger["inventory"]).filter_map { |item| item["id"] }
+      @inventory.filter_map do |target|
+        "inventory missing target #{target.fetch('id')}" unless actual_ids.include?(target.fetch("id"))
+      end
+    end
+
+    def private_field_errors
+      forbidden = %w[
+        app_identity credentials deployment_url logs private_details private_repository private_url
+        production_sha route secret_name
+      ]
+      Array(@ledger["blockers"]).flat_map do |blocker|
+        (blocker.keys & forbidden).map do |field|
+          "blocker #{blocker['id'] || 'missing-id'} contains forbidden private field #{field}"
+        end
+      end
+    end
+
+    def review_app_error
+      count = Array(@ledger["inventory"]).count do |item|
+        item["work_state"] != "not_started" && item.dig("review_app", "state").to_s.casecmp("unknown").zero?
+      end
+      return if count.zero?
+
+      "review app capability UNKNOWN for #{count} started target(s)"
+    end
+
+    def required_path_errors
+      paths = Array(@ledger["required_paths"])
+      @required_paths.filter_map do |required|
+        path = paths.find { |item| item["id"] == required.fetch("id") }
+        next if path_evidenced?(path)
+
+        "required path #{required.fetch('id')} has no passing evidence or waiver"
+      end
+    end
+
+    def blocker_owner_errors
+      Array(@ledger["blockers"]).filter_map do |blocker|
+        next if %w[resolved waived deferred].include?(blocker["status"])
+        next if durable_owner?(blocker["owner"])
+
+        "blocker #{blocker['id'] || 'missing-id'} has no durable owner"
+      end
+    end
+
+    def base_movement_error
+      merge = @ledger.fetch("merge", {})
+      reviewed = merge["reviewed_base_commit"]
+      current = merge["current_base_commit"]
+      return unless present?(reviewed) && present?(current) && reviewed != current
+      return if merge["base_reconciliation"] == "passed"
+
+      "base moved after audit without passing reconciliation"
+    end
+
+    def preflight_errors
+      preflight = @ledger.fetch("preflight", {})
+      waived = preflight["status"] == "waived" && valid_waiver?(preflight["waiver"])
+      errors = %w[release_ci artifacts generator_matrix].filter_map do |field|
+        next if preflight[field] == "passed" || waived
+
+        "release-wide preflight #{field} is not passed or explicitly waived"
+      end
+      capabilities = preflight.fetch("capabilities", {})
+      %w[status permissions git_auth github_auth registry_network toolchains host_capacity coordination].each do |field|
+        next if capabilities[field] == "passed" || waived
+
+        errors << "capability #{field} is not passed or explicitly waived"
+      end
+      errors
+    end
+
+    def pack_identity_errors
+      pack = @ledger.fetch("pack", {})
+      %w[candidate candidate_commit policy_commit tracker_mode].filter_map do |field|
+        "pack #{field} is missing" unless present?(pack[field])
+      end
+    end
+
+    def inventory_completion_error
+      count = Array(@ledger["inventory"]).count do |item|
+        terminal_results = item["tier"] == "hard_gate" ? %w[passed blocked waived] : %w[reported blocked waived]
+        baseline = item.dig("baseline", "classification")
+        !terminal_results.include?(item["result"]) || %w[pending unknown].include?(baseline)
+      end
+      return if count.zero?
+
+      "#{count} inventory target(s) are unknown or nonterminal"
+    end
+
+    def package_lock_error
+      count = Array(@ledger["inventory"]).count do |item|
+        next false unless item["tier"] == "hard_gate"
+
+        locks = item["package_locks"]
+        !locks.is_a?(Array) || locks.empty? || locks.any? do |lock|
+          %w[ecosystem name version source].any? { |field| !present?(lock[field]) }
+        end
+      end
+      return if count.zero?
+
+      "#{count} hard-gate target(s) are missing retained package lock evidence"
+    end
+
+    def check_evidence_error
+      count = Array(@ledger["inventory"]).count do |item|
+        next false unless item["tier"] == "hard_gate"
+
+        checks = item["checks"]
+        !checks.is_a?(Hash) || %w[install build test local_smoke hosted_ci review].any? do |name|
+          check = checks[name]
+          !check.is_a?(Hash) || !%w[passed blocked waived].include?(check["status"]) ||
+            !present?(check["evidence"])
+        end
+      end
+      return if count.zero?
+
+      "#{count} hard-gate target(s) have unknown or nonterminal check evidence"
+    end
+
+    def independent_audit_error
+      audit = @ledger.fetch("audit", {})
+      return unless Array(audit["maker_ids"]).include?(audit["checker"])
+
+      "independent audit checker is also a maker"
+    end
+
+    def reachability_errors
+      reachability = @ledger.fetch("reachability", {})
+      %w[default_branch tree_parity].filter_map do |field|
+        "reachability #{field} is not passed" unless reachability[field] == "passed"
+      end
+    end
+
+    def merge_authority_error
+      merge = @ledger.fetch("merge", {})
+      return unless merge["status"] == "merged"
+
+      authorized = %w[ask auto_merge_when_gates_pass].include?(merge["authority"])
+      conflict = merge["freeze_state"] != "clear" || @ledger.dig("pack", "tracker_mode") == "conflict"
+      return if authorized && !conflict
+
+      "merge is not allowed while tracker mode or freeze state conflicts"
+    end
+
+    def promotion_error
+      return unless @ledger.dig("tracker", "promotion") == "recommend"
+      return unless release_blocked?
+
+      "promotion cannot be recommended while release blockers remain"
+    end
+
+    def durable_owner?(owner)
+      return false unless owner.is_a?(Hash)
+
+      %w[issue_url waiver_url public_tracker_reason].any? { |key| present?(owner[key]) }
+    end
+
+    def path_evidenced?(path)
+      return false unless path
+      return true if path["status"] == "passed" && present?(path["lane"]) && present?(path["evidence"])
+
+      path["status"] == "waived" && valid_waiver?(path["waiver"])
+    end
+
+    def present?(value)
+      !value.nil? && !value.to_s.empty?
+    end
+
+    def app_work_allowed?
+      preflight = @ledger.fetch("preflight", {})
+      preflight["status"] == "passed" || (preflight["status"] == "waived" && valid_waiver?(preflight["waiver"]))
+    end
+
+    def valid_waiver?(waiver)
+      waiver.is_a?(Hash) && %w[authority evidence_url reason].all? { |field| present?(waiver[field]) }
+    end
+
+    def release_blocked?
+      hard_gate_blocked = Array(@ledger["inventory"]).any? do |item|
+        item["tier"] == "hard_gate" && !%w[passed waived].include?(item["result"])
+      end
+      required_path_blocked = @required_paths.any? do |required|
+        path = Array(@ledger["required_paths"]).find { |item| item["id"] == required.fetch("id") }
+        !path_evidenced?(path)
+      end
+      active_blocker = Array(@ledger["blockers"]).any? do |blocker|
+        !%w[resolved waived deferred].include?(blocker["status"])
+      end
+
+      hard_gate_blocked || required_path_blocked || active_blocker
+    end
+  end
+
+  class SchemaValidator
+    def initialize(schema)
+      @schema = schema
+    end
+
+    def errors(value)
+      validate(value, @schema, "$")
+    end
+
+    private
+
+    def validate(value, schema, path)
+      errors = []
+      errors << "#{path} must equal #{schema['const'].inspect}" if schema.key?("const") && value != schema["const"]
+      errors << "#{path} is not an allowed value" if schema["enum"] && !schema["enum"].include?(value)
+      return errors unless valid_type?(value, schema["type"], path, errors)
+
+      if value.is_a?(Hash)
+        errors.concat(validate_object(value, schema, path))
+      elsif value.is_a?(Array) && schema["items"]
+        value.each_with_index do |item, index|
+          errors.concat(validate(item, schema.fetch("items"), "#{path}[#{index}]"))
+        end
+      elsif value.is_a?(String) && schema["minLength"] && value.length < schema["minLength"]
+        errors << "#{path} is shorter than #{schema['minLength']}"
+      end
+      errors
+    end
+
+    def valid_type?(value, declared, path, errors)
+      return true unless declared
+
+      allowed = Array(declared)
+      return true if allowed.any? { |type| type_matches?(value, type) }
+
+      errors << "#{path} has invalid type"
+      false
+    end
+
+    def type_matches?(value, type)
+      {
+        "array" => Array,
+        "integer" => Integer,
+        "null" => NilClass,
+        "object" => Hash,
+        "string" => String
+      }.fetch(type).then { |klass| value.is_a?(klass) }
+    end
+
+    def validate_object(value, schema, path)
+      errors = Array(schema["required"]).filter_map do |field|
+        "#{path} is missing required field #{field}" unless value.key?(field)
+      end
+      properties = schema.fetch("properties", {})
+      if schema["additionalProperties"] == false
+        (value.keys - properties.keys).each do |field|
+          errors << "#{path} has unsupported field #{field}"
+        end
+      end
+      value.each do |field, child|
+        next unless properties[field]
+
+        errors.concat(validate(child, properties.fetch(field), "#{path}.#{field}"))
+      end
+      errors
+    end
+  end
+
+  class TrackerRenderer
+    def initialize(ledger)
+      @ledger = ledger
+    end
+
+    def render
+      rows = @ledger.fetch("inventory").map do |target|
+        [
+          target["id"],
+          target["tier"],
+          target["result"],
+          target.dig("baseline", "classification"),
+          target.dig("review_app", "state"),
+          target["evidence"]
+        ].map { |value| escape(value) }.then { |cells| "| #{cells.join(' | ')} |" }
+      end
+      required_path_rows = Array(@ledger["required_paths"]).map do |path|
+        [path["id"], path["status"], path["lane"], path["evidence"]]
+          .map { |value| escape(value) }
+          .then { |cells| "| #{cells.join(' | ')} |" }
+      end
+      blocker_rows = Array(@ledger["blockers"]).map do |blocker|
+        owner = blocker.fetch("owner", nil)
+        owner_evidence = owner.is_a?(Hash) ? owner.values.compact.join(", ") : nil
+        [blocker["id"], blocker["status"], blocker["public_summary"], owner_evidence]
+          .map { |value| escape(value) }
+          .then { |cells| "| #{cells.join(' | ')} |" }
+      end
+      blocker_rows << "| None | resolved | No release blockers recorded | n/a |" if blocker_rows.empty?
+
+      <<~MARKDOWN
+        <!-- fleet-validation-closeout:#{escape(@ledger.dig('pack', 'pack_id'))} -->
+        ## Fleet validation closeout
+
+        Candidate: #{escape(@ledger.dig('pack', 'candidate'))}
+        Verdict: #{verdict}
+
+        | Target | Tier | Result | Baseline | Review app | Evidence |
+        | --- | --- | --- | --- | --- | --- |
+        #{rows.join("\n")}
+
+        ## Required release paths
+
+        | Path | Status | Lane | Evidence |
+        | --- | --- | --- | --- |
+        #{required_path_rows.join("\n")}
+
+        ## Blocker ownership
+
+        | Blocker | Status | Public summary | Durable owner |
+        | --- | --- | --- | --- |
+        #{blocker_rows.join("\n")}
+
+        Promotion recommendation: #{escape(@ledger.dig('tracker', 'promotion'))}
+      MARKDOWN
+    end
+
+    private
+
+    def verdict
+      inventory = Array(@ledger["inventory"])
+      blockers = Array(@ledger["blockers"])
+      paths = Array(@ledger["required_paths"])
+      blocked = inventory.any? do |item|
+        item["tier"] == "hard_gate" && !%w[passed waived].include?(item["result"])
+      end
+      blocked ||= paths.any? { |path| !%w[passed waived].include?(path["status"]) }
+      blocked ||= blockers.any? { |blocker| !%w[resolved waived deferred].include?(blocker["status"]) }
+      blocked ||= @ledger.dig("tracker", "promotion") == "blocked"
+      return "BLOCKED" if blocked
+
+      partial = inventory.any? do |item|
+        item["result"] == "waived" || (item["tier"] == "soft_track" && item["result"] == "blocked")
+      end
+      partial ||= paths.any? { |path| path["status"] == "waived" }
+      partial ||= blockers.any? { |blocker| %w[waived deferred].include?(blocker["status"]) }
+      partial ||= @ledger.dig("tracker", "promotion") == "hold"
+
+      partial ? "PARTIAL" : "PASS"
+    end
+
+    def escape(value)
+      value.to_s.gsub(/\s+/, " ").strip.gsub("|", "\\|").gsub("<!--", "&lt;!--").gsub("-->", "--&gt;")
+    end
+  end
+end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -759,7 +759,11 @@ module FleetValidation
         versioned dependency locks retain the versions observed in their target. The aggregate
         merge/reachability state is derived from the per-target rows. If
         any lane has already merged, its base, authority/freeze, merge-commit, reachability, and
-        tree-parity proofs remain required even when another lane blocks overall promotion.
+        tree-parity proofs remain required even when another lane blocks overall promotion. An
+        unmerged blocked lane retains pristine pending reachability with no stale proof fields, while
+        a non-mutation lane records an evidenced, freeze-clear `not_applicable` merge disposition.
+        Supply both the expected pack ID and generated release selector from the independent launch
+        record when validating; never derive the expected snapshot identity from the ledger itself.
       MARKDOWN
     end
 
@@ -1690,6 +1694,9 @@ module FleetValidation
              present?(merge["merge_commit"])
             errors << "target #{item['id']} not-applicable merge retains mutation state"
           end
+          unless merge["freeze_state"] == "clear" && present?(merge["evidence"])
+            errors << "target #{item['id']} not-applicable merge disposition is incomplete"
+          end
           unless pristine_reachability?(item.fetch("reachability", {}))
             errors << "target #{item['id']} non-mutation target retains reachability state"
           end
@@ -1712,12 +1719,21 @@ module FleetValidation
           errors << "target #{item['id']} merge evidence is missing" unless present?(merge["evidence"])
         elsif merge["status"] == "blocked"
           errors << "target #{item['id']} blocked merge disposition has no evidence" unless present?(merge["evidence"])
+          if merge["authority"] != "none" || present?(merge["authority_evidence"])
+            errors << "target #{item['id']} blocked merge retains mutation authority"
+          end
+          unless merge["freeze_state"] == "clear"
+            errors << "target #{item['id']} blocked merge freeze state is unresolved"
+          end
           if present?(merge["merge_commit"])
             errors << "target #{item['id']} blocked merge retains a merge commit"
           end
           reachability = item.fetch("reachability", {})
           if reachability["default_branch"] == "passed" || reachability["tree_parity"] == "passed"
             errors << "target #{item['id']} blocked merge retains successful reachability"
+          end
+          unless pristine_reachability?(reachability)
+            errors << "target #{item['id']} blocked merge retains unresolved reachability"
           end
         end
         if !release_blocked? && merge["status"] != "merged"

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -762,8 +762,9 @@ module FleetValidation
         tree-parity proofs remain required even when another lane blocks overall promotion. An
         unmerged blocked lane retains pristine pending reachability with no stale proof fields, while
         a non-mutation lane records an evidenced, freeze-clear `not_applicable` merge disposition.
-        Supply both the expected pack ID and generated release selector from the independent launch
-        record when validating; never derive the expected snapshot identity from the ledger itself.
+        Supply the expected pack ID, generated release selector, candidate tag, and candidate source
+        commit from the independent launch record when validating; never derive the expected snapshot
+        identity from the ledger itself.
       MARKDOWN
     end
 
@@ -821,7 +822,9 @@ module FleetValidation
       inventory:,
       required_paths:,
       expected_candidate: nil,
+      expected_candidate_commit: nil,
       expected_pack_id: nil,
+      expected_release_selector: nil,
       expected_snapshot_fingerprint: nil,
       closeout: false
     )
@@ -829,7 +832,9 @@ module FleetValidation
       @inventory = inventory
       @required_paths = required_paths
       @expected_candidate = expected_candidate
+      @expected_candidate_commit = expected_candidate_commit
       @expected_pack_id = expected_pack_id
+      @expected_release_selector = expected_release_selector
       @expected_snapshot_fingerprint = expected_snapshot_fingerprint
       @closeout = closeout
     end
@@ -1371,6 +1376,14 @@ module FleetValidation
       end
       if @expected_pack_id && pack["pack_id"] != @expected_pack_id
         errors << "pack ID mismatch: expected #{@expected_pack_id}, got #{pack['pack_id']}"
+      end
+      if @expected_release_selector && pack["release_selector"] != @expected_release_selector
+        errors << "pack release selector mismatch: expected #{@expected_release_selector}, " \
+                  "got #{pack['release_selector']}"
+      end
+      if @expected_candidate_commit && pack["candidate_commit"] != @expected_candidate_commit
+        errors << "pack candidate commit mismatch: expected #{@expected_candidate_commit}, " \
+                  "got #{pack['candidate_commit']}"
       end
       errors
     end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -22,7 +22,11 @@ module FleetValidation
       "packages" => [
         { "ecosystem" => "gem", "name" => "react_on_rails" },
         { "ecosystem" => "npm", "name" => "react-on-rails" },
-        { "ecosystem" => "npm", "name" => "create-react-on-rails-app" }
+        { "ecosystem" => "npm", "name" => "create-react-on-rails-app" },
+        { "ecosystem" => "gem", "name" => "react_on_rails_pro" },
+        { "ecosystem" => "npm", "name" => "react-on-rails-pro" },
+        { "ecosystem" => "npm", "name" => "react-on-rails-pro-node-renderer" },
+        { "ecosystem" => "npm", "name" => "react-on-rails-rsc" }
       ]
     }.freeze
 
@@ -83,6 +87,7 @@ module FleetValidation
         },
         "inventory" => inventory.map do |target|
           target.slice("id", "tier", "work_mode").merge(
+            "maker_id" => nil,
             "work_state" => "not_started",
             "work_started_at" => nil,
             "result" => "pending",
@@ -297,13 +302,14 @@ module FleetValidation
     def inventory_item_schema
       object_schema(
         %w[
-          id tier work_mode work_state work_started_at result waiver blocker_id package_locks checks
+          id tier work_mode maker_id work_state work_started_at result waiver blocker_id package_locks checks
           review_app baseline bases reachability evidence
         ],
         {
           "id" => nonempty_string,
           "tier" => { "enum" => %w[hard_gate soft_track] },
           "work_mode" => { "enum" => %w[mutation validation_only report_only] },
+          "maker_id" => nullable_string,
           "work_state" => { "enum" => %w[not_started running finished blocked unknown] },
           "work_started_at" => nullable_string,
           "result" => { "enum" => %w[pending passed reported blocked waived unknown] },
@@ -599,6 +605,8 @@ module FleetValidation
         Reserve an independent checker whose identity is absent from every maker ID in the result
         ledger. The checker audits every hard-gate diff, all report-only dispositions, required-path
         coverage, baseline classifications, exact-head CI/review evidence, and blocker ownership.
+        Every mutable target records its maker identity; `audit.maker_ids` must exactly cover those
+        identities before independence can pass.
 
         Immediately before any merge or tracker write, re-read tracker mode and freeze state. Merge only
         with explicit merge authority and no phase/freeze conflict. Reconcile default-base movement,
@@ -607,7 +615,8 @@ module FleetValidation
         For each authorized lane, merge through the repository's normal reviewed path, fetch the new
         default, then prove default-branch reachability and tree parity against the audited result.
         A squash merge need not retain the maker head commit, but its resulting tree must contain the
-        audited patch.
+        audited patch. The validation-only generator/install gate creates no branch and is therefore
+        excluded from per-target merge-base, reachability, and tree-parity evidence.
 
         Validate the final ledger, regenerate the append-only tracker matrix from that exact file, and
         post it without hand-copying worker prose. End with exact `PASS`, `PARTIAL`, or `BLOCKED`
@@ -703,10 +712,12 @@ module FleetValidation
       end
       result.concat(reachability_errors) if @closeout && merge_eligible?
       result.concat(tracker_errors) if @closeout
-      result << merge_authority_error if @closeout && merge_eligible? && merge_authority_error
+      recorded_merge = @ledger.dig("merge", "status") == "merged"
+      if @closeout && (merge_eligible? || recorded_merge) && merge_authority_error
+        result << merge_authority_error
+      end
       result << promotion_error if @closeout && promotion_error
-      if @closeout && merge_eligible? && @ledger.dig("merge", "status") == "merged" &&
-         !present?(@ledger.dig("merge", "authority_evidence"))
+      if @closeout && recorded_merge && !present?(@ledger.dig("merge", "authority_evidence"))
         result << "merged result is missing explicit authority evidence"
       end
       result
@@ -859,7 +870,7 @@ module FleetValidation
     def base_movement_error
       merge = @ledger.fetch("merge", {})
       moved = Array(@ledger["inventory"]).any? do |item|
-        next false unless item["tier"] == "hard_gate"
+        next false unless item["work_mode"] == "mutation"
 
         bases = item.fetch("bases", {})
         present?(bases["reviewed"]) && present?(bases["current"]) &&
@@ -1010,9 +1021,17 @@ module FleetValidation
     def independent_audit_errors
       audit = @ledger.fetch("audit", {})
       errors = []
+      audit_maker_ids = Array(audit["maker_ids"])
+      mutable_maker_ids = Array(@ledger["inventory"]).filter_map do |item|
+        item["maker_id"] if item["work_mode"] == "mutation"
+      end
+      mutable_count = Array(@ledger["inventory"]).count { |item| item["work_mode"] == "mutation" }
       errors << "independent audit checker is missing" unless present?(audit["checker"])
-      errors << "independent audit maker identities are missing" if Array(audit["maker_ids"]).empty?
-      if present?(audit["checker"]) && Array(audit["maker_ids"]).include?(audit["checker"])
+      errors << "independent audit maker identities are missing" if audit_maker_ids.empty?
+      if mutable_maker_ids.length != mutable_count || mutable_maker_ids.uniq.sort != audit_maker_ids.uniq.sort
+        errors << "independent audit maker identities do not cover every mutable target"
+      end
+      if present?(audit["checker"]) && audit_maker_ids.include?(audit["checker"])
         errors << "independent audit checker is also a maker"
       end
       errors
@@ -1033,7 +1052,7 @@ module FleetValidation
         errors << "audit base_commit does not match merge reviewed_base_commit"
       end
       Array(@ledger["inventory"]).each do |item|
-        next unless item["tier"] == "hard_gate"
+        next unless item["work_mode"] == "mutation"
 
         bases = item.fetch("bases", {})
         %w[audit reviewed current].each do |field|
@@ -1091,6 +1110,10 @@ module FleetValidation
            !valid_waiver?(item.dig("baseline", "waiver"), "#{item['id']}:baseline")
           errors << "target #{item['id']} waived baseline is missing structured waiver evidence"
         end
+        if item.dig("baseline", "classification") == "baseline_defect" &&
+           !valid_waiver?(item.dig("baseline", "waiver"), "#{item['id']}:baseline")
+          errors << "target #{item['id']} baseline defect is missing structured waiver evidence"
+        end
         item.fetch("checks", {}).each do |name, check|
           next unless check["status"] == "waived"
           next if valid_waiver?(check["waiver"], "#{item['id']}:#{name}")
@@ -1107,7 +1130,7 @@ module FleetValidation
         "reachability #{field} is not passed" unless reachability[field] == "passed"
       end
       Array(@ledger["inventory"]).each do |item|
-        next unless item["tier"] == "hard_gate"
+        next unless item["work_mode"] == "mutation"
 
         target = item.fetch("reachability", {})
         unless target["default_branch"] == "passed" && commit_identity?(target["default_commit"]) &&
@@ -1206,9 +1229,12 @@ module FleetValidation
         top_level_blocked = !%w[passed waived].include?(item["result"]) || item["work_state"] == "blocked"
         check_blocked = item.fetch("checks", {}).values.any? { |check| check["status"] == "blocked" }
         candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
+        unwaived_baseline_defect = item.dig("baseline", "classification") == "baseline_defect" &&
+                                   !valid_waiver?(item.dig("baseline", "waiver"), "#{item['id']}:baseline")
         review_app_blocked = item.dig("review_app", "state") == "configured_broken" ||
                              item.dig("review_app", "deployed_smoke") == "blocked"
-        top_level_blocked || check_blocked || candidate_regression || review_app_blocked
+        top_level_blocked || check_blocked || candidate_regression || unwaived_baseline_defect ||
+          review_app_blocked
       end
       required_path_blocked = @required_paths.any? do |required|
         path = Array(@ledger["required_paths"]).find { |item| item["id"] == required.fetch("id") }
@@ -1362,7 +1388,11 @@ module FleetValidation
         candidate_regression = item.dig("baseline", "classification") == "candidate_regression"
         review_app_blocked = item.dig("review_app", "state") == "configured_broken" ||
                              item.dig("review_app", "deployed_smoke") == "blocked"
-        top_level_blocked || check_blocked || candidate_regression || review_app_blocked
+        baseline = item.fetch("baseline", {})
+        unwaived_baseline_defect = baseline["classification"] == "baseline_defect" &&
+                                   !structured_waiver?(baseline["waiver"], "#{item['id']}:baseline")
+        top_level_blocked || check_blocked || candidate_regression || unwaived_baseline_defect ||
+          review_app_blocked
       end
       blocked ||= paths.any? { |path| !%w[passed waived].include?(path["status"]) }
       blocked ||= blockers.any? { |blocker| !%w[resolved waived deferred].include?(blocker["status"]) }
@@ -1373,9 +1403,10 @@ module FleetValidation
         target_waived = item["result"] == "waived"
         check_waived = item.fetch("checks", {}).values.any? { |check| check["status"] == "waived" }
         baseline_waived = item.dig("baseline", "classification") == "waived"
+        baseline_defect = item.dig("baseline", "classification") == "baseline_defect"
         review_app_waived = item.dig("review_app", "deployed_smoke") == "waived" &&
                             item.dig("review_app", "state") != "not_configured"
-        target_waived || check_waived || baseline_waived || review_app_waived ||
+        target_waived || check_waived || baseline_waived || baseline_defect || review_app_waived ||
           (item["tier"] == "soft_track" && item["result"] == "blocked")
       end
       partial ||= @ledger.dig("preflight", "status") == "waived"
@@ -1391,6 +1422,11 @@ module FleetValidation
 
     def escape(value)
       value.to_s.gsub(/\s+/, " ").strip.gsub("|", "\\|").gsub("<!--", "&lt;!--").gsub("-->", "--&gt;")
+    end
+
+    def structured_waiver?(waiver, gate)
+      waiver.is_a?(Hash) && waiver["gate"] == gate &&
+        %w[authority evidence_url reason].all? { |field| !waiver[field].to_s.empty? }
     end
   end
 end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_lifecycle.rb
@@ -686,7 +686,8 @@ module FleetValidation
         If an owned release-wide blocker makes opening the barrier impossible, close the pack with
         `preflight.status: blocked`, a durable `preflight.blocker_id`, public-safe
         `preflight.blocker_evidence`, and `APP_WORK_ALLOWED` still false. In that terminal path every
-        app target remains untouched, although it may retain read-only package-lock probe evidence.
+        app target remains untouched, although it may retain read-only package-lock probe evidence,
+        and the public marker remains pristine `pending` state with no publication fields or evidence.
         The independent audit records no maker IDs, and aggregate merge/reachability plus tracker
         promotion remain blocked.
 
@@ -732,9 +733,10 @@ module FleetValidation
         Reserve an independent checker whose identity is absent from every maker ID in the result
         ledger. The checker audits every hard-gate diff, all report-only dispositions, required-path
         coverage, baseline classifications, exact-head CI/review evidence, and blocker ownership.
-        Every mutable target records its maker identity; `audit.maker_ids` must exactly cover those
-        identities before independence can pass. The audit records replayable public-safe evidence,
-        and every check head must match the target's exact audited, reviewed, and current revision.
+        Every mutable target records its canonical nonblank maker identity; `audit.maker_ids` must
+        exactly cover those identities, and the checker must remain different after canonical
+        comparison. The audit records replayable public-safe evidence, and every check head must match
+        the target's exact audited, reviewed, and current revision.
 
         Immediately before each merge or tracker write, re-read tracker mode and freeze state. Record
         authority, freeze state, merge commit, and evidence on that mutable target. Merge only with
@@ -1085,7 +1087,16 @@ module FleetValidation
     end
 
     def blocked_preflight_state_errors
-      errors = Array(@ledger["inventory"]).flat_map do |item|
+      marker = @ledger.dig("preflight", "public_marker")
+      pristine_marker = marker.is_a?(Hash) && marker["status"] == "pending" &&
+                        %w[pack_id candidate candidate_commit snapshot_fingerprint opened_at evidence].all? do |field|
+                          marker[field].nil?
+                        end
+      errors = []
+      unless pristine_marker
+        errors << "blocked preflight public marker must remain pristine and unpublished"
+      end
+      errors.concat(Array(@ledger["inventory"]).flat_map do |item|
         if item["work_mode"] == "validation_only" && item["work_state"] != "not_started"
           next validation_only_preflight_evidence_errors(item)
         end
@@ -1113,7 +1124,7 @@ module FleetValidation
           item_errors << "blocked preflight target #{item['id']} contains reachability state"
         end
         item_errors
-      end
+      end)
       errors << "blocked preflight aggregate merge status must be blocked" unless @ledger.dig("merge", "status") == "blocked"
       unless @ledger.dig("tracker", "promotion") == "blocked"
         errors << "blocked preflight tracker promotion must be blocked"
@@ -1559,32 +1570,38 @@ module FleetValidation
     def independent_audit_errors
       audit = @ledger.fetch("audit", {})
       errors = []
-      audit_maker_ids = Array(audit["maker_ids"])
+      raw_audit_maker_ids = Array(audit["maker_ids"])
       raw_mutable_maker_ids = Array(@ledger["inventory"]).filter_map do |item|
         item["maker_id"] if item["work_mode"] == "mutation"
       end
+      raw_actor_identities = [audit["checker"]] + raw_audit_maker_ids + raw_mutable_maker_ids
+      if raw_actor_identities.compact.any? { |identity| !canonical_actor_identity?(identity) }
+        errors << "independent audit actor identities must be canonical nonblank strings"
+      end
+      checker_identity = canonical_actor_identity(audit["checker"])
+      audit_maker_ids = raw_audit_maker_ids.filter_map { |identity| canonical_actor_identity(identity) }
+      mutable_maker_ids = raw_mutable_maker_ids.filter_map { |identity| canonical_actor_identity(identity) }
       mutable_count = Array(@ledger["inventory"]).count { |item| item["work_mode"] == "mutation" }
-      errors << "independent audit checker is missing" unless present?(audit["checker"])
+      errors << "independent audit checker is missing" unless checker_identity
       errors << "independent audit evidence is missing" unless present?(audit["evidence"])
       if preflight_blocked?
-        unless raw_mutable_maker_ids.none? { |maker_id| present?(maker_id) } && audit_maker_ids.empty?
+        unless mutable_maker_ids.empty? && raw_audit_maker_ids.empty?
           errors << "blocked preflight audit must not claim maker identities"
         end
       else
-        errors << "independent audit maker identities are missing" if audit_maker_ids.empty?
+        errors << "independent audit maker identities are missing" if raw_audit_maker_ids.empty?
         if audit_maker_ids.length != audit_maker_ids.uniq.length
           errors << "independent audit maker identities must be unique"
         end
-        if raw_mutable_maker_ids.any? { |maker_id| !present?(maker_id) } ||
-           audit_maker_ids.any? { |maker_id| !present?(maker_id) }
+        if raw_mutable_maker_ids.any? { |maker_id| canonical_actor_identity(maker_id).nil? } ||
+           raw_audit_maker_ids.any? { |maker_id| canonical_actor_identity(maker_id).nil? }
           errors << "independent audit maker identities contain blank values"
         end
-        mutable_maker_ids = raw_mutable_maker_ids.select { |maker_id| present?(maker_id) }
         if mutable_maker_ids.length != mutable_count || mutable_maker_ids.uniq.sort != audit_maker_ids.uniq.sort
           errors << "independent audit maker identities do not cover every mutable target"
         end
       end
-      if present?(audit["checker"]) && audit_maker_ids.include?(audit["checker"])
+      if checker_identity && audit_maker_ids.include?(checker_identity)
         errors << "independent audit checker is also a maker"
       end
       errors
@@ -1832,6 +1849,18 @@ module FleetValidation
 
     def active_blocker?(blocker)
       %w[open pending blocked unknown].include?(blocker["status"])
+    end
+
+    def canonical_actor_identity(value)
+      return unless value.is_a?(String)
+
+      identity = value.strip
+      identity unless identity.empty?
+    end
+
+    def canonical_actor_identity?(value)
+      canonical = canonical_actor_identity(value)
+      canonical && value == canonical
     end
 
     def inactive_blocker_error(subject, blocker)

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -4,6 +4,7 @@
 require "fileutils"
 require "optparse"
 require "securerandom"
+require "shellwords"
 require "yaml"
 require_relative "fleet_lifecycle"
 
@@ -301,7 +302,25 @@ module FleetValidation
            read-only evidence while waiting.
         4. Run [REPORT-ONLY.md](REPORT-ONLY.md) for the complete soft-track inventory.
         5. Run [CLOSEOUT.md](CLOSEOUT.md) with an independent checker, validate `result-ledger.json`
-           against `result-ledger.schema.json`, and render the tracker matrix from that ledger.
+           against `result-ledger.schema.json`, and render the tracker matrix from that ledger. The
+           checker must copy the policy commit and initial tracker mode from the unique public snapshot
+           comment, never from `result-ledger.json`, before running:
+
+           ```bash
+           EXPECTED_CANDIDATE=RESOLVED_CANDIDATE_TAG
+           EXPECTED_CANDIDATE_COMMIT=RESOLVED_CANDIDATE_COMMIT
+           EXPECTED_POLICY_COMMIT=FULL_POLICY_COMMIT_SHA
+           EXPECTED_TRACKER_MODE=INITIAL_TRACKER_MODE
+           ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
+             --ledger result-ledger.json \
+             --expected-pack-id #{Shellwords.escape(@pack_id)} \
+             --expected-release-selector #{Shellwords.escape(@release_selector)} \
+             --expected-candidate "$EXPECTED_CANDIDATE" \
+             --expected-candidate-commit "$EXPECTED_CANDIDATE_COMMIT" \
+             --expected-policy-commit "$EXPECTED_POLICY_COMMIT" \
+             --expected-tracker-mode "$EXPECTED_TRACKER_MODE" \
+             --render-tracker tracker-closeout.md
+           ```
 
         This layout runs at most
         #{(@prompt_count.to_f / @machines.length).ceil} prompts on one machine; use the exact allocation
@@ -482,17 +501,27 @@ module FleetValidation
           - Derive the independently released `react-on-rails-rsc` version separately from the tagged
             product manifests and the release tracker, then verify that exact RSC artifact is published.
             Never require it to share the React on Rails product version.
+          - Before any lane changes tracker state, resolve the exact release policy/default commit and
+            initial tracker mode from trusted repository/tracker state. Do not derive either from the
+            result ledger.
           - Post one tracker snapshot comment marked `<!-- fleet-validation-snapshot:#{@pack_id} -->` with
-            the exact tag, normalized gem/npm product versions, RSC version, commit SHA, and resolution time.
-            Heartbeat/close the snapshot claim only after the public-safe comment is readable.
+            the exact tag, normalized gem/npm product versions, RSC version, candidate commit SHA,
+            resolution time, `policy_commit: FULL_POLICY_COMMIT_SHA`, and
+            `tracker_mode: INITIAL_TRACKER_MODE`. Replace both placeholders with the exact resolved
+            values. The independent checker must
+            copy both exact values from that unique snapshot comment rather than the ledger.
+            Heartbeat/close the snapshot claim only after the
+            public-safe comment is readable.
         STEPS
       else
         <<~STEPS.chomp
           - Do not select a candidate independently. Wait up to five minutes for the tracker comment marked
             `<!-- fleet-validation-snapshot:#{@pack_id} -->` from coordinator 1, then use its exact tag,
-            product gem/npm versions, independently versioned RSC pin, and commit SHA for the whole lane.
-            Cross-check those artifacts and tag before mutation. If the snapshot is absent, malformed, or
-            inconsistent, report UNKNOWN and make no writes.
+            product gem/npm versions, independently versioned RSC pin, candidate commit, policy commit,
+            and initial tracker mode for the whole lane. Cross-check those artifacts and tag before
+            mutation. The independent checker must
+            copy both exact values from that unique snapshot comment rather than the ledger.
+            If the snapshot is absent, malformed, or inconsistent, report UNKNOWN and make no writes.
         STEPS
       end
     end

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -188,8 +188,10 @@ module FleetValidation
       end
 
       packages.each_with_index do |package, package_index|
-        unless package.is_a?(Hash) && package["ecosystem"].to_s != "" && package["name"].to_s != ""
-          raise ManifestError, "repos[#{index}].packages[#{package_index}] must name an ecosystem and package"
+        unless package.is_a?(Hash) && package["ecosystem"].to_s != "" &&
+               package["name"].is_a?(String) && !package["name"].strip.empty?
+          raise ManifestError,
+                "repos[#{index}].packages[#{package_index}] must name an ecosystem and nonblank string package"
         end
         unless %w[gem npm].include?(package["ecosystem"])
           raise ManifestError, "repos[#{index}].packages[#{package_index}] ecosystem must be gem or npm"

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -16,7 +16,7 @@ module FleetValidation
   }.freeze
 
   class Generator
-    attr_reader :assignments, :lifecycle_inventory, :required_paths
+    attr_reader :assignments, :lifecycle_inventory, :required_paths, :snapshot_fingerprint
 
     def initialize(manifest_path:, prompt_count:, machines:, release_selector:, pack_id: nil)
       @manifest_path = manifest_path
@@ -29,6 +29,7 @@ module FleetValidation
       @lifecycle = Lifecycle.new(manifest: @manifest, pack_id: @pack_id, release_selector: @release_selector)
       @lifecycle_inventory = @lifecycle.inventory
       @required_paths = @lifecycle.required_paths
+      @snapshot_fingerprint = @lifecycle.snapshot_fingerprint
       @targets = build_targets
       validate_target_ids!
       @assignments = assign_machines(build_lanes)
@@ -68,6 +69,7 @@ module FleetValidation
     end
 
     def write_pack(output_dir)
+      @lifecycle.validate_existing_ledger(File.join(output_dir, "result-ledger.json"))
       FileUtils.mkdir_p(output_dir)
       clear_generated_prompts(output_dir)
       rendered_prompts = []
@@ -136,6 +138,9 @@ module FleetValidation
 
       @manifest.fetch("repos").each_with_index do |repo, index|
         raise ManifestError, "repos[#{index}] must be a mapping" unless repo.is_a?(Hash)
+        unless %w[hard_gate soft_track].include?(repo["tier"])
+          raise ManifestError, "repos[#{index}] tier must be hard_gate or soft_track"
+        end
 
         next unless repo["tier"] == "hard_gate"
 
@@ -327,8 +332,9 @@ module FleetValidation
            needed to resolve disagreement. Never convert missing evidence into a pass.
 
         Execution contract:
-        - Do not start app mutation work until `APP_WORK_ALLOWED` is present in the pack-specific
-          release-wide preflight ledger. The marker is valid only when release commit CI, published
+        - Do not start app mutation work until `preflight.app_work_allowed: true` records the
+          `APP_WORK_ALLOWED` marker in the pack-specific release-wide preflight ledger. The marker
+          is valid only when release commit CI, published
           artifacts, and the standard / Pro / Pro+RSC generator matrix are terminal green, or when
           an explicit public-safe waiver names the failed gate and authority.
         - Read AGENTS.md and repository-specific instructions before changing any target repo. Treat the

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -110,6 +110,9 @@ module FleetValidation
     def validate_options!
       raise ManifestError, "schema_version must be 1" unless @manifest["schema_version"] == 1
       raise ManifestError, "repos must be an array" unless @manifest["repos"].is_a?(Array)
+      unless @release_selector.is_a?(String) && !@release_selector.strip.empty?
+        raise ManifestError, "release selector must be nonempty"
+      end
 
       validate_repo_entries!
       raise ManifestError, "--prompts must be positive" unless @prompt_count.positive?

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -260,9 +260,12 @@ module FleetValidation
       <<~MARKDOWN
         # Fleet validation launch index
 
-        1. Run [PREFLIGHT.md](PREFLIGHT.md) and record its results in `result-ledger.json`.
-        2. Start prompt coordinator 1 so the release-snapshot leader can resolve and publish the shared snapshot.
-        3. Start the remaining prompt coordinators after that snapshot exists.
+        1. Start prompt coordinator 1 in snapshot/read-only mode so the release-snapshot leader can
+           resolve and publish the shared snapshot and generator-matrix evidence. It must not start its
+           assigned app mutation yet.
+        2. Run [PREFLIGHT.md](PREFLIGHT.md) against that exact snapshot and record its results in
+           `result-ledger.json`.
+        3. Start the remaining prompt coordinators after the snapshot exists and preflight opens the barrier.
            Do not start the app mutation prompts before `APP_WORK_ALLOWED`; coordinators may prepare
            read-only evidence while waiting.
         4. Run [REPORT-ONLY.md](REPORT-ONLY.md) for the complete soft-track inventory.

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -371,10 +371,20 @@ module FleetValidation
           artifacts: do not create a bump branch or PR for it.
         - Capture dependency install, intentional lockfile diff, build/assets, target tests, required CI,
           primary route smoke, SSR/hydration, and the target's headline Pro/RSC behavior where applicable.
-          Record the immutable target head for every check; a later commit invalidates that evidence and
-          requires the audited, reviewed, and current revision plus affected checks to be refreshed.
+          Record the immutable target head for every check and the reconciled current base for every
+          mutable app check; a later target or base commit invalidates that evidence and requires the
+          audited, reviewed, and current revisions, bases, and affected checks to be refreshed.
           When review-app metadata is null/unverified, derive a repo-owned local boot/smoke command from
           target docs; do not invent a public deployment URL or claim hosted review-app smoke.
+        - For every assigned target, produce its complete schema-valid `inventory` row. It must include
+          id, tier, work_mode, maker_id, work_state, work_started_at, result, waiver, blocker_id,
+          package_locks, checks, review_app, baseline, revisions, bases, merge, reachability, and evidence.
+          Validate it against the inventory-item definition in `result-ledger.schema.json` and write the
+          exact fragment to `lane-result-#{number}.json`. Only an explicitly designated single ledger
+          writer may take the pack's lock and atomically merge the row into `result-ledger.json`;
+          otherwise include the exact JSON fragment in the final response for the closeout coordinator
+          to validate and merge. Do not return only a prose summary, and never hand-copy prose into the
+          ledger.
         - A confirmed candidate regression is BLOCKED and needs a linked issue. Unrelated failures remain
           PENDING until an allowed tracker waiver exists. Lane 4b artifact defects cannot be waived.
         - For HiChee or Pro/private material, never paste private logs, URLs, screenshots, credentials, or
@@ -390,6 +400,8 @@ module FleetValidation
 
         Final response:
         - Resolved release identifiers and tracking issue.
+        - One exact JSON fragment containing each assigned target's complete schema-valid `inventory` row,
+          unless those rows were already atomically merged into the shared `result-ledger.json`.
         - One row per target: PASSED / BLOCKED / PENDING / UNKNOWN, PR, current-head CI, smoke evidence,
           blocker/waiver link, and next owner/action.
         - Any manifest fields proven stale, with an exact proposed YAML patch.

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -292,7 +292,8 @@ module FleetValidation
            resolve and publish the shared snapshot and generator-matrix evidence. It must not start its
            assigned app mutation yet.
         2. Run [PREFLIGHT.md](PREFLIGHT.md) against that exact snapshot and record its results in
-           `result-ledger.json`.
+           `result-ledger.json`. Before remote makers start, publish its pack-bound public-safe
+           `APP_WORK_ALLOWED` tracker marker and verify that it is readable.
         3. Start the remaining prompt coordinators after the snapshot exists and preflight opens the barrier.
            Do not start the app mutation prompts before `APP_WORK_ALLOWED`; coordinators may prepare
            read-only evidence while waiting.
@@ -325,6 +326,7 @@ module FleetValidation
         #{candidate_resolution_steps(number)}
         #{tracker_resolution_steps(number)}
         #{snapshot_resolution_steps(number)}
+        #{preflight_resolution_steps}
 
         Assigned targets:
         #{targets.map { |target| render_target(target) }.join("\n")}
@@ -518,6 +520,20 @@ module FleetValidation
             artifacts or the matching tag conflict with the pinned selector, stop writes and report UNKNOWN.
         STEPS
       end
+    end
+
+    def preflight_resolution_steps
+      <<~STEPS.chomp
+        - The designated preflight runner must publish the public-safe `APP_WORK_ALLOWED` marker
+          `<!-- fleet-validation-preflight:#{@pack_id} -->` on the resolved release tracker before any
+          remote maker starts. The comment must record the exact candidate tag and commit, snapshot
+          fingerprint #{@snapshot_fingerprint}, `preflight.opened_at`, every release-wide gate's terminal
+          status and replayable evidence, and `app_work_allowed: true`.
+        - Do not start a remote mutable worker until one unique preflight marker is readable. Cross-check
+          its candidate tag and commit, snapshot fingerprint, opened_at, gate evidence, and barrier state
+          against the pack snapshot and the local ledger when accessible. Missing, duplicate, stale,
+          malformed, or mismatched markers are `UNKNOWN`: make no app write and do not trust launch timing.
+      STEPS
     end
 
     def install_command(package_manager)

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -345,7 +345,7 @@ module FleetValidation
           and release commit CI, published
           artifacts, and the standard / Pro / Pro+RSC generator matrix are terminal green, or when
           an explicit public-safe waiver names the failed gate and authority. Record `work_started_at`
-          for every mutable target before its first write.
+          and the stable worker/coordinator `maker_id` for every mutable target before its first write.
         - Read AGENTS.md and repository-specific instructions before changing any target repo. Treat the
           manifest commands as starting data; because `verify: true` entries are provisional, confirm
           commands against the target before running or proposing a manifest correction.

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -533,6 +533,8 @@ module FleetValidation
           its candidate tag and commit, snapshot fingerprint, opened_at, gate evidence, and barrier state
           against the pack snapshot and the local ledger when accessible. Missing, duplicate, stale,
           malformed, or mismatched markers are `UNKNOWN`: make no app write and do not trust launch timing.
+          Record a successful cross-check in `preflight.public_marker` with `status: unique`, the exact
+          pack/candidate/commit/fingerprint/opened-at fields, and replayable public-safe evidence.
       STEPS
     end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -148,6 +148,7 @@ module FleetValidation
               raise ManifestError, "repos[#{index}] soft track is missing #{field}"
             end
           end
+          validate_package_entries!(repo.fetch("packages", []), index)
           next
         end
 
@@ -175,7 +176,15 @@ module FleetValidation
         raise ManifestError, "repos[#{index}] hard gate smoke entries must be non-empty strings"
       end
 
-      repo.fetch("packages").each_with_index do |package, package_index|
+      validate_package_entries!(repo.fetch("packages"), index)
+    end
+
+    def validate_package_entries!(packages, index)
+      unless packages.is_a?(Array)
+        raise ManifestError, "repos[#{index}] packages must be an array"
+      end
+
+      packages.each_with_index do |package, package_index|
         unless package.is_a?(Hash) && package["ecosystem"].to_s != "" && package["name"].to_s != ""
           raise ManifestError, "repos[#{index}].packages[#{package_index}] must name an ecosystem and package"
         end
@@ -251,7 +260,8 @@ module FleetValidation
 
     def ordered_assignments
       assignments.sort_by do |assignment|
-        [@machines.index(assignment.fetch(:machine)), -assignment.fetch(:weight)]
+        has_core_gate = assignment.fetch(:targets).any? { |target| target["kind"] == "core" }
+        [has_core_gate ? 0 : 1, @machines.index(assignment.fetch(:machine)), -assignment.fetch(:weight)]
       end
     end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -5,6 +5,7 @@ require "fileutils"
 require "optparse"
 require "securerandom"
 require "yaml"
+require_relative "fleet_lifecycle"
 
 module FleetValidation
   CORE_GATE = {
@@ -14,10 +15,8 @@ module FleetValidation
     "weight" => 5
   }.freeze
 
-  class ManifestError < StandardError; end
-
   class Generator
-    attr_reader :assignments
+    attr_reader :assignments, :lifecycle_inventory, :required_paths
 
     def initialize(manifest_path:, prompt_count:, machines:, release_selector:, pack_id: nil)
       @manifest_path = manifest_path
@@ -27,6 +26,9 @@ module FleetValidation
       @pack_id = pack_id || default_pack_id
       @manifest = load_manifest
       validate_options!
+      @lifecycle = Lifecycle.new(manifest: @manifest, pack_id: @pack_id, release_selector: @release_selector)
+      @lifecycle_inventory = @lifecycle.inventory
+      @required_paths = @lifecycle.required_paths
       @targets = build_targets
       validate_target_ids!
       @assignments = assign_machines(build_lanes)
@@ -57,6 +59,14 @@ module FleetValidation
       MARKDOWN
     end
 
+    def ledger_template
+      @lifecycle.ledger_template
+    end
+
+    def ledger_schema
+      @lifecycle.schema
+    end
+
     def write_pack(output_dir)
       FileUtils.mkdir_p(output_dir)
       clear_generated_prompts(output_dir)
@@ -74,6 +84,7 @@ module FleetValidation
       end
 
       File.write(File.join(output_dir, "INDEX.md"), render_index(rendered_prompts))
+      @lifecycle.write_artifacts(output_dir)
     end
 
     private
@@ -249,7 +260,15 @@ module FleetValidation
       <<~MARKDOWN
         # Fleet validation launch index
 
-        Start all #{@prompt_count} prompts simultaneously. This layout runs at most
+        1. Run [PREFLIGHT.md](PREFLIGHT.md) and record its results in `result-ledger.json`.
+        2. Start all #{@prompt_count} prompt coordinators simultaneously after the snapshot exists.
+           Do not start the app mutation prompts before `APP_WORK_ALLOWED`; coordinators may prepare
+           read-only evidence while waiting.
+        3. Run [REPORT-ONLY.md](REPORT-ONLY.md) for the complete soft-track inventory.
+        4. Run [CLOSEOUT.md](CLOSEOUT.md) with an independent checker, validate `result-ledger.json`
+           against `result-ledger.schema.json`, and render the tracker matrix from that ledger.
+
+        This layout runs at most
         #{(@prompt_count.to_f / @machines.length).ceil} prompts on one machine; use the exact allocation
         below. Do not share mutable app checkouts between prompts.
 
@@ -304,6 +323,10 @@ module FleetValidation
            needed to resolve disagreement. Never convert missing evidence into a pass.
 
         Execution contract:
+        - Do not start app mutation work until `APP_WORK_ALLOWED` is present in the pack-specific
+          release-wide preflight ledger. The marker is valid only when release commit CI, published
+          artifacts, and the standard / Pro / Pro+RSC generator matrix are terminal green, or when
+          an explicit public-safe waiver names the failed gate and authority.
         - Read AGENTS.md and repository-specific instructions before changing any target repo. Treat the
           manifest commands as starting data; because `verify: true` entries are provisional, confirm
           commands against the target before running or proposing a manifest correction.

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -188,6 +188,9 @@ module FleetValidation
         unless package.is_a?(Hash) && package["ecosystem"].to_s != "" && package["name"].to_s != ""
           raise ManifestError, "repos[#{index}].packages[#{package_index}] must name an ecosystem and package"
         end
+        unless %w[gem npm].include?(package["ecosystem"])
+          raise ManifestError, "repos[#{index}].packages[#{package_index}] ecosystem must be gem or npm"
+        end
       end
     end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -261,11 +261,12 @@ module FleetValidation
         # Fleet validation launch index
 
         1. Run [PREFLIGHT.md](PREFLIGHT.md) and record its results in `result-ledger.json`.
-        2. Start all #{@prompt_count} prompt coordinators simultaneously after the snapshot exists.
+        2. Start prompt coordinator 1 so the release-snapshot leader can resolve and publish the shared snapshot.
+        3. Start the remaining prompt coordinators after that snapshot exists.
            Do not start the app mutation prompts before `APP_WORK_ALLOWED`; coordinators may prepare
            read-only evidence while waiting.
-        3. Run [REPORT-ONLY.md](REPORT-ONLY.md) for the complete soft-track inventory.
-        4. Run [CLOSEOUT.md](CLOSEOUT.md) with an independent checker, validate `result-ledger.json`
+        4. Run [REPORT-ONLY.md](REPORT-ONLY.md) for the complete soft-track inventory.
+        5. Run [CLOSEOUT.md](CLOSEOUT.md) with an independent checker, validate `result-ledger.json`
            against `result-ledger.schema.json`, and render the tracker matrix from that ledger.
 
         This layout runs at most

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -142,7 +142,14 @@ module FleetValidation
           raise ManifestError, "repos[#{index}] tier must be hard_gate or soft_track"
         end
 
-        next unless repo["tier"] == "hard_gate"
+        if repo["tier"] == "soft_track"
+          %w[name headline].each do |field|
+            unless repo[field].is_a?(String) && !repo[field].empty?
+              raise ManifestError, "repos[#{index}] soft track is missing #{field}"
+            end
+          end
+          next
+        end
 
         validate_hard_gate_repo!(defaults.merge(repo), index)
       end
@@ -188,7 +195,7 @@ module FleetValidation
     end
 
     def validate_target_ids!
-      ids = @targets.map { |target| stable_target_id(target) }
+      ids = @lifecycle_inventory.map { |target| target.fetch("id") }
       raise ManifestError, "target names must have non-empty stable IDs" if ids.any?(&:empty?)
 
       duplicates = ids.tally.select { |_id, count| count > 1 }.keys
@@ -334,9 +341,11 @@ module FleetValidation
         Execution contract:
         - Do not start app mutation work until `preflight.app_work_allowed: true` records the
           `APP_WORK_ALLOWED` marker in the pack-specific release-wide preflight ledger. The marker
-          is valid only when release commit CI, published
+          is valid only when `preflight.opened_at` records when the exact snapshot barrier opened
+          and release commit CI, published
           artifacts, and the standard / Pro / Pro+RSC generator matrix are terminal green, or when
-          an explicit public-safe waiver names the failed gate and authority.
+          an explicit public-safe waiver names the failed gate and authority. Record `work_started_at`
+          for every mutable target before its first write.
         - Read AGENTS.md and repository-specific instructions before changing any target repo. Treat the
           manifest commands as starting data; because `verify: true` entries are provisional, confirm
           commands against the target before running or proposing a manifest correction.

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -365,6 +365,8 @@ module FleetValidation
           artifacts: do not create a bump branch or PR for it.
         - Capture dependency install, intentional lockfile diff, build/assets, target tests, required CI,
           primary route smoke, SSR/hydration, and the target's headline Pro/RSC behavior where applicable.
+          Record the immutable target head for every check; a later commit invalidates that evidence and
+          requires the audited, reviewed, and current revision plus affected checks to be refreshed.
           When review-app metadata is null/unverified, derive a repo-owned local boot/smoke command from
           target docs; do not invent a public deployment URL or claim hosted review-app smoke.
         - A confirmed candidate regression is BLOCKED and needs a linked issue. Unrelated failures remain

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -729,6 +729,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "independent audit maker identities contain blank values"
   end
 
+  def test_independent_audit_rejects_duplicate_maker_identities
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("audit")["maker_ids"] = %w[maker-1 maker-1]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit maker identities must be unique"
+  end
+
   def test_closeout_requires_identified_checker_and_makers
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -860,6 +875,26 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_empty schema_errors
     assert_empty semantic_errors
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+  end
+
+  def test_preflight_status_rejects_disposition_fields_from_other_states
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight")["waiver"] = {
+      "gate" => "release_ci",
+      "authority" => "maintainer",
+      "evidence_url" => "https://example.invalid/waiver",
+      "reason" => "Sanitized stale disposition"
+    }
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "passed preflight retains disposition fields from another state"
   end
 
   def test_published_artifact_defects_cannot_be_waived
@@ -1453,6 +1488,82 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "1 hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
   end
 
+  def test_report_only_lock_versions_match_the_resolved_snapshot
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    lock = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+                 .fetch("package_locks").first
+    lock["version"] = "0.0.1"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes(
+      errors,
+      "1 report-only target(s) retain package versions or sources outside the resolved release snapshot"
+    )
+  end
+
+  def test_target_check_path_and_blocker_dispositions_match_their_statuses
+    generator = build_generator
+    waiver = {
+      "gate" => "stale",
+      "authority" => "maintainer",
+      "evidence_url" => "https://example.invalid/waiver",
+      "reason" => "Sanitized stale disposition"
+    }
+    cases = [
+      {
+        mutate: ->(ledger) { ledger.fetch("inventory").first["waiver"] = waiver },
+        expected: "target result passed retains disposition fields from another state"
+      },
+      {
+        mutate: ->(ledger) { ledger.fetch("inventory").first.fetch("checks").fetch("install")["blocker_id"] = "stale" },
+        expected: "target check install passed retains disposition fields from another state"
+      },
+      {
+        mutate: ->(ledger) { ledger.fetch("inventory").first.fetch("baseline")["waiver"] = waiver },
+        expected: "target baseline clean retains a waiver from another state"
+      },
+      {
+        mutate: ->(ledger) { ledger.fetch("required_paths").first["blocker_id"] = "stale" },
+        expected: "required path passed retains disposition fields from another state"
+      },
+      {
+        mutate: lambda do |ledger|
+          ledger["blockers"] = [
+            {
+              "id" => "open-blocker",
+              "status" => "open",
+              "public_summary" => "Sanitized open blocker",
+              "owner" => { "issue_url" => "https://example.invalid/issues/open" },
+              "disposition" => waiver.merge("gate" => "open-blocker")
+            }
+          ]
+          ledger.fetch("tracker")["promotion"] = "blocked"
+        end,
+        expected: "blocker open-blocker open status retains a waiver disposition"
+      }
+    ]
+
+    cases.each do |test_case|
+      ledger = complete_ledger(generator)
+      test_case.fetch(:mutate).call(ledger)
+      errors = FleetValidation::LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths,
+        closeout: true
+      ).errors
+
+      assert_includes errors, test_case.fetch(:expected)
+    end
+  end
+
   def test_closeout_rejects_nonterminal_work_and_blank_result_or_baseline_evidence
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -1587,6 +1698,55 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     refute(errors.any? { |error| error.match?(/merge status|reachability|base is missing/) }, errors.join("\n"))
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+  end
+
+  def test_blocked_merge_cannot_retain_a_merge_commit_or_successful_reachability
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("merge")["status"] = "blocked"
+    ledger["blockers"] = [
+      {
+        "id" => "owned-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized release blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/owned" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("merge")["status"] = "partial"
+    ledger.fetch("reachability").merge!("default_branch" => "partial", "tree_parity" => "partial")
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "target #{target.fetch('id')} blocked merge retains a merge commit"
+    assert_includes errors, "target #{target.fetch('id')} blocked merge retains successful reachability"
+  end
+
+  def test_not_applicable_merge_cannot_retain_mutation_authority_or_commit
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+    target.fetch("merge").merge!(
+      "authority" => "ask",
+      "authority_evidence" => "stale mutation authority",
+      "merge_commit" => "cccccccccccccccccccccccccccccccccccccccc"
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "target #{target.fetch('id')} not-applicable merge retains mutation state"
   end
 
   def test_blocked_closeout_rejects_an_unauthorized_recorded_merge
@@ -1818,6 +1978,22 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert(errors.any? { |error| error.include?("default-branch reachability evidence is incomplete") })
     assert(errors.any? { |error| error.include?("tree-parity evidence is incomplete") })
+  end
+
+  def test_mutation_base_reconciliation_must_be_explicitly_passed_even_without_base_movement
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("bases")["reconciliation"] = "reported"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "target #{target.fetch('id')} base reconciliation is not passed"
   end
 
   def test_validation_only_core_gate_does_not_require_merge_base_or_reachability_evidence

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -317,7 +317,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       expected_candidate: "v17.0.0.rc.12"
     ).errors
 
-    assert_includes errors, "candidate mismatch: expected v17.0.0.rc.12, got v17.0.0.rc.11"
+    assert_includes errors, "candidate mismatch: pinned selector v17.0.0.rc.12, got v17.0.0.rc.11"
   end
 
   def test_ledger_rejects_unknown_coordination_or_machine_capabilities
@@ -480,6 +480,36 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_includes errors, "blocker waived-blocker is missing structured waived disposition evidence"
     assert_includes errors, "blocker deferred-blocker is missing structured deferred disposition evidence"
+  end
+
+  def test_waived_and_deferred_blockers_require_durable_owners_in_addition_to_dispositions
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = %w[waived deferred].map do |status|
+      {
+        "id" => "#{status}-blocker",
+        "status" => status,
+        "public_summary" => "Sanitized #{status} blocker",
+        "owner" => nil,
+        "disposition" => {
+          "gate" => "#{status}-blocker",
+          "authority" => "maintainer",
+          "evidence_url" => "https://example.invalid/dispositions/#{status}",
+          "reason" => "Sanitized disposition"
+        }
+      }
+    end
+    ledger.fetch("tracker")["promotion"] = "hold"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocker waived-blocker has no durable owner"
+    assert_includes errors, "blocker deferred-blocker has no durable owner"
   end
 
   def test_public_ledger_rejects_private_blocker_fields
@@ -1415,6 +1445,22 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_external_expected_candidate_does_not_override_a_pinned_selector
+    generator = build_generator(release_selector: "v17.0.0.rc.11")
+    ledger = complete_ledger(generator)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      expected_snapshot_fingerprint: generator.snapshot_fingerprint,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "candidate mismatch: pinned selector v17.0.0.rc.11, got v17.0.0.rc.12"
+  end
+
   def test_closeout_rejects_a_ledger_from_a_different_manifest_snapshot
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -1501,6 +1547,71 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     refute(errors.any? { |error| error.include?(core.fetch("id")) }, errors.join("\n"))
+  end
+
+  def test_recorded_merges_retain_base_and_reachability_proofs_when_another_lane_blocks
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = [
+      {
+        "id" => "later-blocker",
+        "status" => "open",
+        "public_summary" => "Another lane blocked after merges",
+        "owner" => { "issue_url" => "https://example.invalid/issues/later" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("tracker")["promotion"] = "blocked"
+    ledger.fetch("audit")["base_commit"] = nil
+    ledger.fetch("merge").merge!("reviewed_base_commit" => nil, "current_base_commit" => nil)
+    ledger.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
+    ledger.fetch("inventory").select { |item| item["work_mode"] == "mutation" }.each do |item|
+      item.fetch("bases").merge!("audit" => nil, "reviewed" => nil, "current" => nil)
+      item.fetch("reachability").merge!(
+        "default_branch" => "pending",
+        "default_commit" => nil,
+        "default_evidence" => nil,
+        "tree_parity" => "pending",
+        "tree" => nil,
+        "tree_evidence" => nil
+      )
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "audit base_commit is missing or not an exact commit identity"
+    assert_includes errors, "reachability default_branch is not passed"
+    assert(errors.any? { |error| error.include?("default-branch reachability evidence is incomplete") })
+  end
+
+  def test_report_only_tracks_retain_post_preflight_work_start_ordering
+    generator = build_generator
+    missing = complete_ledger(generator)
+    missing.fetch("inventory").find { |item| item["work_mode"] == "report_only" }["work_started_at"] = nil
+    early = complete_ledger(generator)
+    early.fetch("inventory").find { |item| item["work_mode"] == "report_only" }["work_started_at"] =
+      "2026-07-18T09:59:00Z"
+
+    missing_errors = FleetValidation::LedgerValidator.new(
+      missing,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+    early_errors = FleetValidation::LedgerValidator.new(
+      early,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(missing_errors.any? { |error| error.include?("missing replayable barrier/work-start ordering evidence") })
+    assert(early_errors.any? { |error| error.include?("started before the preflight barrier opened") })
   end
 
   def test_closeout_requires_terminal_install_build_test_smoke_ci_and_review_evidence

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -116,6 +116,8 @@ class FleetValidationGeneratorTest < Minitest::Test
           "evidence" => "no mutable branch"
         )
       end
+      next unless item["work_mode"] == "mutation"
+
       item.fetch("reachability").merge!(
         "default_branch" => "passed",
         "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",
@@ -141,6 +143,59 @@ class FleetValidationGeneratorTest < Minitest::Test
       "comment_url" => "https://example.invalid/tracker-comment",
       "promotion" => "recommend"
     )
+    ledger
+  end
+
+  def blocked_preflight_ledger(generator, validation_only_evidence: false)
+    ledger = generator.ledger_template
+    completed = complete_ledger(generator)
+    ledger["pack"] = Marshal.load(Marshal.dump(completed.fetch("pack")))
+    ledger.fetch("preflight").merge!(
+      "status" => "blocked",
+      "app_work_allowed" => false,
+      "blocker_id" => "artifact-blocker",
+      "blocker_evidence" => "public-safe artifact mismatch evidence"
+    )
+    ledger.fetch("preflight").fetch("artifacts").merge!(
+      "status" => "blocked",
+      "evidence" => "public-safe artifact mismatch evidence"
+    )
+    if validation_only_evidence
+      completed_core = completed.fetch("inventory").find { |item| item["work_mode"] == "validation_only" }
+      core = Marshal.load(Marshal.dump(completed_core))
+      core.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "artifact-blocker")
+      core.fetch("checks").each_value do |check|
+        check.merge!("status" => "blocked", "blocker_id" => "artifact-blocker")
+      end
+      core.fetch("reachability").merge!(
+        "default_branch" => "pending",
+        "default_commit" => nil,
+        "default_evidence" => nil,
+        "tree_parity" => "pending",
+        "tree" => nil,
+        "tree_evidence" => nil
+      )
+      index = ledger.fetch("inventory").index { |item| item["work_mode"] == "validation_only" }
+      ledger.fetch("inventory")[index] = core
+    end
+    ledger["blockers"] = [
+      {
+        "id" => "artifact-blocker",
+        "status" => "open",
+        "public_summary" => "Published candidate artifacts are incoherent",
+        "owner" => { "issue_url" => "https://example.invalid/issues/artifact-blocker" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("audit").merge!(
+      "status" => "passed",
+      "checker" => "independent-checker",
+      "maker_ids" => [],
+      "evidence" => "public-safe blocked-preflight audit"
+    )
+    ledger.fetch("merge")["status"] = "blocked"
+    ledger.fetch("reachability").merge!("default_branch" => "blocked", "tree_parity" => "blocked")
+    ledger.fetch("tracker").merge!("status" => "ready", "promotion" => "blocked")
     ledger
   end
 
@@ -875,6 +930,51 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_empty schema_errors
     assert_empty semantic_errors
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+  end
+
+  def test_blocked_preflight_retains_legitimate_validation_only_evidence
+    generator = build_generator
+    ledger = blocked_preflight_ledger(generator, validation_only_evidence: true)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      expected_snapshot_fingerprint: generator.snapshot_fingerprint,
+      closeout: true
+    ).errors
+
+    assert_empty errors
+  end
+
+  def test_blocked_preflight_rejects_nested_mutation_and_reachability_state
+    generator = build_generator
+    ledger = blocked_preflight_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("merge").merge!(
+      "authority" => "ask",
+      "authority_evidence" => "stale authority",
+      "merge_commit" => "cccccccccccccccccccccccccccccccccccccccc"
+    )
+    target.fetch("reachability").merge!(
+      "default_branch" => "passed",
+      "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+      "default_evidence" => "stale reachability",
+      "tree_parity" => "passed",
+      "tree" => "dddddddddddddddddddddddddddddddddddddddd",
+      "tree_evidence" => "stale tree parity"
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocked preflight target #{target.fetch('id')} contains nested merge state"
+    assert_includes errors, "blocked preflight target #{target.fetch('id')} contains reachability state"
   end
 
   def test_preflight_status_rejects_disposition_fields_from_other_states
@@ -1749,6 +1849,29 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "target #{target.fetch('id')} not-applicable merge retains mutation state"
   end
 
+  def test_non_mutation_target_cannot_retain_post_merge_reachability
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+    target.fetch("reachability").merge!(
+      "default_branch" => "passed",
+      "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+      "default_evidence" => "synthetic reachability",
+      "tree_parity" => "passed",
+      "tree" => "dddddddddddddddddddddddddddddddddddddddd",
+      "tree_evidence" => "synthetic tree parity"
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "target #{target.fetch('id')} non-mutation target retains reachability state"
+  end
+
   def test_blocked_closeout_rejects_an_unauthorized_recorded_merge
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -2359,6 +2482,21 @@ class FleetValidationGeneratorTest < Minitest::Test
 
       index = manifest.fetch("repos").index(soft_track)
       assert_equal "repos[#{index}].packages[0] must name an ecosystem and package", error.message
+    end
+  end
+
+  def test_rejects_unsupported_package_ecosystems
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      manifest.fetch("repos").first.fetch("packages").first["ecosystem"] = "rubygems"
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      assert_equal "repos[0].packages[0] ecosystem must be gem or npm", error.message
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1051,6 +1051,28 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_empty errors
   end
 
+  def test_blocked_preflight_retains_read_only_package_lock_probes
+    generator = build_generator
+    ledger = blocked_preflight_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    expected = generator.lifecycle_inventory.find { |item| item["id"] == target["id"] }
+    target["package_locks"] = expected.fetch("packages").map do |package|
+      ledger.fetch("pack").fetch("resolved_packages").find do |resolved|
+        resolved.slice("ecosystem", "name") == package.slice("ecosystem", "name")
+      end.dup
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_empty errors
+  end
+
   def test_blocked_preflight_rejects_nested_mutation_and_reachability_state
     generator = build_generator
     ledger = blocked_preflight_ledger(generator)
@@ -2514,6 +2536,56 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert(errors.any? { |error| error.include?("check evidence is not bound to its immutable current head") })
   end
 
+  def test_validation_only_evidence_must_match_the_candidate_commit
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "validation_only" }
+    wrong_commit = "ffffffffffffffffffffffffffffffffffffffff"
+    target.fetch("revisions").merge!(
+      "audit" => wrong_commit,
+      "reviewed" => wrong_commit,
+      "current" => wrong_commit
+    )
+    target.fetch("checks").each_value { |check| check["head_commit"] = wrong_commit }
+    target.fetch("review_app")["head_commit"] = wrong_commit
+    target.fetch("baseline")["head_commit"] = wrong_commit
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "validation-only target revision does not match the candidate commit"
+  end
+
+  def test_blocked_preflight_validation_only_evidence_must_match_the_candidate_commit
+    generator = build_generator
+    ledger = blocked_preflight_ledger(generator, validation_only_evidence: true)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "validation_only" }
+    wrong_commit = "ffffffffffffffffffffffffffffffffffffffff"
+    target.fetch("revisions").merge!(
+      "audit" => wrong_commit,
+      "reviewed" => wrong_commit,
+      "current" => wrong_commit
+    )
+    target.fetch("checks").each_value { |check| check["head_commit"] = wrong_commit }
+    target.fetch("review_app")["head_commit"] = wrong_commit
+    target.fetch("baseline")["head_commit"] = wrong_commit
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "validation-only target revision does not match the candidate commit"
+  end
+
   def test_report_only_checks_must_have_terminal_current_head_evidence
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -2830,6 +2902,23 @@ class FleetValidationGeneratorTest < Minitest::Test
       end
 
       assert_equal "lifecycle.required_paths must be a nonempty array", error.message
+    end
+  end
+
+  def test_rejects_non_string_required_lifecycle_path_fields
+    %w[id evidence_source].each do |field|
+      Dir.mktmpdir do |directory|
+        manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+        manifest.fetch("lifecycle").fetch("required_paths").first[field] = 1
+        manifest_path = File.join(directory, "fleet.yml")
+        File.write(manifest_path, YAML.dump(manifest))
+
+        error = assert_raises(FleetValidation::ManifestError) do
+          build_generator(manifest_path:)
+        end
+
+        assert_equal "lifecycle.required_paths must contain mappings with string IDs and evidence sources", error.message
+      end
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1019,6 +1019,22 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "resolved product package versions do not match candidate v17.0.0.rc.12"
   end
 
+  def test_blocked_preflight_requires_an_explicitly_blocked_promotion
+    generator = build_generator
+    ledger = blocked_preflight_ledger(generator)
+    ledger.fetch("tracker")["promotion"] = "hold"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocked preflight tracker promotion must be blocked"
+  end
+
   def test_blocked_preflight_retains_legitimate_validation_only_evidence
     generator = build_generator
     ledger = blocked_preflight_ledger(generator, validation_only_evidence: true)
@@ -1383,6 +1399,62 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "promotion cannot be recommended while release blockers remain"
   end
 
+  def test_owned_soft_track_followup_is_partial_but_does_not_block_promotion
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+    target.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "soft-followup")
+    ledger["blockers"] = [
+      {
+        "id" => "soft-followup",
+        "status" => "open",
+        "public_summary" => "Shelved demo follow-up remains open",
+        "owner" => { "issue_url" => "https://example.invalid/issues/soft-followup" },
+        "disposition" => nil
+      }
+    ]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_empty errors
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: PARTIAL"
+  end
+
+  def test_blocker_shared_with_a_hard_gate_remains_release_gating
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    soft_target = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+    soft_target.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "shared-blocker")
+    hard_target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    hard_target.fetch("checks").fetch("review")["blocker_id"] = "shared-blocker"
+    ledger["blockers"] = [
+      {
+        "id" => "shared-blocker",
+        "status" => "open",
+        "public_summary" => "Shared hard-gate and soft-track blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/shared-blocker" },
+        "disposition" => nil
+      }
+    ]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "promotion cannot be recommended while release blockers remain"
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+  end
+
   def test_nested_hard_gate_failure_blocks_promotion
     generator = build_generator
     check_failure = complete_ledger(generator)
@@ -1701,13 +1773,22 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "1 hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
   end
 
-  def test_report_only_lock_versions_match_the_resolved_snapshot
+  def test_report_only_and_independently_managed_locks_may_retain_their_own_versions
     generator = build_generator
     ledger = complete_ledger(generator)
-    lock = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
-                 .fetch("package_locks").first
-    lock["version"] = "0.0.1"
+    report_lock = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+                        .fetch("package_locks").first
+    report_lock["version"] = "16.0.0"
+    candidate_managed = FleetValidation::LedgerValidator::PRODUCT_PACKAGES.values.flatten +
+                        ["react-on-rails-rsc"]
+    independent_lock = ledger.fetch("inventory").filter_map do |item|
+      next unless item["tier"] == "hard_gate"
 
+      item.fetch("package_locks").find do |lock|
+        !candidate_managed.include?(lock["name"])
+      end
+    end.first
+    independent_lock["version"] = "independently-managed"
     errors = FleetValidation::LedgerValidator.new(
       ledger,
       inventory: generator.lifecycle_inventory,
@@ -1715,9 +1796,9 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes(
-      errors,
-      "1 report-only target(s) retain package versions or sources outside the resolved release snapshot"
+    refute(
+      errors.any? { |error| error.include?("retain package versions or sources outside") },
+      errors.join("\n")
     )
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1613,6 +1613,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--manifest", MANIFEST,
         "--ledger", ledger_path,
         "--expected-pack-id", "fleet-test-pack",
+        "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12",
         "--render-tracker", tracker_path
       )
@@ -1638,6 +1639,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         ledger_path,
         "--expected-pack-id",
         "fleet-test-pack",
+        "--expected-release-selector",
+        "latest RC or beta",
         "--expected-candidate",
         "v17.0.0.rc.12"
       )
@@ -1672,6 +1675,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         VALIDATOR,
         "--manifest", MANIFEST,
         "--ledger", ledger_path,
+        "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12"
       )
       _stdout, mismatch_stderr, mismatch_status = Open3.capture3(
@@ -1680,6 +1684,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--manifest", MANIFEST,
         "--ledger", ledger_path,
         "--expected-pack-id", "another-pack",
+        "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12"
       )
 
@@ -1687,6 +1692,45 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_includes missing_stderr, "missing argument: --expected-pack-id"
       refute mismatch_status.success?
       assert_includes mismatch_stderr, "pack ID mismatch: expected another-pack, got fleet-test-pack"
+    end
+  end
+
+  def test_ledger_cli_requires_and_enforces_an_external_release_selector
+    generator = build_generator
+    ledger = complete_ledger(generator)
+
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      _stdout, missing_stderr, missing_status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-pack-id", "fleet-test-pack",
+        "--expected-candidate", "v17.0.0.rc.12"
+      )
+
+      ledger.fetch("pack")["release_selector"] = "v17.0.0.rc.12"
+      pinned = build_generator(release_selector: "v17.0.0.rc.12")
+      ledger.fetch("pack")["snapshot_fingerprint"] = pinned.snapshot_fingerprint
+      ledger.fetch("preflight").fetch("public_marker")["snapshot_fingerprint"] = pinned.snapshot_fingerprint
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+      _stdout, mismatch_stderr, mismatch_status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-pack-id", "fleet-test-pack",
+        "--expected-release-selector", "latest RC or beta",
+        "--expected-candidate", "v17.0.0.rc.12"
+      )
+
+      refute missing_status.success?
+      assert_includes missing_stderr, "missing argument: --expected-release-selector"
+      refute mismatch_status.success?
+      assert_includes mismatch_stderr, "pack snapshot_fingerprint does not match the current manifest"
     end
   end
 
@@ -2095,7 +2139,14 @@ class FleetValidationGeneratorTest < Minitest::Test
         "merge_commit" => nil,
         "evidence" => "release blocked before merge"
       )
-      item.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
+      item.fetch("reachability").merge!(
+        "default_branch" => "pending",
+        "default_commit" => nil,
+        "default_evidence" => nil,
+        "tree_parity" => "pending",
+        "tree" => nil,
+        "tree_evidence" => nil
+      )
     end
     ledger.fetch("merge")["status"] = "blocked"
     ledger.fetch("reachability").merge!("default_branch" => "blocked", "tree_parity" => "blocked")
@@ -2159,6 +2210,68 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "target #{target.fetch('id')} not-applicable merge retains mutation state"
+  end
+
+  def test_closeout_requires_terminal_state_for_blocked_and_non_mutation_merges
+    generator = build_generator
+    blocked = complete_ledger(generator)
+    blocked_target = blocked.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    blocked_target.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "owned-blocker")
+    blocked_target.fetch("checks").each_value do |check|
+      check.merge!("status" => "blocked", "blocker_id" => "owned-blocker")
+    end
+    blocked_target.fetch("merge").merge!(
+      "status" => "blocked",
+      "authority" => "none",
+      "authority_evidence" => nil,
+      "freeze_state" => "unknown",
+      "merge_commit" => nil,
+      "evidence" => "release blocked before merge"
+    )
+    blocked_target.fetch("reachability").merge!(
+      "default_branch" => "unknown",
+      "default_commit" => nil,
+      "default_evidence" => nil,
+      "tree_parity" => "unknown",
+      "tree" => nil,
+      "tree_evidence" => nil
+    )
+    blocked["blockers"] = [
+      {
+        "id" => "owned-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized release blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/owned" },
+        "disposition" => nil
+      }
+    ]
+    blocked.fetch("merge")["status"] = "partial"
+    blocked.fetch("reachability").merge!("default_branch" => "partial", "tree_parity" => "partial")
+    blocked.fetch("tracker")["promotion"] = "blocked"
+
+    blocked_errors = FleetValidation::LedgerValidator.new(
+      blocked,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes blocked_errors, "target #{blocked_target.fetch('id')} blocked merge freeze state is unresolved"
+    assert_includes blocked_errors, "target #{blocked_target.fetch('id')} blocked merge retains unresolved reachability"
+
+    non_mutation = complete_ledger(generator)
+    non_mutation_target = non_mutation.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+    non_mutation_target.fetch("merge")["freeze_state"] = "unknown"
+
+    non_mutation_errors = FleetValidation::LedgerValidator.new(
+      non_mutation,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes non_mutation_errors,
+                    "target #{non_mutation_target.fetch('id')} not-applicable merge disposition is incomplete"
   end
 
   def test_non_mutation_target_cannot_retain_post_merge_reachability
@@ -2942,7 +3055,10 @@ class FleetValidationGeneratorTest < Minitest::Test
       end
 
       index = manifest.fetch("repos").index(soft_track)
-      assert_equal "repos[#{index}].packages[0] must name an ecosystem and package", error.message
+      assert_equal(
+        "repos[#{index}].packages[0] must name an ecosystem and nonblank string package",
+        error.message
+      )
     end
   end
 
@@ -3014,6 +3130,24 @@ class FleetValidationGeneratorTest < Minitest::Test
         end
 
         assert_equal "lifecycle.required_paths must contain mappings with string IDs and evidence sources", error.message
+      end
+    end
+  end
+
+  def test_rejects_non_string_or_blank_manifest_package_names
+    [123, "   "].each do |invalid_name|
+      Dir.mktmpdir do |directory|
+        manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+        manifest.fetch("repos").find { |repo| repo["tier"] == "soft_track" }
+                .fetch("packages").first["name"] = invalid_name
+        manifest_path = File.join(directory, "fleet.yml")
+        File.write(manifest_path, YAML.dump(manifest))
+
+        error = assert_raises(FleetValidation::ManifestError) do
+          build_generator(manifest_path:)
+        end
+
+        assert_match(/must name an ecosystem and nonblank string package/, error.message)
       end
     end
   end

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -35,6 +35,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     )
     ledger.fetch("preflight")["status"] = "passed"
     ledger.fetch("preflight")["app_work_allowed"] = true
+    ledger.fetch("preflight")["opened_at"] = "2026-07-18T10:00:00Z"
     %w[release_ci artifacts generator_matrix].each do |gate|
       ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
     end
@@ -44,6 +45,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       item.merge!(
         "work_state" => "finished",
         "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
+        "work_started_at" => "2026-07-18T10:01:00Z",
         "evidence" => "public-safe evidence"
       )
       expected = generator.lifecycle_inventory.find { |target| target["id"] == item["id"] }
@@ -131,7 +133,8 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_equal 8, (inventory.count { |target| target.fetch("tier") == "hard_gate" })
     assert_equal 5, (inventory.count { |target| target.fetch("tier") == "soft_track" })
-    assert(inventory.any? { |target| target.fetch("id") == "react-on-rails-generator-install-smoke" })
+    core = inventory.find { |target| target.fetch("id") == "react-on-rails-generator-install-smoke" }
+    assert_equal "validation_only", core.fetch("work_mode")
     assert(inventory.select { |target| target.fetch("tier") == "soft_track" }
                     .all? { |target| target.fetch("work_mode") == "report_only" })
   end
@@ -224,7 +227,7 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_ledger_blocks_app_work_until_release_preflight_passes_or_is_waived
     generator = build_generator
     ledger = generator.ledger_template
-    ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }["work_state"] = "running"
+    ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }["work_state"] = "running"
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -248,6 +251,42 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_includes errors, "app work started before APP_WORK_ALLOWED"
     assert_empty FleetValidation::SchemaValidator.new(generator.ledger_schema).errors(ledger)
+  end
+
+  def test_app_work_allowed_requires_the_exact_pack_snapshot_and_restart_handoff
+    generator = build_generator
+    missing_snapshot = complete_ledger(generator)
+    missing_snapshot.fetch("pack")["candidate_commit"] = nil
+    missing_handoff = complete_ledger(generator)
+    missing_handoff.fetch("preflight").fetch("capabilities")["restart_handoff"] = nil
+
+    [missing_snapshot, missing_handoff].each do |ledger|
+      errors = FleetValidation::LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths,
+        expected_candidate: "v17.0.0.rc.12",
+        expected_snapshot_fingerprint: generator.snapshot_fingerprint
+      ).errors
+
+      assert_includes errors, "app work started before APP_WORK_ALLOWED"
+    end
+  end
+
+  def test_closeout_preserves_barrier_before_work_start_ordering
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target["work_started_at"] = "2026-07-18T09:59:00Z"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("started before the preflight barrier opened") })
   end
 
   def test_ledger_fails_closed_when_a_report_only_soft_track_is_missing
@@ -318,6 +357,26 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_includes unknown_errors, "review app capability UNKNOWN for 1 started target(s)"
     refute_includes absent_errors, "review app capability UNKNOWN for 1 started target(s)"
+  end
+
+  def test_closeout_requires_terminal_evidence_for_configured_review_apps
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.fetch("review_app").merge!(
+      "state" => "configured_runnable",
+      "deployed_smoke" => "pending",
+      "evidence" => "configuration found"
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("review-app smoke is not terminal") })
   end
 
   def test_closeout_fails_when_required_web_pack_rsc_path_has_no_evidence_or_waiver
@@ -957,7 +1016,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       target.fetch("checks").keys.sort
     )
     assert_equal %w[classification evidence waiver], target.fetch("baseline").keys.sort
-    assert_equal %w[deployed_smoke evidence state], target.fetch("review_app").keys.sort
+    assert_equal %w[blocker_id deployed_smoke evidence state waiver], target.fetch("review_app").keys.sort
   end
 
   def test_closeout_requires_exact_retained_package_lock_versions_and_sources
@@ -1017,7 +1076,27 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "1 hard-gate target(s) retain package versions outside the resolved release snapshot"
+    assert_includes(
+      errors,
+      "1 hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
+    )
+  end
+
+  def test_closeout_rejects_retained_lock_sources_that_do_not_match_the_resolved_snapshot
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    lock = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+                 .fetch("package_locks").first
+    lock["source"] = "git-or-path-override"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 hard-gate target(s) retain package versions or sources outside the resolved release snapshot"
   end
 
   def test_closeout_rejects_nonterminal_work_and_blank_result_or_baseline_evidence
@@ -1422,6 +1501,102 @@ class FleetValidationGeneratorTest < Minitest::Test
 
       assert_equal "repos[0] tier must be hard_gate or soft_track", error.message
     end
+  end
+
+  def test_rejects_a_manifest_without_required_lifecycle_paths
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      manifest.delete("lifecycle")
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      assert_equal "lifecycle.required_paths must be a nonempty array", error.message
+    end
+  end
+
+  def test_lifecycle_invariant_families_fail_closed_table
+    generator = build_generator
+    cases = [
+      {
+        name: "exact snapshot identity",
+        mutate: ->(ledger) { ledger.fetch("pack")["candidate_commit"] = nil },
+        expected: "app work started before APP_WORK_ALLOWED"
+      },
+      {
+        name: "resolved artifact snapshot",
+        mutate: ->(ledger) { ledger.fetch("pack")["resolved_packages"] = [] },
+        expected: "app work started before APP_WORK_ALLOWED"
+      },
+      {
+        name: "transition ordering",
+        mutate: lambda do |ledger|
+          ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }["work_started_at"] =
+            "2026-07-18T09:59:00Z"
+        end,
+        expected: "started before the preflight barrier opened"
+      },
+      {
+        name: "terminal review evidence",
+        mutate: lambda do |ledger|
+          ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }.fetch("review_app").merge!(
+            "state" => "configured_runnable",
+            "deployed_smoke" => "pending"
+          )
+        end,
+        expected: "review-app smoke is not terminal"
+      },
+      {
+        name: "complete inventory",
+        mutate: ->(ledger) { ledger.fetch("inventory").pop },
+        expected: "inventory missing target"
+      },
+      {
+        name: "restart equivalence",
+        mutate: lambda do |ledger|
+          ledger.fetch("preflight").fetch("capabilities")["restart_handoff"] = nil
+        end,
+        expected: "app work started before APP_WORK_ALLOWED"
+      }
+    ]
+
+    cases.each do |test_case|
+      ledger = complete_ledger(generator)
+      test_case.fetch(:mutate).call(ledger)
+      errors = FleetValidation::LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths,
+        expected_candidate: "v17.0.0.rc.12",
+        expected_snapshot_fingerprint: generator.snapshot_fingerprint,
+        closeout: true
+      ).errors
+
+      assert(
+        errors.any? { |error| error.include?(test_case.fetch(:expected)) },
+        "#{test_case.fetch(:name)} did not fail closed:\n#{errors.join("\n")}"
+      )
+    end
+
+    read_only = complete_ledger(generator)
+    read_only.fetch("preflight")["app_work_allowed"] = false
+    read_only.fetch("inventory").select { |item| item["work_mode"] == "mutation" }.each do |item|
+      item.merge!("work_state" => "not_started", "work_started_at" => nil)
+    end
+    core = read_only.fetch("inventory").find { |item| item["work_mode"] == "validation_only" }
+    core["work_state"] = "running"
+    errors = FleetValidation::LedgerValidator.new(
+      read_only,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      expected_snapshot_fingerprint: generator.snapshot_fingerprint
+    ).errors
+
+    refute_includes errors, "app work started before APP_WORK_ALLOWED"
   end
 
   def test_rejects_a_hard_gate_missing_a_required_field

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -2,11 +2,14 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "open3"
 require "tmpdir"
 require_relative "generate_prompts"
 
 class FleetValidationGeneratorTest < Minitest::Test
   MANIFEST = File.expand_path("../../../../internal/contributor-info/demo-fleet.yml", __dir__)
+  VALIDATOR = File.expand_path("validate_ledger.rb", __dir__)
+  RC12_REPLAY = File.expand_path("replay_rc12_lifecycle.rb", __dir__)
 
   def build_generator(**overrides)
     defaults = {
@@ -17,6 +20,73 @@ class FleetValidationGeneratorTest < Minitest::Test
       pack_id: "fleet-test-pack"
     }
     FleetValidation::Generator.new(**defaults.merge(overrides))
+  end
+
+  def complete_ledger(generator)
+    ledger = generator.ledger_template
+    ledger.fetch("pack").merge!(
+      "candidate" => "v17.0.0.rc.12",
+      "candidate_commit" => "candidate-commit",
+      "policy_commit" => "policy-commit",
+      "tracker_mode" => "strict-rc"
+    )
+    ledger.fetch("preflight").merge!(
+      "status" => "passed",
+      "release_ci" => "passed",
+      "artifacts" => "passed",
+      "generator_matrix" => "passed"
+    )
+    ledger.fetch("preflight").fetch("capabilities").transform_values! { "passed" }
+    ledger.fetch("preflight").fetch("capabilities")["restart_handoff"] = "restart-safe handoff"
+    ledger.fetch("inventory").each do |item|
+      item.merge!(
+        "work_state" => "finished",
+        "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
+        "evidence" => "public-safe evidence"
+      )
+      item["package_locks"] = [
+        {
+          "ecosystem" => "gem",
+          "name" => "example-package",
+          "version" => "1.0.0",
+          "source" => "registry"
+        }
+      ]
+      item.fetch("checks").each_value do |check|
+        check.merge!("status" => "passed", "evidence" => "public-safe evidence")
+      end
+      item.fetch("review_app").merge!(
+        "state" => "not_configured",
+        "evidence" => "not configured",
+        "deployed_smoke" => "waived"
+      )
+      item.fetch("baseline").merge!("classification" => "clean", "evidence" => "fresh default passed")
+    end
+    ledger.fetch("required_paths").each do |path|
+      path.merge!("status" => "passed", "lane" => "sanitized-lane", "evidence" => "public-safe evidence")
+    end
+    ledger.fetch("audit").merge!(
+      "status" => "passed",
+      "checker" => "independent-checker",
+      "maker_ids" => ["maker-1"],
+      "base_commit" => "base-commit"
+    )
+    ledger.fetch("merge").merge!(
+      "authority" => "auto_merge_when_gates_pass",
+      "authority_evidence" => "trusted batch goal",
+      "freeze_state" => "clear",
+      "status" => "merged",
+      "reviewed_base_commit" => "base-commit",
+      "current_base_commit" => "base-commit",
+      "base_reconciliation" => "passed"
+    )
+    ledger.fetch("reachability").merge!("default_branch" => "passed", "tree_parity" => "passed")
+    ledger.fetch("tracker").merge!(
+      "status" => "ready",
+      "comment_url" => "https://example.invalid/tracker-comment",
+      "promotion" => "recommend"
+    )
+    ledger
   end
 
   def test_balances_six_prompts_across_two_machines
@@ -42,6 +112,577 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_equal expected_names.sort, assigned_names.sort
     assert_equal assigned_names.length, assigned_names.uniq.length
+  end
+
+  def test_lifecycle_inventory_includes_every_hard_gate_and_report_only_soft_track
+    inventory = build_generator.lifecycle_inventory
+
+    assert_equal 7, (inventory.count { |target| target.fetch("tier") == "hard_gate" })
+    assert_equal 5, (inventory.count { |target| target.fetch("tier") == "soft_track" })
+    assert(inventory.select { |target| target.fetch("tier") == "soft_track" }
+                    .all? { |target| target.fetch("work_mode") == "report_only" })
+  end
+
+  def test_report_only_prompt_covers_all_five_soft_tracks_without_mutation
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      report_only = File.read(File.join(directory, "REPORT-ONLY.md"))
+
+      assert_equal 5, (report_only.lines.count { |line| line.include?("Report only; do not mutate") })
+      assert_includes report_only, "fresh default"
+      assert_includes report_only, "archived or deferred disposition"
+    end
+  end
+
+  def test_writes_lifecycle_inventory_and_closeout_artifacts
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+
+      %w[LIFECYCLE.md PREFLIGHT.md REPORT-ONLY.md CLOSEOUT.md result-ledger.json result-ledger.schema.json].each do |name|
+        assert File.exist?(File.join(directory, name)), "expected generated #{name}"
+      end
+    end
+  end
+
+  def test_declares_required_web_pack_rsc_path_before_closeout
+    required_path_ids = build_generator.required_paths.map { |path| path.fetch("id") }
+
+    assert_includes required_path_ids, "webpack-rsc-production"
+  end
+
+  def test_generated_preflight_is_a_terminal_barrier_with_restart_safe_capability_evidence
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      preflight = File.read(File.join(directory, "PREFLIGHT.md"))
+      maker_prompt = Dir.glob(File.join(directory, "*", "*-fleet-lane.md")).min.then { |path| File.read(path) }
+
+      assert_includes preflight, "APP_WORK_ALLOWED"
+      assert_includes preflight, "release commit CI"
+      assert_includes preflight, "registry and tarball artifacts"
+      assert_includes preflight, "standard / Pro / Pro+RSC generator matrix"
+      assert_includes preflight, "nonblocking permissions"
+      assert_includes preflight, "restart-safe handoff"
+      assert_includes preflight,
+                      "configured/runnable, configured/broken, not configured, or `UNKNOWN`"
+      assert_includes maker_prompt, "Do not start app mutation work until `APP_WORK_ALLOWED`"
+    end
+  end
+
+  def test_lifecycle_artifact_orders_snapshot_preflight_inventory_audit_merge_and_closeout
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      lifecycle = File.read(File.join(directory, "LIFECYCLE.md"))
+
+      phases = [
+        "Phase 0 — snapshot",
+        "Phase 1 — capability preflight",
+        "Phase 2 — release-wide barrier",
+        "Phase 3 — fleet execution",
+        "Phase 4 — independent audit",
+        "Phase 5 — authorized merge",
+        "Phase 6 — reachability and tree parity",
+        "Phase 7 — tracker closeout"
+      ]
+      phases.each_cons(2) do |first, second|
+        assert_operator lifecycle.index(first), :<, lifecycle.index(second)
+      end
+      assert_includes lifecycle, "webpack-rsc-production"
+    end
+  end
+
+  def test_ledger_blocks_app_work_until_release_preflight_passes_or_is_waived
+    generator = build_generator
+    ledger = generator.ledger_template
+    ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }["work_state"] = "running"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    assert_includes errors, "app work started before APP_WORK_ALLOWED"
+  end
+
+  def test_ledger_fails_closed_when_a_report_only_soft_track_is_missing
+    generator = build_generator
+    ledger = generator.ledger_template
+    removed = ledger.fetch("inventory").find { |item| item["tier"] == "soft_track" }
+    ledger.fetch("inventory").delete(removed)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    assert_includes errors, "inventory missing target #{removed.fetch('id')}"
+  end
+
+  def test_ledger_rejects_a_stale_candidate_pack
+    generator = build_generator(release_selector: "v17.0.0.rc.12")
+    ledger = generator.ledger_template
+    ledger.fetch("pack")["candidate"] = "v17.0.0.rc.11"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12"
+    ).errors
+
+    assert_includes errors, "candidate mismatch: expected v17.0.0.rc.12, got v17.0.0.rc.11"
+  end
+
+  def test_ledger_rejects_unknown_coordination_or_machine_capabilities
+    generator = build_generator
+    ledger = generator.ledger_template
+    capabilities = ledger.fetch("preflight").fetch("capabilities")
+    capabilities["coordination"] = "unknown"
+    capabilities["permissions"] = "unknown"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    assert_includes errors, "capability coordination is UNKNOWN"
+    assert_includes errors, "capability permissions is UNKNOWN"
+  end
+
+  def test_review_app_capability_accepts_not_configured_but_rejects_unknown_after_work_starts
+    generator = build_generator
+    unknown_ledger = generator.ledger_template
+    unknown_ledger.fetch("preflight")["status"] = "passed"
+    target = unknown_ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target["work_state"] = "running"
+    unknown_errors = FleetValidation::LedgerValidator.new(
+      unknown_ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    target.fetch("review_app")["state"] = "not_configured"
+    absent_errors = FleetValidation::LedgerValidator.new(
+      unknown_ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    assert_includes unknown_errors, "review app capability UNKNOWN for 1 started target(s)"
+    refute_includes absent_errors, "review app capability UNKNOWN for 1 started target(s)"
+  end
+
+  def test_closeout_fails_when_required_web_pack_rsc_path_has_no_evidence_or_waiver
+    generator = build_generator
+    ledger = generator.ledger_template
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "required path webpack-rsc-production has no passing evidence or waiver"
+  end
+
+  def test_all_six_sanitized_closeout_blockers_require_durable_owners
+    generator = build_generator
+    ledger = generator.ledger_template
+    ledger["blockers"] = (1..6).map do |number|
+      {
+        "id" => "blocker-#{number}",
+        "status" => "open",
+        "public_summary" => "Sanitized closeout blocker #{number}",
+        "owner" => nil
+      }
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors.grep(/has no durable owner/)
+
+    assert_equal 6, errors.length
+  end
+
+  def test_public_ledger_rejects_private_blocker_fields
+    generator = build_generator
+    ledger = generator.ledger_template
+    ledger["blockers"] = [
+      {
+        "id" => "blocker-1",
+        "status" => "open",
+        "public_summary" => "Sanitized blocker",
+        "owner" => { "public_tracker_reason" => "Public identity cannot be exposed" },
+        "deployment_url" => "redacted"
+      }
+    ]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    assert_includes errors, "blocker blocker-1 contains forbidden private field deployment_url"
+  end
+
+  def test_closeout_requires_reconciliation_when_the_default_base_moves
+    generator = build_generator
+    ledger = generator.ledger_template
+    ledger.fetch("merge")["reviewed_base_commit"] = "base-before"
+    ledger.fetch("merge")["current_base_commit"] = "base-after"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "base moved after audit without passing reconciliation"
+  end
+
+  def test_generated_closeout_requires_independent_audit_authorized_merge_reachability_and_tree_parity
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      closeout = File.read(File.join(directory, "CLOSEOUT.md"))
+
+      assert_includes closeout, "independent checker"
+      assert_includes closeout, "tracker mode and freeze"
+      assert_includes closeout, "explicit merge authority"
+      assert_includes closeout, "default-branch reachability"
+      assert_includes closeout, "tree parity"
+      assert_includes closeout, "PASS`, `PARTIAL`, or `BLOCKED"
+    end
+  end
+
+  def test_closeout_rejects_a_checker_that_was_also_a_maker
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("audit")["checker"] = "maker-1"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit checker is also a maker"
+  end
+
+  def test_closeout_rejects_a_pending_independent_audit
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("audit")["status"] = "pending"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit is not passed"
+  end
+
+  def test_closeout_requires_a_restart_safe_capability_handoff
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight").fetch("capabilities")["restart_handoff"] = nil
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "capability restart_handoff is missing"
+  end
+
+  def test_closeout_requires_all_release_wide_preflight_gates_to_pass
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight")["artifacts"] = "unknown"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "release-wide preflight artifacts is not passed or explicitly waived"
+  end
+
+  def test_empty_preflight_waiver_does_not_open_the_app_work_barrier
+    generator = build_generator
+    ledger = generator.ledger_template
+    ledger.fetch("preflight").merge!("status" => "waived", "waiver" => {})
+    ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }["work_state"] = "running"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    assert_includes errors, "app work started before APP_WORK_ALLOWED"
+  end
+
+  def test_closeout_rejects_unknown_or_nonterminal_inventory_results
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("inventory").first["result"] = "unknown"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 inventory target(s) are unknown or nonterminal"
+  end
+
+  def test_closeout_requires_candidate_policy_and_default_snapshot_identities
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("pack")["policy_commit"] = nil
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "pack policy_commit is missing"
+  end
+
+  def test_closeout_rejects_unknown_default_reachability_or_tree_parity
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("reachability")["tree_parity"] = "unknown"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "reachability tree_parity is not passed"
+  end
+
+  def test_closeout_rejects_merge_during_a_freeze_conflict
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("merge")["freeze_state"] = "conflict"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "merge is not allowed while tracker mode or freeze state conflicts"
+  end
+
+  def test_closeout_requires_replayable_explicit_merge_authority_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("merge")["authority_evidence"] = nil
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "merged result is missing explicit authority evidence"
+  end
+
+  def test_validated_ledger_regenerates_the_append_only_tracker_matrix
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    validator = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    )
+
+    assert_empty validator.errors
+
+    tracker = FleetValidation::TrackerRenderer.new(ledger).render
+
+    assert_includes tracker, "<!-- fleet-validation-closeout:fleet-test-pack -->"
+    assert_includes tracker, "Verdict: PASS"
+    assert_equal 12, (tracker.lines.count { |line| line.match?(/\| (hard_gate|soft_track) \|/) })
+    assert_includes tracker, "## Required release paths"
+    assert_includes tracker, "## Blocker ownership"
+    assert_includes tracker, "Promotion recommendation: recommend"
+  end
+
+  def test_tracker_derives_partial_and_blocked_verdicts_from_the_ledger
+    generator = build_generator
+    partial = complete_ledger(generator)
+    partial.fetch("inventory").find { |item| item["tier"] == "soft_track" }["result"] = "blocked"
+    blocked = complete_ledger(generator)
+    blocked.fetch("inventory").find { |item| item["tier"] == "hard_gate" }["result"] = "blocked"
+
+    assert_includes FleetValidation::TrackerRenderer.new(partial).render, "Verdict: PARTIAL"
+    assert_includes FleetValidation::TrackerRenderer.new(blocked).render, "Verdict: BLOCKED"
+  end
+
+  def test_promotion_recommendation_is_rejected_while_a_blocker_remains_active
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = [
+      {
+        "id" => "sanitized-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized active blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/1" }
+      }
+    ]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "promotion cannot be recommended while release blockers remain"
+  end
+
+  def test_ledger_cli_validates_and_renders_the_tracker_from_one_file
+    generator = build_generator
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      tracker_path = File.join(directory, "tracker.md")
+      File.write(ledger_path, JSON.pretty_generate(complete_ledger(generator)))
+
+      stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-candidate", "v17.0.0.rc.12",
+        "--render-tracker", tracker_path
+      )
+
+      assert status.success?, stderr
+      assert_includes stdout, "VALID fleet result ledger"
+      assert File.exist?(tracker_path)
+    end
+  end
+
+  def test_result_ledger_schema_closes_public_blocker_and_review_app_shapes
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      schema = JSON.parse(File.read(File.join(directory, "result-ledger.schema.json")))
+
+      assert_equal false, schema.dig("properties", "blockers", "items", "additionalProperties")
+      assert_equal(
+        %w[configured_runnable configured_broken not_configured unknown],
+        schema.dig(
+          "properties", "inventory", "items", "properties", "review_app", "properties", "state", "enum"
+        )
+      )
+    end
+  end
+
+  def test_schema_validator_rejects_unknown_fields_and_invalid_enums
+    generator = build_generator
+    ledger = generator.ledger_template
+    ledger["unexpected"] = true
+    ledger.fetch("inventory").first.fetch("review_app")["state"] = "invented"
+
+    errors = FleetValidation::SchemaValidator.new(generator.ledger_schema).errors(ledger)
+
+    assert_includes errors, "$ has unsupported field unexpected"
+    assert_includes errors, "$.inventory[0].review_app.state is not an allowed value"
+  end
+
+  def test_ledger_template_has_exact_package_check_baseline_and_review_app_evidence_slots
+    target = build_generator.ledger_template.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+
+    assert_equal [], target.fetch("package_locks")
+    assert_equal(
+      %w[build hosted_ci install local_smoke review test],
+      target.fetch("checks").keys.sort
+    )
+    assert_equal %w[classification evidence], target.fetch("baseline").keys.sort
+    assert_equal %w[deployed_smoke evidence state], target.fetch("review_app").keys.sort
+  end
+
+  def test_closeout_requires_exact_retained_package_lock_versions_and_sources
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }["package_locks"] = []
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 hard-gate target(s) are missing retained package lock evidence"
+  end
+
+  def test_closeout_requires_terminal_install_build_test_smoke_ci_and_review_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.fetch("checks").fetch("hosted_ci")["status"] = "unknown"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 hard-gate target(s) have unknown or nonterminal check evidence"
+  end
+
+  def test_sanitized_rc12_replay_exercises_inventory_barriers_ownership_and_tracker_regeneration
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, RC12_REPLAY)
+
+    assert status.success?, stderr
+    assert_includes stdout, "hard_gates=7"
+    assert_includes stdout, "soft_tracks=5"
+    assert_includes stdout, "required_path=webpack-rsc-production:scheduled"
+    assert_includes stdout, "unowned_blockers_rejected=6"
+    assert_includes stdout, "tracker_rows=12"
+    assert_includes stdout, "tracker_verdict=PARTIAL"
+    assert_includes stdout, "SANITIZED_RC12_REPLAY_PASS"
   end
 
   def test_generated_prompts_are_dynamic_and_require_bounded_subagents
@@ -84,6 +725,19 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert File.exist?(File.join(directory, "INDEX.md"))
       assert_equal 3, Dir.glob(File.join(directory, "local", "*.md")).length
       assert_equal 3, Dir.glob(File.join(directory, "m1", "*.md")).length
+    end
+  end
+
+  def test_index_launches_preflight_before_makers_and_closeout_after_ledger_validation
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      index = File.read(File.join(directory, "INDEX.md"))
+
+      assert_includes index, "[PREFLIGHT.md](PREFLIGHT.md)"
+      assert_includes index, "[REPORT-ONLY.md](REPORT-ONLY.md)"
+      assert_includes index, "[CLOSEOUT.md](CLOSEOUT.md)"
+      assert_includes index, "`result-ledger.json`"
+      assert_includes index, "Do not start the app mutation prompts before `APP_WORK_ALLOWED`"
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -28,7 +28,10 @@ class FleetValidationGeneratorTest < Minitest::Test
       "candidate" => "v17.0.0.rc.12",
       "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-      "tracker_mode" => "strict-rc"
+      "tracker_mode" => "strict-rc",
+      "resolved_packages" => generator.lifecycle_inventory.flat_map { |target| target.fetch("packages") }
+                                      .uniq { |package| [package["ecosystem"], package["name"]] }
+                                      .map { |package| package.merge("version" => "1.0.0", "source" => "registry") }
     )
     ledger.fetch("preflight")["status"] = "passed"
     %w[release_ci artifacts generator_matrix].each do |gate|
@@ -56,9 +59,9 @@ class FleetValidationGeneratorTest < Minitest::Test
       )
       item.fetch("baseline").merge!("classification" => "clean", "evidence" => "fresh default passed")
       item.fetch("bases").merge!(
-        "audit" => "base-commit",
-        "reviewed" => "base-commit",
-        "current" => "base-commit",
+        "audit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "reviewed" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "current" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         "reconciliation" => "passed"
       )
       item.fetch("reachability").merge!(
@@ -77,15 +80,15 @@ class FleetValidationGeneratorTest < Minitest::Test
       "status" => "passed",
       "checker" => "independent-checker",
       "maker_ids" => ["maker-1"],
-      "base_commit" => "base-commit"
+      "base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
     )
     ledger.fetch("merge").merge!(
       "authority" => "auto_merge_when_gates_pass",
       "authority_evidence" => "trusted batch goal",
       "freeze_state" => "clear",
       "status" => "merged",
-      "reviewed_base_commit" => "base-commit",
-      "current_base_commit" => "base-commit",
+      "reviewed_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "current_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "base_reconciliation" => "passed"
     )
     ledger.fetch("reachability").merge!("default_branch" => "passed", "tree_parity" => "passed")
@@ -125,8 +128,9 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_lifecycle_inventory_includes_every_hard_gate_and_report_only_soft_track
     inventory = build_generator.lifecycle_inventory
 
-    assert_equal 7, (inventory.count { |target| target.fetch("tier") == "hard_gate" })
+    assert_equal 8, (inventory.count { |target| target.fetch("tier") == "hard_gate" })
     assert_equal 5, (inventory.count { |target| target.fetch("tier") == "soft_track" })
+    assert(inventory.any? { |target| target.fetch("id") == "react-on-rails-generator-install-smoke" })
     assert(inventory.select { |target| target.fetch("tier") == "soft_track" }
                     .all? { |target| target.fetch("work_mode") == "report_only" })
   end
@@ -390,9 +394,9 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "audit base_commit is missing"
-    assert_includes errors, "merge reviewed_base_commit is missing"
-    assert_includes errors, "merge current_base_commit is missing"
+    assert_includes errors, "audit base_commit is missing or not an exact commit identity"
+    assert_includes errors, "merge reviewed_base_commit is missing or not an exact commit identity"
+    assert_includes errors, "merge current_base_commit is missing or not an exact commit identity"
     assert(errors.any? { |error| error.include?("audit base is missing") })
   end
 
@@ -677,7 +681,7 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_includes tracker, "<!-- fleet-validation-closeout:fleet-test-pack -->"
     assert_includes tracker, "Verdict: PASS"
-    assert_equal 12, (tracker.lines.count { |line| line.match?(/\| (hard_gate|soft_track) \|/) })
+    assert_equal 13, (tracker.lines.count { |line| line.match?(/\| (hard_gate|soft_track) \|/) })
     assert_includes tracker, "## Required release paths"
     assert_includes tracker, "## Blocker ownership"
     assert_includes tracker, "Promotion recommendation: recommend"
@@ -898,7 +902,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       %w[build hosted_ci install local_smoke review test],
       target.fetch("checks").keys.sort
     )
-    assert_equal %w[classification evidence], target.fetch("baseline").keys.sort
+    assert_equal %w[classification evidence waiver], target.fetch("baseline").keys.sort
     assert_equal %w[deployed_smoke evidence state], target.fetch("review_app").keys.sort
   end
 
@@ -934,6 +938,23 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "1 hard-gate target(s) are missing retained package lock evidence"
   end
 
+  def test_closeout_rejects_retained_lock_versions_that_do_not_match_the_resolved_snapshot
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    lock = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+                 .fetch("package_locks").first
+    lock["version"] = "0.0.1"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 hard-gate target(s) retain package versions outside the resolved release snapshot"
+  end
+
   def test_closeout_rejects_nonterminal_work_and_blank_result_or_baseline_evidence
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -950,6 +971,133 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "1 inventory target(s) are unknown or nonterminal"
+  end
+
+  def test_closeout_rejects_a_blocked_work_state_with_a_passing_result
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }["work_state"] = "blocked"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 inventory target(s) have inconsistent work-state/result combinations"
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+  end
+
+  def test_closeout_requires_structured_baseline_waiver_and_renders_partial
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.fetch("baseline").merge!("classification" => "waived", "waiver" => nil)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("waived baseline is missing structured waiver evidence") })
+    target.fetch("baseline")["waiver"] = {
+      "gate" => "#{target['id']}:baseline",
+      "authority" => "maintainer",
+      "evidence_url" => "https://example.invalid/baseline-waiver",
+      "reason" => "sanitized"
+    }
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: PARTIAL"
+  end
+
+  def test_blocked_closeout_does_not_require_merge_or_post_merge_reachability
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "owned-blocker")
+    target.fetch("checks").each_value do |check|
+      check.merge!("status" => "blocked", "blocker_id" => "owned-blocker")
+    end
+    ledger["blockers"] = [
+      {
+        "id" => "owned-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized release blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/1" }
+      }
+    ]
+    ledger.fetch("merge").merge!(
+      "authority" => "none",
+      "authority_evidence" => nil,
+      "status" => "blocked",
+      "reviewed_base_commit" => nil,
+      "current_base_commit" => nil
+    )
+    ledger.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
+    target.fetch("reachability").transform_values! { nil }
+    target.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    refute(errors.any? { |error| error.match?(/merge status|reachability|base is missing/) }, errors.join("\n"))
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+  end
+
+  def test_closeout_binds_audited_bases_to_reviewed_revisions
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("audit")["base_commit"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ledger.fetch("merge")["reviewed_base_commit"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.fetch("bases").merge!(
+      "audit" => "cccccccccccccccccccccccccccccccccccccccc",
+      "reviewed" => "dddddddddddddddddddddddddddddddddddddddd"
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("audit base does not match reviewed base") })
+    assert_includes errors, "audit base_commit does not match merge reviewed_base_commit"
+  end
+
+  def test_same_pack_id_cannot_be_reused_for_a_different_release_snapshot
+    Dir.mktmpdir do |directory|
+      build_generator(release_selector: "v17.0.0.rc.12").write_pack(directory)
+      regenerated = build_generator(release_selector: "v17.0.0.rc.13")
+
+      error = assert_raises(FleetValidation::ManifestError) { regenerated.write_pack(directory) }
+      assert_includes error.message, "existing result ledger belongs to a different release snapshot"
+    end
+  end
+
+  def test_same_pack_id_cannot_be_reused_after_manifest_policy_changes
+    Dir.mktmpdir do |directory|
+      build_generator(release_selector: "v17.0.0.rc.12").write_pack(directory)
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      manifest.fetch("defaults")["build"] = "changed sanitized build command"
+      manifest_path = File.join(directory, "changed-manifest.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+      regenerated = build_generator(
+        manifest_path:,
+        release_selector: "v17.0.0.rc.12"
+      )
+
+      error = assert_raises(FleetValidation::ManifestError) { regenerated.write_pack(directory) }
+      assert_includes error.message, "existing result ledger belongs to a different release snapshot"
+    end
   end
 
   def test_closeout_requires_per_target_reachability_and_tree_parity_evidence
@@ -990,11 +1138,11 @@ class FleetValidationGeneratorTest < Minitest::Test
     stdout, stderr, status = Open3.capture3(RbConfig.ruby, RC12_REPLAY)
 
     assert status.success?, stderr
-    assert_includes stdout, "hard_gates=7"
+    assert_includes stdout, "hard_gates=8"
     assert_includes stdout, "soft_tracks=5"
     assert_includes stdout, "required_path=webpack-rsc-production:scheduled"
     assert_includes stdout, "unowned_blockers_rejected=6"
-    assert_includes stdout, "tracker_rows=12"
+    assert_includes stdout, "tracker_rows=13"
     assert_includes stdout, "tracker_verdict=PARTIAL"
     assert_includes stdout, "SANITIZED_RC12_REPLAY_PASS"
   end

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -30,12 +30,10 @@ class FleetValidationGeneratorTest < Minitest::Test
       "policy_commit" => "policy-commit",
       "tracker_mode" => "strict-rc"
     )
-    ledger.fetch("preflight").merge!(
-      "status" => "passed",
-      "release_ci" => "passed",
-      "artifacts" => "passed",
-      "generator_matrix" => "passed"
-    )
+    ledger.fetch("preflight")["status"] = "passed"
+    %w[release_ci artifacts generator_matrix].each do |gate|
+      ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
+    end
     ledger.fetch("preflight").fetch("capabilities").transform_values! { "passed" }
     ledger.fetch("preflight").fetch("capabilities")["restart_handoff"] = "restart-safe handoff"
     ledger.fetch("inventory").each do |item|
@@ -44,14 +42,10 @@ class FleetValidationGeneratorTest < Minitest::Test
         "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
         "evidence" => "public-safe evidence"
       )
-      item["package_locks"] = [
-        {
-          "ecosystem" => "gem",
-          "name" => "example-package",
-          "version" => "1.0.0",
-          "source" => "registry"
-        }
-      ]
+      expected = generator.lifecycle_inventory.find { |target| target["id"] == item["id"] }
+      item["package_locks"] = expected.fetch("packages").map do |package|
+        package.merge("version" => "1.0.0", "source" => "registry")
+      end
       item.fetch("checks").each_value do |check|
         check.merge!("status" => "passed", "evidence" => "public-safe evidence")
       end
@@ -61,6 +55,12 @@ class FleetValidationGeneratorTest < Minitest::Test
         "deployed_smoke" => "waived"
       )
       item.fetch("baseline").merge!("classification" => "clean", "evidence" => "fresh default passed")
+      item.fetch("bases").merge!(
+        "audit" => "base-commit",
+        "reviewed" => "base-commit",
+        "current" => "base-commit",
+        "reconciliation" => "passed"
+      )
     end
     ledger.fetch("required_paths").each do |path|
       path.merge!("status" => "passed", "lane" => "sanitized-lane", "evidence" => "public-safe evidence")
@@ -352,9 +352,11 @@ class FleetValidationGeneratorTest < Minitest::Test
 
   def test_closeout_requires_reconciliation_when_the_default_base_moves
     generator = build_generator
-    ledger = generator.ledger_template
+    ledger = complete_ledger(generator)
     ledger.fetch("merge")["reviewed_base_commit"] = "base-before"
     ledger.fetch("merge")["current_base_commit"] = "base-after"
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.fetch("bases").merge!("reviewed" => "target-before", "current" => "target-after", "reconciliation" => "blocked")
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -371,6 +373,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger = complete_ledger(generator)
     ledger.fetch("audit")["base_commit"] = nil
     ledger.fetch("merge").merge!("reviewed_base_commit" => nil, "current_base_commit" => nil)
+    ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }.fetch("bases")["audit"] = nil
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -382,6 +385,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "audit base_commit is missing"
     assert_includes errors, "merge reviewed_base_commit is missing"
     assert_includes errors, "merge current_base_commit is missing"
+    assert(errors.any? { |error| error.include?("audit base is missing") })
   end
 
   def test_generated_closeout_requires_independent_audit_authorized_merge_reachability_and_tree_parity
@@ -465,7 +469,7 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_closeout_requires_all_release_wide_preflight_gates_to_pass
     generator = build_generator
     ledger = complete_ledger(generator)
-    ledger.fetch("preflight")["artifacts"] = "unknown"
+    ledger.fetch("preflight").fetch("artifacts")["status"] = "unknown"
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -483,7 +487,6 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger = complete_ledger(generator)
     ledger.fetch("preflight").merge!(
       "status" => "waived",
-      "artifacts" => "blocked",
       "waiver" => {
         "gate" => "artifacts",
         "authority" => "maintainer",
@@ -491,6 +494,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         "reason" => "sanitized"
       }
     )
+    ledger.fetch("preflight").fetch("artifacts")["status"] = "blocked"
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -500,6 +504,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "release-wide preflight artifacts must pass and cannot be waived"
+  end
+
+  def test_release_wide_preflight_passes_require_retained_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight").fetch("release_ci")["evidence"] = nil
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "release-wide preflight release_ci is not passed or explicitly waived"
   end
 
   def test_empty_preflight_waiver_does_not_open_the_app_work_barrier
@@ -579,6 +598,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "merge is not allowed while tracker mode or freeze state conflicts"
+  end
+
+  def test_closeout_requires_applicable_merges_to_be_complete
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("merge")["status"] = "authorized"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "closeout merge status is not merged"
   end
 
   def test_closeout_requires_replayable_explicit_merge_authority_evidence
@@ -676,6 +710,25 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_blocked_hard_gate_outcomes_require_owned_blocker_references
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target["result"] = "blocked"
+    target.fetch("checks").fetch("hosted_ci")["status"] = "blocked"
+    ledger.fetch("tracker")["promotion"] = "hold"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("blocked result has no owned blocker reference") })
+    assert(errors.any? { |error| error.include?("blocked check hosted_ci has no owned blocker reference") })
+  end
+
   def test_waived_hard_gate_and_check_require_structured_waiver_evidence
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -713,6 +766,19 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert status.success?, stderr
       assert_includes stdout, "VALID fleet result ledger"
       assert File.exist?(tracker_path)
+    end
+  end
+
+  def test_ledger_cli_requires_an_external_expected_candidate
+    generator = build_generator
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(complete_ledger(generator)))
+
+      _stdout, stderr, status = Open3.capture3(RbConfig.ruby, VALIDATOR, "--manifest", MANIFEST, "--ledger", ledger_path)
+
+      refute status.success?
+      assert_includes stderr, "missing argument: --expected-candidate"
     end
   end
 
@@ -769,6 +835,40 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "1 hard-gate target(s) are missing retained package lock evidence"
+  end
+
+  def test_closeout_requires_every_manifest_package_in_the_retained_lock_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" && item["package_locks"].length > 1 }
+    target.fetch("package_locks").pop
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 hard-gate target(s) are missing retained package lock evidence"
+  end
+
+  def test_closeout_rejects_nonterminal_work_and_blank_result_or_baseline_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").first
+    target["work_state"] = "not_started"
+    target["evidence"] = nil
+    target.fetch("baseline")["evidence"] = nil
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 inventory target(s) are unknown or nonterminal"
   end
 
   def test_closeout_requires_terminal_install_build_test_smoke_ci_and_review_evidence
@@ -854,7 +954,8 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_includes index, "[CLOSEOUT.md](CLOSEOUT.md)"
       assert_includes index, "`result-ledger.json`"
       assert_includes index, "Do not start the app mutation prompts before `APP_WORK_ALLOWED`"
-      assert_operator index.index("Start prompt coordinator 1"), :<, index.index("Start the remaining prompt coordinators")
+      assert_operator index.index("Start prompt coordinator 1"), :<, index.index("[PREFLIGHT.md](PREFLIGHT.md)")
+      assert_operator index.index("[PREFLIGHT.md](PREFLIGHT.md)"), :<, index.index("Start the remaining prompt coordinators")
       refute_includes index, "Start all 6 prompt coordinators simultaneously after the snapshot exists"
     end
   end

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -48,6 +48,15 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger.fetch("preflight")["status"] = "passed"
     ledger.fetch("preflight")["app_work_allowed"] = true
     ledger.fetch("preflight")["opened_at"] = "2026-07-18T10:00:00Z"
+    ledger.fetch("preflight")["public_marker"] = {
+      "status" => "unique",
+      "pack_id" => ledger.dig("pack", "pack_id"),
+      "candidate" => ledger.dig("pack", "candidate"),
+      "candidate_commit" => ledger.dig("pack", "candidate_commit"),
+      "snapshot_fingerprint" => generator.snapshot_fingerprint,
+      "opened_at" => "2026-07-18T10:00:00Z",
+      "evidence" => "public-safe unique marker evidence"
+    }
     %w[release_ci artifacts generator_matrix].each do |gate|
       ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
     end
@@ -352,6 +361,31 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_includes errors, "app work started before APP_WORK_ALLOWED"
     assert_empty FleetValidation::SchemaValidator.new(generator.ledger_schema).errors(ledger)
+  end
+
+  def test_app_work_allowed_requires_a_unique_pack_bound_public_marker
+    generator = build_generator
+    mutations = [
+      ->(marker) { marker["status"] = "duplicate" },
+      ->(marker) { marker["pack_id"] = "another-pack" },
+      ->(marker) { marker["candidate"] = "v17.0.0.rc.11" },
+      ->(marker) { marker["candidate_commit"] = "ffffffffffffffffffffffffffffffffffffffff" },
+      ->(marker) { marker["snapshot_fingerprint"] = "stale-fingerprint" },
+      ->(marker) { marker["opened_at"] = "2026-07-18T09:00:00Z" },
+      ->(marker) { marker["evidence"] = nil }
+    ]
+
+    mutations.each do |mutate|
+      ledger = complete_ledger(generator)
+      mutate.call(ledger.fetch("preflight").fetch("public_marker"))
+      errors = FleetValidation::LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths
+      ).errors
+
+      assert_includes errors, "public preflight marker is not unique and snapshot-bound"
+    end
   end
 
   def test_app_work_allowed_requires_the_exact_pack_snapshot_and_restart_handoff
@@ -1448,6 +1482,36 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: PARTIAL"
   end
 
+  def test_nested_soft_track_blocker_renders_partial_without_blocking_promotion
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+    target.fetch("checks").fetch("hosted_ci").merge!(
+      "status" => "blocked",
+      "blocker_id" => "soft-check-followup"
+    )
+    ledger["blockers"] = [
+      {
+        "id" => "soft-check-followup",
+        "status" => "open",
+        "public_summary" => "Soft-track hosted CI follow-up",
+        "owner" => { "issue_url" => "https://example.invalid/issues/soft-check-followup" },
+        "disposition" => nil
+      }
+    ]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_empty errors
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: PARTIAL"
+  end
+
   def test_blocker_shared_with_a_hard_gate_remains_release_gating
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -1548,6 +1612,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         VALIDATOR,
         "--manifest", MANIFEST,
         "--ledger", ledger_path,
+        "--expected-pack-id", "fleet-test-pack",
         "--expected-candidate", "v17.0.0.rc.12",
         "--render-tracker", tracker_path
       )
@@ -1571,6 +1636,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         VALIDATOR,
         "--ledger",
         ledger_path,
+        "--expected-pack-id",
+        "fleet-test-pack",
         "--expected-candidate",
         "v17.0.0.rc.12"
       )
@@ -1591,6 +1658,35 @@ class FleetValidationGeneratorTest < Minitest::Test
 
       refute status.success?
       assert_includes stderr, "missing argument: --expected-candidate"
+    end
+  end
+
+  def test_ledger_cli_requires_and_enforces_an_external_expected_pack_id
+    generator = build_generator
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(complete_ledger(generator)))
+
+      _stdout, missing_stderr, missing_status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-candidate", "v17.0.0.rc.12"
+      )
+      _stdout, mismatch_stderr, mismatch_status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-pack-id", "another-pack",
+        "--expected-candidate", "v17.0.0.rc.12"
+      )
+
+      refute missing_status.success?
+      assert_includes missing_stderr, "missing argument: --expected-pack-id"
+      refute mismatch_status.success?
+      assert_includes mismatch_stderr, "pack ID mismatch: expected another-pack, got fleet-test-pack"
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -75,7 +75,12 @@ class FleetValidationGeneratorTest < Minitest::Test
         resolved.dup
       end
       item.fetch("checks").each_value do |check|
-        check.merge!("status" => "passed", "head_commit" => revision, "evidence" => "public-safe evidence")
+        check.merge!(
+          "status" => "passed",
+          "head_commit" => revision,
+          "base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "evidence" => "public-safe evidence"
+        )
       end
       item.fetch("review_app").merge!(
         "state" => "not_configured",
@@ -677,6 +682,31 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "blocker IDs must be unique: duplicate-blocker"
   end
 
+  def test_closeout_rejects_unknown_blocker_status_even_with_a_durable_owner
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = [
+      {
+        "id" => "uncertain-blocker",
+        "status" => "unknown",
+        "public_summary" => "Public-safe state is still unknown",
+        "owner" => { "issue_url" => "https://example.invalid/issues/uncertain-blocker" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocker uncertain-blocker remains UNKNOWN at closeout"
+  end
+
   def test_public_ledger_rejects_private_blocker_fields
     generator = build_generator
     ledger = generator.ledger_template
@@ -714,6 +744,26 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "base moved after audit without passing reconciliation"
+  end
+
+  def test_closeout_requires_checks_to_be_bound_to_the_reconciled_current_base
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    reconciled_base = "ffffffffffffffffffffffffffffffffffffffff"
+    target.fetch("bases").merge!("current" => reconciled_base, "reconciliation" => "passed")
+    target.fetch("baseline")["head_commit"] = reconciled_base
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors,
+                    "target #{target.fetch('id')} check evidence is not bound to its reconciled current base"
   end
 
   def test_closeout_requires_per_target_audit_reviewed_and_current_base_identities
@@ -1494,6 +1544,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       %w[build hosted_ci install local_smoke review test],
       target.fetch("checks").keys.sort
     )
+    assert(target.fetch("checks").values.all? { |check| check.key?("base_commit") })
     assert_equal %w[classification evidence head_commit waiver], target.fetch("baseline").keys.sort
     assert_equal %w[blocker_id deployed_smoke evidence head_commit state waiver], target.fetch("review_app").keys.sort
   end
@@ -2358,6 +2409,19 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes pack, "create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-rsc --rsc"
     assert_includes pack, "independently resolved RSC version only in the RSC app"
     assert_includes pack, "verify: true"
+  end
+
+  def test_each_lane_emits_a_complete_schema_valid_inventory_fragment_for_closeout
+    pack = build_generator.render_pack
+
+    assert_includes pack, "complete schema-valid `inventory` row"
+    assert_includes pack, "Do not return only a prose summary"
+    assert_includes pack, "id, tier, work_mode, maker_id, work_state, work_started_at, result, waiver, blocker_id,"
+    assert_includes pack, "package_locks, checks, review_app, baseline, revisions, bases, merge, reachability, and evidence"
+    assert_includes pack, "`lane-result-1.json`"
+    assert_includes pack, "`lane-result-6.json`"
+    assert_includes pack, "atomically merge the row into `result-ledger.json`"
+    assert_includes pack, "exact JSON fragment"
   end
 
   def test_rejects_machine_names_that_collide_as_paths

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -385,6 +385,24 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert(errors.any? { |error| error.include?("started before the preflight barrier opened") })
   end
 
+  def test_lifecycle_timestamps_require_explicit_offsets
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight")["opened_at"] = "2026-07-18T10:00:00"
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target["work_started_at"] = "2026-07-18T10:01:00"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "preflight opened_at must be an ISO8601 timestamp with an explicit offset"
+    assert_includes errors, "target #{target.fetch('id')} work_started_at must be an ISO8601 timestamp with an explicit offset"
+  end
+
   def test_ledger_fails_closed_when_a_report_only_soft_track_is_missing
     generator = build_generator
     ledger = generator.ledger_template
@@ -1049,6 +1067,31 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "app work started before APP_WORK_ALLOWED"
+  end
+
+  def test_preflight_waiver_requires_a_terminal_failed_gate_with_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight").merge!(
+      "status" => "waived",
+      "waiver" => {
+        "gate" => "release_ci",
+        "authority" => "maintainer",
+        "evidence_url" => "https://example.invalid/waiver",
+        "reason" => "Sanitized waiver"
+      }
+    )
+    ledger.fetch("preflight").fetch("release_ci").merge!("status" => "unknown", "evidence" => nil)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "waived preflight has no terminal failed gate with replayable evidence"
+    assert_includes errors, "release-wide preflight release_ci is not passed or explicitly waived"
   end
 
   def test_closeout_rejects_unknown_or_nonterminal_inventory_results
@@ -2005,6 +2048,22 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_same_pack_regeneration_rejects_a_ledger_outside_the_current_schema
+    Dir.mktmpdir do |directory|
+      generator = build_generator(release_selector: "v17.0.0.rc.12")
+      generator.write_pack(directory)
+      ledger_path = File.join(directory, "result-ledger.json")
+      ledger = JSON.parse(File.read(ledger_path))
+      ledger.fetch("pack")["candidate"] = "v17.0.0.rc.12"
+      ledger.delete("tracker")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      error = assert_raises(FleetValidation::ManifestError) { generator.write_pack(directory) }
+
+      assert_includes error.message, "existing result ledger does not match the current schema"
+    end
+  end
+
   def test_dynamic_selector_pack_cannot_reuse_a_resolved_candidate_barrier
     Dir.mktmpdir do |directory|
       generator = build_generator
@@ -2498,6 +2557,31 @@ class FleetValidationGeneratorTest < Minitest::Test
 
       assert_equal "repos[0].packages[0] ecosystem must be gem or npm", error.message
     end
+  end
+
+  def test_hard_gate_inventory_uses_the_same_default_derived_packages_as_its_prompt
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      repo = manifest.fetch("repos").first
+      packages = repo.delete("packages")
+      manifest.fetch("defaults")["packages"] = packages
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      generator = build_generator(manifest_path:)
+      inventory = generator.lifecycle_inventory.find { |target| target["id"] == "shakacode-hichee" }
+
+      assert_equal packages, inventory.fetch("packages")
+      assert_includes generator.render_pack, "gem:react_on_rails"
+    end
+  end
+
+  def test_rejects_blank_release_selectors_before_writing_a_pack
+    error = assert_raises(FleetValidation::ManifestError) do
+      build_generator(release_selector: "   ")
+    end
+
+    assert_equal "release selector must be nonempty", error.message
   end
 
   def test_rejects_a_manifest_without_required_lifecycle_paths

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1855,6 +1855,31 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "tracker promotion is blocked without a release blocker"
   end
 
+  def test_tracker_must_claim_blocked_when_a_release_blocker_remains
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = [
+      {
+        "id" => "release-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized release blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/release-blocker" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("tracker")["promotion"] = "hold"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "tracker promotion must be blocked while a release blocker remains"
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+  end
+
   def test_result_ledger_schema_closes_public_blocker_and_review_app_shapes
     Dir.mktmpdir do |directory|
       build_generator.write_pack(directory)

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -34,6 +34,7 @@ class FleetValidationGeneratorTest < Minitest::Test
                                       .map { |package| package.merge("version" => "1.0.0", "source" => "registry") }
     )
     ledger.fetch("preflight")["status"] = "passed"
+    ledger.fetch("preflight")["app_work_allowed"] = true
     %w[release_ci artifacts generator_matrix].each do |gate|
       ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
     end
@@ -194,7 +195,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_includes preflight, "restart-safe handoff"
       assert_includes preflight,
                       "configured/runnable, configured/broken, not configured, or `UNKNOWN`"
-      assert_includes maker_prompt, "Do not start app mutation work until `APP_WORK_ALLOWED`"
+      assert_includes maker_prompt, "`preflight.app_work_allowed: true` records the"
     end
   end
 
@@ -232,6 +233,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "app work started before APP_WORK_ALLOWED"
+  end
+
+  def test_app_work_allowed_is_an_explicit_schema_validated_ledger_marker
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight")["app_work_allowed"] = false
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths
+    ).errors
+
+    assert_includes errors, "app work started before APP_WORK_ALLOWED"
+    assert_empty FleetValidation::SchemaValidator.new(generator.ledger_schema).errors(ledger)
   end
 
   def test_ledger_fails_closed_when_a_report_only_soft_track_is_missing
@@ -601,6 +617,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "pack tracker_mode is not allowed"
   end
 
+  def test_closeout_requires_full_length_commit_identities
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("pack")["candidate_commit"] = "abc1234"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "pack candidate_commit is not an exact commit identity"
+  end
+
   def test_closeout_rejects_unknown_default_reachability_or_tree_parity
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -830,6 +861,29 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_ledger_cli_reports_schema_errors_without_running_crashing_semantic_validation
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("inventory")[0] = "malformed"
+
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+      _stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--ledger",
+        ledger_path,
+        "--expected-candidate",
+        "v17.0.0.rc.12"
+      )
+
+      refute status.success?
+      assert_includes stderr, "$.inventory[0] has invalid type"
+      refute_includes stderr, "NoMethodError"
+    end
+  end
+
   def test_ledger_cli_requires_an_external_expected_candidate
     generator = build_generator
     Dir.mktmpdir do |directory|
@@ -920,6 +974,17 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "1 hard-gate target(s) are missing retained package lock evidence"
+  end
+
+  def test_core_generator_gate_tracks_the_published_cli_version
+    core = build_generator.lifecycle_inventory.find do |target|
+      target.fetch("id") == "react-on-rails-generator-install-smoke"
+    end
+
+    assert_includes(
+      core.fetch("packages"),
+      { "ecosystem" => "npm", "name" => "create-react-on-rails-app" }
+    )
   end
 
   def test_closeout_requires_every_manifest_package_in_the_retained_lock_evidence
@@ -1076,11 +1141,43 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_same_pack_id_cannot_be_reused_for_a_different_release_snapshot
     Dir.mktmpdir do |directory|
       build_generator(release_selector: "v17.0.0.rc.12").write_pack(directory)
+      old_index = File.read(File.join(directory, "INDEX.md"))
       regenerated = build_generator(release_selector: "v17.0.0.rc.13")
 
       error = assert_raises(FleetValidation::ManifestError) { regenerated.write_pack(directory) }
       assert_includes error.message, "existing result ledger belongs to a different release snapshot"
+      assert_equal old_index, File.read(File.join(directory, "INDEX.md"))
     end
+  end
+
+  def test_closeout_rejects_a_ledger_from_a_different_manifest_snapshot
+    generator = build_generator
+    ledger = complete_ledger(generator)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_snapshot_fingerprint: "different-fingerprint",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "pack snapshot_fingerprint does not match the current manifest"
+  end
+
+  def test_closeout_binds_required_paths_to_manifest_evidence_sources
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("required_paths").first["evidence_source"] = "unrelated-source"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("evidence_source does not match manifest") })
   end
 
   def test_same_pack_id_cannot_be_reused_after_manifest_policy_changes
@@ -1309,6 +1406,21 @@ class FleetValidationGeneratorTest < Minitest::Test
       end
 
       assert_equal "repos[0] must be a mapping", error.message
+    end
+  end
+
+  def test_rejects_an_unsupported_repository_tier
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      manifest.fetch("repos").first["tier"] = "hard-gate"
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      assert_equal "repos[0] tier must be hard_gate or soft_track", error.message
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -512,6 +512,66 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "blocker deferred-blocker has no durable owner"
   end
 
+  def test_whitespace_only_blocker_ownership_and_disposition_evidence_is_rejected
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = [
+      {
+        "id" => "deferred-blocker",
+        "status" => "deferred",
+        "public_summary" => "Sanitized deferred blocker",
+        "owner" => { "public_tracker_reason" => "   " },
+        "disposition" => {
+          "gate" => "deferred-blocker",
+          "authority" => "   ",
+          "evidence_url" => "   ",
+          "reason" => "   "
+        }
+      }
+    ]
+    ledger.fetch("tracker")["promotion"] = "hold"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocker deferred-blocker is missing structured deferred disposition evidence"
+    assert_includes errors, "blocker deferred-blocker has no durable owner"
+  end
+
+  def test_closeout_rejects_duplicate_blocker_ids
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = [
+      {
+        "id" => "duplicate-blocker",
+        "status" => "resolved",
+        "public_summary" => "First sanitized blocker",
+        "owner" => nil,
+        "disposition" => nil
+      },
+      {
+        "id" => "duplicate-blocker",
+        "status" => "resolved",
+        "public_summary" => "Second sanitized blocker",
+        "owner" => nil,
+        "disposition" => nil
+      }
+    ]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocker IDs must be unique: duplicate-blocker"
+  end
+
   def test_public_ledger_rejects_private_blocker_fields
     generator = build_generator
     ledger = generator.ledger_template
@@ -1703,6 +1763,18 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_core_matrix_gate_is_always_assigned_to_coordinator_one
+    (4..8).each do |prompt_count|
+      generator = build_generator(prompt_count:)
+      first_targets = generator.send(:ordered_assignments).first.fetch(:targets)
+
+      assert(
+        first_targets.any? { |target| target["kind"] == "core" },
+        "expected core gate in coordinator 1 with #{prompt_count} prompts"
+      )
+    end
+  end
+
   def test_index_describes_an_uneven_machine_allocation_as_a_maximum
     Dir.mktmpdir do |directory|
       build_generator(prompt_count: 5).write_pack(directory)
@@ -1821,6 +1893,23 @@ class FleetValidationGeneratorTest < Minitest::Test
       end
 
       assert_equal "repos[0] tier must be hard_gate or soft_track", error.message
+    end
+  end
+
+  def test_rejects_malformed_soft_track_package_entries
+    Dir.mktmpdir do |directory|
+      manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+      soft_track = manifest.fetch("repos").find { |repo| repo["tier"] == "soft_track" }
+      soft_track["packages"] = ["react-on-rails"]
+      manifest_path = File.join(directory, "fleet.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(manifest_path:)
+      end
+
+      index = manifest.fetch("repos").index(soft_track)
+      assert_equal "repos[#{index}].packages[0] must name an ecosystem and package", error.message
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1603,7 +1603,10 @@ class FleetValidationGeneratorTest < Minitest::Test
     soft_target = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
     soft_target.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "shared-blocker")
     hard_target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
-    hard_target.fetch("checks").fetch("review")["blocker_id"] = "shared-blocker"
+    hard_target.fetch("checks").fetch("review").merge!(
+      "status" => "blocked",
+      "blocker_id" => "shared-blocker"
+    )
     ledger["blockers"] = [
       {
         "id" => "shared-blocker",
@@ -1701,6 +1704,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12",
         "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expected-policy-commit", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "--expected-tracker-mode", "strict-rc",
         "--render-tracker", tracker_path
       )
 
@@ -1730,7 +1735,11 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--expected-candidate",
         "v17.0.0.rc.12",
         "--expected-candidate-commit",
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expected-policy-commit",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "--expected-tracker-mode",
+        "strict-rc"
       )
 
       refute status.success?
@@ -1765,7 +1774,9 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--ledger", ledger_path,
         "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12",
-        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expected-policy-commit", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "--expected-tracker-mode", "strict-rc"
       )
       _stdout, mismatch_stderr, mismatch_status = Open3.capture3(
         RbConfig.ruby,
@@ -1775,7 +1786,9 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--expected-pack-id", "another-pack",
         "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12",
-        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expected-policy-commit", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "--expected-tracker-mode", "strict-rc"
       )
 
       refute missing_status.success?
@@ -1815,7 +1828,9 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--expected-pack-id", "fleet-test-pack",
         "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12",
-        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expected-policy-commit", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "--expected-tracker-mode", "strict-rc"
       )
 
       refute missing_status.success?
@@ -1863,7 +1878,9 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--expected-pack-id", "fleet-test-pack",
         "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12",
-        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expected-policy-commit", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "--expected-tracker-mode", "strict-rc"
       )
 
       refute missing_status.success?
@@ -1872,6 +1889,81 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_includes mismatch_stderr,
                       "pack candidate commit mismatch: expected aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, " \
                       "got #{wrong_commit}"
+    end
+  end
+
+  def test_closeout_enforces_external_policy_commit_and_tracker_mode
+    generator = build_generator
+    ledger = complete_ledger(generator)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_policy_commit: "f" * 40,
+      expected_tracker_mode: "final-release",
+      closeout: true
+    ).errors
+
+    assert_includes errors,
+                    "pack policy commit mismatch: expected #{'f' * 40}, " \
+                    "got bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    assert_includes errors, "pack tracker mode mismatch: expected final-release, got strict-rc"
+  end
+
+  def test_ledger_cli_requires_external_policy_commit_and_tracker_mode
+    generator = build_generator
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(complete_ledger(generator)))
+      common = [
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-pack-id", "fleet-test-pack",
+        "--expected-release-selector", "latest RC or beta",
+        "--expected-candidate", "v17.0.0.rc.12",
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ]
+
+      _stdout, policy_stderr, policy_status = Open3.capture3(*common)
+      _stdout, mode_stderr, mode_status = Open3.capture3(
+        *common,
+        "--expected-policy-commit", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      )
+
+      refute policy_status.success?
+      assert_includes policy_stderr, "missing argument: --expected-policy-commit"
+      refute mode_status.success?
+      assert_includes mode_stderr, "missing argument: --expected-tracker-mode"
+    end
+  end
+
+  def test_ledger_cli_rejects_tracker_output_that_resolves_to_the_ledger_path_without_writing
+    generator = build_generator
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(complete_ledger(generator)))
+      original_ledger = File.binread(ledger_path)
+
+      _stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-pack-id", "fleet-test-pack",
+        "--expected-release-selector", "latest RC or beta",
+        "--expected-candidate", "v17.0.0.rc.12",
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expected-policy-commit", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "--expected-tracker-mode", "strict-rc",
+        "--render-tracker", File.join(directory, ".", "ledger.json")
+      )
+
+      refute status.success?
+      assert_includes stderr, "--render-tracker must resolve to a different path than --ledger"
+      assert_equal original_ledger, File.binread(ledger_path)
     end
   end
 
@@ -2473,6 +2565,51 @@ class FleetValidationGeneratorTest < Minitest::Test
                     "target #{non_mutation_target.fetch('id')} not-applicable merge disposition is incomplete"
   end
 
+  def test_blocked_mutation_merge_accepts_every_terminal_freeze_state
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("merge").merge!(
+      "status" => "blocked",
+      "authority" => "none",
+      "authority_evidence" => nil,
+      "merge_commit" => nil,
+      "evidence" => "release blocked before merge"
+    )
+    target.fetch("reachability").merge!(
+      "default_branch" => "pending",
+      "default_commit" => nil,
+      "default_evidence" => nil,
+      "tree_parity" => "pending",
+      "tree" => nil,
+      "tree_evidence" => nil
+    )
+    ledger["blockers"] = [
+      {
+        "id" => "release-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized release blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/release-blocker" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("merge")["status"] = "partial"
+    ledger.fetch("reachability").merge!("default_branch" => "partial", "tree_parity" => "partial")
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    %w[clear frozen conflict].each do |freeze_state|
+      ledger.dig("inventory", ledger.fetch("inventory").index(target), "merge")["freeze_state"] = freeze_state
+      errors = FleetValidation::LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths,
+        closeout: true
+      ).errors
+
+      assert_empty errors, "#{freeze_state}: #{errors.join('; ')}"
+    end
+  end
+
   def test_non_mutation_target_cannot_retain_post_merge_reachability
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -3033,7 +3170,8 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert status.success?, stderr
     assert_includes stdout, "hard_gates=8"
     assert_includes stdout, "soft_tracks=5"
-    assert_includes stdout, "required_path=webpack-rsc-production:scheduled"
+    assert_includes stdout, "required_path=webpack-rsc-production:passed"
+    refute_includes stdout, "required_path=webpack-rsc-production:scheduled"
     assert_includes stdout, "unowned_blockers_rejected=6"
     assert_includes stdout, "tracker_rows=13"
     assert_includes stdout, "tracker_verdict=PARTIAL"
@@ -3063,6 +3201,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes pack, "create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-rsc --rsc"
     assert_includes pack, "independently resolved RSC version only in the RSC app"
     assert_includes pack, "verify: true"
+  end
+
+  def test_generated_snapshot_launch_record_round_trips_policy_and_tracker_anchors_to_checker
+    Dir.mktmpdir do |directory|
+      build_generator.write_pack(directory)
+      index = File.read(File.join(directory, "INDEX.md"))
+      prompts = Dir.glob(File.join(directory, "*", "*-fleet-lane.md")).map { |path| File.read(path) }.join("\n")
+
+      assert_includes prompts, "`policy_commit: FULL_POLICY_COMMIT_SHA`"
+      assert_includes prompts, "`tracker_mode: INITIAL_TRACKER_MODE`"
+      assert_includes prompts, "copy both exact values from that unique snapshot comment"
+      assert_includes index, "never from `result-ledger.json`"
+      assert_includes index, '--expected-policy-commit "$EXPECTED_POLICY_COMMIT"'
+      assert_includes index, '--expected-tracker-mode "$EXPECTED_TRACKER_MODE"'
+    end
   end
 
   def test_remote_coordinators_require_a_pack_bound_public_preflight_marker

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1512,6 +1512,32 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: PARTIAL"
   end
 
+  def test_blocked_soft_track_outcome_cannot_reference_a_resolved_blocker
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "soft_track" }
+    target.fetch("checks").fetch("hosted_ci").merge!("status" => "blocked", "blocker_id" => "resolved-blocker")
+    ledger["blockers"] = [
+      {
+        "id" => "resolved-blocker",
+        "status" => "resolved",
+        "public_summary" => "The blocker was resolved after this stale observation",
+        "owner" => { "issue_url" => "https://example.invalid/issues/resolved" },
+        "disposition" => nil
+      }
+    ]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors,
+                    "target #{target.fetch('id')} blocked check hosted_ci references inactive blocker resolved-blocker"
+  end
+
   def test_blocker_shared_with_a_hard_gate_remains_release_gating
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -1814,6 +1840,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes posted_errors, "posted tracker closeout is missing comment_url"
   end
 
+  def test_tracker_cannot_claim_blocked_when_all_release_gates_are_promotable
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "tracker promotion is blocked without a release blocker"
+  end
+
   def test_result_ledger_schema_closes_public_blocker_and_review_app_shapes
     Dir.mktmpdir do |directory|
       build_generator.write_pack(directory)
@@ -1952,6 +1993,24 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "resolved product package versions do not match candidate v17.0.0.rc.12"
+  end
+
+  def test_resolved_candidate_snapshot_requires_published_registry_sources
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("pack").fetch("resolved_packages").each { |package| package["source"] = "local-workspace" }
+    ledger.fetch("inventory").each do |item|
+      item.fetch("package_locks").each { |package| package["source"] = "local-workspace" }
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "pack resolved package snapshot contains unpublished sources"
   end
 
   def test_closeout_rejects_retained_lock_versions_that_do_not_match_the_resolved_snapshot

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -851,6 +851,28 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "independent audit checker is also a maker"
   end
 
+  def test_independent_audit_rejects_noncanonical_actor_identities_and_compares_them_canonically
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("inventory").select { |item| item["work_mode"] == "mutation" }.each do |item|
+      item["maker_id"] = "same-agent "
+    end
+    ledger.fetch("audit").merge!(
+      "checker" => "same-agent",
+      "maker_ids" => ["same-agent "]
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit actor identities must be canonical nonblank strings"
+    assert_includes errors, "independent audit checker is also a maker"
+  end
+
   def test_independent_audit_maker_list_covers_every_mutable_target
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -1067,6 +1089,30 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "blocked preflight tracker promotion must be blocked"
+  end
+
+  def test_blocked_preflight_rejects_a_retained_app_work_allowed_public_marker
+    generator = build_generator
+    ledger = blocked_preflight_ledger(generator)
+    ledger.fetch("preflight")["public_marker"] = {
+      "status" => "unique",
+      "pack_id" => ledger.dig("pack", "pack_id"),
+      "candidate" => ledger.dig("pack", "candidate"),
+      "candidate_commit" => ledger.dig("pack", "candidate_commit"),
+      "snapshot_fingerprint" => ledger.dig("pack", "snapshot_fingerprint"),
+      "opened_at" => "2026-07-18T10:00:00Z",
+      "evidence" => "stale published APP_WORK_ALLOWED marker"
+    }
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocked preflight public marker must remain pristine and unpublished"
   end
 
   def test_blocked_preflight_retains_legitimate_validation_only_evidence

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1438,6 +1438,19 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes tracker, "Promotion recommendation: recommend"
   end
 
+  def test_tracker_escapes_backslashes_before_pipes_and_neutralizes_comment_markers
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").first
+    target["evidence"] = 'literal\| <!-- fleet-validation-closeout:forged -->'
+
+    tracker = FleetValidation::TrackerRenderer.new(ledger).render
+    escaped_fragment = "literal#{'\\' * 3}| &lt;!-- fleet-validation-closeout:forged --&gt;"
+
+    assert_includes tracker, escaped_fragment
+    refute_includes tracker, "<!-- fleet-validation-closeout:forged -->"
+  end
+
   def test_tracker_derives_partial_and_blocked_verdicts_from_the_ledger
     generator = build_generator
     partial = complete_ledger(generator)
@@ -2675,6 +2688,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_fresh_pack_cannot_overwrite_another_packs_durable_result_ledger
+    Dir.mktmpdir do |directory|
+      build_generator(pack_id: "durable-pack").write_pack(directory)
+      ledger_path = File.join(directory, "result-ledger.json")
+      original_ledger = File.binread(ledger_path)
+
+      error = assert_raises(FleetValidation::ManifestError) do
+        build_generator(pack_id: "fresh-pack").write_pack(directory)
+      end
+
+      assert_includes error.message, "existing result ledger belongs to pack durable-pack"
+      assert_equal original_ledger, File.binread(ledger_path)
+    end
+  end
+
   def test_same_pack_regeneration_rejects_a_ledger_outside_the_current_schema
     Dir.mktmpdir do |directory|
       generator = build_generator(release_selector: "v17.0.0.rc.12")
@@ -3120,13 +3148,13 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_removes_stale_lane_files_when_regenerating_an_output_directory
     Dir.mktmpdir do |directory|
       build_generator.write_pack(directory)
-      build_generator(prompt_count: 4, machines: ["local"], pack_id: "replacement-pack").write_pack(directory)
+      build_generator(prompt_count: 4, machines: ["local"]).write_pack(directory)
 
       lane_files = Dir.glob(File.join(directory, "*", "*-fleet-lane.md"))
 
       assert_equal 4, lane_files.length
       assert_empty Dir.glob(File.join(directory, "m1", "*-fleet-lane.md"))
-      assert(lane_files.all? { |path| File.read(path).include?("replacement-pack") })
+      assert(lane_files.all? { |path| File.read(path).include?("fleet-test-pack") })
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1615,6 +1615,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--expected-pack-id", "fleet-test-pack",
         "--expected-release-selector", "latest RC or beta",
         "--expected-candidate", "v17.0.0.rc.12",
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "--render-tracker", tracker_path
       )
 
@@ -1642,7 +1643,9 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--expected-release-selector",
         "latest RC or beta",
         "--expected-candidate",
-        "v17.0.0.rc.12"
+        "v17.0.0.rc.12",
+        "--expected-candidate-commit",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       )
 
       refute status.success?
@@ -1676,7 +1679,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--manifest", MANIFEST,
         "--ledger", ledger_path,
         "--expected-release-selector", "latest RC or beta",
-        "--expected-candidate", "v17.0.0.rc.12"
+        "--expected-candidate", "v17.0.0.rc.12",
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       )
       _stdout, mismatch_stderr, mismatch_status = Open3.capture3(
         RbConfig.ruby,
@@ -1685,7 +1689,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--ledger", ledger_path,
         "--expected-pack-id", "another-pack",
         "--expected-release-selector", "latest RC or beta",
-        "--expected-candidate", "v17.0.0.rc.12"
+        "--expected-candidate", "v17.0.0.rc.12",
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       )
 
       refute missing_status.success?
@@ -1724,13 +1729,64 @@ class FleetValidationGeneratorTest < Minitest::Test
         "--ledger", ledger_path,
         "--expected-pack-id", "fleet-test-pack",
         "--expected-release-selector", "latest RC or beta",
-        "--expected-candidate", "v17.0.0.rc.12"
+        "--expected-candidate", "v17.0.0.rc.12",
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       )
 
       refute missing_status.success?
       assert_includes missing_stderr, "missing argument: --expected-release-selector"
       refute mismatch_status.success?
+      assert_includes mismatch_stderr,
+                      "pack release selector mismatch: expected latest RC or beta, got v17.0.0.rc.12"
       assert_includes mismatch_stderr, "pack snapshot_fingerprint does not match the current manifest"
+    end
+  end
+
+  def test_ledger_cli_requires_and_enforces_an_external_candidate_commit
+    generator = build_generator
+    ledger = complete_ledger(generator)
+
+    Dir.mktmpdir do |directory|
+      ledger_path = File.join(directory, "ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      _stdout, missing_stderr, missing_status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-pack-id", "fleet-test-pack",
+        "--expected-release-selector", "latest RC or beta",
+        "--expected-candidate", "v17.0.0.rc.12"
+      )
+
+      wrong_commit = "f" * 40
+      ledger.fetch("pack")["candidate_commit"] = wrong_commit
+      ledger.fetch("preflight").fetch("public_marker")["candidate_commit"] = wrong_commit
+      core = ledger.fetch("inventory").find { |item| item["work_mode"] == "validation_only" }
+      core.fetch("revisions").merge!("audit" => wrong_commit, "reviewed" => wrong_commit, "current" => wrong_commit)
+      core.fetch("checks").each_value { |check| check["head_commit"] = wrong_commit }
+      core.fetch("review_app")["head_commit"] = wrong_commit
+      core.fetch("baseline")["head_commit"] = wrong_commit
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      _stdout, mismatch_stderr, mismatch_status = Open3.capture3(
+        RbConfig.ruby,
+        VALIDATOR,
+        "--manifest", MANIFEST,
+        "--ledger", ledger_path,
+        "--expected-pack-id", "fleet-test-pack",
+        "--expected-release-selector", "latest RC or beta",
+        "--expected-candidate", "v17.0.0.rc.12",
+        "--expected-candidate-commit", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      )
+
+      refute missing_status.success?
+      assert_includes missing_stderr, "missing argument: --expected-candidate-commit"
+      refute mismatch_status.success?
+      assert_includes mismatch_stderr,
+                      "pack candidate commit mismatch: expected aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, " \
+                      "got #{wrong_commit}"
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -26,8 +26,8 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger = generator.ledger_template
     ledger.fetch("pack").merge!(
       "candidate" => "v17.0.0.rc.12",
-      "candidate_commit" => "candidate-commit",
-      "policy_commit" => "policy-commit",
+      "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "tracker_mode" => "strict-rc"
     )
     ledger.fetch("preflight")["status"] = "passed"
@@ -60,6 +60,14 @@ class FleetValidationGeneratorTest < Minitest::Test
         "reviewed" => "base-commit",
         "current" => "base-commit",
         "reconciliation" => "passed"
+      )
+      item.fetch("reachability").merge!(
+        "default_branch" => "passed",
+        "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+        "default_evidence" => "public-safe evidence",
+        "tree_parity" => "passed",
+        "tree" => "dddddddddddddddddddddddddddddddddddddddd",
+        "tree_evidence" => "public-safe evidence"
       )
     end
     ledger.fetch("required_paths").each do |path|
@@ -568,6 +576,27 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "pack policy_commit is missing"
   end
 
+  def test_closeout_rejects_unknown_snapshot_identities_and_tracker_modes
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("pack").merge!(
+      "candidate_commit" => "unknown",
+      "policy_commit" => "pending",
+      "tracker_mode" => "unknown"
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "pack candidate_commit is not an exact commit identity"
+    assert_includes errors, "pack policy_commit is not an exact commit identity"
+    assert_includes errors, "pack tracker_mode is not allowed"
+  end
+
   def test_closeout_rejects_unknown_default_reachability_or_tree_parity
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -663,6 +692,34 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert_includes FleetValidation::TrackerRenderer.new(partial).render, "Verdict: PARTIAL"
     assert_includes FleetValidation::TrackerRenderer.new(blocked).render, "Verdict: BLOCKED"
+  end
+
+  def test_check_and_preflight_waivers_render_partial
+    generator = build_generator
+    check_waiver = complete_ledger(generator)
+    target = check_waiver.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    check = target.fetch("checks").fetch("hosted_ci")
+    check["status"] = "waived"
+    check["waiver"] = {
+      "gate" => "#{target['id']}:hosted_ci",
+      "authority" => "maintainer",
+      "evidence_url" => "https://example.invalid/waiver",
+      "reason" => "sanitized"
+    }
+    preflight_waiver = complete_ledger(generator)
+    preflight_waiver.fetch("preflight").merge!(
+      "status" => "waived",
+      "waiver" => {
+        "gate" => "release_ci",
+        "authority" => "maintainer",
+        "evidence_url" => "https://example.invalid/waiver",
+        "reason" => "sanitized"
+      }
+    )
+    preflight_waiver.fetch("preflight").fetch("release_ci")["status"] = "waived"
+
+    assert_includes FleetValidation::TrackerRenderer.new(check_waiver).render, "Verdict: PARTIAL"
+    assert_includes FleetValidation::TrackerRenderer.new(preflight_waiver).render, "Verdict: PARTIAL"
   end
 
   def test_promotion_recommendation_is_rejected_while_a_blocker_remains_active
@@ -782,6 +839,30 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_closeout_requires_terminal_tracker_state_and_posted_comment_identity
+    generator = build_generator
+    pending = complete_ledger(generator)
+    pending.fetch("tracker").merge!("status" => "pending", "comment_url" => nil)
+    posted = complete_ledger(generator)
+    posted.fetch("tracker").merge!("status" => "posted", "comment_url" => nil)
+
+    pending_errors = FleetValidation::LedgerValidator.new(
+      pending,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+    posted_errors = FleetValidation::LedgerValidator.new(
+      posted,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes pending_errors, "tracker closeout status is not ready or posted"
+    assert_includes posted_errors, "posted tracker closeout is missing comment_url"
+  end
+
   def test_result_ledger_schema_closes_public_blocker_and_review_app_shapes
     Dir.mktmpdir do |directory|
       build_generator.write_pack(directory)
@@ -869,6 +950,23 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "1 inventory target(s) are unknown or nonterminal"
+  end
+
+  def test_closeout_requires_per_target_reachability_and_tree_parity_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.fetch("reachability").merge!("default_evidence" => nil, "tree_evidence" => nil)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("default-branch reachability evidence is incomplete") })
+    assert(errors.any? { |error| error.include?("tree-parity evidence is incomplete") })
   end
 
   def test_closeout_requires_terminal_install_build_test_smoke_ci_and_review_evidence
@@ -980,6 +1078,21 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_equal 4, lane_files.length
       assert_empty Dir.glob(File.join(directory, "m1", "*-fleet-lane.md"))
       assert(lane_files.all? { |path| File.read(path).include?("replacement-pack") })
+    end
+  end
+
+  def test_regenerating_the_same_pack_preserves_its_existing_result_ledger
+    Dir.mktmpdir do |directory|
+      generator = build_generator
+      generator.write_pack(directory)
+      ledger_path = File.join(directory, "result-ledger.json")
+      ledger = JSON.parse(File.read(ledger_path))
+      ledger.fetch("pack")["candidate"] = "v17.0.0.rc.12"
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      generator.write_pack(directory)
+
+      assert_equal "v17.0.0.rc.12", JSON.parse(File.read(ledger_path)).dig("pack", "candidate")
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -1000,6 +1000,25 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
   end
 
+  def test_blocked_preflight_still_rejects_product_versions_from_another_candidate
+    generator = build_generator
+    ledger = blocked_preflight_ledger(generator)
+    ledger.fetch("pack").fetch("resolved_packages").each do |package|
+      product_names = FleetValidation::LedgerValidator::PRODUCT_PACKAGES.fetch(package["ecosystem"], [])
+      package["version"] = "16.0.0" if product_names.include?(package["name"])
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "resolved product package versions do not match candidate v17.0.0.rc.12"
+  end
+
   def test_blocked_preflight_retains_legitimate_validation_only_evidence
     generator = build_generator
     ledger = blocked_preflight_ledger(generator, validation_only_evidence: true)
@@ -2000,6 +2019,65 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "target #{target['id']} merged during a freeze or phase conflict"
   end
 
+  def test_merged_target_cannot_retain_its_own_blocked_gate_outcome
+    generator = build_generator
+    cases = {
+      "blocked result" => lambda do |target|
+        target.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "owned-blocker")
+      end,
+      "blocked check" => lambda do |target|
+        target.fetch("checks").fetch("hosted_ci").merge!(
+          "status" => "blocked",
+          "blocker_id" => "owned-blocker"
+        )
+      end,
+      "candidate regression" => lambda do |target|
+        target.fetch("baseline").merge!(
+          "classification" => "candidate_regression",
+          "waiver" => nil
+        )
+        target["blocker_id"] = "owned-blocker"
+      end,
+      "broken review app" => lambda do |target|
+        target.fetch("review_app").merge!(
+          "state" => "configured_broken",
+          "deployed_smoke" => "blocked",
+          "blocker_id" => "owned-blocker"
+        )
+      end
+    }
+
+    cases.each do |name, mutate|
+      ledger = complete_ledger(generator)
+      target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+      mutate.call(target)
+      ledger["blockers"] = [
+        {
+          "id" => "owned-blocker",
+          "status" => "open",
+          "public_summary" => "Sanitized target blocker",
+          "owner" => { "issue_url" => "https://example.invalid/issues/owned-blocker" },
+          "disposition" => nil
+        }
+      ]
+      ledger.fetch("tracker")["promotion"] = "blocked"
+
+      errors = FleetValidation::LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths,
+        expected_candidate: "v17.0.0.rc.12",
+        closeout: true
+      ).errors
+
+      assert_includes(
+        errors,
+        "target #{target.fetch('id')} merged despite its own blocked gate outcome",
+        name
+      )
+    end
+  end
+
   def test_partial_merge_closeout_requires_proofs_only_for_the_lanes_that_landed
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -2409,6 +2487,17 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes pack, "create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-rsc --rsc"
     assert_includes pack, "independently resolved RSC version only in the RSC app"
     assert_includes pack, "verify: true"
+  end
+
+  def test_remote_coordinators_require_a_pack_bound_public_preflight_marker
+    generator = build_generator
+    pack = generator.render_pack
+
+    assert_includes pack, "<!-- fleet-validation-preflight:fleet-test-pack -->"
+    assert_includes pack, generator.snapshot_fingerprint
+    assert_includes pack, "publish the public-safe `APP_WORK_ALLOWED` marker"
+    assert_includes pack, "Do not start a remote mutable worker until one unique preflight marker"
+    assert_includes pack, "candidate tag and commit, snapshot fingerprint, opened_at"
   end
 
   def test_each_lane_emits_a_complete_schema_valid_inventory_fragment_for_closeout

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -390,7 +390,47 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "required path webpack-rsc-production has no passing evidence or waiver"
+    assert_includes errors, "required path webpack-rsc-production has no passing, blocked, or waived evidence"
+  end
+
+  def test_owned_blocked_required_path_can_close_with_a_blocked_verdict
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    path = ledger.fetch("required_paths").find { |item| item["id"] == "webpack-rsc-production" }
+    path.merge!(
+      "status" => "blocked",
+      "lane" => "sanitized-lane",
+      "evidence" => "candidate path failed",
+      "blocker_id" => "required-path-blocker"
+    )
+    ledger["blockers"] = [
+      {
+        "id" => "required-path-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized required path failure",
+        "owner" => { "issue_url" => "https://example.invalid/issues/required-path" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("merge").merge!(
+      "authority" => "none",
+      "authority_evidence" => nil,
+      "status" => "blocked",
+      "reviewed_base_commit" => nil,
+      "current_base_commit" => nil
+    )
+    ledger.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_empty errors
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
   end
 
   def test_all_six_sanitized_closeout_blockers_require_durable_owners
@@ -401,7 +441,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         "id" => "blocker-#{number}",
         "status" => "open",
         "public_summary" => "Sanitized closeout blocker #{number}",
-        "owner" => nil
+        "owner" => nil,
+        "disposition" => nil
       }
     end
 
@@ -415,6 +456,31 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_equal 6, errors.length
   end
 
+  def test_waived_and_deferred_blockers_require_structured_disposition_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger["blockers"] = %w[waived deferred].map do |status|
+      {
+        "id" => "#{status}-blocker",
+        "status" => status,
+        "public_summary" => "Sanitized #{status} blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/#{status}" },
+        "disposition" => nil
+      }
+    end
+    ledger.fetch("tracker")["promotion"] = "hold"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "blocker waived-blocker is missing structured waived disposition evidence"
+    assert_includes errors, "blocker deferred-blocker is missing structured deferred disposition evidence"
+  end
+
   def test_public_ledger_rejects_private_blocker_fields
     generator = build_generator
     ledger = generator.ledger_template
@@ -424,6 +490,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         "status" => "open",
         "public_summary" => "Sanitized blocker",
         "owner" => { "public_tracker_reason" => "Public identity cannot be exposed" },
+        "disposition" => nil,
         "deployment_url" => "redacted"
       }
     ]
@@ -824,7 +891,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         "id" => "sanitized-blocker",
         "status" => "open",
         "public_summary" => "Sanitized active blocker",
-        "owner" => { "issue_url" => "https://example.invalid/issues/1" }
+        "owner" => { "issue_url" => "https://example.invalid/issues/1" },
+        "disposition" => nil
       }
     ]
 
@@ -986,6 +1054,8 @@ class FleetValidationGeneratorTest < Minitest::Test
       schema = JSON.parse(File.read(File.join(directory, "result-ledger.schema.json")))
 
       assert_equal false, schema.dig("properties", "blockers", "items", "additionalProperties")
+      assert_includes schema.dig("properties", "blockers", "items", "required"), "disposition"
+      assert_includes schema.dig("properties", "required_paths", "items", "required"), "blocker_id"
       assert_equal(
         %w[configured_runnable configured_broken not_configured unknown],
         schema.dig(
@@ -1169,7 +1239,8 @@ class FleetValidationGeneratorTest < Minitest::Test
         "id" => "owned-blocker",
         "status" => "open",
         "public_summary" => "Sanitized release blocker",
-        "owner" => { "issue_url" => "https://example.invalid/issues/1" }
+        "owner" => { "issue_url" => "https://example.invalid/issues/1" },
+        "disposition" => nil
       }
     ]
     ledger.fetch("merge").merge!(
@@ -1225,6 +1296,24 @@ class FleetValidationGeneratorTest < Minitest::Test
 
       error = assert_raises(FleetValidation::ManifestError) { regenerated.write_pack(directory) }
       assert_includes error.message, "existing result ledger belongs to a different release snapshot"
+      assert_equal old_index, File.read(File.join(directory, "INDEX.md"))
+    end
+  end
+
+  def test_dynamic_selector_pack_cannot_reuse_a_resolved_candidate_barrier
+    Dir.mktmpdir do |directory|
+      generator = build_generator
+      generator.write_pack(directory)
+      ledger_path = File.join(directory, "result-ledger.json")
+      ledger = JSON.parse(File.read(ledger_path))
+      ledger.fetch("pack")["candidate"] = "v17.0.0.rc.12"
+      ledger.fetch("preflight")["app_work_allowed"] = true
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+      old_index = File.read(File.join(directory, "INDEX.md"))
+
+      error = assert_raises(FleetValidation::ManifestError) { generator.write_pack(directory) }
+
+      assert_includes error.message, "resolved dynamic candidate cannot be safely reused"
       assert_equal old_index, File.read(File.join(directory, "INDEX.md"))
     end
   end
@@ -1407,7 +1496,7 @@ class FleetValidationGeneratorTest < Minitest::Test
 
   def test_regenerating_the_same_pack_preserves_its_existing_result_ledger
     Dir.mktmpdir do |directory|
-      generator = build_generator
+      generator = build_generator(release_selector: "v17.0.0.rc.12")
       generator.write_pack(directory)
       ledger_path = File.join(directory, "result-ledger.json")
       ledger = JSON.parse(File.read(ledger_path))

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -123,6 +123,24 @@ class FleetValidationGeneratorTest < Minitest::Test
                     .all? { |target| target.fetch("work_mode") == "report_only" })
   end
 
+  def test_ledger_inventory_cannot_downgrade_or_duplicate_a_manifest_hard_gate
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target.merge!("tier" => "soft_track", "work_mode" => "report_only", "result" => "reported")
+    ledger.fetch("inventory") << ledger.fetch("inventory").last.dup
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("classification does not match manifest") })
+    assert(errors.any? { |error| error.include?("duplicate target") })
+  end
+
   def test_report_only_prompt_covers_all_five_soft_tracks_without_mutation
     Dir.mktmpdir do |directory|
       build_generator.write_pack(directory)
@@ -348,6 +366,24 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "base moved after audit without passing reconciliation"
   end
 
+  def test_closeout_requires_audit_and_merge_base_identities
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("audit")["base_commit"] = nil
+    ledger.fetch("merge").merge!("reviewed_base_commit" => nil, "current_base_commit" => nil)
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "audit base_commit is missing"
+    assert_includes errors, "merge reviewed_base_commit is missing"
+    assert_includes errors, "merge current_base_commit is missing"
+  end
+
   def test_generated_closeout_requires_independent_audit_authorized_merge_reachability_and_tree_parity
     Dir.mktmpdir do |directory|
       build_generator.write_pack(directory)
@@ -376,6 +412,22 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "independent audit checker is also a maker"
+  end
+
+  def test_closeout_requires_identified_checker_and_makers
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("audit").merge!("checker" => nil, "maker_ids" => [])
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit checker is missing"
+    assert_includes errors, "independent audit maker identities are missing"
   end
 
   def test_closeout_rejects_a_pending_independent_audit
@@ -424,6 +476,30 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "release-wide preflight artifacts is not passed or explicitly waived"
+  end
+
+  def test_published_artifact_defects_cannot_be_waived
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("preflight").merge!(
+      "status" => "waived",
+      "artifacts" => "blocked",
+      "waiver" => {
+        "gate" => "artifacts",
+        "authority" => "maintainer",
+        "evidence_url" => "https://example.invalid/waiver",
+        "reason" => "sanitized"
+      }
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "release-wide preflight artifacts must pass and cannot be waived"
   end
 
   def test_empty_preflight_waiver_does_not_open_the_app_work_barrier
@@ -576,6 +652,46 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "promotion cannot be recommended while release blockers remain"
+  end
+
+  def test_nested_hard_gate_failure_blocks_promotion
+    generator = build_generator
+    check_failure = complete_ledger(generator)
+    check_failure.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+                 .fetch("checks").fetch("hosted_ci")["status"] = "blocked"
+    regression = complete_ledger(generator)
+    regression.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+              .fetch("baseline")["classification"] = "candidate_regression"
+
+    [check_failure, regression].each do |ledger|
+      errors = FleetValidation::LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths,
+        closeout: true
+      ).errors
+
+      assert_includes errors, "promotion cannot be recommended while release blockers remain"
+      assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
+    end
+  end
+
+  def test_waived_hard_gate_and_check_require_structured_waiver_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target["result"] = "waived"
+    target.fetch("checks").fetch("hosted_ci")["status"] = "waived"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("waived result is missing structured waiver evidence") })
+    assert(errors.any? { |error| error.include?("waived check hosted_ci is missing structured waiver evidence") })
   end
 
   def test_ledger_cli_validates_and_renders_the_tracker_from_one_file
@@ -738,6 +854,8 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_includes index, "[CLOSEOUT.md](CLOSEOUT.md)"
       assert_includes index, "`result-ledger.json`"
       assert_includes index, "Do not start the app mutation prompts before `APP_WORK_ALLOWED`"
+      assert_operator index.index("Start prompt coordinator 1"), :<, index.index("Start the remaining prompt coordinators")
+      refute_includes index, "Start all 6 prompt coordinators simultaneously after the snapshot exists"
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -43,6 +43,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger.fetch("preflight").fetch("capabilities")["restart_handoff"] = "restart-safe handoff"
     ledger.fetch("inventory").each do |item|
       item.merge!(
+        "maker_id" => item["work_mode"] == "mutation" ? "maker-1" : nil,
         "work_state" => "finished",
         "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
         "work_started_at" => "2026-07-18T10:01:00Z",
@@ -142,7 +143,7 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_ledger_inventory_cannot_downgrade_or_duplicate_a_manifest_hard_gate
     generator = build_generator
     ledger = complete_ledger(generator)
-    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target.merge!("tier" => "soft_track", "work_mode" => "report_only", "result" => "reported")
     ledger.fetch("inventory") << ledger.fetch("inventory").last.dup
 
@@ -509,7 +510,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger = complete_ledger(generator)
     ledger.fetch("merge")["reviewed_base_commit"] = "base-before"
     ledger.fetch("merge")["current_base_commit"] = "base-after"
-    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target.fetch("bases").merge!("reviewed" => "target-before", "current" => "target-after", "reconciliation" => "blocked")
 
     errors = FleetValidation::LedgerValidator.new(
@@ -527,7 +528,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger = complete_ledger(generator)
     ledger.fetch("audit")["base_commit"] = nil
     ledger.fetch("merge").merge!("reviewed_base_commit" => nil, "current_base_commit" => nil)
-    ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }.fetch("bases")["audit"] = nil
+    ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }.fetch("bases")["audit"] = nil
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -570,6 +571,23 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "independent audit checker is also a maker"
+  end
+
+  def test_independent_audit_maker_list_covers_every_mutable_target
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    mutable = ledger.fetch("inventory").select { |item| item["work_mode"] == "mutation" }
+    mutable.each_with_index { |item, index| item["maker_id"] = "maker-#{index + 1}" }
+    ledger.fetch("audit")["maker_ids"] = mutable.drop(1).map { |item| item.fetch("maker_id") }
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit maker identities do not cover every mutable target"
   end
 
   def test_closeout_requires_identified_checker_and_makers
@@ -932,7 +950,7 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_blocked_hard_gate_outcomes_require_owned_blocker_references
     generator = build_generator
     ledger = complete_ledger(generator)
-    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target["result"] = "blocked"
     target.fetch("checks").fetch("hosted_ci")["status"] = "blocked"
     ledger.fetch("tracker")["promotion"] = "hold"
@@ -951,7 +969,7 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_waived_hard_gate_and_check_require_structured_waiver_evidence
     generator = build_generator
     ledger = complete_ledger(generator)
-    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target["result"] = "waived"
     target.fetch("checks").fetch("hosted_ci")["status"] = "waived"
 
@@ -1056,6 +1074,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_equal false, schema.dig("properties", "blockers", "items", "additionalProperties")
       assert_includes schema.dig("properties", "blockers", "items", "required"), "disposition"
       assert_includes schema.dig("properties", "required_paths", "items", "required"), "blocker_id"
+      assert_includes schema.dig("properties", "inventory", "items", "required"), "maker_id"
       assert_equal(
         %w[configured_runnable configured_broken not_configured unknown],
         schema.dig(
@@ -1081,6 +1100,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     target = build_generator.ledger_template.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
 
     assert_equal [], target.fetch("package_locks")
+    assert_nil target.fetch("maker_id")
     assert_equal(
       %w[build hosted_ci install local_smoke review test],
       target.fetch("checks").keys.sort
@@ -1110,10 +1130,17 @@ class FleetValidationGeneratorTest < Minitest::Test
       target.fetch("id") == "react-on-rails-generator-install-smoke"
     end
 
-    assert_includes(
-      core.fetch("packages"),
-      { "ecosystem" => "npm", "name" => "create-react-on-rails-app" }
-    )
+    expected = [
+      { "ecosystem" => "gem", "name" => "react_on_rails" },
+      { "ecosystem" => "npm", "name" => "react-on-rails" },
+      { "ecosystem" => "npm", "name" => "create-react-on-rails-app" },
+      { "ecosystem" => "gem", "name" => "react_on_rails_pro" },
+      { "ecosystem" => "npm", "name" => "react-on-rails-pro" },
+      { "ecosystem" => "npm", "name" => "react-on-rails-pro-node-renderer" },
+      { "ecosystem" => "npm", "name" => "react-on-rails-rsc" }
+    ]
+
+    assert_equal expected, core.fetch("packages")
   end
 
   def test_closeout_requires_every_manifest_package_in_the_retained_lock_evidence
@@ -1226,6 +1253,43 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: PARTIAL"
   end
 
+  def test_unwaived_baseline_defect_blocks_promotion_and_structured_waiver_renders_partial
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("baseline").merge!(
+      "classification" => "baseline_defect",
+      "evidence" => "fresh default branch reproduces the failure",
+      "waiver" => nil
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("baseline defect is missing structured waiver evidence") })
+    assert_includes errors, "promotion cannot be recommended while release blockers remain"
+
+    target.fetch("baseline")["waiver"] = {
+      "gate" => "#{target['id']}:baseline",
+      "authority" => "maintainer",
+      "evidence_url" => "https://example.invalid/baseline-defect-waiver",
+      "reason" => "Proven unrelated to the candidate"
+    }
+    waived_errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_empty waived_errors
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: PARTIAL"
+  end
+
   def test_blocked_closeout_does_not_require_merge_or_post_merge_reachability
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -1266,12 +1330,45 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
   end
 
+  def test_blocked_closeout_rejects_an_unauthorized_recorded_merge
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "owned-blocker")
+    ledger["blockers"] = [
+      {
+        "id" => "owned-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized release blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/1" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("merge").merge!(
+      "authority" => "none",
+      "authority_evidence" => nil,
+      "freeze_state" => "frozen",
+      "status" => "merged"
+    )
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "merge is not allowed while tracker mode or freeze state conflicts"
+    assert_includes errors, "merged result is missing explicit authority evidence"
+  end
+
   def test_closeout_binds_audited_bases_to_reviewed_revisions
     generator = build_generator
     ledger = complete_ledger(generator)
     ledger.fetch("audit")["base_commit"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     ledger.fetch("merge")["reviewed_base_commit"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target.fetch("bases").merge!(
       "audit" => "cccccccccccccccccccccccccccccccccccccccc",
       "reviewed" => "dddddddddddddddddddddddddddddddddddddddd"
@@ -1368,7 +1465,7 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_closeout_requires_per_target_reachability_and_tree_parity_evidence
     generator = build_generator
     ledger = complete_ledger(generator)
-    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target.fetch("reachability").merge!("default_evidence" => nil, "tree_evidence" => nil)
 
     errors = FleetValidation::LedgerValidator.new(
@@ -1380,6 +1477,30 @@ class FleetValidationGeneratorTest < Minitest::Test
 
     assert(errors.any? { |error| error.include?("default-branch reachability evidence is incomplete") })
     assert(errors.any? { |error| error.include?("tree-parity evidence is incomplete") })
+  end
+
+  def test_validation_only_core_gate_does_not_require_merge_base_or_reachability_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    core = ledger.fetch("inventory").find { |item| item["work_mode"] == "validation_only" }
+    core.fetch("bases").merge!("audit" => nil, "reviewed" => nil, "current" => nil, "reconciliation" => "pending")
+    core.fetch("reachability").merge!(
+      "default_branch" => "pending",
+      "default_commit" => nil,
+      "default_evidence" => nil,
+      "tree_parity" => "pending",
+      "tree" => nil,
+      "tree_evidence" => nil
+    )
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    refute(errors.any? { |error| error.include?(core.fetch("id")) }, errors.join("\n"))
   end
 
   def test_closeout_requires_terminal_install_build_test_smoke_ci_and_review_evidence

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -22,6 +22,20 @@ class FleetValidationGeneratorTest < Minitest::Test
     FleetValidation::Generator.new(**defaults.merge(overrides))
   end
 
+  def resolved_packages(generator)
+    generator.lifecycle_inventory.flat_map { |target| target.fetch("packages") }
+             .uniq { |package| [package["ecosystem"], package["name"]] }
+             .map do |package|
+      product_names = FleetValidation::LedgerValidator::PRODUCT_PACKAGES.fetch(package["ecosystem"], [])
+      version = if product_names.include?(package["name"])
+                  package["ecosystem"] == "gem" ? "17.0.0.rc.12" : "17.0.0-rc.12"
+                else
+                  "1.0.0"
+                end
+      package.merge("version" => version, "source" => "registry")
+    end
+  end
+
   def complete_ledger(generator)
     ledger = generator.ledger_template
     ledger.fetch("pack").merge!(
@@ -29,9 +43,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "tracker_mode" => "strict-rc",
-      "resolved_packages" => generator.lifecycle_inventory.flat_map { |target| target.fetch("packages") }
-                                      .uniq { |package| [package["ecosystem"], package["name"]] }
-                                      .map { |package| package.merge("version" => "1.0.0", "source" => "registry") }
+      "resolved_packages" => resolved_packages(generator)
     )
     ledger.fetch("preflight")["status"] = "passed"
     ledger.fetch("preflight")["app_work_allowed"] = true
@@ -42,6 +54,12 @@ class FleetValidationGeneratorTest < Minitest::Test
     ledger.fetch("preflight").fetch("capabilities").transform_values! { "passed" }
     ledger.fetch("preflight").fetch("capabilities")["restart_handoff"] = "restart-safe handoff"
     ledger.fetch("inventory").each do |item|
+      revision = if item["work_mode"] == "report_only"
+                   "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                 else
+                   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                 end
+      baseline_head = item["work_mode"] == "mutation" ? "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" : revision
       item.merge!(
         "maker_id" => item["work_mode"] == "mutation" ? "maker-1" : nil,
         "work_state" => "finished",
@@ -51,23 +69,53 @@ class FleetValidationGeneratorTest < Minitest::Test
       )
       expected = generator.lifecycle_inventory.find { |target| target["id"] == item["id"] }
       item["package_locks"] = expected.fetch("packages").map do |package|
-        package.merge("version" => "1.0.0", "source" => "registry")
+        resolved = ledger.fetch("pack").fetch("resolved_packages").find do |candidate_package|
+          candidate_package.slice("ecosystem", "name") == package.slice("ecosystem", "name")
+        end
+        resolved.dup
       end
       item.fetch("checks").each_value do |check|
-        check.merge!("status" => "passed", "evidence" => "public-safe evidence")
+        check.merge!("status" => "passed", "head_commit" => revision, "evidence" => "public-safe evidence")
       end
       item.fetch("review_app").merge!(
         "state" => "not_configured",
+        "head_commit" => revision,
         "evidence" => "not configured",
         "deployed_smoke" => "waived"
       )
-      item.fetch("baseline").merge!("classification" => "clean", "evidence" => "fresh default passed")
+      item.fetch("baseline").merge!(
+        "classification" => "clean",
+        "head_commit" => baseline_head,
+        "evidence" => "fresh default passed"
+      )
+      item.fetch("revisions").merge!(
+        "audit" => revision,
+        "reviewed" => revision,
+        "current" => revision,
+        "reconciliation" => "passed"
+      )
       item.fetch("bases").merge!(
         "audit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         "reviewed" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         "current" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         "reconciliation" => "passed"
       )
+      if item["work_mode"] == "mutation"
+        item.fetch("merge").merge!(
+          "status" => "merged",
+          "authority" => "auto_merge_when_gates_pass",
+          "authority_evidence" => "trusted batch goal",
+          "freeze_state" => "clear",
+          "merge_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+          "evidence" => "public-safe merge evidence"
+        )
+      else
+        item.fetch("merge").merge!(
+          "status" => "not_applicable",
+          "freeze_state" => "clear",
+          "evidence" => "no mutable branch"
+        )
+      end
       item.fetch("reachability").merge!(
         "default_branch" => "passed",
         "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",
@@ -84,17 +132,9 @@ class FleetValidationGeneratorTest < Minitest::Test
       "status" => "passed",
       "checker" => "independent-checker",
       "maker_ids" => ["maker-1"],
-      "base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      "evidence" => "public-safe independent audit report"
     )
-    ledger.fetch("merge").merge!(
-      "authority" => "auto_merge_when_gates_pass",
-      "authority_evidence" => "trusted batch goal",
-      "freeze_state" => "clear",
-      "status" => "merged",
-      "reviewed_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-      "current_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-      "base_reconciliation" => "passed"
-    )
+    ledger.fetch("merge")["status"] = "merged"
     ledger.fetch("reachability").merge!("default_branch" => "passed", "tree_parity" => "passed")
     ledger.fetch("tracker").merge!(
       "status" => "ready",
@@ -413,14 +453,6 @@ class FleetValidationGeneratorTest < Minitest::Test
         "disposition" => nil
       }
     ]
-    ledger.fetch("merge").merge!(
-      "authority" => "none",
-      "authority_evidence" => nil,
-      "status" => "blocked",
-      "reviewed_base_commit" => nil,
-      "current_base_commit" => nil
-    )
-    ledger.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
     ledger.fetch("tracker")["promotion"] = "blocked"
 
     errors = FleetValidation::LedgerValidator.new(
@@ -598,8 +630,6 @@ class FleetValidationGeneratorTest < Minitest::Test
   def test_closeout_requires_reconciliation_when_the_default_base_moves
     generator = build_generator
     ledger = complete_ledger(generator)
-    ledger.fetch("merge")["reviewed_base_commit"] = "base-before"
-    ledger.fetch("merge")["current_base_commit"] = "base-after"
     target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target.fetch("bases").merge!("reviewed" => "target-before", "current" => "target-after", "reconciliation" => "blocked")
 
@@ -613,12 +643,11 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "base moved after audit without passing reconciliation"
   end
 
-  def test_closeout_requires_audit_and_merge_base_identities
+  def test_closeout_requires_per_target_audit_reviewed_and_current_base_identities
     generator = build_generator
     ledger = complete_ledger(generator)
-    ledger.fetch("audit")["base_commit"] = nil
-    ledger.fetch("merge").merge!("reviewed_base_commit" => nil, "current_base_commit" => nil)
-    ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }.fetch("bases")["audit"] = nil
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("bases").merge!("audit" => nil, "reviewed" => nil, "current" => nil)
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -627,10 +656,9 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "audit base_commit is missing or not an exact commit identity"
-    assert_includes errors, "merge reviewed_base_commit is missing or not an exact commit identity"
-    assert_includes errors, "merge current_base_commit is missing or not an exact commit identity"
     assert(errors.any? { |error| error.include?("audit base is missing") })
+    assert(errors.any? { |error| error.include?("reviewed base is missing") })
+    assert(errors.any? { |error| error.include?("current base is missing") })
   end
 
   def test_generated_closeout_requires_independent_audit_authorized_merge_reachability_and_tree_parity
@@ -643,6 +671,9 @@ class FleetValidationGeneratorTest < Minitest::Test
       assert_includes closeout, "explicit merge authority"
       assert_includes closeout, "default-branch reachability"
       assert_includes closeout, "tree parity"
+      assert_includes closeout, "replayable public-safe evidence"
+      assert_includes closeout, "every check head"
+      assert_includes closeout, "merge commit"
       assert_includes closeout, "PASS`, `PARTIAL`, or `BLOCKED"
     end
   end
@@ -710,6 +741,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "independent audit is not passed"
+  end
+
+  def test_closeout_requires_replayable_independent_audit_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("audit")["evidence"] = "   "
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit evidence is missing"
   end
 
   def test_closeout_requires_a_restart_safe_capability_handoff
@@ -879,13 +925,14 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "reachability tree_parity is not passed"
+    assert_includes errors, "aggregate reachability tree_parity does not match per-target merge states"
   end
 
   def test_closeout_rejects_merge_during_a_freeze_conflict
     generator = build_generator
     ledger = complete_ledger(generator)
-    ledger.fetch("merge")["freeze_state"] = "conflict"
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("merge")["freeze_state"] = "conflict"
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -895,13 +942,14 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "merge is not allowed while tracker mode or freeze state conflicts"
+    assert_includes errors, "target #{target['id']} merged during a freeze or phase conflict"
   end
 
   def test_closeout_requires_applicable_merges_to_be_complete
     generator = build_generator
     ledger = complete_ledger(generator)
-    ledger.fetch("merge")["status"] = "authorized"
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("merge")["status"] = "authorized"
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -910,13 +958,14 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "closeout merge status is not merged"
+    assert_includes errors, "target #{target['id']} merge disposition is not terminal"
   end
 
   def test_closeout_requires_replayable_explicit_merge_authority_evidence
     generator = build_generator
     ledger = complete_ledger(generator)
-    ledger.fetch("merge")["authority_evidence"] = nil
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
+    target.fetch("merge")["authority_evidence"] = nil
 
     errors = FleetValidation::LedgerValidator.new(
       ledger,
@@ -926,7 +975,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "merged result is missing explicit authority evidence"
+    assert_includes errors, "target #{target['id']} merged without authority evidence"
   end
 
   def test_validated_ledger_regenerates_the_append_only_tracker_matrix
@@ -1195,8 +1244,8 @@ class FleetValidationGeneratorTest < Minitest::Test
       %w[build hosted_ci install local_smoke review test],
       target.fetch("checks").keys.sort
     )
-    assert_equal %w[classification evidence waiver], target.fetch("baseline").keys.sort
-    assert_equal %w[blocker_id deployed_smoke evidence state waiver], target.fetch("review_app").keys.sort
+    assert_equal %w[classification evidence head_commit waiver], target.fetch("baseline").keys.sort
+    assert_equal %w[blocker_id deployed_smoke evidence head_commit state waiver], target.fetch("review_app").keys.sort
   end
 
   def test_closeout_requires_exact_retained_package_lock_versions_and_sources
@@ -1247,6 +1296,37 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "1 hard-gate target(s) are missing retained package lock evidence"
+  end
+
+  def test_resolved_product_versions_must_match_the_selected_candidate
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("pack").fetch("resolved_packages").each do |package|
+      next if package["name"] == "react-on-rails-rsc"
+
+      package["version"] = package["ecosystem"] == "gem" ? "17.0.0.rc.11" : "17.0.0-rc.11"
+    end
+    ledger.fetch("inventory").each do |item|
+      item.fetch("package_locks").each do |package|
+        next if package["name"] == "react-on-rails-rsc"
+        next unless %w[
+          react_on_rails react_on_rails_pro react-on-rails create-react-on-rails-app
+          react-on-rails-pro react-on-rails-pro-node-renderer
+        ].include?(package["name"])
+
+        package["version"] = package["ecosystem"] == "gem" ? "17.0.0.rc.11" : "17.0.0-rc.11"
+      end
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      closeout: true
+    ).errors
+
+    assert_includes errors, "resolved product package versions do not match candidate v17.0.0.rc.12"
   end
 
   def test_closeout_rejects_retained_lock_versions_that_do_not_match_the_resolved_snapshot
@@ -1397,16 +1477,18 @@ class FleetValidationGeneratorTest < Minitest::Test
         "disposition" => nil
       }
     ]
-    ledger.fetch("merge").merge!(
-      "authority" => "none",
-      "authority_evidence" => nil,
-      "status" => "blocked",
-      "reviewed_base_commit" => nil,
-      "current_base_commit" => nil
-    )
-    ledger.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
-    target.fetch("reachability").transform_values! { nil }
-    target.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
+    ledger.fetch("inventory").select { |item| item["work_mode"] == "mutation" }.each do |item|
+      item.fetch("merge").merge!(
+        "status" => "blocked",
+        "authority" => "none",
+        "authority_evidence" => nil,
+        "merge_commit" => nil,
+        "evidence" => "release blocked before merge"
+      )
+      item.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
+    end
+    ledger.fetch("merge")["status"] = "blocked"
+    ledger.fetch("reachability").merge!("default_branch" => "blocked", "tree_parity" => "blocked")
     ledger.fetch("tracker")["promotion"] = "blocked"
 
     errors = FleetValidation::LedgerValidator.new(
@@ -1434,7 +1516,7 @@ class FleetValidationGeneratorTest < Minitest::Test
         "disposition" => nil
       }
     ]
-    ledger.fetch("merge").merge!(
+    target.fetch("merge").merge!(
       "authority" => "none",
       "authority_evidence" => nil,
       "freeze_state" => "frozen",
@@ -1449,15 +1531,82 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "merge is not allowed while tracker mode or freeze state conflicts"
-    assert_includes errors, "merged result is missing explicit authority evidence"
+    assert_includes errors, "target #{target['id']} merged without explicit authority"
+    assert_includes errors, "target #{target['id']} merged without authority evidence"
+    assert_includes errors, "target #{target['id']} merged during a freeze or phase conflict"
   end
 
-  def test_closeout_binds_audited_bases_to_reviewed_revisions
+  def test_partial_merge_closeout_requires_proofs_only_for_the_lanes_that_landed
     generator = build_generator
     ledger = complete_ledger(generator)
-    ledger.fetch("audit")["base_commit"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    ledger.fetch("merge")["reviewed_base_commit"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    mutable = ledger.fetch("inventory").select { |item| item["work_mode"] == "mutation" }
+    merged = mutable.first
+    blocked = mutable.last
+    mutable.each do |item|
+      item["merge"] = {
+        "status" => "blocked",
+        "authority" => "none",
+        "authority_evidence" => nil,
+        "freeze_state" => "clear",
+        "merge_commit" => nil,
+        "evidence" => "public-safe merge disposition"
+      }
+      item.fetch("reachability").merge!(
+        "default_branch" => "pending",
+        "default_commit" => nil,
+        "default_evidence" => nil,
+        "tree_parity" => "pending",
+        "tree" => nil,
+        "tree_evidence" => nil
+      )
+    end
+    merged.fetch("merge").merge!(
+      "status" => "merged",
+      "authority" => "auto_merge_when_gates_pass",
+      "authority_evidence" => "trusted batch goal",
+      "merge_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+      "evidence" => "public-safe merge evidence"
+    )
+    merged.fetch("reachability").merge!(
+      "default_branch" => "passed",
+      "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+      "default_evidence" => "public-safe reachability",
+      "tree_parity" => "passed",
+      "tree" => "dddddddddddddddddddddddddddddddddddddddd",
+      "tree_evidence" => "public-safe tree parity"
+    )
+    blocked.merge!("work_state" => "blocked", "result" => "blocked", "blocker_id" => "owned-blocker")
+    blocked.fetch("checks").each_value do |check|
+      check.merge!("status" => "blocked", "blocker_id" => "owned-blocker")
+    end
+    ledger["blockers"] = [
+      {
+        "id" => "owned-blocker",
+        "status" => "open",
+        "public_summary" => "Sanitized release blocker",
+        "owner" => { "issue_url" => "https://example.invalid/issues/1" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("merge")["status"] = "partial"
+    ledger.fetch("reachability").merge!("default_branch" => "partial", "tree_parity" => "partial")
+    ledger.fetch("tracker")["promotion"] = "blocked"
+
+    schema_errors = FleetValidation::SchemaValidator.new(generator.ledger_schema).errors(ledger)
+    semantic_errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_empty schema_errors
+    assert_empty semantic_errors
+  end
+
+  def test_closeout_binds_each_target_audit_base_to_its_reviewed_base
+    generator = build_generator
+    ledger = complete_ledger(generator)
     target = ledger.fetch("inventory").find { |item| item["work_mode"] == "mutation" }
     target.fetch("bases").merge!(
       "audit" => "cccccccccccccccccccccccccccccccccccccccc",
@@ -1472,7 +1621,6 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert(errors.any? { |error| error.include?("audit base does not match reviewed base") })
-    assert_includes errors, "audit base_commit does not match merge reviewed_base_commit"
   end
 
   def test_same_pack_id_cannot_be_reused_for_a_different_release_snapshot
@@ -1622,9 +1770,6 @@ class FleetValidationGeneratorTest < Minitest::Test
       }
     ]
     ledger.fetch("tracker")["promotion"] = "blocked"
-    ledger.fetch("audit")["base_commit"] = nil
-    ledger.fetch("merge").merge!("reviewed_base_commit" => nil, "current_base_commit" => nil)
-    ledger.fetch("reachability").merge!("default_branch" => "pending", "tree_parity" => "pending")
     ledger.fetch("inventory").select { |item| item["work_mode"] == "mutation" }.each do |item|
       item.fetch("bases").merge!("audit" => nil, "reviewed" => nil, "current" => nil)
       item.fetch("reachability").merge!(
@@ -1644,8 +1789,7 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "audit base_commit is missing or not an exact commit identity"
-    assert_includes errors, "reachability default_branch is not passed"
+    assert(errors.any? { |error| error.include?("audit base is missing or not an exact commit identity") })
     assert(errors.any? { |error| error.include?("default-branch reachability evidence is incomplete") })
   end
 
@@ -1688,7 +1832,31 @@ class FleetValidationGeneratorTest < Minitest::Test
       closeout: true
     ).errors
 
-    assert_includes errors, "1 hard-gate target(s) have unknown or nonterminal check evidence"
+    assert_includes errors, "1 hard-gate target(s) check evidence is not bound to its immutable current head"
+  end
+
+  def test_hard_gate_checks_must_match_the_immutable_current_head
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["tier"] == "hard_gate" }
+    target["revisions"] = {
+      "audit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "reviewed" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "current" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "reconciliation" => "passed"
+    }
+    target.fetch("checks").each_value do |check|
+      check["head_commit"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert(errors.any? { |error| error.include?("check evidence is not bound to its immutable current head") })
   end
 
   def test_sanitized_rc12_replay_exercises_inventory_barriers_ownership_and_tracker_regeneration

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -711,6 +711,24 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes errors, "independent audit maker identities do not cover every mutable target"
   end
 
+  def test_independent_audit_rejects_blank_maker_identities
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("inventory").select { |item| item["work_mode"] == "mutation" }.each do |item|
+      item["maker_id"] = "   "
+    end
+    ledger.fetch("audit")["maker_ids"] = ["   "]
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "independent audit maker identities contain blank values"
+  end
+
   def test_closeout_requires_identified_checker_and_makers
     generator = build_generator
     ledger = complete_ledger(generator)
@@ -788,6 +806,60 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "release-wide preflight artifacts is not passed or explicitly waived"
+  end
+
+  def test_owned_preflight_blocker_can_close_without_opening_the_app_work_barrier
+    generator = build_generator
+    ledger = generator.ledger_template
+    ledger.fetch("pack").merge!(
+      "candidate" => "v17.0.0.rc.12",
+      "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "tracker_mode" => "strict-rc",
+      "resolved_packages" => resolved_packages(generator)
+    )
+    ledger.fetch("preflight").merge!(
+      "status" => "blocked",
+      "app_work_allowed" => false,
+      "blocker_id" => "artifact-blocker",
+      "blocker_evidence" => "public-safe artifact mismatch evidence"
+    )
+    ledger.fetch("preflight").fetch("artifacts").merge!(
+      "status" => "blocked",
+      "evidence" => "public-safe artifact mismatch evidence"
+    )
+    ledger["blockers"] = [
+      {
+        "id" => "artifact-blocker",
+        "status" => "open",
+        "public_summary" => "Published candidate artifacts are incoherent",
+        "owner" => { "issue_url" => "https://example.invalid/issues/artifact-blocker" },
+        "disposition" => nil
+      }
+    ]
+    ledger.fetch("audit").merge!(
+      "status" => "passed",
+      "checker" => "independent-checker",
+      "maker_ids" => [],
+      "evidence" => "public-safe blocked-preflight audit"
+    )
+    ledger.fetch("merge")["status"] = "blocked"
+    ledger.fetch("reachability").merge!("default_branch" => "blocked", "tree_parity" => "blocked")
+    ledger.fetch("tracker").merge!("status" => "ready", "promotion" => "blocked")
+
+    schema_errors = FleetValidation::SchemaValidator.new(generator.ledger_schema).errors(ledger)
+    semantic_errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      expected_candidate: "v17.0.0.rc.12",
+      expected_snapshot_fingerprint: generator.snapshot_fingerprint,
+      closeout: true
+    ).errors
+
+    assert_empty schema_errors
+    assert_empty semantic_errors
+    assert_includes FleetValidation::TrackerRenderer.new(ledger).render, "Verdict: BLOCKED"
   end
 
   def test_published_artifact_defects_cannot_be_waived
@@ -1296,6 +1368,21 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert_includes errors, "1 hard-gate target(s) are missing retained package lock evidence"
+  end
+
+  def test_report_only_targets_require_retained_package_lock_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }["package_locks"] = []
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 inventory target(s) are missing retained package lock evidence"
   end
 
   def test_resolved_product_versions_must_match_the_selected_candidate
@@ -1857,6 +1944,24 @@ class FleetValidationGeneratorTest < Minitest::Test
     ).errors
 
     assert(errors.any? { |error| error.include?("check evidence is not bound to its immutable current head") })
+  end
+
+  def test_report_only_checks_must_have_terminal_current_head_evidence
+    generator = build_generator
+    ledger = complete_ledger(generator)
+    target = ledger.fetch("inventory").find { |item| item["work_mode"] == "report_only" }
+    target.fetch("checks").each_value do |check|
+      check.merge!("status" => "unknown", "head_commit" => nil, "evidence" => nil)
+    end
+
+    errors = FleetValidation::LedgerValidator.new(
+      ledger,
+      inventory: generator.lifecycle_inventory,
+      required_paths: generator.required_paths,
+      closeout: true
+    ).errors
+
+    assert_includes errors, "1 report-only target(s) have unknown or stale check evidence"
   end
 
   def test_sanitized_rc12_replay_exercises_inventory_barriers_ownership_and_tracker_regeneration

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -80,6 +80,7 @@ module FleetValidation
       )
       ledger.fetch("preflight")["status"] = "passed"
       ledger.fetch("preflight")["app_work_allowed"] = true
+      ledger.fetch("preflight")["opened_at"] = "2026-07-18T10:00:00Z"
       %w[release_ci artifacts generator_matrix].each do |gate|
         ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
       end
@@ -119,6 +120,7 @@ module FleetValidation
         item.merge!(
           "work_state" => "finished",
           "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
+          "work_started_at" => "2026-07-18T10:01:00Z",
           "evidence" => "public-safe evidence"
         )
         expected = generator.lifecycle_inventory.find { |target| target["id"] == item["id"] }

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -148,7 +148,12 @@ module FleetValidation
           resolved.dup
         end
         item.fetch("checks").each_value do |check|
-          check.merge!("status" => "passed", "head_commit" => revision, "evidence" => "public-safe evidence")
+          check.merge!(
+            "status" => "passed",
+            "head_commit" => revision,
+            "base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "evidence" => "public-safe evidence"
+          )
         end
         item.fetch("review_app").merge!(
           "state" => "not_configured",

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -68,6 +68,7 @@ module FleetValidation
         ledger,
         inventory: generator.lifecycle_inventory,
         required_paths: generator.required_paths,
+        expected_pack_id: ledger.dig("pack", "pack_id"),
         expected_candidate: CANDIDATE,
         closeout: true
       )
@@ -85,6 +86,15 @@ module FleetValidation
       ledger.fetch("preflight")["status"] = "passed"
       ledger.fetch("preflight")["app_work_allowed"] = true
       ledger.fetch("preflight")["opened_at"] = "2026-07-18T10:00:00Z"
+      ledger.fetch("preflight")["public_marker"] = {
+        "status" => "unique",
+        "pack_id" => ledger.dig("pack", "pack_id"),
+        "candidate" => CANDIDATE,
+        "candidate_commit" => ledger.dig("pack", "candidate_commit"),
+        "snapshot_fingerprint" => generator.snapshot_fingerprint,
+        "opened_at" => ledger.dig("preflight", "opened_at"),
+        "evidence" => "public-safe unique marker evidence"
+      }
       %w[release_ci artifacts generator_matrix].each do |gate|
         ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
       end

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -71,8 +71,8 @@ module FleetValidation
       ledger = generator.ledger_template
       ledger.fetch("pack").merge!(
         "candidate" => CANDIDATE,
-        "candidate_commit" => "sanitized-candidate-commit",
-        "policy_commit" => "sanitized-policy-commit",
+        "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "tracker_mode" => "strict-rc"
       )
       ledger.fetch("preflight")["status"] = "passed"
@@ -138,6 +138,14 @@ module FleetValidation
           "reviewed" => "sanitized-base",
           "current" => "sanitized-base",
           "reconciliation" => "passed"
+        )
+        item.fetch("reachability").merge!(
+          "default_branch" => "passed",
+          "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+          "default_evidence" => "public-safe evidence",
+          "tree_parity" => "passed",
+          "tree" => "dddddddddddddddddddddddddddddddddddddddd",
+          "tree_evidence" => "public-safe evidence"
         )
       end
     end

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -12,6 +12,8 @@ module FleetValidation
     CANDIDATE = "v17.0.0.rc.12"
     CANDIDATE_COMMIT = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     PACK_ID = "rc12-sanitized"
+    POLICY_COMMIT = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    TRACKER_MODE = "strict-rc"
 
     def run
       generator = Generator.new(
@@ -52,9 +54,12 @@ module FleetValidation
 
       hard_gates = generator.lifecycle_inventory.count { |target| target["tier"] == "hard_gate" }
       soft_tracks = generator.lifecycle_inventory.count { |target| target["tier"] == "soft_track" }
+      required_path = ledger.fetch("required_paths").find { |path| path["id"] == "webpack-rsc-production" }
+      raise "webpack-rsc-production path missing from validated ledger" unless required_path
+
       puts "hard_gates=#{hard_gates}"
       puts "soft_tracks=#{soft_tracks}"
-      puts "required_path=webpack-rsc-production:scheduled"
+      puts "required_path=#{required_path.fetch('id')}:#{required_path.fetch('status')}"
       puts "unowned_blockers_rejected=#{rejected}"
       puts "tracker_rows=#{tracker_rows}"
       puts "tracker_verdict=PARTIAL"
@@ -74,7 +79,9 @@ module FleetValidation
         expected_release_selector: CANDIDATE,
         expected_candidate: CANDIDATE,
         expected_candidate_commit: CANDIDATE_COMMIT,
+        expected_policy_commit: POLICY_COMMIT,
         expected_snapshot_fingerprint: generator.snapshot_fingerprint,
+        expected_tracker_mode: TRACKER_MODE,
         closeout: true
       )
     end
@@ -84,8 +91,8 @@ module FleetValidation
       ledger.fetch("pack").merge!(
         "candidate" => CANDIDATE,
         "candidate_commit" => CANDIDATE_COMMIT,
-        "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "tracker_mode" => "strict-rc",
+        "policy_commit" => POLICY_COMMIT,
+        "tracker_mode" => TRACKER_MODE,
         "resolved_packages" => resolved_packages(generator)
       )
       ledger.fetch("preflight")["status"] = "passed"

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -34,7 +34,7 @@ module FleetValidation
 
       tracker = TrackerRenderer.new(ledger).render
       tracker_rows = tracker.lines.count { |line| line.match?(/\| (hard_gate|soft_track) \|/) }
-      raise "tracker row mismatch" unless tracker_rows == 12
+      raise "tracker row mismatch" unless tracker_rows == 13
       raise "tracker verdict mismatch" unless tracker.include?("Verdict: PARTIAL")
 
       Dir.mktmpdir do |directory|
@@ -73,7 +73,10 @@ module FleetValidation
         "candidate" => CANDIDATE,
         "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "tracker_mode" => "strict-rc"
+        "tracker_mode" => "strict-rc",
+        "resolved_packages" => generator.lifecycle_inventory.flat_map { |target| target.fetch("packages") }
+                                      .uniq { |package| [package["ecosystem"], package["name"]] }
+                                      .map { |package| package.merge("version" => "1.0.0", "source" => "registry") }
       )
       ledger.fetch("preflight")["status"] = "passed"
       %w[release_ci artifacts generator_matrix].each do |gate|
@@ -90,15 +93,15 @@ module FleetValidation
         "status" => "passed",
         "checker" => "independent-checker",
         "maker_ids" => ["maker-1"],
-        "base_commit" => "sanitized-base"
+        "base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
       )
       ledger.fetch("merge").merge!(
         "authority" => "auto_merge_when_gates_pass",
         "authority_evidence" => "sanitized trusted batch goal",
         "freeze_state" => "clear",
         "status" => "merged",
-        "reviewed_base_commit" => "sanitized-base",
-        "current_base_commit" => "sanitized-base",
+        "reviewed_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "current_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         "base_reconciliation" => "passed"
       )
       ledger.fetch("reachability").merge!("default_branch" => "passed", "tree_parity" => "passed")
@@ -134,9 +137,9 @@ module FleetValidation
           "evidence" => "sanitized fresh-default control"
         )
         item.fetch("bases").merge!(
-          "audit" => "sanitized-base",
-          "reviewed" => "sanitized-base",
-          "current" => "sanitized-base",
+          "audit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "reviewed" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "current" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
           "reconciliation" => "passed"
         )
         item.fetch("reachability").merge!(

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -27,6 +27,12 @@ module FleetValidation
       ledger.fetch("blockers").each_with_index do |blocker, index|
         blocker["status"] = "deferred"
         blocker["owner"] = { "issue_url" => "https://example.invalid/issues/#{index + 1}" }
+        blocker["disposition"] = {
+          "gate" => blocker.fetch("id"),
+          "authority" => "release-owner",
+          "evidence_url" => "https://example.invalid/issues/#{index + 1}",
+          "reason" => "Public-safe sanitized deferral"
+        }
       end
       ledger.fetch("tracker")["promotion"] = "hold"
       final_errors = validator(generator, ledger).errors
@@ -162,7 +168,8 @@ module FleetValidation
           "id" => "blocker-#{number}",
           "status" => "open",
           "public_summary" => "Sanitized RC12 closeout blocker #{number}",
-          "owner" => nil
+          "owner" => nil,
+          "disposition" => nil
         }
       end
     end

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -10,6 +10,8 @@ module FleetValidation
 
     FIXTURE = File.expand_path("../fixtures/rc12-sanitized.yml", __dir__)
     CANDIDATE = "v17.0.0.rc.12"
+    CANDIDATE_COMMIT = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    PACK_ID = "rc12-sanitized"
 
     def run
       generator = Generator.new(
@@ -17,7 +19,7 @@ module FleetValidation
         prompt_count: 6,
         machines: %w[local m1],
         release_selector: CANDIDATE,
-        pack_id: "rc12-sanitized"
+        pack_id: PACK_ID
       )
       ledger = completed_ledger(generator)
       ledger["blockers"] = six_unowned_blockers
@@ -68,8 +70,11 @@ module FleetValidation
         ledger,
         inventory: generator.lifecycle_inventory,
         required_paths: generator.required_paths,
-        expected_pack_id: ledger.dig("pack", "pack_id"),
+        expected_pack_id: PACK_ID,
+        expected_release_selector: CANDIDATE,
         expected_candidate: CANDIDATE,
+        expected_candidate_commit: CANDIDATE_COMMIT,
+        expected_snapshot_fingerprint: generator.snapshot_fingerprint,
         closeout: true
       )
     end
@@ -78,7 +83,7 @@ module FleetValidation
       ledger = generator.ledger_template
       ledger.fetch("pack").merge!(
         "candidate" => CANDIDATE,
-        "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "candidate_commit" => CANDIDATE_COMMIT,
         "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "tracker_mode" => "strict-rc",
         "resolved_packages" => resolved_packages(generator)

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -75,16 +75,14 @@ module FleetValidation
         "policy_commit" => "sanitized-policy-commit",
         "tracker_mode" => "strict-rc"
       )
-      ledger.fetch("preflight").merge!(
-        "status" => "passed",
-        "release_ci" => "passed",
-        "artifacts" => "passed",
-        "generator_matrix" => "passed"
-      )
+      ledger.fetch("preflight")["status"] = "passed"
+      %w[release_ci artifacts generator_matrix].each do |gate|
+        ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
+      end
       capabilities = ledger.fetch("preflight").fetch("capabilities")
       capabilities.transform_values! { "passed" }
       capabilities["restart_handoff"] = "sanitized restart-safe handoff"
-      complete_inventory(ledger)
+      complete_inventory(ledger, generator)
       ledger.fetch("required_paths").each do |path|
         path.merge!("status" => "passed", "lane" => "sanitized-lane", "evidence" => "public-safe evidence")
       end
@@ -112,21 +110,17 @@ module FleetValidation
       ledger
     end
 
-    def complete_inventory(ledger)
+    def complete_inventory(ledger, generator)
       ledger.fetch("inventory").each do |item|
         item.merge!(
           "work_state" => "finished",
           "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
           "evidence" => "public-safe evidence"
         )
-        item["package_locks"] = [
-          {
-            "ecosystem" => "gem",
-            "name" => "example-package",
-            "version" => "1.0.0",
-            "source" => "registry"
-          }
-        ]
+        expected = generator.lifecycle_inventory.find { |target| target["id"] == item["id"] }
+        item["package_locks"] = expected.fetch("packages").map do |package|
+          package.merge("version" => "1.0.0", "source" => "registry")
+        end
         item.fetch("checks").each_value do |check|
           check.merge!("status" => "passed", "evidence" => "public-safe evidence")
         end
@@ -138,6 +132,12 @@ module FleetValidation
         item.fetch("baseline").merge!(
           "classification" => "clean",
           "evidence" => "sanitized fresh-default control"
+        )
+        item.fetch("bases").merge!(
+          "audit" => "sanitized-base",
+          "reviewed" => "sanitized-base",
+          "current" => "sanitized-base",
+          "reconciliation" => "passed"
         )
       end
     end

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -189,6 +189,8 @@ module FleetValidation
             "evidence" => "no mutable branch"
           )
         end
+        next unless item["work_mode"] == "mutation"
+
         item.fetch("reachability").merge!(
           "default_branch" => "passed",
           "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -1,0 +1,158 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "generate_prompts"
+
+module FleetValidation
+  module RC12Replay
+    module_function
+
+    FIXTURE = File.expand_path("../fixtures/rc12-sanitized.yml", __dir__)
+    CANDIDATE = "v17.0.0.rc.12"
+
+    def run
+      generator = Generator.new(
+        manifest_path: FIXTURE,
+        prompt_count: 6,
+        machines: %w[local m1],
+        release_selector: CANDIDATE,
+        pack_id: "rc12-sanitized"
+      )
+      ledger = completed_ledger(generator)
+      ledger["blockers"] = six_unowned_blockers
+      rejected = validator(generator, ledger).errors.grep(/has no durable owner/).length
+      raise "expected six unowned blockers to fail closeout" unless rejected == 6
+
+      ledger.fetch("blockers").each_with_index do |blocker, index|
+        blocker["status"] = "deferred"
+        blocker["owner"] = { "issue_url" => "https://example.invalid/issues/#{index + 1}" }
+      end
+      ledger.fetch("tracker")["promotion"] = "hold"
+      final_errors = validator(generator, ledger).errors
+      raise "recovered ledger did not validate: #{final_errors.join('; ')}" unless final_errors.empty?
+
+      tracker = TrackerRenderer.new(ledger).render
+      tracker_rows = tracker.lines.count { |line| line.match?(/\| (hard_gate|soft_track) \|/) }
+      raise "tracker row mismatch" unless tracker_rows == 12
+      raise "tracker verdict mismatch" unless tracker.include?("Verdict: PARTIAL")
+
+      Dir.mktmpdir do |directory|
+        generator.write_pack(directory)
+        raise "lifecycle artifact missing" unless File.exist?(File.join(directory, "CLOSEOUT.md"))
+      end
+
+      hard_gates = generator.lifecycle_inventory.count { |target| target["tier"] == "hard_gate" }
+      soft_tracks = generator.lifecycle_inventory.count { |target| target["tier"] == "soft_track" }
+      puts "hard_gates=#{hard_gates}"
+      puts "soft_tracks=#{soft_tracks}"
+      puts "required_path=webpack-rsc-production:scheduled"
+      puts "unowned_blockers_rejected=#{rejected}"
+      puts "tracker_rows=#{tracker_rows}"
+      puts "tracker_verdict=PARTIAL"
+      puts "SANITIZED_RC12_REPLAY_PASS"
+      0
+    rescue ManifestError, RuntimeError => e
+      warn "SANITIZED_RC12_REPLAY_FAIL: #{e.message}"
+      1
+    end
+
+    def validator(generator, ledger)
+      LedgerValidator.new(
+        ledger,
+        inventory: generator.lifecycle_inventory,
+        required_paths: generator.required_paths,
+        expected_candidate: CANDIDATE,
+        closeout: true
+      )
+    end
+
+    def completed_ledger(generator)
+      ledger = generator.ledger_template
+      ledger.fetch("pack").merge!(
+        "candidate" => CANDIDATE,
+        "candidate_commit" => "sanitized-candidate-commit",
+        "policy_commit" => "sanitized-policy-commit",
+        "tracker_mode" => "strict-rc"
+      )
+      ledger.fetch("preflight").merge!(
+        "status" => "passed",
+        "release_ci" => "passed",
+        "artifacts" => "passed",
+        "generator_matrix" => "passed"
+      )
+      capabilities = ledger.fetch("preflight").fetch("capabilities")
+      capabilities.transform_values! { "passed" }
+      capabilities["restart_handoff"] = "sanitized restart-safe handoff"
+      complete_inventory(ledger)
+      ledger.fetch("required_paths").each do |path|
+        path.merge!("status" => "passed", "lane" => "sanitized-lane", "evidence" => "public-safe evidence")
+      end
+      ledger.fetch("audit").merge!(
+        "status" => "passed",
+        "checker" => "independent-checker",
+        "maker_ids" => ["maker-1"],
+        "base_commit" => "sanitized-base"
+      )
+      ledger.fetch("merge").merge!(
+        "authority" => "auto_merge_when_gates_pass",
+        "authority_evidence" => "sanitized trusted batch goal",
+        "freeze_state" => "clear",
+        "status" => "merged",
+        "reviewed_base_commit" => "sanitized-base",
+        "current_base_commit" => "sanitized-base",
+        "base_reconciliation" => "passed"
+      )
+      ledger.fetch("reachability").merge!("default_branch" => "passed", "tree_parity" => "passed")
+      ledger.fetch("tracker").merge!(
+        "status" => "ready",
+        "comment_url" => "https://example.invalid/tracker",
+        "promotion" => "recommend"
+      )
+      ledger
+    end
+
+    def complete_inventory(ledger)
+      ledger.fetch("inventory").each do |item|
+        item.merge!(
+          "work_state" => "finished",
+          "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
+          "evidence" => "public-safe evidence"
+        )
+        item["package_locks"] = [
+          {
+            "ecosystem" => "gem",
+            "name" => "example-package",
+            "version" => "1.0.0",
+            "source" => "registry"
+          }
+        ]
+        item.fetch("checks").each_value do |check|
+          check.merge!("status" => "passed", "evidence" => "public-safe evidence")
+        end
+        item.fetch("review_app").merge!(
+          "state" => "not_configured",
+          "evidence" => "not configured",
+          "deployed_smoke" => "waived"
+        )
+        item.fetch("baseline").merge!(
+          "classification" => "clean",
+          "evidence" => "sanitized fresh-default control"
+        )
+      end
+    end
+
+    def six_unowned_blockers
+      (1..6).map do |number|
+        {
+          "id" => "blocker-#{number}",
+          "status" => "open",
+          "public_summary" => "Sanitized RC12 closeout blocker #{number}",
+          "owner" => nil
+        }
+      end
+    end
+  end
+end
+
+exit FleetValidation::RC12Replay.run if $PROGRAM_NAME == __FILE__

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -79,6 +79,7 @@ module FleetValidation
                                       .map { |package| package.merge("version" => "1.0.0", "source" => "registry") }
       )
       ledger.fetch("preflight")["status"] = "passed"
+      ledger.fetch("preflight")["app_work_allowed"] = true
       %w[release_ci artifacts generator_matrix].each do |gate|
         ledger.fetch("preflight").fetch(gate).merge!("status" => "passed", "evidence" => "public-safe evidence")
       end

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -124,6 +124,7 @@ module FleetValidation
     def complete_inventory(ledger, generator)
       ledger.fetch("inventory").each do |item|
         item.merge!(
+          "maker_id" => item["work_mode"] == "mutation" ? "maker-1" : nil,
           "work_state" => "finished",
           "result" => item["tier"] == "hard_gate" ? "passed" : "reported",
           "work_started_at" => "2026-07-18T10:01:00Z",

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
@@ -80,9 +80,7 @@ module FleetValidation
         "candidate_commit" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "policy_commit" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "tracker_mode" => "strict-rc",
-        "resolved_packages" => generator.lifecycle_inventory.flat_map { |target| target.fetch("packages") }
-                                      .uniq { |package| [package["ecosystem"], package["name"]] }
-                                      .map { |package| package.merge("version" => "1.0.0", "source" => "registry") }
+        "resolved_packages" => resolved_packages(generator)
       )
       ledger.fetch("preflight")["status"] = "passed"
       ledger.fetch("preflight")["app_work_allowed"] = true
@@ -101,17 +99,9 @@ module FleetValidation
         "status" => "passed",
         "checker" => "independent-checker",
         "maker_ids" => ["maker-1"],
-        "base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        "evidence" => "sanitized independent audit report"
       )
-      ledger.fetch("merge").merge!(
-        "authority" => "auto_merge_when_gates_pass",
-        "authority_evidence" => "sanitized trusted batch goal",
-        "freeze_state" => "clear",
-        "status" => "merged",
-        "reviewed_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-        "current_base_commit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-        "base_reconciliation" => "passed"
-      )
+      ledger.fetch("merge")["status"] = "merged"
       ledger.fetch("reachability").merge!("default_branch" => "passed", "tree_parity" => "passed")
       ledger.fetch("tracker").merge!(
         "status" => "ready",
@@ -121,8 +111,28 @@ module FleetValidation
       ledger
     end
 
+    def resolved_packages(generator)
+      generator.lifecycle_inventory.flat_map { |target| target.fetch("packages") }
+               .uniq { |package| [package["ecosystem"], package["name"]] }
+               .map do |package|
+        product_names = LedgerValidator::PRODUCT_PACKAGES.fetch(package["ecosystem"], [])
+        version = if product_names.include?(package["name"])
+                    package["ecosystem"] == "gem" ? "17.0.0.rc.12" : "17.0.0-rc.12"
+                  else
+                    "1.0.0"
+                  end
+        package.merge("version" => version, "source" => "registry")
+      end
+    end
+
     def complete_inventory(ledger, generator)
       ledger.fetch("inventory").each do |item|
+        revision = if item["work_mode"] == "report_only"
+                     "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                   else
+                     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                   end
+        baseline_head = item["work_mode"] == "mutation" ? "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" : revision
         item.merge!(
           "maker_id" => item["work_mode"] == "mutation" ? "maker-1" : nil,
           "work_state" => "finished",
@@ -132,19 +142,30 @@ module FleetValidation
         )
         expected = generator.lifecycle_inventory.find { |target| target["id"] == item["id"] }
         item["package_locks"] = expected.fetch("packages").map do |package|
-          package.merge("version" => "1.0.0", "source" => "registry")
+          resolved = ledger.fetch("pack").fetch("resolved_packages").find do |candidate_package|
+            candidate_package.slice("ecosystem", "name") == package.slice("ecosystem", "name")
+          end
+          resolved.dup
         end
         item.fetch("checks").each_value do |check|
-          check.merge!("status" => "passed", "evidence" => "public-safe evidence")
+          check.merge!("status" => "passed", "head_commit" => revision, "evidence" => "public-safe evidence")
         end
         item.fetch("review_app").merge!(
           "state" => "not_configured",
+          "head_commit" => revision,
           "evidence" => "not configured",
           "deployed_smoke" => "waived"
         )
         item.fetch("baseline").merge!(
           "classification" => "clean",
+          "head_commit" => baseline_head,
           "evidence" => "sanitized fresh-default control"
+        )
+        item.fetch("revisions").merge!(
+          "audit" => revision,
+          "reviewed" => revision,
+          "current" => revision,
+          "reconciliation" => "passed"
         )
         item.fetch("bases").merge!(
           "audit" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -152,6 +173,22 @@ module FleetValidation
           "current" => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
           "reconciliation" => "passed"
         )
+        if item["work_mode"] == "mutation"
+          item.fetch("merge").merge!(
+            "status" => "merged",
+            "authority" => "auto_merge_when_gates_pass",
+            "authority_evidence" => "sanitized trusted batch goal",
+            "freeze_state" => "clear",
+            "merge_commit" => "cccccccccccccccccccccccccccccccccccccccc",
+            "evidence" => "public-safe merge evidence"
+          )
+        else
+          item.fetch("merge").merge!(
+            "status" => "not_applicable",
+            "freeze_state" => "clear",
+            "evidence" => "no mutable branch"
+          )
+        end
         item.fetch("reachability").merge!(
           "default_branch" => "passed",
           "default_commit" => "cccccccccccccccccccccccccccccccccccccccc",

--- a/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
+++ b/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
@@ -18,6 +18,8 @@ module FleetValidation
         expected_release_selector: nil,
         expected_candidate: nil,
         expected_candidate_commit: nil,
+        expected_policy_commit: nil,
+        expected_tracker_mode: nil,
         tracker_path: nil
       }
       parser = option_parser(options)
@@ -27,6 +29,13 @@ module FleetValidation
       raise OptionParser::MissingArgument, "--expected-pack-id" unless options[:expected_pack_id]
       raise OptionParser::MissingArgument, "--expected-release-selector" unless options[:expected_release_selector]
       raise OptionParser::MissingArgument, "--expected-candidate-commit" unless options[:expected_candidate_commit]
+      raise OptionParser::MissingArgument, "--expected-policy-commit" unless options[:expected_policy_commit]
+      raise OptionParser::MissingArgument, "--expected-tracker-mode" unless options[:expected_tracker_mode]
+
+      if options[:tracker_path] && same_path?(options.fetch(:ledger_path), options.fetch(:tracker_path))
+        raise OptionParser::InvalidArgument,
+              "--render-tracker must resolve to a different path than --ledger"
+      end
 
       manifest = YAML.safe_load_file(options.fetch(:manifest_path), aliases: false)
       ledger = JSON.parse(File.read(options.fetch(:ledger_path)))
@@ -49,7 +58,9 @@ module FleetValidation
         expected_release_selector: options[:expected_release_selector],
         expected_candidate: options[:expected_candidate],
         expected_candidate_commit: options[:expected_candidate_commit],
+        expected_policy_commit: options[:expected_policy_commit],
         expected_snapshot_fingerprint: lifecycle.snapshot_fingerprint,
+        expected_tracker_mode: options[:expected_tracker_mode],
         closeout: true
       ).errors)
 
@@ -86,10 +97,24 @@ module FleetValidation
         parser.on("--expected-candidate-commit SHA", "Require this exact candidate source commit") do |value|
           options[:expected_candidate_commit] = value
         end
+        parser.on("--expected-policy-commit SHA", "Require this exact release policy/default commit") do |value|
+          options[:expected_policy_commit] = value
+        end
+        parser.on("--expected-tracker-mode MODE", "Require this exact tracker mode") do |value|
+          options[:expected_tracker_mode] = value
+        end
         parser.on("--render-tracker PATH", "Write append-only tracker Markdown") do |value|
           options[:tracker_path] = value
         end
       end
+    end
+
+    def same_path?(first, second)
+      first_path = File.expand_path(first)
+      second_path = File.expand_path(second)
+      return true if first_path == second_path
+
+      File.exist?(first_path) && File.exist?(second_path) && File.identical?(first_path, second_path)
     end
   end
 end

--- a/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
+++ b/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
@@ -20,6 +20,7 @@ module FleetValidation
       parser = option_parser(options)
       parser.parse!(argv)
       raise OptionParser::MissingArgument, "--ledger" unless options[:ledger_path]
+      raise OptionParser::MissingArgument, "--expected-candidate" unless options[:expected_candidate]
 
       manifest = YAML.safe_load_file(options.fetch(:manifest_path), aliases: false)
       ledger = JSON.parse(File.read(options.fetch(:ledger_path)))

--- a/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
+++ b/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
@@ -15,6 +15,7 @@ module FleetValidation
         manifest_path: "internal/contributor-info/demo-fleet.yml",
         ledger_path: nil,
         expected_pack_id: nil,
+        expected_release_selector: nil,
         expected_candidate: nil,
         tracker_path: nil
       }
@@ -23,14 +24,14 @@ module FleetValidation
       raise OptionParser::MissingArgument, "--ledger" unless options[:ledger_path]
       raise OptionParser::MissingArgument, "--expected-candidate" unless options[:expected_candidate]
       raise OptionParser::MissingArgument, "--expected-pack-id" unless options[:expected_pack_id]
+      raise OptionParser::MissingArgument, "--expected-release-selector" unless options[:expected_release_selector]
 
       manifest = YAML.safe_load_file(options.fetch(:manifest_path), aliases: false)
       ledger = JSON.parse(File.read(options.fetch(:ledger_path)))
-      pack = ledger.is_a?(Hash) && ledger["pack"].is_a?(Hash) ? ledger["pack"] : {}
       lifecycle = Lifecycle.new(
         manifest:,
         pack_id: options.fetch(:expected_pack_id),
-        release_selector: pack["release_selector"].to_s
+        release_selector: options.fetch(:expected_release_selector)
       )
       errors = SchemaValidator.new(lifecycle.schema).errors(ledger)
       unless errors.empty?
@@ -71,6 +72,9 @@ module FleetValidation
         parser.on("--ledger PATH", "Result ledger JSON path") { |value| options[:ledger_path] = value }
         parser.on("--expected-pack-id ID", "Require this exact generated pack ID") do |value|
           options[:expected_pack_id] = value
+        end
+        parser.on("--expected-release-selector SELECTOR", "Require this exact generated release selector") do |value|
+          options[:expected_release_selector] = value
         end
         parser.on("--expected-candidate TAG", "Require this exact candidate") do |value|
           options[:expected_candidate] = value

--- a/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
+++ b/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "optparse"
+require "yaml"
+require_relative "fleet_lifecycle"
+
+module FleetValidation
+  module LedgerCLI
+    module_function
+
+    def run(argv)
+      options = {
+        manifest_path: "internal/contributor-info/demo-fleet.yml",
+        ledger_path: nil,
+        expected_candidate: nil,
+        tracker_path: nil
+      }
+      parser = option_parser(options)
+      parser.parse!(argv)
+      raise OptionParser::MissingArgument, "--ledger" unless options[:ledger_path]
+
+      manifest = YAML.safe_load_file(options.fetch(:manifest_path), aliases: false)
+      ledger = JSON.parse(File.read(options.fetch(:ledger_path)))
+      lifecycle = Lifecycle.new(
+        manifest:,
+        pack_id: ledger.dig("pack", "pack_id").to_s,
+        release_selector: ledger.dig("pack", "release_selector").to_s
+      )
+      errors = SchemaValidator.new(lifecycle.schema).errors(ledger)
+      errors.concat(LedgerValidator.new(
+        ledger,
+        inventory: lifecycle.inventory,
+        required_paths: lifecycle.required_paths,
+        expected_candidate: options[:expected_candidate],
+        closeout: true
+      ).errors)
+
+      unless errors.empty?
+        errors.each { |error| warn "ERROR: #{error}" }
+        return 1
+      end
+
+      if options[:tracker_path]
+        File.write(options.fetch(:tracker_path), TrackerRenderer.new(ledger).render)
+      end
+      puts "VALID fleet result ledger"
+      0
+    rescue Errno::ENOENT, JSON::ParserError, Psych::Exception, ManifestError, OptionParser::ParseError => e
+      warn "ERROR: #{e.message}"
+      warn parser
+      1
+    end
+
+    def option_parser(options)
+      OptionParser.new do |parser|
+        parser.banner = "Usage: validate_ledger.rb --ledger PATH [options]"
+        parser.on("--manifest PATH", "Fleet manifest path") { |value| options[:manifest_path] = value }
+        parser.on("--ledger PATH", "Result ledger JSON path") { |value| options[:ledger_path] = value }
+        parser.on("--expected-candidate TAG", "Require this exact candidate") do |value|
+          options[:expected_candidate] = value
+        end
+        parser.on("--render-tracker PATH", "Write append-only tracker Markdown") do |value|
+          options[:tracker_path] = value
+        end
+      end
+    end
+  end
+end
+
+exit FleetValidation::LedgerCLI.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
+++ b/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
@@ -24,17 +24,24 @@ module FleetValidation
 
       manifest = YAML.safe_load_file(options.fetch(:manifest_path), aliases: false)
       ledger = JSON.parse(File.read(options.fetch(:ledger_path)))
+      pack = ledger.is_a?(Hash) && ledger["pack"].is_a?(Hash) ? ledger["pack"] : {}
       lifecycle = Lifecycle.new(
         manifest:,
-        pack_id: ledger.dig("pack", "pack_id").to_s,
-        release_selector: ledger.dig("pack", "release_selector").to_s
+        pack_id: pack["pack_id"].to_s,
+        release_selector: pack["release_selector"].to_s
       )
       errors = SchemaValidator.new(lifecycle.schema).errors(ledger)
+      unless errors.empty?
+        errors.each { |error| warn "ERROR: #{error}" }
+        return 1
+      end
+
       errors.concat(LedgerValidator.new(
         ledger,
         inventory: lifecycle.inventory,
         required_paths: lifecycle.required_paths,
         expected_candidate: options[:expected_candidate],
+        expected_snapshot_fingerprint: lifecycle.snapshot_fingerprint,
         closeout: true
       ).errors)
 

--- a/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
+++ b/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
@@ -14,6 +14,7 @@ module FleetValidation
       options = {
         manifest_path: "internal/contributor-info/demo-fleet.yml",
         ledger_path: nil,
+        expected_pack_id: nil,
         expected_candidate: nil,
         tracker_path: nil
       }
@@ -21,13 +22,14 @@ module FleetValidation
       parser.parse!(argv)
       raise OptionParser::MissingArgument, "--ledger" unless options[:ledger_path]
       raise OptionParser::MissingArgument, "--expected-candidate" unless options[:expected_candidate]
+      raise OptionParser::MissingArgument, "--expected-pack-id" unless options[:expected_pack_id]
 
       manifest = YAML.safe_load_file(options.fetch(:manifest_path), aliases: false)
       ledger = JSON.parse(File.read(options.fetch(:ledger_path)))
       pack = ledger.is_a?(Hash) && ledger["pack"].is_a?(Hash) ? ledger["pack"] : {}
       lifecycle = Lifecycle.new(
         manifest:,
-        pack_id: pack["pack_id"].to_s,
+        pack_id: options.fetch(:expected_pack_id),
         release_selector: pack["release_selector"].to_s
       )
       errors = SchemaValidator.new(lifecycle.schema).errors(ledger)
@@ -40,6 +42,7 @@ module FleetValidation
         ledger,
         inventory: lifecycle.inventory,
         required_paths: lifecycle.required_paths,
+        expected_pack_id: options[:expected_pack_id],
         expected_candidate: options[:expected_candidate],
         expected_snapshot_fingerprint: lifecycle.snapshot_fingerprint,
         closeout: true
@@ -66,6 +69,9 @@ module FleetValidation
         parser.banner = "Usage: validate_ledger.rb --ledger PATH [options]"
         parser.on("--manifest PATH", "Fleet manifest path") { |value| options[:manifest_path] = value }
         parser.on("--ledger PATH", "Result ledger JSON path") { |value| options[:ledger_path] = value }
+        parser.on("--expected-pack-id ID", "Require this exact generated pack ID") do |value|
+          options[:expected_pack_id] = value
+        end
         parser.on("--expected-candidate TAG", "Require this exact candidate") do |value|
           options[:expected_candidate] = value
         end

--- a/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
+++ b/.agents/skills/run-fleet-validation/scripts/validate_ledger.rb
@@ -17,6 +17,7 @@ module FleetValidation
         expected_pack_id: nil,
         expected_release_selector: nil,
         expected_candidate: nil,
+        expected_candidate_commit: nil,
         tracker_path: nil
       }
       parser = option_parser(options)
@@ -25,6 +26,7 @@ module FleetValidation
       raise OptionParser::MissingArgument, "--expected-candidate" unless options[:expected_candidate]
       raise OptionParser::MissingArgument, "--expected-pack-id" unless options[:expected_pack_id]
       raise OptionParser::MissingArgument, "--expected-release-selector" unless options[:expected_release_selector]
+      raise OptionParser::MissingArgument, "--expected-candidate-commit" unless options[:expected_candidate_commit]
 
       manifest = YAML.safe_load_file(options.fetch(:manifest_path), aliases: false)
       ledger = JSON.parse(File.read(options.fetch(:ledger_path)))
@@ -44,7 +46,9 @@ module FleetValidation
         inventory: lifecycle.inventory,
         required_paths: lifecycle.required_paths,
         expected_pack_id: options[:expected_pack_id],
+        expected_release_selector: options[:expected_release_selector],
         expected_candidate: options[:expected_candidate],
+        expected_candidate_commit: options[:expected_candidate_commit],
         expected_snapshot_fingerprint: lifecycle.snapshot_fingerprint,
         closeout: true
       ).errors)
@@ -78,6 +82,9 @@ module FleetValidation
         end
         parser.on("--expected-candidate TAG", "Require this exact candidate") do |value|
           options[:expected_candidate] = value
+        end
+        parser.on("--expected-candidate-commit SHA", "Require this exact candidate source commit") do |value|
+          options[:expected_candidate_commit] = value
         end
         parser.on("--render-tracker PATH", "Write append-only tracker Markdown") do |value|
           options[:tracker_path] = value

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,8 +109,10 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 - When a maintainer wants to run or inspect RC/beta validation across the demo
   fleet, use the repo-local `.agents/skills/run-fleet-validation/SKILL.md`; a
   short invocation is `$run-fleet-validation`. Its Ruby generator reads
-  `internal/contributor-info/demo-fleet.yml` and emits balanced, subagent-driven
-  prompts for simultaneous execution across multiple machines.
+  `internal/contributor-info/demo-fleet.yml` and emits a complete lifecycle pack:
+  release/capability preflight, balanced subagent-driven hard-gate prompts,
+  report-only soft-track coverage, a durable result ledger/schema, independent
+  audit, authorized merge, reachability/tree-parity proof, and tracker closeout.
 - Default simplify model: `claude-opus-4-8`
 
 ## External Flagship Demo Coordination

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -42,6 +42,25 @@
 
 schema_version: 1
 
+lifecycle:
+  # Release-path coverage is independent from repository tier. Every required
+  # path needs a generated lane/evidence source or an explicit public waiver.
+  required_paths:
+    - id: standard-generator
+      evidence_source: core_generator
+    - id: pro-ssr
+      evidence_source: core_generator
+    - id: pro-rsc
+      evidence_source: core_generator
+    - id: rspack
+      evidence_source: fleet
+    - id: webpack-rsc-production
+      evidence_source: release_must_have
+    - id: ssr-rsc-html
+      evidence_source: fleet
+    - id: client-navigation-interaction
+      evidence_source: fleet
+
 # Bounded parallelism for a single release/freshness run. Caps wall time at the
 # slowest repo rather than the sum of all repos. Override per-run with the
 # DEMO_FLEET_CONCURRENCY env var (read by the demo_fleet:* Rake tasks).

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -8,7 +8,8 @@
 # Field semantics:
 #   tier           — hard_gate | soft_track. hard_gate failures block a final
 #                    release. soft_track repos are remembered for follow-up but
-#                    do not block.
+#                    do not block; blockers referenced only by soft tracks are
+#                    non-gating PARTIAL follow-up state.
 #   packages       — which of our packages the demo consumes. Each entry must
 #                    declare an ecosystem (`gem` | `npm`) and a package name.
 #                    The orchestrator only proposes bumps for listed packages,

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -150,13 +150,16 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --expected-release-selector "GENERATED_RELEASE_SELECTOR" \
   --expected-candidate vX.Y.Z.rc.N \
   --expected-candidate-commit CANDIDATE_COMMIT_SHA \
+  --expected-policy-commit POLICY_COMMIT_SHA \
+  --expected-tracker-mode TRACKER_MODE \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
 Every nonterminal blocker needs a durable issue or public-safe tracker-only reason before closeout.
-The independently supplied expected pack ID, generated release selector, candidate tag, and source
-commit, plus the ledger's unique public preflight-marker record, must match the exact candidate
-snapshot before any distributed app work can validate.
+The independently supplied expected pack ID, generated release selector, candidate tag, source
+commit, policy commit, and tracker mode, plus the ledger's unique public preflight-marker record,
+must match the exact candidate snapshot before any distributed app work can validate. The rendered
+tracker path must remain distinct from the durable ledger path.
 Resolved package entries use the canonical `registry` source so local workspace/path overrides
 cannot stand in for published artifacts. Blocked outcomes must reference active owned blockers, and
 tracker promotion must be `blocked` exactly when a release blocker remains; `hold` is only a

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -145,7 +145,13 @@ required-path coverage, current-head evidence, independent audit, merge authorit
 reachability, tree parity, or any `UNKNOWN` keeps the ledger non-passing.
 
 Every mutable target records the stable maker identity that performed its work, and the independent
-audit's maker list must exactly cover those target identities. The validation-only monorepo gate
+audit's maker list must exactly cover those target identities and retain replayable public-safe
+audit evidence. Each hard-gate check is bound to the target's exact audited, reviewed, and current
+revision. Product gem/npm versions must normalize to the selected candidate; the independently
+versioned RSC package retains its separately resolved version. Merge authority, freeze state,
+merge commit, reachability, and tree parity are recorded per mutable target, with a derived
+aggregate that can represent partial fleet merges without dropping landed-lane proof.
+The validation-only monorepo gate
 retains the exact OSS, Pro, node-renderer, RSC, and generator CLI versions exercised by its matrix,
 but it has no synthetic branch merge, per-target reachability, or tree-parity evidence.
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -156,6 +156,9 @@ Every nonterminal blocker needs a durable issue or public-safe tracker-only reas
 The independently supplied expected pack ID, generated release selector, candidate tag, and source
 commit, plus the ledger's unique public preflight-marker record, must match the exact candidate
 snapshot before any distributed app work can validate.
+Resolved package entries use the canonical `registry` source so local workspace/path overrides
+cannot stand in for published artifacts. Blocked outcomes must reference active owned blockers, and
+tracker promotion must agree with whether a release blocker remains.
 Waived and deferred blockers additionally retain a durable owner and need a structured disposition
 naming the gate, authority, evidence URL, and public-safe reason. A failed required path may close
 the run as `BLOCKED` only with its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -97,6 +97,13 @@ per assigned target. With the default partition, no coordinator receives more th
 targets. Run each prompt as a separate top-level task; do not place all six under one shared
 four-slot agent tree.
 
+If the release-wide preflight finds an owned terminal blocker, do not manufacture passing app
+results to finish the ledger. Keep `APP_WORK_ALLOWED` false, retain the blocker ID and public-safe
+evidence, leave every app target untouched, audit the blocked disposition with no maker IDs, and
+close aggregate merge/reachability and promotion as blocked. When report-only tracks do run, their
+closeout evidence includes retained package versions/sources and terminal checks bound to the exact
+inspected head; `pending` or `unknown` is not a completed report.
+
 Prompt 1 is the release-snapshot leader. It resolves the latest product RC/beta and the separately
 versioned `react-on-rails-rsc` pin once, then posts the pack's unique snapshot marker. The other
 five prompts may start simultaneously but must wait for that exact marker before mutation. This

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -148,13 +148,14 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --expected-pack-id PACK_ID \
   --expected-release-selector "GENERATED_RELEASE_SELECTOR" \
   --expected-candidate vX.Y.Z.rc.N \
+  --expected-candidate-commit CANDIDATE_COMMIT_SHA \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
 Every nonterminal blocker needs a durable issue or public-safe tracker-only reason before closeout.
-The independently supplied expected pack ID and generated release selector, plus the ledger's unique
-public preflight-marker record, must match the exact candidate snapshot before any distributed app
-work can validate.
+The independently supplied expected pack ID, generated release selector, candidate tag, and source
+commit, plus the ledger's unique public preflight-marker record, must match the exact candidate
+snapshot before any distributed app work can validate.
 Waived and deferred blockers additionally retain a durable owner and need a structured disposition
 naming the gate, authority, evidence URL, and public-safe reason. A failed required path may close
 the run as `BLOCKED` only with its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -89,7 +89,8 @@ ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
 
 The default prompt contract resolves the **latest RC or beta** when each lane starts. Use
 `--release vX.Y.Z.rc.N` only for a deliberately pinned rerun. Follow
-`tmp/fleet-validation-prompts/INDEX.md`: run `PREFLIGHT.md`, start the prompt coordinators, run
+`tmp/fleet-validation-prompts/INDEX.md`: start prompt 1 for the exact snapshot and read-only generator
+matrix, run `PREFLIGHT.md`, start the remaining prompt coordinators, run
 `REPORT-ONLY.md`, then reserve a maker-independent checker for `CLOSEOUT.md`. Each prompt
 coordinates bounded subagents: one read-only live-evidence pass plus one isolated execution worker
 per assigned target. With the default partition, no coordinator receives more than two execution

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -144,6 +144,11 @@ its lane, failure evidence, and a `blocker_id` that resolves to a durable owner.
 required-path coverage, current-head evidence, independent audit, merge authority, default
 reachability, tree parity, or any `UNKNOWN` keeps the ledger non-passing.
 
+Every mutable target records the stable maker identity that performed its work, and the independent
+audit's maker list must exactly cover those target identities. The validation-only monorepo gate
+retains the exact OSS, Pro, node-renderer, RSC, and generator CLI versions exercised by its matrix,
+but it has no synthetic branch merge, per-target reachability, or tree-parity evidence.
+
 1. Cut the RC packages.
 2. Create or update the release-gate tracking issue from
    `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`.

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -73,9 +73,10 @@ The tracking issue is the single source of truth for:
 ### Fast parallel launch
 
 Use the repo-local `$run-fleet-validation` skill to avoid hand-copying the fleet or pinning a
-candidate into six separate prompts. Its generator reads the hard gates from `demo-fleet.yml`,
-adds the monorepo generator/install gate, and emits six self-contained coordinator prompts
-balanced three-per-machine by default:
+candidate into six separate prompts. Its generator reads the complete `demo-fleet.yml` inventory,
+adds the monorepo generator/install gate and required release-path axes, and emits a lifecycle pack:
+release/capability preflight, six hard-gate coordinator prompts balanced three-per-machine by
+default, report-only soft-track coverage, a durable result ledger/schema, and independent closeout.
 
 From the repository root, run:
 
@@ -87,16 +88,24 @@ ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
 ```
 
 The default prompt contract resolves the **latest RC or beta** when each lane starts. Use
-`--release vX.Y.Z.rc.N` only for a deliberately pinned rerun. Launch every prompt listed in
-`tmp/fleet-validation-prompts/INDEX.md` simultaneously. Each prompt coordinates bounded subagents:
-one read-only live-evidence pass plus one isolated execution worker per assigned target. With the
-default partition, no coordinator receives more than two execution targets. Run each prompt as a
-separate top-level task; do not place all six under one shared four-slot agent tree.
+`--release vX.Y.Z.rc.N` only for a deliberately pinned rerun. Follow
+`tmp/fleet-validation-prompts/INDEX.md`: run `PREFLIGHT.md`, start the prompt coordinators, run
+`REPORT-ONLY.md`, then reserve a maker-independent checker for `CLOSEOUT.md`. Each prompt
+coordinates bounded subagents: one read-only live-evidence pass plus one isolated execution worker
+per assigned target. With the default partition, no coordinator receives more than two execution
+targets. Run each prompt as a separate top-level task; do not place all six under one shared
+four-slot agent tree.
 
 Prompt 1 is the release-snapshot leader. It resolves the latest product RC/beta and the separately
 versioned `react-on-rails-rsc` pin once, then posts the pack's unique snapshot marker. The other
 five prompts may start simultaneously but must wait for that exact marker before mutation. This
 prevents a newly published candidate from splitting a staggered launch across versions.
+
+The release-wide barrier also requires exact-commit CI, registry/tarball coherence, and the
+published standard/Pro/Pro+RSC generator matrix to be terminal green, or an explicit public-safe
+waiver allowed by this plan. Machine/session capability attestation and target capability/baseline
+probes run before expensive app work. Review-app state is classified as configured/runnable,
+configured/broken, not configured, or `UNKNOWN`; absence is recorded instead of inventing a deploy.
 
 Each lane must acquire or resume an authoritative coordination claim before creating a mutable app
 checkout. It must reuse live candidate ownership first and use the pack's generated fallback claim
@@ -107,8 +116,28 @@ concurrently rewrite the issue body. Generate a fresh pack and snapshot identity
 replacement candidate, even when the manifest is unchanged. Within one exact-candidate run, reuse
 that pack ID and rerun only the prompt files that own affected targets.
 
-The generated prompts accelerate the fleet hard gates; they do not replace the independent
-behavioral lanes in `release-verification-runbook.md` or the maintainer's final go/no-go decision.
+The candidate-scoped lifecycle is distinct from standing fleet-health automation: standing health
+detects currency/staleness between releases, while this pack proves one exact candidate and closes
+its release tracker. It is also distinct from hosted-CI dispatch and generator-routing
+optimizations: those shorten individual gates but do not supply inventory, blocker ownership,
+independent audit, merge/reachability, or closeout. The generated pack does not replace the
+independent behavioral lanes in `release-verification-runbook.md` or the maintainer's final
+promotion decision.
+
+The checker validates one public-safe `result-ledger.json` and renders the append-only tracker
+matrix from that exact file:
+
+```bash
+ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
+  --ledger tmp/fleet-validation-prompts/result-ledger.json \
+  --expected-candidate vX.Y.Z.rc.N \
+  --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
+```
+
+Every nonterminal blocker needs a durable issue, explicit waiver/deferral, or public-safe
+tracker-only reason before closeout. Missing ownership, required-path coverage, current-head
+evidence, independent audit, merge authority, default reachability, tree parity, or any `UNKNOWN`
+keeps the ledger non-passing.
 
 1. Cut the RC packages.
 2. Create or update the release-gate tracking issue from

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -106,6 +106,8 @@ checks bound to the exact inspected head; those observed locks need not match th
 snapshot, and `pending` or `unknown` is not a completed report. Candidate snapshot matching applies
 only to candidate-managed hard-gate packages, including the separately resolved RSC package, not
 independently versioned Shakapacker or Control Plane Flow dependencies.
+Untouched app rows may retain read-only package-lock probes, while validation-only generator
+evidence must use the pack's exact candidate commit.
 
 Prompt 1 is the release-snapshot leader. It resolves the latest product RC/beta and the separately
 versioned `react-on-rails-rsc` pin once, then posts the pack's unique snapshot marker. The other

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -115,7 +115,9 @@ not pack ID, so independently generated packs cannot race. Each lane then reuses
 idempotent marker comment per stable target identity to the tracking issue. Lanes must not
 concurrently rewrite the issue body. Generate a fresh pack and snapshot identity for every
 replacement candidate, even when the manifest is unchanged. Within one exact-candidate run, reuse
-that pack ID and rerun only the prompt files that own affected targets.
+the existing prompt files for affected targets. Regenerate a same-ID pack only when its original
+selector was pinned to the exact resolved candidate; after a dynamic `latest RC or beta` selector
+resolves, regeneration fails closed because it cannot prove that the selector has not advanced.
 
 The candidate-scoped lifecycle is distinct from standing fleet-health automation: standing health
 detects currency/staleness between releases, while this pack proves one exact candidate and closes
@@ -135,10 +137,12 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
-Every nonterminal blocker needs a durable issue, explicit waiver/deferral, or public-safe
-tracker-only reason before closeout. Missing ownership, required-path coverage, current-head
-evidence, independent audit, merge authority, default reachability, tree parity, or any `UNKNOWN`
-keeps the ledger non-passing.
+Every nonterminal blocker needs a durable issue or public-safe tracker-only reason before closeout.
+Waived and deferred blockers additionally need a structured disposition naming the gate, authority,
+evidence URL, and public-safe reason. A failed required path may close the run as `BLOCKED` only with
+its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,
+required-path coverage, current-head evidence, independent audit, merge authority, default
+reachability, tree parity, or any `UNKNOWN` keeps the ledger non-passing.
 
 1. Cut the RC packages.
 2. Create or update the release-gate tracking issue from

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -146,13 +146,15 @@ matrix from that exact file:
 ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --ledger tmp/fleet-validation-prompts/result-ledger.json \
   --expected-pack-id PACK_ID \
+  --expected-release-selector "GENERATED_RELEASE_SELECTOR" \
   --expected-candidate vX.Y.Z.rc.N \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
 Every nonterminal blocker needs a durable issue or public-safe tracker-only reason before closeout.
-The independently supplied expected pack ID and the ledger's unique public preflight-marker record
-must match the exact candidate snapshot before any distributed app work can validate.
+The independently supplied expected pack ID and generated release selector, plus the ledger's unique
+public preflight-marker record, must match the exact candidate snapshot before any distributed app
+work can validate.
 Waived and deferred blockers additionally retain a durable owner and need a structured disposition
 naming the gate, authority, evidence URL, and public-safe reason. A failed required path may close
 the run as `BLOCKED` only with its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -100,9 +100,12 @@ four-slot agent tree.
 If the release-wide preflight finds an owned terminal blocker, do not manufacture passing app
 results to finish the ledger. Keep `APP_WORK_ALLOWED` false, retain the blocker ID and public-safe
 evidence, leave every app target untouched, audit the blocked disposition with no maker IDs, and
-close aggregate merge/reachability and promotion as blocked. When report-only tracks do run, their
-closeout evidence includes retained package versions/sources and terminal checks bound to the exact
-inspected head; `pending` or `unknown` is not a completed report.
+close aggregate merge/reachability and promotion exactly as `blocked`, not `hold`. When report-only
+tracks do run, their closeout evidence includes retained package versions/sources and terminal
+checks bound to the exact inspected head; those observed locks need not match the candidate
+snapshot, and `pending` or `unknown` is not a completed report. Candidate snapshot matching applies
+only to candidate-managed hard-gate packages, including the separately resolved RSC package, not
+independently versioned Shakapacker or Control Plane Flow dependencies.
 
 Prompt 1 is the release-snapshot leader. It resolves the latest product RC/beta and the separately
 versioned `react-on-rails-rsc` pin once, then posts the pack's unique snapshot marker. The other
@@ -150,6 +153,9 @@ naming the gate, authority, evidence URL, and public-safe reason. A failed requi
 the run as `BLOCKED` only with its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,
 required-path coverage, current-head evidence, independent audit, merge authority, default
 reachability, tree parity, or any `UNKNOWN` keeps the ledger non-passing.
+An owned blocker referenced exclusively by soft-track inventory is non-gating follow-up and renders
+the run `PARTIAL`; it becomes release-gating when preflight, a hard gate, or a required path shares
+that blocker.
 
 Every mutable target records the stable maker identity that performed its work, and the independent
 audit's maker list must exactly cover those target identities and retain replayable public-safe

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -138,9 +138,9 @@ ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
 ```
 
 Every nonterminal blocker needs a durable issue or public-safe tracker-only reason before closeout.
-Waived and deferred blockers additionally need a structured disposition naming the gate, authority,
-evidence URL, and public-safe reason. A failed required path may close the run as `BLOCKED` only with
-its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,
+Waived and deferred blockers additionally retain a durable owner and need a structured disposition
+naming the gate, authority, evidence URL, and public-safe reason. A failed required path may close
+the run as `BLOCKED` only with its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,
 required-path coverage, current-head evidence, independent audit, merge authority, default
 reachability, tree parity, or any `UNKNOWN` keeps the ledger non-passing.
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -158,7 +158,8 @@ commit, plus the ledger's unique public preflight-marker record, must match the 
 snapshot before any distributed app work can validate.
 Resolved package entries use the canonical `registry` source so local workspace/path overrides
 cannot stand in for published artifacts. Blocked outcomes must reference active owned blockers, and
-tracker promotion must agree with whether a release blocker remains.
+tracker promotion must be `blocked` exactly when a release blocker remains; `hold` is only a
+non-gating partial disposition.
 Waived and deferred blockers additionally retain a durable owner and need a structured disposition
 naming the gate, authority, evidence URL, and public-safe reason. A failed required path may close
 the run as `BLOCKED` only with its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -99,8 +99,9 @@ four-slot agent tree.
 
 If the release-wide preflight finds an owned terminal blocker, do not manufacture passing app
 results to finish the ledger. Keep `APP_WORK_ALLOWED` false, retain the blocker ID and public-safe
-evidence, leave every app target untouched, audit the blocked disposition with no maker IDs, and
-close aggregate merge/reachability and promotion exactly as `blocked`, not `hold`. When report-only
+evidence, leave every app target untouched, keep the public marker pristine and unpublished, audit
+the blocked disposition with no maker IDs, and close aggregate merge/reachability and promotion
+exactly as `blocked`, not `hold`. When report-only
 tracks do run, their closeout evidence includes retained package versions/sources and terminal
 checks bound to the exact inspected head; those observed locks need not match the candidate
 snapshot, and `pending` or `unknown` is not a completed report. Candidate snapshot matching applies
@@ -169,7 +170,8 @@ An owned blocker referenced exclusively by soft-track inventory is non-gating fo
 the run `PARTIAL`; it becomes release-gating when preflight, a hard gate, or a required path shares
 that blocker.
 
-Every mutable target records the stable maker identity that performed its work, and the independent
+Every mutable target records the stable canonical nonblank maker identity that performed its work,
+and the independent checker must differ from every maker after canonical comparison. The independent
 audit's maker list must exactly cover those target identities and retain replayable public-safe
 audit evidence. Each hard-gate check is bound to the target's exact audited, reviewed, and current
 revision. Product gem/npm versions must normalize to the selected candidate; the independently

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -145,11 +145,14 @@ matrix from that exact file:
 ```bash
 ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --ledger tmp/fleet-validation-prompts/result-ledger.json \
+  --expected-pack-id PACK_ID \
   --expected-candidate vX.Y.Z.rc.N \
   --render-tracker tmp/fleet-validation-prompts/tracker-closeout.md
 ```
 
 Every nonterminal blocker needs a durable issue or public-safe tracker-only reason before closeout.
+The independently supplied expected pack ID and the ledger's unique public preflight-marker record
+must match the exact candidate snapshot before any distributed app work can validate.
 Waived and deferred blockers additionally retain a durable owner and need a structured disposition
 naming the gate, authority, evidence URL, and public-safe reason. A failed required path may close
 the run as `BLOCKED` only with its lane, failure evidence, and a `blocker_id` that resolves to a durable owner. Missing ownership,

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -80,6 +80,8 @@ targets that do run must retain their inspected package versions/sources and ter
 check evidence; their observed locks need not match the candidate snapshot. Candidate matching
 applies only to candidate-managed packages on hard gates, including the separately resolved RSC
 package, not independently versioned Shakapacker or Control Plane Flow dependencies.
+Untouched app rows may retain read-only package-lock probes, and the validation-only generator gate
+must bind its revision and check evidence to the pack's exact candidate commit.
 
 This candidate-scoped orchestration does not replace standing fleet-health/currency automation,
 which detects drift between releases. Hosted-CI dispatch and generator-CI routing improvements are

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -62,6 +62,11 @@ authorized merge, default reachability/tree parity, and tracker-matrix rendering
 prompt below remains the behavioral depth contract and a manual fallback; its evidence must still
 land in the generated ledger before closeout.
 
+The ledger binds each hard-gate check to an immutable audited/reviewed/current target revision,
+normalizes product gem/npm versions to the selected candidate, retains replayable independent-audit
+evidence, and records merge/reachability proof per mutable target. Its derived aggregate therefore
+represents partial fleet merges without discarding proof for lanes that already landed.
+
 A failed required release path closes as `BLOCKED` with lane evidence and an owned blocker reference;
 it must never be relabeled as passed or waived merely to satisfy closeout. Waived and deferred
 blockers require structured authority, evidence URL, and reason fields in addition to any durable

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -79,8 +79,9 @@ owner.
 
 An owned release-wide preflight defect may also close the candidate as `BLOCKED` without fabricating
 an app run. Keep `APP_WORK_ALLOWED` false, retain the preflight blocker ID and public-safe evidence,
-leave every app target untouched, record no maker identities in the independent audit, and mark
-aggregate merge/reachability plus tracker promotion `blocked` (not merely `hold`). Report-only
+leave every app target untouched, keep the public marker pristine and unpublished, record no maker
+identities in the independent audit, and mark aggregate merge/reachability plus tracker promotion
+`blocked` (not merely `hold`). Report-only
 targets that do run must retain their inspected package versions/sources and terminal exact-head
 check evidence; their observed locks need not match the candidate snapshot. Candidate matching
 applies only to candidate-managed packages on hard gates, including the separately resolved RSC

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -66,6 +66,9 @@ The ledger binds each hard-gate check to an immutable audited/reviewed/current t
 normalizes product gem/npm versions to the selected candidate, retains replayable independent-audit
 evidence, and records merge/reachability proof per mutable target. Its derived aggregate therefore
 represents partial fleet merges without discarding proof for lanes that already landed.
+Distributed app work additionally requires a `preflight.public_marker` record with unique status,
+exact pack/candidate/commit/fingerprint/opened-at identity, and replayable public-safe evidence.
+Closeout validation receives the expected pack ID independently rather than trusting the ledger.
 
 A failed required release path closes as `BLOCKED` with lane evidence and an owned blocker reference;
 it must never be relabeled as passed or waived merely to satisfy closeout. Waived and deferred

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -55,6 +55,18 @@ Use this prompt to update the demo fleet for an RC or final release. It compleme
 [`demo-fleet.yml`](demo-fleet.yml) block final release readiness, while soft-track repos are
 inspected and filed as follow-up unless a maintainer explicitly promotes them.
 
+For a coordinated candidate run, prefer the repo-local `$run-fleet-validation` lifecycle pack.
+That pack owns candidate snapshotting, the release-wide preflight barrier, complete hard/soft
+inventory, capability and baseline probes, the public-safe result ledger, independent audit,
+authorized merge, default reachability/tree parity, and tracker-matrix rendering. The long-form
+prompt below remains the behavioral depth contract and a manual fallback; its evidence must still
+land in the generated ledger before closeout.
+
+This candidate-scoped orchestration does not replace standing fleet-health/currency automation,
+which detects drift between releases. Hosted-CI dispatch and generator-CI routing improvements are
+also dependencies, not substitutes: they shorten individual gates but do not own blocker
+identities, combined audit, merge authority, or promotion closeout.
+
 ```text
 You are updating the React on Rails demo fleet for {{RELEASE_REF}}.
 

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -62,6 +62,11 @@ authorized merge, default reachability/tree parity, and tracker-matrix rendering
 prompt below remains the behavioral depth contract and a manual fallback; its evidence must still
 land in the generated ledger before closeout.
 
+A failed required release path closes as `BLOCKED` with lane evidence and an owned blocker reference;
+it must never be relabeled as passed or waived merely to satisfy closeout. Waived and deferred
+blockers require structured authority, evidence URL, and reason fields in addition to any durable
+owner.
+
 This candidate-scoped orchestration does not replace standing fleet-health/currency automation,
 which detects drift between releases. Hosted-CI dispatch and generator-CI routing improvements are
 also dependencies, not substitutes: they shorten individual gates but do not own blocker

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -68,8 +68,9 @@ evidence, and records merge/reachability proof per mutable target. Its derived a
 represents partial fleet merges without discarding proof for lanes that already landed.
 Distributed app work additionally requires a `preflight.public_marker` record with unique status,
 exact pack/candidate/commit/fingerprint/opened-at identity, and replayable public-safe evidence.
-Closeout validation receives the expected pack ID and generated release selector independently
-rather than trusting the ledger to redefine its own snapshot identity.
+Closeout validation receives the expected pack ID, generated release selector, candidate tag, and
+candidate source commit independently rather than trusting the ledger to redefine its own snapshot
+identity.
 
 A failed required release path closes as `BLOCKED` with lane evidence and an owned blocker reference;
 it must never be relabeled as passed or waived merely to satisfy closeout. Waived and deferred

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -72,6 +72,12 @@ it must never be relabeled as passed or waived merely to satisfy closeout. Waive
 blockers require structured authority, evidence URL, and reason fields in addition to any durable
 owner.
 
+An owned release-wide preflight defect may also close the candidate as `BLOCKED` without fabricating
+an app run. Keep `APP_WORK_ALLOWED` false, retain the preflight blocker ID and public-safe evidence,
+leave every app target untouched, record no maker identities in the independent audit, and mark
+aggregate merge/reachability plus tracker promotion blocked. Report-only targets that do run must
+retain their inspected package versions/sources and terminal exact-head check evidence.
+
 This candidate-scoped orchestration does not replace standing fleet-health/currency automation,
 which detects drift between releases. Hosted-CI dispatch and generator-CI routing improvements are
 also dependencies, not substitutes: they shorten individual gates but do not own blocker

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -68,7 +68,8 @@ evidence, and records merge/reachability proof per mutable target. Its derived a
 represents partial fleet merges without discarding proof for lanes that already landed.
 Distributed app work additionally requires a `preflight.public_marker` record with unique status,
 exact pack/candidate/commit/fingerprint/opened-at identity, and replayable public-safe evidence.
-Closeout validation receives the expected pack ID independently rather than trusting the ledger.
+Closeout validation receives the expected pack ID and generated release selector independently
+rather than trusting the ledger to redefine its own snapshot identity.
 
 A failed required release path closes as `BLOCKED` with lane evidence and an owned blocker reference;
 it must never be relabeled as passed or waived merely to satisfy closeout. Waived and deferred

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -68,9 +68,9 @@ evidence, and records merge/reachability proof per mutable target. Its derived a
 represents partial fleet merges without discarding proof for lanes that already landed.
 Distributed app work additionally requires a `preflight.public_marker` record with unique status,
 exact pack/candidate/commit/fingerprint/opened-at identity, and replayable public-safe evidence.
-Closeout validation receives the expected pack ID, generated release selector, candidate tag, and
-candidate source commit independently rather than trusting the ledger to redefine its own snapshot
-identity.
+Closeout validation receives the expected pack ID, generated release selector, candidate tag,
+candidate source commit, policy commit, and tracker mode independently rather than trusting the
+ledger to redefine its own snapshot identity.
 
 A failed required release path closes as `BLOCKED` with lane evidence and an owned blocker reference;
 it must never be relabeled as passed or waived merely to satisfy closeout. Waived and deferred

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -75,8 +75,11 @@ owner.
 An owned release-wide preflight defect may also close the candidate as `BLOCKED` without fabricating
 an app run. Keep `APP_WORK_ALLOWED` false, retain the preflight blocker ID and public-safe evidence,
 leave every app target untouched, record no maker identities in the independent audit, and mark
-aggregate merge/reachability plus tracker promotion blocked. Report-only targets that do run must
-retain their inspected package versions/sources and terminal exact-head check evidence.
+aggregate merge/reachability plus tracker promotion `blocked` (not merely `hold`). Report-only
+targets that do run must retain their inspected package versions/sources and terminal exact-head
+check evidence; their observed locks need not match the candidate snapshot. Candidate matching
+applies only to candidate-managed packages on hard gates, including the separately resolved RSC
+package, not independently versioned Shakapacker or Control Plane Flow dependencies.
 
 This candidate-scoped orchestration does not replace standing fleet-health/currency automation,
 which detects drift between releases. Hosted-CI dispatch and generator-CI routing improvements are
@@ -128,6 +131,8 @@ Repos:
 - Prioritize every `hard_gate` repo first; hard-gate failures block final release readiness.
 - Then inspect every `soft_track` repo; do not let soft-track failures block final unless a
   maintainer promotes that repo.
+- Keep an owned blocker referenced exclusively by soft tracks as non-gating `PARTIAL` follow-up.
+  The same blocker is release-gating if preflight, a hard gate, or a required path also references it.
 - Treat `shakacode/hichee` and Pro details as private: public tracker comments may say
   install/build/smoke/CI passed or failed, but must not expose private logs, URLs, screenshots,
   customer data, secrets, or proprietary Pro source details.


### PR DESCRIPTION
## Why

Fleet validation prompts could be generated, but the repository did not provide a complete, fail-closed lifecycle for preflight authorization, evidence capture, ledger validation, independent audit, merge reachability, and release closeout. That made sanitized RC replay and cross-machine coordination difficult to verify.

## What

- Add a typed fleet lifecycle generator and ledger validator with exact external pack, selector, tag, candidate-commit, and fingerprint anchors.
- Enforce preflight barriers, canonical maker/checker identities, immutable evidence binding, hard/soft blocker semantics, published-artifact source rules, merge reachability, and exact promotion outcomes.
- Generate schema-valid lane inventory and pack-bound public preflight markers for distributed execution.
- Add a sanitized RC12 lifecycle fixture and replay command.
- Document generation, ledger updates, audit, closeout, and release-verification responsibilities.

## Verification

- 164 lifecycle/generator tests, 661 assertions, 0 failures
- Sanitized RC12 lifecycle replay: PASS
- RuboCop on 5 changed Ruby files: no offenses
- Skill quick validation: PASS
- Agent workflow seam doctor: PASS
- `git diff --check`: PASS
- Full pre-commit and commit hooks with Lychee 0.23.0: PASS, no skipped hooks
- Pre-push RuboCop and online Markdown link checks: PASS
- Repeated bounded adversarial and type/state-machine review; all preserved findings covered by focused RED/GREEN tests

Closes #4713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full React on Rails release-validation lifecycle with preflight barriers, fail-closed ledger validation, structured lifecycle artifacts, and a durable result ledger/schema with closeout tracker rendering.
  * Enforced hard-gate coordination with report-only coverage for non-gating tracks, including stricter blocker ownership and app-work authority rules.
  * Added a result-ledger validation CLI plus an RC12 replay workflow for end-to-end verification.

* **Documentation**
  * Updated the workflow guidance, runbook, and testing plan with tighter sequencing, evidence, and closure invariants.

* **Tests**
  * Added extensive generator/ledger validation, CLI failure-path coverage, and RC12 replay regression checks (including new sanitized fixtures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

