### PR TITLE
CI verification: exercise post-merge gem selectors

### DIFF
--- a/react_on_rails/spec/react_on_rails/configuration_spec.rb
+++ b/react_on_rails/spec/react_on_rails/configuration_spec.rb
@@ -37,8 +37,6 @@ module ReactOnRails
       end
 
       it "does not throw if the generated assets dir is blank with shakapacker" do
-        expect(described_class.name).to eq("ReactOnRails::Configuration")
-
         expect do
           ReactOnRails.configure do |config|
             config.generated_assets_dir = ""

--- a/react_on_rails/spec/react_on_rails/configuration_spec.rb
+++ b/react_on_rails/spec/react_on_rails/configuration_spec.rb
@@ -3,6 +3,7 @@
 require_relative "spec_helper"
 require "shakapacker"
 
+# Verification-only touch for the post-merge unit-row selector exercise.
 # rubocop:disable Metrics/ModuleLength
 
 module ReactOnRails

--- a/react_on_rails/spec/react_on_rails/configuration_spec.rb
+++ b/react_on_rails/spec/react_on_rails/configuration_spec.rb
@@ -3,7 +3,6 @@
 require_relative "spec_helper"
 require "shakapacker"
 
-# Verification-only touch for the post-merge unit-row selector exercise.
 # rubocop:disable Metrics/ModuleLength
 
 module ReactOnRails
@@ -38,6 +37,8 @@ module ReactOnRails
       end
 
       it "does not throw if the generated assets dir is blank with shakapacker" do
+        expect(described_class.name).to eq("ReactOnRails::Configuration")
+
         expect do
           ReactOnRails.configure do |config|
             config.generated_assets_dir = ""

--- a/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
@@ -7,6 +7,7 @@ require_relative "../support/generator_spec_helper"
 describe GeneratorMessages do
   it "has an empty messages array" do
     expect(described_class.messages).to be_empty
+    expect(described_class.messages).to eq([])
   end
 
   it "has a method that can add errors" do


### PR DESCRIPTION
Disposable verification PR for #4683 after #4746 merged.

Exact-head exercise plan:

1. Current head changes only a non-generator gem spec and must run exactly the optimized latest-dependency unit row.
2. A follow-up head will add a generator-spec-only touch and must run the latest unit row plus all three deterministic generator subshards.

Capture head SHAs, workflow run IDs, generated matrices, required gate, and `+ci-status` evidence on #4683. Close unmerged and delete this branch after both heads verify.

Do not merge this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a test assertion for clearer verification of the generator messages’ initial empty state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->