### PR TITLE
Agents: automate public demo fleet standing health

### DIFF
--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -48,19 +48,19 @@ entries explicitly marked `standing_health.public: true` plus the manifest's arc
 targets. It never queries or emits a non-public lane, never mutates a demo repository, and never
 turns archived or `soft_track` entries into blocking targets.
 
-For the v17 stable line:
+The manifest's `standing_health.stable_release` and `standing_health.rsc_version` fields are the
+authoritative scheduled defaults:
 
 ```bash
 GITHUB_TOKEN="$(gh auth token)" \
   bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
     --live \
-    --release v17.0.0 \
-    --rsc-version 19.2.1 \
-    --pack-id "fleet-health-v17-$(date -u +%Y%m%dT%H%M%SZ)" \
+    --pack-id "fleet-health-stable-$(date -u +%Y%m%dT%H%M%SZ)" \
     --policy-commit "$(git rev-parse HEAD)" \
-    --output-dir tmp/fleet-health-v17
+    --output-dir tmp/fleet-health-stable
 ```
 
+Pass `--release` and/or `--rsc-version` only for an intentional manual override.
 The command verifies both `react_on_rails` gems and all four unified-version npm packages, plus the
 independently versioned `react-on-rails-rsc`, before inspecting public default heads. It writes
 `fleet-health.json`, `fleet-health.schema.json`, and `fleet-health.md`. Currency uses only direct

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -65,16 +65,21 @@ The command verifies both `react_on_rails` gems and all four unified-version npm
 independently versioned `react-on-rails-rsc`, before inspecting public default heads. It writes
 `fleet-health.json`, `fleet-health.schema.json`, and `fleet-health.md`. Currency uses only direct
 root `DEPENDS_ON` packages from each public SPDX SBOM and rejects mixed direct versions; missing
-root identity fails closed. CI and reusable-smoke evidence remains exact-default-head, while
-PR-only review-app capability uses the exact `standing_health.review_app_workflow` public path and
-its latest public run URL and timestamp. Staging, cleanup, delete, help, and promotion workflows
-never substitute for that path. Active public targets block on missing, stale, failed, or unknown
-required evidence.
+root identity fails closed. npm prereleases use the repository's dot-to-hyphen ecosystem
+normalization. CI remains exact-default-head. Reusable-smoke evidence requires a successful
+exact-head execution of the workflow that actually calls the shared contract; required commands
+must be nonblank and required stages must all succeed. PR-only review-app capability uses the exact
+`standing_health.review_app_workflow` public path and a recent `pull_request` run whose base branch,
+head branch, and head SHA agree with its public PR metadata. Staging, cleanup, delete, help, and
+promotion workflows never substitute for that path. GitHub archival of an active target is
+surfaced as blocking manifest drift. Active public targets block on missing, stale, failed, or
+unknown required evidence.
 Report-only and archived targets retain findings without blocking the aggregate. The scheduled
 `.github/workflows/demo-fleet-health.yml` run uploads the same three evidence files.
 
-The Dependabot v1 evaluation is deliberately narrow: weekly enabled Bundler/npm/GitHub Actions
-coverage plus grouped React on Rails gem/npm updates. Do not substitute a generic Renovate preset.
+The Dependabot v1 evaluation is deliberately narrow: the same enabled weekly root entry must
+provide Bundler/npm/GitHub Actions coverage, with React on Rails grouping on the qualifying gem/npm
+entry. Do not substitute a generic Renovate preset.
 
 ## Launch and coordinate
 

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -12,7 +12,7 @@ Generate the prompt pack from the manifest instead of copying repository lists i
 From the React on Rails repository root, run:
 
 ```bash
-ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
   --machines local,m1 \
   --prompts 6 \
   --output-dir tmp/fleet-validation-prompts
@@ -52,7 +52,7 @@ For the v17 stable line:
 
 ```bash
 GITHUB_TOKEN="$(gh auth token)" \
-  ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
+  bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
     --live \
     --release v17.0.0 \
     --rsc-version 19.2.1 \
@@ -156,7 +156,7 @@ The independent checker validates the exact ledger and renders the append-only t
 that same file:
 
 ```bash
-ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --ledger tmp/fleet-validation-prompts/result-ledger.json \
   --expected-pack-id PACK_ID \
   --expected-release-selector "GENERATED_RELEASE_SELECTOR" \
@@ -211,8 +211,8 @@ audit also records replayable public-safe evidence.
 For the checked-in sanitized RC12 regression corpus:
 
 ```bash
-ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
-ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
 ```
 
 ## Validate changes to this skill
@@ -220,10 +220,10 @@ ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
 Run both checks after changing the generator or prompt contract:
 
 ```bash
-ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
-ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
-ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
-ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
 python3 "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" \
   .agents/skills/run-fleet-validation
 ```

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -61,12 +61,15 @@ GITHUB_TOKEN="$(gh auth token)" \
     --output-dir tmp/fleet-health-v17
 ```
 
-The command verifies the exact public RubyGems/npm artifacts before inspecting public default
-heads. It writes `fleet-health.json`, `fleet-health.schema.json`, and `fleet-health.md`, binding
-currency, CI, reusable-smoke adoption, review-app capability, staleness, and Dependabot v1 evidence
-to exact public default commits. Active public targets block on missing, stale, failed, or unknown
-required evidence. Report-only and archived targets retain findings without blocking the aggregate.
-The scheduled `.github/workflows/demo-fleet-health.yml` run uploads the same three artifacts.
+The command verifies both `react_on_rails` gems and all four unified-version npm packages, plus the
+independently versioned `react-on-rails-rsc`, before inspecting public default heads. It writes
+`fleet-health.json`, `fleet-health.schema.json`, and `fleet-health.md`. Currency uses only direct
+root `DEPENDS_ON` packages from each public SPDX SBOM and rejects mixed direct versions; missing
+root identity fails closed. CI and reusable-smoke evidence remains exact-default-head, while
+PR-only review-app capability uses the configured public workflow and its latest public run URL
+and timestamp. Active public targets block on missing, stale, failed, or unknown required evidence.
+Report-only and archived targets retain findings without blocking the aggregate. The scheduled
+`.github/workflows/demo-fleet-health.yml` run uploads the same three evidence files.
 
 The Dependabot v1 evaluation is deliberately narrow: weekly enabled Bundler/npm/GitHub Actions
 coverage plus grouped React on Rails gem/npm updates. Do not substitute a generic Renovate preset.

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-fleet-validation
-description: Generate and coordinate the complete React on Rails release fleet lifecycle from internal/contributor-info/demo-fleet.yml. Use when a maintainer wants to validate the latest RC or beta, split fleet work across machines or agent sessions, inspect fleet progress, or run fail-closed release closeout from a durable result ledger.
+description: Generate and coordinate the complete React on Rails release fleet lifecycle or public-only standing-health evidence from internal/contributor-info/demo-fleet.yml. Use when a maintainer wants to validate an RC/beta/final, inspect fleet currency/default health, split release work across machines, or run fail-closed closeout.
 ---
 
 # Run Fleet Validation
@@ -40,6 +40,36 @@ candidate, reuse its existing generated files or create a fresh pack; regenerati
 prove that the dynamic selector still resolves to the same candidate. A changed candidate or
 policy/inventory manifest fails closed. Generate a fresh pack in a fresh output directory; one pack
 must never replace another pack's durable result ledger.
+
+## Generate public standing-health evidence
+
+Standing health is a sibling contract, not a shortened candidate closeout. It reads only manifest
+entries explicitly marked `standing_health.public: true` plus the manifest's archived public
+targets. It never queries or emits a non-public lane, never mutates a demo repository, and never
+turns archived or `soft_track` entries into blocking targets.
+
+For the v17 stable line:
+
+```bash
+GITHUB_TOKEN="$(gh auth token)" \
+  ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
+    --live \
+    --release v17.0.0 \
+    --rsc-version 19.2.1 \
+    --pack-id "fleet-health-v17-$(date -u +%Y%m%dT%H%M%SZ)" \
+    --policy-commit "$(git rev-parse HEAD)" \
+    --output-dir tmp/fleet-health-v17
+```
+
+The command verifies the exact public RubyGems/npm artifacts before inspecting public default
+heads. It writes `fleet-health.json`, `fleet-health.schema.json`, and `fleet-health.md`, binding
+currency, CI, reusable-smoke adoption, review-app capability, staleness, and Dependabot v1 evidence
+to exact public default commits. Active public targets block on missing, stale, failed, or unknown
+required evidence. Report-only and archived targets retain findings without blocking the aggregate.
+The scheduled `.github/workflows/demo-fleet-health.yml` run uploads the same three artifacts.
+
+The Dependabot v1 evaluation is deliberately narrow: weekly enabled Bundler/npm/GitHub Actions
+coverage plus grouped React on Rails gem/npm updates. Do not substitute a generic Renovate preset.
 
 ## Launch and coordinate
 
@@ -172,6 +202,7 @@ For the checked-in sanitized RC12 regression corpus:
 
 ```bash
 ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
 ```
 
 ## Validate changes to this skill
@@ -181,6 +212,8 @@ Run both checks after changing the generator or prompt contract:
 ```bash
 ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
 ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb
+ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
 python3 "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" \
   .agents/skills/run-fleet-validation
 ```

--- a/.agents/skills/run-fleet-validation/SKILL.md
+++ b/.agents/skills/run-fleet-validation/SKILL.md
@@ -66,8 +66,10 @@ independently versioned `react-on-rails-rsc`, before inspecting public default h
 `fleet-health.json`, `fleet-health.schema.json`, and `fleet-health.md`. Currency uses only direct
 root `DEPENDS_ON` packages from each public SPDX SBOM and rejects mixed direct versions; missing
 root identity fails closed. CI and reusable-smoke evidence remains exact-default-head, while
-PR-only review-app capability uses the configured public workflow and its latest public run URL
-and timestamp. Active public targets block on missing, stale, failed, or unknown required evidence.
+PR-only review-app capability uses the exact `standing_health.review_app_workflow` public path and
+its latest public run URL and timestamp. Staging, cleanup, delete, help, and promotion workflows
+never substitute for that path. Active public targets block on missing, stale, failed, or unknown
+required evidence.
 Report-only and archived targets retain findings without blocking the aggregate. The scheduled
 `.github/workflows/demo-fleet-health.yml` run uploads the same three evidence files.
 

--- a/.agents/skills/run-fleet-validation/agents/openai.yaml
+++ b/.agents/skills/run-fleet-validation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Run Fleet Validation"
-  short_description: "Run release fleet validation through durable closeout"
-  default_prompt: "Use $run-fleet-validation to generate and coordinate the latest RC or beta through preflight, fleet evidence, independent audit, and ledger-driven closeout."
+  short_description: "Run release lifecycle or standing fleet-health validation"
+  default_prompt: "Use $run-fleet-validation to generate either a candidate lifecycle pack through durable closeout or a public-only stable standing-health evidence pack."

--- a/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
+++ b/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
@@ -2,6 +2,8 @@ manifest:
   schema_version: 1
   standing_health:
     schema_version: 1
+    stable_release: v17.0.0
+    rsc_version: 19.2.1
     max_minor_lag: 1
     max_default_age_days: 45
     dependabot_policy: v1

--- a/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
+++ b/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
@@ -20,6 +20,7 @@ manifest:
         public: true
         disposition: active
         review_app: required
+        review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     - name: sanitized/active-drifted
       headline: Active drifted demo
       tier: hard_gate
@@ -31,6 +32,7 @@ manifest:
         public: true
         disposition: active
         review_app: required
+        review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     - name: sanitized/report-only
       headline: Report-only historical demo
       tier: soft_track

--- a/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
+++ b/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
@@ -53,6 +53,7 @@ observations:
     default_branch: main
     default_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     default_commit_at: "2026-07-17T12:00:00Z"
+    repository_archived: false
     observed_at: "2026-07-18T12:00:00Z"
     package_versions:
       - { ecosystem: gem, name: react_on_rails, version: 17.0.0, source: lockfile }
@@ -68,6 +69,7 @@ observations:
     default_branch: main
     default_commit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     default_commit_at: "2026-03-01T12:00:00Z"
+    repository_archived: false
     observed_at: "2026-07-18T12:00:00Z"
     package_versions:
       - { ecosystem: gem, name: react_on_rails, version: 16.6.0, source: lockfile }
@@ -84,6 +86,7 @@ observations:
     default_branch: main
     default_commit: cccccccccccccccccccccccccccccccccccccccc
     default_commit_at: "2024-01-01T12:00:00Z"
+    repository_archived: false
     observed_at: "2026-07-18T12:00:00Z"
     package_versions:
       - { ecosystem: gem, name: react_on_rails, version: 14.0.3, source: lockfile }
@@ -98,6 +101,7 @@ observations:
     default_branch: main
     default_commit: dddddddddddddddddddddddddddddddddddddddd
     default_commit_at: "2023-01-01T12:00:00Z"
+    repository_archived: true
     observed_at: "2026-07-18T12:00:00Z"
     package_versions: []
     default_ci: { status: not_applicable, evidence: "archived" }

--- a/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
+++ b/.agents/skills/run-fleet-validation/fixtures/rc12-health-drift.yml
@@ -1,0 +1,107 @@
+manifest:
+  schema_version: 1
+  standing_health:
+    schema_version: 1
+    max_minor_lag: 1
+    max_default_age_days: 45
+    dependabot_policy: v1
+    archived_targets:
+      - name: sanitized/archived
+        headline: Archived demo
+        packages: []
+  repos:
+    - name: sanitized/active-current
+      headline: Active current demo
+      tier: hard_gate
+      packages:
+        - { ecosystem: gem, name: react_on_rails }
+        - { ecosystem: npm, name: react-on-rails }
+      standing_health:
+        public: true
+        disposition: active
+        review_app: required
+    - name: sanitized/active-drifted
+      headline: Active drifted demo
+      tier: hard_gate
+      packages:
+        - { ecosystem: gem, name: react_on_rails }
+        - { ecosystem: npm, name: react-on-rails }
+        - { ecosystem: npm, name: react-on-rails-rsc }
+      standing_health:
+        public: true
+        disposition: active
+        review_app: required
+    - name: sanitized/report-only
+      headline: Report-only historical demo
+      tier: soft_track
+      packages:
+        - { ecosystem: gem, name: react_on_rails }
+      standing_health:
+        public: true
+        disposition: report_only
+        review_app: not_required
+    - name: sanitized/not-in-public-health
+      headline: Excluded target
+      tier: hard_gate
+      packages:
+        - { ecosystem: gem, name: react_on_rails }
+
+observations:
+  sanitized-active-current:
+    default_branch: main
+    default_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    default_commit_at: "2026-07-17T12:00:00Z"
+    observed_at: "2026-07-18T12:00:00Z"
+    package_versions:
+      - { ecosystem: gem, name: react_on_rails, version: 17.0.0, source: lockfile }
+      - { ecosystem: npm, name: react-on-rails, version: 17.0.0, source: lockfile }
+    default_ci: { status: passed, evidence: "sanitized current-head CI" }
+    smoke: { status: passed, shared_contract: true, evidence: "sanitized exact-head smoke" }
+    review_app: { status: passed, evidence: "sanitized review-app smoke" }
+    dependabot:
+      status: passed
+      policy: v1
+      evidence: "sanitized Dependabot ecosystems and weekly groups"
+  sanitized-active-drifted:
+    default_branch: main
+    default_commit: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    default_commit_at: "2026-03-01T12:00:00Z"
+    observed_at: "2026-07-18T12:00:00Z"
+    package_versions:
+      - { ecosystem: gem, name: react_on_rails, version: 16.6.0, source: lockfile }
+      - { ecosystem: npm, name: react-on-rails, version: 16.6.0, source: lockfile }
+      - { ecosystem: npm, name: react-on-rails-rsc, version: 19.2.1-rc.0, source: lockfile }
+    default_ci: { status: blocked, evidence: "sanitized baseline gate failure" }
+    smoke: { status: blocked, shared_contract: false, evidence: "sanitized interaction drift" }
+    review_app: { status: unknown, evidence: "sanitized inconclusive deployed smoke" }
+    dependabot:
+      status: blocked
+      policy: v1
+      evidence: "sanitized missing ecosystem coverage"
+  sanitized-report-only:
+    default_branch: main
+    default_commit: cccccccccccccccccccccccccccccccccccccccc
+    default_commit_at: "2024-01-01T12:00:00Z"
+    observed_at: "2026-07-18T12:00:00Z"
+    package_versions:
+      - { ecosystem: gem, name: react_on_rails, version: 14.0.3, source: lockfile }
+    default_ci: { status: unknown, evidence: "sanitized report-only CI" }
+    smoke: { status: unknown, shared_contract: false, evidence: "sanitized report-only smoke" }
+    review_app: { status: not_applicable, evidence: "report-only" }
+    dependabot:
+      status: blocked
+      policy: v1
+      evidence: "sanitized report-only missing config"
+  sanitized-archived:
+    default_branch: main
+    default_commit: dddddddddddddddddddddddddddddddddddddddd
+    default_commit_at: "2023-01-01T12:00:00Z"
+    observed_at: "2026-07-18T12:00:00Z"
+    package_versions: []
+    default_ci: { status: not_applicable, evidence: "archived" }
+    smoke: { status: not_applicable, shared_contract: false, evidence: "archived" }
+    review_app: { status: not_applicable, evidence: "archived" }
+    dependabot:
+      status: not_applicable
+      policy: v1
+      evidence: "archived"

--- a/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
@@ -5,17 +5,22 @@ require "optparse"
 require "base64"
 require "json"
 require "net/http"
+require "openssl"
 require "securerandom"
+require "timeout"
 require "uri"
 require "yaml"
 require_relative "fleet_health"
 
 module FleetValidation
+  class TransientPublicRequestError < StandardError; end
+
   class PublicHTTPClient
     USER_AGENT = "react-on-rails-fleet-health/1"
 
-    def initialize(github_token: ENV["GITHUB_TOKEN"])
+    def initialize(github_token: ENV["GITHUB_TOKEN"], transport: Net::HTTP)
       @github_token = github_token
+      @transport = transport
     end
 
     def json(url)
@@ -24,7 +29,7 @@ module FleetValidation
       request["Accept"] = "application/vnd.github+json"
       request["User-Agent"] = USER_AGENT
       request["Authorization"] = "Bearer #{@github_token}" if @github_token && uri.host == "api.github.com"
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 15, read_timeout: 30) do |http|
+      response = @transport.start(uri.host, uri.port, use_ssl: true, open_timeout: 15, read_timeout: 30) do |http|
         http.request(request)
       end
       unless response.is_a?(Net::HTTPSuccess)
@@ -34,6 +39,8 @@ module FleetValidation
       JSON.parse(response.body)
     rescue JSON::ParserError => e
       raise ManifestError, "public HTTP GET #{url} returned invalid JSON: #{e.message}"
+    rescue SocketError, SystemCallError, Timeout::Error, EOFError, OpenSSL::SSL::SSLError => e
+      raise TransientPublicRequestError, "#{e.class}: #{e.message}"
     end
   end
 
@@ -60,7 +67,7 @@ module FleetValidation
   module FleetHealthCLI
     module_function
 
-    def run(argv)
+    def run(argv, http: nil)
       options = {
         manifest_path: "internal/contributor-info/demo-fleet.yml",
         observations_path: nil,
@@ -75,9 +82,10 @@ module FleetValidation
       }
       parser = option_parser(options)
       parser.parse!(argv)
-      require_options!(options)
 
       manifest = load_yaml(options.fetch(:manifest_path))
+      apply_manifest_versions!(options, manifest)
+      require_options!(options)
       contract = FleetHealth.new(
         manifest:,
         pack_id: options[:pack_id] || "fleet-health-#{SecureRandom.hex(4)}",
@@ -86,12 +94,15 @@ module FleetValidation
         policy_commit: options.fetch(:policy_commit),
         generated_at: options.fetch(:generated_at)
       )
-      observations, registry_artifacts = evidence_inputs(options, contract)
+      observations, registry_artifacts = evidence_inputs(options, contract, http:)
       evidence = contract.evaluate(observations:, registry_artifacts:)
       contract.write_pack(options.fetch(:output_dir), evidence)
       puts "Wrote public fleet health pack to #{options.fetch(:output_dir)}"
       puts "Aggregate: #{evidence.dig('aggregate', 'status')}"
       0
+    rescue TransientPublicRequestError => e
+      warn "ERROR: live public request failed: #{e.message}"
+      1
     rescue Errno::ENOENT, Psych::Exception, ManifestError, OptionParser::ParseError => e
       warn "ERROR: #{e.message}"
       warn parser
@@ -141,11 +152,16 @@ module FleetValidation
             "--live or both --observations and --registry-artifacts"
     end
 
+    def apply_manifest_versions!(options, manifest)
+      options[:release] ||= manifest.dig("standing_health", "stable_release")
+      options[:rsc_version] ||= manifest.dig("standing_health", "rsc_version")
+    end
+
     def load_yaml(path)
       YAML.safe_load_file(path, permitted_classes: [], permitted_symbols: [], aliases: false)
     end
 
-    def evidence_inputs(options, contract)
+    def evidence_inputs(options, contract, http: nil)
       unless options[:live]
         return [
           load_yaml(options.fetch(:observations_path)),
@@ -153,7 +169,7 @@ module FleetValidation
         ]
       end
 
-      http = PublicHTTPClient.new
+      http ||= PublicHTTPClient.new
       registry = PublicRegistryResolver.new(fetcher: ->(url) { http.json(url) }).resolve(
         release: options.fetch(:release),
         rsc_version: options.fetch(:rsc_version)

--- a/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
@@ -190,7 +190,10 @@ module FleetValidation
         release: options.fetch(:release),
         rsc_version: options.fetch(:rsc_version)
       )
-      probe = PublicGitHubProbe.new(client: PublicGitHubClient.new(http:))
+      probe = PublicGitHubProbe.new(
+        client: PublicGitHubClient.new(http:),
+        max_default_age_days: contract.max_default_age_days
+      )
       observations = contract.targets.to_h do |target|
         [target.fetch("id"), probe.observe(target, observed_at: options.fetch(:generated_at))]
       end

--- a/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
@@ -15,6 +15,15 @@ require_relative "fleet_health"
 module FleetValidation
   class TransientPublicRequestError < StandardError; end
 
+  class PublicHTTPResponseError < ManifestError
+    attr_reader :status
+
+    def initialize(status, message)
+      @status = status.to_i
+      super(message)
+    end
+  end
+
   class PublicHTTPClient
     USER_AGENT = "react-on-rails-fleet-health/1"
 
@@ -33,7 +42,10 @@ module FleetValidation
         http.request(request)
       end
       unless response.is_a?(Net::HTTPSuccess)
-        raise ManifestError, "public HTTP GET #{uri} failed with #{response.code}"
+        raise PublicHTTPResponseError.new(
+          response.code,
+          "public HTTP GET #{uri} failed with #{response.code}"
+        )
       end
 
       JSON.parse(response.body)
@@ -61,6 +73,10 @@ module FleetValidation
       raise ManifestError, "#{repo}:#{path} is not a file" unless result["type"] == "file"
 
       Base64.decode64(result.fetch("content"))
+    rescue PublicHTTPResponseError => e
+      raise unless e.status == 404
+
+      raise MissingPublicContentError, "#{repo}:#{path} is unavailable"
     end
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/check_fleet_health.rb
@@ -1,0 +1,170 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "base64"
+require "json"
+require "net/http"
+require "securerandom"
+require "uri"
+require "yaml"
+require_relative "fleet_health"
+
+module FleetValidation
+  class PublicHTTPClient
+    USER_AGENT = "react-on-rails-fleet-health/1"
+
+    def initialize(github_token: ENV["GITHUB_TOKEN"])
+      @github_token = github_token
+    end
+
+    def json(url)
+      uri = URI(url)
+      request = Net::HTTP::Get.new(uri)
+      request["Accept"] = "application/vnd.github+json"
+      request["User-Agent"] = USER_AGENT
+      request["Authorization"] = "Bearer #{@github_token}" if @github_token && uri.host == "api.github.com"
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 15, read_timeout: 30) do |http|
+        http.request(request)
+      end
+      unless response.is_a?(Net::HTTPSuccess)
+        raise ManifestError, "public HTTP GET #{uri} failed with #{response.code}"
+      end
+
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      raise ManifestError, "public HTTP GET #{url} returned invalid JSON: #{e.message}"
+    end
+  end
+
+  class PublicGitHubClient
+    API = "https://api.github.com"
+
+    def initialize(http:)
+      @http = http
+    end
+
+    def get(path)
+      @http.json("#{API}#{path}")
+    end
+
+    def content(repo, path, ref:)
+      encoded = path.split("/").map { |part| URI.encode_www_form_component(part) }.join("/")
+      result = get("/repos/#{repo}/contents/#{encoded}?ref=#{URI.encode_www_form_component(ref)}")
+      raise ManifestError, "#{repo}:#{path} is not a file" unless result["type"] == "file"
+
+      Base64.decode64(result.fetch("content"))
+    end
+  end
+
+  module FleetHealthCLI
+    module_function
+
+    def run(argv)
+      options = {
+        manifest_path: "internal/contributor-info/demo-fleet.yml",
+        observations_path: nil,
+        registry_artifacts_path: nil,
+        release: nil,
+        rsc_version: nil,
+        pack_id: nil,
+        policy_commit: nil,
+        generated_at: Time.now.utc.iso8601,
+        output_dir: nil,
+        live: false
+      }
+      parser = option_parser(options)
+      parser.parse!(argv)
+      require_options!(options)
+
+      manifest = load_yaml(options.fetch(:manifest_path))
+      contract = FleetHealth.new(
+        manifest:,
+        pack_id: options[:pack_id] || "fleet-health-#{SecureRandom.hex(4)}",
+        release: options.fetch(:release),
+        rsc_version: options.fetch(:rsc_version),
+        policy_commit: options.fetch(:policy_commit),
+        generated_at: options.fetch(:generated_at)
+      )
+      observations, registry_artifacts = evidence_inputs(options, contract)
+      evidence = contract.evaluate(observations:, registry_artifacts:)
+      contract.write_pack(options.fetch(:output_dir), evidence)
+      puts "Wrote public fleet health pack to #{options.fetch(:output_dir)}"
+      puts "Aggregate: #{evidence.dig('aggregate', 'status')}"
+      0
+    rescue Errno::ENOENT, Psych::Exception, ManifestError, OptionParser::ParseError => e
+      warn "ERROR: #{e.message}"
+      warn parser
+      1
+    end
+
+    def option_parser(options)
+      OptionParser.new do |parser|
+        parser.banner = "Usage: check_fleet_health.rb --release TAG --rsc-version VERSION [options]"
+        parser.on("--manifest PATH", "Fleet manifest path") { |value| options[:manifest_path] = value }
+        parser.on("--observations PATH", "Offline public observations YAML") do |value|
+          options[:observations_path] = value
+        end
+        parser.on("--registry-artifacts PATH", "Offline public registry artifacts YAML") do |value|
+          options[:registry_artifacts_path] = value
+        end
+        parser.on("--live", "Read public registries and public GitHub default heads") { options[:live] = true }
+        parser.on("--release TAG", "Stable React on Rails tag") { |value| options[:release] = value }
+        parser.on("--rsc-version VERSION", "Stable react-on-rails-rsc version") do |value|
+          options[:rsc_version] = value
+        end
+        parser.on("--pack-id ID", "Stable evidence pack ID") { |value| options[:pack_id] = value }
+        parser.on("--policy-commit SHA", "Exact policy commit") { |value| options[:policy_commit] = value }
+        parser.on("--generated-at TIME", "ISO-8601 evidence timestamp") { |value| options[:generated_at] = value }
+        parser.on("--output-dir PATH", "Output directory") { |value| options[:output_dir] = value }
+        parser.on("-h", "--help", "Show help") do
+          puts parser
+          exit 0
+        end
+      end
+    end
+
+    def require_options!(options)
+      %i[release rsc_version policy_commit output_dir].each do |key|
+        next if options[key]
+
+        raise OptionParser::MissingArgument, "--#{key.to_s.tr('_', '-')}"
+      end
+      offline = options[:observations_path] && options[:registry_artifacts_path]
+      partial_offline = options[:observations_path] || options[:registry_artifacts_path]
+      if options[:live] && partial_offline
+        raise OptionParser::InvalidArgument, "--live cannot be combined with offline evidence paths"
+      end
+      return if options[:live] || offline
+
+      raise OptionParser::MissingArgument,
+            "--live or both --observations and --registry-artifacts"
+    end
+
+    def load_yaml(path)
+      YAML.safe_load_file(path, permitted_classes: [], permitted_symbols: [], aliases: false)
+    end
+
+    def evidence_inputs(options, contract)
+      unless options[:live]
+        return [
+          load_yaml(options.fetch(:observations_path)),
+          load_yaml(options.fetch(:registry_artifacts_path))
+        ]
+      end
+
+      http = PublicHTTPClient.new
+      registry = PublicRegistryResolver.new(fetcher: ->(url) { http.json(url) }).resolve(
+        release: options.fetch(:release),
+        rsc_version: options.fetch(:rsc_version)
+      )
+      probe = PublicGitHubProbe.new(client: PublicGitHubClient.new(http:))
+      observations = contract.targets.to_h do |target|
+        [target.fetch("id"), probe.observe(target, observed_at: options.fetch(:generated_at))]
+      end
+      [observations, registry]
+    end
+  end
+end
+
+exit FleetValidation::FleetHealthCLI.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -195,10 +195,10 @@ module FleetValidation
     PASSING_CONCLUSIONS = %w[success neutral skipped].freeze
     DEPENDABOT_PATHS = %w[.github/dependabot.yml .github/dependabot.yaml].freeze
     MAX_PAGES = 20
-    REVIEW_APP_MAX_AGE_DAYS = 45
 
-    def initialize(client:)
+    def initialize(client:, max_default_age_days:)
       @client = client
+      @max_default_age_days = max_default_age_days
     end
 
     def observe(target, observed_at:)
@@ -479,9 +479,9 @@ module FleetValidation
 
       started_at = Time.iso8601(run["run_started_at"].to_s)
       age_seconds = Time.iso8601(observed_at) - started_at
-      return "run age exceeds #{REVIEW_APP_MAX_AGE_DAYS} days" unless age_seconds.between?(
+      return "run age exceeds #{@max_default_age_days} days" unless age_seconds.between?(
         0,
-        REVIEW_APP_MAX_AGE_DAYS * 86_400
+        @max_default_age_days * 86_400
       )
 
       nil
@@ -565,7 +565,7 @@ module FleetValidation
       %w[npm react-on-rails-rsc]
     ].freeze
 
-    attr_reader :targets
+    attr_reader :max_default_age_days, :targets
 
     def initialize(manifest:, pack_id:, release:, rsc_version:, policy_commit:, generated_at:)
       @manifest = manifest

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -236,7 +236,7 @@ module FleetValidation
     rescue NonPublicRepositoryError
       raise
     rescue StandardError => e
-      unknown_observation(observed_at, e.message)
+      unknown_observation(observed_at, "#{e.class}: #{e.message}")
     end
 
     private
@@ -258,8 +258,6 @@ module FleetValidation
 
     def package_versions(repo)
       PublicSBOM.package_versions(@client.get("/repos/#{repo}/dependency-graph/sbom"))
-    rescue StandardError
-      []
     end
 
     def check_status(checks)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -12,6 +12,14 @@ module FleetValidation
   class PublicRegistryResolver
     RUBYGEMS = "https://rubygems.org"
     NPM = "https://registry.npmjs.org"
+    PRODUCT_GEMS = %w[react_on_rails react_on_rails_pro].freeze
+    PRODUCT_NPM = %w[
+      react-on-rails
+      react-on-rails-pro
+      react-on-rails-pro-node-renderer
+      create-react-on-rails-app
+    ].freeze
+    RSC_NPM = "react-on-rails-rsc"
 
     def initialize(fetcher:)
       @fetcher = fetcher
@@ -19,39 +27,39 @@ module FleetValidation
 
     def resolve(release:, rsc_version:)
       product_version = release.delete_prefix("v")
-      gem_versions = @fetcher.call("#{RUBYGEMS}/api/v1/versions/react_on_rails.json")
-      npm_product = @fetcher.call("#{NPM}/react-on-rails")
-      npm_rsc = @fetcher.call("#{NPM}/react-on-rails-rsc")
-      unless Array(gem_versions).any? { |entry| entry["number"] == product_version && entry["yanked"] != true }
-        raise ManifestError, "react_on_rails #{product_version} is not a public non-yanked RubyGems artifact"
+      gem_artifacts = PRODUCT_GEMS.map do |name|
+        versions = @fetcher.call("#{RUBYGEMS}/api/v1/versions/#{name}.json")
+        unless Array(versions).any? { |entry| entry["number"] == product_version && entry["yanked"] != true }
+          raise ManifestError, "#{name} #{product_version} is not a public non-yanked RubyGems artifact"
+        end
+
+        registry_artifact("gem", name, product_version, RUBYGEMS)
       end
-      unless npm_product.fetch("versions", {}).key?(product_version)
-        raise ManifestError, "react-on-rails #{product_version} is not a public npm artifact"
+      npm_artifacts = PRODUCT_NPM.map do |name|
+        document = @fetcher.call("#{NPM}/#{name}")
+        unless document.fetch("versions", {}).key?(product_version)
+          raise ManifestError, "#{name} #{product_version} is not a public npm artifact"
+        end
+
+        registry_artifact("npm", name, product_version, NPM)
       end
+      npm_rsc = @fetcher.call("#{NPM}/#{RSC_NPM}")
       unless npm_rsc.fetch("versions", {}).key?(rsc_version)
-        raise ManifestError, "react-on-rails-rsc #{rsc_version} is not a public npm artifact"
+        raise ManifestError, "#{RSC_NPM} #{rsc_version} is not a public npm artifact"
       end
 
-      [
-        {
-          "ecosystem" => "gem",
-          "name" => "react_on_rails",
-          "version" => product_version,
-          "source" => RUBYGEMS
-        },
-        {
-          "ecosystem" => "npm",
-          "name" => "react-on-rails",
-          "version" => product_version,
-          "source" => NPM
-        },
-        {
-          "ecosystem" => "npm",
-          "name" => "react-on-rails-rsc",
-          "version" => rsc_version,
-          "source" => NPM
-        }
-      ]
+      gem_artifacts + npm_artifacts + [registry_artifact("npm", RSC_NPM, rsc_version, NPM)]
+    end
+
+    private
+
+    def registry_artifact(ecosystem, name, version, source)
+      {
+        "ecosystem" => ecosystem,
+        "name" => name,
+        "version" => version,
+        "source" => source
+      }
     end
   end
 
@@ -59,11 +67,36 @@ module FleetValidation
     module_function
 
     def package_versions(document)
-      versions = Array(document.dig("sbom", "packages")).filter_map do |package|
+      sbom = document["sbom"]
+      return [] unless sbom.is_a?(Hash)
+
+      direct_ids = direct_dependency_ids(sbom)
+      return [] if direct_ids.empty?
+
+      versions = Array(sbom["packages"]).filter_map do |package|
+        next unless direct_ids.include?(package["SPDXID"])
+
         purl = Array(package["externalRefs"]).find { |reference| reference["referenceType"] == "purl" }
         parse_purl(purl && purl["referenceLocator"])
       end
       versions.uniq { |package| [package["ecosystem"], package["name"], package["version"]] }
+    end
+
+    def direct_dependency_ids(sbom)
+      document_id = sbom["SPDXID"]
+      return [] if document_id.to_s.empty?
+
+      relationships = Array(sbom["relationships"])
+      root_ids = relationships.filter_map do |relationship|
+        relationship["relatedSpdxElement"] if relationship["spdxElementId"] == document_id &&
+                                              relationship["relationshipType"] == "DESCRIBES"
+      end
+      return [] if root_ids.empty?
+
+      relationships.filter_map do |relationship|
+        relationship["relatedSpdxElement"] if root_ids.include?(relationship["spdxElementId"]) &&
+                                              relationship["relationshipType"] == "DEPENDS_ON"
+      end.uniq
     end
 
     def parse_purl(value)
@@ -149,7 +182,7 @@ module FleetValidation
         "package_versions" => package_versions(repo),
         "default_ci" => check_status(checks),
         "smoke" => smoke_status(repo, head, checks, workflows),
-        "review_app" => review_app_status(target, checks, workflows),
+        "review_app" => review_app_status(repo, target, workflows),
         "dependabot" => dependabot_status(repo, head, target.fetch("packages"))
       }
     rescue StandardError => e
@@ -197,18 +230,49 @@ module FleetValidation
       )
     end
 
-    def review_app_status(target, checks, workflows)
-      review_workflows = workflows.select { |workflow| review_app_name?(workflow["name"]) || review_app_name?(workflow["path"]) }
-      review_checks = checks.select { |check| review_app_name?(check["name"]) }
+    def review_app_status(repo, target, workflows)
+      review_workflows = workflows.select do |workflow|
+        review_app_name?(workflow["name"]) || review_app_name?(workflow["path"])
+      end
       if review_workflows.empty? && target.fetch("review_app") == "not_required"
         return evidence_status("not_applicable", "Review app is not required by public fleet policy")
       end
       return evidence_status("unknown", "Required review-app workflow was not found") if review_workflows.empty?
 
-      status = check_status(review_checks)
-      status["evidence"] = [status["evidence"], review_workflows.map { |workflow| workflow["path"] }.join(", ")]
-                           .reject { |value| value.to_s.empty? }.join("; ")
-      status
+      statuses = review_workflows.map { |workflow| review_workflow_status(repo, workflow) }
+      aggregate_status = if statuses.any? { |status| status["status"] == "blocked" }
+                           "blocked"
+                         elsif statuses.any? { |status| status["status"] == "unknown" }
+                           "unknown"
+                         else
+                           "passed"
+                         end
+      evidence_status(aggregate_status, statuses.filter_map { |status| status["evidence"] }.join("; "))
+    end
+
+    def review_workflow_status(repo, workflow)
+      workflow_evidence = workflow["html_url"] || workflow["path"]
+      unless workflow["state"] == "active"
+        return evidence_status("blocked", "#{workflow_evidence}; state=#{workflow['state'] || 'unknown'}")
+      end
+
+      workflow_id = workflow.fetch("id")
+      runs = @client.get("/repos/#{repo}/actions/workflows/#{workflow_id}/runs?per_page=1")
+                    .fetch("workflow_runs", [])
+      return evidence_status("unknown", "#{workflow_evidence}; no public workflow run") if runs.empty?
+
+      run = runs.first
+      evidence = [
+        workflow_evidence,
+        run["html_url"],
+        ("updated_at=#{run['updated_at']}" if run["updated_at"])
+      ].compact.join("; ")
+      return evidence_status("unknown", evidence) unless run["status"] == "completed"
+
+      status = PASSING_CONCLUSIONS.include?(run["conclusion"]) ? "passed" : "blocked"
+      evidence_status(status, evidence)
+    rescue StandardError => e
+      evidence_status("unknown", "#{workflow_evidence}; workflow run unavailable: #{e.class}")
     end
 
     def dependabot_status(repo, head, packages)
@@ -263,12 +327,16 @@ module FleetValidation
     PRODUCT_PACKAGES = {
       "gem" => %w[react_on_rails react_on_rails_pro],
       "npm" => %w[
-        react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer
+        react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer create-react-on-rails-app
       ]
     }.freeze
     PUBLIC_REGISTRY_ARTIFACTS = [
       %w[gem react_on_rails],
+      %w[gem react_on_rails_pro],
       %w[npm react-on-rails],
+      %w[npm react-on-rails-pro],
+      %w[npm react-on-rails-pro-node-renderer],
+      %w[npm create-react-on-rails-app],
       %w[npm react-on-rails-rsc]
     ].freeze
 
@@ -341,7 +409,11 @@ module FleetValidation
             %w[status artifacts findings],
             {
               "status" => { "enum" => %w[passed blocked] },
-              "artifacts" => { "type" => "array", "items" => registry_artifact_schema },
+              "artifacts" => {
+                "type" => "array",
+                "minItems" => PUBLIC_REGISTRY_ARTIFACTS.length,
+                "items" => registry_artifact_schema
+              },
               "findings" => string_array
             }
           ),
@@ -513,9 +585,10 @@ module FleetValidation
         actual_versions = observed.filter_map do |actual|
           actual["version"] if key == [actual["ecosystem"], actual["name"]]
         end
-        package["name"] unless actual_versions.any? do |actual|
+        all_acceptable = actual_versions.any? && actual_versions.all? do |actual|
           acceptable_version?(package["ecosystem"], package["name"], actual, package["expected"])
         end
+        package["name"] unless all_acceptable
       end
 
       {

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -333,8 +333,10 @@ module FleetValidation
       workflow_evidence = workflow["html_url"] || workflow["path"]
       workflow_id = workflow.fetch("id")
       branch = URI.encode_www_form_component(default_branch)
-      runs = @client.get("/repos/#{repo}/actions/workflows/#{workflow_id}/runs?branch=#{branch}&per_page=20")
-                    .fetch("workflow_runs", [])
+      runs = paginated_collection(
+        "/repos/#{repo}/actions/workflows/#{workflow_id}/runs?branch=#{branch}&per_page=100",
+        "workflow_runs"
+      )
       run = runs.find { |candidate| candidate["head_sha"] == head }
       return evidence_status("unknown", "#{workflow_evidence}; no exact-head public workflow run") unless run
 
@@ -360,7 +362,10 @@ module FleetValidation
     end
 
     def shared_smoke_job_status(repo, run, caller)
-      jobs = @client.get("/repos/#{repo}/actions/runs/#{run.fetch('id')}/jobs?per_page=100").fetch("jobs", [])
+      jobs = paginated_collection(
+        "/repos/#{repo}/actions/runs/#{run.fetch('id')}/jobs?per_page=100",
+        "jobs"
+      )
       expected_name = called_smoke_job_name(caller)
       identity = "caller_job=#{caller.fetch('key')}; caller_name=#{caller.fetch('name')}; expected_job=#{expected_name}"
       smoke_jobs = jobs.select { |job| job["name"] == expected_name }
@@ -429,8 +434,10 @@ module FleetValidation
       end
 
       workflow_id = workflow.fetch("id")
-      runs = @client.get("/repos/#{repo}/actions/workflows/#{workflow_id}/runs?event=pull_request&per_page=20")
-                    .fetch("workflow_runs", [])
+      runs = paginated_collection(
+        "/repos/#{repo}/actions/workflows/#{workflow_id}/runs?event=pull_request&per_page=100",
+        "workflow_runs"
+      )
       run = runs.find do |candidate|
         Array(candidate["pull_requests"]).any? { |pull_request| pull_request.dig("base", "ref") == default_branch }
       end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -283,11 +283,19 @@ module FleetValidation
     end
 
     def smoke_status(repo, head, _checks, workflows, default_branch:)
+      discovery_errors = []
       shared_callers = workflows.flat_map do |workflow|
         content = @client.content(repo, workflow.fetch("path"), ref: head)
         shared_smoke_callers(content).map { |caller| [workflow, caller] }
-      rescue StandardError
+      rescue StandardError => e
+        discovery_errors << "#{workflow['path'] || 'unknown workflow'}: #{e.class}: #{e.message}"
         []
+      end
+      unless discovery_errors.empty?
+        return evidence_status(
+          "unknown",
+          "Reusable fleet-smoke caller discovery was incomplete: #{discovery_errors.join('; ')}"
+        ).merge("shared_contract" => shared_callers.any?)
       end
       if shared_callers.empty?
         return evidence_status("unknown", "No reusable fleet-smoke caller was found at the default head")
@@ -402,8 +410,6 @@ module FleetValidation
       callers.each do |caller|
         caller["name_collision"] = local_job_names.include?(called_smoke_job_name(caller))
       end
-    rescue Psych::Exception
-      []
     end
 
     def called_smoke_job_name(caller)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -209,7 +209,8 @@ module FleetValidation
       end
 
       default_branch = metadata.fetch("default_branch")
-      commit = @client.get("/repos/#{repo}/commits/#{default_branch}")
+      encoded_branch = URI.encode_www_form_component(default_branch)
+      commit = @client.get("/repos/#{repo}/commits/#{encoded_branch}")
       head = commit.fetch("sha")
       checks = paginated_collection(
         "/repos/#{repo}/commits/#{head}/check-runs?per_page=100",

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -302,9 +302,30 @@ module FleetValidation
       ].compact.join("; ")
       return evidence_status("unknown", evidence) unless run["status"] == "completed"
 
-      evidence_status(run["conclusion"] == "success" ? "passed" : "blocked", evidence)
+      smoke_job = shared_smoke_job_status(repo, run)
+      status = if run["conclusion"] == "success" && smoke_job["status"] == "passed"
+                 "passed"
+               elsif smoke_job["status"] == "unknown"
+                 "unknown"
+               else
+                 "blocked"
+               end
+      evidence_status(status, [evidence, smoke_job["evidence"]].compact.join("; "))
     rescue StandardError => e
       evidence_status("unknown", "#{workflow_evidence}; workflow run unavailable: #{e.class}")
+    end
+
+    def shared_smoke_job_status(repo, run)
+      jobs = @client.get("/repos/#{repo}/actions/runs/#{run.fetch('id')}/jobs?per_page=100").fetch("jobs", [])
+      smoke_jobs = jobs.select { |job| job["name"].to_s.split(" / ").last == "Demo fleet smoke" }
+      return evidence_status("unknown", "called Demo fleet smoke job was not found") if smoke_jobs.empty?
+
+      evidence = smoke_jobs.filter_map { |job| job["html_url"] }.join(", ")
+      return evidence_status("unknown", evidence) if smoke_jobs.any? { |job| job["status"] != "completed" }
+      return evidence_status("unknown", evidence) if smoke_jobs.any? { |job| job["conclusion"] == "skipped" }
+
+      status = smoke_jobs.all? { |job| job["conclusion"] == "success" } ? "passed" : "blocked"
+      evidence_status(status, evidence)
     end
 
     def shared_smoke_caller?(content)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -260,32 +260,52 @@ module FleetValidation
     end
 
     def smoke_status(repo, head, _checks, workflows, default_branch:)
-      shared_workflows = workflows.select do |workflow|
+      shared_callers = workflows.flat_map do |workflow|
         content = @client.content(repo, workflow.fetch("path"), ref: head)
-        shared_smoke_caller?(content)
+        shared_smoke_callers(content).map { |caller| [workflow, caller] }
       rescue StandardError
-        false
+        []
       end
-      if shared_workflows.empty?
+      if shared_callers.empty?
         return evidence_status("unknown", "No reusable fleet-smoke caller was found at the default head")
                .merge("shared_contract" => false)
       end
 
-      statuses = shared_workflows.map do |workflow|
-        shared_smoke_workflow_status(repo, head, default_branch, workflow)
+      caller_identities = shared_callers.map do |workflow, caller|
+        [workflow["path"], caller.fetch("name")]
       end
-      status = if statuses.any? { |candidate| candidate["status"] == "passed" }
+      duplicate_identities = caller_identities.tally.select { |_identity, count| count > 1 }.keys
+      unless duplicate_identities.empty?
+        evidence = duplicate_identities.map do |path, name|
+          "#{path}: ambiguous reusable caller name #{name.inspect}"
+        end.join("; ")
+        return evidence_status("unknown", evidence).merge("shared_contract" => true)
+      end
+
+      name_collisions = shared_callers.select { |_workflow, caller| caller.fetch("name_collision") }
+      unless name_collisions.empty?
+        evidence = name_collisions.map do |workflow, caller|
+          "#{workflow['path']}: caller_job=#{caller.fetch('key')} expected job name " \
+            "#{called_smoke_job_name(caller).inspect} collides with a non-reusable job"
+        end.join("; ")
+        return evidence_status("unknown", evidence).merge("shared_contract" => true)
+      end
+
+      statuses = shared_callers.map do |workflow, caller|
+        shared_smoke_workflow_status(repo, head, default_branch, workflow, caller)
+      end
+      status = if statuses.all? { |candidate| candidate["status"] == "passed" }
                  "passed"
-               elsif statuses.any? { |candidate| candidate["status"] == "unknown" }
-                 "unknown"
-               else
+               elsif statuses.any? { |candidate| candidate["status"] == "blocked" }
                  "blocked"
+               else
+                 "unknown"
                end
       evidence_status(status, statuses.filter_map { |candidate| candidate["evidence"] }.join("; "))
         .merge("shared_contract" => true)
     end
 
-    def shared_smoke_workflow_status(repo, head, default_branch, workflow)
+    def shared_smoke_workflow_status(repo, head, default_branch, workflow, caller)
       workflow_evidence = workflow["html_url"] || workflow["path"]
       workflow_id = workflow.fetch("id")
       branch = URI.encode_www_form_component(default_branch)
@@ -302,7 +322,7 @@ module FleetValidation
       ].compact.join("; ")
       return evidence_status("unknown", evidence) unless run["status"] == "completed"
 
-      smoke_job = shared_smoke_job_status(repo, run)
+      smoke_job = shared_smoke_job_status(repo, run, caller)
       status = if run["conclusion"] == "success" && smoke_job["status"] == "passed"
                  "passed"
                elsif smoke_job["status"] == "unknown"
@@ -315,29 +335,51 @@ module FleetValidation
       evidence_status("unknown", "#{workflow_evidence}; workflow run unavailable: #{e.class}")
     end
 
-    def shared_smoke_job_status(repo, run)
+    def shared_smoke_job_status(repo, run, caller)
       jobs = @client.get("/repos/#{repo}/actions/runs/#{run.fetch('id')}/jobs?per_page=100").fetch("jobs", [])
-      smoke_jobs = jobs.select { |job| job["name"].to_s.split(" / ").last == "Demo fleet smoke" }
-      return evidence_status("unknown", "called Demo fleet smoke job was not found") if smoke_jobs.empty?
+      expected_name = called_smoke_job_name(caller)
+      identity = "caller_job=#{caller.fetch('key')}; caller_name=#{caller.fetch('name')}; expected_job=#{expected_name}"
+      smoke_jobs = jobs.select { |job| job["name"] == expected_name }
+      return evidence_status("unknown", "#{identity}; called reusable smoke job was not found") if smoke_jobs.empty?
+      if smoke_jobs.length > 1
+        return evidence_status("unknown", "#{identity}; called reusable smoke job identity is ambiguous")
+      end
 
-      evidence = smoke_jobs.filter_map { |job| job["html_url"] }.join(", ")
-      return evidence_status("unknown", evidence) if smoke_jobs.any? { |job| job["status"] != "completed" }
-      return evidence_status("unknown", evidence) if smoke_jobs.any? { |job| job["conclusion"] == "skipped" }
+      smoke_job = smoke_jobs.fetch(0)
+      evidence = [identity, smoke_job["html_url"]].compact.join("; ")
+      return evidence_status("unknown", evidence) unless smoke_job["status"] == "completed"
+      return evidence_status("unknown", evidence) if smoke_job["conclusion"] == "skipped"
 
-      status = smoke_jobs.all? { |job| job["conclusion"] == "success" } ? "passed" : "blocked"
+      status = smoke_job["conclusion"] == "success" ? "passed" : "blocked"
       evidence_status(status, evidence)
     end
 
-    def shared_smoke_caller?(content)
+    def shared_smoke_callers(content)
       document = YAML.safe_load(content, permitted_classes: [], permitted_symbols: [], aliases: false)
       jobs = document.is_a?(Hash) ? document["jobs"] : nil
-      return false unless jobs.is_a?(Hash)
+      return [] unless jobs.is_a?(Hash)
 
-      jobs.values.any? do |job|
-        job.is_a?(Hash) && job["uses"].to_s.start_with?(SHARED_SMOKE_REFERENCE)
+      callers = jobs.filter_map do |key, job|
+        next unless job.is_a?(Hash) && job["uses"].to_s.start_with?(SHARED_SMOKE_REFERENCE)
+
+        name = present_string?(job["name"]) ? job.fetch("name") : key.to_s
+        { "key" => key.to_s, "name" => name }
+      end
+      local_job_names = jobs.values.filter_map do |job|
+        next unless job.is_a?(Hash)
+        next if job["uses"].to_s.start_with?(SHARED_SMOKE_REFERENCE)
+
+        job["name"] if present_string?(job["name"])
+      end
+      callers.each do |caller|
+        caller["name_collision"] = local_job_names.include?(called_smoke_job_name(caller))
       end
     rescue Psych::Exception
-      false
+      []
+    end
+
+    def called_smoke_job_name(caller)
+      "#{caller.fetch('name')} / Demo fleet smoke"
     end
 
     def review_app_status(repo, target, workflows, default_branch:, observed_at:)
@@ -983,7 +1025,7 @@ module FleetValidation
     end
 
     def commit_string
-      { "type" => "string", "pattern" => "\\A[0-9a-f]{40}\\z" }
+      { "type" => "string", "pattern" => "^[0-9a-f]{40}$" }
     end
 
     def nullable_string

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -9,6 +9,7 @@ require "yaml"
 require_relative "fleet_lifecycle"
 
 module FleetValidation
+  class MissingPublicContentError < ManifestError; end
   class NonPublicRepositoryError < ManifestError; end
 
   module ProductVersion
@@ -192,6 +193,7 @@ module FleetValidation
   class PublicGitHubProbe
     SHARED_SMOKE_REFERENCE = "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@"
     PASSING_CONCLUSIONS = %w[success neutral skipped].freeze
+    DEPENDABOT_PATHS = %w[.github/dependabot.yml .github/dependabot.yaml].freeze
     MAX_PAGES = 20
     REVIEW_APP_MAX_AGE_DAYS = 45
 
@@ -481,13 +483,13 @@ module FleetValidation
     end
 
     def dependabot_status(repo, head, packages)
-      content = @client.content(repo, ".github/dependabot.yml", ref: head)
+      content, path = dependabot_content(repo, head)
       config = YAML.safe_load(content, permitted_classes: [], permitted_symbols: [], aliases: false)
       result = DependabotV1.evaluate(config, packages)
       {
         "status" => result.fetch("status"),
         "policy" => "v1",
-        "evidence" => result.fetch("findings").empty? ? ".github/dependabot.yml" : result.fetch("findings").join(", ")
+        "evidence" => result.fetch("findings").empty? ? path : result.fetch("findings").join(", ")
       }
     rescue StandardError => e
       {
@@ -495,6 +497,16 @@ module FleetValidation
         "policy" => "v1",
         "evidence" => "Dependabot v1 config unavailable: #{e.class}"
       }
+    end
+
+    def dependabot_content(repo, head)
+      DEPENDABOT_PATHS.each do |path|
+        return [@client.content(repo, path, ref: head), path]
+      rescue MissingPublicContentError
+        next
+      end
+
+      raise MissingPublicContentError, "No supported Dependabot config path is readable"
     end
 
     def unknown_observation(observed_at, reason)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -9,6 +9,8 @@ require "yaml"
 require_relative "fleet_lifecycle"
 
 module FleetValidation
+  class NonPublicRepositoryError < ManifestError; end
+
   module ProductVersion
     module_function
 
@@ -199,6 +201,10 @@ module FleetValidation
     def observe(target, observed_at:)
       repo = target.fetch("name")
       metadata = @client.get("/repos/#{repo}")
+      unless metadata["visibility"] == "public"
+        raise NonPublicRepositoryError, "Standing-health target is not publicly visible"
+      end
+
       default_branch = metadata.fetch("default_branch")
       commit = @client.get("/repos/#{repo}/commits/#{default_branch}")
       head = commit.fetch("sha")
@@ -217,6 +223,8 @@ module FleetValidation
         "review_app" => review_app_status(repo, target, workflows, default_branch:, observed_at:),
         "dependabot" => dependabot_status(repo, head, target.fetch("packages"))
       }
+    rescue NonPublicRepositoryError
+      raise
     rescue StandardError => e
       unknown_observation(observed_at, e.message)
     end
@@ -233,25 +241,28 @@ module FleetValidation
       return evidence_status("unknown", "No current-head check runs found") if checks.empty?
 
       pending = checks.any? { |check| check["status"] != "completed" }
-      failures = checks.reject do |check|
-        check["status"] == "completed" && PASSING_CONCLUSIONS.include?(check["conclusion"])
+      failures = checks.select do |check|
+        check["status"] == "completed" && !PASSING_CONCLUSIONS.include?(check["conclusion"])
+      end
+      successes = checks.count do |check|
+        check["status"] == "completed" && check["conclusion"] == "success"
       end
       status = if pending
                  "unknown"
-               elsif failures.empty?
+               elsif failures.any?
+                 "blocked"
+               elsif successes.positive?
                  "passed"
                else
-                 "blocked"
+                 "unknown"
                end
       evidence_status(status, evidence_urls(checks))
     end
 
     def smoke_status(repo, head, _checks, workflows, default_branch:)
-      candidate_workflows = workflows.select do |workflow|
-        smoke_name?(workflow["name"]) || smoke_name?(workflow["path"])
-      end
-      shared_workflows = candidate_workflows.select do |workflow|
-        @client.content(repo, workflow.fetch("path"), ref: head).include?(SHARED_SMOKE_REFERENCE)
+      shared_workflows = workflows.select do |workflow|
+        content = @client.content(repo, workflow.fetch("path"), ref: head)
+        shared_smoke_caller?(content)
       rescue StandardError
         false
       end
@@ -294,6 +305,18 @@ module FleetValidation
       evidence_status(run["conclusion"] == "success" ? "passed" : "blocked", evidence)
     rescue StandardError => e
       evidence_status("unknown", "#{workflow_evidence}; workflow run unavailable: #{e.class}")
+    end
+
+    def shared_smoke_caller?(content)
+      document = YAML.safe_load(content, permitted_classes: [], permitted_symbols: [], aliases: false)
+      jobs = document.is_a?(Hash) ? document["jobs"] : nil
+      return false unless jobs.is_a?(Hash)
+
+      jobs.values.any? do |job|
+        job.is_a?(Hash) && job["uses"].to_s.start_with?(SHARED_SMOKE_REFERENCE)
+      end
+    rescue Psych::Exception
+      false
     end
 
     def review_app_status(repo, target, workflows, default_branch:, observed_at:)
@@ -415,10 +438,6 @@ module FleetValidation
     def present_string?(value)
       value.is_a?(String) && !value.empty?
     end
-
-    def smoke_name?(value)
-      value.to_s.match?(/smoke/i)
-    end
   end
 
   class FleetHealth
@@ -427,6 +446,10 @@ module FleetValidation
       "npm" => %w[
         react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer create-react-on-rails-app
       ]
+    }.freeze
+    ALLOWED_PACKAGES = {
+      "gem" => (PRODUCT_PACKAGES.fetch("gem") + %w[shakapacker cpflow]).freeze,
+      "npm" => (PRODUCT_PACKAGES.fetch("npm") + %w[react-on-rails-rsc shakapacker shakapacker-rspack]).freeze
     }.freeze
     PUBLIC_REGISTRY_ARTIFACTS = [
       %w[gem react_on_rails],
@@ -558,9 +581,8 @@ module FleetValidation
           raise ManifestError, "standing_health.#{field} must be a nonnegative integer"
         end
       end
-      return if @manifest["repos"].is_a?(Array)
-
-      raise ManifestError, "repos must be an array"
+      repos = @manifest["repos"]
+      raise ManifestError, "repos must be an array" unless repos.is_a?(Array)
     end
 
     def build_targets
@@ -594,7 +616,7 @@ module FleetValidation
           "disposition" => disposition,
           "review_app" => review_app,
           "review_app_workflow" => review_app_workflow,
-          "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
+          "packages" => validated_packages(repo)
         }
       end
       archived = Array(@manifest.dig("standing_health", "archived_targets")).map do |repo|
@@ -609,7 +631,7 @@ module FleetValidation
           "disposition" => "archived",
           "review_app" => "not_required",
           "review_app_workflow" => nil,
-          "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
+          "packages" => validated_packages(repo)
         }
       end
       selected.concat(archived)
@@ -622,6 +644,18 @@ module FleetValidation
 
     def exact_workflow_path?(value)
       value.is_a?(String) && value.match?(%r{\A\.github/workflows/[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml\z})
+    end
+
+    def validated_packages(repo)
+      Array(repo["packages"]).map do |package|
+        ecosystem = package["ecosystem"] if package.is_a?(Hash)
+        name = package["name"] if package.is_a?(Hash)
+        unless present?(ecosystem) && present?(name) && ALLOWED_PACKAGES.fetch(ecosystem, []).include?(name)
+          raise ManifestError, "#{repo['name']} has unsupported package #{ecosystem}:#{name}"
+        end
+
+        { "ecosystem" => ecosystem, "name" => name }
+      end
     end
 
     def evaluate_registry(artifacts)
@@ -653,16 +687,14 @@ module FleetValidation
       staleness = evaluate_staleness(observation["default_commit_at"])
       repository_archived = boolean_or_nil(observation["repository_archived"])
 
-      if target.fetch("disposition") == "active"
-        findings << "repository_archived" if repository_archived
-        findings << "default_ci" unless default_ci.fetch("status") == "passed"
-        findings << "smoke" unless smoke.fetch("status") == "passed" && smoke.fetch("shared_contract")
-        if target.fetch("review_app") == "required" && review_app.fetch("status") != "passed"
-          findings << "review_app"
-        end
-        findings << "dependabot" unless dependabot.fetch("status") == "passed"
-        findings << "staleness" unless staleness.fetch("status") == "passed"
+      findings << "repository_archived" if target.fetch("disposition") == "active" && repository_archived
+      findings << "default_ci" unless default_ci.fetch("status") == "passed"
+      findings << "smoke" unless smoke.fetch("status") == "passed" && smoke.fetch("shared_contract")
+      if target.fetch("review_app") == "required" && review_app.fetch("status") != "passed"
+        findings << "review_app"
       end
+      findings << "dependabot" unless dependabot.fetch("status") == "passed"
+      findings << "staleness" unless staleness.fetch("status") == "passed"
 
       {
         "id" => target.fetch("id"),
@@ -978,6 +1010,8 @@ module FleetValidation
 
     def escape(value)
       value.to_s.gsub("\\") { "\\\\" }
+           .gsub(/[\r\n]+/, " ")
+           .gsub("`") { "\\`" }
            .gsub("|", "\\|")
            .gsub("<!--", "&lt;!--")
            .gsub("-->", "--&gt;")

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -231,23 +231,19 @@ module FleetValidation
     end
 
     def review_app_status(repo, target, workflows)
-      review_workflows = workflows.select do |workflow|
-        review_app_name?(workflow["name"]) || review_app_name?(workflow["path"])
-      end
-      if review_workflows.empty? && target.fetch("review_app") == "not_required"
+      if target.fetch("review_app") == "not_required"
         return evidence_status("not_applicable", "Review app is not required by public fleet policy")
       end
-      return evidence_status("unknown", "Required review-app workflow was not found") if review_workflows.empty?
 
-      statuses = review_workflows.map { |workflow| review_workflow_status(repo, workflow) }
-      aggregate_status = if statuses.any? { |status| status["status"] == "blocked" }
-                           "blocked"
-                         elsif statuses.any? { |status| status["status"] == "unknown" }
-                           "unknown"
-                         else
-                           "passed"
-                         end
-      evidence_status(aggregate_status, statuses.filter_map { |status| status["evidence"] }.join("; "))
+      workflow_path = target["review_app_workflow"]
+      unless workflow_path.is_a?(String) && !workflow_path.empty?
+        return evidence_status("unknown", "Required review-app workflow path is not configured")
+      end
+
+      workflow = workflows.find { |candidate| candidate["path"] == workflow_path }
+      return evidence_status("unknown", "Configured review-app workflow was not found: #{workflow_path}") unless workflow
+
+      review_workflow_status(repo, workflow)
     end
 
     def review_workflow_status(repo, workflow)
@@ -316,10 +312,6 @@ module FleetValidation
 
     def smoke_name?(value)
       value.to_s.match?(/smoke/i)
-    end
-
-    def review_app_name?(value)
-      value.to_s.match?(/review.?app|cpflow/i)
     end
   end
 
@@ -478,12 +470,24 @@ module FleetValidation
           raise ManifestError, "#{repo['name']} soft_track cannot be active standing health"
         end
 
+        review_app = health.fetch("review_app", "not_required")
+        unless %w[required not_required].include?(review_app)
+          raise ManifestError, "#{repo['name']} standing_health.review_app is invalid"
+        end
+
+        review_app_workflow = health["review_app_workflow"]
+        if review_app == "required" && !exact_workflow_path?(review_app_workflow)
+          raise ManifestError,
+                "#{repo['name']} standing_health.review_app_workflow must be an exact .github/workflows YAML path"
+        end
+
         {
           "id" => slug(repo.fetch("name")),
           "name" => repo.fetch("name"),
           "tier" => repo.fetch("tier"),
           "disposition" => disposition,
-          "review_app" => health.fetch("review_app", "not_required"),
+          "review_app" => review_app,
+          "review_app_workflow" => review_app_workflow,
           "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
         }
       end
@@ -498,6 +502,7 @@ module FleetValidation
           "tier" => "soft_track",
           "disposition" => "archived",
           "review_app" => "not_required",
+          "review_app_workflow" => nil,
           "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
         }
       end
@@ -507,6 +512,10 @@ module FleetValidation
       raise ManifestError, "standing health has no public targets" if selected.empty?
 
       selected
+    end
+
+    def exact_workflow_path?(value)
+      value.is_a?(String) && value.match?(%r{\A\.github/workflows/[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml\z})
     end
 
     def evaluate_registry(artifacts)

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -9,6 +9,15 @@ require "yaml"
 require_relative "fleet_lifecycle"
 
 module FleetValidation
+  module ProductVersion
+    module_function
+
+    def normalize(release, ecosystem)
+      version = release.delete_prefix("v")
+      ecosystem == "npm" ? version.gsub(/\.((?:rc|beta))\.(\d+)\z/, '-\\1.\\2') : version
+    end
+  end
+
   class PublicRegistryResolver
     RUBYGEMS = "https://rubygems.org"
     NPM = "https://registry.npmjs.org"
@@ -26,22 +35,23 @@ module FleetValidation
     end
 
     def resolve(release:, rsc_version:)
-      product_version = release.delete_prefix("v")
+      gem_version = ProductVersion.normalize(release, "gem")
+      npm_version = ProductVersion.normalize(release, "npm")
       gem_artifacts = PRODUCT_GEMS.map do |name|
         versions = @fetcher.call("#{RUBYGEMS}/api/v1/versions/#{name}.json")
-        unless Array(versions).any? { |entry| entry["number"] == product_version && entry["yanked"] != true }
-          raise ManifestError, "#{name} #{product_version} is not a public non-yanked RubyGems artifact"
+        unless Array(versions).any? { |entry| entry["number"] == gem_version && entry["yanked"] != true }
+          raise ManifestError, "#{name} #{gem_version} is not a public non-yanked RubyGems artifact"
         end
 
-        registry_artifact("gem", name, product_version, RUBYGEMS)
+        registry_artifact("gem", name, gem_version, RUBYGEMS)
       end
       npm_artifacts = PRODUCT_NPM.map do |name|
         document = @fetcher.call("#{NPM}/#{name}")
-        unless document.fetch("versions", {}).key?(product_version)
-          raise ManifestError, "#{name} #{product_version} is not a public npm artifact"
+        unless document.fetch("versions", {}).key?(npm_version)
+          raise ManifestError, "#{name} #{npm_version} is not a public npm artifact"
         end
 
-        registry_artifact("npm", name, product_version, NPM)
+        registry_artifact("npm", name, npm_version, NPM)
       end
       npm_rsc = @fetcher.call("#{NPM}/#{RSC_NPM}")
       unless npm_rsc.fetch("versions", {}).key?(rsc_version)
@@ -135,13 +145,29 @@ module FleetValidation
           next
         end
 
-        findings << "#{ecosystem}:not-weekly" unless entries.any? { |entry| entry.dig("schedule", "interval") == "weekly" }
-        if entries.all? { |entry| entry.fetch("open-pull-requests-limit", 1).zero? }
-          findings << "#{ecosystem}:version-updates-disabled"
+        root_entries = entries.select { |entry| root_directory?(entry) }
+        if root_entries.empty?
+          findings << "#{ecosystem}:root-missing"
+          next
         end
+
+        enabled_root_entries = root_entries.reject { |entry| entry.fetch("open-pull-requests-limit", 1).zero? }
+        if enabled_root_entries.empty?
+          findings << "#{ecosystem}:version-updates-disabled"
+          next
+        end
+
+        weekly_root_entries = enabled_root_entries.select do |entry|
+          entry.dig("schedule", "interval") == "weekly"
+        end
+        if weekly_root_entries.empty?
+          findings << "#{ecosystem}:not-weekly"
+          next
+        end
+
         next if ecosystem == "github-actions"
 
-        patterns = entries.flat_map do |entry|
+        patterns = weekly_root_entries.flat_map do |entry|
           entry.fetch("groups", {}).values.flat_map { |group| Array(group["patterns"]) }
         end
         expected_prefix = ecosystem == "bundler" ? "react_on_rails" : "react-on-rails"
@@ -155,11 +181,16 @@ module FleetValidation
         "findings" => findings
       }
     end
+
+    def root_directory?(entry)
+      entry["directory"] == "/" || Array(entry["directories"]).include?("/")
+    end
   end
 
   class PublicGitHubProbe
     SHARED_SMOKE_REFERENCE = "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@"
     PASSING_CONCLUSIONS = %w[success neutral skipped].freeze
+    REVIEW_APP_MAX_AGE_DAYS = 45
 
     def initialize(client:)
       @client = client
@@ -178,11 +209,12 @@ module FleetValidation
         "default_branch" => default_branch,
         "default_commit" => head,
         "default_commit_at" => commit.dig("commit", "committer", "date"),
+        "repository_archived" => metadata["archived"] == true,
         "observed_at" => observed_at,
         "package_versions" => package_versions(repo),
         "default_ci" => check_status(checks),
-        "smoke" => smoke_status(repo, head, checks, workflows),
-        "review_app" => review_app_status(repo, target, workflows),
+        "smoke" => smoke_status(repo, head, checks, workflows, default_branch:),
+        "review_app" => review_app_status(repo, target, workflows, default_branch:, observed_at:),
         "dependabot" => dependabot_status(repo, head, target.fetch("packages"))
       }
     rescue StandardError => e
@@ -214,23 +246,57 @@ module FleetValidation
       evidence_status(status, evidence_urls(checks))
     end
 
-    def smoke_status(repo, head, checks, workflows)
-      smoke_workflows = workflows.select { |workflow| smoke_name?(workflow["name"]) || smoke_name?(workflow["path"]) }
-      smoke_checks = checks.select { |check| smoke_name?(check["name"]) }
-      status = check_status(smoke_checks)
-      shared_contract = smoke_workflows.any? do |workflow|
+    def smoke_status(repo, head, _checks, workflows, default_branch:)
+      candidate_workflows = workflows.select do |workflow|
+        smoke_name?(workflow["name"]) || smoke_name?(workflow["path"])
+      end
+      shared_workflows = candidate_workflows.select do |workflow|
         @client.content(repo, workflow.fetch("path"), ref: head).include?(SHARED_SMOKE_REFERENCE)
       rescue StandardError
         false
       end
-      status.merge(
-        "shared_contract" => shared_contract,
-        "evidence" => [status["evidence"], smoke_workflows.map { |workflow| workflow["path"] }.join(", ")]
-          .reject { |value| value.to_s.empty? }.join("; ")
-      )
+      if shared_workflows.empty?
+        return evidence_status("unknown", "No reusable fleet-smoke caller was found at the default head")
+               .merge("shared_contract" => false)
+      end
+
+      statuses = shared_workflows.map do |workflow|
+        shared_smoke_workflow_status(repo, head, default_branch, workflow)
+      end
+      status = if statuses.any? { |candidate| candidate["status"] == "passed" }
+                 "passed"
+               elsif statuses.any? { |candidate| candidate["status"] == "unknown" }
+                 "unknown"
+               else
+                 "blocked"
+               end
+      evidence_status(status, statuses.filter_map { |candidate| candidate["evidence"] }.join("; "))
+        .merge("shared_contract" => true)
     end
 
-    def review_app_status(repo, target, workflows)
+    def shared_smoke_workflow_status(repo, head, default_branch, workflow)
+      workflow_evidence = workflow["html_url"] || workflow["path"]
+      workflow_id = workflow.fetch("id")
+      branch = URI.encode_www_form_component(default_branch)
+      runs = @client.get("/repos/#{repo}/actions/workflows/#{workflow_id}/runs?branch=#{branch}&per_page=20")
+                    .fetch("workflow_runs", [])
+      run = runs.find { |candidate| candidate["head_sha"] == head }
+      return evidence_status("unknown", "#{workflow_evidence}; no exact-head public workflow run") unless run
+
+      evidence = [
+        workflow_evidence,
+        run["html_url"],
+        "head_sha=#{run['head_sha']}",
+        ("updated_at=#{run['updated_at']}" if run["updated_at"])
+      ].compact.join("; ")
+      return evidence_status("unknown", evidence) unless run["status"] == "completed"
+
+      evidence_status(run["conclusion"] == "success" ? "passed" : "blocked", evidence)
+    rescue StandardError => e
+      evidence_status("unknown", "#{workflow_evidence}; workflow run unavailable: #{e.class}")
+    end
+
+    def review_app_status(repo, target, workflows, default_branch:, observed_at:)
       if target.fetch("review_app") == "not_required"
         return evidence_status("not_applicable", "Review app is not required by public fleet policy")
       end
@@ -243,32 +309,67 @@ module FleetValidation
       workflow = workflows.find { |candidate| candidate["path"] == workflow_path }
       return evidence_status("unknown", "Configured review-app workflow was not found: #{workflow_path}") unless workflow
 
-      review_workflow_status(repo, workflow)
+      review_workflow_status(repo, workflow, default_branch:, observed_at:)
     end
 
-    def review_workflow_status(repo, workflow)
+    def review_workflow_status(repo, workflow, default_branch:, observed_at:)
       workflow_evidence = workflow["html_url"] || workflow["path"]
       unless workflow["state"] == "active"
         return evidence_status("blocked", "#{workflow_evidence}; state=#{workflow['state'] || 'unknown'}")
       end
 
       workflow_id = workflow.fetch("id")
-      runs = @client.get("/repos/#{repo}/actions/workflows/#{workflow_id}/runs?per_page=1")
+      runs = @client.get("/repos/#{repo}/actions/workflows/#{workflow_id}/runs?event=pull_request&per_page=20")
                     .fetch("workflow_runs", [])
-      return evidence_status("unknown", "#{workflow_evidence}; no public workflow run") if runs.empty?
+      run = runs.find do |candidate|
+        Array(candidate["pull_requests"]).any? { |pull_request| pull_request.dig("base", "ref") == default_branch }
+      end
+      return evidence_status("unknown", "#{workflow_evidence}; no public workflow run targeting #{default_branch}") unless run
 
-      run = runs.first
       evidence = [
         workflow_evidence,
         run["html_url"],
+        ("event=#{run['event']}" if run["event"]),
+        ("head_branch=#{run['head_branch']}" if run["head_branch"]),
+        ("head_sha=#{run['head_sha']}" if run["head_sha"]),
+        ("run_started_at=#{run['run_started_at']}" if run["run_started_at"]),
         ("updated_at=#{run['updated_at']}" if run["updated_at"])
       ].compact.join("; ")
+      identity_error = review_run_identity_error(run, default_branch:, observed_at:)
+      return evidence_status("unknown", "#{evidence}; #{identity_error}") if identity_error
       return evidence_status("unknown", evidence) unless run["status"] == "completed"
 
-      status = PASSING_CONCLUSIONS.include?(run["conclusion"]) ? "passed" : "blocked"
+      status = run["conclusion"] == "success" ? "passed" : "blocked"
       evidence_status(status, evidence)
     rescue StandardError => e
       evidence_status("unknown", "#{workflow_evidence}; workflow run unavailable: #{e.class}")
+    end
+
+    def review_run_identity_error(run, default_branch:, observed_at:)
+      return "event is not pull_request" unless run["event"] == "pull_request"
+
+      pull_request = Array(run["pull_requests"]).find do |candidate|
+        candidate.dig("base", "ref") == default_branch
+      end
+      return "run is not bound to a pull request targeting #{default_branch}" unless pull_request
+      unless present_string?(run["head_branch"]) && run["head_branch"] == pull_request.dig("head", "ref")
+        return "head branch does not match the pull request"
+      end
+      unless run["head_sha"].to_s.match?(/\A[0-9a-f]{40}\z/) &&
+             run["head_sha"] == pull_request.dig("head", "sha")
+        return "head SHA does not match the pull request"
+      end
+
+      started_at = Time.iso8601(run["run_started_at"].to_s)
+      age_seconds = Time.iso8601(observed_at) - started_at
+      return "run age exceeds #{REVIEW_APP_MAX_AGE_DAYS} days" unless age_seconds.between?(
+        0,
+        REVIEW_APP_MAX_AGE_DAYS * 86_400
+      )
+
+      nil
+    rescue ArgumentError
+      "run start or observation time is invalid"
     end
 
     def dependabot_status(repo, head, packages)
@@ -293,6 +394,7 @@ module FleetValidation
         "default_branch" => nil,
         "default_commit" => nil,
         "default_commit_at" => nil,
+        "repository_archived" => nil,
         "observed_at" => observed_at,
         "package_versions" => [],
         "default_ci" => evidence_status("unknown", reason),
@@ -308,6 +410,10 @@ module FleetValidation
 
     def evidence_urls(checks)
       checks.filter_map { |check| check["html_url"] }.uniq.join(", ")
+    end
+
+    def present_string?(value)
+      value.is_a?(String) && !value.empty?
     end
 
     def smoke_name?(value)
@@ -545,8 +651,10 @@ module FleetValidation
       review_app = normalize_evidence_status(observation["review_app"])
       dependabot = normalize_dependabot_status(observation["dependabot"])
       staleness = evaluate_staleness(observation["default_commit_at"])
+      repository_archived = boolean_or_nil(observation["repository_archived"])
 
       if target.fetch("disposition") == "active"
+        findings << "repository_archived" if repository_archived
         findings << "default_ci" unless default_ci.fetch("status") == "passed"
         findings << "smoke" unless smoke.fetch("status") == "passed" && smoke.fetch("shared_contract")
         if target.fetch("review_app") == "required" && review_app.fetch("status") != "passed"
@@ -564,6 +672,7 @@ module FleetValidation
         "default_branch" => nullable_string_value(observation["default_branch"]),
         "default_commit" => nullable_string_value(observation["default_commit"]),
         "default_commit_at" => nullable_string_value(observation["default_commit_at"]),
+        "repository_archived" => repository_archived,
         "observed_at" => nullable_string_value(observation["observed_at"]),
         "currency" => currency,
         "default_ci" => default_ci,
@@ -633,8 +742,7 @@ module FleetValidation
     end
 
     def normalized_release(ecosystem)
-      version = @release.delete_prefix("v")
-      ecosystem == "npm" ? version.gsub(/\.((?:rc|beta))\.(\d+)\z/, '-\\1.\\2') : version
+      ProductVersion.normalize(@release, ecosystem)
     end
 
     def normalize_evidence_status(value)
@@ -680,7 +788,8 @@ module FleetValidation
     def render_summary(evidence)
       rows = evidence.fetch("targets").map do |target|
         findings = target.fetch("findings")
-        "| `#{escape(target.fetch('id'))}` | #{target.fetch('disposition')} | #{target.fetch('status')} | " \
+        archived = target["repository_archived"].nil? ? "unknown" : target["repository_archived"]
+        "| `#{escape(target.fetch('id'))}` | #{target.fetch('disposition')} | #{archived} | #{target.fetch('status')} | " \
           "#{findings.empty? ? 'none' : findings.join(', ')} |"
       end
       <<~MARKDOWN
@@ -691,8 +800,8 @@ module FleetValidation
         RSC: `#{escape(evidence.dig('pack', 'rsc_version'))}`
         Aggregate: **#{escape(evidence.dig('aggregate', 'status').upcase)}**
 
-        | Target | Disposition | Status | Findings |
-        | --- | --- | --- | --- |
+        | Target | Disposition | GitHub archived | Status | Findings |
+        | --- | --- | --- | --- | --- |
         #{rows.join("\n")}
       MARKDOWN
     end
@@ -700,8 +809,8 @@ module FleetValidation
     def target_schema
       object_schema(
         %w[
-          id name tier disposition default_branch default_commit default_commit_at observed_at currency default_ci smoke
-          review_app dependabot staleness status findings
+          id name tier disposition default_branch default_commit default_commit_at repository_archived observed_at currency
+          default_ci smoke review_app dependabot staleness status findings
         ],
         {
           "id" => nonempty_string,
@@ -711,6 +820,7 @@ module FleetValidation
           "default_branch" => nullable_string,
           "default_commit" => nullable_string,
           "default_commit_at" => nullable_string,
+          "repository_archived" => { "type" => %w[boolean null] },
           "observed_at" => nullable_string,
           "currency" => currency_schema,
           "default_ci" => evidence_status_schema,
@@ -835,6 +945,10 @@ module FleetValidation
       present?(value) ? value : nil
     end
 
+    def boolean_or_nil(value)
+      value if [true, false].include?(value)
+    end
+
     def present?(value)
       !value.nil? && (!value.respond_to?(:empty?) || !value.empty?)
     end
@@ -863,7 +977,10 @@ module FleetValidation
     end
 
     def escape(value)
-      value.to_s.gsub("|", "\\|").gsub("<!--", "&lt;!--").gsub("-->", "--&gt;")
+      value.to_s.gsub("\\") { "\\\\" }
+           .gsub("|", "\\|")
+           .gsub("<!--", "&lt;!--")
+           .gsub("-->", "--&gt;")
     end
   end
 end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -213,7 +213,10 @@ module FleetValidation
         "/repos/#{repo}/commits/#{head}/check-runs?per_page=100",
         "check_runs"
       )
-      workflows = @client.get("/repos/#{repo}/actions/workflows?per_page=100").fetch("workflows", [])
+      workflows = paginated_collection(
+        "/repos/#{repo}/actions/workflows?per_page=100",
+        "workflows"
+      )
 
       {
         "default_branch" => default_branch,

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -192,6 +192,7 @@ module FleetValidation
   class PublicGitHubProbe
     SHARED_SMOKE_REFERENCE = "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@"
     PASSING_CONCLUSIONS = %w[success neutral skipped].freeze
+    MAX_PAGES = 20
     REVIEW_APP_MAX_AGE_DAYS = 45
 
     def initialize(client:)
@@ -208,7 +209,10 @@ module FleetValidation
       default_branch = metadata.fetch("default_branch")
       commit = @client.get("/repos/#{repo}/commits/#{default_branch}")
       head = commit.fetch("sha")
-      checks = @client.get("/repos/#{repo}/commits/#{head}/check-runs?per_page=100").fetch("check_runs", [])
+      checks = paginated_collection(
+        "/repos/#{repo}/commits/#{head}/check-runs?per_page=100",
+        "check_runs"
+      )
       workflows = @client.get("/repos/#{repo}/actions/workflows?per_page=100").fetch("workflows", [])
 
       {
@@ -230,6 +234,21 @@ module FleetValidation
     end
 
     private
+
+    def paginated_collection(path, key)
+      items = []
+      1.upto(MAX_PAGES) do |page|
+        separator = path.include?("?") ? "&" : "?"
+        page_path = page == 1 ? path : "#{path}#{separator}page=#{page}"
+        batch = @client.get(page_path).fetch(key, [])
+        raise ManifestError, "#{key} page #{page} is not an array" unless batch.is_a?(Array)
+
+        items.concat(batch)
+        return items if batch.length < 100
+      end
+
+      raise ManifestError, "#{key} pagination remained full after #{MAX_PAGES} pages"
+    end
 
     def package_versions(repo)
       PublicSBOM.package_versions(@client.get("/repos/#{repo}/dependency-graph/sbom"))

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -1,0 +1,787 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "rubygems/version"
+require "time"
+require "uri"
+require "yaml"
+require_relative "fleet_lifecycle"
+
+module FleetValidation
+  class PublicRegistryResolver
+    RUBYGEMS = "https://rubygems.org"
+    NPM = "https://registry.npmjs.org"
+
+    def initialize(fetcher:)
+      @fetcher = fetcher
+    end
+
+    def resolve(release:, rsc_version:)
+      product_version = release.delete_prefix("v")
+      gem_versions = @fetcher.call("#{RUBYGEMS}/api/v1/versions/react_on_rails.json")
+      npm_product = @fetcher.call("#{NPM}/react-on-rails")
+      npm_rsc = @fetcher.call("#{NPM}/react-on-rails-rsc")
+      unless Array(gem_versions).any? { |entry| entry["number"] == product_version && entry["yanked"] != true }
+        raise ManifestError, "react_on_rails #{product_version} is not a public non-yanked RubyGems artifact"
+      end
+      unless npm_product.fetch("versions", {}).key?(product_version)
+        raise ManifestError, "react-on-rails #{product_version} is not a public npm artifact"
+      end
+      unless npm_rsc.fetch("versions", {}).key?(rsc_version)
+        raise ManifestError, "react-on-rails-rsc #{rsc_version} is not a public npm artifact"
+      end
+
+      [
+        {
+          "ecosystem" => "gem",
+          "name" => "react_on_rails",
+          "version" => product_version,
+          "source" => RUBYGEMS
+        },
+        {
+          "ecosystem" => "npm",
+          "name" => "react-on-rails",
+          "version" => product_version,
+          "source" => NPM
+        },
+        {
+          "ecosystem" => "npm",
+          "name" => "react-on-rails-rsc",
+          "version" => rsc_version,
+          "source" => NPM
+        }
+      ]
+    end
+  end
+
+  module PublicSBOM
+    module_function
+
+    def package_versions(document)
+      versions = Array(document.dig("sbom", "packages")).filter_map do |package|
+        purl = Array(package["externalRefs"]).find { |reference| reference["referenceType"] == "purl" }
+        parse_purl(purl && purl["referenceLocator"])
+      end
+      versions.uniq { |package| [package["ecosystem"], package["name"], package["version"]] }
+    end
+
+    def parse_purl(value)
+      match = value.to_s.match(%r{\Apkg:(gem|npm)/(.+)@([^?]+)})
+      return unless match
+
+      {
+        "ecosystem" => match[1],
+        "name" => URI.decode_www_form_component(match[2]),
+        "version" => URI.decode_www_form_component(match[3]),
+        "source" => "github-sbom"
+      }
+    end
+  end
+
+  module DependabotV1
+    module_function
+
+    ECOSYSTEMS = {
+      "gem" => "bundler",
+      "npm" => "npm"
+    }.freeze
+
+    def evaluate(config, packages)
+      findings = []
+      unless config.is_a?(Hash) && config["version"] == 2 && config["updates"].is_a?(Array)
+        return { "status" => "blocked", "findings" => ["invalid-config"] }
+      end
+
+      required = Array(packages).filter_map { |package| ECOSYSTEMS[package["ecosystem"]] }.uniq
+      required << "github-actions"
+      required.each do |ecosystem|
+        entries = config.fetch("updates").select { |entry| entry["package-ecosystem"] == ecosystem }
+        if entries.empty?
+          findings << "#{ecosystem}:missing"
+          next
+        end
+
+        findings << "#{ecosystem}:not-weekly" unless entries.any? { |entry| entry.dig("schedule", "interval") == "weekly" }
+        if entries.all? { |entry| entry.fetch("open-pull-requests-limit", 1).zero? }
+          findings << "#{ecosystem}:version-updates-disabled"
+        end
+        next if ecosystem == "github-actions"
+
+        patterns = entries.flat_map do |entry|
+          entry.fetch("groups", {}).values.flat_map { |group| Array(group["patterns"]) }
+        end
+        expected_prefix = ecosystem == "bundler" ? "react_on_rails" : "react-on-rails"
+        unless patterns.any? { |pattern| pattern.start_with?(expected_prefix) }
+          findings << "#{ecosystem}:product-group-missing"
+        end
+      end
+
+      {
+        "status" => findings.empty? ? "passed" : "blocked",
+        "findings" => findings
+      }
+    end
+  end
+
+  class PublicGitHubProbe
+    SHARED_SMOKE_REFERENCE = "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@"
+    PASSING_CONCLUSIONS = %w[success neutral skipped].freeze
+
+    def initialize(client:)
+      @client = client
+    end
+
+    def observe(target, observed_at:)
+      repo = target.fetch("name")
+      metadata = @client.get("/repos/#{repo}")
+      default_branch = metadata.fetch("default_branch")
+      commit = @client.get("/repos/#{repo}/commits/#{default_branch}")
+      head = commit.fetch("sha")
+      checks = @client.get("/repos/#{repo}/commits/#{head}/check-runs?per_page=100").fetch("check_runs", [])
+      workflows = @client.get("/repos/#{repo}/actions/workflows?per_page=100").fetch("workflows", [])
+
+      {
+        "default_branch" => default_branch,
+        "default_commit" => head,
+        "default_commit_at" => commit.dig("commit", "committer", "date"),
+        "observed_at" => observed_at,
+        "package_versions" => package_versions(repo),
+        "default_ci" => check_status(checks),
+        "smoke" => smoke_status(repo, head, checks, workflows),
+        "review_app" => review_app_status(target, checks, workflows),
+        "dependabot" => dependabot_status(repo, head, target.fetch("packages"))
+      }
+    rescue StandardError => e
+      unknown_observation(observed_at, e.message)
+    end
+
+    private
+
+    def package_versions(repo)
+      PublicSBOM.package_versions(@client.get("/repos/#{repo}/dependency-graph/sbom"))
+    rescue StandardError
+      []
+    end
+
+    def check_status(checks)
+      return evidence_status("unknown", "No current-head check runs found") if checks.empty?
+
+      pending = checks.any? { |check| check["status"] != "completed" }
+      failures = checks.reject do |check|
+        check["status"] == "completed" && PASSING_CONCLUSIONS.include?(check["conclusion"])
+      end
+      status = if pending
+                 "unknown"
+               elsif failures.empty?
+                 "passed"
+               else
+                 "blocked"
+               end
+      evidence_status(status, evidence_urls(checks))
+    end
+
+    def smoke_status(repo, head, checks, workflows)
+      smoke_workflows = workflows.select { |workflow| smoke_name?(workflow["name"]) || smoke_name?(workflow["path"]) }
+      smoke_checks = checks.select { |check| smoke_name?(check["name"]) }
+      status = check_status(smoke_checks)
+      shared_contract = smoke_workflows.any? do |workflow|
+        @client.content(repo, workflow.fetch("path"), ref: head).include?(SHARED_SMOKE_REFERENCE)
+      rescue StandardError
+        false
+      end
+      status.merge(
+        "shared_contract" => shared_contract,
+        "evidence" => [status["evidence"], smoke_workflows.map { |workflow| workflow["path"] }.join(", ")]
+          .reject { |value| value.to_s.empty? }.join("; ")
+      )
+    end
+
+    def review_app_status(target, checks, workflows)
+      review_workflows = workflows.select { |workflow| review_app_name?(workflow["name"]) || review_app_name?(workflow["path"]) }
+      review_checks = checks.select { |check| review_app_name?(check["name"]) }
+      if review_workflows.empty? && target.fetch("review_app") == "not_required"
+        return evidence_status("not_applicable", "Review app is not required by public fleet policy")
+      end
+      return evidence_status("unknown", "Required review-app workflow was not found") if review_workflows.empty?
+
+      status = check_status(review_checks)
+      status["evidence"] = [status["evidence"], review_workflows.map { |workflow| workflow["path"] }.join(", ")]
+                           .reject { |value| value.to_s.empty? }.join("; ")
+      status
+    end
+
+    def dependabot_status(repo, head, packages)
+      content = @client.content(repo, ".github/dependabot.yml", ref: head)
+      config = YAML.safe_load(content, permitted_classes: [], permitted_symbols: [], aliases: false)
+      result = DependabotV1.evaluate(config, packages)
+      {
+        "status" => result.fetch("status"),
+        "policy" => "v1",
+        "evidence" => result.fetch("findings").empty? ? ".github/dependabot.yml" : result.fetch("findings").join(", ")
+      }
+    rescue StandardError => e
+      {
+        "status" => "blocked",
+        "policy" => "v1",
+        "evidence" => "Dependabot v1 config unavailable: #{e.class}"
+      }
+    end
+
+    def unknown_observation(observed_at, reason)
+      {
+        "default_branch" => nil,
+        "default_commit" => nil,
+        "default_commit_at" => nil,
+        "observed_at" => observed_at,
+        "package_versions" => [],
+        "default_ci" => evidence_status("unknown", reason),
+        "smoke" => evidence_status("unknown", reason).merge("shared_contract" => false),
+        "review_app" => evidence_status("unknown", reason),
+        "dependabot" => { "status" => "blocked", "policy" => "v1", "evidence" => reason }
+      }
+    end
+
+    def evidence_status(status, evidence)
+      { "status" => status, "evidence" => evidence }
+    end
+
+    def evidence_urls(checks)
+      checks.filter_map { |check| check["html_url"] }.uniq.join(", ")
+    end
+
+    def smoke_name?(value)
+      value.to_s.match?(/smoke/i)
+    end
+
+    def review_app_name?(value)
+      value.to_s.match?(/review.?app|cpflow/i)
+    end
+  end
+
+  class FleetHealth
+    PRODUCT_PACKAGES = {
+      "gem" => %w[react_on_rails react_on_rails_pro],
+      "npm" => %w[
+        react-on-rails react-on-rails-pro react-on-rails-pro-node-renderer
+      ]
+    }.freeze
+    PUBLIC_REGISTRY_ARTIFACTS = [
+      %w[gem react_on_rails],
+      %w[npm react-on-rails],
+      %w[npm react-on-rails-rsc]
+    ].freeze
+
+    attr_reader :targets
+
+    def initialize(manifest:, pack_id:, release:, rsc_version:, policy_commit:, generated_at:)
+      @manifest = manifest
+      @pack_id = require_nonempty(pack_id, "pack ID")
+      @release = require_nonempty(release, "release")
+      @rsc_version = require_nonempty(rsc_version, "RSC version")
+      @policy_commit = require_commit(policy_commit, "policy commit")
+      @generated_at = require_timestamp(generated_at, "generated_at")
+      validate_manifest!
+      @max_minor_lag = @manifest.dig("standing_health", "max_minor_lag")
+      @max_default_age_days = @manifest.dig("standing_health", "max_default_age_days")
+      @targets = build_targets
+    end
+
+    def evaluate(observations:, registry_artifacts:)
+      registry = evaluate_registry(registry_artifacts)
+      evaluated_targets = targets.map do |target|
+        evaluate_target(target, observations.fetch(target.fetch("id"), {}))
+      end
+      blocking_targets = evaluated_targets.filter_map do |target|
+        target.fetch("id") if target.fetch("status") == "blocked" && target.fetch("disposition") == "active"
+      end
+      aggregate_findings = []
+      aggregate_findings << "registry" unless registry.fetch("status") == "passed"
+      aggregate_findings << "active_targets" unless blocking_targets.empty?
+
+      {
+        "schema_version" => 1,
+        "pack" => {
+          "pack_id" => @pack_id,
+          "release" => @release,
+          "rsc_version" => @rsc_version,
+          "policy_commit" => @policy_commit,
+          "generated_at" => @generated_at
+        },
+        "registry" => registry,
+        "targets" => evaluated_targets,
+        "aggregate" => {
+          "status" => aggregate_findings.empty? ? "passed" : "blocked",
+          "blocking_targets" => blocking_targets,
+          "findings" => aggregate_findings
+        }
+      }
+    end
+
+    def schema
+      {
+        "$schema" => "https://json-schema.org/draft/2020-12/schema",
+        "title" => "React on Rails public demo fleet standing-health evidence",
+        "type" => "object",
+        "additionalProperties" => false,
+        "required" => %w[schema_version pack registry targets aggregate],
+        "properties" => {
+          "schema_version" => { "const" => 1 },
+          "pack" => object_schema(
+            %w[pack_id release rsc_version policy_commit generated_at],
+            {
+              "pack_id" => nonempty_string,
+              "release" => nonempty_string,
+              "rsc_version" => nonempty_string,
+              "policy_commit" => commit_string,
+              "generated_at" => nonempty_string
+            }
+          ),
+          "registry" => object_schema(
+            %w[status artifacts findings],
+            {
+              "status" => { "enum" => %w[passed blocked] },
+              "artifacts" => { "type" => "array", "items" => registry_artifact_schema },
+              "findings" => string_array
+            }
+          ),
+          "targets" => { "type" => "array", "items" => target_schema },
+          "aggregate" => object_schema(
+            %w[status blocking_targets findings],
+            {
+              "status" => { "enum" => %w[passed blocked] },
+              "blocking_targets" => string_array,
+              "findings" => string_array
+            }
+          )
+        }
+      }
+    end
+
+    def write_pack(output_dir, evidence)
+      errors = SchemaValidator.new(schema).errors(evidence)
+      raise ManifestError, "fleet health evidence is invalid: #{errors.join('; ')}" unless errors.empty?
+
+      FileUtils.mkdir_p(output_dir)
+      File.write(File.join(output_dir, "fleet-health.json"), "#{JSON.pretty_generate(evidence)}\n")
+      File.write(File.join(output_dir, "fleet-health.schema.json"), "#{JSON.pretty_generate(schema)}\n")
+      File.write(File.join(output_dir, "fleet-health.md"), render_summary(evidence))
+    end
+
+    private
+
+    def validate_manifest!
+      raise ManifestError, "schema_version must be 1" unless @manifest["schema_version"] == 1
+
+      standing_health = @manifest["standing_health"]
+      raise ManifestError, "standing_health must be a mapping" unless standing_health.is_a?(Hash)
+      unless standing_health["schema_version"] == 1
+        raise ManifestError, "standing_health.schema_version must be 1"
+      end
+      unless standing_health["dependabot_policy"] == "v1"
+        raise ManifestError, "standing_health.dependabot_policy must be v1"
+      end
+
+      %w[max_minor_lag max_default_age_days].each do |field|
+        value = standing_health[field]
+        unless value.is_a?(Integer) && value >= 0
+          raise ManifestError, "standing_health.#{field} must be a nonnegative integer"
+        end
+      end
+      return if @manifest["repos"].is_a?(Array)
+
+      raise ManifestError, "repos must be an array"
+    end
+
+    def build_targets
+      selected = @manifest.fetch("repos").filter_map do |repo|
+        health = repo["standing_health"]
+        next unless health.is_a?(Hash) && health["public"] == true
+
+        disposition = health["disposition"]
+        unless %w[active report_only archived].include?(disposition)
+          raise ManifestError, "#{repo['name']} standing_health.disposition is invalid"
+        end
+        if repo["tier"] == "soft_track" && disposition == "active"
+          raise ManifestError, "#{repo['name']} soft_track cannot be active standing health"
+        end
+
+        {
+          "id" => slug(repo.fetch("name")),
+          "name" => repo.fetch("name"),
+          "tier" => repo.fetch("tier"),
+          "disposition" => disposition,
+          "review_app" => health.fetch("review_app", "not_required"),
+          "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
+        }
+      end
+      archived = Array(@manifest.dig("standing_health", "archived_targets")).map do |repo|
+        unless repo.is_a?(Hash) && present?(repo["name"]) && present?(repo["headline"])
+          raise ManifestError, "standing_health.archived_targets entries must name a repo and headline"
+        end
+
+        {
+          "id" => slug(repo.fetch("name")),
+          "name" => repo.fetch("name"),
+          "tier" => "soft_track",
+          "disposition" => "archived",
+          "review_app" => "not_required",
+          "packages" => Array(repo["packages"]).map { |package| package.slice("ecosystem", "name") }
+        }
+      end
+      selected.concat(archived)
+      duplicates = selected.map { |target| target.fetch("id") }.tally.select { |_id, count| count > 1 }.keys
+      raise ManifestError, "standing health target IDs collide: #{duplicates.join(', ')}" unless duplicates.empty?
+      raise ManifestError, "standing health has no public targets" if selected.empty?
+
+      selected
+    end
+
+    def evaluate_registry(artifacts)
+      indexed = Array(artifacts).to_h do |artifact|
+        [[artifact["ecosystem"], artifact["name"]], artifact]
+      end
+      findings = PUBLIC_REGISTRY_ARTIFACTS.filter_map do |ecosystem, name|
+        artifact = indexed[[ecosystem, name]]
+        expected = name == "react-on-rails-rsc" ? @rsc_version : normalized_release(ecosystem)
+        "#{ecosystem}:#{name}" unless artifact && artifact["version"] == expected && present?(artifact["source"])
+      end
+
+      {
+        "status" => findings.empty? ? "passed" : "blocked",
+        "artifacts" => Array(artifacts),
+        "findings" => findings
+      }
+    end
+
+    def evaluate_target(target, observation)
+      findings = []
+      currency = evaluate_currency(target, observation)
+      findings << "currency" unless currency.fetch("status") == "passed"
+
+      default_ci = normalize_evidence_status(observation["default_ci"])
+      smoke = normalize_smoke_status(observation["smoke"])
+      review_app = normalize_evidence_status(observation["review_app"])
+      dependabot = normalize_dependabot_status(observation["dependabot"])
+      staleness = evaluate_staleness(observation["default_commit_at"])
+
+      if target.fetch("disposition") == "active"
+        findings << "default_ci" unless default_ci.fetch("status") == "passed"
+        findings << "smoke" unless smoke.fetch("status") == "passed" && smoke.fetch("shared_contract")
+        if target.fetch("review_app") == "required" && review_app.fetch("status") != "passed"
+          findings << "review_app"
+        end
+        findings << "dependabot" unless dependabot.fetch("status") == "passed"
+        findings << "staleness" unless staleness.fetch("status") == "passed"
+      end
+
+      {
+        "id" => target.fetch("id"),
+        "name" => target.fetch("name"),
+        "tier" => target.fetch("tier"),
+        "disposition" => target.fetch("disposition"),
+        "default_branch" => nullable_string_value(observation["default_branch"]),
+        "default_commit" => nullable_string_value(observation["default_commit"]),
+        "default_commit_at" => nullable_string_value(observation["default_commit_at"]),
+        "observed_at" => nullable_string_value(observation["observed_at"]),
+        "currency" => currency,
+        "default_ci" => default_ci,
+        "smoke" => smoke,
+        "review_app" => review_app,
+        "dependabot" => dependabot,
+        "staleness" => staleness,
+        "status" => if target.fetch("disposition") == "active"
+                      findings.empty? ? "passed" : "blocked"
+                    else
+                      "reported"
+                    end,
+        "findings" => findings
+      }
+    end
+
+    def evaluate_currency(target, observation)
+      expected_packages = target.fetch("packages").filter_map do |package|
+        expected = expected_version(package["ecosystem"], package["name"])
+        package.merge("expected" => expected) if expected
+      end
+      expected_keys = expected_packages.map { |package| [package["ecosystem"], package["name"]] }
+      observed = Array(observation["package_versions"]).select do |package|
+        expected_keys.include?([package["ecosystem"], package["name"]])
+      end
+      findings = expected_packages.filter_map do |package|
+        key = [package["ecosystem"], package["name"]]
+        actual_versions = observed.filter_map do |actual|
+          actual["version"] if key == [actual["ecosystem"], actual["name"]]
+        end
+        package["name"] unless actual_versions.any? do |actual|
+          acceptable_version?(package["ecosystem"], package["name"], actual, package["expected"])
+        end
+      end
+
+      {
+        "status" => findings.empty? ? "passed" : "blocked",
+        "expected" => expected_packages,
+        "observed" => observed,
+        "findings" => findings
+      }
+    end
+
+    def expected_version(ecosystem, name)
+      if name == "react-on-rails-rsc"
+        @rsc_version
+      elsif PRODUCT_PACKAGES.fetch(ecosystem, []).include?(name)
+        normalized_release(ecosystem)
+      end
+    end
+
+    def acceptable_version?(_ecosystem, name, actual, expected)
+      return actual == expected if name == "react-on-rails-rsc"
+
+      actual_version = Gem::Version.new(actual)
+      expected_version = Gem::Version.new(expected)
+      return false if actual_version.prerelease? || expected_version.prerelease?
+
+      actual_segments = actual_version.segments
+      expected_segments = expected_version.segments
+      same_major = actual_segments.fetch(0, 0) == expected_segments.fetch(0, 0)
+      minor_lag = expected_segments.fetch(1, 0) - actual_segments.fetch(1, 0)
+      same_major && minor_lag.between?(0, @max_minor_lag)
+    rescue ArgumentError
+      false
+    end
+
+    def normalized_release(ecosystem)
+      version = @release.delete_prefix("v")
+      ecosystem == "npm" ? version.gsub(/\.((?:rc|beta))\.(\d+)\z/, '-\\1.\\2') : version
+    end
+
+    def normalize_evidence_status(value)
+      value = {} unless value.is_a?(Hash)
+      status = value["status"]
+      status = "unknown" unless %w[passed blocked unknown not_applicable].include?(status)
+      {
+        "status" => status,
+        "evidence" => nullable_string_value(value["evidence"])
+      }
+    end
+
+    def normalize_smoke_status(value)
+      normalized = normalize_evidence_status(value)
+      normalized["shared_contract"] = value.is_a?(Hash) && value["shared_contract"] == true
+      normalized
+    end
+
+    def normalize_dependabot_status(value)
+      normalized = normalize_evidence_status(value)
+      normalized["policy"] = value.is_a?(Hash) && value["policy"] == "v1" ? "v1" : "unknown"
+      normalized
+    end
+
+    def evaluate_staleness(default_commit_at)
+      commit_time = Time.iso8601(default_commit_at.to_s)
+      age_days = ((Time.iso8601(@generated_at) - commit_time) / 86_400).floor
+      {
+        "status" => age_days <= @max_default_age_days ? "passed" : "blocked",
+        "age_days" => age_days,
+        "max_age_days" => @max_default_age_days,
+        "evidence" => default_commit_at
+      }
+    rescue ArgumentError
+      {
+        "status" => "unknown",
+        "age_days" => nil,
+        "max_age_days" => @max_default_age_days,
+        "evidence" => nullable_string_value(default_commit_at)
+      }
+    end
+
+    def render_summary(evidence)
+      rows = evidence.fetch("targets").map do |target|
+        findings = target.fetch("findings")
+        "| `#{escape(target.fetch('id'))}` | #{target.fetch('disposition')} | #{target.fetch('status')} | " \
+          "#{findings.empty? ? 'none' : findings.join(', ')} |"
+      end
+      <<~MARKDOWN
+        # Public demo fleet standing health
+
+        Pack: `#{escape(evidence.dig('pack', 'pack_id'))}`
+        Release: `#{escape(evidence.dig('pack', 'release'))}`
+        RSC: `#{escape(evidence.dig('pack', 'rsc_version'))}`
+        Aggregate: **#{escape(evidence.dig('aggregate', 'status').upcase)}**
+
+        | Target | Disposition | Status | Findings |
+        | --- | --- | --- | --- |
+        #{rows.join("\n")}
+      MARKDOWN
+    end
+
+    def target_schema
+      object_schema(
+        %w[
+          id name tier disposition default_branch default_commit default_commit_at observed_at currency default_ci smoke
+          review_app dependabot staleness status findings
+        ],
+        {
+          "id" => nonempty_string,
+          "name" => nonempty_string,
+          "tier" => { "enum" => %w[hard_gate soft_track] },
+          "disposition" => { "enum" => %w[active report_only archived] },
+          "default_branch" => nullable_string,
+          "default_commit" => nullable_string,
+          "default_commit_at" => nullable_string,
+          "observed_at" => nullable_string,
+          "currency" => currency_schema,
+          "default_ci" => evidence_status_schema,
+          "smoke" => smoke_status_schema,
+          "review_app" => evidence_status_schema,
+          "dependabot" => dependabot_status_schema,
+          "staleness" => staleness_schema,
+          "status" => { "enum" => %w[passed blocked reported] },
+          "findings" => string_array
+        }
+      )
+    end
+
+    def currency_schema
+      object_schema(
+        %w[status expected observed findings],
+        {
+          "status" => { "enum" => %w[passed blocked] },
+          "expected" => {
+            "type" => "array",
+            "items" => object_schema(
+              %w[ecosystem name expected],
+              {
+                "ecosystem" => { "enum" => %w[gem npm] },
+                "name" => nonempty_string,
+                "expected" => nonempty_string
+              }
+            )
+          },
+          "observed" => { "type" => "array", "items" => package_version_schema },
+          "findings" => string_array
+        }
+      )
+    end
+
+    def registry_artifact_schema
+      object_schema(
+        %w[ecosystem name version source],
+        {
+          "ecosystem" => { "enum" => %w[gem npm] },
+          "name" => nonempty_string,
+          "version" => nonempty_string,
+          "source" => nonempty_string
+        }
+      )
+    end
+
+    def package_version_schema
+      object_schema(
+        %w[ecosystem name version source],
+        {
+          "ecosystem" => { "enum" => %w[gem npm] },
+          "name" => nonempty_string,
+          "version" => nonempty_string,
+          "source" => nonempty_string
+        }
+      )
+    end
+
+    def evidence_status_schema
+      object_schema(
+        %w[status evidence],
+        {
+          "status" => { "enum" => %w[passed blocked unknown not_applicable] },
+          "evidence" => nullable_string
+        }
+      )
+    end
+
+    def smoke_status_schema
+      object_schema(
+        %w[status evidence shared_contract],
+        evidence_status_schema.fetch("properties").merge("shared_contract" => { "type" => "boolean" })
+      )
+    end
+
+    def dependabot_status_schema
+      object_schema(
+        %w[status evidence policy],
+        evidence_status_schema.fetch("properties").merge("policy" => { "enum" => %w[v1 unknown] })
+      )
+    end
+
+    def staleness_schema
+      object_schema(
+        %w[status age_days max_age_days evidence],
+        {
+          "status" => { "enum" => %w[passed blocked unknown] },
+          "age_days" => { "type" => %w[integer null] },
+          "max_age_days" => { "type" => "integer" },
+          "evidence" => nullable_string
+        }
+      )
+    end
+
+    def object_schema(required, properties)
+      {
+        "type" => "object",
+        "additionalProperties" => false,
+        "required" => required,
+        "properties" => properties
+      }
+    end
+
+    def nonempty_string
+      { "type" => "string", "minLength" => 1 }
+    end
+
+    def commit_string
+      { "type" => "string", "pattern" => "\\A[0-9a-f]{40}\\z" }
+    end
+
+    def nullable_string
+      { "type" => %w[string null] }
+    end
+
+    def string_array
+      { "type" => "array", "items" => nonempty_string }
+    end
+
+    def nullable_string_value(value)
+      present?(value) ? value : nil
+    end
+
+    def present?(value)
+      !value.nil? && (!value.respond_to?(:empty?) || !value.empty?)
+    end
+
+    def require_nonempty(value, label)
+      raise ManifestError, "#{label} must be nonempty" unless present?(value)
+
+      value
+    end
+
+    def require_commit(value, label)
+      raise ManifestError, "#{label} must be a 40-character commit" unless value.to_s.match?(/\A[0-9a-f]{40}\z/)
+
+      value
+    end
+
+    def require_timestamp(value, label)
+      Time.iso8601(value)
+      value
+    rescue ArgumentError
+      raise ManifestError, "#{label} must be an ISO-8601 timestamp"
+    end
+
+    def slug(value)
+      value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-\z/, "")
+    end
+
+    def escape(value)
+      value.to_s.gsub("|", "\\|").gsub("<!--", "&lt;!--").gsub("-->", "--&gt;")
+    end
+  end
+end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -906,6 +906,15 @@ module FleetValidation
     def evaluate_staleness(default_commit_at)
       commit_time = Time.iso8601(default_commit_at.to_s)
       age_days = ((Time.iso8601(@generated_at) - commit_time) / 86_400).floor
+      if age_days.negative?
+        return {
+          "status" => "unknown",
+          "age_days" => age_days,
+          "max_age_days" => @max_default_age_days,
+          "evidence" => "#{default_commit_at}; generated_at=#{@generated_at}; future default commit timestamp"
+        }
+      end
+
       {
         "status" => age_days <= @max_default_age_days ? "passed" : "blocked",
         "age_days" => age_days,

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -438,10 +438,27 @@ module FleetValidation
         "/repos/#{repo}/actions/workflows/#{workflow_id}/runs?event=pull_request&per_page=100",
         "workflow_runs"
       )
-      run = runs.find do |candidate|
-        Array(candidate["pull_requests"]).any? { |pull_request| pull_request.dig("base", "ref") == default_branch }
+      run = nil
+      rejections = []
+      runs.each_with_index do |candidate, index|
+        identity_error = review_run_identity_error(candidate, default_branch:, observed_at:)
+        if identity_error
+          rejections << "run[#{index}]: #{identity_error}"
+          next
+        end
+
+        run = candidate
+        break
       end
-      return evidence_status("unknown", "#{workflow_evidence}; no public workflow run targeting #{default_branch}") unless run
+      unless run
+        evidence = if rejections.empty?
+                     "#{workflow_evidence}; no public workflow run targeting #{default_branch}"
+                   else
+                     "#{workflow_evidence}; no identity-valid public workflow run targeting #{default_branch}; " \
+                       "rejected candidates: #{rejections.join(', ')}"
+                   end
+        return evidence_status("unknown", evidence)
+      end
 
       evidence = [
         workflow_evidence,
@@ -452,8 +469,6 @@ module FleetValidation
         ("run_started_at=#{run['run_started_at']}" if run["run_started_at"]),
         ("updated_at=#{run['updated_at']}" if run["updated_at"])
       ].compact.join("; ")
-      identity_error = review_run_identity_error(run, default_branch:, observed_at:)
-      return evidence_status("unknown", "#{evidence}; #{identity_error}") if identity_error
       return evidence_status("unknown", evidence) unless run["status"] == "completed"
 
       status = run["conclusion"] == "success" ? "passed" : "blocked"

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -103,7 +103,7 @@ class FleetHealthTest < Minitest::Test
     assert_equal "passed", target(evidence, "sanitized-active-current").dig("currency", "status")
   end
 
-  def test_currency_evidence_keeps_only_relevant_packages_and_accepts_any_matching_version
+  def test_currency_rejects_mixed_direct_versions_and_keeps_only_relevant_packages
     observations = Marshal.load(Marshal.dump(@observations))
     current = observations.fetch("sanitized-active-current")
     current.fetch("package_versions").prepend(
@@ -127,7 +127,8 @@ class FleetHealthTest < Minitest::Test
     )
     currency = target(evidence, "sanitized-active-current").fetch("currency")
 
-    assert_equal "passed", currency.fetch("status")
+    assert_equal "blocked", currency.fetch("status")
+    assert_includes currency.fetch("findings"), "react_on_rails"
     refute_includes currency.fetch("observed").map { |package| package.fetch("name") }, "unrelated"
   end
 
@@ -235,10 +236,43 @@ class FleetHealthTest < Minitest::Test
   def test_public_sbom_parser_extracts_gem_and_npm_versions
     sbom = {
       "sbom" => {
+        "SPDXID" => "SPDXRef-DOCUMENT",
         "packages" => [
-          { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:gem/react_on_rails@17.0.0" }] },
-          { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:npm/react-on-rails@17.0.0" }] },
-          { "externalRefs" => [{ "referenceType" => "website", "referenceLocator" => "https://example.invalid" }] }
+          { "SPDXID" => "SPDXRef-Root", "name" => "demo" },
+          {
+            "SPDXID" => "SPDXRef-Gem",
+            "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:gem/react_on_rails@17.0.0" }]
+          },
+          {
+            "SPDXID" => "SPDXRef-Npm",
+            "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:npm/react-on-rails@17.0.0" }]
+          },
+          {
+            "SPDXID" => "SPDXRef-Transitive",
+            "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:npm/react-on-rails@16.0.0" }]
+          }
+        ],
+        "relationships" => [
+          {
+            "spdxElementId" => "SPDXRef-DOCUMENT",
+            "relationshipType" => "DESCRIBES",
+            "relatedSpdxElement" => "SPDXRef-Root"
+          },
+          {
+            "spdxElementId" => "SPDXRef-Root",
+            "relationshipType" => "DEPENDS_ON",
+            "relatedSpdxElement" => "SPDXRef-Gem"
+          },
+          {
+            "spdxElementId" => "SPDXRef-Root",
+            "relationshipType" => "DEPENDS_ON",
+            "relatedSpdxElement" => "SPDXRef-Npm"
+          },
+          {
+            "spdxElementId" => "SPDXRef-Npm",
+            "relationshipType" => "DEPENDS_ON",
+            "relatedSpdxElement" => "SPDXRef-Transitive"
+          }
         ]
       }
     }
@@ -254,14 +288,35 @@ class FleetHealthTest < Minitest::Test
     )
   end
 
+  def test_public_sbom_parser_fails_closed_without_a_root_dependency_identity
+    sbom = {
+      "sbom" => {
+        "SPDXID" => "SPDXRef-DOCUMENT",
+        "packages" => [
+          {
+            "SPDXID" => "SPDXRef-Gem",
+            "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:gem/react_on_rails@17.0.0" }]
+          }
+        ],
+        "relationships" => []
+      }
+    }
+
+    assert_empty FleetValidation::PublicSBOM.package_versions(sbom)
+  end
+
   def test_public_registry_resolver_verifies_exact_stable_artifacts
     responses = {
       "https://rubygems.org/api/v1/versions/react_on_rails.json" => [
         { "number" => "17.0.0", "yanked" => false }
       ],
-      "https://registry.npmjs.org/react-on-rails" => {
-        "versions" => { "17.0.0" => {} }
-      },
+      "https://rubygems.org/api/v1/versions/react_on_rails_pro.json" => [
+        { "number" => "17.0.0", "yanked" => false }
+      ],
+      "https://registry.npmjs.org/react-on-rails" => { "versions" => { "17.0.0" => {} } },
+      "https://registry.npmjs.org/react-on-rails-pro" => { "versions" => { "17.0.0" => {} } },
+      "https://registry.npmjs.org/react-on-rails-pro-node-renderer" => { "versions" => { "17.0.0" => {} } },
+      "https://registry.npmjs.org/create-react-on-rails-app" => { "versions" => { "17.0.0" => {} } },
       "https://registry.npmjs.org/react-on-rails-rsc" => {
         "versions" => { "19.2.1" => {} }
       }
@@ -271,6 +326,24 @@ class FleetHealthTest < Minitest::Test
     artifacts = resolver.resolve(release: "v17.0.0", rsc_version: "19.2.1")
 
     assert_equal stable_registry_artifacts, artifacts
+    assert_equal 7, @contract.schema.dig("properties", "registry", "properties", "artifacts", "minItems")
+  end
+
+  def test_public_registry_resolver_rejects_an_incomplete_product_suite
+    resolver = FleetValidation::PublicRegistryResolver.new(fetcher: lambda do |url|
+      next [] if url.end_with?("react_on_rails_pro.json")
+
+      if url.include?("rubygems.org")
+        [{ "number" => "17.0.0", "yanked" => false }]
+      else
+        { "versions" => { "17.0.0" => {}, "19.2.1" => {} } }
+      end
+    end)
+
+    error = assert_raises(FleetValidation::ManifestError) do
+      resolver.resolve(release: "v17.0.0", rsc_version: "19.2.1")
+    end
+    assert_includes error.message, "react_on_rails_pro"
   end
 
   def test_public_github_probe_binds_health_evidence_to_the_default_head
@@ -293,9 +366,38 @@ class FleetHealthTest < Minitest::Test
         },
         "/repos/#{repo}/dependency-graph/sbom" => {
           "sbom" => {
+            "SPDXID" => "SPDXRef-DOCUMENT",
             "packages" => [
-              { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:gem/react_on_rails@17.0.0" }] },
-              { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:npm/react-on-rails@17.0.0" }] }
+              { "SPDXID" => "SPDXRef-Root", "name" => "demo" },
+              {
+                "SPDXID" => "SPDXRef-Gem",
+                "externalRefs" => [
+                  { "referenceType" => "purl", "referenceLocator" => "pkg:gem/react_on_rails@17.0.0" }
+                ]
+              },
+              {
+                "SPDXID" => "SPDXRef-Npm",
+                "externalRefs" => [
+                  { "referenceType" => "purl", "referenceLocator" => "pkg:npm/react-on-rails@17.0.0" }
+                ]
+              }
+            ],
+            "relationships" => [
+              {
+                "spdxElementId" => "SPDXRef-DOCUMENT",
+                "relationshipType" => "DESCRIBES",
+                "relatedSpdxElement" => "SPDXRef-Root"
+              },
+              {
+                "spdxElementId" => "SPDXRef-Root",
+                "relationshipType" => "DEPENDS_ON",
+                "relatedSpdxElement" => "SPDXRef-Gem"
+              },
+              {
+                "spdxElementId" => "SPDXRef-Root",
+                "relationshipType" => "DEPENDS_ON",
+                "relatedSpdxElement" => "SPDXRef-Npm"
+              }
             ]
           }
         },
@@ -307,19 +409,29 @@ class FleetHealthTest < Minitest::Test
               "status" => "completed",
               "conclusion" => "success",
               "html_url" => "https://example.invalid/smoke"
-            },
-            {
-              "name" => "cpflow/review-app",
-              "status" => "completed",
-              "conclusion" => "success",
-              "html_url" => "https://example.invalid/review-app"
             }
           ]
         },
         "/repos/#{repo}/actions/workflows?per_page=100" => {
           "workflows" => [
             { "path" => ".github/workflows/demo-fleet-smoke.yml", "name" => "Demo fleet smoke" },
-            { "path" => ".github/workflows/cpflow-review-app.yml", "name" => "Review app" }
+            {
+              "id" => 42,
+              "path" => ".github/workflows/cpflow-review-app.yml",
+              "name" => "Review app",
+              "state" => "active",
+              "html_url" => "https://example.invalid/workflow"
+            }
+          ]
+        },
+        "/repos/#{repo}/actions/workflows/42/runs?per_page=1" => {
+          "workflow_runs" => [
+            {
+              "status" => "completed",
+              "conclusion" => "success",
+              "html_url" => "https://example.invalid/review-app-run",
+              "updated_at" => "2026-07-18T10:00:00Z"
+            }
           ]
         }
       },
@@ -344,7 +456,47 @@ class FleetHealthTest < Minitest::Test
     assert_equal "passed", observation.dig("default_ci", "status")
     assert_equal true, observation.dig("smoke", "shared_contract")
     assert_equal "passed", observation.dig("review_app", "status")
+    assert_includes observation.dig("review_app", "evidence"), "2026-07-18T10:00:00Z"
     assert_equal "passed", observation.dig("dependabot", "status")
+  end
+
+  def test_review_app_capability_distinguishes_broken_pending_and_missing_runs
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-review-app.yml",
+      "name" => "Review app",
+      "state" => "active",
+      "html_url" => "https://example.invalid/workflow"
+    }
+    client = Struct.new(:runs) do
+      def get(_path)
+        { "workflow_runs" => runs }
+      end
+    end
+    probe = FleetValidation::PublicGitHubProbe.new(client: client.new([
+                                                                        {
+                                                                          "status" => "completed",
+                                                                          "conclusion" => "failure",
+                                                                          "html_url" => "https://example.invalid/run",
+                                                                          "updated_at" => "2026-07-18T10:00:00Z"
+                                                                        }
+                                                                      ]))
+
+    broken = probe.send(:review_app_status, repo, target, [workflow])
+    probe = FleetValidation::PublicGitHubProbe.new(client: client.new([
+                                                                        { "status" => "in_progress", "html_url" => "https://example.invalid/run", "updated_at" => "2026-07-18T11:00:00Z" }
+                                                                      ]))
+    pending = probe.send(:review_app_status, repo, target, [workflow])
+    probe = FleetValidation::PublicGitHubProbe.new(client: client.new([]))
+    missing_run = probe.send(:review_app_status, repo, target, [workflow])
+    absent_workflow = probe.send(:review_app_status, repo, target, [])
+
+    assert_equal "blocked", broken.fetch("status")
+    assert_equal "unknown", pending.fetch("status")
+    assert_equal "unknown", missing_run.fetch("status")
+    assert_equal "unknown", absent_workflow.fetch("status")
   end
 
   def test_public_github_probe_degrades_a_target_failure_to_unknown
@@ -399,8 +551,32 @@ class FleetHealthTest < Minitest::Test
         "source" => "https://rubygems.org"
       },
       {
+        "ecosystem" => "gem",
+        "name" => "react_on_rails_pro",
+        "version" => "17.0.0",
+        "source" => "https://rubygems.org"
+      },
+      {
         "ecosystem" => "npm",
         "name" => "react-on-rails",
+        "version" => "17.0.0",
+        "source" => "https://registry.npmjs.org"
+      },
+      {
+        "ecosystem" => "npm",
+        "name" => "react-on-rails-pro",
+        "version" => "17.0.0",
+        "source" => "https://registry.npmjs.org"
+      },
+      {
+        "ecosystem" => "npm",
+        "name" => "react-on-rails-pro-node-renderer",
+        "version" => "17.0.0",
+        "source" => "https://registry.npmjs.org"
+      },
+      {
+        "ecosystem" => "npm",
+        "name" => "create-react-on-rails-app",
         "version" => "17.0.0",
         "source" => "https://registry.npmjs.org"
       },

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -13,6 +13,10 @@ class FleetHealthTest < Minitest::Test
   CHECK_FLEET_HEALTH = File.expand_path("check_fleet_health.rb", __dir__)
   REUSABLE_SMOKE = File.expand_path("../../../../.github/workflows/demo-fleet-smoke.yml", __dir__)
   SCHEDULED_HEALTH = File.expand_path("../../../../.github/workflows/demo-fleet-health.yml", __dir__)
+  SKILL = File.expand_path("../SKILL.md", __dir__)
+  RC_PLAN = File.expand_path("../../../../internal/contributor-info/rc-testing-plan.md", __dir__)
+  RELEASE_RUNBOOK = File.expand_path("../../../../internal/contributor-info/release-verification-runbook.md", __dir__)
+  RUBY_SETUP_SHA = "9eb537ca036ebaed86729dcb9309076e4c5c3b74"
 
   def setup
     fixture = YAML.safe_load_file(FIXTURE, aliases: false)
@@ -58,6 +62,43 @@ class FleetHealthTest < Minitest::Test
     assert_includes error.message, "review_app_workflow"
   end
 
+  def test_manifest_rejects_unknown_package_ecosystems_and_names
+    unknown_name = Marshal.load(Marshal.dump(@manifest))
+    unknown_name.fetch("repos").first.fetch("packages") << {
+      "ecosystem" => "npm",
+      "name" => "react-on-rail"
+    }
+    error = assert_raises(FleetValidation::ManifestError) { build_contract(unknown_name) }
+    assert_includes error.message, "react-on-rail"
+
+    unknown_ecosystem = Marshal.load(Marshal.dump(@manifest))
+    unknown_ecosystem.fetch("repos").first.fetch("packages") << {
+      "ecosystem" => "cargo",
+      "name" => "react-on-rails"
+    }
+    error = assert_raises(FleetValidation::ManifestError) { build_contract(unknown_ecosystem) }
+    assert_includes error.message, "cargo"
+  end
+
+  def test_manifest_allows_intentional_non_product_packages
+    manifest = Marshal.load(Marshal.dump(@manifest))
+    packages = [
+      { "ecosystem" => "gem", "name" => "shakapacker" },
+      { "ecosystem" => "gem", "name" => "cpflow" },
+      { "ecosystem" => "npm", "name" => "shakapacker" },
+      { "ecosystem" => "npm", "name" => "shakapacker-rspack" }
+    ]
+    manifest.fetch("repos").first.fetch("packages").concat(packages)
+
+    contract = build_contract(manifest)
+
+    assert_includes contract.targets.first.fetch("packages"), { "ecosystem" => "gem", "name" => "cpflow" }
+    assert_includes contract.targets.first.fetch("packages"), {
+      "ecosystem" => "npm",
+      "name" => "shakapacker-rspack"
+    }
+  end
+
   def test_active_drift_blocks_aggregate_while_soft_and_archived_targets_are_report_only
     evidence = @contract.evaluate(
       observations: @observations,
@@ -81,8 +122,27 @@ class FleetHealthTest < Minitest::Test
     assert_equal "blocked", drifted.dig("staleness", "status")
     assert_equal "reported", report_only.fetch("status")
     assert_equal "reported", archived.fetch("status")
+    assert_equal %w[currency default_ci smoke dependabot staleness], report_only.fetch("findings")
+    assert_equal %w[default_ci smoke dependabot staleness], archived.fetch("findings")
     assert_equal "blocked", evidence.dig("aggregate", "status")
     assert_equal ["sanitized-active-drifted"], evidence.dig("aggregate", "blocking_targets")
+  end
+
+  def test_report_only_target_retains_required_review_app_drift_without_blocking
+    manifest = Marshal.load(Marshal.dump(@manifest))
+    report_only = manifest.fetch("repos").find { |repo| repo["name"] == "sanitized/report-only" }
+    report_only.fetch("standing_health").merge!(
+      "review_app" => "required",
+      "review_app_workflow" => ".github/workflows/cpflow-deploy-review-app.yml"
+    )
+    contract = build_contract(manifest)
+
+    evidence = contract.evaluate(observations: @observations, registry_artifacts: stable_registry_artifacts)
+    target = target(evidence, "sanitized-report-only")
+
+    assert_equal "reported", target.fetch("status")
+    assert_includes target.fetch("findings"), "review_app"
+    refute_includes evidence.dig("aggregate", "blocking_targets"), "sanitized-report-only"
   end
 
   def test_active_repository_archival_is_surfaced_as_blocking_manifest_drift
@@ -178,10 +238,12 @@ class FleetHealthTest < Minitest::Test
   end
 
   def test_markdown_escaping_preserves_literal_backslashes_and_table_delimiters
-    escaped = @contract.send(:escape, 'literal\path|column')
+    escaped = @contract.send(:escape, "literal\\path|column`code\nnext")
 
-    assert_equal 3, escaped.count("\\")
+    assert_equal 4, escaped.count("\\")
     assert_includes escaped, '\|'
+    assert_includes escaped, '\`'
+    refute_includes escaped, "\n"
   end
 
   def test_writes_a_machine_readable_pack_and_human_summary
@@ -200,7 +262,7 @@ class FleetHealthTest < Minitest::Test
   end
 
   def test_sanitized_rc12_replay_detects_standing_health_drift
-    stdout, stderr, status = Open3.capture3("ruby", RC12_REPLAY)
+    stdout, stderr, status = Open3.capture3("bundle", "exec", "ruby", RC12_REPLAY)
 
     assert status.success?, stderr
     assert_includes stdout, "SANITIZED_RC12_FLEET_HEALTH_REPLAY_PASS"
@@ -219,7 +281,7 @@ class FleetHealthTest < Minitest::Test
       File.write(registry_path, YAML.dump(stable_registry_artifacts))
 
       _stdout, stderr, status = Open3.capture3(
-        "ruby", CHECK_FLEET_HEALTH,
+        "bundle", "exec", "ruby", CHECK_FLEET_HEALTH,
         "--manifest", manifest_path,
         "--observations", observations_path,
         "--registry-artifacts", registry_path,
@@ -462,6 +524,47 @@ class FleetHealthTest < Minitest::Test
     assert_includes error.message, "react_on_rails_pro"
   end
 
+  def test_public_github_probe_stops_after_non_public_metadata
+    target = @contract.targets.first
+    requests = []
+    client = Object.new
+    client.define_singleton_method(:get) do |path|
+      requests << path
+      raise "non-metadata read attempted" unless requests.one?
+
+      { "visibility" => "private-secret", "default_branch" => "main" }
+    end
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    error = assert_raises(FleetValidation::ManifestError) do
+      probe.observe(target, observed_at: "2026-07-18T12:00:00Z")
+    end
+
+    assert_equal ["/repos/#{target.fetch('name')}"], requests
+    assert_equal "FleetValidation::NonPublicRepositoryError", error.class.name
+    refute_includes error.message, "private-secret"
+  end
+
+  def test_default_ci_requires_a_successful_exact_head_check
+    probe = FleetValidation::PublicGitHubProbe.new(client: nil)
+    skipped = {
+      "name" => "Paths filtered",
+      "status" => "completed",
+      "conclusion" => "skipped",
+      "html_url" => "https://example.invalid/skipped"
+    }
+    success = skipped.merge(
+      "name" => "CI",
+      "conclusion" => "success",
+      "html_url" => "https://example.invalid/success"
+    )
+    pending = success.merge("status" => "in_progress", "conclusion" => nil)
+
+    assert_equal "unknown", probe.send(:check_status, [skipped]).fetch("status")
+    assert_equal "passed", probe.send(:check_status, [skipped, success]).fetch("status")
+    assert_equal "unknown", probe.send(:check_status, [success, pending]).fetch("status")
+  end
+
   def test_public_github_probe_binds_health_evidence_to_the_default_head
     target = @contract.targets.first
     repo = target.fetch("name")
@@ -475,7 +578,7 @@ class FleetHealthTest < Minitest::Test
       end
     end.new(
       {
-        "/repos/#{repo}" => { "default_branch" => "main", "archived" => false },
+        "/repos/#{repo}" => { "visibility" => "public", "default_branch" => "main", "archived" => false },
         "/repos/#{repo}/commits/main" => {
           "sha" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "commit" => { "committer" => { "date" => "2026-07-17T12:00:00Z" } }
@@ -563,7 +666,14 @@ class FleetHealthTest < Minitest::Test
           repo,
           ".github/workflows/demo-fleet-smoke.yml",
           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        ] => "uses: shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main",
+        ] => YAML.dump(
+          "name" => "CI",
+          "jobs" => {
+            "fleet" => {
+              "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+            }
+          }
+        ),
         [
           repo,
           ".github/dependabot.yml",
@@ -772,15 +882,21 @@ class FleetHealthTest < Minitest::Test
     head = "a" * 40
     workflow = {
       "id" => 41,
-      "path" => ".github/workflows/smoke-caller.yml",
-      "name" => "Fleet smoke caller",
+      "path" => ".github/workflows/ci.yml",
+      "name" => "CI",
       "html_url" => "https://example.invalid/workflow"
     }
     client = Struct.new(:contents) do
       def content(_repo, _path, ref:)
         raise "wrong head" unless ref == "a" * 40
 
-        "uses: shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+        YAML.dump(
+          "jobs" => {
+            "fleet" => {
+              "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+            }
+          }
+        )
       end
 
       def get(_path)
@@ -809,6 +925,57 @@ class FleetHealthTest < Minitest::Test
     refute_includes status.fetch("evidence"), "unrelated"
   end
 
+  def test_shared_smoke_ignores_raw_reference_outside_jobs_uses
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = {
+      "id" => 41,
+      "path" => ".github/workflows/smoke.yml",
+      "name" => "Smoke",
+      "html_url" => "https://example.invalid/workflow"
+    }
+    content = YAML.dump(
+      "jobs" => {
+        "smoke" => {
+          "runs-on" => "ubuntu-latest",
+          "steps" => [{
+            "run" => "echo shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+          }]
+        }
+      }
+    )
+    client = Struct.new(:content_value) do
+      def content(_repo, _path, ref:)
+        raise "wrong head" unless ref == "a" * 40
+
+        content_value
+      end
+
+      def get(_path)
+        {
+          "workflow_runs" => [{
+            "head_sha" => "a" * 40,
+            "status" => "completed",
+            "conclusion" => "success"
+          }]
+        }
+      end
+    end.new(content)
+
+    status = FleetValidation::PublicGitHubProbe.new(client:)
+                                               .send(
+                                                 :smoke_status,
+                                                 repo,
+                                                 head,
+                                                 [],
+                                                 [workflow],
+                                                 default_branch: "main"
+                                               )
+
+    assert_equal false, status.fetch("shared_contract")
+    assert_equal "unknown", status.fetch("status")
+  end
+
   def test_public_github_probe_degrades_a_target_failure_to_unknown
     client = Object.new
     def client.get(_path)
@@ -830,9 +997,11 @@ class FleetHealthTest < Minitest::Test
 
     assert_includes workflow, "workflow_call:"
     assert_includes workflow, "contents: read"
+    assert_includes workflow, "ruby/setup-ruby@#{RUBY_SETUP_SHA}"
     assert_includes workflow, "fleet-smoke-evidence-${{ github.sha }}"
     assert_includes workflow, '"head_sha"'
     refute_includes workflow, "secrets: inherit"
+    refute_includes workflow, "bundle exec ruby"
   end
 
   def test_reusable_smoke_workflow_rejects_blank_required_commands
@@ -885,13 +1054,42 @@ class FleetHealthTest < Minitest::Test
 
     assert_includes workflow, "schedule:"
     assert_includes workflow, "workflow_dispatch:"
+    assert_includes workflow, "ruby/setup-ruby@#{RUBY_SETUP_SHA}"
+    assert_includes workflow, "bundler-cache: true"
+    assert_includes workflow, 'bundle exec ruby "$HEALTH_SCRIPT"'
+    assert_includes workflow, "bundle exec ruby -rjson"
     assert_includes workflow, "check_fleet_health.rb"
     assert_includes workflow, "--live"
     assert_includes workflow, "actions/upload-artifact@v4"
     assert_includes workflow, "fleet-health.json"
   end
 
+  def test_central_fleet_health_docs_use_the_repo_bundle
+    skill = File.read(SKILL)
+    rc_plan = File.read(RC_PLAN)
+    runbook = File.read(RELEASE_RUNBOOK)
+
+    refute_match(/^\s*ruby .*fleet_health/m, skill)
+    refute_match(/^\s*ruby .*check_fleet_health/m, skill)
+    assert_includes skill, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb"
+    assert_includes rc_plan, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
+    assert_includes runbook, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
+    assert_includes runbook, '--policy-commit "$(git rev-parse HEAD)"'
+    assert_includes runbook, "--output-dir tmp/fleet-health-v17"
+  end
+
   private
+
+  def build_contract(manifest)
+    FleetValidation::FleetHealth.new(
+      manifest:,
+      pack_id: "manifest-test",
+      release: "v17.0.0",
+      rsc_version: "19.2.1",
+      policy_commit: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      generated_at: "2026-07-18T12:00:00Z"
+    )
+  end
 
   def reusable_smoke_steps
     YAML.safe_load_file(REUSABLE_SMOKE, aliases: false).dig("jobs", "smoke", "steps")

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -85,6 +85,21 @@ class FleetHealthTest < Minitest::Test
     assert_equal ["sanitized-active-drifted"], evidence.dig("aggregate", "blocking_targets")
   end
 
+  def test_active_repository_archival_is_surfaced_as_blocking_manifest_drift
+    observations = Marshal.load(Marshal.dump(@observations))
+    observations.fetch("sanitized-active-current")["repository_archived"] = true
+
+    evidence = @contract.evaluate(
+      observations:,
+      registry_artifacts: stable_registry_artifacts
+    )
+    current = target(evidence, "sanitized-active-current")
+
+    assert_equal true, current.fetch("repository_archived")
+    assert_includes current.fetch("findings"), "repository_archived"
+    assert_equal "blocked", current.fetch("status")
+  end
+
   def test_registry_artifacts_must_be_exact_stable_public_versions
     artifacts = stable_registry_artifacts
     artifacts[0]["version"] = "17.0.0.rc.12"
@@ -160,6 +175,13 @@ class FleetHealthTest < Minitest::Test
     errors = FleetValidation::SchemaValidator.new(@contract.schema).errors(evidence)
 
     assert(errors.any? { |error| error.include?("unexpected") })
+  end
+
+  def test_markdown_escaping_preserves_literal_backslashes_and_table_delimiters
+    escaped = @contract.send(:escape, 'literal\path|column')
+
+    assert_equal 3, escaped.count("\\")
+    assert_includes escaped, '\|'
   end
 
   def test_writes_a_machine_readable_pack_and_human_summary
@@ -249,6 +271,60 @@ class FleetHealthTest < Minitest::Test
     assert_equal "passed", passed.fetch("status")
     assert_equal "blocked", blocked.fetch("status")
     assert_includes blocked.fetch("findings"), "npm:version-updates-disabled"
+  end
+
+  def test_dependabot_v1_requires_one_enabled_weekly_root_entry
+    config = dependabot_v1_config
+    npm = config.fetch("updates").find { |entry| entry["package-ecosystem"] == "npm" }
+    npm["open-pull-requests-limit"] = 0
+    config.fetch("updates") << npm.merge(
+      "schedule" => { "interval" => "daily" },
+      "open-pull-requests-limit" => 5
+    )
+
+    result = FleetValidation::DependabotV1.evaluate(
+      config,
+      [{ "ecosystem" => "npm", "name" => "react-on-rails" }]
+    )
+
+    assert_equal "blocked", result.fetch("status")
+    assert_includes result.fetch("findings"), "npm:not-weekly"
+  end
+
+  def test_dependabot_v1_rejects_weekly_coverage_outside_the_root
+    config = dependabot_v1_config
+    npm = config.fetch("updates").find { |entry| entry["package-ecosystem"] == "npm" }
+    npm["directory"] = "/docs"
+    config.fetch("updates") << npm.merge(
+      "directory" => "/",
+      "schedule" => { "interval" => "daily" }
+    )
+
+    result = FleetValidation::DependabotV1.evaluate(
+      config,
+      [{ "ecosystem" => "npm", "name" => "react-on-rails" }]
+    )
+
+    assert_equal "blocked", result.fetch("status")
+    assert_includes result.fetch("findings"), "npm:not-weekly"
+  end
+
+  def test_dependabot_v1_requires_product_grouping_on_an_enabled_weekly_root_entry
+    config = dependabot_v1_config
+    npm = config.fetch("updates").find { |entry| entry["package-ecosystem"] == "npm" }
+    npm["open-pull-requests-limit"] = 0
+    config.fetch("updates") << npm.merge(
+      "groups" => {},
+      "open-pull-requests-limit" => 5
+    )
+
+    result = FleetValidation::DependabotV1.evaluate(
+      config,
+      [{ "ecosystem" => "npm", "name" => "react-on-rails" }]
+    )
+
+    assert_equal "blocked", result.fetch("status")
+    assert_includes result.fetch("findings"), "npm:product-group-missing"
   end
 
   def test_public_sbom_parser_extracts_gem_and_npm_versions
@@ -347,11 +423,33 @@ class FleetHealthTest < Minitest::Test
     assert_equal 7, @contract.schema.dig("properties", "registry", "properties", "artifacts", "minItems")
   end
 
+  def test_public_registry_resolver_normalizes_npm_prerelease_versions
+    resolver = FleetValidation::PublicRegistryResolver.new(fetcher: lambda do |url|
+      if URI(url).host == "rubygems.org"
+        [{ "number" => "17.0.0.rc.12", "yanked" => false }]
+      else
+        { "versions" => { "17.0.0-rc.12" => {}, "19.2.1" => {} } }
+      end
+    end)
+
+    artifacts = resolver.resolve(release: "v17.0.0.rc.12", rsc_version: "19.2.1")
+
+    assert_equal(
+      Array.new(4, "17.0.0-rc.12"),
+      artifacts.select { |artifact| artifact["ecosystem"] == "npm" && artifact["name"] != "react-on-rails-rsc" }
+               .map { |artifact| artifact.fetch("version") }
+    )
+    assert_equal(
+      Array.new(2, "17.0.0.rc.12"),
+      artifacts.select { |artifact| artifact["ecosystem"] == "gem" }.map { |artifact| artifact.fetch("version") }
+    )
+  end
+
   def test_public_registry_resolver_rejects_an_incomplete_product_suite
     resolver = FleetValidation::PublicRegistryResolver.new(fetcher: lambda do |url|
       next [] if url.end_with?("react_on_rails_pro.json")
 
-      if url.include?("rubygems.org")
+      if URI(url).host == "rubygems.org"
         [{ "number" => "17.0.0", "yanked" => false }]
       else
         { "versions" => { "17.0.0" => {}, "19.2.1" => {} } }
@@ -432,7 +530,12 @@ class FleetHealthTest < Minitest::Test
         },
         "/repos/#{repo}/actions/workflows?per_page=100" => {
           "workflows" => [
-            { "path" => ".github/workflows/demo-fleet-smoke.yml", "name" => "Demo fleet smoke" },
+            {
+              "id" => 41,
+              "path" => ".github/workflows/demo-fleet-smoke.yml",
+              "name" => "Demo fleet smoke",
+              "html_url" => "https://example.invalid/smoke-workflow"
+            },
             {
               "id" => 42,
               "path" => ".github/workflows/cpflow-deploy-review-app.yml",
@@ -442,15 +545,17 @@ class FleetHealthTest < Minitest::Test
             }
           ]
         },
-        "/repos/#{repo}/actions/workflows/42/runs?per_page=1" => {
-          "workflow_runs" => [
-            {
-              "status" => "completed",
-              "conclusion" => "success",
-              "html_url" => "https://example.invalid/review-app-run",
-              "updated_at" => "2026-07-18T10:00:00Z"
-            }
-          ]
+        "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=20" => {
+          "workflow_runs" => [{
+            "head_sha" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "status" => "completed",
+            "conclusion" => "success",
+            "html_url" => "https://example.invalid/smoke-run",
+            "updated_at" => "2026-07-18T10:00:00Z"
+          }]
+        },
+        "/repos/#{repo}/actions/workflows/42/runs?event=pull_request&per_page=20" => {
+          "workflow_runs" => [valid_review_run]
         }
       },
       {
@@ -471,6 +576,7 @@ class FleetHealthTest < Minitest::Test
     observation = probe.observe(target, observed_at: "2026-07-18T12:00:00Z")
 
     assert_equal "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", observation.fetch("default_commit")
+    assert_equal false, observation.fetch("repository_archived")
     assert_equal "passed", observation.dig("default_ci", "status")
     assert_equal true, observation.dig("smoke", "shared_contract")
     assert_equal "passed", observation.dig("review_app", "status")
@@ -493,26 +599,26 @@ class FleetHealthTest < Minitest::Test
         { "workflow_runs" => runs }
       end
     end
-    probe = FleetValidation::PublicGitHubProbe.new(client: client.new([
-                                                                        {
-                                                                          "status" => "completed",
-                                                                          "conclusion" => "failure",
-                                                                          "html_url" => "https://example.invalid/run",
-                                                                          "updated_at" => "2026-07-18T10:00:00Z"
-                                                                        }
-                                                                      ]))
+    probe = FleetValidation::PublicGitHubProbe.new(
+      client: client.new([valid_review_run("conclusion" => "failure")])
+    )
 
-    broken = probe.send(:review_app_status, repo, target, [workflow])
-    probe = FleetValidation::PublicGitHubProbe.new(client: client.new([
-                                                                        { "status" => "in_progress", "html_url" => "https://example.invalid/run", "updated_at" => "2026-07-18T11:00:00Z" }
-                                                                      ]))
-    pending = probe.send(:review_app_status, repo, target, [workflow])
+    broken = review_app_status(probe, repo, target, workflow)
+    probe = FleetValidation::PublicGitHubProbe.new(
+      client: client.new([valid_review_run("status" => "in_progress", "conclusion" => nil)])
+    )
+    pending = review_app_status(probe, repo, target, workflow)
+    probe = FleetValidation::PublicGitHubProbe.new(
+      client: client.new([valid_review_run("conclusion" => "skipped")])
+    )
+    skipped = review_app_status(probe, repo, target, workflow)
     probe = FleetValidation::PublicGitHubProbe.new(client: client.new([]))
-    missing_run = probe.send(:review_app_status, repo, target, [workflow])
-    absent_workflow = probe.send(:review_app_status, repo, target, [])
+    missing_run = review_app_status(probe, repo, target, workflow)
+    absent_workflow = review_app_status(probe, repo, target, nil)
 
     assert_equal "blocked", broken.fetch("status")
     assert_equal "unknown", pending.fetch("status")
+    assert_equal "blocked", skipped.fetch("status")
     assert_equal "unknown", missing_run.fetch("status")
     assert_equal "unknown", absent_workflow.fetch("status")
   end
@@ -542,7 +648,14 @@ class FleetHealthTest < Minitest::Test
               }
             ])
     status = FleetValidation::PublicGitHubProbe.new(client:)
-                                               .send(:review_app_status, target.fetch("name"), target, [staging_workflow])
+                                               .send(
+                                                 :review_app_status,
+                                                 target.fetch("name"),
+                                                 target,
+                                                 [staging_workflow],
+                                                 default_branch: "main",
+                                                 observed_at: "2026-07-18T12:00:00Z"
+                                               )
 
     assert_equal "not_applicable", status.fetch("status")
   end
@@ -568,25 +681,14 @@ class FleetHealthTest < Minitest::Test
         responses.fetch(path)
       end
     end.new({
-              "/repos/#{target.fetch('name')}/actions/workflows/42/runs?per_page=1" => {
-                "workflow_runs" => [
-                  {
-                    "status" => "completed",
-                    "conclusion" => "success",
-                    "html_url" => "https://example.invalid/review-run",
-                    "updated_at" => "2026-07-18T10:00:00Z"
-                  }
-                ]
+              "/repos/#{target.fetch('name')}/actions/workflows/42/runs?event=pull_request&per_page=20" => {
+                "workflow_runs" => [valid_review_run("html_url" => "https://example.invalid/review-run")]
               },
-              "/repos/#{target.fetch('name')}/actions/workflows/43/runs?per_page=1" => {
-                "workflow_runs" => [
-                  {
-                    "status" => "completed",
-                    "conclusion" => "failure",
-                    "html_url" => "https://example.invalid/cleanup-run",
-                    "updated_at" => "2026-07-18T11:00:00Z"
-                  }
-                ]
+              "/repos/#{target.fetch('name')}/actions/workflows/43/runs?event=pull_request&per_page=20" => {
+                "workflow_runs" => [valid_review_run(
+                  "conclusion" => "failure",
+                  "html_url" => "https://example.invalid/cleanup-run"
+                )]
               }
             })
     status = FleetValidation::PublicGitHubProbe.new(client:)
@@ -594,12 +696,117 @@ class FleetHealthTest < Minitest::Test
                                                  :review_app_status,
                                                  target.fetch("name"),
                                                  target,
-                                                 [exact_workflow, cleanup_workflow]
+                                                 [exact_workflow, cleanup_workflow],
+                                                 default_branch: "main",
+                                                 observed_at: "2026-07-18T12:00:00Z"
                                                )
 
     assert_equal "passed", status.fetch("status")
     assert_includes status.fetch("evidence"), "review-run"
     refute_includes status.fetch("evidence"), "cleanup-run"
+  end
+
+  def test_review_app_rejects_non_pr_mismatched_and_stale_runs
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Deploy review app",
+      "state" => "active"
+    }
+    client = Struct.new(:runs) do
+      def get(_path)
+        { "workflow_runs" => runs }
+      end
+    end
+    manual = review_app_status(
+      FleetValidation::PublicGitHubProbe.new(client: client.new([valid_review_run("event" => "workflow_dispatch")])),
+      repo,
+      target,
+      workflow
+    )
+    mismatched_head = review_app_status(
+      FleetValidation::PublicGitHubProbe.new(client: client.new([valid_review_run("head_sha" => "b" * 40)])),
+      repo,
+      target,
+      workflow
+    )
+    mismatched_branch = review_app_status(
+      FleetValidation::PublicGitHubProbe.new(client: client.new([valid_review_run("head_branch" => "other")])),
+      repo,
+      target,
+      workflow
+    )
+    wrong_base = review_app_status(
+      FleetValidation::PublicGitHubProbe.new(
+        client: client.new([valid_review_run(
+          "pull_requests" => [{
+            "head" => { "ref" => "feature/review-app", "sha" => "c" * 40 },
+            "base" => { "ref" => "release/17.0.0" }
+          }]
+        )])
+      ),
+      repo,
+      target,
+      workflow
+    )
+    stale = review_app_status(
+      FleetValidation::PublicGitHubProbe.new(
+        client: client.new([valid_review_run("run_started_at" => "2026-04-01T10:00:00Z")])
+      ),
+      repo,
+      target,
+      workflow
+    )
+
+    assert_equal "unknown", manual.fetch("status")
+    assert_equal "unknown", mismatched_head.fetch("status")
+    assert_equal "unknown", mismatched_branch.fetch("status")
+    assert_equal "unknown", wrong_base.fetch("status")
+    assert_equal "unknown", stale.fetch("status")
+  end
+
+  def test_shared_smoke_requires_an_exact_head_run_of_the_shared_workflow
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = {
+      "id" => 41,
+      "path" => ".github/workflows/smoke-caller.yml",
+      "name" => "Fleet smoke caller",
+      "html_url" => "https://example.invalid/workflow"
+    }
+    client = Struct.new(:contents) do
+      def content(_repo, _path, ref:)
+        raise "wrong head" unless ref == "a" * 40
+
+        "uses: shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+      end
+
+      def get(_path)
+        { "workflow_runs" => [] }
+      end
+    end.new({})
+    unrelated_check = {
+      "name" => "Unrelated smoke",
+      "status" => "completed",
+      "conclusion" => "success",
+      "html_url" => "https://example.invalid/unrelated"
+    }
+
+    status = FleetValidation::PublicGitHubProbe.new(client:)
+                                               .send(
+                                                 :smoke_status,
+                                                 repo,
+                                                 head,
+                                                 [unrelated_check],
+                                                 [workflow],
+                                                 default_branch: "main"
+                                               )
+
+    assert_equal true, status.fetch("shared_contract")
+    assert_equal "unknown", status.fetch("status")
+    refute_includes status.fetch("evidence"), "unrelated"
   end
 
   def test_public_github_probe_degrades_a_target_failure_to_unknown
@@ -628,6 +835,51 @@ class FleetHealthTest < Minitest::Test
     refute_includes workflow, "secrets: inherit"
   end
 
+  def test_reusable_smoke_workflow_rejects_blank_required_commands
+    step = reusable_smoke_steps.find { |candidate| candidate["name"] == "Validate required commands" }
+    assert step, "workflow must validate required commands before execution"
+
+    env = {
+      "INSTALL_COMMAND" => "bundle install",
+      "BUILD_COMMAND" => " ",
+      "SMOKE_COMMAND" => "bin/smoke"
+    }
+    _stdout, _stderr, status = Open3.capture3(env, "bash", "-lc", step.fetch("run"))
+
+    refute status.success?
+  end
+
+  def test_reusable_smoke_evidence_requires_success_for_every_required_stage
+    step = reusable_smoke_steps.find { |candidate| candidate["name"] == "Write exact-head smoke evidence" }
+    assert step
+    env = {
+      "HEAD_SHA" => "a" * 40,
+      "REPOSITORY" => "sanitized/demo",
+      "VALIDATE_OUTCOME" => "success",
+      "INSTALL_OUTCOME" => "cancelled",
+      "TEST_OUTCOME" => "skipped",
+      "BUILD_OUTCOME" => "success",
+      "SMOKE_OUTCOME" => "success"
+    }
+
+    Dir.mktmpdir do |directory|
+      _stdout, stderr, status = Open3.capture3(env, "bash", "-lc", step.fetch("run"), chdir: directory)
+      assert status.success?, stderr
+      evidence = JSON.parse(File.read(File.join(directory, "fleet-smoke-evidence.json")))
+
+      assert_equal "blocked", evidence.fetch("status")
+    end
+
+    env["INSTALL_OUTCOME"] = "success"
+    Dir.mktmpdir do |directory|
+      _stdout, stderr, status = Open3.capture3(env, "bash", "-lc", step.fetch("run"), chdir: directory)
+      assert status.success?, stderr
+      evidence = JSON.parse(File.read(File.join(directory, "fleet-smoke-evidence.json")))
+
+      assert_equal "passed", evidence.fetch("status")
+    end
+  end
+
   def test_scheduled_health_workflow_runs_live_scan_and_uploads_the_pack
     workflow = File.read(SCHEDULED_HEALTH)
 
@@ -641,8 +893,40 @@ class FleetHealthTest < Minitest::Test
 
   private
 
+  def reusable_smoke_steps
+    YAML.safe_load_file(REUSABLE_SMOKE, aliases: false).dig("jobs", "smoke", "steps")
+  end
+
   def target(evidence, id)
     evidence.fetch("targets").find { |candidate| candidate.fetch("id") == id }
+  end
+
+  def review_app_status(probe, repo, target, workflow)
+    probe.send(
+      :review_app_status,
+      repo,
+      target,
+      workflow ? [workflow] : [],
+      default_branch: "main",
+      observed_at: "2026-07-18T12:00:00Z"
+    )
+  end
+
+  def valid_review_run(overrides = {})
+    {
+      "event" => "pull_request",
+      "status" => "completed",
+      "conclusion" => "success",
+      "head_branch" => "feature/review-app",
+      "head_sha" => "c" * 40,
+      "run_started_at" => "2026-07-18T10:00:00Z",
+      "updated_at" => "2026-07-18T10:05:00Z",
+      "html_url" => "https://example.invalid/review-app-run",
+      "pull_requests" => [{
+        "head" => { "ref" => "feature/review-app", "sha" => "c" * 40 },
+        "base" => { "ref" => "main" }
+      }]
+    }.merge(overrides)
   end
 
   def stable_registry_artifacts

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -625,6 +625,52 @@ class FleetHealthTest < Minitest::Test
     assert_equal "unknown", probe.send(:check_status, [success, pending]).fetch("status")
   end
 
+  def test_default_ci_includes_check_runs_after_the_first_page
+    path = "/repos/sanitized/demo/commits/#{'a' * 40}/check-runs?per_page=100"
+    success = {
+      "status" => "completed",
+      "conclusion" => "success",
+      "html_url" => "https://example.invalid/success"
+    }
+    failure = {
+      "status" => "completed",
+      "conclusion" => "failure",
+      "html_url" => "https://example.invalid/failure"
+    }
+    client = Struct.new(:first_path, :success, :failure) do
+      def get(path)
+        return { "check_runs" => Array.new(100) { success.dup } } if path == first_path
+        return { "check_runs" => [failure] } if path == "#{first_path}&page=2"
+
+        raise "unexpected page #{path}"
+      end
+    end.new(path, success, failure)
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    checks = probe.send(:paginated_collection, path, "check_runs")
+
+    assert_equal 101, checks.length
+    assert_equal "blocked", probe.send(:check_status, checks).fetch("status")
+  end
+
+  def test_check_run_pagination_fails_closed_at_the_bound
+    path = "/repos/sanitized/demo/commits/#{'a' * 40}/check-runs?per_page=100"
+    client = Struct.new(:requests) do
+      def get(path)
+        requests << path
+        { "check_runs" => Array.new(100) { { "status" => "completed", "conclusion" => "success" } } }
+      end
+    end.new([])
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    error = assert_raises(FleetValidation::ManifestError) do
+      probe.send(:paginated_collection, path, "check_runs")
+    end
+
+    assert_includes error.message, "pagination remained full"
+    assert_equal FleetValidation::PublicGitHubProbe::MAX_PAGES, client.requests.length
+  end
+
   def test_public_github_probe_binds_health_evidence_to_the_default_head
     target = @contract.targets.first
     repo = target.fetch("name")
@@ -1320,7 +1366,9 @@ class FleetHealthTest < Minitest::Test
     assert_includes skill, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb"
     assert_includes rc_plan, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
     assert_includes runbook, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
-    assert_includes runbook, '--policy-commit "$(git rev-parse HEAD)"'
+    assert_includes runbook, 'test -z "$(git status --porcelain)"'
+    assert_includes runbook, 'POLICY_COMMIT="$(git rev-parse HEAD)"'
+    assert_includes runbook, '--policy-commit "$POLICY_COMMIT"'
     assert_includes runbook, "--output-dir tmp/fleet-health-stable"
   end
 

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -692,6 +692,30 @@ class FleetHealthTest < Minitest::Test
     refute_includes error.message, "private-secret"
   end
 
+  def test_public_github_probe_encodes_the_default_branch_in_the_commit_path
+    target = @contract.targets.first
+    branch = "release/17.0 + café"
+    requests = []
+    client = Object.new
+    client.define_singleton_method(:get) do |path|
+      requests << path
+      raise "stop after commit lookup" unless requests.one?
+
+      { "visibility" => "public", "default_branch" => branch, "archived" => false }
+    end
+
+    public_github_probe(client:).observe(target, observed_at: "2026-07-18T12:00:00Z")
+
+    encoded_branch = URI.encode_www_form_component(branch)
+    assert_equal(
+      [
+        "/repos/#{target.fetch('name')}",
+        "/repos/#{target.fetch('name')}/commits/#{encoded_branch}"
+      ],
+      requests
+    )
+  end
+
   def test_default_ci_requires_a_successful_exact_head_check
     probe = public_github_probe(client: nil)
     skipped = {

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -40,6 +40,24 @@ class FleetHealthTest < Minitest::Test
     )
   end
 
+  def test_required_review_app_requires_an_exact_workflow_path
+    manifest = Marshal.load(Marshal.dump(@manifest))
+    manifest.fetch("repos").first.fetch("standing_health")["review_app_workflow"] = " "
+
+    error = assert_raises(FleetValidation::ManifestError) do
+      FleetValidation::FleetHealth.new(
+        manifest:,
+        pack_id: "missing-review-app-path",
+        release: "v17.0.0",
+        rsc_version: "19.2.1",
+        policy_commit: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        generated_at: "2026-07-18T12:00:00Z"
+      )
+    end
+
+    assert_includes error.message, "review_app_workflow"
+  end
+
   def test_active_drift_blocks_aggregate_while_soft_and_archived_targets_are_report_only
     evidence = @contract.evaluate(
       observations: @observations,
@@ -417,7 +435,7 @@ class FleetHealthTest < Minitest::Test
             { "path" => ".github/workflows/demo-fleet-smoke.yml", "name" => "Demo fleet smoke" },
             {
               "id" => 42,
-              "path" => ".github/workflows/cpflow-review-app.yml",
+              "path" => ".github/workflows/cpflow-deploy-review-app.yml",
               "name" => "Review app",
               "state" => "active",
               "html_url" => "https://example.invalid/workflow"
@@ -465,7 +483,7 @@ class FleetHealthTest < Minitest::Test
     repo = target.fetch("name")
     workflow = {
       "id" => 42,
-      "path" => ".github/workflows/cpflow-review-app.yml",
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
       "name" => "Review app",
       "state" => "active",
       "html_url" => "https://example.invalid/workflow"
@@ -497,6 +515,91 @@ class FleetHealthTest < Minitest::Test
     assert_equal "unknown", pending.fetch("status")
     assert_equal "unknown", missing_run.fetch("status")
     assert_equal "unknown", absent_workflow.fetch("status")
+  end
+
+  def test_review_app_ignores_staging_when_policy_does_not_require_a_review_app
+    target = @contract.targets.first.merge(
+      "review_app" => "not_required",
+      "review_app_workflow" => nil
+    )
+    staging_workflow = {
+      "id" => 41,
+      "path" => ".github/workflows/cpflow-deploy-staging.yml",
+      "name" => "Deploy staging",
+      "state" => "active",
+      "html_url" => "https://example.invalid/staging-workflow"
+    }
+    client = Struct.new(:runs) do
+      def get(_path)
+        { "workflow_runs" => runs }
+      end
+    end.new([
+              {
+                "status" => "completed",
+                "conclusion" => "success",
+                "html_url" => "https://example.invalid/staging-run",
+                "updated_at" => "2026-07-18T10:00:00Z"
+              }
+            ])
+    status = FleetValidation::PublicGitHubProbe.new(client:)
+                                               .send(:review_app_status, target.fetch("name"), target, [staging_workflow])
+
+    assert_equal "not_applicable", status.fetch("status")
+  end
+
+  def test_review_app_ignores_auxiliary_failure_when_exact_deploy_review_workflow_passes
+    target = @contract.targets.first
+    exact_workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Deploy review app",
+      "state" => "active",
+      "html_url" => "https://example.invalid/review-workflow"
+    }
+    cleanup_workflow = {
+      "id" => 43,
+      "path" => ".github/workflows/cpflow-cleanup-review-app.yml",
+      "name" => "Cleanup review app",
+      "state" => "active",
+      "html_url" => "https://example.invalid/cleanup-workflow"
+    }
+    client = Struct.new(:responses) do
+      def get(path)
+        responses.fetch(path)
+      end
+    end.new({
+              "/repos/#{target.fetch('name')}/actions/workflows/42/runs?per_page=1" => {
+                "workflow_runs" => [
+                  {
+                    "status" => "completed",
+                    "conclusion" => "success",
+                    "html_url" => "https://example.invalid/review-run",
+                    "updated_at" => "2026-07-18T10:00:00Z"
+                  }
+                ]
+              },
+              "/repos/#{target.fetch('name')}/actions/workflows/43/runs?per_page=1" => {
+                "workflow_runs" => [
+                  {
+                    "status" => "completed",
+                    "conclusion" => "failure",
+                    "html_url" => "https://example.invalid/cleanup-run",
+                    "updated_at" => "2026-07-18T11:00:00Z"
+                  }
+                ]
+              }
+            })
+    status = FleetValidation::PublicGitHubProbe.new(client:)
+                                               .send(
+                                                 :review_app_status,
+                                                 target.fetch("name"),
+                                                 target,
+                                                 [exact_workflow, cleanup_workflow]
+                                               )
+
+    assert_equal "passed", status.fetch("status")
+    assert_includes status.fetch("evidence"), "review-run"
+    refute_includes status.fetch("evidence"), "cleanup-run"
   end
 
   def test_public_github_probe_degrades_a_target_failure_to_unknown

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -1494,6 +1494,59 @@ class FleetHealthTest < Minitest::Test
     assert_includes status.fetch("evidence"), "run age exceeds 1 days"
   end
 
+  def test_shared_smoke_reports_incomplete_discovery_when_all_workflow_reads_fail
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = { "id" => 41, "path" => ".github/workflows/ci.yml" }
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, _path, ref:|
+      raise "wrong head" unless ref == head
+
+      raise FleetValidation::ManifestError, "workflow content forbidden"
+    end
+
+    status = public_github_probe(client:)
+             .send(:smoke_status, repo, head, [], [workflow], default_branch: "main")
+
+    assert_equal "unknown", status.fetch("status")
+    assert_equal false, status.fetch("shared_contract")
+    assert_includes status.fetch("evidence"), ".github/workflows/ci.yml"
+    assert_includes status.fetch("evidence"), "FleetValidation::ManifestError"
+    assert_includes status.fetch("evidence"), "workflow content forbidden"
+    refute_includes status.fetch("evidence"), "No reusable fleet-smoke caller"
+  end
+
+  def test_shared_smoke_does_not_pass_when_discovery_is_partially_incomplete
+    repo = "sanitized/demo"
+    head = "a" * 40
+    healthy = { "id" => 41, "path" => ".github/workflows/ci.yml" }
+    unreadable = { "id" => 42, "path" => ".github/workflows/private.yml" }
+    caller_content = YAML.dump(
+      "jobs" => {
+        "fleet" => {
+          "name" => "Fleet",
+          "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+        }
+      }
+    )
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      raise "wrong head" unless ref == head
+      return caller_content if path == healthy.fetch("path")
+
+      raise FleetValidation::ManifestError, "workflow content forbidden"
+    end
+    client.define_singleton_method(:get) { |_path| raise "run lookup must not start with incomplete discovery" }
+
+    status = public_github_probe(client:)
+             .send(:smoke_status, repo, head, [], [healthy, unreadable], default_branch: "main")
+
+    assert_equal "unknown", status.fetch("status")
+    assert_equal true, status.fetch("shared_contract")
+    assert_includes status.fetch("evidence"), ".github/workflows/private.yml"
+    assert_includes status.fetch("evidence"), "workflow content forbidden"
+  end
+
   def test_shared_smoke_requires_an_exact_head_run_of_the_shared_workflow
     repo = "sanitized/demo"
     head = "a" * 40

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -239,6 +239,13 @@ class FleetHealthTest < Minitest::Test
     assert(errors.any? { |error| error.include?("unexpected") })
   end
 
+  def test_schema_uses_an_ecma_262_commit_pattern
+    pattern = @contract.schema.dig("properties", "pack", "properties", "policy_commit", "pattern")
+
+    assert_equal "^[0-9a-f]{40}$", pattern
+    assert_match Regexp.new(pattern), "7d787fcc1e3fbcfd655bc8bc79401e3a657d9550"
+  end
+
   def test_markdown_escaping_preserves_literal_backslashes_and_table_delimiters
     escaped = @contract.send(:escape, "literal\\path|column`code\nnext")
 
@@ -732,6 +739,7 @@ class FleetHealthTest < Minitest::Test
           "name" => "CI",
           "jobs" => {
             "fleet" => {
+              "name" => "Fleet",
               "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
             }
           }
@@ -955,6 +963,7 @@ class FleetHealthTest < Minitest::Test
         YAML.dump(
           "jobs" => {
             "fleet" => {
+              "name" => "Fleet",
               "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
             }
           }
@@ -1020,15 +1029,139 @@ class FleetHealthTest < Minitest::Test
       end
     end.new(responses)
     probe = FleetValidation::PublicGitHubProbe.new(client:)
+    caller = { "key" => "fleet", "name" => "Fleet" }
 
-    skipped = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow)
+    skipped = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow, caller)
     responses.fetch("/repos/#{repo}/actions/runs/4101/jobs?per_page=100")
              .fetch("jobs").first["conclusion"] = "success"
-    passed = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow)
+    passed = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow, caller)
 
     assert_equal "unknown", skipped.fetch("status")
     assert_equal "passed", passed.fetch("status")
     assert_includes passed.fetch("evidence"), "https://example.invalid/job"
+  end
+
+  def test_shared_smoke_rejects_an_unrelated_local_job_when_the_caller_is_skipped
+    repo = "sanitized/demo"
+    run = { "id" => 4101 }
+    jobs_path = "/repos/#{repo}/actions/runs/4101/jobs?per_page=100"
+    client = Struct.new(:jobs_path) do
+      def get(path)
+        raise "unexpected path" unless path == jobs_path
+
+        {
+          "jobs" => [
+            {
+              "name" => "Demo fleet smoke",
+              "status" => "completed",
+              "conclusion" => "success",
+              "html_url" => "https://example.invalid/unrelated"
+            },
+            {
+              "name" => "Fleet",
+              "status" => "completed",
+              "conclusion" => "skipped",
+              "html_url" => "https://example.invalid/skipped-caller"
+            }
+          ]
+        }
+      end
+    end.new(jobs_path)
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    caller = { "key" => "fleet", "name" => "Fleet" }
+
+    status = probe.send(:shared_smoke_job_status, repo, run, caller)
+
+    assert_equal "unknown", status.fetch("status")
+    assert_includes status.fetch("evidence"), "caller_job=fleet"
+    refute_includes status.fetch("evidence"), "https://example.invalid/unrelated"
+  end
+
+  def test_shared_smoke_fails_closed_on_ambiguous_caller_names
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = { "id" => 41, "path" => ".github/workflows/ci.yml" }
+    content = YAML.dump(
+      "jobs" => {
+        "fleet_a" => {
+          "name" => "Fleet",
+          "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+        },
+        "fleet_b" => {
+          "name" => "Fleet",
+          "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+        }
+      }
+    )
+    client = Struct.new(:content_value) do
+      def content(_repo, _path, ref:)
+        raise "wrong head" unless ref == "a" * 40
+
+        content_value
+      end
+
+      def get(_path)
+        raise "ambiguous callers must fail before run lookup"
+      end
+    end.new(content)
+
+    status = FleetValidation::PublicGitHubProbe.new(client:)
+                                               .send(
+                                                 :smoke_status,
+                                                 repo,
+                                                 head,
+                                                 [],
+                                                 [workflow],
+                                                 default_branch: "main"
+                                               )
+
+    assert_equal true, status.fetch("shared_contract")
+    assert_equal "unknown", status.fetch("status")
+    assert_includes status.fetch("evidence"), "ambiguous reusable caller name"
+  end
+
+  def test_shared_smoke_rejects_a_local_job_name_that_spoofs_the_called_job
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = { "id" => 41, "path" => ".github/workflows/ci.yml" }
+    content = YAML.dump(
+      "jobs" => {
+        "fleet" => {
+          "name" => "Fleet",
+          "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+        },
+        "spoof" => {
+          "name" => "Fleet / Demo fleet smoke",
+          "runs-on" => "ubuntu-latest",
+          "steps" => [{ "run" => "true" }]
+        }
+      }
+    )
+    client = Struct.new(:content_value) do
+      def content(_repo, _path, ref:)
+        raise "wrong head" unless ref == "a" * 40
+
+        content_value
+      end
+
+      def get(_path)
+        raise "spoofing definition must fail before run lookup"
+      end
+    end.new(content)
+
+    status = FleetValidation::PublicGitHubProbe.new(client:)
+                                               .send(
+                                                 :smoke_status,
+                                                 repo,
+                                                 head,
+                                                 [],
+                                                 [workflow],
+                                                 default_branch: "main"
+                                               )
+
+    assert_equal true, status.fetch("shared_contract")
+    assert_equal "unknown", status.fetch("status")
+    assert_includes status.fetch("evidence"), "collides with a non-reusable job"
   end
 
   def test_shared_smoke_ignores_raw_reference_outside_jobs_uses

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -671,6 +671,116 @@ class FleetHealthTest < Minitest::Test
     assert_equal FleetValidation::PublicGitHubProbe::MAX_PAGES, client.requests.length
   end
 
+  def test_later_workflow_page_supplies_smoke_and_review_app_discovery
+    repo = "sanitized/demo"
+    head = "a" * 40
+    path = "/repos/#{repo}/actions/workflows?per_page=100"
+    filler = Array.new(100) do |index|
+      { "id" => index, "path" => ".github/workflows/filler-#{index}.yml", "name" => "Filler #{index}" }
+    end
+    caller = {
+      "id" => 4100,
+      "path" => ".github/workflows/ci.yml",
+      "name" => "CI",
+      "html_url" => "https://example.invalid/ci"
+    }
+    review = {
+      "id" => 4200,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Review app",
+      "state" => "active",
+      "html_url" => "https://example.invalid/review"
+    }
+    responses = {
+      path => { "workflows" => filler },
+      "#{path}&page=2" => { "workflows" => [caller, review] },
+      "/repos/#{repo}/actions/workflows/4100/runs?branch=main&per_page=20" => {
+        "workflow_runs" => [{
+          "id" => 4101,
+          "head_sha" => head,
+          "status" => "completed",
+          "conclusion" => "success",
+          "html_url" => "https://example.invalid/smoke-run"
+        }]
+      },
+      "/repos/#{repo}/actions/runs/4101/jobs?per_page=100" => {
+        "jobs" => [{
+          "name" => "Fleet / Demo fleet smoke",
+          "status" => "completed",
+          "conclusion" => "success",
+          "html_url" => "https://example.invalid/smoke-job"
+        }]
+      },
+      "/repos/#{repo}/actions/workflows/4200/runs?event=pull_request&per_page=20" => {
+        "workflow_runs" => [valid_review_run]
+      }
+    }
+    client = Struct.new(:responses) do
+      def get(path)
+        responses.fetch(path)
+      end
+
+      def content(_repo, path, ref:)
+        raise "wrong head" unless ref == "a" * 40
+        return YAML.dump("jobs" => {}) unless path == ".github/workflows/ci.yml"
+
+        YAML.dump(
+          "jobs" => {
+            "fleet" => {
+              "name" => "Fleet",
+              "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+            }
+          }
+        )
+      end
+    end.new(responses)
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    workflows = probe.send(:paginated_collection, path, "workflows")
+    smoke = probe.send(:smoke_status, repo, head, [], workflows, default_branch: "main")
+    review_app = probe.send(
+      :review_app_status,
+      repo,
+      @contract.targets.first,
+      workflows,
+      default_branch: "main",
+      observed_at: "2026-07-18T12:00:00Z"
+    )
+
+    assert_equal 102, workflows.length
+    assert_equal "passed", smoke.fetch("status")
+    assert_equal "passed", review_app.fetch("status")
+  end
+
+  def test_workflow_pagination_rejects_malformed_and_incomplete_pages
+    path = "/repos/sanitized/demo/actions/workflows?per_page=100"
+    malformed_client = Struct.new(:path) do
+      def get(request_path)
+        raise "unexpected path" unless request_path == path
+
+        { "workflows" => {} }
+      end
+    end.new(path)
+    error = assert_raises(FleetValidation::ManifestError) do
+      FleetValidation::PublicGitHubProbe.new(client: malformed_client)
+                                        .send(:paginated_collection, path, "workflows")
+    end
+    assert_includes error.message, "is not an array"
+
+    requests = []
+    full_client = Object.new
+    full_client.define_singleton_method(:get) do |request_path|
+      requests << request_path
+      { "workflows" => Array.new(100) { { "path" => ".github/workflows/filler.yml" } } }
+    end
+    error = assert_raises(FleetValidation::ManifestError) do
+      FleetValidation::PublicGitHubProbe.new(client: full_client)
+                                        .send(:paginated_collection, path, "workflows")
+    end
+    assert_includes error.message, "pagination remained full"
+    assert_equal FleetValidation::PublicGitHubProbe::MAX_PAGES, requests.length
+  end
+
   def test_public_github_probe_binds_health_evidence_to_the_default_head
     target = @contract.targets.first
     repo = target.fetch("name")
@@ -738,6 +848,15 @@ class FleetHealthTest < Minitest::Test
           ]
         },
         "/repos/#{repo}/actions/workflows?per_page=100" => {
+          "workflows" => Array.new(100) do |index|
+            {
+              "id" => index,
+              "path" => ".github/workflows/filler-#{index}.yml",
+              "name" => "Filler #{index}"
+            }
+          end
+        },
+        "/repos/#{repo}/actions/workflows?per_page=100&page=2" => {
           "workflows" => [
             {
               "id" => 41,

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -6,6 +6,7 @@ require "open3"
 require "tmpdir"
 require "yaml"
 require_relative "fleet_health"
+require_relative "check_fleet_health"
 
 class FleetHealthTest < Minitest::Test
   FIXTURE = File.expand_path("../fixtures/rc12-health-drift.yml", __dir__)
@@ -16,6 +17,7 @@ class FleetHealthTest < Minitest::Test
   SKILL = File.expand_path("../SKILL.md", __dir__)
   RC_PLAN = File.expand_path("../../../../internal/contributor-info/rc-testing-plan.md", __dir__)
   RELEASE_RUNBOOK = File.expand_path("../../../../internal/contributor-info/release-verification-runbook.md", __dir__)
+  MANIFEST = File.expand_path("../../../../internal/contributor-info/demo-fleet.yml", __dir__)
   RUBY_SETUP_SHA = "9eb537ca036ebaed86729dcb9309076e4c5c3b74"
 
   def setup
@@ -285,8 +287,6 @@ class FleetHealthTest < Minitest::Test
         "--manifest", manifest_path,
         "--observations", observations_path,
         "--registry-artifacts", registry_path,
-        "--release", "v17.0.0",
-        "--rsc-version", "19.2.1",
         "--pack-id", "offline-test",
         "--policy-commit", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         "--generated-at", "2026-07-18T12:00:00Z",
@@ -294,8 +294,62 @@ class FleetHealthTest < Minitest::Test
       )
 
       assert status.success?, stderr
-      assert File.exist?(File.join(output_dir, "fleet-health.json"))
+      evidence = JSON.parse(File.read(File.join(output_dir, "fleet-health.json")))
+      assert_equal "v17.0.0", evidence.dig("pack", "release")
+      assert_equal "19.2.1", evidence.dig("pack", "rsc_version")
     end
+  end
+
+  def test_live_cli_reports_transient_network_errors_without_a_backtrace
+    Dir.mktmpdir do |directory|
+      manifest = Marshal.load(Marshal.dump(@manifest))
+      manifest.fetch("standing_health").merge!(
+        "stable_release" => "v17.0.0",
+        "rsc_version" => "19.2.1"
+      )
+      manifest_path = File.join(directory, "manifest.yml")
+      File.write(manifest_path, YAML.dump(manifest))
+      client = Object.new
+      client.define_singleton_method(:json) do |_url|
+        raise FleetValidation::TransientPublicRequestError, "SocketError: temporary DNS failure"
+      end
+      result = nil
+      arguments = [
+        "--manifest", manifest_path,
+        "--live",
+        "--policy-commit", "e" * 40,
+        "--output-dir", File.join(directory, "pack")
+      ]
+
+      _stdout, stderr = capture_io do
+        result = FleetValidation::FleetHealthCLI.run(arguments, http: client)
+      end
+
+      assert_equal 1, result
+      assert_match(/\AERROR: live public request failed: SocketError: temporary DNS failure\n\z/, stderr)
+      refute_includes stderr, CHECK_FLEET_HEALTH
+    end
+  end
+
+  def test_public_http_client_wraps_only_transient_transport_errors
+    transport = Object.new
+    transport.define_singleton_method(:start) { |*_args, **_kwargs| raise SocketError, "temporary DNS failure" }
+    client = FleetValidation::PublicHTTPClient.new(github_token: nil, transport:)
+
+    error = assert_raises(FleetValidation::TransientPublicRequestError) do
+      client.json("https://registry.npmjs.org/react-on-rails")
+    end
+
+    assert_equal "SocketError: temporary DNS failure", error.message
+  end
+
+  def test_cli_explicit_versions_override_manifest_defaults
+    options = { release: "v18.0.0", rsc_version: "20.0.0" }
+
+    FleetValidation::FleetHealthCLI.apply_manifest_versions!(options, @manifest)
+
+    assert_equal "v18.0.0", options.fetch(:release)
+    assert_equal "20.0.0", options.fetch(:rsc_version)
   end
 
   def test_dependabot_v1_requires_enabled_weekly_coverage_for_each_ecosystem
@@ -536,12 +590,11 @@ class FleetHealthTest < Minitest::Test
     end
     probe = FleetValidation::PublicGitHubProbe.new(client:)
 
-    error = assert_raises(FleetValidation::ManifestError) do
+    error = assert_raises(FleetValidation::NonPublicRepositoryError) do
       probe.observe(target, observed_at: "2026-07-18T12:00:00Z")
     end
 
     assert_equal ["/repos/#{target.fetch('name')}"], requests
-    assert_equal "FleetValidation::NonPublicRepositoryError", error.class.name
     refute_includes error.message, "private-secret"
   end
 
@@ -1104,17 +1157,24 @@ class FleetHealthTest < Minitest::Test
 
   def test_scheduled_health_workflow_runs_live_scan_and_uploads_the_pack
     workflow = File.read(SCHEDULED_HEALTH)
+    manifest = YAML.safe_load_file(MANIFEST, aliases: false)
 
     assert_includes workflow, "schedule:"
     assert_includes workflow, "workflow_dispatch:"
-    assert_includes workflow, "ruby/setup-ruby@#{RUBY_SETUP_SHA}"
-    assert_includes workflow, "bundler-cache: true"
+    assert_includes workflow, "uses: ./.github/actions/setup-bundle"
+    refute_includes workflow, "uses: ruby/setup-ruby@"
+    assert_includes workflow, "RELEASE_OVERRIDE"
+    assert_includes workflow, "RSC_VERSION_OVERRIDE"
+    refute_includes workflow, "default: v17.0.0"
+    refute_includes workflow, "default: 19.2.1"
     assert_includes workflow, 'bundle exec ruby "$HEALTH_SCRIPT"'
     assert_includes workflow, "bundle exec ruby -rjson"
     assert_includes workflow, "check_fleet_health.rb"
     assert_includes workflow, "--live"
     assert_includes workflow, "actions/upload-artifact@v4"
     assert_includes workflow, "fleet-health.json"
+    assert_match(/\Av\d+\.\d+\.\d+\z/, manifest.dig("standing_health", "stable_release"))
+    assert Gem::Version.correct?(manifest.dig("standing_health", "rsc_version"))
   end
 
   def test_central_fleet_health_docs_use_the_repo_bundle
@@ -1128,7 +1188,7 @@ class FleetHealthTest < Minitest::Test
     assert_includes rc_plan, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
     assert_includes runbook, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
     assert_includes runbook, '--policy-commit "$(git rev-parse HEAD)"'
-    assert_includes runbook, "--output-dir tmp/fleet-health-v17"
+    assert_includes runbook, "--output-dir tmp/fleet-health-stable"
   end
 
   private

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -650,11 +650,20 @@ class FleetHealthTest < Minitest::Test
         },
         "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=20" => {
           "workflow_runs" => [{
+            "id" => 4101,
             "head_sha" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "status" => "completed",
             "conclusion" => "success",
             "html_url" => "https://example.invalid/smoke-run",
             "updated_at" => "2026-07-18T10:00:00Z"
+          }]
+        },
+        "/repos/#{repo}/actions/runs/4101/jobs?per_page=100" => {
+          "jobs" => [{
+            "name" => "Fleet / Demo fleet smoke",
+            "status" => "completed",
+            "conclusion" => "success",
+            "html_url" => "https://example.invalid/smoke-job"
           }]
         },
         "/repos/#{repo}/actions/workflows/42/runs?event=pull_request&per_page=20" => {
@@ -923,6 +932,50 @@ class FleetHealthTest < Minitest::Test
     assert_equal true, status.fetch("shared_contract")
     assert_equal "unknown", status.fetch("status")
     refute_includes status.fetch("evidence"), "unrelated"
+  end
+
+  def test_shared_smoke_requires_the_called_reusable_job_to_succeed
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = {
+      "id" => 41,
+      "path" => ".github/workflows/ci.yml",
+      "html_url" => "https://example.invalid/workflow"
+    }
+    responses = {
+      "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=20" => {
+        "workflow_runs" => [{
+          "id" => 4101,
+          "head_sha" => head,
+          "status" => "completed",
+          "conclusion" => "success",
+          "html_url" => "https://example.invalid/run"
+        }]
+      },
+      "/repos/#{repo}/actions/runs/4101/jobs?per_page=100" => {
+        "jobs" => [{
+          "name" => "Fleet / Demo fleet smoke",
+          "status" => "completed",
+          "conclusion" => "skipped",
+          "html_url" => "https://example.invalid/job"
+        }]
+      }
+    }
+    client = Struct.new(:responses) do
+      def get(path)
+        responses.fetch(path)
+      end
+    end.new(responses)
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    skipped = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow)
+    responses.fetch("/repos/#{repo}/actions/runs/4101/jobs?per_page=100")
+             .fetch("jobs").first["conclusion"] = "success"
+    passed = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow)
+
+    assert_equal "unknown", skipped.fetch("status")
+    assert_equal "passed", passed.fetch("status")
+    assert_includes passed.fetch("evidence"), "https://example.invalid/job"
   end
 
   def test_shared_smoke_ignores_raw_reference_outside_jobs_uses

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -498,7 +498,7 @@ class FleetHealthTest < Minitest::Test
 
       YAML.dump(config)
     end
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     result = probe.send(:dependabot_status, repo, head, @contract.targets.first.fetch("packages"))
 
@@ -522,7 +522,7 @@ class FleetHealthTest < Minitest::Test
       requests << [path, ref]
       raise FleetValidation::MissingPublicContentError, "missing"
     end
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     result = probe.send(:dependabot_status, repo, head, @contract.targets.first.fetch("packages"))
 
@@ -682,7 +682,7 @@ class FleetHealthTest < Minitest::Test
 
       { "visibility" => "private-secret", "default_branch" => "main" }
     end
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     error = assert_raises(FleetValidation::NonPublicRepositoryError) do
       probe.observe(target, observed_at: "2026-07-18T12:00:00Z")
@@ -693,7 +693,7 @@ class FleetHealthTest < Minitest::Test
   end
 
   def test_default_ci_requires_a_successful_exact_head_check
-    probe = FleetValidation::PublicGitHubProbe.new(client: nil)
+    probe = public_github_probe(client: nil)
     skipped = {
       "name" => "Paths filtered",
       "status" => "completed",
@@ -732,7 +732,7 @@ class FleetHealthTest < Minitest::Test
         raise "unexpected page #{path}"
       end
     end.new(path, success, failure)
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     checks = probe.send(:paginated_collection, path, "check_runs")
 
@@ -748,7 +748,7 @@ class FleetHealthTest < Minitest::Test
         { "check_runs" => Array.new(100) { { "status" => "completed", "conclusion" => "success" } } }
       end
     end.new([])
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     error = assert_raises(FleetValidation::ManifestError) do
       probe.send(:paginated_collection, path, "check_runs")
@@ -821,7 +821,7 @@ class FleetHealthTest < Minitest::Test
         )
       end
     end.new(responses)
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     workflows = probe.send(:paginated_collection, path, "workflows")
     smoke = probe.send(:smoke_status, repo, head, [], workflows, default_branch: "main")
@@ -880,7 +880,7 @@ class FleetHealthTest < Minitest::Test
         responses.fetch(path)
       end
     end.new(responses, [])
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
     caller = { "key" => "fleet", "name" => "Fleet" }
 
     status = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow, caller)
@@ -915,7 +915,7 @@ class FleetHealthTest < Minitest::Test
         responses.fetch(path)
       end
     end.new(responses, [])
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
     caller = { "key" => "fleet", "name" => "Fleet" }
 
     status = probe.send(:shared_smoke_job_status, repo, run, caller)
@@ -946,7 +946,7 @@ class FleetHealthTest < Minitest::Test
         responses.fetch(path)
       end
     end.new(responses, [])
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     status = probe.send(
       :review_workflow_status,
@@ -1035,7 +1035,7 @@ class FleetHealthTest < Minitest::Test
       end
     end
 
-    observation = FleetValidation::PublicGitHubProbe.new(client:).observe(
+    observation = public_github_probe(client:).observe(
       target,
       observed_at: "2026-07-18T12:00:00Z"
     )
@@ -1059,8 +1059,8 @@ class FleetHealthTest < Minitest::Test
       end
     end.new(path)
     error = assert_raises(FleetValidation::ManifestError) do
-      FleetValidation::PublicGitHubProbe.new(client: malformed_client)
-                                        .send(:paginated_collection, path, "workflows")
+      public_github_probe(client: malformed_client)
+        .send(:paginated_collection, path, "workflows")
     end
     assert_includes error.message, "is not an array"
 
@@ -1071,8 +1071,8 @@ class FleetHealthTest < Minitest::Test
       { "workflows" => Array.new(100) { { "path" => ".github/workflows/filler.yml" } } }
     end
     error = assert_raises(FleetValidation::ManifestError) do
-      FleetValidation::PublicGitHubProbe.new(client: full_client)
-                                        .send(:paginated_collection, path, "workflows")
+      public_github_probe(client: full_client)
+        .send(:paginated_collection, path, "workflows")
     end
     assert_includes error.message, "pagination remained full"
     assert_equal FleetValidation::PublicGitHubProbe::MAX_PAGES, requests.length
@@ -1213,7 +1213,7 @@ class FleetHealthTest < Minitest::Test
         ] => YAML.dump(dependabot_v1_config)
       }
     )
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
 
     observation = probe.observe(target, observed_at: "2026-07-18T12:00:00Z")
 
@@ -1241,20 +1241,20 @@ class FleetHealthTest < Minitest::Test
         { "workflow_runs" => runs }
       end
     end
-    probe = FleetValidation::PublicGitHubProbe.new(
+    probe = public_github_probe(
       client: client.new([valid_review_run("conclusion" => "failure")])
     )
 
     broken = review_app_status(probe, repo, target, workflow)
-    probe = FleetValidation::PublicGitHubProbe.new(
+    probe = public_github_probe(
       client: client.new([valid_review_run("status" => "in_progress", "conclusion" => nil)])
     )
     pending = review_app_status(probe, repo, target, workflow)
-    probe = FleetValidation::PublicGitHubProbe.new(
+    probe = public_github_probe(
       client: client.new([valid_review_run("conclusion" => "skipped")])
     )
     skipped = review_app_status(probe, repo, target, workflow)
-    probe = FleetValidation::PublicGitHubProbe.new(client: client.new([]))
+    probe = public_github_probe(client: client.new([]))
     missing_run = review_app_status(probe, repo, target, workflow)
     absent_workflow = review_app_status(probe, repo, target, nil)
 
@@ -1289,15 +1289,15 @@ class FleetHealthTest < Minitest::Test
                 "updated_at" => "2026-07-18T10:00:00Z"
               }
             ])
-    status = FleetValidation::PublicGitHubProbe.new(client:)
-                                               .send(
-                                                 :review_app_status,
-                                                 target.fetch("name"),
-                                                 target,
-                                                 [staging_workflow],
-                                                 default_branch: "main",
-                                                 observed_at: "2026-07-18T12:00:00Z"
-                                               )
+    status = public_github_probe(client:)
+             .send(
+               :review_app_status,
+               target.fetch("name"),
+               target,
+               [staging_workflow],
+               default_branch: "main",
+               observed_at: "2026-07-18T12:00:00Z"
+             )
 
     assert_equal "not_applicable", status.fetch("status")
   end
@@ -1333,15 +1333,15 @@ class FleetHealthTest < Minitest::Test
                 )]
               }
             })
-    status = FleetValidation::PublicGitHubProbe.new(client:)
-                                               .send(
-                                                 :review_app_status,
-                                                 target.fetch("name"),
-                                                 target,
-                                                 [exact_workflow, cleanup_workflow],
-                                                 default_branch: "main",
-                                                 observed_at: "2026-07-18T12:00:00Z"
-                                               )
+    status = public_github_probe(client:)
+             .send(
+               :review_app_status,
+               target.fetch("name"),
+               target,
+               [exact_workflow, cleanup_workflow],
+               default_branch: "main",
+               observed_at: "2026-07-18T12:00:00Z"
+             )
 
     assert_equal "passed", status.fetch("status")
     assert_includes status.fetch("evidence"), "review-run"
@@ -1363,25 +1363,25 @@ class FleetHealthTest < Minitest::Test
       end
     end
     manual = review_app_status(
-      FleetValidation::PublicGitHubProbe.new(client: client.new([valid_review_run("event" => "workflow_dispatch")])),
+      public_github_probe(client: client.new([valid_review_run("event" => "workflow_dispatch")])),
       repo,
       target,
       workflow
     )
     mismatched_head = review_app_status(
-      FleetValidation::PublicGitHubProbe.new(client: client.new([valid_review_run("head_sha" => "b" * 40)])),
+      public_github_probe(client: client.new([valid_review_run("head_sha" => "b" * 40)])),
       repo,
       target,
       workflow
     )
     mismatched_branch = review_app_status(
-      FleetValidation::PublicGitHubProbe.new(client: client.new([valid_review_run("head_branch" => "other")])),
+      public_github_probe(client: client.new([valid_review_run("head_branch" => "other")])),
       repo,
       target,
       workflow
     )
     wrong_base = review_app_status(
-      FleetValidation::PublicGitHubProbe.new(
+      public_github_probe(
         client: client.new([valid_review_run(
           "pull_requests" => [{
             "head" => { "ref" => "feature/review-app", "sha" => "c" * 40 },
@@ -1394,7 +1394,7 @@ class FleetHealthTest < Minitest::Test
       workflow
     )
     stale = review_app_status(
-      FleetValidation::PublicGitHubProbe.new(
+      public_github_probe(
         client: client.new([valid_review_run("run_started_at" => "2026-04-01T10:00:00Z")])
       ),
       repo,
@@ -1407,6 +1407,34 @@ class FleetHealthTest < Minitest::Test
     assert_equal "unknown", mismatched_branch.fetch("status")
     assert_equal "unknown", wrong_base.fetch("status")
     assert_equal "unknown", stale.fetch("status")
+  end
+
+  def test_review_app_recency_uses_the_manifest_staleness_limit
+    manifest = Marshal.load(Marshal.dump(@manifest))
+    manifest.fetch("standing_health")["max_default_age_days"] = 1
+    contract = build_contract(manifest)
+    target = contract.targets.first
+    repo = target.fetch("name")
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Deploy review app",
+      "state" => "active"
+    }
+    client = Struct.new(:run) do
+      def get(_path)
+        { "workflow_runs" => [run] }
+      end
+    end.new(valid_review_run("run_started_at" => "2026-07-16T12:00:00Z"))
+    probe = public_github_probe(
+      client:,
+      max_default_age_days: contract.max_default_age_days
+    )
+
+    status = review_app_status(probe, repo, target, workflow)
+
+    assert_equal "unknown", status.fetch("status")
+    assert_includes status.fetch("evidence"), "run age exceeds 1 days"
   end
 
   def test_shared_smoke_requires_an_exact_head_run_of_the_shared_workflow
@@ -1443,15 +1471,15 @@ class FleetHealthTest < Minitest::Test
       "html_url" => "https://example.invalid/unrelated"
     }
 
-    status = FleetValidation::PublicGitHubProbe.new(client:)
-                                               .send(
-                                                 :smoke_status,
-                                                 repo,
-                                                 head,
-                                                 [unrelated_check],
-                                                 [workflow],
-                                                 default_branch: "main"
-                                               )
+    status = public_github_probe(client:)
+             .send(
+               :smoke_status,
+               repo,
+               head,
+               [unrelated_check],
+               [workflow],
+               default_branch: "main"
+             )
 
     assert_equal true, status.fetch("shared_contract")
     assert_equal "unknown", status.fetch("status")
@@ -1490,7 +1518,7 @@ class FleetHealthTest < Minitest::Test
         responses.fetch(path)
       end
     end.new(responses)
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
     caller = { "key" => "fleet", "name" => "Fleet" }
 
     skipped = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow, caller)
@@ -1529,7 +1557,7 @@ class FleetHealthTest < Minitest::Test
         }
       end
     end.new(jobs_path)
-    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    probe = public_github_probe(client:)
     caller = { "key" => "fleet", "name" => "Fleet" }
 
     status = probe.send(:shared_smoke_job_status, repo, run, caller)
@@ -1567,15 +1595,15 @@ class FleetHealthTest < Minitest::Test
       end
     end.new(content)
 
-    status = FleetValidation::PublicGitHubProbe.new(client:)
-                                               .send(
-                                                 :smoke_status,
-                                                 repo,
-                                                 head,
-                                                 [],
-                                                 [workflow],
-                                                 default_branch: "main"
-                                               )
+    status = public_github_probe(client:)
+             .send(
+               :smoke_status,
+               repo,
+               head,
+               [],
+               [workflow],
+               default_branch: "main"
+             )
 
     assert_equal true, status.fetch("shared_contract")
     assert_equal "unknown", status.fetch("status")
@@ -1611,15 +1639,15 @@ class FleetHealthTest < Minitest::Test
       end
     end.new(content)
 
-    status = FleetValidation::PublicGitHubProbe.new(client:)
-                                               .send(
-                                                 :smoke_status,
-                                                 repo,
-                                                 head,
-                                                 [],
-                                                 [workflow],
-                                                 default_branch: "main"
-                                               )
+    status = public_github_probe(client:)
+             .send(
+               :smoke_status,
+               repo,
+               head,
+               [],
+               [workflow],
+               default_branch: "main"
+             )
 
     assert_equal true, status.fetch("shared_contract")
     assert_equal "unknown", status.fetch("status")
@@ -1663,15 +1691,15 @@ class FleetHealthTest < Minitest::Test
       end
     end.new(content)
 
-    status = FleetValidation::PublicGitHubProbe.new(client:)
-                                               .send(
-                                                 :smoke_status,
-                                                 repo,
-                                                 head,
-                                                 [],
-                                                 [workflow],
-                                                 default_branch: "main"
-                                               )
+    status = public_github_probe(client:)
+             .send(
+               :smoke_status,
+               repo,
+               head,
+               [],
+               [workflow],
+               default_branch: "main"
+             )
 
     assert_equal false, status.fetch("shared_contract")
     assert_equal "unknown", status.fetch("status")
@@ -1683,7 +1711,7 @@ class FleetHealthTest < Minitest::Test
       raise "public API unavailable"
     end
 
-    observation = FleetValidation::PublicGitHubProbe.new(client:).observe(
+    observation = public_github_probe(client:).observe(
       @contract.targets.first,
       observed_at: "2026-07-18T12:00:00Z"
     )
@@ -1789,6 +1817,10 @@ class FleetHealthTest < Minitest::Test
   end
 
   private
+
+  def public_github_probe(client:, max_default_age_days: @contract.max_default_age_days)
+    FleetValidation::PublicGitHubProbe.new(client:, max_default_age_days:)
+  end
 
   def build_contract(manifest)
     FleetValidation::FleetHealth.new(

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -130,6 +130,23 @@ class FleetHealthTest < Minitest::Test
     assert_equal ["sanitized-active-drifted"], evidence.dig("aggregate", "blocking_targets")
   end
 
+  def test_future_default_commit_timestamp_is_unknown_instead_of_fresh
+    observations = Marshal.load(Marshal.dump(@observations))
+    observations.fetch("sanitized-active-current")["default_commit_at"] = "2026-07-19T12:00:00Z"
+
+    evidence = @contract.evaluate(
+      observations:,
+      registry_artifacts: stable_registry_artifacts
+    )
+    current = target(evidence, "sanitized-active-current")
+
+    assert_equal "unknown", current.dig("staleness", "status")
+    assert_equal(-1, current.dig("staleness", "age_days"))
+    assert_includes current.dig("staleness", "evidence"), "future default commit timestamp"
+    assert_includes current.fetch("findings"), "staleness"
+    assert_equal "blocked", current.fetch("status")
+  end
+
   def test_report_only_target_retains_required_review_app_drift_without_blocking
     manifest = Marshal.load(Marshal.dump(@manifest))
     report_only = manifest.fetch("repos").find { |repo| repo["name"] == "sanitized/report-only" }

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -764,7 +764,7 @@ class FleetHealthTest < Minitest::Test
     responses = {
       path => { "workflows" => filler },
       "#{path}&page=2" => { "workflows" => [caller, review] },
-      "/repos/#{repo}/actions/workflows/4100/runs?branch=main&per_page=20" => {
+      "/repos/#{repo}/actions/workflows/4100/runs?branch=main&per_page=100" => {
         "workflow_runs" => [{
           "id" => 4101,
           "head_sha" => head,
@@ -781,7 +781,7 @@ class FleetHealthTest < Minitest::Test
           "html_url" => "https://example.invalid/smoke-job"
         }]
       },
-      "/repos/#{repo}/actions/workflows/4200/runs?event=pull_request&per_page=20" => {
+      "/repos/#{repo}/actions/workflows/4200/runs?event=pull_request&per_page=100" => {
         "workflow_runs" => [valid_review_run]
       }
     }
@@ -820,6 +820,216 @@ class FleetHealthTest < Minitest::Test
     assert_equal 102, workflows.length
     assert_equal "passed", smoke.fetch("status")
     assert_equal "passed", review_app.fetch("status")
+  end
+
+  def test_exact_head_smoke_run_can_appear_after_the_first_page
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = {
+      "id" => 41,
+      "path" => ".github/workflows/ci.yml",
+      "html_url" => "https://example.invalid/workflow"
+    }
+    runs_path = "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=100"
+    jobs_path = "/repos/#{repo}/actions/runs/4101/jobs?per_page=100"
+    filler_run = {
+      "head_sha" => "b" * 40,
+      "status" => "completed",
+      "conclusion" => "success"
+    }
+    responses = {
+      runs_path => { "workflow_runs" => Array.new(100) { filler_run.dup } },
+      "#{runs_path}&page=2" => {
+        "workflow_runs" => [{
+          "id" => 4101,
+          "head_sha" => head,
+          "status" => "completed",
+          "conclusion" => "success",
+          "html_url" => "https://example.invalid/run"
+        }]
+      },
+      jobs_path => {
+        "jobs" => [{
+          "name" => "Fleet / Demo fleet smoke",
+          "status" => "completed",
+          "conclusion" => "success",
+          "html_url" => "https://example.invalid/job"
+        }]
+      }
+    }
+    client = Struct.new(:responses, :requests) do
+      def get(path)
+        requests << path
+        responses.fetch(path)
+      end
+    end.new(responses, [])
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    caller = { "key" => "fleet", "name" => "Fleet" }
+
+    status = probe.send(:shared_smoke_workflow_status, repo, head, "main", workflow, caller)
+
+    assert_equal "passed", status.fetch("status")
+    assert_includes client.requests, "#{runs_path}&page=2"
+  end
+
+  def test_called_reusable_smoke_job_can_appear_after_the_first_page
+    repo = "sanitized/demo"
+    run = { "id" => 4101 }
+    jobs_path = "/repos/#{repo}/actions/runs/4101/jobs?per_page=100"
+    filler_job = {
+      "name" => "Unrelated",
+      "status" => "completed",
+      "conclusion" => "success"
+    }
+    responses = {
+      jobs_path => { "jobs" => Array.new(100) { filler_job.dup } },
+      "#{jobs_path}&page=2" => {
+        "jobs" => [{
+          "name" => "Fleet / Demo fleet smoke",
+          "status" => "completed",
+          "conclusion" => "success",
+          "html_url" => "https://example.invalid/job"
+        }]
+      }
+    }
+    client = Struct.new(:responses, :requests) do
+      def get(path)
+        requests << path
+        responses.fetch(path)
+      end
+    end.new(responses, [])
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+    caller = { "key" => "fleet", "name" => "Fleet" }
+
+    status = probe.send(:shared_smoke_job_status, repo, run, caller)
+
+    assert_equal "passed", status.fetch("status")
+    assert_includes client.requests, "#{jobs_path}&page=2"
+  end
+
+  def test_eligible_review_app_run_can_appear_after_the_first_page
+    repo = "sanitized/demo"
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "state" => "active",
+      "html_url" => "https://example.invalid/workflow"
+    }
+    runs_path = "/repos/#{repo}/actions/workflows/42/runs?event=pull_request&per_page=100"
+    filler_run = {
+      "pull_requests" => [{ "base" => { "ref" => "develop" } }]
+    }
+    responses = {
+      runs_path => { "workflow_runs" => Array.new(100) { filler_run.dup } },
+      "#{runs_path}&page=2" => { "workflow_runs" => [valid_review_run] }
+    }
+    client = Struct.new(:responses, :requests) do
+      def get(path)
+        requests << path
+        responses.fetch(path)
+      end
+    end.new(responses, [])
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    status = probe.send(
+      :review_workflow_status,
+      repo,
+      workflow,
+      default_branch: "main",
+      observed_at: "2026-07-18T12:00:00Z"
+    )
+
+    assert_equal "passed", status.fetch("status")
+    assert_includes client.requests, "#{runs_path}&page=2"
+  end
+
+  def test_observe_degrades_malformed_and_full_bound_nested_collections_to_unknown
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    head = "a" * 40
+    smoke_workflow = {
+      "id" => 41,
+      "path" => ".github/workflows/ci.yml",
+      "html_url" => "https://example.invalid/smoke-workflow"
+    }
+    review_workflow = {
+      "id" => 42,
+      "path" => target.fetch("review_app_workflow"),
+      "state" => "active",
+      "html_url" => "https://example.invalid/review-workflow"
+    }
+    checks_path = "/repos/#{repo}/commits/#{head}/check-runs?per_page=100"
+    workflows_path = "/repos/#{repo}/actions/workflows?per_page=100"
+    smoke_runs_path = "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=100"
+    jobs_path = "/repos/#{repo}/actions/runs/4101/jobs?per_page=100"
+    review_runs_path = "/repos/#{repo}/actions/workflows/42/runs?event=pull_request&per_page=100"
+    requests = []
+    client = Object.new
+    client.define_singleton_method(:get) do |path|
+      requests << path
+      case path
+      when "/repos/#{repo}"
+        { "visibility" => "public", "default_branch" => "main", "archived" => false }
+      when "/repos/#{repo}/commits/main"
+        { "sha" => head }
+      when checks_path
+        { "check_runs" => [] }
+      when workflows_path
+        { "workflows" => [smoke_workflow, review_workflow] }
+      when "/repos/#{repo}/dependency-graph/sbom"
+        {}
+      when smoke_runs_path
+        {
+          "workflow_runs" => [{
+            "id" => 4101,
+            "head_sha" => head,
+            "status" => "completed",
+            "conclusion" => "success"
+          }]
+        }
+      when jobs_path
+        { "jobs" => {} }
+      else
+        raise "unexpected path #{path}" unless path.start_with?(review_runs_path)
+
+        { "workflow_runs" => Array.new(100) { { "pull_requests" => [] } } }
+      end
+    end
+    dependabot_config = dependabot_v1_config
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      raise "wrong head" unless ref == head
+
+      case path
+      when smoke_workflow.fetch("path")
+        YAML.dump(
+          "jobs" => {
+            "fleet" => {
+              "name" => "Fleet",
+              "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+            }
+          }
+        )
+      when review_workflow.fetch("path")
+        YAML.dump("jobs" => {})
+      when ".github/dependabot.yml"
+        YAML.dump(dependabot_config)
+      else
+        raise "unexpected content path #{path}"
+      end
+    end
+
+    observation = FleetValidation::PublicGitHubProbe.new(client:).observe(
+      target,
+      observed_at: "2026-07-18T12:00:00Z"
+    )
+
+    assert_equal head, observation.fetch("default_commit")
+    assert_equal "unknown", observation.dig("smoke", "status")
+    assert_equal "unknown", observation.dig("review_app", "status")
+    assert_includes observation.dig("smoke", "evidence"), "ManifestError"
+    assert_includes observation.dig("review_app", "evidence"), "ManifestError"
+    assert_equal FleetValidation::PublicGitHubProbe::MAX_PAGES,
+                 (requests.count { |path| path.start_with?(review_runs_path) })
   end
 
   def test_workflow_pagination_rejects_malformed_and_incomplete_pages
@@ -943,7 +1153,7 @@ class FleetHealthTest < Minitest::Test
             }
           ]
         },
-        "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=20" => {
+        "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=100" => {
           "workflow_runs" => [{
             "id" => 4101,
             "head_sha" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -961,7 +1171,7 @@ class FleetHealthTest < Minitest::Test
             "html_url" => "https://example.invalid/smoke-job"
           }]
         },
-        "/repos/#{repo}/actions/workflows/42/runs?event=pull_request&per_page=20" => {
+        "/repos/#{repo}/actions/workflows/42/runs?event=pull_request&per_page=100" => {
           "workflow_runs" => [valid_review_run]
         }
       },
@@ -1096,10 +1306,10 @@ class FleetHealthTest < Minitest::Test
         responses.fetch(path)
       end
     end.new({
-              "/repos/#{target.fetch('name')}/actions/workflows/42/runs?event=pull_request&per_page=20" => {
+              "/repos/#{target.fetch('name')}/actions/workflows/42/runs?event=pull_request&per_page=100" => {
                 "workflow_runs" => [valid_review_run("html_url" => "https://example.invalid/review-run")]
               },
-              "/repos/#{target.fetch('name')}/actions/workflows/43/runs?event=pull_request&per_page=20" => {
+              "/repos/#{target.fetch('name')}/actions/workflows/43/runs?event=pull_request&per_page=100" => {
                 "workflow_runs" => [valid_review_run(
                   "conclusion" => "failure",
                   "html_url" => "https://example.invalid/cleanup-run"
@@ -1240,7 +1450,7 @@ class FleetHealthTest < Minitest::Test
       "html_url" => "https://example.invalid/workflow"
     }
     responses = {
-      "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=20" => {
+      "/repos/#{repo}/actions/workflows/41/runs?branch=main&per_page=100" => {
         "workflow_runs" => [{
           "id" => 4101,
           "head_sha" => head,

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -1,0 +1,440 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "tmpdir"
+require "yaml"
+require_relative "fleet_health"
+
+class FleetHealthTest < Minitest::Test
+  FIXTURE = File.expand_path("../fixtures/rc12-health-drift.yml", __dir__)
+  RC12_REPLAY = File.expand_path("replay_rc12_fleet_health.rb", __dir__)
+  CHECK_FLEET_HEALTH = File.expand_path("check_fleet_health.rb", __dir__)
+  REUSABLE_SMOKE = File.expand_path("../../../../.github/workflows/demo-fleet-smoke.yml", __dir__)
+  SCHEDULED_HEALTH = File.expand_path("../../../../.github/workflows/demo-fleet-health.yml", __dir__)
+
+  def setup
+    fixture = YAML.safe_load_file(FIXTURE, aliases: false)
+    @manifest = fixture.fetch("manifest")
+    @observations = fixture.fetch("observations")
+    @contract = FleetValidation::FleetHealth.new(
+      manifest: @manifest,
+      pack_id: "stable-public-17-0-0",
+      release: "v17.0.0",
+      rsc_version: "19.2.1",
+      policy_commit: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      generated_at: "2026-07-18T12:00:00Z"
+    )
+  end
+
+  def test_selects_only_explicit_public_health_targets
+    assert_equal(
+      %w[
+        sanitized-active-current
+        sanitized-active-drifted
+        sanitized-report-only
+        sanitized-archived
+      ],
+      @contract.targets.map { |target| target.fetch("id") }
+    )
+  end
+
+  def test_active_drift_blocks_aggregate_while_soft_and_archived_targets_are_report_only
+    evidence = @contract.evaluate(
+      observations: @observations,
+      registry_artifacts: stable_registry_artifacts
+    )
+
+    current = target(evidence, "sanitized-active-current")
+    drifted = target(evidence, "sanitized-active-drifted")
+    report_only = target(evidence, "sanitized-report-only")
+    archived = target(evidence, "sanitized-archived")
+
+    assert_equal "passed", current.fetch("status")
+    assert_equal "blocked", drifted.fetch("status")
+    assert_includes drifted.fetch("findings"), "currency"
+    assert_includes drifted.fetch("findings"), "default_ci"
+    assert_includes drifted.fetch("findings"), "smoke"
+    assert_includes drifted.fetch("findings"), "review_app"
+    assert_includes drifted.fetch("findings"), "dependabot"
+    assert_includes drifted.fetch("findings"), "staleness"
+    assert_equal "passed", current.dig("staleness", "status")
+    assert_equal "blocked", drifted.dig("staleness", "status")
+    assert_equal "reported", report_only.fetch("status")
+    assert_equal "reported", archived.fetch("status")
+    assert_equal "blocked", evidence.dig("aggregate", "status")
+    assert_equal ["sanitized-active-drifted"], evidence.dig("aggregate", "blocking_targets")
+  end
+
+  def test_registry_artifacts_must_be_exact_stable_public_versions
+    artifacts = stable_registry_artifacts
+    artifacts[0]["version"] = "17.0.0.rc.12"
+
+    evidence = @contract.evaluate(observations: @observations, registry_artifacts: artifacts)
+
+    assert_equal "blocked", evidence.dig("registry", "status")
+    assert_includes evidence.dig("aggregate", "findings"), "registry"
+  end
+
+  def test_product_currency_allows_at_most_one_minor_of_stable_lag
+    contract = FleetValidation::FleetHealth.new(
+      manifest: @manifest,
+      pack_id: "minor-lag",
+      release: "v17.1.0",
+      rsc_version: "19.2.1",
+      policy_commit: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      generated_at: "2026-07-18T12:00:00Z"
+    )
+    observations = Marshal.load(Marshal.dump(@observations))
+    current = observations.fetch("sanitized-active-current")
+    current.fetch("package_versions").each do |package|
+      package["version"] = "17.0.5" unless package["name"] == "react-on-rails-rsc"
+    end
+    evidence = contract.evaluate(
+      observations:,
+      registry_artifacts: [
+        { "ecosystem" => "gem", "name" => "react_on_rails", "version" => "17.1.0", "source" => "registry" },
+        { "ecosystem" => "npm", "name" => "react-on-rails", "version" => "17.1.0", "source" => "registry" },
+        { "ecosystem" => "npm", "name" => "react-on-rails-rsc", "version" => "19.2.1", "source" => "registry" }
+      ]
+    )
+
+    assert_equal "passed", target(evidence, "sanitized-active-current").dig("currency", "status")
+  end
+
+  def test_currency_evidence_keeps_only_relevant_packages_and_accepts_any_matching_version
+    observations = Marshal.load(Marshal.dump(@observations))
+    current = observations.fetch("sanitized-active-current")
+    current.fetch("package_versions").prepend(
+      {
+        "ecosystem" => "gem",
+        "name" => "unrelated",
+        "version" => "1.0.0",
+        "source" => "github-sbom"
+      },
+      {
+        "ecosystem" => "gem",
+        "name" => "react_on_rails",
+        "version" => "16.0.0",
+        "source" => "github-sbom"
+      }
+    )
+
+    evidence = @contract.evaluate(
+      observations:,
+      registry_artifacts: stable_registry_artifacts
+    )
+    currency = target(evidence, "sanitized-active-current").fetch("currency")
+
+    assert_equal "passed", currency.fetch("status")
+    refute_includes currency.fetch("observed").map { |package| package.fetch("name") }, "unrelated"
+  end
+
+  def test_schema_rejects_unknown_fields
+    evidence = @contract.evaluate(
+      observations: @observations,
+      registry_artifacts: stable_registry_artifacts
+    )
+    evidence["unexpected"] = true
+
+    errors = FleetValidation::SchemaValidator.new(@contract.schema).errors(evidence)
+
+    assert(errors.any? { |error| error.include?("unexpected") })
+  end
+
+  def test_writes_a_machine_readable_pack_and_human_summary
+    evidence = @contract.evaluate(
+      observations: @observations,
+      registry_artifacts: stable_registry_artifacts
+    )
+
+    Dir.mktmpdir do |directory|
+      @contract.write_pack(directory, evidence)
+
+      assert File.exist?(File.join(directory, "fleet-health.json"))
+      assert File.exist?(File.join(directory, "fleet-health.schema.json"))
+      assert_includes File.read(File.join(directory, "fleet-health.md")), "sanitized-active-drifted"
+    end
+  end
+
+  def test_sanitized_rc12_replay_detects_standing_health_drift
+    stdout, stderr, status = Open3.capture3("ruby", RC12_REPLAY)
+
+    assert status.success?, stderr
+    assert_includes stdout, "SANITIZED_RC12_FLEET_HEALTH_REPLAY_PASS"
+    assert_includes stdout, "blocking_targets=1"
+    assert_includes stdout, "report_only_targets=2"
+  end
+
+  def test_cli_writes_an_offline_evidence_pack
+    Dir.mktmpdir do |directory|
+      manifest_path = File.join(directory, "manifest.yml")
+      observations_path = File.join(directory, "observations.yml")
+      registry_path = File.join(directory, "registry.yml")
+      output_dir = File.join(directory, "pack")
+      File.write(manifest_path, YAML.dump(@manifest))
+      File.write(observations_path, YAML.dump(@observations))
+      File.write(registry_path, YAML.dump(stable_registry_artifacts))
+
+      _stdout, stderr, status = Open3.capture3(
+        "ruby", CHECK_FLEET_HEALTH,
+        "--manifest", manifest_path,
+        "--observations", observations_path,
+        "--registry-artifacts", registry_path,
+        "--release", "v17.0.0",
+        "--rsc-version", "19.2.1",
+        "--pack-id", "offline-test",
+        "--policy-commit", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "--generated-at", "2026-07-18T12:00:00Z",
+        "--output-dir", output_dir
+      )
+
+      assert status.success?, stderr
+      assert File.exist?(File.join(output_dir, "fleet-health.json"))
+    end
+  end
+
+  def test_dependabot_v1_requires_enabled_weekly_coverage_for_each_ecosystem
+    config = {
+      "version" => 2,
+      "updates" => [
+        {
+          "package-ecosystem" => "bundler",
+          "directory" => "/",
+          "schedule" => { "interval" => "weekly" },
+          "groups" => { "react-on-rails" => { "patterns" => ["react_on_rails*"] } }
+        },
+        {
+          "package-ecosystem" => "npm",
+          "directory" => "/",
+          "schedule" => { "interval" => "weekly" },
+          "groups" => { "react-on-rails" => { "patterns" => ["react-on-rails*"] } }
+        },
+        {
+          "package-ecosystem" => "github-actions",
+          "directory" => "/",
+          "schedule" => { "interval" => "weekly" }
+        }
+      ]
+    }
+    packages = [
+      { "ecosystem" => "gem", "name" => "react_on_rails" },
+      { "ecosystem" => "npm", "name" => "react-on-rails" }
+    ]
+
+    passed = FleetValidation::DependabotV1.evaluate(config, packages)
+    config.fetch("updates")[1]["open-pull-requests-limit"] = 0
+    blocked = FleetValidation::DependabotV1.evaluate(config, packages)
+
+    assert_equal "passed", passed.fetch("status")
+    assert_equal "blocked", blocked.fetch("status")
+    assert_includes blocked.fetch("findings"), "npm:version-updates-disabled"
+  end
+
+  def test_public_sbom_parser_extracts_gem_and_npm_versions
+    sbom = {
+      "sbom" => {
+        "packages" => [
+          { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:gem/react_on_rails@17.0.0" }] },
+          { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:npm/react-on-rails@17.0.0" }] },
+          { "externalRefs" => [{ "referenceType" => "website", "referenceLocator" => "https://example.invalid" }] }
+        ]
+      }
+    }
+
+    versions = FleetValidation::PublicSBOM.package_versions(sbom)
+
+    assert_equal(
+      [
+        { "ecosystem" => "gem", "name" => "react_on_rails", "version" => "17.0.0", "source" => "github-sbom" },
+        { "ecosystem" => "npm", "name" => "react-on-rails", "version" => "17.0.0", "source" => "github-sbom" }
+      ],
+      versions
+    )
+  end
+
+  def test_public_registry_resolver_verifies_exact_stable_artifacts
+    responses = {
+      "https://rubygems.org/api/v1/versions/react_on_rails.json" => [
+        { "number" => "17.0.0", "yanked" => false }
+      ],
+      "https://registry.npmjs.org/react-on-rails" => {
+        "versions" => { "17.0.0" => {} }
+      },
+      "https://registry.npmjs.org/react-on-rails-rsc" => {
+        "versions" => { "19.2.1" => {} }
+      }
+    }
+    resolver = FleetValidation::PublicRegistryResolver.new(fetcher: ->(url) { responses.fetch(url) })
+
+    artifacts = resolver.resolve(release: "v17.0.0", rsc_version: "19.2.1")
+
+    assert_equal stable_registry_artifacts, artifacts
+  end
+
+  def test_public_github_probe_binds_health_evidence_to_the_default_head
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    client = Struct.new(:responses, :contents) do
+      def get(path)
+        responses.fetch(path)
+      end
+
+      def content(repo_name, path, ref:)
+        contents.fetch([repo_name, path, ref])
+      end
+    end.new(
+      {
+        "/repos/#{repo}" => { "default_branch" => "main", "archived" => false },
+        "/repos/#{repo}/commits/main" => {
+          "sha" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "commit" => { "committer" => { "date" => "2026-07-17T12:00:00Z" } }
+        },
+        "/repos/#{repo}/dependency-graph/sbom" => {
+          "sbom" => {
+            "packages" => [
+              { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:gem/react_on_rails@17.0.0" }] },
+              { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => "pkg:npm/react-on-rails@17.0.0" }] }
+            ]
+          }
+        },
+        "/repos/#{repo}/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs?per_page=100" => {
+          "check_runs" => [
+            { "name" => "CI", "status" => "completed", "conclusion" => "success", "html_url" => "https://example.invalid/ci" },
+            {
+              "name" => "Demo fleet smoke",
+              "status" => "completed",
+              "conclusion" => "success",
+              "html_url" => "https://example.invalid/smoke"
+            },
+            {
+              "name" => "cpflow/review-app",
+              "status" => "completed",
+              "conclusion" => "success",
+              "html_url" => "https://example.invalid/review-app"
+            }
+          ]
+        },
+        "/repos/#{repo}/actions/workflows?per_page=100" => {
+          "workflows" => [
+            { "path" => ".github/workflows/demo-fleet-smoke.yml", "name" => "Demo fleet smoke" },
+            { "path" => ".github/workflows/cpflow-review-app.yml", "name" => "Review app" }
+          ]
+        }
+      },
+      {
+        [
+          repo,
+          ".github/workflows/demo-fleet-smoke.yml",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ] => "uses: shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main",
+        [
+          repo,
+          ".github/dependabot.yml",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ] => YAML.dump(dependabot_v1_config)
+      }
+    )
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    observation = probe.observe(target, observed_at: "2026-07-18T12:00:00Z")
+
+    assert_equal "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", observation.fetch("default_commit")
+    assert_equal "passed", observation.dig("default_ci", "status")
+    assert_equal true, observation.dig("smoke", "shared_contract")
+    assert_equal "passed", observation.dig("review_app", "status")
+    assert_equal "passed", observation.dig("dependabot", "status")
+  end
+
+  def test_public_github_probe_degrades_a_target_failure_to_unknown
+    client = Object.new
+    def client.get(_path)
+      raise "public API unavailable"
+    end
+
+    observation = FleetValidation::PublicGitHubProbe.new(client:).observe(
+      @contract.targets.first,
+      observed_at: "2026-07-18T12:00:00Z"
+    )
+
+    assert_nil observation.fetch("default_commit")
+    assert_equal "unknown", observation.dig("default_ci", "status")
+    assert_includes observation.dig("default_ci", "evidence"), "public API unavailable"
+  end
+
+  def test_reusable_smoke_workflow_is_read_only_and_emits_exact_head_evidence
+    workflow = File.read(REUSABLE_SMOKE)
+
+    assert_includes workflow, "workflow_call:"
+    assert_includes workflow, "contents: read"
+    assert_includes workflow, "fleet-smoke-evidence-${{ github.sha }}"
+    assert_includes workflow, '"head_sha"'
+    refute_includes workflow, "secrets: inherit"
+  end
+
+  def test_scheduled_health_workflow_runs_live_scan_and_uploads_the_pack
+    workflow = File.read(SCHEDULED_HEALTH)
+
+    assert_includes workflow, "schedule:"
+    assert_includes workflow, "workflow_dispatch:"
+    assert_includes workflow, "check_fleet_health.rb"
+    assert_includes workflow, "--live"
+    assert_includes workflow, "actions/upload-artifact@v4"
+    assert_includes workflow, "fleet-health.json"
+  end
+
+  private
+
+  def target(evidence, id)
+    evidence.fetch("targets").find { |candidate| candidate.fetch("id") == id }
+  end
+
+  def stable_registry_artifacts
+    [
+      {
+        "ecosystem" => "gem",
+        "name" => "react_on_rails",
+        "version" => "17.0.0",
+        "source" => "https://rubygems.org"
+      },
+      {
+        "ecosystem" => "npm",
+        "name" => "react-on-rails",
+        "version" => "17.0.0",
+        "source" => "https://registry.npmjs.org"
+      },
+      {
+        "ecosystem" => "npm",
+        "name" => "react-on-rails-rsc",
+        "version" => "19.2.1",
+        "source" => "https://registry.npmjs.org"
+      }
+    ]
+  end
+
+  def dependabot_v1_config
+    {
+      "version" => 2,
+      "updates" => [
+        {
+          "package-ecosystem" => "bundler",
+          "directory" => "/",
+          "schedule" => { "interval" => "weekly" },
+          "groups" => { "react-on-rails" => { "patterns" => ["react_on_rails*"] } }
+        },
+        {
+          "package-ecosystem" => "npm",
+          "directory" => "/",
+          "schedule" => { "interval" => "weekly" },
+          "groups" => { "react-on-rails" => { "patterns" => ["react-on-rails*"] } }
+        },
+        {
+          "package-ecosystem" => "github-actions",
+          "directory" => "/",
+          "schedule" => { "interval" => "weekly" }
+        }
+      ]
+    }
+  end
+end

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -1409,6 +1409,39 @@ class FleetHealthTest < Minitest::Test
     assert_equal "unknown", stale.fetch("status")
   end
 
+  def test_review_app_skips_a_newer_invalid_run_for_an_older_valid_run
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Deploy review app",
+      "state" => "active"
+    }
+    newer_invalid = valid_review_run(
+      "head_sha" => "b" * 40,
+      "html_url" => "https://example.invalid/newer-invalid",
+      "run_started_at" => "2026-07-18T11:00:00Z",
+      "updated_at" => "2026-07-18T11:05:00Z"
+    )
+    older_valid = valid_review_run(
+      "html_url" => "https://example.invalid/older-valid",
+      "run_started_at" => "2026-07-18T10:00:00Z",
+      "updated_at" => "2026-07-18T10:05:00Z"
+    )
+    client = Struct.new(:runs) do
+      def get(_path)
+        { "workflow_runs" => runs }
+      end
+    end.new([newer_invalid, older_valid])
+
+    status = review_app_status(public_github_probe(client:), repo, target, workflow)
+
+    assert_equal "passed", status.fetch("status")
+    assert_includes status.fetch("evidence"), "older-valid"
+    refute_includes status.fetch("evidence"), "newer-invalid"
+  end
+
   def test_review_app_recency_uses_the_manifest_staleness_limit
     manifest = Marshal.load(Marshal.dump(@manifest))
     manifest.fetch("standing_health")["max_default_age_days"] = 1

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -350,6 +350,25 @@ class FleetHealthTest < Minitest::Test
     assert_equal "SocketError: temporary DNS failure", error.message
   end
 
+  def test_public_github_client_translates_only_missing_content_responses
+    status = 404
+    http = Object.new
+    http.define_singleton_method(:json) do |_url|
+      raise FleetValidation::PublicHTTPResponseError.new(status, "request failed")
+    end
+    client = FleetValidation::PublicGitHubClient.new(http:)
+
+    assert_raises(FleetValidation::MissingPublicContentError) do
+      client.content("sanitized/demo", ".github/dependabot.yml", ref: "a" * 40)
+    end
+
+    status = 500
+    error = assert_raises(FleetValidation::PublicHTTPResponseError) do
+      client.content("sanitized/demo", ".github/dependabot.yml", ref: "a" * 40)
+    end
+    assert_equal 500, error.status
+  end
+
   def test_cli_explicit_versions_override_manifest_defaults
     options = { release: "v18.0.0", rsc_version: "20.0.0" }
 
@@ -448,6 +467,57 @@ class FleetHealthTest < Minitest::Test
 
     assert_equal "blocked", result.fetch("status")
     assert_includes result.fetch("findings"), "npm:product-group-missing"
+  end
+
+  def test_dependabot_status_falls_back_to_the_supported_yaml_path
+    repo = "sanitized/demo"
+    head = "a" * 40
+    requests = []
+    config = dependabot_v1_config
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      requests << [path, ref]
+      raise FleetValidation::MissingPublicContentError, "missing" if path == ".github/dependabot.yml"
+
+      YAML.dump(config)
+    end
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    result = probe.send(:dependabot_status, repo, head, @contract.targets.first.fetch("packages"))
+
+    assert_equal "passed", result.fetch("status")
+    assert_equal ".github/dependabot.yaml", result.fetch("evidence")
+    assert_equal(
+      [
+        [".github/dependabot.yml", head],
+        [".github/dependabot.yaml", head]
+      ],
+      requests
+    )
+  end
+
+  def test_dependabot_status_fails_closed_when_both_supported_paths_are_unavailable
+    repo = "sanitized/demo"
+    head = "a" * 40
+    requests = []
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      requests << [path, ref]
+      raise FleetValidation::MissingPublicContentError, "missing"
+    end
+    probe = FleetValidation::PublicGitHubProbe.new(client:)
+
+    result = probe.send(:dependabot_status, repo, head, @contract.targets.first.fetch("packages"))
+
+    assert_equal "blocked", result.fetch("status")
+    assert_includes result.fetch("evidence"), "MissingPublicContentError"
+    assert_equal(
+      [
+        [".github/dependabot.yml", head],
+        [".github/dependabot.yaml", head]
+      ],
+      requests
+    )
   end
 
   def test_public_sbom_parser_extracts_gem_and_npm_versions

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -1778,6 +1778,46 @@ class FleetHealthTest < Minitest::Test
     assert_includes observation.dig("default_ci", "evidence"), "public API unavailable"
   end
 
+  def test_public_github_probe_preserves_sbom_failure_as_unknown_evidence
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    head = "a" * 40
+    client = Object.new
+    client.define_singleton_method(:get) do |path|
+      case path
+      when "/repos/#{repo}"
+        { "visibility" => "public", "default_branch" => "main", "archived" => false }
+      when "/repos/#{repo}/commits/main"
+        { "sha" => head }
+      when "/repos/#{repo}/commits/#{head}/check-runs?per_page=100"
+        { "check_runs" => [] }
+      when "/repos/#{repo}/actions/workflows?per_page=100"
+        { "workflows" => [] }
+      when "/repos/#{repo}/dependency-graph/sbom"
+        raise FleetValidation::ManifestError, "SBOM permission denied"
+      else
+        raise "unexpected path #{path}"
+      end
+    end
+    dependabot_config = dependabot_v1_config
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      raise "unexpected content path #{path}" unless path == ".github/dependabot.yml" && ref == head
+
+      YAML.dump(dependabot_config)
+    end
+
+    observation = public_github_probe(client:).observe(
+      target,
+      observed_at: "2026-07-18T12:00:00Z"
+    )
+
+    assert_nil observation.fetch("default_commit")
+    assert_equal "unknown", observation.dig("default_ci", "status")
+    assert_includes observation.dig("default_ci", "evidence"), "FleetValidation::ManifestError"
+    assert_includes observation.dig("default_ci", "evidence"), "SBOM permission denied"
+    refute_includes observation.dig("default_ci", "evidence"), "react_on_rails"
+  end
+
   def test_reusable_smoke_workflow_is_read_only_and_emits_exact_head_evidence
     workflow = File.read(REUSABLE_SMOKE)
 

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+require_relative "fleet_health"
+
+module FleetValidation
+  module RC12FleetHealthReplay
+    module_function
+
+    FIXTURE = File.expand_path("../fixtures/rc12-health-drift.yml", __dir__)
+
+    def run
+      fixture = YAML.safe_load_file(FIXTURE, aliases: false)
+      contract = FleetHealth.new(
+        manifest: fixture.fetch("manifest"),
+        pack_id: "rc12-standing-health-replay",
+        release: "v17.0.0",
+        rsc_version: "19.2.1",
+        policy_commit: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        generated_at: "2026-07-18T12:00:00Z"
+      )
+      evidence = contract.evaluate(
+        observations: fixture.fetch("observations"),
+        registry_artifacts: stable_registry_artifacts
+      )
+      errors = SchemaValidator.new(contract.schema).errors(evidence)
+      raise "schema errors: #{errors.join('; ')}" unless errors.empty?
+
+      blocking_targets = evidence.dig("aggregate", "blocking_targets")
+      report_only_targets = evidence.fetch("targets").count { |target| target["status"] == "reported" }
+      raise "expected one active blocking target" unless blocking_targets.length == 1
+      raise "expected two report-only targets" unless report_only_targets == 2
+
+      puts "blocking_targets=#{blocking_targets.length}"
+      puts "report_only_targets=#{report_only_targets}"
+      puts "SANITIZED_RC12_FLEET_HEALTH_REPLAY_PASS"
+      0
+    rescue ManifestError, RuntimeError => e
+      warn "SANITIZED_RC12_FLEET_HEALTH_REPLAY_FAIL: #{e.message}"
+      1
+    end
+
+    def stable_registry_artifacts
+      [
+        {
+          "ecosystem" => "gem",
+          "name" => "react_on_rails",
+          "version" => "17.0.0",
+          "source" => "https://rubygems.org"
+        },
+        {
+          "ecosystem" => "npm",
+          "name" => "react-on-rails",
+          "version" => "17.0.0",
+          "source" => "https://registry.npmjs.org"
+        },
+        {
+          "ecosystem" => "npm",
+          "name" => "react-on-rails-rsc",
+          "version" => "19.2.1",
+          "source" => "https://registry.npmjs.org"
+        }
+      ]
+    end
+  end
+end
+
+exit FleetValidation::RC12FleetHealthReplay.run if $PROGRAM_NAME == __FILE__

--- a/.agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb
@@ -50,8 +50,32 @@ module FleetValidation
           "source" => "https://rubygems.org"
         },
         {
+          "ecosystem" => "gem",
+          "name" => "react_on_rails_pro",
+          "version" => "17.0.0",
+          "source" => "https://rubygems.org"
+        },
+        {
           "ecosystem" => "npm",
           "name" => "react-on-rails",
+          "version" => "17.0.0",
+          "source" => "https://registry.npmjs.org"
+        },
+        {
+          "ecosystem" => "npm",
+          "name" => "react-on-rails-pro",
+          "version" => "17.0.0",
+          "source" => "https://registry.npmjs.org"
+        },
+        {
+          "ecosystem" => "npm",
+          "name" => "react-on-rails-pro-node-renderer",
+          "version" => "17.0.0",
+          "source" => "https://registry.npmjs.org"
+        },
+        {
+          "ecosystem" => "npm",
+          "name" => "create-react-on-rails-app",
           "version" => "17.0.0",
           "source" => "https://registry.npmjs.org"
         },

--- a/.github/workflows/demo-fleet-health.yml
+++ b/.github/workflows/demo-fleet-health.yml
@@ -6,15 +6,15 @@ name: Public demo fleet standing health
   workflow_dispatch:
     inputs:
       release:
-        description: Stable React on Rails tag
+        description: Stable React on Rails tag; blank uses demo-fleet.yml
         required: false
         type: string
-        default: v17.0.0
+        default: ""
       rsc-version:
-        description: Stable react-on-rails-rsc version
+        description: Stable react-on-rails-rsc version; blank uses demo-fleet.yml
         required: false
         type: string
-        default: 19.2.1
+        default: ""
 
 permissions:
   actions: read
@@ -26,22 +26,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74  # v1
+      - uses: ./.github/actions/setup-bundle
         with:
+          working-directory: .
           ruby-version: "3.3"
-          bundler-cache: true
 
       - name: Generate public standing-health evidence
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          RELEASE: ${{ inputs.release || 'v17.0.0' }}
-          RSC_VERSION: ${{ inputs['rsc-version'] || '19.2.1' }}
+          RELEASE_OVERRIDE: ${{ inputs.release || '' }}
+          RSC_VERSION_OVERRIDE: ${{ inputs['rsc-version'] || '' }}
         run: |
           HEALTH_SCRIPT=".agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
+          VERSION_ARGS=()
+          if [[ -n "$RELEASE_OVERRIDE" ]]; then
+            VERSION_ARGS+=(--release "$RELEASE_OVERRIDE")
+          fi
+          if [[ -n "$RSC_VERSION_OVERRIDE" ]]; then
+            VERSION_ARGS+=(--rsc-version "$RSC_VERSION_OVERRIDE")
+          fi
           bundle exec ruby "$HEALTH_SCRIPT" \
             --live \
-            --release "$RELEASE" \
-            --rsc-version "$RSC_VERSION" \
+            "${VERSION_ARGS[@]}" \
             --pack-id "fleet-health-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --policy-commit "$GITHUB_SHA" \
             --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/.github/workflows/demo-fleet-health.yml
+++ b/.github/workflows/demo-fleet-health.yml
@@ -1,0 +1,68 @@
+name: Public demo fleet standing health
+
+"on":
+  schedule:
+    - cron: "23 16 * * 1"
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Stable React on Rails tag
+        required: false
+        type: string
+        default: v17.0.0
+      rsc-version:
+        description: Stable react-on-rails-rsc version
+        required: false
+        type: string
+        default: 19.2.1
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  standing-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Generate public standing-health evidence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE: ${{ inputs.release || 'v17.0.0' }}
+          RSC_VERSION: ${{ inputs['rsc-version'] || '19.2.1' }}
+        run: |
+          HEALTH_SCRIPT=".agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
+          ruby "$HEALTH_SCRIPT" \
+            --live \
+            --release "$RELEASE" \
+            --rsc-version "$RSC_VERSION" \
+            --pack-id "fleet-health-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --policy-commit "$GITHUB_SHA" \
+            --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --output-dir tmp/fleet-health
+
+      - name: Upload standing-health evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: >-
+            public-demo-fleet-health-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            tmp/fleet-health/fleet-health.json
+            tmp/fleet-health/fleet-health.schema.json
+            tmp/fleet-health/fleet-health.md
+          if-no-files-found: error
+
+      - name: Enforce active public target health
+        if: always()
+        run: |
+          ruby -rjson -e '
+            path = "tmp/fleet-health/fleet-health.json"
+            evidence = JSON.parse(File.read(path))
+            exit(evidence.dig("aggregate", "status") == "passed" ? 0 : 1)
+          '

--- a/.github/workflows/demo-fleet-health.yml
+++ b/.github/workflows/demo-fleet-health.yml
@@ -26,9 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74  # v1
         with:
           ruby-version: "3.3"
+          bundler-cache: true
 
       - name: Generate public standing-health evidence
         env:
@@ -37,7 +38,7 @@ jobs:
           RSC_VERSION: ${{ inputs['rsc-version'] || '19.2.1' }}
         run: |
           HEALTH_SCRIPT=".agents/skills/run-fleet-validation/scripts/check_fleet_health.rb"
-          ruby "$HEALTH_SCRIPT" \
+          bundle exec ruby "$HEALTH_SCRIPT" \
             --live \
             --release "$RELEASE" \
             --rsc-version "$RSC_VERSION" \
@@ -61,7 +62,7 @@ jobs:
       - name: Enforce active public target health
         if: always()
         run: |
-          ruby -rjson -e '
+          bundle exec ruby -rjson -e '
             path = "tmp/fleet-health/fleet-health.json"
             evidence = JSON.parse(File.read(path))
             exit(evidence.dig("aggregate", "status") == "passed" ? 0 : 1)

--- a/.github/workflows/demo-fleet-smoke.yml
+++ b/.github/workflows/demo-fleet-smoke.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74  # v1
         with:
           ruby-version: ${{ inputs['ruby-version'] }}
 

--- a/.github/workflows/demo-fleet-smoke.yml
+++ b/.github/workflows/demo-fleet-smoke.yml
@@ -1,0 +1,129 @@
+name: Demo fleet reusable smoke
+
+"on":
+  workflow_call:
+    inputs:
+      ruby-version:
+        description: Ruby version used by the caller repository
+        required: false
+        type: string
+        default: "3.3"
+      node-version:
+        description: Node.js version used by the caller repository
+        required: false
+        type: string
+        default: "22"
+      install-command:
+        description: Caller-owned dependency installation command
+        required: true
+        type: string
+      test-command:
+        description: Caller-owned test command; empty skips this step
+        required: false
+        type: string
+        default: ""
+      build-command:
+        description: Caller-owned build command
+        required: true
+        type: string
+      smoke-command:
+        description: Caller-owned local smoke command
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Demo fleet smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact caller head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs['ruby-version'] }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs['node-version'] }}
+
+      - name: Install dependencies
+        id: install
+        continue-on-error: true
+        env:
+          COMMAND: ${{ inputs['install-command'] }}
+        run: bash -lc "$COMMAND"
+
+      - name: Run tests
+        id: test
+        if: ${{ inputs['test-command'] != '' }}
+        continue-on-error: true
+        env:
+          COMMAND: ${{ inputs['test-command'] }}
+        run: bash -lc "$COMMAND"
+
+      - name: Build application
+        id: build
+        continue-on-error: true
+        env:
+          COMMAND: ${{ inputs['build-command'] }}
+        run: bash -lc "$COMMAND"
+
+      - name: Run local smoke
+        id: smoke
+        continue-on-error: true
+        env:
+          COMMAND: ${{ inputs['smoke-command'] }}
+        run: bash -lc "$COMMAND"
+
+      - name: Write exact-head smoke evidence
+        if: always()
+        env:
+          HEAD_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          INSTALL_OUTCOME: ${{ steps.install.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+        run: |
+          ruby -rjson -e '
+            outcomes = {
+              "install" => ENV.fetch("INSTALL_OUTCOME"),
+              "test" => ENV.fetch("TEST_OUTCOME"),
+              "build" => ENV.fetch("BUILD_OUTCOME"),
+              "smoke" => ENV.fetch("SMOKE_OUTCOME")
+            }
+            evidence = {
+              "schema_version" => 1,
+              "repository" => ENV.fetch("REPOSITORY"),
+              "head_sha" => ENV.fetch("HEAD_SHA"),
+              "outcomes" => outcomes,
+              "status" => outcomes.values.none? { |value| value == "failure" } ?
+                "passed" : "blocked"
+            }
+            rendered = "#{JSON.pretty_generate(evidence)}\n"
+            File.write("fleet-smoke-evidence.json", rendered)
+          '
+
+      - name: Upload exact-head smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fleet-smoke-evidence-${{ github.sha }}
+          path: fleet-smoke-evidence.json
+          if-no-files-found: error
+
+      - name: Enforce smoke result
+        if: always()
+        run: |
+          ruby -rjson -e '
+            evidence = JSON.parse(File.read("fleet-smoke-evidence.json"))
+            exit(evidence.fetch("status") == "passed" ? 0 : 1)
+          '

--- a/.github/workflows/demo-fleet-smoke.yml
+++ b/.github/workflows/demo-fleet-smoke.yml
@@ -54,8 +54,27 @@ jobs:
         with:
           node-version: ${{ inputs['node-version'] }}
 
+      - name: Validate required commands
+        id: validate
+        continue-on-error: true
+        env:
+          INSTALL_COMMAND: ${{ inputs['install-command'] }}
+          BUILD_COMMAND: ${{ inputs['build-command'] }}
+          SMOKE_COMMAND: ${{ inputs['smoke-command'] }}
+        run: |
+          ruby -e '
+            required = {
+              "install-command" => ENV.fetch("INSTALL_COMMAND"),
+              "build-command" => ENV.fetch("BUILD_COMMAND"),
+              "smoke-command" => ENV.fetch("SMOKE_COMMAND")
+            }
+            blank = required.filter_map { |name, command| name if command.strip.empty? }
+            abort("Required workflow commands are blank: #{blank.join(", ")}") unless blank.empty?
+          '
+
       - name: Install dependencies
         id: install
+        if: ${{ steps.validate.outcome == 'success' }}
         continue-on-error: true
         env:
           COMMAND: ${{ inputs['install-command'] }}
@@ -63,7 +82,7 @@ jobs:
 
       - name: Run tests
         id: test
-        if: ${{ inputs['test-command'] != '' }}
+        if: ${{ steps.validate.outcome == 'success' && inputs['test-command'] != '' }}
         continue-on-error: true
         env:
           COMMAND: ${{ inputs['test-command'] }}
@@ -71,6 +90,7 @@ jobs:
 
       - name: Build application
         id: build
+        if: ${{ steps.validate.outcome == 'success' }}
         continue-on-error: true
         env:
           COMMAND: ${{ inputs['build-command'] }}
@@ -78,6 +98,7 @@ jobs:
 
       - name: Run local smoke
         id: smoke
+        if: ${{ steps.validate.outcome == 'success' }}
         continue-on-error: true
         env:
           COMMAND: ${{ inputs['smoke-command'] }}
@@ -88,6 +109,7 @@ jobs:
         env:
           HEAD_SHA: ${{ github.sha }}
           REPOSITORY: ${{ github.repository }}
+          VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
           INSTALL_OUTCOME: ${{ steps.install.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
           BUILD_OUTCOME: ${{ steps.build.outcome }}
@@ -95,18 +117,22 @@ jobs:
         run: |
           ruby -rjson -e '
             outcomes = {
+              "validate" => ENV.fetch("VALIDATE_OUTCOME"),
               "install" => ENV.fetch("INSTALL_OUTCOME"),
               "test" => ENV.fetch("TEST_OUTCOME"),
               "build" => ENV.fetch("BUILD_OUTCOME"),
               "smoke" => ENV.fetch("SMOKE_OUTCOME")
             }
+            required_passed = %w[validate install build smoke].all? do |step|
+              outcomes.fetch(step) == "success"
+            end
+            test_passed = %w[success skipped].include?(outcomes.fetch("test"))
             evidence = {
               "schema_version" => 1,
               "repository" => ENV.fetch("REPOSITORY"),
               "head_sha" => ENV.fetch("HEAD_SHA"),
               "outcomes" => outcomes,
-              "status" => outcomes.values.none? { |value| value == "failure" } ?
-                "passed" : "blocked"
+              "status" => required_passed && test_passed ? "passed" : "blocked"
             }
             rendered = "#{JSON.pretty_generate(evidence)}\n"
             File.write("fleet-smoke-evidence.json", rendered)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,10 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
   release/capability preflight, balanced subagent-driven hard-gate prompts,
   report-only soft-track coverage, a durable result ledger/schema, independent
   audit, authorized merge, reachability/tree-parity proof, and tracker closeout.
+  The same skill also generates public-only standing-health packs that verify
+  stable artifact currency, exact-default-head CI/smoke, review-app capability,
+  default-branch staleness, and the evaluated Dependabot v1 policy without
+  mutating demo repositories.
 - Default simplify model: `claude-opus-4-8`
 
 ## External Flagship Demo Coordination

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,11 @@ source "https://rubygems.org"
 # Package/runtime dependencies stay in the package Gemfiles so root bundle install
 # remains small.
 group :development, :test do
+  gem "base64", "0.3.0", require: false
   gem "benchmark", "0.5.0", require: false
   gem "gem-release", "2.2.4", require: false
   gem "lefthook", "2.1.9", require: false
+  gem "minitest", "6.0.6", require: false
   gem "rake", "13.4.2", require: false
   gem "rspec", "3.13.2", require: false
   gem "rubocop", "1.61.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    base64 (0.3.0)
     benchmark (0.5.0)
     diff-lcs (1.6.2)
+    drb (2.2.3)
     gem-release (2.2.4)
     json (2.19.8)
     language_server-protocol (3.17.0.5)
     lefthook (2.1.9)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -74,9 +79,11 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  base64 (= 0.3.0)
   benchmark (= 0.5.0)
   gem-release (= 2.2.4)
   lefthook (= 2.1.9)
+  minitest (= 6.0.6)
   rake (= 13.4.2)
   rspec (= 3.13.2)
   rubocop (= 1.61.0)
@@ -85,12 +92,15 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   gem-release (2.2.4) sha256=2f11124c1580c811507c3b47e875e420cf3ed792a98105b49df11971e6e94db3
   json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lefthook (2.1.9) sha256=2d4d2e028d4ac4b265675c1180fe1f7c50230200630e65c3aff7d3ed90a1a334
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -43,6 +43,20 @@
 
 schema_version: 1
 
+standing_health:
+  # Standing health is intentionally public-only and independent from the
+  # candidate lifecycle below. Only repos with `standing_health.public: true`
+  # are queried. Archived targets are retained here as report-only catalog
+  # evidence and never become release mutation lanes.
+  schema_version: 1
+  max_minor_lag: 1
+  max_default_age_days: 45
+  dependabot_policy: v1
+  archived_targets:
+    - name: shakacode/react-on-rails-rsc-demo
+      headline: Retired manual RSC generator demo
+      packages: []
+
 lifecycle:
   # Release-path coverage is independent from repository tier. Every required
   # path needs a generated lane/evidence source or an explicit public waiver.
@@ -123,6 +137,10 @@ repos:
   - name: shakacode/react-on-rails-demo-flagship
     tier: hard_gate
     headline: Flagship Pro + RSC happy path
+    standing_health:
+      public: true
+      disposition: active
+      review_app: required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -148,6 +166,10 @@ repos:
   - name: shakacode/react-on-rails-demo-hacker-news-rsc
     tier: hard_gate
     headline: RSC streaming with comment trees
+    standing_health:
+      public: true
+      disposition: active
+      review_app: required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -166,6 +188,10 @@ repos:
   - name: shakacode/react-on-rails-demo-marketplace-rsc
     tier: hard_gate
     headline: RSC product grid + filter
+    standing_health:
+      public: true
+      disposition: active
+      review_app: required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -183,6 +209,10 @@ repos:
   - name: shakacode/react-on-rails-demo-gumroad-rsc
     tier: hard_gate
     headline: RSC dashboards + performance
+    standing_health:
+      public: true
+      disposition: active
+      review_app: required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -199,6 +229,10 @@ repos:
   - name: shakacode/react-webpack-rails-tutorial
     tier: hard_gate
     headline: Pro + RSC tutorial reference app
+    standing_health:
+      public: true
+      disposition: active
+      review_app: required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -218,6 +252,10 @@ repos:
   - name: shakacode/react-on-rails-starter-tanstack
     tier: hard_gate
     headline: TanStack Pro + RSC starter example
+    standing_health:
+      public: true
+      disposition: active
+      review_app: required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -237,6 +275,10 @@ repos:
   - name: shakacode/react_on_rails-demo-octochangelog-on-rails-pro
     tier: soft_track
     headline: RSC + server-rendered markdown
+    standing_health:
+      public: true
+      disposition: report_only
+      review_app: not_required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -254,6 +296,10 @@ repos:
   - name: shakacode/react-on-rails-demo-ssr-hmr
     tier: soft_track
     headline: SSR + HMR coexistence
+    standing_health:
+      public: true
+      disposition: report_only
+      review_app: not_required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -267,6 +313,10 @@ repos:
   - name: shakacode/react-on-rails-demo-v16-bundle-splitting
     tier: soft_track
     headline: On-demand bundle loading
+    standing_health:
+      public: true
+      disposition: report_only
+      review_app: not_required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -281,6 +331,10 @@ repos:
   - name: shakacode/react-on-rails-example-open-flights
     tier: soft_track
     headline: Larger migrated app (search + map)
+    standing_health:
+      public: true
+      disposition: report_only
+      review_app: not_required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -294,6 +348,10 @@ repos:
   - name: shakacode/react-on-rails-example-migration
     tier: soft_track
     headline: react-rails → React on Rails migration
+    standing_health:
+      public: true
+      disposition: report_only
+      review_app: not_required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -30,6 +30,9 @@
 #                    `cpflow_app_name` must be non-null before `verify: true` can
 #                    be cleared; a null name inside the block is an unverified
 #                    placeholder. The orchestrator skips smoke when no app is set.
+#   standing_health.review_app_workflow
+#                  — exact public workflow path used for standing review-app
+#                    evidence when `standing_health.review_app: required`.
 #   smoke          — list of paths the orchestrator hits against the
 #                    review-app URL after deploy. Each must return 2xx.
 #   headline       — short name of the per-repo appendix in the RC plan.
@@ -140,7 +143,7 @@ repos:
     standing_health:
       public: true
       disposition: active
-      review_app: required
+      review_app: not_required
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -170,6 +173,7 @@ repos:
       public: true
       disposition: active
       review_app: required
+      review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -192,6 +196,7 @@ repos:
       public: true
       disposition: active
       review_app: required
+      review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -213,6 +218,7 @@ repos:
       public: true
       disposition: active
       review_app: required
+      review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -233,6 +239,7 @@ repos:
       public: true
       disposition: active
       review_app: required
+      review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }
@@ -256,6 +263,7 @@ repos:
       public: true
       disposition: active
       review_app: required
+      review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
       - { ecosystem: npm, name: react-on-rails }

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -33,6 +33,9 @@
 #   standing_health.review_app_workflow
 #                  — exact public workflow path used for standing review-app
 #                    evidence when `standing_health.review_app: required`.
+#   standing_health.stable_release / rsc_version
+#                  — authoritative stable versions used by scheduled public
+#                    health checks when no manual workflow override is supplied.
 #   smoke          — list of paths the orchestrator hits against the
 #                    review-app URL after deploy. Each must return 2xx.
 #   headline       — short name of the per-repo appendix in the RC plan.
@@ -52,6 +55,8 @@ standing_health:
   # are queried. Archived targets are retained here as report-only catalog
   # evidence and never become release mutation lanes.
   schema_version: 1
+  stable_release: v17.0.0
+  rsc_version: 19.2.1
   max_minor_lag: 1
   max_default_age_days: 45
   dependabot_policy: v1

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -140,6 +140,24 @@ independent audit, merge/reachability, or closeout. The generated pack does not 
 independent behavioral lanes in `release-verification-runbook.md` or the maintainer's final
 promotion decision.
 
+The standing-health implementation uses the same canonical manifest but a separate public-only
+schema and evidence pack:
+
+```bash
+ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
+  --live \
+  --release v17.0.0 \
+  --rsc-version 19.2.1 \
+  --pack-id "fleet-health-v17-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --policy-commit "$(git rev-parse HEAD)" \
+  --output-dir tmp/fleet-health-v17
+```
+
+Only explicitly public standing-health entries are queried. Active public targets gate the
+standing-health result; soft-track and archived targets are report-only. The evidence records
+exact-default-head currency, CI, reusable-smoke adoption, review-app capability, staleness, and
+Dependabot v1 conformance. It does not grant candidate promotion or mutate any demo.
+
 The checker validates one public-safe `result-ledger.json` and renders the append-only tracker
 matrix from that exact file:
 

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -81,7 +81,7 @@ default, report-only soft-track coverage, a durable result ledger/schema, and in
 From the repository root, run:
 
 ```bash
-ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/generate_prompts.rb \
   --machines local,m1 \
   --prompts 6 \
   --output-dir tmp/fleet-validation-prompts
@@ -144,7 +144,7 @@ The standing-health implementation uses the same canonical manifest but a separa
 schema and evidence pack:
 
 ```bash
-ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
   --live \
   --release v17.0.0 \
   --rsc-version 19.2.1 \
@@ -162,7 +162,7 @@ The checker validates one public-safe `result-ledger.json` and renders the appen
 matrix from that exact file:
 
 ```bash
-ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
   --ledger tmp/fleet-validation-prompts/result-ledger.json \
   --expected-pack-id PACK_ID \
   --expected-release-selector "GENERATED_RELEASE_SELECTOR" \

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -146,13 +146,14 @@ schema and evidence pack:
 ```bash
 bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
   --live \
-  --release v17.0.0 \
-  --rsc-version 19.2.1 \
-  --pack-id "fleet-health-v17-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --pack-id "fleet-health-stable-$(date -u +%Y%m%dT%H%M%SZ)" \
   --policy-commit "$(git rev-parse HEAD)" \
-  --output-dir tmp/fleet-health-v17
+  --output-dir tmp/fleet-health-stable
 ```
 
+The scheduled/default stable versions come from `standing_health.stable_release` and
+`standing_health.rsc_version` in the manifest. Pass explicit version flags only for a manual
+historical or forward-looking probe.
 Only explicitly public standing-health entries are queried. Active public targets gate the
 standing-health result; soft-track and archived targets are report-only. The evidence records
 exact-default-head currency, CI, reusable-smoke adoption, review-app capability, staleness, and

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -94,16 +94,15 @@ which detects drift between releases. Hosted-CI dispatch and generator-CI routin
 also dependencies, not substitutes: they shorten individual gates but do not own blocker
 identities, combined audit, merge authority, or promotion closeout.
 
-After stable publication, generate a fresh public standing-health pack:
+After stable publication, update `standing_health.stable_release` and `standing_health.rsc_version`
+in `demo-fleet.yml`, then generate a fresh public standing-health pack:
 
 ```bash
 bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
   --live \
-  --release v17.0.0 \
-  --rsc-version 19.2.1 \
-  --pack-id "fleet-health-v17-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --pack-id "fleet-health-stable-$(date -u +%Y%m%dT%H%M%SZ)" \
   --policy-commit "$(git rev-parse HEAD)" \
-  --output-dir tmp/fleet-health-v17
+  --output-dir tmp/fleet-health-stable
 ```
 
 The command verifies those

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -94,6 +94,12 @@ which detects drift between releases. Hosted-CI dispatch and generator-CI routin
 also dependencies, not substitutes: they shorten individual gates but do not own blocker
 identities, combined audit, merge authority, or promotion closeout.
 
+After stable publication, generate a fresh public standing-health pack with
+`check_fleet_health.rb --live --release v17.0.0 --rsc-version 19.2.1`. The command verifies those
+exact public registry artifacts and binds default-health evidence to current public default heads.
+Keep soft-track and archived findings report-only. This pack is evidence for fleet currency and
+capability drift; it is not a replacement for the candidate ledger or a release-promotion signal.
+
 ```text
 You are updating the React on Rails demo fleet for {{RELEASE_REF}}.
 

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -98,12 +98,18 @@ After stable publication, generate a fresh public standing-health pack with
 `check_fleet_health.rb --live --release v17.0.0 --rsc-version 19.2.1`. The command verifies those
 exact public registry artifacts across both gems, all four unified-version npm packages, and the
 independently versioned RSC package. Direct-lock currency comes only from root `DEPENDS_ON` SPDX
-relationships; mixed direct versions block and missing root identity fails closed. Default CI and
-smoke stay bound to public default heads, while PR-only review-app capability uses the exact
-`standing_health.review_app_workflow` public path and its latest public run URL and timestamp.
-Staging, cleanup, delete, help, and promotion workflows never substitute for that path. Keep
-soft-track and archived findings report-only. This pack is evidence for fleet currency and
-capability drift; it is not a replacement for the candidate ledger or a release-promotion signal.
+relationships; mixed direct versions block and missing root identity fails closed. npm
+prereleases use ecosystem-normalized hyphen notation. Default CI stays bound to the public default
+head. Smoke passes only after the workflow containing the shared smoke contract succeeds for that
+exact head, with nonblank required commands and every required stage successful. PR-only
+review-app capability uses the exact `standing_health.review_app_workflow` public path and a recent
+`pull_request` run whose base branch, head branch, and head SHA agree with its PR metadata. Staging,
+cleanup, delete, help, and promotion workflows never substitute for that path. GitHub archival of
+an active target blocks as manifest drift. Dependabot requires one enabled weekly root entry per
+required ecosystem; separate disabled, non-root, or differently scheduled entries cannot combine
+into a pass. Keep soft-track and archived findings report-only. This pack is evidence for fleet
+currency and capability drift; it is not a replacement for the candidate ledger or a
+release-promotion signal.
 
 ```text
 You are updating the React on Rails demo fleet for {{RELEASE_REF}}.

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -94,8 +94,19 @@ which detects drift between releases. Hosted-CI dispatch and generator-CI routin
 also dependencies, not substitutes: they shorten individual gates but do not own blocker
 identities, combined audit, merge authority, or promotion closeout.
 
-After stable publication, generate a fresh public standing-health pack with
-`check_fleet_health.rb --live --release v17.0.0 --rsc-version 19.2.1`. The command verifies those
+After stable publication, generate a fresh public standing-health pack:
+
+```bash
+bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
+  --live \
+  --release v17.0.0 \
+  --rsc-version 19.2.1 \
+  --pack-id "fleet-health-v17-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --policy-commit "$(git rev-parse HEAD)" \
+  --output-dir tmp/fleet-health-v17
+```
+
+The command verifies those
 exact public registry artifacts across both gems, all four unified-version npm packages, and the
 independently versioned RSC package. Direct-lock currency comes only from root `DEPENDS_ON` SPDX
 relationships; mixed direct versions block and missing root identity fails closed. npm

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -96,9 +96,13 @@ identities, combined audit, merge authority, or promotion closeout.
 
 After stable publication, generate a fresh public standing-health pack with
 `check_fleet_health.rb --live --release v17.0.0 --rsc-version 19.2.1`. The command verifies those
-exact public registry artifacts and binds default-health evidence to current public default heads.
-Keep soft-track and archived findings report-only. This pack is evidence for fleet currency and
-capability drift; it is not a replacement for the candidate ledger or a release-promotion signal.
+exact public registry artifacts across both gems, all four unified-version npm packages, and the
+independently versioned RSC package. Direct-lock currency comes only from root `DEPENDS_ON` SPDX
+relationships; mixed direct versions block and missing root identity fails closed. Default CI and
+smoke stay bound to public default heads, while PR-only review-app capability uses the configured
+workflow's latest public run URL and timestamp. Keep soft-track and archived findings report-only.
+This pack is evidence for fleet currency and capability drift; it is not a replacement for the
+candidate ledger or a release-promotion signal.
 
 ```text
 You are updating the React on Rails demo fleet for {{RELEASE_REF}}.

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -99,10 +99,11 @@ After stable publication, generate a fresh public standing-health pack with
 exact public registry artifacts across both gems, all four unified-version npm packages, and the
 independently versioned RSC package. Direct-lock currency comes only from root `DEPENDS_ON` SPDX
 relationships; mixed direct versions block and missing root identity fails closed. Default CI and
-smoke stay bound to public default heads, while PR-only review-app capability uses the configured
-workflow's latest public run URL and timestamp. Keep soft-track and archived findings report-only.
-This pack is evidence for fleet currency and capability drift; it is not a replacement for the
-candidate ledger or a release-promotion signal.
+smoke stay bound to public default heads, while PR-only review-app capability uses the exact
+`standing_health.review_app_workflow` public path and its latest public run URL and timestamp.
+Staging, cleanup, delete, help, and promotion workflows never substitute for that path. Keep
+soft-track and archived findings report-only. This pack is evidence for fleet currency and
+capability drift; it is not a replacement for the candidate ledger or a release-promotion signal.
 
 ```text
 You are updating the React on Rails demo fleet for {{RELEASE_REF}}.

--- a/internal/contributor-info/release-verification-runbook.md
+++ b/internal/contributor-info/release-verification-runbook.md
@@ -95,13 +95,19 @@ also dependencies, not substitutes: they shorten individual gates but do not own
 identities, combined audit, merge authority, or promotion closeout.
 
 After stable publication, update `standing_health.stable_release` and `standing_health.rsc_version`
-in `demo-fleet.yml`, then generate a fresh public standing-health pack:
+in `demo-fleet.yml` and commit that manifest change. Generate evidence only from a clean working
+tree so the policy commit names the exact checked-in manifest:
 
 ```bash
+test -z "$(git status --porcelain)" || {
+  echo "Commit the manifest and clean the working tree before generating fleet evidence." >&2
+  exit 1
+}
+POLICY_COMMIT="$(git rev-parse HEAD)"
 bundle exec ruby .agents/skills/run-fleet-validation/scripts/check_fleet_health.rb \
   --live \
   --pack-id "fleet-health-stable-$(date -u +%Y%m%dT%H%M%SZ)" \
-  --policy-commit "$(git rev-parse HEAD)" \
+  --policy-commit "$POLICY_COMMIT" \
   --output-dir tmp/fleet-health-stable
 ```
 


### PR DESCRIPTION
## Why

React on Rails 17.0.0 and `react-on-rails-rsc` 19.2.1 are public, but the official public demo fleet still needs a durable way to detect release drift, stale defaults, missing smoke coverage, broken review-app capability, and dependency-automation gaps.

This is the central automation portion of #3898. The issue stays open until every active public demo reaches the final release or receives a durable disposition.

## What changed

- Adds an explicit public-only standing-health policy to `demo-fleet.yml`.
- Verifies all seven public release artifacts: both gems, the four unified npm packages, and RSC 19.2.1.
- Reads root-direct SPDX dependencies from each public repo's default-head SBOM so transitive or duplicate versions cannot mask a stale direct lock.
- Records exact default commit/time, current-head CI, reusable smoke adoption, one explicitly configured review-app workflow, 45-day staleness, and evaluated Dependabot-v1 coverage.
- Keeps soft and archived public targets report-only; no private or redacted lane is enumerated.
- Emits strict JSON/schema/Markdown evidence and a sanitized RC12 drift replay.
- Adds a read-only reusable smoke workflow and a weekly/manual standing-health workflow.

The fresh live pack is intentionally `BLOCKED`: all six active public demos still have final-release and/or health drift. The subsequent repo lanes in #3898 will clear those findings.

## Verification

- `fleet_health_test.rb`: 22 runs, 102 assertions, 0 failures/errors/skips
- Existing prompt generator: 164 runs, 661 assertions, green
- Sanitized standing-health RC12 replay: PASS
- Existing lifecycle RC12 replay: PASS
- Exact-head live pack:
  - policy commit `9680514a260d7312b298632eeccabb1c64585ec4`
  - registry: PASS for all seven artifacts
  - targets: 6 active, 5 report-only, 1 archived
  - review-app capability: 5 passed, 7 not applicable
  - aggregate: expected `BLOCKED` on the six active demos
- RuboCop for all four new Ruby files: PASS
- actionlint and targeted yamllint: PASS
- skill validation and `git diff --check`: PASS
- normal commit and pre-push hooks: PASS without bypass, using the repo-compatible Lychee 0.23.0

`.agents/bin/validate --changed` passed setup, docs, Ruby/benchmark lint, ESLint, Prettier, TypeScript, package builds, Pro dummy bundles, and all OSS/Pro/create-app/Node Renderer JavaScript jobs. It then failed in untouched gem specs under Ruby 4.0.5 RBS runtime checking: `Configuration#node_modules_location=` expects `String?` while the existing implementation receives/returns `Pathname`. The output was truncated after failure numbering reached at least 73, so the exact failure count is `UNKNOWN`.

## Workflow audit

- New semantic workflows:
  - `.github/workflows/demo-fleet-smoke.yml`
  - `.github/workflows/demo-fleet-health.yml`
- Permissions are read-only (`contents: read`; scanner also uses `actions: read`).
- No `secrets: inherit` or new secrets.
- Existing trusted action tags only: checkout v4, setup-ruby v1, setup-node v4, upload-artifact v4.
- A required post-merge workflow-exercise issue will be linked before merge.

## Changelog

No changelog entry: this is internal release-operations automation and policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly/manual “public demo fleet standing health” workflow that generates evidence packs and only succeeds when `aggregate.status` is `passed`.
  * Added public-only standing-health validation tooling, including a dedicated evidence generator/checker and RC12 replay support.
  * Added/extended a reusable “demo fleet reusable smoke” workflow that records step outcomes and uploads smoke evidence.
* **Documentation**
  * Updated skill docs and runbook guidance for public-only standing-health scope, exact review-app workflow requirements, and report-only behavior for soft/archived targets.
* **Tests**
  * Expanded Minitest coverage for contract validation, registry/currency rules, GitHub probing, replay, and evidence pack output.
* **Chores**
  * Updated examples to run Ruby via Bundler and adjusted dev/test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->