### PR TITLE
CI: exclude unreliable gem badge from link checks

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -70,6 +70,7 @@ exclude = [
   # BADGE AND CI SERVICES
   # ============================================================================
   '^https://badge\.fury\.io',  # Returns 403 for automated requests
+  '^https://img\.shields\.io/gem/dt/react_on_rails$',  # Repeatedly times out during full CI link sweeps
   '^https://coveralls\.io',    # Returns 503 for automated requests
 
   # ============================================================================

--- a/markdown-link-check-probe.md
+++ b/markdown-link-check-probe.md
@@ -1,0 +1,4 @@
+# Markdown Link Check Probe
+
+This temporary file triggers the pull request Markdown link workflow so its behavior can be compared with recent
+`main` and pull request runs. It will be removed when the probe is complete.

--- a/markdown-link-check-probe.md
+++ b/markdown-link-check-probe.md
@@ -1,4 +1,0 @@
-# Markdown Link Check Probe
-
-This temporary file triggers the pull request Markdown link workflow so its behavior can be compared with recent
-`main` and pull request runs. It will be removed when the probe is complete.


### PR DESCRIPTION
## Why

The full Markdown link sweep repeatedly spends about 24 minutes retrying the dynamic RubyGems download-count badge before failing on:

`https://img.shields.io/gem/dt/react_on_rails`

This reproduced on two heads of PR #4715 and again on this independent branch based directly on `main`. The separate reproduction examined 3,398 links and reported exactly one timeout—the unchanged README badge—with zero ordinary link errors.

Because this is a generated status badge rather than a documentation destination, checking it does not provide useful dead-link coverage. Its repeated timeout instead blocks otherwise valid PRs.

## Change

- Exclude only the exact React on Rails gem download-count badge URL in `.lychee.toml`.
- Keep all other Shields.io URLs eligible for link checking.
- Remove the temporary Markdown trigger file used for the independent reproduction; the final PR diff contains only the exclusion.

## Verification

- Parsed `.lychee.toml` with Python's TOML parser.
- Verified the new anchored regex matches the exact failing URL.
- Commit and push hooks passed without bypassing hooks.
- Hosted `markdown-link-check`: pending on the current head.
- No local specs were run.

## Reproduction evidence

- Independent probe PR: #4758
- [Failed probe job](https://github.com/shakacode/react_on_rails/actions/runs/29686997485/job/88192926234)
- Probe result: 23m 49s, 3,398 links, one timeout, zero ordinary errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link checking to skip a Shields.io badge URL that was timing out during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->