### PR TITLE
Agents: ignore synthetic workflow rows in fleet health

### DIFF
--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -194,6 +194,7 @@ module FleetValidation
     SHARED_SMOKE_REFERENCE = "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@"
     PASSING_CONCLUSIONS = %w[success neutral skipped].freeze
     DEPENDABOT_PATHS = %w[.github/dependabot.yml .github/dependabot.yaml].freeze
+    REPOSITORY_WORKFLOW_PATH = %r{\A\.github/workflows/[^/]+\.ya?ml\z}
     MAX_PAGES = 20
 
     def initialize(client:, max_default_age_days:)
@@ -284,7 +285,10 @@ module FleetValidation
 
     def smoke_status(repo, head, _checks, workflows, default_branch:)
       discovery_errors = []
-      shared_callers = workflows.flat_map do |workflow|
+      repository_workflows = workflows.select do |workflow|
+        workflow["path"].to_s.match?(REPOSITORY_WORKFLOW_PATH)
+      end
+      shared_callers = repository_workflows.flat_map do |workflow|
         content = @client.content(repo, workflow.fetch("path"), ref: head)
         shared_smoke_callers(content).map { |caller| [workflow, caller] }
       rescue StandardError => e

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -1516,6 +1516,54 @@ class FleetHealthTest < Minitest::Test
     refute_includes status.fetch("evidence"), "No reusable fleet-smoke caller"
   end
 
+  def test_shared_smoke_ignores_synthetic_non_repository_workflow_paths
+    repo = "sanitized/demo"
+    head = "a" * 40
+    real_workflow = { "id" => 41, "path" => ".github/workflows/ci.yml" }
+    synthetic_workflow = { "id" => 42, "path" => "dynamic/dependabot/dependabot-updates" }
+    content_reads = []
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      raise "wrong head" unless ref == head
+
+      content_reads << path
+      unless path == real_workflow.fetch("path")
+        raise FleetValidation::ManifestError, "synthetic workflow content is not repository-backed"
+      end
+
+      "{}"
+    end
+
+    status = public_github_probe(client:)
+             .send(:smoke_status, repo, head, [], [real_workflow, synthetic_workflow], default_branch: "main")
+
+    assert_equal [real_workflow.fetch("path")], content_reads
+    assert_equal "unknown", status.fetch("status")
+    assert_equal false, status.fetch("shared_contract")
+    assert_equal "No reusable fleet-smoke caller was found at the default head", status.fetch("evidence")
+  end
+
+  def test_shared_smoke_reads_direct_workflow_paths_with_unusual_filenames
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = { "id" => 41, "path" => ".github/workflows/_fleet smoke.yml" }
+    content_reads = []
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      raise "wrong head" unless ref == head
+
+      content_reads << path
+      "{}"
+    end
+
+    status = public_github_probe(client:)
+             .send(:smoke_status, repo, head, [], [workflow], default_branch: "main")
+
+    assert_equal [workflow.fetch("path")], content_reads
+    assert_equal "unknown", status.fetch("status")
+    assert_equal false, status.fetch("shared_contract")
+  end
+
   def test_shared_smoke_does_not_pass_when_discovery_is_partially_incomplete
     repo = "sanitized/demo"
     head = "a" * 40


### PR DESCRIPTION
## Why

The public demo fleet scanner receives synthetic GitHub Actions rows such as `dynamic/dependabot/dependabot-updates`. Those rows are not repository files, so trying to read them through the contents API makes reusable-smoke discovery incomplete and leaves the standing-health pack `UNKNOWN` even when real workflow files are readable.

This is a focused correction for the standing-health automation added for #3898.

## What changed

- Limit reusable-smoke caller discovery to direct YAML files under `.github/workflows/`.
- Preserve fail-closed behavior when a real repository workflow cannot be read.
- Accept valid unusual workflow filenames while excluding synthetic non-repository paths.
- Add regression coverage for both boundaries.

## Verification

- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb`: 67 runs, 329 assertions, green
- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb`: PASS
- targeted regression reproduced red before the fix and passed after it
- RuboCop on both changed Ruby files: clean
- `.agents/bin/validate --changed`: passed its selected checks; its detector classified `.agents` changes as documentation-only, so the explicit fleet-health tests above are the authoritative coverage
- mandatory OSS RuboCop completed clean before the review fix; the amended files also passed the repo pre-commit RuboCop/autofix hooks
- `git diff --check`: clean
- `codex review --base origin/main`: clean after one independently confirmed finding was fixed

## Changelog

No changelog entry: this is internal release-operations automation.

Refs #3898


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation to ignore synthetic or non-repository workflow paths.
  * Added support for repository workflow files with unusual filenames.
  * Improved smoke validation results and evidence when no reusable workflow caller is found.

* **Tests**
  * Added coverage for synthetic workflow filtering and direct workflow path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->