### PR TITLE
Fix Pro demo ESLint failures

### DIFF
--- a/react_on_rails_pro/spec/dummy/client/app/components/CacheSection.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/components/CacheSection.jsx
@@ -23,7 +23,9 @@ import React, { Suspense } from 'react';
 async function AsyncSectionContent({ delayMs, children }) {
   // Wait for the specified delay
   if (delayMs > 0) {
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await new Promise((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
   }
   return children;
 }
@@ -41,5 +43,3 @@ export default function CacheSection({ fallback = null, children, delayMs = 0 })
     </Suspense>
   );
 }
-
-export { CacheSection };


### PR DESCRIPTION
## Why

The current `main` lint job fails on two Pro dummy-app ESLint rules: the promise executor implicitly returns the timer ID, and `CacheSection` exposes a redundant named export that conflicts with its only default-import call site. This blocks a green current-main lint gate.

## What changed

- use a block-bodied promise executor so no timer ID is returned
- remove the unused named `CacheSection` export while retaining the default export and all call-site behavior
- preserve the React on Rails Pro license header

## Verification

- RED: `pnpm exec eslint react_on_rails_pro/spec/dummy/client/app/components/CacheSection.jsx react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/SelectiveHydrationDemo.jsx` reproduced exactly `no-promise-executor-return` and `import/no-named-as-default`
- GREEN: the same targeted ESLint command passes
- `.agents/bin/validate --changed` passes all selected local CI checks
- `pnpm --dir react_on_rails_pro/spec/dummy run build:test` builds the client, server, and RSC bundles
- `pnpm run type-check` passes
- `script/check-pro-license-headers` passes for all 873 in-scope files
- pre-commit and pre-push hooks pass
- one bounded `codex review --uncommitted` pass reports no actionable findings

No new regression test is added because the two enforced ESLint rules are the direct executable regressions and were captured RED/GREEN. No RSC guardrail invariant changes: no payload/script emission, mutable module state, manifest resolution, auth surface, or logging changes.

## Delivery notes

- Changelog: not user-visible
- Labels: ready-for-hosted-ci; this lane exists to restore the hosted/current-main lint gate
- Benchmarks: not applicable; runtime behavior is unchanged
- Post-push review churn: 0 follow-up commits, 0 review-fix rounds so far


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated asynchronous delay handling without changing its behavior.
  * Simplified the component’s public exports to use the default export only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->\n\n## Final confidence

- Release mode: development / main beta; no active release-gate tracker blocks this merge.

- Local evidence: targeted ESLint RED/GREEN; .agents/bin/validate --changed; Pro dummy build:test; workspace type-check; Pro license headers; pre-commit and pre-push hooks all pass.
- Hosted evidence: all nine optimized exact-head workflows passed for 26efde24d197f8a8a9ca01e17e0fa53b43fbdd9d, including Lint JS and Ruby (run 29747861405), Pro Package Tests (29747861355), and Pro Integration Tests (29747861486).
- Review evidence: Claude, Greptile, and CodeRabbit each completed an exact-head review with no findings; the full review inventory has zero summaries, inline comments, or threads.
- Trust evidence: strict PR security preflight passes with no hidden, untrusted, suspicious, or high-risk findings.
- UNKNOWN: none.

- Residual risk: minimal; the change is lint-only and preserves the timer delay plus default-import API.
- Merge qualification: exact-head checks and configured reviews are green, no unresolved threads exist, and auto-merge is authorized when the strict ledger passes.