### PR TITLE
Pro dummy: update error-scenarios hub for post-#4631 reporter visibility

### DIFF
--- a/react_on_rails_pro/spec/dummy/app/views/pages/error_scenarios_hub.html.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/pages/error_scenarios_hub.html.erb
@@ -266,14 +266,17 @@ end</pre>
     the readable stream, which the Node renderer&rsquo;s <code>handleStreamError</code> picks up and
     reports to error tracking.
     <br/><br/>
-    <strong>Since Jul 2026 (PR #4631, fixes #4629):</strong> for streaming and RSC rendering this config
-    no longer decides <em>whether</em> error tracking sees component errors. With <code>false</code>,
+    <strong>Since Jul 2026 (PR #4631, fixes #4629):</strong> for streaming and RSC rendering with an
+    active response consumer, this config no longer decides <em>whether</em> error tracking sees component
+    errors. With <code>false</code>,
     <code>reportError</code> emits a custom <code>'renderingError'</code> stream event (ignored by
     standard stream consumers) that the Node renderer&rsquo;s <code>vm.ts</code> listener also reports to
     <code>errorReporter</code>; a <code>WeakSet</code> deduplicates when both events fire for the same
     error. The config now only selects <em>how</em> a streaming error surfaces on the stream (a standard
     <code>'error'</code> event vs. metadata-only completion). Non-streaming rendering is unchanged: with
-    <code>false</code>, those errors still never reach <code>errorReporter</code>.
+    <code>false</code>, those errors still never reach <code>errorReporter</code>. If the response consumer
+    disconnects before a streaming/RSC error occurs, both stream-event helpers suppress the later error
+    as part of render teardown, so <code>errorReporter</code> is not called.
   </div>
 
   <p><strong>What it controls (JS side):</strong> This is the <em>only</em> config that is passed from Ruby to
@@ -291,13 +294,13 @@ end</pre>
       <td><code>false</code></td>
       <td>Error caught in JS. Returns error HTML with <code>hasErrors: true</code>. Ruby decides via <code>raise_on_prerender_error</code>.</td>
       <td>Error recorded in <code>renderState.hasErrors</code> and serialized into JSON chunk. No standard <code>'error'</code> event &mdash; a custom <code>'renderingError'</code> event notifies the Node renderer (PR #4631).</td>
-      <td>Non-streaming: NOT called &mdash; those errors are invisible to Sentry/Honeybadger. Streaming/RSC: called via the <code>'renderingError'</code> listener in <code>vm.ts</code> (PR #4631).</td>
+      <td>Non-streaming: NOT called &mdash; those errors are invisible to Sentry/Honeybadger. Streaming/RSC with an active consumer: called via the <code>'renderingError'</code> listener in <code>vm.ts</code> (PR #4631); suppressed after consumer disconnect.</td>
     </tr>
     <tr<%= ' style="background: #e8f5e9;"'.html_safe if throw_js_errors %>>
       <td><code>true</code></td>
       <td>Error <strong>re-thrown</strong> in JS. The Node renderer catches it and returns an error HTTP response to Rails. Ruby wraps it as <code>PrerenderError</code> (always raised, regardless of <code>raise_on_prerender_error</code>).</td>
       <td><code>emitError(error)</code> emits an <code>'error'</code> event on the readable stream, in addition to setting <code>renderState.hasErrors</code>.</td>
-      <td>Called via <code>handleStreamError</code> in <code>vm.ts</code>. Errors are reported to Sentry/Honeybadger.</td>
+      <td>With an active consumer, called via <code>handleStreamError</code> in <code>vm.ts</code>. Errors are reported to Sentry/Honeybadger; post-disconnect errors are suppressed.</td>
     </tr>
   </table>
 
@@ -518,9 +521,9 @@ const reportError = (error: Error) => {
   renderState.hasErrors = true;
   renderState.error = error;
   if (throwJsErrors) {            // Currently: <%= throw_js_errors %>
-    emitError(error);             // <%= throw_js_errors ? "CALLED — 'error' event on the stream" : "NOT taken" %>
+    emitError(error);             // <%= throw_js_errors ? "CALLED while connected — 'error' event on the stream" : "NOT taken" %>
   } else {
-    notifyRenderingError(error);  // <%= throw_js_errors ? "NOT taken" : "CALLED — 'renderingError' event (PR #4631)" %>
+    notifyRenderingError(error);  // <%= throw_js_errors ? "NOT taken" : "CALLED while connected — 'renderingError' event (PR #4631)" %>
   }
 };
 
@@ -541,7 +544,7 @@ onShellError(e) {
     <% end %>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: false</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — emitError() emits 'error' → handleStreamError → errorReporter.message()." : "Called — notifyRenderingError() emits 'renderingError' → vm.ts listener → errorReporter.message() (PR #4631)." %>
+    <%= throw_js_errors ? "Called while connected — emitError() emits 'error' → handleStreamError → errorReporter.message()." : "Called while connected — notifyRenderingError() emits 'renderingError' → vm.ts listener → errorReporter.message() (PR #4631)." %>
   </div>
 </div>
 
@@ -594,7 +597,7 @@ const StreamErrorDemo = () => (
     <% end %><br/>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: true</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — emitError() emits 'error' → handleStreamError → errorReporter.message()." : "Called — notifyRenderingError() emits 'renderingError' → vm.ts listener → errorReporter.message() (PR #4631)." %>
+    <%= throw_js_errors ? "Called while connected — emitError() emits 'error' → handleStreamError → errorReporter.message()." : "Called while connected — notifyRenderingError() emits 'renderingError' → vm.ts listener → errorReporter.message() (PR #4631)." %>
   </div>
 </div>
 
@@ -635,7 +638,7 @@ const StreamErrorDemo = () => (
     <% end %>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: false</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
+    <%= throw_js_errors ? "Called while connected — via emitError()." : "Called while connected — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -680,7 +683,7 @@ const StreamErrorDemo = () => (
     <% end %><br/>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: true</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
+    <%= throw_js_errors ? "Called while connected — via emitError()." : "Called while connected — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -744,9 +747,9 @@ const StreamErrorDemo = () => (
   <pre>const reportError = (error: Error): Error => {
   const diagnosticError = addRSCClientHookDiagnostic(error, componentName);
   if (throwJsErrors) {            // Currently: <%= throw_js_errors %>
-    emitError(diagnosticError);   // <%= throw_js_errors ? "CALLED — 'error' event" : "NOT taken" %>
+    emitError(diagnosticError);   // <%= throw_js_errors ? "CALLED while connected — 'error' event" : "NOT taken" %>
   } else {
-    notifyRenderingError(diagnosticError);  // <%= throw_js_errors ? "NOT taken" : "CALLED — 'renderingError' event" %>
+    notifyRenderingError(diagnosticError);  // <%= throw_js_errors ? "NOT taken" : "CALLED while connected — 'renderingError' event" %>
   }
   renderState.hasErrors = true;
   renderState.error = diagnosticError;
@@ -764,7 +767,7 @@ const StreamErrorDemo = () => (
       and this is a post-shell error (<code>isShellReady = true</code>).
     <% end %><br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
+    <%= throw_js_errors ? "Called while connected — via emitError()." : "Called while connected — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -806,7 +809,7 @@ const StreamErrorDemo = () => (
       and this is a post-shell error (<code>isShellReady = true</code>).
     <% end %><br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
+    <%= throw_js_errors ? "Called while connected — via emitError()." : "Called while connected — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -953,7 +956,7 @@ const StreamErrorDemo = () => (
       <td><code>StreamShellErrorDemo</code></td>
       <td><code>false</code></td>
       <td><%= raise_on_prerender_error ? "PrerenderError (rescue_from handler)" : "Error HTML box" %></td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td><%= raise_on_prerender_error ? "Yes (raise_on_prerender_error)" : "No" %></td>
     </tr>
     <tr>
@@ -962,7 +965,7 @@ const StreamErrorDemo = () => (
       <td><code>StreamErrorDemo</code></td>
       <td><code>true</code></td>
       <td><%= raise_non_shell ? "Stream aborted" : "Shell renders, async fails silently" %></td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr>
@@ -971,7 +974,7 @@ const StreamErrorDemo = () => (
       <td><code>AsyncComponentsTreeForTesting</code></td>
       <td><code>false</code></td>
       <td><%= raise_on_prerender_error ? "PrerenderError (rescue_from handler)" : "Error HTML box" %></td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td><%= raise_on_prerender_error ? "Yes (raise_on_prerender_error)" : "No" %></td>
     </tr>
     <tr>
@@ -980,7 +983,7 @@ const StreamErrorDemo = () => (
       <td><code>AsyncComponentsTreeForTesting</code></td>
       <td><code>true</code></td>
       <td><%= raise_non_shell ? "Stream aborted" : "Shell renders, one Suspense fails" %></td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr>
@@ -989,7 +992,7 @@ const StreamErrorDemo = () => (
       <td><code>DeterministicRSCErrorComponent</code></td>
       <td><code>true</code> (always post-shell)</td>
       <td><%= raise_non_shell ? "Stream aborted" : "RSC error HTML" %></td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr>
@@ -998,7 +1001,7 @@ const StreamErrorDemo = () => (
       <td><code>DeterministicRSCErrorComponent</code></td>
       <td><code>true</code> (always post-shell)</td>
       <td>ErrorBoundary fallback</td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr style="background: #fce4ec;">
@@ -1016,7 +1019,7 @@ const StreamErrorDemo = () => (
       <td><code>NonExistentComponent</code></td>
       <td><code>false</code></td>
       <td>Registry error</td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td>Yes (component not found)</td>
     </tr>
     <tr style="background: #fce4ec;">
@@ -1025,7 +1028,7 @@ const StreamErrorDemo = () => (
       <td><code>NonExistentComponent</code></td>
       <td>&mdash;</td>
       <td>Registry error</td>
-      <td>Yes (always)</td>
+      <td>Yes (while connected)</td>
       <td>Yes (component not found)</td>
     </tr>
     <tr style="background: #fff8e1;">
@@ -1039,10 +1042,12 @@ const StreamErrorDemo = () => (
   </tbody>
 </table>
 
-<p><em>Streaming and RSC rows (A&ndash;F, H, I) reach <code>errorReporter</code> regardless of
-   <code>throw_js_errors</code> since PR #4631 &mdash; the config only selects the stream event
-   (<code>'error'</code> vs <code>'renderingError'</code>). Non-streaming rows (N, G) still require
-   <code>throw_js_errors = true</code>.</em></p>
+<p><em>While the response stream has an active consumer, streaming and RSC rows (A&ndash;F, H, I)
+   reach <code>errorReporter</code> regardless of <code>throw_js_errors</code> since PR #4631 &mdash;
+   the config only selects the stream event (<code>'error'</code> vs <code>'renderingError'</code>).
+   After consumer disconnect, <code>emitError</code> and <code>notifyRenderingError</code> suppress later
+   errors as part of render teardown, so <code>errorReporter</code> is not called. Non-streaming rows
+   (N, G) still require <code>throw_js_errors = true</code>.</em></p>
 
 <hr/>
 
@@ -1078,6 +1083,11 @@ onError / onShellError callback
          |
          v
 reportError(error) → renderState.hasErrors = true
+         |
+         +--- response consumer already disconnected?
+         |     YES: stream-event helpers return without emitting
+         |          → errorReporter is NOT called
+         |     NO:
          |
          +--- throwJsErrors == true? (currently: <%= throw_js_errors %>)
          |     YES: emitError(error) → stream 'error' event

--- a/react_on_rails_pro/spec/dummy/app/views/pages/error_scenarios_hub.html.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/pages/error_scenarios_hub.html.erb
@@ -265,6 +265,15 @@ end</pre>
     (which would crash the render), <code>emitError(error)</code> emits an <code>'error'</code> event on
     the readable stream, which the Node renderer&rsquo;s <code>handleStreamError</code> picks up and
     reports to error tracking.
+    <br/><br/>
+    <strong>Since Jul 2026 (PR #4631, fixes #4629):</strong> for streaming and RSC rendering this config
+    no longer decides <em>whether</em> error tracking sees component errors. With <code>false</code>,
+    <code>reportError</code> emits a custom <code>'renderingError'</code> stream event (ignored by
+    standard stream consumers) that the Node renderer&rsquo;s <code>vm.ts</code> listener also reports to
+    <code>errorReporter</code>; a <code>WeakSet</code> deduplicates when both events fire for the same
+    error. The config now only selects <em>how</em> a streaming error surfaces on the stream (a standard
+    <code>'error'</code> event vs. metadata-only completion). Non-streaming rendering is unchanged: with
+    <code>false</code>, those errors still never reach <code>errorReporter</code>.
   </div>
 
   <p><strong>What it controls (JS side):</strong> This is the <em>only</em> config that is passed from Ruby to
@@ -281,8 +290,8 @@ end</pre>
     <tr<%= ' style="background: #e8f5e9;"'.html_safe unless throw_js_errors %>>
       <td><code>false</code></td>
       <td>Error caught in JS. Returns error HTML with <code>hasErrors: true</code>. Ruby decides via <code>raise_on_prerender_error</code>.</td>
-      <td>Error recorded in <code>renderState.hasErrors</code> and serialized into JSON chunk. No <code>'error'</code> event emitted on the stream.</td>
-      <td>NOT called for component errors. Errors are invisible to Sentry/Honeybadger.</td>
+      <td>Error recorded in <code>renderState.hasErrors</code> and serialized into JSON chunk. No standard <code>'error'</code> event &mdash; a custom <code>'renderingError'</code> event notifies the Node renderer (PR #4631).</td>
+      <td>Non-streaming: NOT called &mdash; those errors are invisible to Sentry/Honeybadger. Streaming/RSC: called via the <code>'renderingError'</code> listener in <code>vm.ts</code> (PR #4631).</td>
     </tr>
     <tr<%= ' style="background: #e8f5e9;"'.html_safe if throw_js_errors %>>
       <td><code>true</code></td>
@@ -505,10 +514,13 @@ onError(e) {
 },
 
 const reportError = (error: Error) => {
+  sawUnexpectedRenderError = true;
   renderState.hasErrors = true;
   renderState.error = error;
   if (throwJsErrors) {            // Currently: <%= throw_js_errors %>
-    emitError(error);             // <%= throw_js_errors ? "CALLED — error emitted on stream" : "NOT called — throwJsErrors is false" %>
+    emitError(error);             // <%= throw_js_errors ? "CALLED — 'error' event on the stream" : "NOT taken" %>
+  } else {
+    notifyRenderingError(error);  // <%= throw_js_errors ? "NOT taken" : "CALLED — 'renderingError' event (PR #4631)" %>
   }
 };
 
@@ -529,7 +541,7 @@ onShellError(e) {
     <% end %>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: false</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — emitError() emits on the stream → errorReporter.message()." : "Not called — throwJsErrors is false." %>
+    <%= throw_js_errors ? "Called — emitError() emits 'error' → handleStreamError → errorReporter.message()." : "Called — notifyRenderingError() emits 'renderingError' → vm.ts listener → errorReporter.message() (PR #4631)." %>
   </div>
 </div>
 
@@ -582,7 +594,7 @@ const StreamErrorDemo = () => (
     <% end %><br/>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: true</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called — emitError() emits on the stream → errorReporter.message()." : "Not called — throwJsErrors is false." %>
+    <%= throw_js_errors ? "Called — emitError() emits 'error' → handleStreamError → errorReporter.message()." : "Called — notifyRenderingError() emits 'renderingError' → vm.ts listener → errorReporter.message() (PR #4631)." %>
   </div>
 </div>
 
@@ -623,7 +635,7 @@ const StreamErrorDemo = () => (
     <% end %>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: false</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called." : "Not called." %>
+    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -668,7 +680,7 @@ const StreamErrorDemo = () => (
     <% end %><br/>
     <span class="label">JSON chunk:</span> <code>hasErrors: true</code>, <code>isShellReady: true</code>.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called." : "Not called." %>
+    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -710,7 +722,7 @@ const StreamErrorDemo = () => (
 
   <p><span class="label">Component:</span> <code>DeterministicRSCErrorComponent</code> (rendered standalone via <code>stream_react_component</code> with <code>prerender: true</code>)</p>
   <p><span class="label">Timing:</span> <strong>Immediate</strong> &mdash; throws synchronously during RSC render. Unlike <code>ErrorThrowingServerComponent</code> (50% random), this always fails.</p>
-  <p><span class="label">Error path:</span> RSC <code>onError</code> &rarr; <code>reportError</code> (always <code>console.error</code>). This is a <strong>post-shell</strong> error because of the Suspense wrapping described above.</p>
+  <p><span class="label">Error path:</span> RSC <code>onError</code> &rarr; <code>reportError</code>. This is a <strong>post-shell</strong> error because of the Suspense wrapping described above.</p>
 
   <p><strong>View template</strong> (<code>rsc_component_error.html.erb</code>):</p>
   <pre>&lt;%= stream_react_component(
@@ -726,14 +738,19 @@ const StreamErrorDemo = () => (
   throw new Error('Deterministic RSC error: always fails for error path testing');
 };</pre>
 
-  <p><strong>Error handler</strong> (<code>ReactOnRailsRSC.ts</code>) &mdash; RSC <code>reportError</code> always calls <code>console.error</code>:</p>
-  <pre>const reportError = (error: Error) => {
-  console.error('Error in RSC stream', error);  // always logged
+  <p><strong>Error handler</strong> (<code>capabilities/proRSC.ts</code>) &mdash; RSC <code>reportError</code>
+     reports through one of the two stream events (PR #4631 removed the old unconditional
+     <code>console.error</code>, which error reporters never captured):</p>
+  <pre>const reportError = (error: Error): Error => {
+  const diagnosticError = addRSCClientHookDiagnostic(error, componentName);
   if (throwJsErrors) {            // Currently: <%= throw_js_errors %>
-    emitError(error);             // <%= throw_js_errors ? "CALLED" : "NOT called" %>
+    emitError(diagnosticError);   // <%= throw_js_errors ? "CALLED — 'error' event" : "NOT taken" %>
+  } else {
+    notifyRenderingError(diagnosticError);  // <%= throw_js_errors ? "NOT taken" : "CALLED — 'renderingError' event" %>
   }
   renderState.hasErrors = true;
-  renderState.error = error;
+  renderState.error = diagnosticError;
+  return diagnosticError;
 };</pre>
 
   <div class="expected-behavior">
@@ -746,9 +763,8 @@ const StreamErrorDemo = () => (
       Rails does <strong>not</strong> raise because <code>raise_non_shell_server_rendering_errors = false</code>
       and this is a post-shell error (<code>isShellReady = true</code>).
     <% end %><br/>
-    <span class="label">Logs:</span> <code>Error in RSC stream ...</code> always appears in node-renderer logs.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called." : "Not called — throwJsErrors is false." %>
+    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -789,9 +805,8 @@ const StreamErrorDemo = () => (
       Rails does <strong>not</strong> raise because <code>raise_non_shell_server_rendering_errors = false</code>
       and this is a post-shell error (<code>isShellReady = true</code>).
     <% end %><br/>
-    <span class="label">Logs:</span> <code>Error in RSC stream ...</code> always appears in node-renderer logs.<br/>
     <span class="label">errorReporter:</span>
-    <%= throw_js_errors ? "Called." : "Not called — throwJsErrors is false." %>
+    <%= throw_js_errors ? "Called — via emitError()." : "Called — via notifyRenderingError() (PR #4631)." %>
   </div>
 </div>
 
@@ -938,7 +953,7 @@ const StreamErrorDemo = () => (
       <td><code>StreamShellErrorDemo</code></td>
       <td><code>false</code></td>
       <td><%= raise_on_prerender_error ? "PrerenderError (rescue_from handler)" : "Error HTML box" %></td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td><%= raise_on_prerender_error ? "Yes (raise_on_prerender_error)" : "No" %></td>
     </tr>
     <tr>
@@ -947,7 +962,7 @@ const StreamErrorDemo = () => (
       <td><code>StreamErrorDemo</code></td>
       <td><code>true</code></td>
       <td><%= raise_non_shell ? "Stream aborted" : "Shell renders, async fails silently" %></td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr>
@@ -956,7 +971,7 @@ const StreamErrorDemo = () => (
       <td><code>AsyncComponentsTreeForTesting</code></td>
       <td><code>false</code></td>
       <td><%= raise_on_prerender_error ? "PrerenderError (rescue_from handler)" : "Error HTML box" %></td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td><%= raise_on_prerender_error ? "Yes (raise_on_prerender_error)" : "No" %></td>
     </tr>
     <tr>
@@ -965,7 +980,7 @@ const StreamErrorDemo = () => (
       <td><code>AsyncComponentsTreeForTesting</code></td>
       <td><code>true</code></td>
       <td><%= raise_non_shell ? "Stream aborted" : "Shell renders, one Suspense fails" %></td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr>
@@ -974,7 +989,7 @@ const StreamErrorDemo = () => (
       <td><code>DeterministicRSCErrorComponent</code></td>
       <td><code>true</code> (always post-shell)</td>
       <td><%= raise_non_shell ? "Stream aborted" : "RSC error HTML" %></td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr>
@@ -983,7 +998,7 @@ const StreamErrorDemo = () => (
       <td><code>DeterministicRSCErrorComponent</code></td>
       <td><code>true</code> (always post-shell)</td>
       <td>ErrorBoundary fallback</td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td><%= raise_non_shell ? "Yes (raise_non_shell)" : "No" %></td>
     </tr>
     <tr style="background: #fce4ec;">
@@ -1001,7 +1016,7 @@ const StreamErrorDemo = () => (
       <td><code>NonExistentComponent</code></td>
       <td><code>false</code></td>
       <td>Registry error</td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td>Yes (component not found)</td>
     </tr>
     <tr style="background: #fce4ec;">
@@ -1010,7 +1025,7 @@ const StreamErrorDemo = () => (
       <td><code>NonExistentComponent</code></td>
       <td>&mdash;</td>
       <td>Registry error</td>
-      <td><%= throw_js_errors ? "Yes" : "No" %></td>
+      <td>Yes (always)</td>
       <td>Yes (component not found)</td>
     </tr>
     <tr style="background: #fff8e1;">
@@ -1023,6 +1038,11 @@ const StreamErrorDemo = () => (
     </tr>
   </tbody>
 </table>
+
+<p><em>Streaming and RSC rows (A&ndash;F, H, I) reach <code>errorReporter</code> regardless of
+   <code>throw_js_errors</code> since PR #4631 &mdash; the config only selects the stream event
+   (<code>'error'</code> vs <code>'renderingError'</code>). Non-streaming rows (N, G) still require
+   <code>throw_js_errors = true</code>.</em></p>
 
 <hr/>
 
@@ -1062,7 +1082,9 @@ reportError(error) → renderState.hasErrors = true
          +--- throwJsErrors == true? (currently: <%= throw_js_errors %>)
          |     YES: emitError(error) → stream 'error' event
          |          → vm.ts handleStreamError → errorReporter.message()
-         |     NO:  (no error event, errorReporter never sees it)
+         |     NO:  notifyRenderingError(error) → 'renderingError' event (PR #4631)
+         |          → vm.ts 'renderingError' listener → errorReporter.message()
+         |     (a WeakSet in vm.ts dedupes if both fire for the same error)
          |
          v
 JSON chunk: { hasErrors: true, isShellReady: true|false }


### PR DESCRIPTION
🤖 Codex · OpenAI · gpt-6-astra · xhigh

## What changes

The Pro error-scenarios hub now explains when streaming and RSC component failures reach Sentry or Honeybadger: **while the response consumer is connected**, with either value of `throw_js_errors`. Errors after disconnect are suppressed. Non-streaming behavior remains setting-dependent.

This finishes Ihab’s existing one-file documentation change, integrates current main, and corrects the stale “Yes (always)” wording in this description.

[Current code walkthrough](https://github.com/shakacode/react_on_rails/pull/4762#pullrequestreview-5205000843) · [Before/after screenshots and browser verification](https://github.com/shakacode/react_on_rails/pull/4762#issuecomment-5673932182)

<details>
<summary>Verification and review</summary>

Tested head: `10c4f65f816b3a8894af585aba7b9258817097ad`, including main `e3d95bebc743ea9f9ab322f4b370667393c7627a`.

- `.agents/bin/validate --changed --fast`: passed Ruby/JS lint, package build, TypeScript checks, Pro Ruby/RBS/TypeScript checks and docs routing.
- Built the actual Pro dummy test bundles and rendered the hub with `throw_js_errors=false` and `true`; no browser console errors. Before/after screenshots compare the main template with this candidate.
- Rechecked streaming/RSC reporting, renderer deduplication, and consumer-abort guards against current source. No new prose-pinning test; no runtime code changed.
- Slow Pro integration/benchmark suites were omitted locally for this text-only ERB change; hosted CI passed. [Claude CLI and Codex reviews](https://github.com/shakacode/react_on_rails/pull/4762#issuecomment-5674047007) completed with no blocking findings.
- Changelog: `not_user_visible` — internal dummy documentation. Rollback: revert this PR; no migration or runtime behavior change.

</details>

Native usage is PARTIAL. 73 responses. Scope: latest turn only per source; earlier turns excluded.
External reviewer/tool-model usage: UNKNOWN. 

<details>
<summary>Native usage</summary>

10c4f65f816b3a8894af585aba7b9258817097ad / integration
SHARED source interval: 2026-09-15T02:22:24.104Z through 2026-09-15T02:53:18.239Z. Snapshot through the last observed response.
Source selection: host context.
Codex source versions: 0.154.0-alpha.6.2.

| Provider | Configured model | Routed model | Effort | Input | Cached input | Output | Reasoning output | Cache writes | Native total |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| openai | gpt-6-astra | UNKNOWN | xhigh | 10948505 | 10500224 | 46012 | 15143 | 0 | 10994517 |

</details>

This shared interval also includes other pilot work; it is not the cost of this PR alone. Earlier task turns and external reviewer usage are UNKNOWN.

<details>
<summary>Final merge evidence</summary>

`script/pr-merge-ledger 4762 --strict --changelog-classification not_user_visible` passed for `10c4f65f816b3a8894af585aba7b9258817097ad`: complete_allowed=true, no violations or UNKNOWN fields. Current required/native hosted checks pass; no unresolved review threads.

Review coverage: Claude CLI and Codex completed for this candidate. The GitHub Claude job produced no verdict and logged six denied calls; Greptile remains stale; CodeRabbit has no current verdict. These gaps are disclosed and not counted as approval. [Review evidence, triage, and external usage](https://github.com/shakacode/react_on_rails/pull/4762#issuecomment-5674047007).

Justin authorized merge. Submission uses the repository-required native merge queue with the expected head, without bypassing requirements. The V2 immediate-merge helper does not implement queues; this follows the existing repository seam.

</details>
