### PR TITLE
Fix fleet health public evidence selection

### DIFF
--- a/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health.rb
@@ -291,6 +291,8 @@ module FleetValidation
       shared_callers = repository_workflows.flat_map do |workflow|
         content = @client.content(repo, workflow.fetch("path"), ref: head)
         shared_smoke_callers(content).map { |caller| [workflow, caller] }
+      rescue MissingPublicContentError
+        []
       rescue StandardError => e
         discovery_errors << "#{workflow['path'] || 'unknown workflow'}: #{e.class}: #{e.message}"
         []
@@ -473,6 +475,7 @@ module FleetValidation
         workflow_evidence,
         run["html_url"],
         ("event=#{run['event']}" if run["event"]),
+        ("actor=#{run.dig('actor', 'login')}" if run.dig("actor", "login")),
         ("head_branch=#{run['head_branch']}" if run["head_branch"]),
         ("head_sha=#{run['head_sha']}" if run["head_sha"]),
         ("run_started_at=#{run['run_started_at']}" if run["run_started_at"]),
@@ -487,6 +490,12 @@ module FleetValidation
     end
 
     def review_run_identity_error(run, default_branch:, observed_at:)
+      actor = run["actor"]
+      unless actor.is_a?(Hash) && present_string?(actor["login"]) && present_string?(actor["type"])
+        return "run actor identity is unavailable"
+      end
+      return "run actor is a bot" if actor["type"] == "Bot" || actor["login"].end_with?("[bot]")
+
       return "event is not pull_request" unless run["event"] == "pull_request"
 
       pull_request = Array(run["pull_requests"]).find do |candidate|

--- a/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/fleet_health_test.rb
@@ -101,6 +101,28 @@ class FleetHealthTest < Minitest::Test
     }
   end
 
+  def test_active_public_pro_targets_do_not_require_duplicate_direct_react_on_rails_npm_packages
+    manifest = YAML.safe_load_file(MANIFEST, aliases: false)
+    active_public_pro_targets = %w[
+      shakacode/react-on-rails-demo-flagship
+      shakacode/react-on-rails-demo-hacker-news-rsc
+      shakacode/react-on-rails-demo-marketplace-rsc
+      shakacode/react-on-rails-demo-gumroad-rsc
+      shakacode/react-webpack-rails-tutorial
+      shakacode/react-on-rails-starter-tanstack
+    ]
+
+    active_public_pro_targets.each do |name|
+      packages = manifest.fetch("repos").find { |repo| repo.fetch("name") == name }.fetch("packages")
+      npm_packages = packages.filter_map { |package| package["name"] if package["ecosystem"] == "npm" }
+
+      refute_includes npm_packages, "react-on-rails", name
+      assert_includes npm_packages, "react-on-rails-pro", name
+      assert_includes npm_packages, "react-on-rails-pro-node-renderer", name
+      assert_includes npm_packages, "react-on-rails-rsc", name
+    end
+  end
+
   def test_active_drift_blocks_aggregate_while_soft_and_archived_targets_are_report_only
     evidence = @contract.evaluate(
       observations: @observations,
@@ -1466,6 +1488,89 @@ class FleetHealthTest < Minitest::Test
     refute_includes status.fetch("evidence"), "newer-invalid"
   end
 
+  def test_review_app_skips_a_newer_bot_run_that_cannot_access_review_app_secrets
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Deploy review app",
+      "state" => "active"
+    }
+    bot_failure = valid_review_run(
+      "actor" => { "login" => "dependabot[bot]", "type" => "Bot" },
+      "conclusion" => "failure",
+      "html_url" => "https://example.invalid/bot-secret-failure",
+      "run_started_at" => "2026-07-18T11:00:00Z",
+      "updated_at" => "2026-07-18T11:05:00Z"
+    )
+    human_success = valid_review_run(
+      "actor" => { "login" => "source-contributor", "type" => "User" },
+      "html_url" => "https://example.invalid/source-pr-success",
+      "run_started_at" => "2026-07-18T10:00:00Z",
+      "updated_at" => "2026-07-18T10:05:00Z"
+    )
+    client = Struct.new(:runs) do
+      def get(_path)
+        { "workflow_runs" => runs }
+      end
+    end.new([bot_failure, human_success])
+
+    status = review_app_status(public_github_probe(client:), repo, target, workflow)
+
+    assert_equal "passed", status.fetch("status")
+    assert_includes status.fetch("evidence"), "source-pr-success"
+    refute_includes status.fetch("evidence"), "bot-secret-failure"
+  end
+
+  def test_review_app_with_only_bot_runs_is_unknown
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Deploy review app",
+      "state" => "active"
+    }
+    bot_failure = valid_review_run(
+      "actor" => { "login" => "dependabot[bot]", "type" => "Bot" },
+      "conclusion" => "failure",
+      "html_url" => "https://example.invalid/bot-secret-failure"
+    )
+    client = Struct.new(:runs) do
+      def get(_path)
+        { "workflow_runs" => runs }
+      end
+    end.new([bot_failure])
+
+    status = review_app_status(public_github_probe(client:), repo, target, workflow)
+
+    assert_equal "unknown", status.fetch("status")
+    assert_includes status.fetch("evidence"), "run actor is a bot"
+  end
+
+  def test_review_app_without_actor_metadata_fails_closed
+    target = @contract.targets.first
+    repo = target.fetch("name")
+    workflow = {
+      "id" => 42,
+      "path" => ".github/workflows/cpflow-deploy-review-app.yml",
+      "name" => "Deploy review app",
+      "state" => "active"
+    }
+    identity_unknown = valid_review_run("actor" => nil)
+    client = Struct.new(:runs) do
+      def get(_path)
+        { "workflow_runs" => runs }
+      end
+    end.new([identity_unknown])
+
+    status = review_app_status(public_github_probe(client:), repo, target, workflow)
+
+    assert_equal "unknown", status.fetch("status")
+    assert_includes status.fetch("evidence"), "run actor identity is unavailable"
+  end
+
   def test_review_app_recency_uses_the_manifest_staleness_limit
     manifest = Marshal.load(Marshal.dump(@manifest))
     manifest.fetch("standing_health")["max_default_age_days"] = 1
@@ -1514,6 +1619,77 @@ class FleetHealthTest < Minitest::Test
     assert_includes status.fetch("evidence"), "FleetValidation::ManifestError"
     assert_includes status.fetch("evidence"), "workflow content forbidden"
     refute_includes status.fetch("evidence"), "No reusable fleet-smoke caller"
+  end
+
+  def test_shared_smoke_skips_stale_missing_workflow_metadata_and_evaluates_a_valid_caller
+    repo = "sanitized/demo"
+    head = "a" * 40
+    stale_workflow = { "id" => 41, "path" => ".github/workflows/deleted.yml" }
+    caller_workflow = { "id" => 42, "path" => ".github/workflows/ci.yml" }
+    caller_content = YAML.dump(
+      "jobs" => {
+        "fleet" => {
+          "name" => "Fleet",
+          "uses" => "shakacode/react_on_rails/.github/workflows/demo-fleet-smoke.yml@main"
+        }
+      }
+    )
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, path, ref:|
+      raise "wrong head" unless ref == head
+      raise FleetValidation::MissingPublicContentError, "missing at exact head" if path == stale_workflow.fetch("path")
+
+      caller_content
+    end
+    client.define_singleton_method(:get) do |path|
+      case path
+      when "/repos/#{repo}/actions/workflows/42/runs?branch=main&per_page=100"
+        {
+          "workflow_runs" => [{
+            "id" => 4201,
+            "head_sha" => head,
+            "status" => "completed",
+            "conclusion" => "success"
+          }]
+        }
+      when "/repos/#{repo}/actions/runs/4201/jobs?per_page=100"
+        {
+          "jobs" => [{
+            "name" => "Fleet / Demo fleet smoke",
+            "status" => "completed",
+            "conclusion" => "success"
+          }]
+        }
+      else
+        raise "unexpected path #{path}"
+      end
+    end
+
+    status = public_github_probe(client:)
+             .send(:smoke_status, repo, head, [], [stale_workflow, caller_workflow], default_branch: "main")
+
+    assert_equal "passed", status.fetch("status")
+    assert_equal true, status.fetch("shared_contract")
+  end
+
+  def test_shared_smoke_with_only_stale_missing_workflow_metadata_remains_no_caller_unknown
+    repo = "sanitized/demo"
+    head = "a" * 40
+    workflow = { "id" => 41, "path" => ".github/workflows/deleted.yml" }
+    client = Object.new
+    client.define_singleton_method(:content) do |_repo, _path, ref:|
+      raise "wrong head" unless ref == head
+
+      raise FleetValidation::MissingPublicContentError, "missing at exact head"
+    end
+    client.define_singleton_method(:get) { |_path| raise "no caller must not look up runs" }
+
+    status = public_github_probe(client:)
+             .send(:smoke_status, repo, head, [], [workflow], default_branch: "main")
+
+    assert_equal "unknown", status.fetch("status")
+    assert_equal false, status.fetch("shared_contract")
+    assert_equal "No reusable fleet-smoke caller was found at the default head", status.fetch("evidence")
   end
 
   def test_shared_smoke_ignores_synthetic_non_repository_workflow_paths
@@ -2052,6 +2228,7 @@ class FleetHealthTest < Minitest::Test
 
   def valid_review_run(overrides = {})
     {
+      "actor" => { "login" => "source-contributor", "type" => "User" },
       "event" => "pull_request",
       "status" => "completed",
       "conclusion" => "success",

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -151,7 +151,6 @@ repos:
       review_app: not_required
     packages:
       - { ecosystem: gem, name: react_on_rails }
-      - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
@@ -181,7 +180,6 @@ repos:
       review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
-      - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
@@ -204,7 +202,6 @@ repos:
       review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
-      - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
@@ -226,7 +223,6 @@ repos:
       review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
-      - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
@@ -247,7 +243,6 @@ repos:
       review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
-      - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: npm, name: react-on-rails-pro-node-renderer }
@@ -271,7 +266,6 @@ repos:
       review_app_workflow: .github/workflows/cpflow-deploy-review-app.yml
     packages:
       - { ecosystem: gem, name: react_on_rails }
-      - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: react_on_rails_pro }
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: npm, name: react-on-rails-pro-node-renderer }


### PR DESCRIPTION
## Summary

- Ignore only exact-head 404 workflow metadata while preserving fail-closed discovery errors.
- Select review-app evidence only from non-bot pull-request runs with complete public actor identity.
- Remove the obsolete direct `react-on-rails` npm expectation from the six active public Pro/RSC demo targets.

## Why

The public standing-health scanner should not treat deleted workflow metadata as an incomplete discovery, should not report intentionally secret-blocked Dependabot review-app runs as product failures, and should match the direct dependencies emitted by the active demo SBOMs after the duplicate-installation fix.

## Validation

- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb`
- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb`
- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb`
- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb`
- `bundle exec rubocop .agents/skills/run-fleet-validation/scripts/fleet_health.rb .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb`
- CI-equivalent OSS Ruby RuboCop: 243 files, no offenses.
- `codex review --base origin/main` (no findings).
- Live public health pack on this commit completed; it correctly remains blocked on independent public demo evidence outside this PR.

## Decision log

- The scanner skips only `MissingPublicContentError`; malformed content, parser errors, and unavailable reads remain `unknown`.
- Missing actor metadata remains fail-closed; bot-only review-app histories remain `unknown`.
- Scope is limited to fleet-health scanner/tests and the six active public Pro/RSC catalog entries.

## Confidence

The candidate has focused regression coverage, replay coverage, lint, a second-model review, and a live public scan. Remaining live blockers are external public-demo evidence, not a claimed pass by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet validation by ignoring incomplete or outdated workflow metadata when valid evidence is available.
  * Review-app checks now reject runs without verifiable actor information and exclude automated bot activity.
  * Corrected package targeting for public Pro environments to avoid redundant package lookups.

* **Tests**
  * Added coverage for workflow discovery, actor validation, bot-run handling, and package expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->