### PR TITLE
Fix stale RailsContext after Turbo navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **RailsContext now stays current across Turbo and Turbolinks navigation**: Parsed context is cached
+  only while its source element and JSON text remain unchanged. Replacing the context element or
+  morphing its payload in place now makes the next core render or immediate Pro hydration receive the
+  new page's URL, locale, and application-specific values instead of the first page's context. Fixes
+  [Issue 4583](https://github.com/shakacode/react_on_rails/issues/4583).
+  [PR 4765](https://github.com/shakacode/react_on_rails/pull/4765) by
+  [ihabadham](https://github.com/ihabadham).
+
 - **Stopped replacing Shakapacker-owned watch binstubs during installation**: React on Rails no longer ships
   its own `bin/shakapacker-watch` template. Generated Procfiles use Shakapacker's optional watch binstub when
   it is present and fall back to `bin/shakapacker --watch` for older supported Shakapacker installations.

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -18,7 +18,7 @@
  */
 
 import * as React from 'react';
-import { resetRailsContext } from 'react-on-rails/context';
+import { getRailsContext, resetRailsContext } from 'react-on-rails/context';
 import { supportsReact19RootErrorCallbacks } from 'react-on-rails/reactApis';
 import type { RailsContext, RendererFunction } from 'react-on-rails/types';
 import { resetRootErrorHandlers, setRootErrorHandlers } from 'react-on-rails/@internal/rootErrorHandlers';
@@ -131,6 +131,25 @@ describe('ClientSideRenderer', () => {
     addRailsContext();
     await renderOrHydrateComponent(componentSpec);
     expect(mockReactHydrateOrRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses replacement RailsContext for immediate hydration before page-loaded callbacks', async () => {
+    const receivedPathnames: Array<string | undefined> = [];
+    const TestRenderer: RendererFunction = (_props, railsContext, _domNodeId) => {
+      receivedPathnames.push(railsContext?.pathname);
+    };
+    ComponentRegistry.register({ TestComponent: TestRenderer });
+    addRailsContext({ pathname: '/posts/1' });
+    await renderOrHydrateComponent(setupTestComponentDom('page-one'));
+
+    unmountAll();
+    getRailsContext();
+    const contextElement = document.getElementById('js-react-on-rails-context');
+    if (!contextElement) throw new Error('Expected RailsContext element');
+    contextElement.textContent = JSON.stringify({ serverSide: false, rorPro: true, pathname: '/posts/2' });
+    await renderOrHydrateComponent(setupTestComponentDom('page-two'));
+
+    expect(receivedPathnames).toEqual(['/posts/1', '/posts/2']);
   });
 
   it('does not cache a store renderer created before railsContext exists', async () => {

--- a/packages/react-on-rails/src/context.ts
+++ b/packages/react-on-rails/src/context.ts
@@ -7,24 +7,31 @@ declare global {
   /* eslint-enable vars-on-top,no-underscore-dangle */
 }
 
-let currentRailsContext: RailsContext | null = null;
+type CachedRailsContext = {
+  sourceText: string;
+  value: RailsContext;
+};
 
-// caches context and railsContext to avoid re-parsing rails-context each time a component is rendered
-// Cached values will be reset when resetRailsContext() is called
+let railsContextCache = new WeakMap<Element, CachedRailsContext>();
+
+// Key by source element and text so replacements and in-place morphs cannot reuse stale context.
 export function getRailsContext(): RailsContext | null {
-  // Return cached values if already set
-  if (currentRailsContext) {
-    return currentRailsContext;
-  }
-
   const el = document.getElementById('js-react-on-rails-context');
-  if (!el?.textContent) {
+  const sourceText = el?.textContent;
+  if (!el || !sourceText) {
     return null;
   }
 
+  const cachedRailsContext = railsContextCache.get(el);
+  if (cachedRailsContext?.sourceText === sourceText) {
+    return cachedRailsContext.value;
+  }
+
+  railsContextCache.delete(el);
   try {
-    currentRailsContext = JSON.parse(el.textContent) as RailsContext;
-    return currentRailsContext;
+    const railsContext = JSON.parse(sourceText) as RailsContext;
+    railsContextCache.set(el, { sourceText, value: railsContext });
+    return railsContext;
   } catch (e) {
     console.error('Error parsing Rails context:', e);
     return null;
@@ -32,5 +39,5 @@ export function getRailsContext(): RailsContext | null {
 }
 
 export function resetRailsContext(): void {
-  currentRailsContext = null;
+  railsContextCache = new WeakMap<Element, CachedRailsContext>();
 }

--- a/packages/react-on-rails/src/context.ts
+++ b/packages/react-on-rails/src/context.ts
@@ -27,7 +27,6 @@ export function getRailsContext(): RailsContext | null {
     return cachedRailsContext.value;
   }
 
-  railsContextCache.delete(el);
   try {
     const railsContext = JSON.parse(sourceText) as RailsContext;
     railsContextCache.set(el, { sourceText, value: railsContext });

--- a/packages/react-on-rails/tests/context.test.ts
+++ b/packages/react-on-rails/tests/context.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getRailsContext, resetRailsContext } from '../src/context.ts';
+
+function installRailsContext(pathname: string): void {
+  document.body.innerHTML = `<div id="js-react-on-rails-context">${JSON.stringify({ pathname })}</div>`;
+}
+
+describe('RailsContext cache', () => {
+  beforeEach(() => {
+    resetRailsContext();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    resetRailsContext();
+  });
+
+  it('reuses the parsed context while its DOM source is unchanged', () => {
+    installRailsContext('/posts/1');
+
+    expect(getRailsContext()).toBe(getRailsContext());
+  });
+
+  it('reads replacement context before page-loaded callbacks run', () => {
+    installRailsContext('/posts/1');
+    expect(getRailsContext()?.pathname).toBe('/posts/1');
+
+    installRailsContext('/posts/2');
+
+    expect(getRailsContext()?.pathname).toBe('/posts/2');
+  });
+
+  it('reads context text morphed in place before page-loaded callbacks run', () => {
+    installRailsContext('/posts/1');
+    expect(getRailsContext()?.pathname).toBe('/posts/1');
+
+    const contextElement = document.getElementById('js-react-on-rails-context');
+    if (!contextElement) throw new Error('Expected RailsContext element');
+    contextElement.textContent = JSON.stringify({ pathname: '/posts/2' });
+
+    expect(getRailsContext()?.pathname).toBe('/posts/2');
+  });
+});


### PR DESCRIPTION
## Why

`getRailsContext()` cached the first parsed context object without checking whether Turbo or Turbolinks had installed a new context payload. Core renders after a soft navigation could therefore receive the previous page's URL, locale, and application-specific context values.

The cache must also be fresh before ordinary page-loaded callbacks: React on Rails Pro can hydrate from replacement-body scripts immediately, and Turbo morph refreshes can update the existing context element in place.

Fixes #4583.

## What changed

- Cache parsed RailsContext values in a `WeakMap` keyed by their source DOM element.
- Record the exact source text and reparse when either the element is replaced or its JSON is morphed in place.
- Preserve explicit `resetRailsContext()` behavior by replacing the weak cache.
- Add core regression coverage for cache reuse, element replacement, and in-place text morphs.
- Add Pro compatibility coverage for immediate hydration after an unload-time context read and before page-loaded callbacks.
- Document the fix under the Unreleased changelog with the issue and PR links.

Cache hits now verify the current context element and compare its JSON text before reusing the parsed object. That adds a DOM lookup and string comparison to this path, but avoids reparsing unchanged payloads and is required to detect same-element Turbo morphs before hydration.

The store-lifecycle work in #4591 remains separate.

## Empirical evidence

A standalone JSDOM probe exercised the real core `clientStartup`, `ClientRenderer`, `pageLifecycle`, and `context` modules with this ordering:

1. render page 1;
2. dispatch `turbo:before-render`;
3. run a later unload callback that calls `getRailsContext()` and repopulates page 1;
4. morph the existing context element's JSON to page 2;
5. read context immediately, before `turbo:render`;
6. dispatch `turbo:render` and render page 2.

Controlled red/green results against the same harness:

| Source | Immediate pre-`turbo:render` marker | Rendered pathname | Locale | Result |
| --- | --- | --- | --- | --- |
| `origin/main` | `page-one` | `/posts/1` | `en` | stale, expected failure reproduced |
| patched | `page-two` | `/posts/2` | `fr` | fresh |

The run recorded the baseline commit, exact patch, SHA-256 source hashes, commands, and raw output locally.

## Validation

- `pnpm run type-check`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- `(cd react_on_rails_pro && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion)`
- `(cd react_on_rails && bundle exec rake lint)`
- standalone red/green JSDOM lifecycle experiment described above
- pre-commit and pre-push hooks

Repository Jest tests were not run locally under the standing React on Rails PR rule; hosted CI will run the added regression tests.

## Review notes

- An isolated Bloodhound review loop found and drove fixes for unload-callback ordering, Pro hydration before `turbo:render`, and Turbo in-place morphs. The final review reported `CLEAN`.
- The source-comment publication pass made no behavioral edits.
- Claude review identified one redundant cache deletion, which was removed; its performance note is documented above. Its missing-changelog observation was stale because the review snapshot preceded the changelog commit.
- `/simplify` was skipped because the final behavior change is a focused cache invariant and the requested adversarial review loop was clean.
- Private coordination was degraded because the configured backend repository is archived/read-only; the public issue claim was used as the documented fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - RailsContext now stays up to date during Turbo and Turbolinks navigation.
  - Updated page details, including the URL, locale, and app-specific values, are correctly used during rendering and hydration.
  - Context updates are detected when the source element is replaced or its contents change.

- **Documentation**
  - Added an Unreleased changelog entry describing the RailsContext navigation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->