### PR TITLE
Docs: clarify React 18 streaming without RSC

### DIFF
--- a/docs/oss/building-features/streaming-server-rendering.md
+++ b/docs/oss/building-features/streaming-server-rendering.md
@@ -9,8 +9,9 @@ React on Rails Pro supports streaming server rendering using React 18/19's `rend
 :::note React version compatibility
 React 18 applications can progressively stream ordinary components with Suspense and synchronous props without
 installing or enabling React Server Components. React 16 and 17 remain compatible through synchronous SSR fallback,
-but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.
-See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete example.
+but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.7
+or newer. See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete
+example.
 :::
 
 ## Why Streaming SSR?

--- a/docs/oss/building-features/streaming-server-rendering.md
+++ b/docs/oss/building-features/streaming-server-rendering.md
@@ -9,9 +9,9 @@ React on Rails Pro supports streaming server rendering using React 18/19's `rend
 :::note React version compatibility
 React 18 applications can progressively stream ordinary components with Suspense and synchronous props without
 installing or enabling React Server Components. React 16 and 17 remain compatible through synchronous SSR fallback,
-but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.7
-or newer. See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete
-example.
+provided the rendered tree does not actually suspend; `renderToString` cannot complete SSR for a suspended child such
+as `React.lazy`. Async props and React Server Components require React/React DOM 19.2.x with patch 19.2.7 or newer. See
+[React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete example.
 :::
 
 ## Why Streaming SSR?

--- a/docs/oss/building-features/streaming-server-rendering.md
+++ b/docs/oss/building-features/streaming-server-rendering.md
@@ -6,6 +6,13 @@ SSR works in the OSS version via ExecJS. Pro adds streaming SSR with `renderToPi
 
 React on Rails Pro supports streaming server rendering using React 18/19's `renderToPipeableStream` API. Instead of waiting for the entire page to render before sending any HTML, streaming SSR sends HTML to the browser progressively as each part of the page becomes ready.
 
+:::note React version compatibility
+React 18 applications can progressively stream ordinary components with Suspense and synchronous props without
+installing or enabling React Server Components. React 16 and 17 remain compatible through synchronous SSR fallback,
+but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.
+See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete example.
+:::
+
 ## Why Streaming SSR?
 
 Traditional SSR renders the full page on the server, then sends the complete HTML in one response. This means the user sees nothing until the slowest component finishes rendering. Streaming SSR changes this:

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -43,15 +43,15 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 
 ### Compatibility by React Version
 
-| React version | `stream_react_component` behavior                                                                                                                             | Async props and RSC                                                                            |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| React 16/17   | Compatible synchronous SSR fallback. React on Rails renders the complete HTML before returning it; Suspense boundaries do not reveal progressively.           | Not available                                                                                  |
-| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`. | Not available; do not install `react-on-rails-rsc` or enable RSC support                       |
-| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                   | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+| React version | `stream_react_component` behavior                                                                                                                                                  | Async props and RSC                                                                                              |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| React 16/17   | Synchronous SSR fallback for trees that do not suspend. If a child actually suspends, `renderToString` cannot complete SSR; the React 18 example below does not degrade unchanged. | Not available                                                                                                    |
+| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`.                      | Not available; do not install `react-on-rails-rsc` or enable RSC support                                         |
+| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                                        | Async props and RSC require React/React DOM 19.2.x with patch 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
 
 React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
-`stream_react_component` compatible with React 16 and 17 applications while selecting progressive streaming
-automatically on React 18 and 19.
+`stream_react_component` on the synchronous path for React 16 and 17 while selecting progressive streaming
+automatically on React 18 and 19. The React 16/17 path is suitable only when the rendered tree does not suspend.
 
 ## React 18 Streaming Without RSC
 
@@ -61,6 +61,13 @@ synchronous, register an ordinary React component, and render it with `stream_re
 
 For a Suspense boundary to reveal progressively, something below it must suspend during the server render. One
 straightforward React 18 case is a lazily loaded component:
+
+:::note Node Renderer module support
+Lazy or loadable components require `supportModules: true` in the Node Renderer launcher. That option injects selected
+Node.js globals into the renderer VM and changes its runtime capabilities, so review the
+[supportModules configuration and security notes](../oss/building-features/node-renderer/js-configuration.md#node-renderer-javascript-configuration)
+before enabling it.
+:::
 
 ```jsx
 // app/javascript/components/ProductPage.jsx
@@ -155,7 +162,7 @@ SSR can use the same boundary pattern.
 
 This path provides progressive **HTML streaming**, but all Rails props are still loaded before React begins rendering.
 To stream Rails data as each slow query finishes, use [async props](#progressive-data-with-async-props), which require
-React 19.2.7 or newer and RSC.
+React/React DOM 19.2.x with patch 19.2.7 or newer and RSC.
 
 ## Progressive Data with Async Props
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -43,11 +43,11 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 
 ### Compatibility by React Version
 
-| React version | `stream_react_component` behavior                                                                                                                                                  | Async props and RSC                                                                                              |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| React 16/17   | Synchronous SSR fallback for trees that do not suspend. If a child actually suspends, `renderToString` cannot complete SSR; the React 18 example below does not degrade unchanged. | Not available                                                                                                    |
-| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`.                      | Not available; do not install `react-on-rails-rsc` or enable RSC support                                         |
-| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                                        | Async props and RSC require React/React DOM 19.2.x with patch 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+| React version | `stream_react_component` behavior                                                                                                                                               | Async props and RSC                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| React 16/17   | Synchronous SSR fallback for trees that do not suspend. If a child actually suspends, `renderToString` cannot complete SSR; the React 18 example below will not work unchanged. | Not available                                                                                                    |
+| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`.                   | Not available; do not install `react-on-rails-rsc` or enable RSC support                                         |
+| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                                     | Async props and RSC require React/React DOM 19.2.x with patch 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
 
 React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
 `stream_react_component` on the synchronous path for React 16 and 17 while selecting progressive streaming
@@ -63,8 +63,9 @@ For a Suspense boundary to reveal progressively, something below it must suspend
 straightforward React 18 case is a lazily loaded component:
 
 :::note Node Renderer module support
-Lazy or loadable components require `supportModules: true` in the Node Renderer launcher. That option injects selected
-Node.js globals into the renderer VM and changes its runtime capabilities, so review the
+This example assumes the server bundle can resolve its dynamic import. If your bundler's lazy or loadable component
+runtime needs Node.js globals, enable `supportModules: true` in the Node Renderer launcher. Because that option changes
+the renderer VM's runtime capabilities, review the
 [supportModules configuration and security notes](../oss/building-features/node-renderer/js-configuration.md#node-renderer-javascript-configuration)
 before enabling it.
 :::

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -41,16 +41,13 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 - Node Renderer running (streaming requires Node.js, not ExecJS)
 - For async props (streaming each slow prop independently): React Server Components enabled — `config.enable_rsc_support = true`
 
-React 18 support is scoped to non-RSC `stream_react_component` with synchronous props. Async props,
-`stream_react_component_with_async_props`, and React Server Components require React 19.2.x with patch 19.2.7 or newer.
-
 ### Compatibility by React Version
 
 | React version | `stream_react_component` behavior                                                                                                                             | Async props and RSC                                                                            |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | React 16/17   | Compatible synchronous SSR fallback. React on Rails renders the complete HTML before returning it; Suspense boundaries do not reveal progressively.           | Not available                                                                                  |
 | React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`. | Not available; do not install `react-on-rails-rsc` or enable RSC support                       |
-| React 19      | Progressive streaming for ordinary components.                                                                                                                | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                   | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
 
 React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
 `stream_react_component` compatible with React 16 and 17 applications while selecting progressive streaming
@@ -158,7 +155,7 @@ SSR can use the same boundary pattern.
 
 This path provides progressive **HTML streaming**, but all Rails props are still loaded before React begins rendering.
 To stream Rails data as each slow query finishes, use [async props](#progressive-data-with-async-props), which require
-React 19.2 and RSC.
+React 19.2.7 or newer and RSC.
 
 ## Progressive Data with Async Props
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -112,7 +112,7 @@ the browser and server bundle entrypoints so the browser can hydrate the streame
 
 ```js
 // app/javascript/packs/react-on-rails-components.js
-import ReactOnRails from 'react-on-rails';
+import ReactOnRails from 'react-on-rails-pro';
 import ProductPage from '../components/ProductPage';
 
 ReactOnRails.register({ ProductPage });

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -35,13 +35,130 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 ## Prerequisites
 
 - React on Rails Pro
-- React 18 or 19 for `stream_react_component`; React 19.2.x with patch 19.2.7 or newer for async props and React Server Components
+- React 18 or 19 for progressive `stream_react_component`; React 16/17 use synchronous SSR fallback
+- React 19.2.x with patch 19.2.7 or newer for async props and React Server Components
 - React on Rails v16.0.0 or higher
 - Node Renderer running (streaming requires Node.js, not ExecJS)
 - For async props (streaming each slow prop independently): React Server Components enabled — `config.enable_rsc_support = true`
 
 React 18 support is scoped to non-RSC `stream_react_component` with synchronous props. Async props,
 `stream_react_component_with_async_props`, and React Server Components require React 19.2.x with patch 19.2.7 or newer.
+
+### Compatibility by React Version
+
+| React version | `stream_react_component` behavior                                                                                                                             | Async props and RSC                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| React 16/17   | Compatible synchronous SSR fallback. React on Rails renders the complete HTML before returning it; Suspense boundaries do not reveal progressively.           | Not available                                                                                  |
+| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`. | Not available; do not install `react-on-rails-rsc` or enable RSC support                       |
+| React 19      | Progressive streaming for ordinary components.                                                                                                                | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+
+React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
+`stream_react_component` compatible with React 16 and 17 applications while selecting progressive streaming
+automatically on React 18 and 19.
+
+## React 18 Streaming Without RSC
+
+React 18 applications can use progressive SSR before adopting React Server Components. Keep all Rails props
+synchronous, register an ordinary React component, and render it with `stream_react_component`. You do not need
+`react-on-rails-rsc`, `config.enable_rsc_support`, `registerServerComponent`, or an RSC bundle.
+
+For a Suspense boundary to reveal progressively, something below it must suspend during the server render. One
+straightforward React 18 case is a lazily loaded component:
+
+```jsx
+// app/javascript/components/ProductPage.jsx
+import React, { lazy, Suspense } from 'react';
+
+const ProductReviews = lazy(() => import('./ProductReviews'));
+
+const ProductPage = ({ product, reviews }) => (
+  <main>
+    <h1>{product.name}</h1>
+    <p>{product.description}</p>
+
+    <Suspense fallback={<p>Loading reviews...</p>}>
+      <ProductReviews reviews={reviews} />
+    </Suspense>
+  </main>
+);
+
+export default ProductPage;
+```
+
+The lazy module itself remains an ordinary synchronous React component:
+
+```jsx
+// app/javascript/components/ProductReviews.jsx
+import React from 'react';
+
+const ProductReviews = ({ reviews }) => (
+  <ul>
+    {reviews.map((review) => (
+      <li key={review.id}>{review.summary}</li>
+    ))}
+  </ul>
+);
+
+export default ProductReviews;
+```
+
+Register it through the normal, non-RSC API. With manual bundling, import this shared registration module from both
+the browser and server bundle entrypoints so the browser can hydrate the streamed component:
+
+```js
+// app/javascript/packs/react-on-rails-components.js
+import ReactOnRails from 'react-on-rails';
+import ProductPage from '../components/ProductPage';
+
+ReactOnRails.register({ ProductPage });
+```
+
+```js
+// app/javascript/packs/application.js
+import './react-on-rails-components';
+
+// app/javascript/packs/server-bundle.js
+import './react-on-rails-components';
+```
+
+If you use auto-bundling, its generated client and server packs perform the equivalent ordinary component
+registration.
+
+Pass the already-loaded Rails data as ordinary props:
+
+```erb
+<%= stream_react_component(
+      'ProductPage',
+      props: {
+        product: @product.as_json(only: %i[id name description]),
+        reviews: @reviews.as_json(only: %i[id summary])
+      }
+    ) %>
+```
+
+Render the containing view through the streaming controller concern:
+
+```ruby
+class ProductsController < ApplicationController
+  include ActionController::Live
+  include ReactOnRails::Controller
+  include ReactOnRailsPro::Stream
+
+  def show
+    @product = Product.find(params[:id])
+    @reviews = @product.reviews
+    stream_view_containing_react_components(template: "products/show")
+  end
+end
+```
+
+The browser receives the product shell and `Loading reviews...` fallback first. When the lazy module resolves on the
+server, React streams the reviews HTML and replaces that fallback. Existing React 18 data libraries that suspend during
+SSR can use the same boundary pattern.
+
+This path provides progressive **HTML streaming**, but all Rails props are still loaded before React begins rendering.
+To stream Rails data as each slow query finishes, use [async props](#progressive-data-with-async-props), which require
+React 19.2 and RSC.
 
 ## Progressive Data with Async Props
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1975,16 +1975,13 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 - Node Renderer running (streaming requires Node.js, not ExecJS)
 - For async props (streaming each slow prop independently): React Server Components enabled — `config.enable_rsc_support = true`
 
-React 18 support is scoped to non-RSC `stream_react_component` with synchronous props. Async props,
-`stream_react_component_with_async_props`, and React Server Components require React 19.2.x with patch 19.2.7 or newer.
-
 ### Compatibility by React Version
 
 | React version | `stream_react_component` behavior                                                                                                                             | Async props and RSC                                                                            |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | React 16/17   | Compatible synchronous SSR fallback. React on Rails renders the complete HTML before returning it; Suspense boundaries do not reveal progressively.           | Not available                                                                                  |
 | React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`. | Not available; do not install `react-on-rails-rsc` or enable RSC support                       |
-| React 19      | Progressive streaming for ordinary components.                                                                                                                | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                   | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
 
 React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
 `stream_react_component` compatible with React 16 and 17 applications while selecting progressive streaming
@@ -2092,7 +2089,7 @@ SSR can use the same boundary pattern.
 
 This path provides progressive **HTML streaming**, but all Rails props are still loaded before React begins rendering.
 To stream Rails data as each slow query finishes, use [async props](#progressive-data-with-async-props), which require
-React 19.2 and RSC.
+React 19.2.7 or newer and RSC.
 
 ## Progressive Data with Async Props
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1977,15 +1977,15 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 
 ### Compatibility by React Version
 
-| React version | `stream_react_component` behavior                                                                                                                             | Async props and RSC                                                                            |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| React 16/17   | Compatible synchronous SSR fallback. React on Rails renders the complete HTML before returning it; Suspense boundaries do not reveal progressively.           | Not available                                                                                  |
-| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`. | Not available; do not install `react-on-rails-rsc` or enable RSC support                       |
-| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                   | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+| React version | `stream_react_component` behavior                                                                                                                                                  | Async props and RSC                                                                                              |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| React 16/17   | Synchronous SSR fallback for trees that do not suspend. If a child actually suspends, `renderToString` cannot complete SSR; the React 18 example below does not degrade unchanged. | Not available                                                                                                    |
+| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`.                      | Not available; do not install `react-on-rails-rsc` or enable RSC support                                         |
+| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                                        | Async props and RSC require React/React DOM 19.2.x with patch 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
 
 React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
-`stream_react_component` compatible with React 16 and 17 applications while selecting progressive streaming
-automatically on React 18 and 19.
+`stream_react_component` on the synchronous path for React 16 and 17 while selecting progressive streaming
+automatically on React 18 and 19. The React 16/17 path is suitable only when the rendered tree does not suspend.
 
 ## React 18 Streaming Without RSC
 
@@ -1995,6 +1995,13 @@ synchronous, register an ordinary React component, and render it with `stream_re
 
 For a Suspense boundary to reveal progressively, something below it must suspend during the server render. One
 straightforward React 18 case is a lazily loaded component:
+
+:::note Node Renderer module support
+Lazy or loadable components require `supportModules: true` in the Node Renderer launcher. That option injects selected
+Node.js globals into the renderer VM and changes its runtime capabilities, so review the
+[supportModules configuration and security notes](../oss/building-features/node-renderer/js-configuration.md#node-renderer-javascript-configuration)
+before enabling it.
+:::
 
 ```jsx
 // app/javascript/components/ProductPage.jsx
@@ -2089,7 +2096,7 @@ SSR can use the same boundary pattern.
 
 This path provides progressive **HTML streaming**, but all Rails props are still loaded before React begins rendering.
 To stream Rails data as each slow query finishes, use [async props](#progressive-data-with-async-props), which require
-React 19.2.7 or newer and RSC.
+React/React DOM 19.2.x with patch 19.2.7 or newer and RSC.
 
 ## Progressive Data with Async Props
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1969,13 +1969,130 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 ## Prerequisites
 
 - React on Rails Pro
-- React 18 or 19 for `stream_react_component`; React 19.2.x with patch 19.2.7 or newer for async props and React Server Components
+- React 18 or 19 for progressive `stream_react_component`; React 16/17 use synchronous SSR fallback
+- React 19.2.x with patch 19.2.7 or newer for async props and React Server Components
 - React on Rails v16.0.0 or higher
 - Node Renderer running (streaming requires Node.js, not ExecJS)
 - For async props (streaming each slow prop independently): React Server Components enabled — `config.enable_rsc_support = true`
 
 React 18 support is scoped to non-RSC `stream_react_component` with synchronous props. Async props,
 `stream_react_component_with_async_props`, and React Server Components require React 19.2.x with patch 19.2.7 or newer.
+
+### Compatibility by React Version
+
+| React version | `stream_react_component` behavior                                                                                                                             | Async props and RSC                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| React 16/17   | Compatible synchronous SSR fallback. React on Rails renders the complete HTML before returning it; Suspense boundaries do not reveal progressively.           | Not available                                                                                  |
+| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`. | Not available; do not install `react-on-rails-rsc` or enable RSC support                       |
+| React 19      | Progressive streaming for ordinary components.                                                                                                                | Async props and RSC require React/React DOM 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+
+React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
+`stream_react_component` compatible with React 16 and 17 applications while selecting progressive streaming
+automatically on React 18 and 19.
+
+## React 18 Streaming Without RSC
+
+React 18 applications can use progressive SSR before adopting React Server Components. Keep all Rails props
+synchronous, register an ordinary React component, and render it with `stream_react_component`. You do not need
+`react-on-rails-rsc`, `config.enable_rsc_support`, `registerServerComponent`, or an RSC bundle.
+
+For a Suspense boundary to reveal progressively, something below it must suspend during the server render. One
+straightforward React 18 case is a lazily loaded component:
+
+```jsx
+// app/javascript/components/ProductPage.jsx
+import React, { lazy, Suspense } from 'react';
+
+const ProductReviews = lazy(() => import('./ProductReviews'));
+
+const ProductPage = ({ product, reviews }) => (
+  <main>
+    <h1>{product.name}</h1>
+    <p>{product.description}</p>
+
+    <Suspense fallback={<p>Loading reviews...</p>}>
+      <ProductReviews reviews={reviews} />
+    </Suspense>
+  </main>
+);
+
+export default ProductPage;
+```
+
+The lazy module itself remains an ordinary synchronous React component:
+
+```jsx
+// app/javascript/components/ProductReviews.jsx
+import React from 'react';
+
+const ProductReviews = ({ reviews }) => (
+  <ul>
+    {reviews.map((review) => (
+      <li key={review.id}>{review.summary}</li>
+    ))}
+  </ul>
+);
+
+export default ProductReviews;
+```
+
+Register it through the normal, non-RSC API. With manual bundling, import this shared registration module from both
+the browser and server bundle entrypoints so the browser can hydrate the streamed component:
+
+```js
+// app/javascript/packs/react-on-rails-components.js
+import ReactOnRails from 'react-on-rails';
+import ProductPage from '../components/ProductPage';
+
+ReactOnRails.register({ ProductPage });
+```
+
+```js
+// app/javascript/packs/application.js
+import './react-on-rails-components';
+
+// app/javascript/packs/server-bundle.js
+import './react-on-rails-components';
+```
+
+If you use auto-bundling, its generated client and server packs perform the equivalent ordinary component
+registration.
+
+Pass the already-loaded Rails data as ordinary props:
+
+```erb
+<%= stream_react_component(
+      'ProductPage',
+      props: {
+        product: @product.as_json(only: %i[id name description]),
+        reviews: @reviews.as_json(only: %i[id summary])
+      }
+    ) %>
+```
+
+Render the containing view through the streaming controller concern:
+
+```ruby
+class ProductsController < ApplicationController
+  include ActionController::Live
+  include ReactOnRails::Controller
+  include ReactOnRailsPro::Stream
+
+  def show
+    @product = Product.find(params[:id])
+    @reviews = @product.reviews
+    stream_view_containing_react_components(template: "products/show")
+  end
+end
+```
+
+The browser receives the product shell and `Loading reviews...` fallback first. When the lazy module resolves on the
+server, React streams the reviews HTML and replaces that fallback. Existing React 18 data libraries that suspend during
+SSR can use the same boundary pattern.
+
+This path provides progressive **HTML streaming**, but all Rails props are still loaded before React begins rendering.
+To stream Rails data as each slow query finishes, use [async props](#progressive-data-with-async-props), which require
+React 19.2 and RSC.
 
 ## Progressive Data with Async Props
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -2046,7 +2046,7 @@ the browser and server bundle entrypoints so the browser can hydrate the streame
 
 ```js
 // app/javascript/packs/react-on-rails-components.js
-import ReactOnRails from 'react-on-rails';
+import ReactOnRails from 'react-on-rails-pro';
 import ProductPage from '../components/ProductPage';
 
 ReactOnRails.register({ ProductPage });

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1977,11 +1977,11 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 
 ### Compatibility by React Version
 
-| React version | `stream_react_component` behavior                                                                                                                                                  | Async props and RSC                                                                                              |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| React 16/17   | Synchronous SSR fallback for trees that do not suspend. If a child actually suspends, `renderToString` cannot complete SSR; the React 18 example below does not degrade unchanged. | Not available                                                                                                    |
-| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`.                      | Not available; do not install `react-on-rails-rsc` or enable RSC support                                         |
-| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                                        | Async props and RSC require React/React DOM 19.2.x with patch 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
+| React version | `stream_react_component` behavior                                                                                                                                               | Async props and RSC                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| React 16/17   | Synchronous SSR fallback for trees that do not suspend. If a child actually suspends, `renderToString` cannot complete SSR; the React 18 example below will not work unchanged. | Not available                                                                                                    |
+| React 18      | Progressive streaming for ordinary, non-RSC components with synchronous props. Suspense boundaries can reveal independently through `renderToPipeableStream`.                   | Not available; do not install `react-on-rails-rsc` or enable RSC support                                         |
+| React 19      | Progressive streaming for ordinary components, including the same non-RSC path as React 18.                                                                                     | Async props and RSC require React/React DOM 19.2.x with patch 19.2.7+ and compatible `react-on-rails-rsc` 19.2.x |
 
 React on Rails detects whether the installed React DOM server provides `renderToPipeableStream`. This keeps
 `stream_react_component` on the synchronous path for React 16 and 17 while selecting progressive streaming
@@ -1997,8 +1997,9 @@ For a Suspense boundary to reveal progressively, something below it must suspend
 straightforward React 18 case is a lazily loaded component:
 
 :::note Node Renderer module support
-Lazy or loadable components require `supportModules: true` in the Node Renderer launcher. That option injects selected
-Node.js globals into the renderer VM and changes its runtime capabilities, so review the
+This example assumes the server bundle can resolve its dynamic import. If your bundler's lazy or loadable component
+runtime needs Node.js globals, enable `supportModules: true` in the Node Renderer launcher. Because that option changes
+the renderer VM's runtime capabilities, review the
 [supportModules configuration and security notes](../oss/building-features/node-renderer/js-configuration.md#node-renderer-javascript-configuration)
 before enabling it.
 :::

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7388,6 +7388,13 @@ SSR works in the OSS version via ExecJS. Pro adds streaming SSR with `renderToPi
 
 React on Rails Pro supports streaming server rendering using React 18/19's `renderToPipeableStream` API. Instead of waiting for the entire page to render before sending any HTML, streaming SSR sends HTML to the browser progressively as each part of the page becomes ready.
 
+:::note React version compatibility
+React 18 applications can progressively stream ordinary components with Suspense and synchronous props without
+installing or enabling React Server Components. React 16 and 17 remain compatible through synchronous SSR fallback,
+but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.
+See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete example.
+:::
+
 ## Why Streaming SSR?
 
 Traditional SSR renders the full page on the server, then sends the complete HTML in one response. This means the user sees nothing until the slowest component finishes rendering. Streaming SSR changes this:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7391,8 +7391,9 @@ React on Rails Pro supports streaming server rendering using React 18/19's `rend
 :::note React version compatibility
 React 18 applications can progressively stream ordinary components with Suspense and synchronous props without
 installing or enabling React Server Components. React 16 and 17 remain compatible through synchronous SSR fallback,
-but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.
-See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete example.
+but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.7
+or newer. See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete
+example.
 :::
 
 ## Why Streaming SSR?

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7391,9 +7391,9 @@ React on Rails Pro supports streaming server rendering using React 18/19's `rend
 :::note React version compatibility
 React 18 applications can progressively stream ordinary components with Suspense and synchronous props without
 installing or enabling React Server Components. React 16 and 17 remain compatible through synchronous SSR fallback,
-but their Suspense boundaries do not reveal progressively. Async props and React Server Components require React 19.2.7
-or newer. See [React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete
-example.
+provided the rendered tree does not actually suspend; `renderToString` cannot complete SSR for a suspended child such
+as `React.lazy`. Async props and React Server Components require React/React DOM 19.2.x with patch 19.2.7 or newer. See
+[React 18 Streaming Without RSC](../../pro/streaming-ssr.md#react-18-streaming-without-rsc) for a complete example.
 :::
 
 ## Why Streaming SSR?


### PR DESCRIPTION
## Why

The streaming docs already said that React 18 supports non-RSC streaming, but they left two important gaps:

- React 16 and 17 compatibility did not explain the synchronous SSR boundary.
- React 18 users were sent into a guide whose concrete implementation path quickly moved to React 19, async props, and RSC.

This made the migration benefit harder to discover: an existing React 18 application can adopt progressive Suspense SSR without first adopting React Server Components.

## What changed

- Added a React-version compatibility matrix covering React 16/17 synchronous fallback for non-suspending trees, React 18 non-RSC streaming, and the React 19.2.x patch 19.2.7+ async-props/RSC boundary.
- Added a complete React 18 example using ordinary `ReactOnRails.register`, synchronous Rails props, `React.lazy`, `Suspense`, `stream_react_component`, and the streaming controller concern.
- Made the Node Renderer `supportModules` guidance conditional on the bundler/runtime needing Node.js globals and linked its security notes.
- Corrected manual registration to import `react-on-rails-pro`, which provides Pro streaming while retaining the ordinary non-RSC API.
- Added a compatibility callout to the shorter public streaming overview.
- Regenerated `llms-full.txt` and `llms-full-pro.txt`.

## Validation

- `.agents/bin/lint` — passed
- `.agents/bin/validate --changed` — passed
- `.agents/bin/docs` — passed
- `pnpm start format.listDifferent` — passed
- `node script/generate-llms-full.mjs --check` — passed
- `bin/check-links` — 3,411 links checked, zero errors
- `git diff --check` — passed
- isolated React 16.14.0 and 17.0.2 `renderToString` plus suspended `React.lazy` reproductions — both raised `ReactDOMServer does not yet support Suspense`, confirming the pre-18 caveat
- exact-head required and full GitHub check inventories — 24 passed, 18 expected docs-only skips, zero pending or failing
- strict merge ledger — no violations or unknowns; `complete_allowed: true`

## Review and churn notes

- Fresh maker-distinct final checker independently verified the compatibility claims, runnable example, generated parity, checks, and review state at `a60483abaee4a9be5d8b7e03fb5b23dd703d3a59`.
- Current-head working review systems: Claude and CodeRabbit (2 of 5 configured). Copilot also completed current-head review but is acknowledged untrusted advisory input.
- Degraded reviewer coverage acknowledged: Greptile and Codex results are stale-head advisory history; Cursor is absent/non-current. The required two-system floor is met, every full check is terminal, and all 13 review threads are resolved.
- Confirmed findings were batched into review-fix commits. The final wave's two explicitly non-blocking presentation/maintenance nits were answered without restarting the review cycle.
- `/simplify` was skipped because this is a focused documentation-only change with no runtime code.

## Merge qualification

- Release mode/phase: standard `development` gate on `main` (`beta` phase); satisfied.
- Changelog: `not_user_visible`; documentation fixes are excluded by repository policy.
- QA evidence and priority dispositions: [exact-head replayable record](https://github.com/shakacode/react_on_rails/pull/4780#issuecomment-5071142492), replay verdict `SATISFIED`.
- Address-review closeout: [final current-head summary](https://github.com/shakacode/react_on_rails/pull/4780#issuecomment-5071132093).

Confidence note:

- Validated: local lint, changed validation, docs, formatting, generated-doc parity, links, diff integrity, isolated React-version reproductions, exact-head CI, independent checker, strict ledger, and zero unresolved threads.
- Evidence: exact-head QA and priority-disposition comment, final address-review summary, GitHub checks, review records, and resolved thread replies linked above.
- UNKNOWN: none affecting merge safety.
- Residual risk: documentation example is not a new end-to-end fixture; implementation/tests and direct version reproductions were used to verify each technical boundary.

Labels: none — documentation-only change covered by local validation and the required PR gate.

Benchmarks: not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Streaming Server Rendering guidance with clearer React-version compatibility, explaining when progressive Suspense streaming works versus when a synchronous SSR fallback is used.
  * Updated Pro prerequisites with a React-by-version compatibility table, including Node Renderer requirements and the conditions for enabling React Server Components and async props.
  * Added a complete “React 18 Streaming Without Server Components” walkthrough, featuring setup examples and Rails integration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
