### PR TITLE
Docs: forward-port v17 upgrade and generator gate guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/rc-release-tracking.yml
+++ b/.github/ISSUE_TEMPLATE/rc-release-tracking.yml
@@ -63,7 +63,7 @@ body:
         - [ ] `react_on_rails` generator/install smoke
           - RC/final version:
           - Commands:
-            - `bundle exec rspec react_on_rails/spec/react_on_rails/generators`
+            - `(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)`
             - `pnpm run build`
             - `CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`
           - Result:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -497,8 +497,8 @@ That fallback comes from `CI_PNPM_FALLBACK_VERSION` in [`react_on_rails/lib/gene
 **Verification:**
 
 ```sh
-bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb \
-  -e "keeps the fallback pin tied to a version-specific pnpm release note"
+(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb \
+  -e "keeps the fallback pin tied to a version-specific pnpm release note")
 ```
 
 Users who want exact reproducibility in their generated CI can commit a `packageManager: pnpm@<version>` field to their own `package.json`; the generator then omits the fallback `version:` entirely.

--- a/docs/oss/upgrading/upgrading-react-on-rails.md
+++ b/docs/oss/upgrading/upgrading-react-on-rails.md
@@ -109,14 +109,14 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
 
 - **Ruby 3.3+ is required.** Upgrade Ruby before moving to React on Rails v17. React on Rails v16 remains the supported line for applications that must stay on Ruby 3.2 or older.
 - **React on Rails Pro already required Ruby 3.3+.** v17 aligns the open-source gem, Pro gem, create-app validator, and CI minimum matrix on the same Ruby floor.
-- **Three deprecated configuration options were removed.** They were deprecated in v16 and are gone in v17. Setting any of them in `config/initializers/react_on_rails.rb` now raises `NoMethodError` at boot. Run `bin/rake react_on_rails:doctor` to detect any that remain in your initializer.
+- **Four configuration options were removed.** Three were deprecated in v16, while `config.server_render_method` was inert. All four are gone in v17. Setting any of them in `config/initializers/react_on_rails.rb` now raises `NoMethodError` at boot. Run `bin/rake react_on_rails:doctor` to detect any that remain in your initializer.
   - `config.generated_assets_dirs` — delete the line. Public asset paths are determined automatically from `public_output_path` in `config/shakapacker.yml`.
   - `config.skip_display_none` — delete the line. It had no runtime effect.
   - `config.defer_generated_component_packs` — replaced by `config.generated_component_packs_loading_strategy`:
     - `config.defer_generated_component_packs = true` → `config.generated_component_packs_loading_strategy = :defer`
     - `config.defer_generated_component_packs = false` → **delete the line.** The old option was truthy-gated — only `= true` did anything (it set `:defer`); `= false` was a no-op that fell through to the default strategy. Deleting the line preserves that behavior. Set `config.generated_component_packs_loading_strategy = :sync` explicitly only if you specifically relied on synchronous (blocking) pack loading.
     - The default strategy (when you don't set one) is `:async` for Pro or `:defer` for non-Pro on Shakapacker 8.2.0+, and `:sync` on older Shakapacker.
-- **The inert `config.server_render_method` option was removed.** The open-source gem always renders with ExecJS, so this option never selected a server render method — its validator only raised at boot for any non-blank, non-`"ExecJS"` value. Delete any `config.server_render_method = ...` line from `config/initializers/react_on_rails.rb`; leaving it in place now raises `NoMethodError` at boot (`bin/rake react_on_rails:doctor` also flags the stale line). For a standalone Node rendering process, use React on Rails Pro's Node renderer, configured via `ReactOnRailsPro.configure`.
+  - `config.server_render_method` — delete the line. The open-source gem always renders with ExecJS, so this option never selected a server render method — its validator only raised at boot for any non-blank, non-`"ExecJS"` value. Leaving it in place now raises `NoMethodError` at boot (`bin/rake react_on_rails:doctor` also flags the stale line). For a standalone Node rendering process, use React on Rails Pro's Node renderer, configured via `ReactOnRailsPro.configure`.
 
 ### Migration Steps
 

--- a/docs/oss/upgrading/upgrading-react-on-rails.md
+++ b/docs/oss/upgrading/upgrading-react-on-rails.md
@@ -136,11 +136,13 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
    npm install   # or: yarn install / pnpm install
    ```
 
-4. Remove every removed configuration option from `config/initializers/react_on_rails.rb` **before booting**. Any of the options listed in the Breaking Changes above (`config.generated_assets_dirs`, `config.skip_display_none`, `config.defer_generated_component_packs`, `config.server_render_method`) now raises `NoMethodError` at boot. Run the doctor task, which flags each remaining option with the exact fix:
+4. Before booting, run the doctor task to find removed configuration options:
 
    ```bash
    bin/rake react_on_rails:doctor
    ```
+
+   Remove or replace every option it reports in `config/initializers/react_on_rails.rb`. Any remaining option listed in the Breaking Changes above (`config.generated_assets_dirs`, `config.skip_display_none`, `config.defer_generated_component_packs`, `config.server_render_method`) raises `NoMethodError` at boot.
 
 5. Run RuboCop, your app's test suite, and asset build after the Ruby and package updates. The Ruby
    baseline bump can activate cops that were previously inactive:

--- a/docs/oss/upgrading/upgrading-react-on-rails.md
+++ b/docs/oss/upgrading/upgrading-react-on-rails.md
@@ -116,6 +116,7 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
     - `config.defer_generated_component_packs = true` → `config.generated_component_packs_loading_strategy = :defer`
     - `config.defer_generated_component_packs = false` → **delete the line.** The old option was truthy-gated — only `= true` did anything (it set `:defer`); `= false` was a no-op that fell through to the default strategy. Deleting the line preserves that behavior. Set `config.generated_component_packs_loading_strategy = :sync` explicitly only if you specifically relied on synchronous (blocking) pack loading.
     - The default strategy (when you don't set one) is `:async` for Pro or `:defer` for non-Pro on Shakapacker 8.2.0+, and `:sync` on older Shakapacker.
+- **The inert `config.server_render_method` option was removed.** The open-source gem always renders with ExecJS, so this option never selected a server render method — its validator only raised at boot for any non-blank, non-`"ExecJS"` value. Delete any `config.server_render_method = ...` line from `config/initializers/react_on_rails.rb`; leaving it in place now raises `NoMethodError` at boot (`bin/rake react_on_rails:doctor` also flags the stale line). For a standalone Node rendering process, use React on Rails Pro's Node renderer, configured via `ReactOnRailsPro.configure`.
 
 ### Migration Steps
 
@@ -135,7 +136,13 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
    npm install   # or: yarn install / pnpm install
    ```
 
-4. Run RuboCop, your app's test suite, and asset build after the Ruby and package updates. The Ruby
+4. Remove every removed configuration option from `config/initializers/react_on_rails.rb` **before booting**. Any of the options listed in the Breaking Changes above (`config.generated_assets_dirs`, `config.skip_display_none`, `config.defer_generated_component_packs`, `config.server_render_method`) now raises `NoMethodError` at boot. Run the doctor task, which flags each remaining option with the exact fix:
+
+   ```bash
+   bin/rake react_on_rails:doctor
+   ```
+
+5. Run RuboCop, your app's test suite, and asset build after the Ruby and package updates. The Ruby
    baseline bump can activate cops that were previously inactive:
 
    ```bash

--- a/internal/contributor-info/rc-testing-plan.md
+++ b/internal/contributor-info/rc-testing-plan.md
@@ -572,6 +572,9 @@ For each hard-gate app PR:
 For the `react_on_rails` generator/install gate:
 
 ```bash
+# Generator specs run in the react_on_rails/ gem bundle (its Gemfile provides Rails).
+# Running them from the workspace root fails with `cannot load such file -- rails`,
+# because the root workspace bundle does not include Rails.
 (cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)
 pnpm run build
 CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23017,6 +23017,7 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
     - `config.defer_generated_component_packs = true` → `config.generated_component_packs_loading_strategy = :defer`
     - `config.defer_generated_component_packs = false` → **delete the line.** The old option was truthy-gated — only `= true` did anything (it set `:defer`); `= false` was a no-op that fell through to the default strategy. Deleting the line preserves that behavior. Set `config.generated_component_packs_loading_strategy = :sync` explicitly only if you specifically relied on synchronous (blocking) pack loading.
     - The default strategy (when you don't set one) is `:async` for Pro or `:defer` for non-Pro on Shakapacker 8.2.0+, and `:sync` on older Shakapacker.
+- **The inert `config.server_render_method` option was removed.** The open-source gem always renders with ExecJS, so this option never selected a server render method — its validator only raised at boot for any non-blank, non-`"ExecJS"` value. Delete any `config.server_render_method = ...` line from `config/initializers/react_on_rails.rb`; leaving it in place now raises `NoMethodError` at boot (`bin/rake react_on_rails:doctor` also flags the stale line). For a standalone Node rendering process, use React on Rails Pro's Node renderer, configured via `ReactOnRailsPro.configure`.
 
 ### Migration Steps
 
@@ -23036,7 +23037,13 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
    npm install   # or: yarn install / pnpm install
    ```
 
-4. Run RuboCop, your app's test suite, and asset build after the Ruby and package updates. The Ruby
+4. Remove every removed configuration option from `config/initializers/react_on_rails.rb` **before booting**. Any of the options listed in the Breaking Changes above (`config.generated_assets_dirs`, `config.skip_display_none`, `config.defer_generated_component_packs`, `config.server_render_method`) now raises `NoMethodError` at boot. Run the doctor task, which flags each remaining option with the exact fix:
+
+   ```bash
+   bin/rake react_on_rails:doctor
+   ```
+
+5. Run RuboCop, your app's test suite, and asset build after the Ruby and package updates. The Ruby
    baseline bump can activate cops that were previously inactive:
 
    ```bash

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23037,11 +23037,13 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
    npm install   # or: yarn install / pnpm install
    ```
 
-4. Remove every removed configuration option from `config/initializers/react_on_rails.rb` **before booting**. Any of the options listed in the Breaking Changes above (`config.generated_assets_dirs`, `config.skip_display_none`, `config.defer_generated_component_packs`, `config.server_render_method`) now raises `NoMethodError` at boot. Run the doctor task, which flags each remaining option with the exact fix:
+4. Before booting, run the doctor task to find removed configuration options:
 
    ```bash
    bin/rake react_on_rails:doctor
    ```
+
+   Remove or replace every option it reports in `config/initializers/react_on_rails.rb`. Any remaining option listed in the Breaking Changes above (`config.generated_assets_dirs`, `config.skip_display_none`, `config.defer_generated_component_packs`, `config.server_render_method`) raises `NoMethodError` at boot.
 
 5. Run RuboCop, your app's test suite, and asset build after the Ruby and package updates. The Ruby
    baseline bump can activate cops that were previously inactive:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23010,14 +23010,14 @@ In CI, run precompile preparation explicitly once before webpack compilation or 
 
 - **Ruby 3.3+ is required.** Upgrade Ruby before moving to React on Rails v17. React on Rails v16 remains the supported line for applications that must stay on Ruby 3.2 or older.
 - **React on Rails Pro already required Ruby 3.3+.** v17 aligns the open-source gem, Pro gem, create-app validator, and CI minimum matrix on the same Ruby floor.
-- **Three deprecated configuration options were removed.** They were deprecated in v16 and are gone in v17. Setting any of them in `config/initializers/react_on_rails.rb` now raises `NoMethodError` at boot. Run `bin/rake react_on_rails:doctor` to detect any that remain in your initializer.
+- **Four configuration options were removed.** Three were deprecated in v16, while `config.server_render_method` was inert. All four are gone in v17. Setting any of them in `config/initializers/react_on_rails.rb` now raises `NoMethodError` at boot. Run `bin/rake react_on_rails:doctor` to detect any that remain in your initializer.
   - `config.generated_assets_dirs` — delete the line. Public asset paths are determined automatically from `public_output_path` in `config/shakapacker.yml`.
   - `config.skip_display_none` — delete the line. It had no runtime effect.
   - `config.defer_generated_component_packs` — replaced by `config.generated_component_packs_loading_strategy`:
     - `config.defer_generated_component_packs = true` → `config.generated_component_packs_loading_strategy = :defer`
     - `config.defer_generated_component_packs = false` → **delete the line.** The old option was truthy-gated — only `= true` did anything (it set `:defer`); `= false` was a no-op that fell through to the default strategy. Deleting the line preserves that behavior. Set `config.generated_component_packs_loading_strategy = :sync` explicitly only if you specifically relied on synchronous (blocking) pack loading.
     - The default strategy (when you don't set one) is `:async` for Pro or `:defer` for non-Pro on Shakapacker 8.2.0+, and `:sync` on older Shakapacker.
-- **The inert `config.server_render_method` option was removed.** The open-source gem always renders with ExecJS, so this option never selected a server render method — its validator only raised at boot for any non-blank, non-`"ExecJS"` value. Delete any `config.server_render_method = ...` line from `config/initializers/react_on_rails.rb`; leaving it in place now raises `NoMethodError` at boot (`bin/rake react_on_rails:doctor` also flags the stale line). For a standalone Node rendering process, use React on Rails Pro's Node renderer, configured via `ReactOnRailsPro.configure`.
+  - `config.server_render_method` — delete the line. The open-source gem always renders with ExecJS, so this option never selected a server render method — its validator only raised at boot for any non-blank, non-`"ExecJS"` value. Leaving it in place now raises `NoMethodError` at boot (`bin/rake react_on_rails:doctor` also flags the stale line). For a standalone Node rendering process, use React on Rails Pro's Node renderer, configured via `ReactOnRailsPro.configure`.
 
 ### Migration Steps
 


### PR DESCRIPTION
## Why

React on Rails 17.0.0 shipped the documentation fixes from #4539 on the release branch, but those fixes never reached `main`.

Without this forward-port:

- applications can retain the removed `config.server_render_method` setting and fail at boot without migration guidance;
- the release testing plan tells contributors to run generator specs with the root bundle, which does not provide Rails.

This is intentionally a focused replacement for the #4539 portion of draft #4734.

## What

- Document removal of `config.server_render_method` in the v17 upgrade guide.
- Run the doctor before boot, then tell users to remove every reported option.
- Run generator specs from the `react_on_rails/` gem bundle in the RC testing plan.
- Keep the RC release-tracking issue template and focused contributor command on the same working generator invocation.
- Regenerate the affected `llms-full.txt` artifact from current `main`.

The commit preserves source provenance with:

`(cherry picked from commit afab3e5ace5cc056444ee596d8dfde1a97a0500c)`

The old generated artifacts were not copied wholesale: `llms-full.txt` was regenerated against current documentation, and `llms-full-pro.txt` correctly remained unchanged.

## Verification

- `pnpm dlx prettier@3.6.2 --check CONTRIBUTING.md docs/oss/upgrading/upgrading-react-on-rails.md internal/contributor-info/rc-testing-plan.md .github/ISSUE_TEMPLATE/rc-release-tracking.yml`
- `node script/generate-llms-full.mjs --check`
- `bash script/generate-llms-full-test.bash` (7 tests)
- `script/check-docs-sidebar`
- `bin/check-links`
- `ruby -e 'require "yaml"; YAML.safe_load_file(".github/ISSUE_TEMPLATE/rc-release-tracking.yml", aliases: true)'`
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb -e "keeps the fallback pin tied to a version-specific pnpm release note")` (1 example, 0 failures)
- `git diff --check origin/main...HEAD`
- Maker-distinct exact-diff review

## Batch context

- Batch: `ror-17-forward-port-0724`
- Source PR: #4539
- Source release-branch squash: `afab3e5ace5cc056444ee596d8dfde1a97a0500c`
- Base: `main@637b78d7b63403ba061bdeb13135a6519808fc39`
- Merge authority: `auto_merge_when_gates_pass`
- Changelog classification: `not_user_visible` — this restores documentation for an already released change.
- Confidence: high
- UNKNOWN: none
- Residual risk: generated-document drift is guarded by regeneration and the generator test suite.

## Merge qualification

- Release phase: development/beta (`main`; the 17.0.0 release tracker is closed as released).
- Exact head: `cb0fdbdfbfa5eafc0d5f65b3e3a65b4d9027f8b1`
- Exact base: `main@637b78d7b63403ba061bdeb13135a6519808fc39`
- Canonical CI readiness: `READY`; required gate passed with no failing or pending checks.
- Hosted-CI selection: documentation-only; `script/ci-changes-detector` recommends no expanded hosted jobs.
- Review wave: current-head Claude and CodeRabbit checks passed; all three review threads are resolved.
- Degraded reviewer coverage: Greptile and the GitHub Codex reviewer are visible on this PR but did not publish a final-head artifact after `cb0fdbdfbfa5eafc0d5f65b3e3a65b4d9027f8b1`. Their earlier-head findings were independently verified, fixed, replied to, and resolved. No corresponding reviewer check remains pending; current-head Claude plus CodeRabbit provide the required two-system floor.
- Strict merge ledger: `violations=[]`, `unknown_fields=[]`, `complete_allowed=true`.
- Viewer pending review drafts: none.
- Merge authority: `auto_merge_when_gates_pass`.
