### PR TITLE
Forward-port multi-URL rolling-deploy seeding to main

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -4,5 +4,10 @@
 
 - [React on Rails Pro (RSC)](./packages/react-on-rails-pro/CONTEXT.md) — React Server Components integration: payload generation, embedding, caching, and client-router prefetch
 - [Product Strategy & Roadmap](./internal/planning/CONTEXT.md) — release planning, backlog triage, and competitive positioning language (decision records: [internal/adr/](./internal/adr/))
+- [React on Rails Pro (Rolling Deploy)](./react_on_rails_pro/CONTEXT.md) — warming the Node Renderer bundle cache across a rolling deploy: pre-seed source, build-time vs. release-time seed, staging-to-production promotion
 
 Other contexts (core gem, node renderer, generators) are not yet documented; add them here when their first term is resolved.
+
+## Relationships
+
+- **Rolling Deploy → RSC**: when RSC is enabled, each deploy has two **draining bundles** (server + RSC); the pre-seed stages each hash independently and must carry the RSC companion manifests or hydration breaks.

--- a/docs/oss/building-features/node-renderer/container-deployment.md
+++ b/docs/oss/building-features/node-renderer/container-deployment.md
@@ -91,7 +91,7 @@ Rails and the Node Renderer run as independent workloads with their own scaling.
 
 **Disadvantages:**
 
-- **Version drift risk** — During rolling deploys, Rails and the Node Renderer may briefly run different versions. While protocol changes are rare, this is a risk to monitor.
+- **Version drift risk** — During rolling deploys, Rails and the Node Renderer roll independently and briefly run different bundle versions, so the renderer can receive SSR requests for a bundle it hasn't cached. Mitigate this with a [rolling-deploy adapter](../../../pro/rolling-deploy-adapters.md) (Pro): it pre-seeds the new renderer with the draining bundle and makes the renderer-before-Rails ordering explicit. This risk (and that mitigation) is **specific to this separate-workloads option** — Options 1–2 share one lifecycle and cannot drift.
 - **Race conditions** — Pods restart independently, which can cause transient connection errors.
 - **Network dependency** — Renderer must be reachable via internal service DNS.
 - **Overkill for most setups** — If you're running 2–4 replicas, independent scaling adds complexity without real benefit.

--- a/docs/pro/rolling-deploy-adapters.md
+++ b/docs/pro/rolling-deploy-adapters.md
@@ -57,7 +57,7 @@ end
 ```
 
 - **`rolling_deploy_token`** — the shared bearer token ("password"). Generate one with `SecureRandom.hex(32)` and set the **same** value on both the running server (which authenticates incoming pulls) and the build CI (which sends it). The config validator rejects tokens shorter than 32 bytes.
-- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI** or renderer at boot. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery.
+- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI** or release-time seed step. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery.
 - **`rolling_deploy_mount_path`** — the Rails path where the Pro engine auto-mounts the bundle-serving endpoint when the built-in HTTP adapter is configured. Defaults to `/react_on_rails_pro/rolling_deploy`. Set it to a custom path when your previous deployment is reachable elsewhere, or set it to `nil`/blank to opt out of auto-mounting and draw the routes yourself.
 
 Previous URLs must use HTTP or HTTPS and include a host. Credentials, query strings, and fragments are rejected. A bare origin also requires a nonblank `rolling_deploy_mount_path`; use an explicit path when the local engine mount is disabled.
@@ -144,20 +144,24 @@ Pre-seeding runs during `assets:precompile` — at **image-build time**, in the 
 
 ### Why promotion breaks build-time seeding
 
-- The staging build seeds using **staging's** `rolling_deploy_previous_urls` and a snapshot of staging's then-live bundle.
-- When that image is promoted to production, its renderer cache still holds staging's previous bundle — never production's. Production's config never gets a vote because the seed already happened at build time.
+- The staging build captures only the bundles advertised by its configured previous URLs at build time.
+- A multi-source configuration can capture staging and production's then-advertised bundles, but it cannot know which production bundle will be draining when a later promotion occurs.
 
-Even pointing the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)) goes stale across **two pending promotions**: both candidate images snapshot `P0`; after `C1` promotes production from `P0` to `C1`, promoting `C2` needs the draining `C1` bundle, which `C2` never seeded.
+Across **two pending promotions**, both candidate images can snapshot `P0`; after `C1` promotes production from `P0` to `C1`, promoting `C2` needs the draining `C1` bundle, which `C2` never seeded.
 
-### The fix: seed at container boot
+### The fix: seed at release time
 
-The production renderer container knows production's actually-live bundle at boot. Run the standalone seed task from the renderer container's entrypoint before it reports ready:
+The seed is a Rails/Rake task, so it must run in a Ruby-capable step that uses the promoted app artifact and production configuration:
 
 ```bash
 bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
 ```
 
-At boot the task reads production's config, so `rolling_deploy_previous_urls` resolves to production's live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods and advertises the exact bundle the new renderer needs.
+- A combined Ruby+Node application image can run it before starting Node.
+- A Node-only renderer needs a Ruby-capable init, release, or sidecar step using the promoted app artifact/config. That step and the renderer must mount the same writable shared volume at `RENDERER_SERVER_BUNDLE_CACHE_PATH`, or the completed cache must be copied or synced into the renderer before it starts. Gate renderer start and readiness on that step completing.
+- Without a Ruby-capable step that makes the completed cache available to the renderer, this Rake seed cannot run for that renderer. Keep the multi-source build-time fallback and 410 recovery, or use a combined application shape.
+
+When the release-time step runs before new Rails takes traffic, production's live endpoint is still served by draining old pods and advertises the exact bundle the new renderer needs.
 
 Keep build-time seeding too; the layers are complementary:
 
@@ -165,11 +169,11 @@ Keep build-time seeding too; the layers are complementary:
 - **Boot seed** is the correctness path: it resolves the live draining bundle at promotion time.
 
 > [!IMPORTANT]
-> Gate renderer readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback rather than wedge the deploy; the task already warns and continues on fetch failures.
+> Gate renderer start and readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback rather than wedge the deploy; the task already warns and continues on fetch failures.
 
 ## Deploy the renderer before Rails
 
-**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share one workload — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle. The [boot seed](#promotion-deploys-need-a-release-time-boot-seed) simply runs once at container start before either process serves traffic.
+**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share one workload — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle. A Ruby-capable startup step can run the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) before Node serves traffic.
 
 > [!IMPORTANT]
 > During a rolling deploy, the new Node Renderer must be live and cache-warm **before** the new Rails server starts serving traffic. If Rails goes first, the adapter's warm-cache guarantee doesn't hold for that window — you get exactly the 410 storm it's meant to prevent.
@@ -193,7 +197,7 @@ Make the ordering explicit in your pipeline rather than relying on timing:
 
 The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. Prefer a readiness gate over a fixed sleep — it tracks actual state. The exact wiring depends on your deploy tooling.
 
-This ordering is also what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct. The boot seed fetches the draining bundle from the target environment's live endpoint; that endpoint advertises the draining hash while old pods are still serving it. If new Rails cut over first, the endpoint would advertise the new hash and the seed would miss the bundle it needs.
+This ordering is also what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct. The release-time step fetches the draining bundle from the target environment's live endpoint; that endpoint advertises the draining hash while old pods are still serving it. If new Rails cut over first, the endpoint would advertise the new hash and the seed would miss the bundle it needs.
 
 ## Verify your setup with `react_on_rails:doctor`
 

--- a/docs/pro/rolling-deploy-adapters.md
+++ b/docs/pro/rolling-deploy-adapters.md
@@ -32,6 +32,9 @@ A **rolling-deploy adapter** makes new renderer instances start warm for **every
 
 The built-in HTTP adapter is the simplest way to get there, and it's covered next. If your build can't reach the previous deployment, or you'd rather keep bundles in your own store, you can [write a custom adapter](./rolling-deploy-custom-adapters.md) instead.
 
+> [!NOTE]
+> Pre-seeding runs at **image-build time**, in the environment that builds the image. That is sufficient when the image is built and deployed in the **same** environment. If you **promote** an image between environments — build once on staging, then promote that same image to production — build-time seeding alone is not enough. See [Promotion deploys need a boot seed](#promotion-deploys-need-a-release-time-boot-seed).
+
 ## Set up the HTTP adapter
 
 > Introduced as a scaffold in PR [#3379](https://github.com/shakacode/react_on_rails/pull/3379) — part 1 of a multi-PR series. A hard HTTPS gate, streaming download, and additional hardening land in follow-ups; see [Security](#security) below.
@@ -47,14 +50,14 @@ The currently-deployed Rails server already has every bundle and companion asset
 ```ruby
 # config/initializers/react_on_rails_pro.rb
 ReactOnRailsPro.configure do |config|
-  config.rolling_deploy_adapter      = ReactOnRailsPro::RollingDeployAdapters::Http
-  config.rolling_deploy_token        = ENV.fetch("ROLLING_DEPLOY_TOKEN")    # shared secret, ≥ 32 bytes
+  config.rolling_deploy_adapter       = ReactOnRailsPro::RollingDeployAdapters::Http
+  config.rolling_deploy_token         = ENV.fetch("ROLLING_DEPLOY_TOKEN")    # shared secret, ≥ 32 bytes
   config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"] # comma-delimited or an Array
 end
 ```
 
 - **`rolling_deploy_token`** — the shared bearer token ("password"). Generate one with `SecureRandom.hex(32)` and set the **same** value on both the running server (which authenticates incoming pulls) and the build CI (which sends it). The config validator rejects tokens shorter than 32 bytes.
-- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI**. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Leave it unset (or empty) to disable discovery on that build. The singular `rolling_deploy_previous_url` remains supported for compatibility, but configuring both singular and plural values is an error.
+- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI** or renderer at boot. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery.
 - **`rolling_deploy_mount_path`** — the Rails path where the Pro engine auto-mounts the bundle-serving endpoint when the built-in HTTP adapter is configured. Defaults to `/react_on_rails_pro/rolling_deploy`. Set it to a custom path when your previous deployment is reachable elsewhere, or set it to `nil`/blank to opt out of auto-mounting and draw the routes yourself.
 
 Previous URLs must use HTTP or HTTPS and include a host. Credentials, query strings, and fragments are rejected. A bare origin also requires a nonblank `rolling_deploy_mount_path`; use an explicit path when the local engine mount is disabled.
@@ -135,7 +138,38 @@ Current Pro artifact IDs begin with `rorp-v2-` and identify the role, bundle byt
 
 Verified v2 previous-deploy payloads are always staged as captured files, even when pre-seeding uses `MODE=symlink`, because the adapter's source paths may change or disappear after their bytes are verified. Legacy/protocol-v1 payloads continue to honor symlink mode.
 
+## Promotion deploys need a release-time (boot) seed
+
+Pre-seeding runs during `assets:precompile` — at **image-build time**, in the environment that builds the image. That is right when the image is built and deployed in the same environment, but not when you **promote** an image between environments.
+
+### Why promotion breaks build-time seeding
+
+- The staging build seeds using **staging's** `rolling_deploy_previous_urls` and a snapshot of staging's then-live bundle.
+- When that image is promoted to production, its renderer cache still holds staging's previous bundle — never production's. Production's config never gets a vote because the seed already happened at build time.
+
+Even pointing the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)) goes stale across **two pending promotions**: both candidate images snapshot `P0`; after `C1` promotes production from `P0` to `C1`, promoting `C2` needs the draining `C1` bundle, which `C2` never seeded.
+
+### The fix: seed at container boot
+
+The production renderer container knows production's actually-live bundle at boot. Run the standalone seed task from the renderer container's entrypoint before it reports ready:
+
+```bash
+bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
+```
+
+At boot the task reads production's config, so `rolling_deploy_previous_urls` resolves to production's live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods and advertises the exact bundle the new renderer needs.
+
+Keep build-time seeding too; the layers are complementary:
+
+- **Build-time seed** — ideally [multi-source](./rolling-deploy-custom-adapters.md#multi-source-seeding) (staging + production) — is the failure floor if the boot seed cannot reach the live endpoint.
+- **Boot seed** is the correctness path: it resolves the live draining bundle at promotion time.
+
+> [!IMPORTANT]
+> Gate renderer readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback rather than wedge the deploy; the task already warns and continues on fetch failures.
+
 ## Deploy the renderer before Rails
+
+**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share one workload — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle. The [boot seed](#promotion-deploys-need-a-release-time-boot-seed) simply runs once at container start before either process serves traffic.
 
 > [!IMPORTANT]
 > During a rolling deploy, the new Node Renderer must be live and cache-warm **before** the new Rails server starts serving traffic. If Rails goes first, the adapter's warm-cache guarantee doesn't hold for that window — you get exactly the 410 storm it's meant to prevent.
@@ -157,7 +191,9 @@ Make the ordering explicit in your pipeline rather than relying on timing:
 2. Wait until its new revision is **live and healthy** — readiness passing and all new renderer instances up.
 3. Only then deploy/promote the **Rails** workload.
 
-The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. The exact wiring depends on your deploy tooling.
+The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. Prefer a readiness gate over a fixed sleep — it tracks actual state. The exact wiring depends on your deploy tooling.
+
+This ordering is also what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct. The boot seed fetches the draining bundle from the target environment's live endpoint; that endpoint advertises the draining hash while old pods are still serving it. If new Rails cut over first, the endpoint would advertise the new hash and the seed would miss the bundle it needs.
 
 ## Verify your setup with `react_on_rails:doctor`
 

--- a/docs/pro/rolling-deploy-custom-adapters.md
+++ b/docs/pro/rolling-deploy-custom-adapters.md
@@ -100,7 +100,7 @@ end
 For CI and testing, set `PREVIOUS_BUNDLE_HASHES` as a comma-separated list to skip `previous_bundle_hashes` discovery:
 
 ```bash
-PREVIOUS_BUNDLE_HASHES=abc123,def456 rake react_on_rails_pro:pre_seed_renderer_cache
+PREVIOUS_BUNDLE_HASHES=abc123,def456 bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
 ```
 
 This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. The adapter is still required to fetch the actual bundle files; setting the env var without configuring `config.rolling_deploy_adapter` produces a warning and skips seeding.

--- a/docs/pro/rolling-deploy-custom-adapters.md
+++ b/docs/pro/rolling-deploy-custom-adapters.md
@@ -113,6 +113,27 @@ This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. 
 
 In practice this means a `staging` deploy hits the same artifact store as production — it must have the same credentials and write access. This is intentional: a `staging` → `staging` rolling deploy needs the previous staging hash seeded, and a `staging` → `production` promotion benefits from staging having warmed the store. If you need to keep `staging` out of the artifact store entirely, set `config.rolling_deploy_adapter = nil` in a `staging`-specific initializer rather than relying on env-based skipping at the gem level.
 
+> [!NOTE]
+> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: an image built on staging seeds staging's previous bundle, not production's — and with the built-in HTTP adapter (`upload` is a no-op) there is no shared store to paper over it. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
+
+## Multi-source seeding
+
+The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles from **both** — the promoted image is then born ready to serve production's draining bundle:
+
+```ruby
+# config/initializers/react_on_rails_pro.rb
+config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http
+# a single URL, a comma-separated string, or an Array — all three are accepted:
+config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
+# e.g. ROLLING_DEPLOY_PREVIOUS_URLS="https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
+```
+
+Discovery collects hashes from every reachable endpoint, with provenance checks. A hash advertised by only one endpoint is eligible. If more than one endpoint advertises a legacy/protocol-v1 hash, the adapter omits it because it cannot prove which payload is authoritative. A duplicated v2 artifact ID remains eligible only when every advertising endpoint reports the v2 manifest protocol; each downloaded payload is recomputed and rejected when it does not match the requested ID.
+
+For an eligible hash, fetch tries its allowed origins in configured order. A missing, failed, or rejected payload lets the adapter try the next allowed origin within its overall deadline; it uses the first response that passes the applicable identity check. A single unreachable endpoint therefore does not abort discovery or prevent another eligible source from seeding the bundle.
+
+This is the build-time **failure floor**; the correctness path is the [boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed). Use both.
+
 ## Edge cases and error handling
 
 | Scenario                                                                | Behavior                                                                                                                                                        |

--- a/docs/pro/rolling-deploy-custom-adapters.md
+++ b/docs/pro/rolling-deploy-custom-adapters.md
@@ -114,11 +114,11 @@ This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. 
 In practice this means a `staging` deploy hits the same artifact store as production — it must have the same credentials and write access. This is intentional: a `staging` → `staging` rolling deploy needs the previous staging hash seeded, and a `staging` → `production` promotion benefits from staging having warmed the store. If you need to keep `staging` out of the artifact store entirely, set `config.rolling_deploy_adapter = nil` in a `staging`-specific initializer rather than relying on env-based skipping at the gem level.
 
 > [!NOTE]
-> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: an image built on staging seeds staging's previous bundle, not production's — and with the built-in HTTP adapter (`upload` is a no-op) there is no shared store to paper over it. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
+> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: build-time seeding captures only then-advertised bundles. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
 
 ## Multi-source seeding
 
-The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles from **both** — the promoted image is then born ready to serve production's draining bundle:
+The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles then advertised by **both**. This improves fallback warmth, but only the release-time boot seed resolves the target's current draining bundle:
 
 ```ruby
 # config/initializers/react_on_rails_pro.rb

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -4008,7 +4008,7 @@ end
 For CI and testing, set `PREVIOUS_BUNDLE_HASHES` as a comma-separated list to skip `previous_bundle_hashes` discovery:
 
 ```bash
-PREVIOUS_BUNDLE_HASHES=abc123,def456 rake react_on_rails_pro:pre_seed_renderer_cache
+PREVIOUS_BUNDLE_HASHES=abc123,def456 bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
 ```
 
 This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. The adapter is still required to fetch the actual bundle files; setting the env var without configuring `config.rolling_deploy_adapter` produces a warning and skips seeding.

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -3701,6 +3701,9 @@ A **rolling-deploy adapter** makes new renderer instances start warm for **every
 
 The built-in HTTP adapter is the simplest way to get there, and it's covered next. If your build can't reach the previous deployment, or you'd rather keep bundles in your own store, you can [write a custom adapter](./rolling-deploy-custom-adapters.md) instead.
 
+> [!NOTE]
+> Pre-seeding runs at **image-build time**, in the environment that builds the image. That is sufficient when the image is built and deployed in the **same** environment. If you **promote** an image between environments — build once on staging, then promote that same image to production — build-time seeding alone is not enough. See [Promotion deploys need a boot seed](#promotion-deploys-need-a-release-time-boot-seed).
+
 ## Set up the HTTP adapter
 
 > Introduced as a scaffold in PR [#3379](https://github.com/shakacode/react_on_rails/pull/3379) — part 1 of a multi-PR series. A hard HTTPS gate, streaming download, and additional hardening land in follow-ups; see [Security](#security) below.
@@ -3714,14 +3717,14 @@ The currently-deployed Rails server already has every bundle and companion asset
 ```ruby
 # config/initializers/react_on_rails_pro.rb
 ReactOnRailsPro.configure do |config|
-  config.rolling_deploy_adapter      = ReactOnRailsPro::RollingDeployAdapters::Http
-  config.rolling_deploy_token        = ENV.fetch("ROLLING_DEPLOY_TOKEN")    # shared secret, ≥ 32 bytes
+  config.rolling_deploy_adapter       = ReactOnRailsPro::RollingDeployAdapters::Http
+  config.rolling_deploy_token         = ENV.fetch("ROLLING_DEPLOY_TOKEN")    # shared secret, ≥ 32 bytes
   config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"] # comma-delimited or an Array
 end
 ```
 
 - **`rolling_deploy_token`** — the shared bearer token ("password"). Generate one with `SecureRandom.hex(32)` and set the **same** value on both the running server (which authenticates incoming pulls) and the build CI (which sends it). The config validator rejects tokens shorter than 32 bytes.
-- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI**. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Leave it unset (or empty) to disable discovery on that build. The singular `rolling_deploy_previous_url` remains supported for compatibility, but configuring both singular and plural values is an error.
+- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI** or renderer at boot. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery.
 - **`rolling_deploy_mount_path`** — the Rails path where the Pro engine auto-mounts the bundle-serving endpoint when the built-in HTTP adapter is configured. Defaults to `/react_on_rails_pro/rolling_deploy`. Set it to a custom path when your previous deployment is reachable elsewhere, or set it to `nil`/blank to opt out of auto-mounting and draw the routes yourself.
 
 Previous URLs must use HTTP or HTTPS and include a host. Credentials, query strings, and fragments are rejected. A bare origin also requires a nonblank `rolling_deploy_mount_path`; use an explicit path when the local engine mount is disabled.
@@ -3802,7 +3805,38 @@ Current Pro artifact IDs begin with `rorp-v2-` and identify the role, bundle byt
 
 Verified v2 previous-deploy payloads are always staged as captured files, even when pre-seeding uses `MODE=symlink`, because the adapter's source paths may change or disappear after their bytes are verified. Legacy/protocol-v1 payloads continue to honor symlink mode.
 
+## Promotion deploys need a release-time (boot) seed
+
+Pre-seeding runs during `assets:precompile` — at **image-build time**, in the environment that builds the image. That is right when the image is built and deployed in the same environment, but not when you **promote** an image between environments.
+
+### Why promotion breaks build-time seeding
+
+- The staging build seeds using **staging's** `rolling_deploy_previous_urls` and a snapshot of staging's then-live bundle.
+- When that image is promoted to production, its renderer cache still holds staging's previous bundle — never production's. Production's config never gets a vote because the seed already happened at build time.
+
+Even pointing the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)) goes stale across **two pending promotions**: both candidate images snapshot `P0`; after `C1` promotes production from `P0` to `C1`, promoting `C2` needs the draining `C1` bundle, which `C2` never seeded.
+
+### The fix: seed at container boot
+
+The production renderer container knows production's actually-live bundle at boot. Run the standalone seed task from the renderer container's entrypoint before it reports ready:
+
+```bash
+bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
+```
+
+At boot the task reads production's config, so `rolling_deploy_previous_urls` resolves to production's live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods and advertises the exact bundle the new renderer needs.
+
+Keep build-time seeding too; the layers are complementary:
+
+- **Build-time seed** — ideally [multi-source](./rolling-deploy-custom-adapters.md#multi-source-seeding) (staging + production) — is the failure floor if the boot seed cannot reach the live endpoint.
+- **Boot seed** is the correctness path: it resolves the live draining bundle at promotion time.
+
+> [!IMPORTANT]
+> Gate renderer readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback rather than wedge the deploy; the task already warns and continues on fetch failures.
+
 ## Deploy the renderer before Rails
+
+**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share one workload — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle. The [boot seed](#promotion-deploys-need-a-release-time-boot-seed) simply runs once at container start before either process serves traffic.
 
 > [!IMPORTANT]
 > During a rolling deploy, the new Node Renderer must be live and cache-warm **before** the new Rails server starts serving traffic. If Rails goes first, the adapter's warm-cache guarantee doesn't hold for that window — you get exactly the 410 storm it's meant to prevent.
@@ -3824,7 +3858,9 @@ Make the ordering explicit in your pipeline rather than relying on timing:
 2. Wait until its new revision is **live and healthy** — readiness passing and all new renderer instances up.
 3. Only then deploy/promote the **Rails** workload.
 
-The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. The exact wiring depends on your deploy tooling.
+The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. Prefer a readiness gate over a fixed sleep — it tracks actual state. The exact wiring depends on your deploy tooling.
+
+This ordering is also what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct. The boot seed fetches the draining bundle from the target environment's live endpoint; that endpoint advertises the draining hash while old pods are still serving it. If new Rails cut over first, the endpoint would advertise the new hash and the seed would miss the bundle it needs.
 
 ## Verify your setup with `react_on_rails:doctor`
 
@@ -3980,6 +4016,27 @@ This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. 
 `assets:precompile` invokes `upload` for the current build's bundle hashes whenever an adapter is configured **and** `Rails.env` is anything other than `development` or `test`. That includes `staging`, `production`, custom envs like `qa` or `preview`, and any other non-dev/non-test value.
 
 In practice this means a `staging` deploy hits the same artifact store as production — it must have the same credentials and write access. This is intentional: a `staging` → `staging` rolling deploy needs the previous staging hash seeded, and a `staging` → `production` promotion benefits from staging having warmed the store. If you need to keep `staging` out of the artifact store entirely, set `config.rolling_deploy_adapter = nil` in a `staging`-specific initializer rather than relying on env-based skipping at the gem level.
+
+> [!NOTE]
+> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: an image built on staging seeds staging's previous bundle, not production's — and with the built-in HTTP adapter (`upload` is a no-op) there is no shared store to paper over it. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
+
+## Multi-source seeding
+
+The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles from **both** — the promoted image is then born ready to serve production's draining bundle:
+
+```ruby
+# config/initializers/react_on_rails_pro.rb
+config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http
+# a single URL, a comma-separated string, or an Array — all three are accepted:
+config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
+# e.g. ROLLING_DEPLOY_PREVIOUS_URLS="https://staging.example.com/react_on_rails_pro/rolling_deploy,https://app.example.com/react_on_rails_pro/rolling_deploy"
+```
+
+Discovery collects hashes from every reachable endpoint, with provenance checks. A hash advertised by only one endpoint is eligible. If more than one endpoint advertises a legacy/protocol-v1 hash, the adapter omits it because it cannot prove which payload is authoritative. A duplicated v2 artifact ID remains eligible only when every advertising endpoint reports the v2 manifest protocol; each downloaded payload is recomputed and rejected when it does not match the requested ID.
+
+For an eligible hash, fetch tries its allowed origins in configured order. A missing, failed, or rejected payload lets the adapter try the next allowed origin within its overall deadline; it uses the first response that passes the applicable identity check. A single unreachable endpoint therefore does not abort discovery or prevent another eligible source from seeding the bundle.
+
+This is the build-time **failure floor**; the correctness path is the [boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed). Use both.
 
 ## Edge cases and error handling
 

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -3724,7 +3724,7 @@ end
 ```
 
 - **`rolling_deploy_token`** — the shared bearer token ("password"). Generate one with `SecureRandom.hex(32)` and set the **same** value on both the running server (which authenticates incoming pulls) and the build CI (which sends it). The config validator rejects tokens shorter than 32 bytes.
-- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI** or renderer at boot. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery.
+- **`rolling_deploy_previous_urls`** — one or more previous-deployment URLs reachable **from the build CI** or release-time seed step. It accepts an Array, a comma-delimited String, or one String. Use a bare origin such as `https://old.example.com` to inherit `rolling_deploy_mount_path`, or include an explicit path such as `https://old.example.com/internal/rolling-deploy` to preserve that path. Order is retained and duplicates are removed. Pass more than one to seed from several environments at once (e.g. staging + production — see [Multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)). Leave it unset (or empty) to disable discovery.
 - **`rolling_deploy_mount_path`** — the Rails path where the Pro engine auto-mounts the bundle-serving endpoint when the built-in HTTP adapter is configured. Defaults to `/react_on_rails_pro/rolling_deploy`. Set it to a custom path when your previous deployment is reachable elsewhere, or set it to `nil`/blank to opt out of auto-mounting and draw the routes yourself.
 
 Previous URLs must use HTTP or HTTPS and include a host. Credentials, query strings, and fragments are rejected. A bare origin also requires a nonblank `rolling_deploy_mount_path`; use an explicit path when the local engine mount is disabled.
@@ -3811,20 +3811,24 @@ Pre-seeding runs during `assets:precompile` — at **image-build time**, in the 
 
 ### Why promotion breaks build-time seeding
 
-- The staging build seeds using **staging's** `rolling_deploy_previous_urls` and a snapshot of staging's then-live bundle.
-- When that image is promoted to production, its renderer cache still holds staging's previous bundle — never production's. Production's config never gets a vote because the seed already happened at build time.
+- The staging build captures only the bundles advertised by its configured previous URLs at build time.
+- A multi-source configuration can capture staging and production's then-advertised bundles, but it cannot know which production bundle will be draining when a later promotion occurs.
 
-Even pointing the staging build at production so the image is born prod-ready (see [multi-source seeding](./rolling-deploy-custom-adapters.md#multi-source-seeding)) goes stale across **two pending promotions**: both candidate images snapshot `P0`; after `C1` promotes production from `P0` to `C1`, promoting `C2` needs the draining `C1` bundle, which `C2` never seeded.
+Across **two pending promotions**, both candidate images can snapshot `P0`; after `C1` promotes production from `P0` to `C1`, promoting `C2` needs the draining `C1` bundle, which `C2` never seeded.
 
-### The fix: seed at container boot
+### The fix: seed at release time
 
-The production renderer container knows production's actually-live bundle at boot. Run the standalone seed task from the renderer container's entrypoint before it reports ready:
+The seed is a Rails/Rake task, so it must run in a Ruby-capable step that uses the promoted app artifact and production configuration:
 
 ```bash
 bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
 ```
 
-At boot the task reads production's config, so `rolling_deploy_previous_urls` resolves to production's live endpoint. Because the renderer comes up **before** new Rails (see [Deploy the renderer before Rails](#deploy-the-renderer-before-rails)), that endpoint is still served by the draining old pods and advertises the exact bundle the new renderer needs.
+- A combined Ruby+Node application image can run it before starting Node.
+- A Node-only renderer needs a Ruby-capable init, release, or sidecar step using the promoted app artifact/config. That step and the renderer must mount the same writable shared volume at `RENDERER_SERVER_BUNDLE_CACHE_PATH`, or the completed cache must be copied or synced into the renderer before it starts. Gate renderer start and readiness on that step completing.
+- Without a Ruby-capable step that makes the completed cache available to the renderer, this Rake seed cannot run for that renderer. Keep the multi-source build-time fallback and 410 recovery, or use a combined application shape.
+
+When the release-time step runs before new Rails takes traffic, production's live endpoint is still served by draining old pods and advertises the exact bundle the new renderer needs.
 
 Keep build-time seeding too; the layers are complementary:
 
@@ -3832,11 +3836,11 @@ Keep build-time seeding too; the layers are complementary:
 - **Boot seed** is the correctness path: it resolves the live draining bundle at promotion time.
 
 > [!IMPORTANT]
-> Gate renderer readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback rather than wedge the deploy; the task already warns and continues on fetch failures.
+> Gate renderer start and readiness on the boot seed **completing, not succeeding**. A failed seed must degrade to the 410 fallback rather than wedge the deploy; the task already warns and continues on fetch failures.
 
 ## Deploy the renderer before Rails
 
-**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share one workload — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle. The [boot seed](#promotion-deploys-need-a-release-time-boot-seed) simply runs once at container start before either process serves traffic.
+**This ordering requirement applies only when the renderer is a _separate workload_ from Rails** — Option 3 in [Container deployment](../oss/building-features/node-renderer/container-deployment.md#architecture-options). If Rails and the renderer share one workload — a single container or sidecar containers (Options 1–2) — they deploy on one atomic lifecycle. A Ruby-capable startup step can run the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) before Node serves traffic.
 
 > [!IMPORTANT]
 > During a rolling deploy, the new Node Renderer must be live and cache-warm **before** the new Rails server starts serving traffic. If Rails goes first, the adapter's warm-cache guarantee doesn't hold for that window — you get exactly the 410 storm it's meant to prevent.
@@ -3860,7 +3864,7 @@ Make the ordering explicit in your pipeline rather than relying on timing:
 
 The invariant to enforce is **renderer-ready-before-Rails-live**: gate the Rails workload's release on the renderer workload's release completing (sequence them as separate steps in your deploy pipeline), and/or tune the renderer's readiness probe and Rails' startup so Rails does not accept traffic until the renderer reports ready. Prefer a readiness gate over a fixed sleep — it tracks actual state. The exact wiring depends on your deploy tooling.
 
-This ordering is also what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct. The boot seed fetches the draining bundle from the target environment's live endpoint; that endpoint advertises the draining hash while old pods are still serving it. If new Rails cut over first, the endpoint would advertise the new hash and the seed would miss the bundle it needs.
+This ordering is also what makes the [boot seed](#promotion-deploys-need-a-release-time-boot-seed) correct. The release-time step fetches the draining bundle from the target environment's live endpoint; that endpoint advertises the draining hash while old pods are still serving it. If new Rails cut over first, the endpoint would advertise the new hash and the seed would miss the bundle it needs.
 
 ## Verify your setup with `react_on_rails:doctor`
 
@@ -4018,11 +4022,11 @@ This runs the adapter's `fetch(hash)` for each listed hash but skips discovery. 
 In practice this means a `staging` deploy hits the same artifact store as production — it must have the same credentials and write access. This is intentional: a `staging` → `staging` rolling deploy needs the previous staging hash seeded, and a `staging` → `production` promotion benefits from staging having warmed the store. If you need to keep `staging` out of the artifact store entirely, set `config.rolling_deploy_adapter = nil` in a `staging`-specific initializer rather than relying on env-based skipping at the gem level.
 
 > [!NOTE]
-> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: an image built on staging seeds staging's previous bundle, not production's — and with the built-in HTTP adapter (`upload` is a no-op) there is no shared store to paper over it. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
+> This section is about the **upload** (publish) side. Promotion has a second, independent gap on the **seed** side: build-time seeding captures only then-advertised bundles. See [Promotion deploys need a boot seed](./rolling-deploy-adapters.md#promotion-deploys-need-a-release-time-boot-seed) and [Multi-source seeding](#multi-source-seeding) below.
 
 ## Multi-source seeding
 
-The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles from **both** — the promoted image is then born ready to serve production's draining bundle:
+The built-in HTTP adapter's `rolling_deploy_previous_urls` accepts **more than one** endpoint. When you **promote** an image between environments (build on staging, promote to production), pass both the build environment and the promotion target so the built image carries bundles then advertised by **both**. This improves fallback warmth, but only the release-time boot seed resolves the target's current draining bundle:
 
 ```ruby
 # config/initializers/react_on_rails_pro.rb

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16313,7 +16313,7 @@ Rails and the Node Renderer run as independent workloads with their own scaling.
 
 **Disadvantages:**
 
-- **Version drift risk** — During rolling deploys, Rails and the Node Renderer may briefly run different versions. While protocol changes are rare, this is a risk to monitor.
+- **Version drift risk** — During rolling deploys, Rails and the Node Renderer roll independently and briefly run different bundle versions, so the renderer can receive SSR requests for a bundle it hasn't cached. Mitigate this with a [rolling-deploy adapter](../../../pro/rolling-deploy-adapters.md) (Pro): it pre-seeds the new renderer with the draining bundle and makes the renderer-before-Rails ordering explicit. This risk (and that mitigation) is **specific to this separate-workloads option** — Options 1–2 share one lifecycle and cannot drift.
 - **Race conditions** — Pods restart independently, which can cause transient connection errors.
 - **Network dependency** — Renderer must be reachable via internal service DNS.
 - **Overkill for most setups** — If you're running 2–4 replicas, independent scaling adds complexity without real benefit.

--- a/react_on_rails_pro/CONTEXT.md
+++ b/react_on_rails_pro/CONTEXT.md
@@ -1,0 +1,136 @@
+# React on Rails Pro — Rolling Deploy
+
+How the Node Renderer bundle cache is warmed so that during a rolling deploy —
+when old and new app versions run side by side — no SSR request pays the
+cold-bundle penalty. Covers the seeding mechanism and how it interacts with the
+deploy pipeline (build vs. release, staging-to-production promotion).
+
+## Language
+
+**Rolling deploy**:
+The window where old (draining) and new app instances run side by side, both
+sending SSR requests to the Node Renderer fleet.
+
+**Draining bundle**:
+The bundle hash that draining old Rails instances still request during the
+overlap; the new renderer fleet must serve it warm.
+_Avoid_: "old bundle" (old relative to what? — the draining bundle is defined by
+what is live-and-draining in _this environment_, not by build order).
+
+**Pre-seed**:
+Staging previous bundle hashes into the new renderer cache before it serves
+traffic, so **draining bundle** requests hit warm cache instead of the **410
+fallback**.
+_Avoid_: warmup (means the per-request lazy cache fill, the opposite of this).
+
+**Pre-seed source**:
+The deployment(s) the pre-seed pulls bundles from — resolved from that
+environment's `rolling_deploy_previous_urls` (HTTP adapter) at the moment the
+seed runs. The source is whatever environment's config is in effect _when and
+where the seed executes_.
+
+**Build-time seed**:
+Pre-seed baked into the image during `assets:precompile`. Uses the _building_
+environment's config and a _snapshot_ of its then-live bundle. Frozen into the
+image layer.
+
+**Release-time seed** (a.k.a. **boot seed**):
+Pre-seed run by the _target_ environment's renderer container at container boot
+via `rake react_on_rails_pro:pre_seed_renderer_cache`, resolving that
+environment's _actually-live_ bundle at that moment. Readiness-gated.
+_Avoid_: "runtime seed" (ambiguous with the per-request 410 path).
+
+**Multi-source seed**:
+A build-time seed whose **pre-seed source** is a _list_ of endpoints (the
+built-in HTTP adapter's `rolling_deploy_previous_urls` accepts more than one).
+Staging seeds from both staging and production so the promoted image is born
+prod-ready.
+
+**Promotion model**:
+Production is deployed by promoting the _exact staging image_, not by building a
+fresh production image. Consequence: the image's **build-time seed** used the
+_staging_ pipeline's config and snapshots taken at staging-build time. A
+multi-source configuration can include production's then-live bundle, but it
+still cannot know the production bundle that will be draining at a later
+promotion.
+
+**410 fallback**:
+The self-healing but slow per-request cold path: cache miss → `410 Gone` → Rails
+ships the bundle to the renderer → retry, repeating per request until cached.
+The thing pre-seeding exists to avoid.
+
+**Seed correctness (R1)**:
+The requirement that the new renderer fleet holds the exact **draining bundle**
+for _this_ environment at _this_ release.
+
+**Deploy ordering (R2)**:
+The requirement that the new renderer fleet is live and cache-warm _before_ new
+Rails takes traffic, and old renderers stay up until old Rails drains. Also
+called **renderer-before-Rails**.
+
+## Relationships
+
+- A **rolling deploy** has one **draining bundle** per bundle kind (server, and
+  RSC when enabled) that the new renderer fleet must serve warm.
+- **Pre-seed** eliminates the **410 fallback** for the **draining bundle**;
+  without it, every draining-bundle request pays the cold path.
+- **Seed correctness (R1)** and **Deploy ordering (R2)** are independent and
+  _both_ required. R2 alone (a delay) cannot rescue a wrong seed; R1 alone
+  cannot rescue Rails cutting over before the renderer is warm.
+- Under the **promotion model**, a **build-time seed** cannot satisfy R1 for
+  every promotion: it runs against snapshots taken in the staging pipeline, but
+  production's **draining bundle** is only known at the later promotion.
+- Set staging's **pre-seed source** to both **staging and production**, so the
+  image carries each environment's then-live bundle. This keeps staging's own
+  rolling deploys warm and makes the promoted image prod-ready for a single
+  pending promotion, but still goes stale across _two pending promotions_.
+- The residual staleness window (two images built before either is promoted) is
+  closed by a **release-time seed** at promotion, which resolves production's
+  actually-live **draining bundle**.
+
+### Three layers of defense
+
+Correctness is layered; each layer bounds the failure the prior one leaves open.
+
+1. **Multi-source build-time seed** — the image is born prod-ready; failure floor
+   if the boot seed can't reach the live endpoint. (Correct for a single pending
+   promotion.)
+2. **Boot seed (release-time)** — the correctness path: pulls the _actually-live_
+   **draining bundle** at container start, closing the two-pending-promotions
+   window. Subsumes layer 1's correctness; layer 1 remains only as a fallback.
+3. **Deploy ordering (R2)** — renderer live+warm before Rails; readiness gates on
+   the boot seed _completing_ (not succeeding — a failed seed degrades to the 410
+   fallback rather than wedging the deploy).
+
+**Interdependency:** the **boot seed** returns the correct **draining bundle**
+_only because_ the renderer boots before Rails (R2). Before new Rails is live,
+the environment's live endpoint is still served by the draining old pods, so it
+advertises the draining hash. If Rails cut over first, the live endpoint would
+advertise the _new_ hash and the boot seed would miss the very bundle it needs.
+Layer 2 depends on Layer 3.
+
+## Example dialogue
+
+> **Dev:** "We promote the staging image to prod, and pre-seed is on. Why is
+> prod SSR still slow after a rolling deploy?"
+> **Domain expert:** "Because the **build-time seed** ran in the staging
+> pipeline — the image holds staging's previous bundle, not prod's **draining
+> bundle**. The seed was correct for the wrong environment."
+> **Dev:** "So if staging's **pre-seed source** includes staging and production,
+> the promoted image is already prod-ready?"
+> **Domain expert:** "For a single pending promotion, generally yes, while
+> staging still carries its own draining bundle. Two pending promotions still go
+> stale — that's why promotion also runs a **release-time seed** against prod's
+> live bundle."
+> **Dev:** "And that's enough?"
+> **Domain expert:** "That's **R1**. You still need **R2** — the new renderer
+> fleet live and warm before Rails cuts over — or you get the 410 storm anyway."
+
+## Flagged ambiguities
+
+- "old bundle" was used to mean both the build-predecessor and the live-draining
+  bundle — resolved: the term of record is **draining bundle**, defined by what
+  is live in the target environment, not by build order.
+- "the delay" (R2) was initially read as a fix for the slow-SSR report — resolved:
+  the report is an R1 (wrong-seed) failure; the delay is a necessary but separate
+  R2 concern.

--- a/react_on_rails_pro/CONTEXT.md
+++ b/react_on_rails_pro/CONTEXT.md
@@ -35,16 +35,23 @@ environment's config and a _snapshot_ of its then-live bundle. Frozen into the
 image layer.
 
 **Release-time seed** (a.k.a. **boot seed**):
-Pre-seed run by the _target_ environment's renderer container at container boot
-via `rake react_on_rails_pro:pre_seed_renderer_cache`, resolving that
-environment's _actually-live_ bundle at that moment. Readiness-gated.
+Pre-seed run by a Ruby-capable release, init, or startup step via
+`rake react_on_rails_pro:pre_seed_renderer_cache`, resolving the target
+environment's _actually-live_ bundle. A combined Ruby+Node image can run it
+before Node; a Node-only renderer needs a Ruby-capable step with the promoted
+app artifact/config. That step and the renderer must mount the same writable
+shared volume at `RENDERER_SERVER_BUNDLE_CACHE_PATH`, or copy/sync the completed
+cache into the renderer before it starts. Renderer start/readiness waits for
+completion. Without a Ruby-capable step that makes the completed cache available
+to the renderer, use multi-source fallback plus 410 recovery or a combined
+shape.
 _Avoid_: "runtime seed" (ambiguous with the per-request 410 path).
 
 **Multi-source seed**:
 A build-time seed whose **pre-seed source** is a _list_ of endpoints (the
 built-in HTTP adapter's `rolling_deploy_previous_urls` accepts more than one).
-Staging seeds from both staging and production so the promoted image is born
-prod-ready.
+Staging can carry bundles then advertised by both staging and production, which
+improves fallback warmth but cannot determine a later production drain.
 
 **Promotion model**:
 Production is deployed by promoting the _exact staging image_, not by building a
@@ -82,8 +89,8 @@ called **renderer-before-Rails**.
   production's **draining bundle** is only known at the later promotion.
 - Set staging's **pre-seed source** to both **staging and production**, so the
   image carries each environment's then-live bundle. This keeps staging's own
-  rolling deploys warm and makes the promoted image prod-ready for a single
-  pending promotion, but still goes stale across _two pending promotions_.
+  rolling deploys warm and improves fallback warmth, but still goes stale across
+  _two pending promotions_.
 - The residual staleness window (two images built before either is promoted) is
   closed by a **release-time seed** at promotion, which resolves production's
   actually-live **draining bundle**.
@@ -92,18 +99,18 @@ called **renderer-before-Rails**.
 
 Correctness is layered; each layer bounds the failure the prior one leaves open.
 
-1. **Multi-source build-time seed** — the image is born prod-ready; failure floor
-   if the boot seed can't reach the live endpoint. (Correct for a single pending
-   promotion.)
+1. **Multi-source build-time seed** — carries then-advertised bundles as a
+   failure floor if the boot seed cannot reach the live endpoint.
 2. **Boot seed (release-time)** — the correctness path: pulls the _actually-live_
-   **draining bundle** at container start, closing the two-pending-promotions
-   window. Subsumes layer 1's correctness; layer 1 remains only as a fallback.
+   **draining bundle** before renderer readiness, closing the
+   two-pending-promotions window. Layer 1 remains only as a fallback.
 3. **Deploy ordering (R2)** — renderer live+warm before Rails; readiness gates on
    the boot seed _completing_ (not succeeding — a failed seed degrades to the 410
    fallback rather than wedging the deploy).
 
 **Interdependency:** the **boot seed** returns the correct **draining bundle**
-_only because_ the renderer boots before Rails (R2). Before new Rails is live,
+only when its release-time step completes before renderer readiness and Rails
+cutover (R2). Before new Rails is live,
 the environment's live endpoint is still served by the draining old pods, so it
 advertises the draining hash. If Rails cut over first, the live endpoint would
 advertise the _new_ hash and the boot seed would miss the very bundle it needs.
@@ -116,12 +123,11 @@ Layer 2 depends on Layer 3.
 > **Domain expert:** "Because the **build-time seed** ran in the staging
 > pipeline — the image holds staging's previous bundle, not prod's **draining
 > bundle**. The seed was correct for the wrong environment."
-> **Dev:** "So if staging's **pre-seed source** includes staging and production,
-> the promoted image is already prod-ready?"
-> **Domain expert:** "For a single pending promotion, generally yes, while
-> staging still carries its own draining bundle. Two pending promotions still go
-> stale — that's why promotion also runs a **release-time seed** against prod's
-> live bundle."
+> **Dev:** "So does staging's **pre-seed source** including staging and
+> production guarantee the promoted image has prod's draining bundle?"
+> **Domain expert:** "No. It carries then-advertised bundles and improves the
+> fallback, but two pending promotions can still go stale. The **release-time
+> seed** against prod's live bundle establishes correctness."
 > **Dev:** "And that's enough?"
 > **Domain expert:** "That's **R1**. You still need **R2** — the new renderer
 > fleet live and warm before Rails cuts over — or you get the 410 storm anyway."

--- a/react_on_rails_pro/CONTEXT.md
+++ b/react_on_rails_pro/CONTEXT.md
@@ -36,7 +36,7 @@ image layer.
 
 **Release-time seed** (a.k.a. **boot seed**):
 Pre-seed run by a Ruby-capable release, init, or startup step via
-`rake react_on_rails_pro:pre_seed_renderer_cache`, resolving the target
+`bundle exec rake react_on_rails_pro:pre_seed_renderer_cache`, resolving the target
 environment's _actually-live_ bundle. A combined Ruby+Node image can run it
 before Node; a Node-only renderer needs a Ruby-capable step with the promoted
 app artifact/config. That step and the renderer must mount the same writable

--- a/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
+++ b/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
@@ -1,4 +1,4 @@
-# Seed rolling-deploy bundles at renderer boot, not only at build
+# Seed rolling-deploy bundles at release time, not only at build
 
 **Status:** accepted
 
@@ -6,10 +6,17 @@ When the production image is produced by **promoting the staging image**
 (`upstream: hichee-staging` in Control Plane), a build-time pre-seed cannot know
 production's live **draining bundle**: it runs in the staging pipeline against a
 staging snapshot, and promotion happens later and is sometimes skipped. We
-therefore have the **node-renderer container pull the target environment's
-actually-live bundle at boot** (`rake react_on_rails_pro:pre_seed_renderer_cache`,
-readiness-gated) as the correctness path, and keep the build-time seed as a
-fallback floor.
+therefore run the **Rails/Rake seed task**
+(`rake react_on_rails_pro:pre_seed_renderer_cache`) in a Ruby-capable release,
+init, or startup step as the correctness path, and keep the build-time seed as a
+fallback floor. A combined Ruby+Node image can run it before Node. A Node-only
+renderer needs that step to use the promoted app artifact/config. The step and
+renderer must mount the same writable shared volume at
+`RENDERER_SERVER_BUNDLE_CACHE_PATH`, or copy/sync the completed cache into the
+renderer before it starts; gate renderer start/readiness on completion. Without
+a Ruby-capable step that makes the completed cache available to the renderer,
+the Rake seed cannot run for it; use multi-source fallback plus 410 recovery or
+a combined shape.
 
 ## Considered options
 
@@ -28,12 +35,13 @@ fallback floor.
 
 ## Consequences
 
-- Correctness of the boot seed **depends on deploy ordering (R2)**: the renderer
-  must boot before Rails, so the environment's live endpoint still advertises the
-  draining hash. If Rails cut over first, the boot seed would fetch the new hash
-  and miss the draining one.
-- Readiness gates on the boot seed **completing, not succeeding** — a failed seed
-  degrades to the 410 fallback rather than wedging the deploy.
+- Correctness of the boot seed **depends on deploy ordering (R2)**: its
+  Ruby-capable step must complete before renderer readiness and Rails cutover, so
+  the environment's live endpoint still advertises the draining hash. If Rails
+  cuts over first, the boot seed would fetch the new hash and miss the draining
+  one.
+- Renderer start/readiness gates on the boot seed **completing, not succeeding**
+  — a failed seed degrades to the 410 fallback rather than wedging the deploy.
 - The build-time fallback seeds from both staging and production, so the image
   retains each environment's then-live bundle. That keeps staging's own rolling
   deploys warm while still giving a promoted image a recent production bundle if

--- a/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
+++ b/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
@@ -1,0 +1,40 @@
+# Seed rolling-deploy bundles at renderer boot, not only at build
+
+**Status:** accepted
+
+When the production image is produced by **promoting the staging image**
+(`upstream: hichee-staging` in Control Plane), a build-time pre-seed cannot know
+production's live **draining bundle**: it runs in the staging pipeline against a
+staging snapshot, and promotion happens later and is sometimes skipped. We
+therefore have the **node-renderer container pull the target environment's
+actually-live bundle at boot** (`rake react_on_rails_pro:pre_seed_renderer_cache`,
+readiness-gated) as the correctness path, and keep the build-time seed as a
+fallback floor.
+
+## Considered options
+
+- **Build-time seed only (status quo).** Rejected: structurally wrong under the
+  promotion model — the image holds staging's previous bundle, and even a
+  multi-source build-time seed (staging + production) goes stale across two
+  pending promotions.
+- **Build a dedicated production image instead of promoting staging.** Rejected:
+  fights the promotion model (the point of promotion is shipping the exact
+  artifact tested on staging) and still goes stale if a prod image is ever built
+  ahead of its release.
+- **Boot seed only.** Rejected in favor of belt-and-suspenders: a boot seed that
+  can't reach the live endpoint would fall all the way back to the per-request
+  410 path. Keeping the build-time multi-source seed bounds that failure to a
+  small, rare miss.
+
+## Consequences
+
+- Correctness of the boot seed **depends on deploy ordering (R2)**: the renderer
+  must boot before Rails, so the environment's live endpoint still advertises the
+  draining hash. If Rails cut over first, the boot seed would fetch the new hash
+  and miss the draining one.
+- Readiness gates on the boot seed **completing, not succeeding** — a failed seed
+  degrades to the 410 fallback rather than wedging the deploy.
+- The build-time fallback seeds from both staging and production, so the image
+  retains each environment's then-live bundle. That keeps staging's own rolling
+  deploys warm while still giving a promoted image a recent production bundle if
+  the boot seed cannot reach the live endpoint.

--- a/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
+++ b/react_on_rails_pro/docs/adr/0001-boot-seed-rolling-deploy-bundles.md
@@ -2,16 +2,17 @@
 
 **Status:** accepted
 
-When the production image is produced by **promoting the staging image**
-(`upstream: hichee-staging` in Control Plane), a build-time pre-seed cannot know
-production's live **draining bundle**: it runs in the staging pipeline against a
-staging snapshot, and promotion happens later and is sometimes skipped. We
+When the production image is produced by **promoting a staging image** (for
+example, through a Control Plane `upstream:` configuration), a build-time
+pre-seed cannot know production's live **draining bundle**: it runs in the
+staging pipeline against a staging snapshot, and promotion happens later and is
+sometimes skipped. We
 therefore run the **Rails/Rake seed task**
-(`rake react_on_rails_pro:pre_seed_renderer_cache`) in a Ruby-capable release,
-init, or startup step as the correctness path, and keep the build-time seed as a
-fallback floor. A combined Ruby+Node image can run it before Node. A Node-only
-renderer needs that step to use the promoted app artifact/config. The step and
-renderer must mount the same writable shared volume at
+(`bundle exec rake react_on_rails_pro:pre_seed_renderer_cache`) in a
+Ruby-capable release, init, or startup step as the correctness path, and keep
+the build-time seed as a fallback floor. A combined Ruby+Node image can run it
+before Node. A Node-only renderer needs that step to use the promoted app
+artifact/config. The step and renderer must mount the same writable shared volume at
 `RENDERER_SERVER_BUNDLE_CACHE_PATH`, or copy/sync the completed cache into the
 renderer before it starts; gate renderer start/readiness on completion. Without
 a Ruby-capable step that makes the completed cache available to the renderer,

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -39,7 +39,6 @@ module ReactOnRailsPro
       remote_bundle_cache_adapter: Configuration::DEFAULT_REMOTE_BUNDLE_CACHE_ADAPTER,
       rolling_deploy_adapter: Configuration::DEFAULT_ROLLING_DEPLOY_ADAPTER,
       rolling_deploy_token: Configuration::DEFAULT_ROLLING_DEPLOY_TOKEN,
-      rolling_deploy_previous_url: Configuration::DEFAULT_ROLLING_DEPLOY_PREVIOUS_URL,
       rolling_deploy_previous_urls: Configuration::DEFAULT_ROLLING_DEPLOY_PREVIOUS_URLS,
       rolling_deploy_mount_path: Configuration::DEFAULT_ROLLING_DEPLOY_MOUNT_PATH,
       ssr_timeout: Configuration::DEFAULT_SSR_TIMEOUT,
@@ -82,11 +81,6 @@ module ReactOnRailsPro
     DEFAULT_REMOTE_BUNDLE_CACHE_ADAPTER = nil
     DEFAULT_ROLLING_DEPLOY_ADAPTER = nil
     DEFAULT_ROLLING_DEPLOY_TOKEN = nil
-    # Two knobs, both default-unset: `*_URL` is the original single-origin form
-    # (kept for backward compatibility); `*_URLS` is the newer ordered-multi-origin
-    # form. Configure only one — the plural reader falls back to the singular and
-    # setup rejects setting both. See `rolling_deploy_previous_urls` below.
-    DEFAULT_ROLLING_DEPLOY_PREVIOUS_URL = nil
     DEFAULT_ROLLING_DEPLOY_PREVIOUS_URLS = nil
     DEFAULT_ROLLING_DEPLOY_MOUNT_PATH = "/react_on_rails_pro/rolling_deploy"
     # Minimum bearer-token length when using the built-in HTTP rolling-deploy adapter.
@@ -121,7 +115,7 @@ module ReactOnRailsPro
                   :renderer_http_pool_timeout, :renderer_http_pool_warn_timeout,
                   :dependency_globs, :excluded_dependency_globs, :rendering_returns_promises,
                   :remote_bundle_cache_adapter, :rolling_deploy_adapter,
-                  :rolling_deploy_token, :rolling_deploy_previous_url, :rolling_deploy_mount_path,
+                  :rolling_deploy_token, :rolling_deploy_previous_urls, :rolling_deploy_mount_path,
                   :ssr_pre_hook_js, :assets_to_copy,
                   :renderer_request_retry_limit, :throw_js_errors, :ssr_timeout,
                   :profile_server_rendering_js_code, :raise_non_shell_server_rendering_errors, :enable_rsc_support,
@@ -131,15 +125,6 @@ module ReactOnRailsPro
     attr_reader :concurrent_component_streaming_buffer_size, :renderer_http_keep_alive_timeout,
                 :renderer_http_pool_size, :cache_tag_index_expires_in, :cache_tag_index_max_keys,
                 :rsc_payload_authorizer
-
-    attr_writer :rolling_deploy_previous_urls
-
-    # The plural setting is preferred for new deployments. Falling back to the
-    # singular value keeps both constructor and configure-block callers
-    # backward compatible while setup rejects ambiguous use of both knobs.
-    def rolling_deploy_previous_urls
-      @rolling_deploy_previous_urls.nil? ? rolling_deploy_previous_url : @rolling_deploy_previous_urls
-    end
 
     # Sets how long tag->key index entries live (see Cache::TagIndex).
     #
@@ -234,8 +219,7 @@ module ReactOnRailsPro
                    tracing: nil,
                    dependency_globs: nil, excluded_dependency_globs: nil, rendering_returns_promises: nil,
                    remote_bundle_cache_adapter: nil, rolling_deploy_adapter: nil,
-                   rolling_deploy_token: nil, rolling_deploy_previous_url: nil,
-                   rolling_deploy_previous_urls: nil,
+                   rolling_deploy_token: nil, rolling_deploy_previous_urls: nil,
                    rolling_deploy_mount_path: nil,
                    ssr_pre_hook_js: nil, assets_to_copy: nil,
                    renderer_request_retry_limit: nil, throw_js_errors: nil, ssr_timeout: nil,
@@ -264,7 +248,6 @@ module ReactOnRailsPro
       self.remote_bundle_cache_adapter = remote_bundle_cache_adapter
       self.rolling_deploy_adapter = rolling_deploy_adapter
       self.rolling_deploy_token = rolling_deploy_token
-      self.rolling_deploy_previous_url = rolling_deploy_previous_url
       self.rolling_deploy_previous_urls = rolling_deploy_previous_urls
       # Constructor nil/blank means "use the default"; configure-block assignment
       # can still set nil/blank later to opt out of the engine auto-mount.
@@ -292,7 +275,6 @@ module ReactOnRailsPro
       validate_url
       validate_remote_bundle_cache_adapter
       validate_rolling_deploy_adapter
-      validate_rolling_deploy_previous_urls
       validate_rolling_deploy_http_adapter_config
       setup_renderer_password
       validate_renderer_password_for_production
@@ -499,13 +481,6 @@ module ReactOnRailsPro
             "#{ROLLING_DEPLOY_TOKEN_MIN_LENGTH} bytes (got #{token.bytesize}). " \
             "Generate a stronger token with SecureRandom.hex(32). " \
             "See docs/pro/rolling-deploy-adapters.md."
-    end
-
-    def validate_rolling_deploy_previous_urls
-      return unless rolling_deploy_previous_url.present? && @rolling_deploy_previous_urls.present?
-
-      raise ReactOnRailsPro::Error,
-            "Do not configure both rolling_deploy_previous_url and rolling_deploy_previous_urls; choose one."
     end
 
     def validate_rolling_deploy_upload_signature

--- a/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
@@ -40,9 +40,9 @@ module ReactOnRailsPro
     # Configuration (see docs/pro/rolling-deploy-adapters.md):
     #
     #   ReactOnRailsPro.configure do |config|
-    #     config.rolling_deploy_adapter      = ReactOnRailsPro::RollingDeployAdapters::Http
-    #     config.rolling_deploy_token        = ENV.fetch("ROLLING_DEPLOY_TOKEN")
-    #     config.rolling_deploy_previous_url = ENV["ROLLING_DEPLOY_PREVIOUS_URL"]
+    #     config.rolling_deploy_adapter       = ReactOnRailsPro::RollingDeployAdapters::Http
+    #     config.rolling_deploy_token         = ENV.fetch("ROLLING_DEPLOY_TOKEN")
+    #     config.rolling_deploy_previous_urls = ENV["ROLLING_DEPLOY_PREVIOUS_URLS"]
     #   end
     #
     # Error contract matches the rolling_deploy_adapter protocol: every
@@ -272,15 +272,9 @@ module ReactOnRailsPro
           (deadline - monotonic_now).positive?
         end
 
-        def configured_previous_url
-          configured_previous_urls.first
-        end
-
         def configured_previous_urls
           config = ReactOnRailsPro.configuration
-          singular = config.rolling_deploy_previous_url
-          raw = singular.to_s.strip.empty? ? config.rolling_deploy_previous_urls : singular
-          values = Array(raw).flat_map do |entry|
+          values = Array(config.rolling_deploy_previous_urls).flat_map do |entry|
             entry.to_s.split(%r{,\s*(?=[a-z][a-z0-9+.-]*://)}i)
           end
                              .map(&:strip)
@@ -528,7 +522,7 @@ module ReactOnRailsPro
         # by surfacing the cleartext-token risk in build CI logs.
         #
         # Loopback hosts are intentionally exempt so developers running a
-        # local Rails server for `rolling_deploy_previous_url` during
+        # local Rails server for `rolling_deploy_previous_urls` during
         # development don't see noise on every build CI rehearsal — the
         # token never leaves the host in that case.
         LOOPBACK_HOST_PATTERN = /\A(localhost|127(?:\.\d{1,3}){3}|::1|\[::1\])\z/

--- a/react_on_rails_pro/sig/react_on_rails_pro/configuration.rbs
+++ b/react_on_rails_pro/sig/react_on_rails_pro/configuration.rbs
@@ -34,7 +34,6 @@ module ReactOnRailsPro
     DEFAULT_REMOTE_BUNDLE_CACHE_ADAPTER: nil
     DEFAULT_ROLLING_DEPLOY_ADAPTER: nil
     DEFAULT_ROLLING_DEPLOY_TOKEN: nil
-    DEFAULT_ROLLING_DEPLOY_PREVIOUS_URL: nil
     DEFAULT_ROLLING_DEPLOY_PREVIOUS_URLS: nil
     DEFAULT_ROLLING_DEPLOY_MOUNT_PATH: String
     DEFAULT_RENDERER_REQUEST_RETRY_LIMIT: Integer
@@ -72,8 +71,7 @@ module ReactOnRailsPro
     attr_accessor remote_bundle_cache_adapter: Module?
     attr_accessor rolling_deploy_adapter: Module?
     attr_accessor rolling_deploy_token: String?
-    attr_accessor rolling_deploy_previous_url: String?
-    attr_accessor rolling_deploy_previous_urls: String? | Array[String]
+    attr_accessor rolling_deploy_previous_urls: (String | Array[String])?
     attr_accessor rolling_deploy_mount_path: String?
     attr_accessor ssr_pre_hook_js: String?
     attr_accessor assets_to_copy: Array[String]?
@@ -111,8 +109,7 @@ module ReactOnRailsPro
       ?remote_bundle_cache_adapter: Module?,
       ?rolling_deploy_adapter: Module?,
       ?rolling_deploy_token: String?,
-      ?rolling_deploy_previous_url: String?,
-      ?rolling_deploy_previous_urls: String? | Array[String],
+      ?rolling_deploy_previous_urls: (String | Array[String])?,
       ?rolling_deploy_mount_path: String?,
       ?ssr_pre_hook_js: String?,
       ?assets_to_copy: Array[String]?,

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -112,24 +112,14 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
     end
 
     describe ".rolling_deploy_adapter" do
-      it "exposes the singular previous URL through the plural backward-compatible accessor" do
-        config = described_class.new(
-          rolling_deploy_previous_url: "https://old.example.com/rolling"
-        )
-
-        expect(config.rolling_deploy_previous_urls).to eq("https://old.example.com/rolling")
-      end
-
-      it "fails setup clearly when singular and plural previous URLs are both configured" do
+      it "accepts plural previous URLs" do
         config = described_class.new(
           rolling_deploy_adapter: ReactOnRailsPro::RollingDeployAdapters::Http,
           rolling_deploy_token: "t" * 32,
-          rolling_deploy_previous_url: "https://old.example.com/rolling",
           rolling_deploy_previous_urls: ["https://new.example.com/rolling"]
         )
 
-        expect { config.setup_config_values }
-          .to raise_error(ReactOnRailsPro::Error, /both rolling_deploy_previous_url and rolling_deploy_previous_urls/)
+        expect { config.setup_config_values }.not_to raise_error
       end
 
       it "throws if upload does not accept bundle and assets keyword arguments" do

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
@@ -27,7 +27,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "normalizes plural arrays, inherits the mount for bare origins, preserves explicit paths, and deduplicates" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: [
           "https://first.example.com",
           "https://second.example.com/custom/",
@@ -46,7 +45,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "accepts a comma-delimited plural string" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: "https://first.example.com, https://second.example.com/path",
         rolling_deploy_mount_path: "/rolling"
       )
@@ -61,7 +59,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "preserves literal commas inside a single URL path" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: "https://example.com/releases,blue",
         rolling_deploy_mount_path: "/rolling"
       )
@@ -73,7 +70,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "still isolates and rejects unsupported schemes in a comma-delimited string" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: "https://valid.example.com/rolling,file:///etc/passwd",
         rolling_deploy_mount_path: "/rolling"
       )
@@ -86,7 +82,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "collapses repeated slashes in inherited mounts and explicit paths" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: [
           "https://first.example.com",
           "https://second.example.com//custom///nested//"
@@ -104,7 +99,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "normalizes explicit and inherited root paths before endpoint suffixes are appended" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: [
           "https://explicit-root.example.com/",
           "https://inherited-root.example.com"
@@ -126,7 +120,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "preserves an explicit root path instead of replacing it with the configured mount" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://root.example.com/",
+        rolling_deploy_previous_urls: "https://root.example.com/",
         rolling_deploy_mount_path: "/rolling"
       )
       allow(ReactOnRailsPro).to receive(:configuration).and_return(config)
@@ -137,7 +131,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "rejects unsafe URL components and a bare origin when the mount path is blank" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: [
           "https://user:pass@example.com/path",
           "https://example.com/path?query=1",
@@ -156,7 +149,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     it "skips one URL with an invalid inherited path without discarding later explicit URLs" do
       config = instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: [
           "https://invalid-inherited.example.com",
           "https://valid-explicit.example.com/rolling"
@@ -178,7 +170,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: [first, second],
         rolling_deploy_mount_path: "/rolling",
         rolling_deploy_token: "token"
@@ -251,7 +242,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_mount_path: "/react_on_rails_pro/rolling_deploy",
         rolling_deploy_token: "token"
       )
@@ -348,7 +339,6 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: nil,
         rolling_deploy_previous_urls: [first, second],
         rolling_deploy_mount_path: "/rolling",
         rolling_deploy_token: "token"
@@ -474,7 +464,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_mount_path: "/react_on_rails_pro/rolling_deploy",
         rolling_deploy_token: "token"
       )
@@ -564,7 +554,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: previous_url,
+        rolling_deploy_previous_urls: previous_url,
         rolling_deploy_mount_path: "/react_on_rails_pro/rolling_deploy",
         rolling_deploy_token: "token"
       )
@@ -602,7 +592,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_mount_path: "/react_on_rails_pro/rolling_deploy",
         rolling_deploy_token: "token"
       )
@@ -632,7 +622,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
     let(:config) do
       instance_double(
         ReactOnRailsPro::Configuration,
-        rolling_deploy_previous_url: "https://example.com",
+        rolling_deploy_previous_urls: "https://example.com",
         rolling_deploy_mount_path: "/react_on_rails_pro/rolling_deploy",
         rolling_deploy_token: ""
       )


### PR DESCRIPTION
### Summary

Forward-port the source changes from #4544 to `main` as their own focused PR.

The change fixes slow SSR during staging-to-production image promotion. A promoted image can now seed rolling-deploy bundles from multiple previous-deployment endpoints, while a release-time boot seed resolves the target environment's actually draining bundle.

### Implementation

- Rename the RC-only singular `rolling_deploy_previous_url` configuration to plural `rolling_deploy_previous_urls`.
- Accept one URL, a comma-delimited string, or an array of URLs.
- Preserve the newer `main`-branch safety hardening:
  - omit ambiguous multi-origin legacy hashes;
  - verify v2 payload identity before accepting a response;
  - retry only eligible origins in configured order;
  - degrade gracefully when an individual endpoint fails.
- Document build-time multi-source seeding, release-time boot seeding, deployment ordering, and renderer topology.
- Add the Pro context map and ADR, and regenerate the LLM documentation artifacts.

The commit retains `cherry-pick -x` provenance from source squash commit `cb79ee7229a6dddc5bc460109a4185230dce4c9a`.

### Forward-port scope

- `CHANGELOG.md` is intentionally unchanged here. The final 17.0.0 changelog, including this feature, landed separately in #4742.
- Changes already present on `main` were reconciled instead of duplicated.
- During independent review, stale pre-hardening documentation and inconsistent staging-only fallback language inherited from the release branch were corrected before publication.
- This focused PR replaces the #4544 portion of draft combined forward-port #4734.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] ~Update CHANGELOG file~ — already landed in #4742

### Verification

- Focused Pro configuration and HTTP adapter specs: 125 examples, 0 failures
- Pro CI-equivalent RuboCop
- RBS validation
- Pro license-header validation
- Prettier
- Documentation sidebar and full link checks
- LLM documentation generation check and 7-test harness
- Pre-push changed-file RuboCop and online Markdown link checks
- `git diff --check`
- Independent maker-distinct exact-head review: `MERGE_READY`

The CI change detector recommends the full hosted suite because this includes Pro Ruby runtime code. Optimized hosted CI will be requested for the final head before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added release-time (boot) seeding for the Node Renderer cache during rolling deployments.
  - Added multi-source seeding support using multiple prior deployment URLs.
- **Changes**
  - Standardized rolling-deploy configuration on `rolling_deploy_previous_urls` (singular option removed).
  - Improved deploy stability by gating renderer readiness on boot-seed completion to avoid deploy stalls.
- **Documentation**
  - Expanded guidance on promotion behavior, separate-workloads version drift mitigation, and deployment ordering.
  - Updated adapter setup and rolling-deploy correctness notes, including multi-source discovery and RSC draining considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->