### PR TITLE
Release: enforce one-change forward-port closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,7 @@ flagship demo needs the same change.
 Run specific test files:
 
 ```bash
-bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb
+(cd react_on_rails && bundle exec rspec spec/react_on_rails/path/to/spec.rb)
 cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb
 ```
 
@@ -730,7 +730,7 @@ Releases use a release-train branching model. Full mechanics (cut, stabilize, fo
 
 - **`main` never freezes.** It stays in the `beta` phase and keeps absorbing batch work the whole time.
 - **RCs stabilize on an ephemeral `release/X.Y.Z` branch** (one branch per final target, deleted after the final ships; tags are the durable record). Only stabilizing fixes target `release/*`; new features keep targeting `main`.
-- **Forward-port every `release/*` fix to `main` with `git cherry-pick -x <sha>`.** Never `git merge release/X.Y.Z` into `main` — that leaks the RC version-bump commits onto `main`.
+- **Forward-port every missing `release/*` fix to `main` in its own PR with `git cherry-pick -x <sha>`.** Merge each source-change PR before planning the next one from fresh `origin/main`; skip commits the helper proves are already present or empty. Keep the changelog/release reconciliation in a separate squash PR. Never `git merge release/X.Y.Z` into `main` — that leaks the RC version-bump commits onto `main`.
 - **Final = promote the last good RC by dropping `-rc`**, not a re-cut from `main`. The final's runtime code tree must equal the last good RC's tree — only version/changelog **metadata** differs (under unified versioning the release task bumps `version.rb`, the Pro version file, every workspace `package.json`, and lockfiles in addition to `CHANGELOG.md`), never runtime source; post-cut `main` commits roll into the next version. See the [release-train runbook](internal/contributor-info/release-train-runbook.md) for the per-artifact diff check. The release task supports the in-place promotion directly: a stable `release[X.Y.Z]` runs from `main` **or** the matching `release/X.Y.Z` branch, and the CI gate validates the tip of whichever branch you release from (`origin/release/X.Y.Z` for a release-branch cut/promotion, else `origin/main`).
 
 The **merge gate is a function of the target branch's release phase**. Resolve the phase, then apply its row plus the mode rules above:

--- a/internal/contributor-info/release-train-automation-design.md
+++ b/internal/contributor-info/release-train-automation-design.md
@@ -219,8 +219,9 @@ rake promotion guards with confirmations:
   `bundle exec rake release[X.Y.Z]`
   (all promotion guards already enforced in `release.rake`).
 - **Close out (step 5):** forward-port remaining commits to `main` (uses PR 3),
-  then atomically delete `release/X.Y.Z` with matching leases on the checked source and `main` tips
-  (tags are the durable record).
+  then atomically move the checked source tip to a temporary recovery branch while deleting
+  `release/X.Y.Z` with a source lease. Re-fetch `main`; if it raced, atomically restore the release
+  branch before aborting, otherwise delete the recovery branch (tags remain the durable release record).
 
 Surface to pin at PR-4 design: one script with `promote` / `close-out`
 subcommands vs a single linear flow with a confirmation between phases. This PR is

--- a/internal/contributor-info/release-train-automation-design.md
+++ b/internal/contributor-info/release-train-automation-design.md
@@ -221,7 +221,8 @@ rake promotion guards with confirmations:
 - **Close out (step 5):** forward-port remaining commits to `main` (uses PR 3),
   then atomically move the checked source tip to a temporary recovery branch while deleting
   `release/X.Y.Z` with a source lease. Re-fetch `main`; if it raced, atomically restore the release
-  branch before aborting, otherwise delete the recovery branch (tags remain the durable release record).
+  branch before aborting. If the release branch reappears, retain recovery and abort; otherwise delete
+  the recovery branch (tags remain the durable release record).
 
 Surface to pin at PR-4 design: one script with `promote` / `close-out`
 subcommands vs a single linear flow with a confirmation between phases. This PR is

--- a/internal/contributor-info/release-train-automation-design.md
+++ b/internal/contributor-info/release-train-automation-design.md
@@ -219,7 +219,8 @@ rake promotion guards with confirmations:
   `bundle exec rake release[X.Y.Z]`
   (all promotion guards already enforced in `release.rake`).
 - **Close out (step 5):** forward-port remaining commits to `main` (uses PR 3),
-  then `git push origin --delete release/X.Y.Z` (tags are the durable record).
+  then atomically delete `release/X.Y.Z` with matching leases on the checked source and `main` tips
+  (tags are the durable record).
 
 Surface to pin at PR-4 design: one script with `promote` / `close-out`
 subcommands vs a single linear flow with a confirmation between phases. This PR is

--- a/internal/contributor-info/release-train-automation-design.md
+++ b/internal/contributor-info/release-train-automation-design.md
@@ -221,8 +221,8 @@ rake promotion guards with confirmations:
 - **Close out (step 5):** forward-port remaining commits to `main` (uses PR 3),
   then atomically move the checked source tip to a temporary recovery branch while deleting
   `release/X.Y.Z` with a source lease. Re-fetch `main`; if it raced, atomically restore the release
-  branch before aborting. If the release branch reappears, retain recovery and abort; otherwise delete
-  the recovery branch (tags remain the durable release record).
+  branch before aborting. If the release branch reappears, retain recovery and abort; otherwise atomically
+  prove it remains absent while deleting the recovery branch (tags remain the durable release record).
 
 Surface to pin at PR-4 design: one script with `promote` / `close-out`
 subcommands vs a single linear flow with a confirmation between phases. This PR is

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -349,8 +349,9 @@ git commit -m "Reconcile X.Y.Z release changelog on main"
   matching RC section and no release entry reintroduced under `[Unreleased]`; the helper removes that residue
   in a new changelog reconciliation rather than letting the authority check hide it. This permits reviewed
   consolidation of superseded RC-only entries without allowing a later release-branch or target correction
-  to be hidden. For a legacy dedicated changelog PR that predates the sentence, inspect the current source
-  changelog commit and pass
+  to be hidden. The close-out check also fails if `release/X.Y.Z` no longer contains a matching stable or
+  prerelease `X.Y.Z` section, because a non-destructive no-op is not proof of release completion. For a legacy
+  dedicated changelog PR that predates the sentence, inspect the current source changelog commit and pass
   `--ack-final-changelog-source <sha>` to the changelog check and `release-finish close-out`.
 - Do not create empty marker or provenance-only commits for `SKIP` entries. A commit marked already
   present, patch-equivalent, changelog-only, version-only, generated-only, or empty is evidence that
@@ -497,7 +498,8 @@ requires rerunning both checks. Git omits an unchanged `main` refspec from a pus
 cannot close the last network race. Instead, the deletion atomically moves the checked source tip to a
 temporary `release-finish-recovery/*` branch while deleting the release branch with a real source lease.
 It then re-fetches `main`: if `main` raced, it atomically restores the release branch before aborting;
-otherwise it removes the temporary recovery branch. Pass
+if another actor recreated the release branch, it aborts and retains recovery for inspection; otherwise
+it removes the temporary recovery branch. Pass
 `--ack-manual <sha>` for each
 stable version-bump, merge, or rollback item that was inspected and intentionally required no source
 PR. For a legacy authoritative changelog PR without embedded source-SHA provenance, also pass
@@ -547,8 +549,12 @@ git push --atomic \
   ":${release_ref}"
 
 # Re-fetch immediately. Restore the release branch if main changed during deletion;
-# otherwise remove the temporary recovery branch with its own lease.
+# abort with recovery intact if the release branch reappeared; otherwise remove recovery with its own lease.
 git fetch origin
+if git ls-remote --exit-code --heads -- origin release/17.0.0 >/dev/null 2>&1; then
+  echo "release branch reappeared; retain recovery and rerun all completion checks" >&2
+  exit 1
+fi
 if test "$(git rev-parse origin/main)" != "${checked_main_sha}"; then
   git push --atomic \
     --force-with-lease="${release_ref}:" \

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -316,8 +316,8 @@ git push   # or open a PR if main is protected / the fix needs review on main
   on the target branch. For already-applied patches without the footer, it uses `git cherry` as the
   candidate signal before matching the source patch-id to target history and checking for a later standard
   `git revert` of the matching target commit. Combined squash commits can make the whole-commit patch ID
-  differ, so an exact source-subject mention in target history is also a candidate signal; the helper still
-  requires a path-scoped patch-ID match before skipping the source commit.
+  differ, so an exact source-subject or source-PR mention in target history is also a candidate signal; the
+  helper still requires a path-scoped patch-ID match before skipping the source commit.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Pure `CHANGELOG.md` stamp commits are skipped in code mode. After the code picks finish, run the

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -499,7 +499,8 @@ cannot close the last network race. Instead, the deletion atomically moves the c
 temporary `release-finish-recovery/*` branch while deleting the release branch with a real source lease.
 It then re-fetches `main`: if `main` raced, it atomically restores the release branch before aborting;
 if another actor recreated the release branch, it aborts and retains recovery for inspection; otherwise
-it removes the temporary recovery branch. Pass
+it atomically proves the source remains absent while removing the temporary recovery branch. A concurrent
+source recreation rejects that cleanup transaction and leaves recovery available for inspection. Pass
 `--ack-manual <sha>` for each
 stable version-bump, merge, or rollback item that was inspected and intentionally required no source
 PR. For a legacy authoritative changelog PR without embedded source-SHA provenance, also pass
@@ -549,7 +550,8 @@ git push --atomic \
   ":${release_ref}"
 
 # Re-fetch immediately. Restore the release branch if main changed during deletion;
-# abort with recovery intact if the release branch reappeared; otherwise remove recovery with its own lease.
+# abort with recovery intact if the release branch reappeared; otherwise atomically prove it remains
+# absent while removing recovery with its own lease.
 git fetch origin
 if git ls-remote --exit-code --heads -- origin release/17.0.0 >/dev/null 2>&1; then
   echo "release branch reappeared; retain recovery and rerun all completion checks" >&2
@@ -565,7 +567,12 @@ if test "$(git rev-parse origin/main)" != "${checked_main_sha}"; then
   echo "main changed; release branch restored — rerun close-out" >&2
   exit 1
 fi
-git push --force-with-lease="${recovery_ref}:${checked_source_sha}" origin ":${recovery_ref}"
+git push --atomic \
+  --force-with-lease="${release_ref}:" \
+  --force-with-lease="${recovery_ref}:${checked_source_sha}" \
+  origin \
+  ":${release_ref}" \
+  ":${recovery_ref}"
 ```
 
 > **Caveat — do not blindly cherry-pick version-bump commits.** The helper always skips

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -315,7 +315,9 @@ git push   # or open a PR if main is protected / the fix needs review on main
   evidence when available, unless the footer-bearing target commit has a later standard `git revert` commit
   on the target branch. For already-applied patches without the footer, it uses `git cherry` as the
   candidate signal before matching the source patch-id to target history and checking for a later standard
-  `git revert` of the matching target commit.
+  `git revert` of the matching target commit. Combined squash commits can make the whole-commit patch ID
+  differ, so an exact source-subject mention in target history is also a candidate signal; the helper still
+  requires a path-scoped patch-ID match before skipping the source commit.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Pure `CHANGELOG.md` stamp commits are skipped in code mode. After the code picks finish, run the

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -325,7 +325,7 @@ script/release-forward-port \
   --changelog
 git diff --check
 git add CHANGELOG.md
-git commit -m "Reconcile X.Y.Z release changelog on main"
+git commit -m "Reconcile 17.0.0 release changelog on main"
 # Validate, push, and open the dedicated release/changelog PR to main. Squash it with:
 # Record the final React on Rails X.Y.Z changelog (#<pr-number>)
 # Include this exact sentence in the PR body, using the newest release-branch commit that changed CHANGELOG.md:

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -328,6 +328,8 @@ git add CHANGELOG.md
 git commit -m "Reconcile X.Y.Z release changelog on main"
 # Validate, push, and open the dedicated release/changelog PR to main. Squash it with:
 # Record the final React on Rails X.Y.Z changelog (#<pr-number>)
+# Include this exact sentence in the PR body, using the newest release-branch commit that changed CHANGELOG.md:
+# The final changelog records source CHANGELOG.md commit `<40-character-sha>`.
 ```
 
 - Treat the dry-run plan as a queue, not one combined forward-port branch. Land one missing source
@@ -341,8 +343,12 @@ git commit -m "Reconcile X.Y.Z release changelog on main"
   is not a substitute.
 - Squash the dedicated changelog/release reconciliation PR with
   `Record the final React on Rails X.Y.Z changelog (#<pr-number>)`. Do not mix source changes into it.
-  That changelog-only commit is the authoritative final release record while its `X.Y.Z` section remains
-  byte-for-byte unchanged on `main`; this permits reviewed consolidation of superseded RC-only entries.
+  Include the exact source-CHANGELOG sentence shown above in the PR body. That changelog-only commit is
+  authoritative only while the named source commit remains the newest release-branch `CHANGELOG.md` change
+  and its `X.Y.Z` section remains byte-for-byte unchanged on `main`; this permits reviewed consolidation of
+  superseded RC-only entries without allowing a later release-branch correction to be hidden. For a legacy
+  dedicated changelog PR that predates the sentence, inspect the current source changelog commit and pass
+  `--ack-final-changelog-source <sha>` to the changelog check and `release-finish close-out`.
 - Do not create empty marker or provenance-only commits for `SKIP` entries. A commit marked already
   present, patch-equivalent, changelog-only, version-only, generated-only, or empty is evidence that
   no source PR is needed. The helper's empty-commit guard specifically prevents no-op forward-port
@@ -369,7 +375,9 @@ git commit -m "Reconcile X.Y.Z release changelog on main"
   stale relative to current target documentation. Regenerate both files from the resolved target sources.
 - An interim prerelease package pin is skipped only when a later stable source commit names the same stable
   version, covers every non-changelog/non-generated path of the interim pin, and is independently proven live
-  on the target. This prevents replaying an obsolete RC dependency over an already-forward-ported stable pin.
+  on the target. The cumulative contents and modes of the interim pin's paths at that stable source commit
+  must also match the target. If they differ, the helper marks the interim commit `MANUAL` so an unrelated
+  setting cannot be silently omitted while the stable pin is skipped.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Pure `CHANGELOG.md` stamp commits are skipped in code mode. After the code picks finish, run the
@@ -481,17 +489,22 @@ evidence and maintainer sign-off; it must not become a global skip of CI, ShakaP
 `script/release-forward-port --check` code and changelog plans. It does not apply release commits to
 `main`; step 3's separate PRs must already be merged. Only after both checks pass does it ask for
 confirmation before deleting the release branch on the remote. A final fetch must still find local
-`main` exactly equal to `origin/main`; any intervening commit requires rerunning both checks. Pass
+`main` exactly equal to `origin/main` and both checked remote tips unchanged; any intervening commit
+requires rerunning both checks. The deletion uses one atomic push with matching leases for `main` and
+the release branch, so neither ref can change in the final fetch-to-delete window. Pass
 `--ack-manual <sha>` for each
 stable version-bump, merge, or rollback item that was inspected and intentionally required no source
-PR. Preview everything first with `--dry-run`:
+PR. For a legacy authoritative changelog PR without embedded source-SHA provenance, also pass
+`--ack-final-changelog-source <current-source-changelog-sha>`. Preview everything first with `--dry-run`:
 
 ```bash
 git fetch origin
 git checkout main
 git pull --rebase
 script/release-finish close-out 17.0.0 --dry-run   # prints commands + the real forward-port plan
-script/release-finish close-out 17.0.0 --ack-manual <inspected-sha>
+script/release-finish close-out 17.0.0 \
+  --ack-manual <inspected-sha> \
+  --ack-final-changelog-source <current-source-changelog-sha>
 # If either check is incomplete, land the PRs from step 3 and rerun. No source commit is applied here.
 ```
 
@@ -503,15 +516,27 @@ The manual equivalent the script wraps is below.
 git fetch origin
 git checkout main
 git pull --rebase
+checked_main_sha="$(git rev-parse origin/main)"
+checked_source_sha="$(git rev-parse origin/release/17.0.0)"
 
 # The read-only completion checks must pass after every source PR and the separate
 # changelog/release squash PR have merged. Acknowledge only inspected MANUAL items.
 script/release-forward-port --source origin/release/17.0.0 --target main --check \
   --ack-manual <inspected-sha>
-script/release-forward-port --source origin/release/17.0.0 --target main --changelog --check
+script/release-forward-port --source origin/release/17.0.0 --target main --changelog --check \
+  --ack-final-changelog-source <current-source-changelog-sha>
 
-# 2. Delete the ephemeral branch only after both checks pass — tags are the durable record.
-git push origin --delete release/17.0.0
+# 2. Prefer release-finish for deletion. Its atomic leased push verifies that neither checked ref changed.
+# If reproducing it manually, fetch and compare both refs to the SHAs captured before the checks:
+git fetch origin
+test "$(git rev-parse origin/main)" = "${checked_main_sha}"
+test "$(git rev-parse origin/release/17.0.0)" = "${checked_source_sha}"
+git push --atomic \
+  --force-with-lease="refs/heads/main:${checked_main_sha}" \
+  --force-with-lease="refs/heads/release/17.0.0:${checked_source_sha}" \
+  origin \
+  "${checked_main_sha}:refs/heads/main" \
+  ":refs/heads/release/17.0.0"
 ```
 
 > **Caveat — do not blindly cherry-pick version-bump commits.** The helper always skips

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -326,15 +326,21 @@ script/release-forward-port \
 git diff --check
 git add CHANGELOG.md
 git commit -m "Reconcile X.Y.Z release changelog on main"
-# Validate, push, and open the dedicated release/changelog PR to main.
+# Validate, push, and open the dedicated release/changelog PR to main. Squash it with:
+# Record the final React on Rails X.Y.Z changelog (#<pr-number>)
 ```
 
 - Treat the dry-run plan as a queue, not one combined forward-port branch. Land one missing source
   change per PR, wait for it to merge, fetch the new `origin/main`, and then plan the next PR. Prefer
   a history-preserving rebase merge for source-change PRs. If the repository merge queue enforces a
   squash, the one-change-per-PR boundary is mandatory and the PR title/body must identify the release
-  source commit and source PR.
-- Squash the dedicated changelog/release reconciliation PR. Do not mix source changes into it.
+  source commit and source PR. Use this exact positive provenance sentence in the PR body so the
+  squash commit remains machine-checkable even when Markdown wraps it:
+  `The commit retains \`cherry-pick -x\` provenance from source squash commit \`<40-character-sha>\`.`
+- Squash the dedicated changelog/release reconciliation PR with
+  `Record the final React on Rails X.Y.Z changelog (#<pr-number>)`. Do not mix source changes into it.
+  That changelog-only commit is the authoritative final release record while its `X.Y.Z` section remains
+  byte-for-byte unchanged on `main`; this permits reviewed consolidation of superseded RC-only entries.
 - Do not create empty marker or provenance-only commits for `SKIP` entries. A commit marked already
   present, patch-equivalent, changelog-only, version-only, generated-only, or empty is evidence that
   no source PR is needed. The helper's empty-commit guard specifically prevents no-op forward-port
@@ -351,9 +357,10 @@ git commit -m "Reconcile X.Y.Z release changelog on main"
   backport body explicitly names its upstream PR, the helper can use a zero-context path-scoped match so
   harmless neighboring context drift does not hide an otherwise identical patch.
 - Adapted backports can record stronger provenance instead of byte-equivalent patches. The helper recognizes
-  a narrated main commit SHA cherry-picked with `-x`, an explicit upstream PR in a release backport body, or
-  a target `Forward-port ...` commit that names the release PR and records `git cherry-pick -x`. It skips only
-  while the identified target commit remains live; a later standard revert makes the source eligible again.
+  the exact source-SHA sentence above, positive action lines such as `Backports #123 to the release train`,
+  and reviewed replacement/forward-port forms covered by the release tooling specs. Incidental, contrastive,
+  or negated prose such as `not a backport from main PR #123` is never authoritative. The helper skips only
+  while every identified target commit remains live; a later standard revert makes the source eligible again.
 - Generated-only `llms-full.txt` / `llms-full-pro.txt` commits are skipped because release artifacts can be
   stale relative to current target documentation. Regenerate both files from the resolved target sources.
 - An interim prerelease package pin is skipped only when a later stable source commit names the same stable
@@ -469,7 +476,9 @@ evidence and maintainer sign-off; it must not become a global skip of CI, ShakaP
 `git fetch`, asserts you are on a clean and current `main`, and runs the real
 `script/release-forward-port --check` code and changelog plans. It does not apply release commits to
 `main`; step 3's separate PRs must already be merged. Only after both checks pass does it ask for
-confirmation before deleting the release branch on the remote. Pass `--ack-manual <sha>` for each
+confirmation before deleting the release branch on the remote. A final fetch must still find local
+`main` exactly equal to `origin/main`; any intervening commit requires rerunning both checks. Pass
+`--ack-manual <sha>` for each
 stable version-bump, merge, or rollback item that was inspected and intentionally required no source
 PR. Preview everything first with `--dry-run`:
 

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -345,9 +345,12 @@ git commit -m "Reconcile X.Y.Z release changelog on main"
   `Record the final React on Rails X.Y.Z changelog (#<pr-number>)`. Do not mix source changes into it.
   Include the exact source-CHANGELOG sentence shown above in the PR body. That changelog-only commit is
   authoritative only while the named source commit remains the newest release-branch `CHANGELOG.md` change
-  and its `X.Y.Z` section remains byte-for-byte unchanged on `main`; this permits reviewed consolidation of
-  superseded RC-only entries without allowing a later release-branch correction to be hidden. For a legacy
-  dedicated changelog PR that predates the sentence, inspect the current source changelog commit and pass
+  and its `X.Y.Z` section remains byte-for-byte unchanged on `main`. The current target must also have no
+  matching RC section and no release entry reintroduced under `[Unreleased]`; the helper removes that residue
+  in a new changelog reconciliation rather than letting the authority check hide it. This permits reviewed
+  consolidation of superseded RC-only entries without allowing a later release-branch or target correction
+  to be hidden. For a legacy dedicated changelog PR that predates the sentence, inspect the current source
+  changelog commit and pass
   `--ack-final-changelog-source <sha>` to the changelog check and `release-finish close-out`.
 - Do not create empty marker or provenance-only commits for `SKIP` entries. A commit marked already
   present, patch-equivalent, changelog-only, version-only, generated-only, or empty is evidence that
@@ -490,8 +493,11 @@ evidence and maintainer sign-off; it must not become a global skip of CI, ShakaP
 `main`; step 3's separate PRs must already be merged. Only after both checks pass does it ask for
 confirmation before deleting the release branch on the remote. A final fetch must still find local
 `main` exactly equal to `origin/main` and both checked remote tips unchanged; any intervening commit
-requires rerunning both checks. The deletion uses one atomic push with matching leases for `main` and
-the release branch, so neither ref can change in the final fetch-to-delete window. Pass
+requires rerunning both checks. Git omits an unchanged `main` refspec from a push, so a no-op main lease
+cannot close the last network race. Instead, the deletion atomically moves the checked source tip to a
+temporary `release-finish-recovery/*` branch while deleting the release branch with a real source lease.
+It then re-fetches `main`: if `main` raced, it atomically restores the release branch before aborting;
+otherwise it removes the temporary recovery branch. Pass
 `--ack-manual <sha>` for each
 stable version-bump, merge, or rollback item that was inspected and intentionally required no source
 PR. For a legacy authoritative changelog PR without embedded source-SHA provenance, also pass
@@ -526,17 +532,34 @@ script/release-forward-port --source origin/release/17.0.0 --target main --check
 script/release-forward-port --source origin/release/17.0.0 --target main --changelog --check \
   --ack-final-changelog-source <current-source-changelog-sha>
 
-# 2. Prefer release-finish for deletion. Its atomic leased push verifies that neither checked ref changed.
-# If reproducing it manually, fetch and compare both refs to the SHAs captured before the checks:
+# 2. Prefer release-finish for deletion. If reproducing it manually, fetch and compare both refs,
+# then preserve the source tip on a temporary remote branch throughout the destructive window:
 git fetch origin
 test "$(git rev-parse origin/main)" = "${checked_main_sha}"
 test "$(git rev-parse origin/release/17.0.0)" = "${checked_source_sha}"
+release_ref="refs/heads/release/17.0.0"
+recovery_ref="refs/heads/release-finish-recovery/17.0.0-${checked_source_sha:0:12}"
 git push --atomic \
-  --force-with-lease="refs/heads/main:${checked_main_sha}" \
-  --force-with-lease="refs/heads/release/17.0.0:${checked_source_sha}" \
+  --force-with-lease="${release_ref}:${checked_source_sha}" \
+  --force-with-lease="${recovery_ref}:" \
   origin \
-  "${checked_main_sha}:refs/heads/main" \
-  ":refs/heads/release/17.0.0"
+  "${checked_source_sha}:${recovery_ref}" \
+  ":${release_ref}"
+
+# Re-fetch immediately. Restore the release branch if main changed during deletion;
+# otherwise remove the temporary recovery branch with its own lease.
+git fetch origin
+if test "$(git rev-parse origin/main)" != "${checked_main_sha}"; then
+  git push --atomic \
+    --force-with-lease="${release_ref}:" \
+    --force-with-lease="${recovery_ref}:${checked_source_sha}" \
+    origin \
+    "${checked_source_sha}:${release_ref}" \
+    ":${recovery_ref}"
+  echo "main changed; release branch restored — rerun close-out" >&2
+  exit 1
+fi
+git push --force-with-lease="${recovery_ref}:${checked_source_sha}" origin ":${recovery_ref}"
 ```
 
 > **Caveat — do not blindly cherry-pick version-bump commits.** The helper always skips

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -288,29 +288,59 @@ dependency. For `17.0.0` and `react-on-rails-rsc@19.2.1`, use this order:
 Every fix that lands on `release/X.Y.Z` must also reach `main`, or `main` regresses the moment the
 release branch is deleted. Use `script/release-forward-port` first so the operation is dry-run-able,
 idempotent, and skips RC version-bump commits. The helper uses **`git cherry-pick -x`** for commits it
-applies; do not use a branch merge:
+applies; do not use a branch merge or combine the remaining source fixes into one catch-all PR.
 
 ```bash
 git fetch origin
-git checkout main
-git pull --rebase
 
-# Inspect the plan first. Expect fix commits to be PICK and pure CHANGELOG/version-bump
+# Inspect the complete plan from current main. Expect missing fix commits to be PICK and pure CHANGELOG/version-bump
 # commits to be SKIP; changelog content is handled by the reconciliation pass below.
 script/release-forward-port --source origin/release/17.0.0 --target main --dry-run
 
-# Apply the same plan. The helper checks out the local target branch and cherry-picks with -x.
-script/release-forward-port --source origin/release/17.0.0 --target main
+# For EACH remaining PICK, start again from the latest origin/main and create one source-change PR.
+# Replace <source-sha>, <source-pr>, and <slug>; merge this PR before starting the next one.
+git switch -c forward-port/<source-pr>-<slug> origin/main
+script/release-forward-port \
+  --source origin/release/17.0.0 \
+  --target forward-port/<source-pr>-<slug> \
+  --only <source-sha> \
+  --dry-run
+script/release-forward-port \
+  --source origin/release/17.0.0 \
+  --target forward-port/<source-pr>-<slug> \
+  --only <source-sha>
+# Validate, push, open the PR to main, and merge it before repeating from a freshly fetched origin/main.
 
-# Preview, then re-home all release changelog entries under main's [Unreleased].
-script/release-forward-port --source origin/release/17.0.0 --target main --changelog --dry-run
-script/release-forward-port --source origin/release/17.0.0 --target main --changelog
+# After every source-change PR has merged, use a separate release/changelog branch and PR.
+git fetch origin main
+git switch -c release/reconcile-17.0.0-changelog origin/main
+script/release-forward-port \
+  --source origin/release/17.0.0 \
+  --target release/reconcile-17.0.0-changelog \
+  --changelog \
+  --dry-run
+script/release-forward-port \
+  --source origin/release/17.0.0 \
+  --target release/reconcile-17.0.0-changelog \
+  --changelog
 git diff --check
 git add CHANGELOG.md
 git commit -m "Reconcile X.Y.Z release changelog on main"
-git push   # or open a PR if main is protected / the fix needs review on main
+# Validate, push, and open the dedicated release/changelog PR to main.
 ```
 
+- Treat the dry-run plan as a queue, not one combined forward-port branch. Land one missing source
+  change per PR, wait for it to merge, fetch the new `origin/main`, and then plan the next PR. Prefer
+  a history-preserving rebase merge for source-change PRs. If the repository merge queue enforces a
+  squash, the one-change-per-PR boundary is mandatory and the PR title/body must identify the release
+  source commit and source PR.
+- Squash the dedicated changelog/release reconciliation PR. Do not mix source changes into it.
+- Do not create empty marker or provenance-only commits for `SKIP` entries. A commit marked already
+  present, patch-equivalent, changelog-only, version-only, generated-only, or empty is evidence that
+  no source PR is needed. The helper's empty-commit guard specifically prevents no-op forward-port
+  markers from reaching `main`.
+- Normal mode refuses to apply more than one actionable commit unless `--all` is explicit. `--all`
+  exists for exceptional local recovery and is not the main-branch release close-out workflow.
 - The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
   evidence when available, unless the footer-bearing target commit has a later standard `git revert` commit
   on the target branch. For already-applied patches without the footer, it uses `git cherry` as the
@@ -436,36 +466,38 @@ evidence and maintainer sign-off; it must not become a global skip of CI, ShakaP
 ### 5. Close out the release line
 
 **Scripted path (recommended).** `script/release-finish close-out X.Y.Z` orchestrates this step: it runs
-`git fetch`, asserts you are on `main` with a clean tree, shows the real `script/release-forward-port`
-dry-run plan, then asks for explicit confirmation before applying the forward-port and, separately,
-before deleting the release branch on the remote. It shells out to the existing
-`script/release-forward-port` interface (it does not re-implement forward-porting), so the same plan,
-skips, and `MANUAL` handling described in step 3 apply. Preview everything first with `--dry-run`:
+`git fetch`, asserts you are on a clean and current `main`, and runs the real
+`script/release-forward-port --check` code and changelog plans. It does not apply release commits to
+`main`; step 3's separate PRs must already be merged. Only after both checks pass does it ask for
+confirmation before deleting the release branch on the remote. Pass `--ack-manual <sha>` for each
+stable version-bump, merge, or rollback item that was inspected and intentionally required no source
+PR. Preview everything first with `--dry-run`:
 
 ```bash
 git fetch origin
 git checkout main
 git pull --rebase
 script/release-finish close-out 17.0.0 --dry-run   # prints commands + the real forward-port plan
-script/release-finish close-out 17.0.0             # applies, with confirmations before each outward op
-# Then `git push` the forward-ported commits to main (or open a PR if main is protected).
+script/release-finish close-out 17.0.0 --ack-manual <inspected-sha>
+# If either check is incomplete, land the PRs from step 3 and rerun. No source commit is applied here.
 ```
 
 The manual equivalent the script wraps is below.
 
 ```bash
 # After v17.0.0 is published and the GitHub release exists:
-# 1. Forward-port any remaining release-branch commits to main:
+# 1. Forward-port any remaining release-branch commits through the separate PRs in step 3.
 git fetch origin
 git checkout main
 git pull --rebase
 
-# The helper skips rc version bumps and already-forward-ported fixes.
-# It reports stable final version bumps as MANUAL so CHANGELOG extraction is explicit.
-script/release-forward-port --source origin/release/17.0.0 --target main --dry-run
-script/release-forward-port --source origin/release/17.0.0 --target main
-git push   # or open a PR if main is protected
-# 2. Delete the ephemeral branch — the tags are the durable record.
+# The read-only completion checks must pass after every source PR and the separate
+# changelog/release squash PR have merged. Acknowledge only inspected MANUAL items.
+script/release-forward-port --source origin/release/17.0.0 --target main --check \
+  --ack-manual <inspected-sha>
+script/release-forward-port --source origin/release/17.0.0 --target main --changelog --check
+
+# 2. Delete the ephemeral branch only after both checks pass — tags are the durable record.
 git push origin --delete release/17.0.0
 ```
 
@@ -476,9 +508,9 @@ git push origin --delete release/17.0.0
 > `main`'s current version to the commit subject and skips with an explicit version-drift message when
 > `main` has already advanced past the release version (e.g. to `17.1.0.dev`) or already has that version.
 > If the skipped final version-bump commit also contains the only CHANGELOG collapse you need on `main`,
-> use the manual fallback: cherry-pick that one commit, resolve version artifacts to keep `main`'s newer
-> version, keep only the intended CHANGELOG changes, and preserve a `(cherry picked from commit <sha>)`
-> footer in the final commit message. Then bump `main` to the next dev version per
+> use the dedicated `--changelog` reconciliation branch and squash PR; do not cherry-pick the release
+> version commit. After that PR merges and the changelog check passes, give its inspected source SHA to
+> `release-finish close-out --ack-manual <sha>`. Then bump `main` to the next dev version per
 > [`releasing.md`](releasing.md) if it is not already.
 
 See [`releasing.md`](releasing.md) for the next-dev version bump details.

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -337,6 +337,8 @@ git commit -m "Reconcile X.Y.Z release changelog on main"
   source commit and source PR. Use this exact positive provenance sentence in the PR body so the
   squash commit remains machine-checkable even when Markdown wraps it:
   `The commit retains \`cherry-pick -x\` provenance from source squash commit \`<40-character-sha>\`.`
+  That exact sentence is authoritative regardless of the squash title; free-form or negated prose
+  is not a substitute.
 - Squash the dedicated changelog/release reconciliation PR with
   `Record the final React on Rails X.Y.Z changelog (#<pr-number>)`. Do not mix source changes into it.
   That changelog-only commit is the authoritative final release record while its `X.Y.Z` section remains
@@ -347,6 +349,8 @@ git commit -m "Reconcile X.Y.Z release changelog on main"
   markers from reaching `main`.
 - Normal mode refuses to apply more than one actionable commit unless `--all` is explicit. `--all`
   exists for exceptional local recovery and is not the main-branch release close-out workflow.
+- `--check` and `release-finish close-out` refuse to run while a cherry-pick is in progress, including
+  an empty cherry-pick whose porcelain status appears clean. Finish, skip, or abort it first.
 - The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
   evidence when available, unless the footer-bearing target commit has a later standard `git revert` commit
   on the target branch. For already-applied patches without the footer, it uses `git cherry` as the

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -370,15 +370,15 @@ git commit -m "Reconcile 17.0.0 release changelog on main"
   helper still requires a path-scoped patch-ID match before skipping the source commit. When a release
   backport body explicitly names its upstream PR, the helper can use a zero-context path-scoped match so
   harmless neighboring context drift does not hide an otherwise identical patch.
-- Adapted backports can record stronger provenance instead of byte-equivalent patches. The helper recognizes
-  the exact source-SHA sentence above, an explicit whole-commit statement such as
+- Adapted backports can record their upstream PR relationship, but source-commit narration is not content
+  proof. Statements such as `Backports #123 to the release train`,
   `This is equivalent to main PR #123 with release-specific behavior preserved.`, and reviewed
-  replacement/forward-port forms covered by the release tooling specs. The source commit's non-changelog
-  paths must also be covered by the identified target commits. A generic action line such as
-  `Backports #123 to the release train` proves only the source relationship, not whole-commit equivalence,
-  so the helper reports `MANUAL` for inspection instead of silently skipping it. Incidental, contrastive,
-  or negated prose such as `not a backport from main PR #123` is never authoritative. The helper skips only
-  while every identified target commit remains live; a later standard revert makes the source eligible again.
+  replacement/composite forms therefore report `MANUAL` for operator inspection when every required target
+  commit remains live. They never produce an automatic skip from PR numbers or shared path names alone.
+  Automatic skips still require patch equivalence, `cherry-pick -x`, or exact source-bound provenance recorded
+  by the target forward-port commit. Incidental, contrastive, or negated prose such as
+  `not a backport from main PR #123` is never authoritative. A later standard revert makes the source eligible
+  again instead of leaving it as an acknowledged relationship.
 - Generated-only `llms-full.txt` / `llms-full-pro.txt` commits are skipped because release artifacts can be
   stale relative to current target documentation. Regenerate both files from the resolved target sources.
 - An interim prerelease package pin is skipped only when a later stable source commit names the same stable

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -295,12 +295,19 @@ git fetch origin
 git checkout main
 git pull --rebase
 
-# Inspect the plan first. Expect fix/CHANGELOG commits to be PICK and
-# Bump version commits to be SKIP.
+# Inspect the plan first. Expect fix commits to be PICK and pure CHANGELOG/version-bump
+# commits to be SKIP; changelog content is handled by the reconciliation pass below.
 script/release-forward-port --source origin/release/17.0.0 --target main --dry-run
 
 # Apply the same plan. The helper checks out the local target branch and cherry-picks with -x.
 script/release-forward-port --source origin/release/17.0.0 --target main
+
+# Preview, then re-home all release changelog entries under main's [Unreleased].
+script/release-forward-port --source origin/release/17.0.0 --target main --changelog --dry-run
+script/release-forward-port --source origin/release/17.0.0 --target main --changelog
+git diff --check
+git add CHANGELOG.md
+git commit -m "Reconcile X.Y.Z release changelog on main"
 git push   # or open a PR if main is protected / the fix needs review on main
 ```
 
@@ -311,6 +318,9 @@ git push   # or open a PR if main is protected / the fix needs review on main
   `git revert` of the matching target commit.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
+- Pure `CHANGELOG.md` stamp commits are skipped in code mode. After the code picks finish, run the
+  separate `--changelog` dry-run and apply commands shown above; that pass de-duplicates release entries
+  into `main`'s `[Unreleased]` section and removes RC-header residue from mixed code/changelog picks.
 - Known limitation: the "already forward-ported" skip still starts from history evidence. If a later
   target commit quotes the exact `(cherry picked from commit <sha>)` footer in its message body, that can
   look like `-x` evidence. Standard `git revert` commits of the footer-bearing target commit prevent the

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -312,7 +312,7 @@ script/release-forward-port \
 # Validate, push, open the PR to main, and merge it before repeating from a freshly fetched origin/main.
 
 # After every source-change PR has merged, use a separate release/changelog branch and PR.
-git fetch origin main
+git fetch --prune origin main
 git switch -c release/reconcile-17.0.0-changelog origin/main
 script/release-forward-port \
   --source origin/release/17.0.0 \
@@ -371,8 +371,12 @@ git commit -m "Reconcile 17.0.0 release changelog on main"
   backport body explicitly names its upstream PR, the helper can use a zero-context path-scoped match so
   harmless neighboring context drift does not hide an otherwise identical patch.
 - Adapted backports can record stronger provenance instead of byte-equivalent patches. The helper recognizes
-  the exact source-SHA sentence above, positive action lines such as `Backports #123 to the release train`,
-  and reviewed replacement/forward-port forms covered by the release tooling specs. Incidental, contrastive,
+  the exact source-SHA sentence above, an explicit whole-commit statement such as
+  `This is equivalent to main PR #123 with release-specific behavior preserved.`, and reviewed
+  replacement/forward-port forms covered by the release tooling specs. The source commit's non-changelog
+  paths must also be covered by the identified target commits. A generic action line such as
+  `Backports #123 to the release train` proves only the source relationship, not whole-commit equivalence,
+  so the helper reports `MANUAL` for inspection instead of silently skipping it. Incidental, contrastive,
   or negated prose such as `not a backport from main PR #123` is never authoritative. The helper skips only
   while every identified target commit remains live; a later standard revert makes the source eligible again.
 - Generated-only `llms-full.txt` / `llms-full-pro.txt` commits are skipped because release artifacts can be

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -317,7 +317,18 @@ git push   # or open a PR if main is protected / the fix needs review on main
   candidate signal before matching the source patch-id to target history and checking for a later standard
   `git revert` of the matching target commit. Combined squash commits can make the whole-commit patch ID
   differ, so an exact source-subject or source-PR mention in target history is also a candidate signal; the
-  helper still requires a path-scoped patch-ID match before skipping the source commit.
+  helper still requires a path-scoped patch-ID match before skipping the source commit. When a release
+  backport body explicitly names its upstream PR, the helper can use a zero-context path-scoped match so
+  harmless neighboring context drift does not hide an otherwise identical patch.
+- Adapted backports can record stronger provenance instead of byte-equivalent patches. The helper recognizes
+  a narrated main commit SHA cherry-picked with `-x`, an explicit upstream PR in a release backport body, or
+  a target `Forward-port ...` commit that names the release PR and records `git cherry-pick -x`. It skips only
+  while the identified target commit remains live; a later standard revert makes the source eligible again.
+- Generated-only `llms-full.txt` / `llms-full-pro.txt` commits are skipped because release artifacts can be
+  stale relative to current target documentation. Regenerate both files from the resolved target sources.
+- An interim prerelease package pin is skipped only when a later stable source commit names the same stable
+  version, covers every non-changelog/non-generated path of the interim pin, and is independently proven live
+  on the target. This prevents replaying an obsolete RC dependency over an already-forward-ported stable pin.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Pure `CHANGELOG.md` stamp commits are skipped in code mode. After the code picks finish, run the

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -475,7 +475,8 @@ RSpec.describe "script/release-forward-port" do
         "-m",
         "Forward-port release regression (#999)",
         "-m",
-        "- cherry-picked the merged #123 squash commit with `git cherry-pick -x`"
+        "Release PR #123 must be forward-ported with `git cherry-pick -x`.\n\n" \
+        "The conflict resolution preserves newer main behavior."
       )
 
       stdout, stderr, status =
@@ -485,6 +486,36 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("narrated cherry-pick -x evidence")
       expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nnewer main fix\n")
+    end
+  end
+
+  it "uses source-body backport PR references to find exact target patches" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      write_file(repo, "main-only.txt", "combined target work\n")
+      commit_all(repo, "Fix release regression on main (#123)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regression (#456)",
+        "-m",
+        "Backports merged source PR #123 to the release train."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).not_to include("PICK #{release_fix_sha[0, 12]} Backport release regression (#456)")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -1051,6 +1051,44 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "does not mistake an upstream title reference for the composite backport's release PR" do
+    with_release_repo do |repo|
+      shared_base_sha = git(repo, "rev-parse", "HEAD").strip
+      write_file(repo, "base-fix.txt", "main implementation\n")
+      commit_all(repo, "Fix prerelease retry ambiguity (#789)")
+      write_file(repo, "unrelated-review.txt", "unrelated review change\n")
+      git(repo, "add", "unrelated-review.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port an unrelated review guard (#999)",
+        "-m",
+        "Forward-port the review fix from release PR #123."
+      )
+
+      git(repo, "checkout", "-b", "release/1.0.1", shared_base_sha)
+      write_file(repo, "base-fix.txt", "release-adapted implementation\n")
+      write_file(repo, "release-review.txt", "required release review guard\n")
+      git(repo, "add", "base-fix.txt", "release-review.txt")
+      release_sha = commit_all(
+        repo,
+        "Backport upstream #123 with reviewed guard (#456)\n\n" \
+        "Backports #789 and includes the reviewed release-only guard."
+      )
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+      expect(stdout).to include("PICK #{release_sha[0, 12]} Backport upstream #123 with reviewed guard (#456)")
+      expect(stdout).not_to include("source commit identifies a live upstream PR already present on main")
+    end
+  end
+
   it "does not trust negated or contrastive backport prose as provenance" do
     with_release_repo do |repo|
       write_file(repo, "app.txt", "base\nunrelated main change\n")
@@ -1463,6 +1501,36 @@ RSpec.describe "script/release-forward-port" do
 
       expect(status).to be_success, stderr
       expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression (#11)")
+      expect(stdout).not_to include("source-bound forward-port narration")
+    end
+  end
+
+  it "uses only the terminal squash trailer as the source PR identity" do
+    with_release_repo do |repo|
+      shared_base_sha = git(repo, "rev-parse", "HEAD").strip
+      write_file(repo, "other.txt", "unrelated main behavior\n")
+      git(repo, "add", "other.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port unrelated upstream work (#999)",
+        "-m",
+        "- cherry-picked release PR #123 with `git cherry-pick -x`"
+      )
+
+      git(repo, "checkout", "-b", "release/1.0.1", shared_base_sha)
+      write_file(repo, "needed.txt", "required release behavior\n")
+      fix_sha = commit_all(repo, "Backport upstream #123 for release (#456)")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Backport upstream #123 for release (#456)")
       expect(stdout).not_to include("source-bound forward-port narration")
     end
   end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -961,6 +961,68 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "does not let generic backport narration hide release-only changes" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      commit_all(repo, "Fix release regression on main (#123)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nrelease-adapted fix\n")
+      write_file(repo, "release-only.txt", "release-only follow-up\n")
+      git(repo, "add", "app.txt", "release-only.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regression (#456)",
+        "-m",
+        "Backports #123 to the release train."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(1), stderr
+      expect(stdout).to include("MANUAL #{release_fix_sha[0, 12]} Backport release regression (#456)")
+      expect(stdout).not_to include("source commit identifies a live upstream PR already present on main")
+    end
+  end
+
+  it "does not trust an equivalence sentence when the source commit changes an uncovered path" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      commit_all(repo, "Fix release regression on main (#123)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nrelease-adapted fix\n")
+      write_file(repo, "release-only.txt", "release-only follow-up\n")
+      git(repo, "add", "app.txt", "release-only.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regression (#456)",
+        "-m",
+        "Backports #123 to the release train.",
+        "-m",
+        "This is equivalent to main PR #123 with release-specific behavior preserved."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(1), stderr
+      expect(stdout).to include("MANUAL #{release_fix_sha[0, 12]} Backport release regression (#456)")
+      expect(stdout).not_to include("source commit identifies a live upstream PR already present on main")
+    end
+  end
+
   it "recognizes a backport action that replaces code with an already-merged implementation" do
     with_release_repo do |repo|
       write_file(repo, "app.txt", "base\nmain scanner fix\n")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -1253,6 +1253,29 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "ignores regenerated LLM artifacts when matching an independently applied code patch" do
+    with_release_repo do |repo|
+      base_sha = git(repo, "rev-parse", "HEAD").strip
+
+      write_file(repo, "app.txt", "base\nshared fix\n")
+      write_file(repo, "llms-full.txt", "generated from current main docs\n")
+      commit_all(repo, "Apply the equivalent fix independently")
+
+      git(repo, "checkout", "-b", "release/1.0.1", base_sha)
+      write_file(repo, "app.txt", "base\nshared fix\n")
+      write_file(repo, "llms-full.txt", "stale release-branch generation\n")
+      release_fix_sha = commit_all(repo, "Fix release regression and regenerate docs")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{release_fix_sha[0, 12]} Fix release regression and regenerate docs")
+      expect(stdout).to include("patch already exists on main")
+    end
+  end
+
   it "skips no-footer cherry-picks after later target context changes" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -279,6 +279,21 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "defers changelog-only commits to the reconciliation pass" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1.rc.1]\n- Release fix\n")
+      changelog_sha = commit_all(repo, "Update changelog for 1.0.1.rc.1")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{changelog_sha[0, 12]} Update changelog for 1.0.1.rc.1")
+      expect(stdout).to include("changelog-only commit; use --changelog reconciliation")
+    end
+  end
+
   it "prints usage without a stack trace for argument errors" do
     _stdout, stderr, status = run_script_from_repo_root("--bogus")
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -401,6 +401,26 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips source patches embedded in combined target commits that mention the source PR" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      fix_sha = commit_all(repo, "Fix release regression (#123)")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      write_file(repo, "main-only.txt", "combined target work\n")
+      commit_all(repo, "Forward-port release fixes\n\nIncludes #123 with other release work")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
+    end
+  end
+
   it "does not trust a source-subject mention when the target patch differs" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe "script/release-forward-port" do
         "#### Changed\n\n- Intermediate prerelease behavior. (PR #100)\n" \
         "- Final shipped behavior. (PR #101)\n"
       )
-      commit_all(repo, "Stamp final changelog")
+      source_changelog_sha = commit_all(repo, "Stamp final changelog")
       git(repo, "checkout", "main")
 
       write_file(
@@ -311,7 +311,17 @@ RSpec.describe "script/release-forward-port" do
         "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
         "#### Changed\n\n- Final shipped behavior, consolidated after review. (PR #101)\n"
       )
-      authoritative_sha = commit_all(repo, "Record the final React on Rails 1.0.1 changelog (#999)")
+      git(repo, "add", "CHANGELOG.md")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Record the final React on Rails 1.0.1 changelog (#999)",
+        "-m",
+        "The final changelog records source CHANGELOG.md commit `#{source_changelog_sha}`."
+      )
+      authoritative_sha = git(repo, "rev-parse", "HEAD").strip
 
       stdout, stderr, status =
         run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
@@ -332,6 +342,70 @@ RSpec.describe "script/release-forward-port" do
 
       expect(status.exitstatus).to eq(1)
       expect(stderr).to include("CHECK FAILED")
+    end
+  end
+
+  it "requires source-SHA provenance for a dedicated final changelog PR" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n#### Fixed\n\n- Release fix.\n"
+      )
+      source_changelog_sha = commit_all(repo, "Stamp final changelog")
+      git(repo, "checkout", "main")
+
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n#### Fixed\n\n- Consolidated fix.\n"
+      )
+      commit_all(repo, "Record the final React on Rails 1.0.1 changelog (#999)")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+
+      stdout, stderr, status =
+        run_script(
+          repo,
+          "--source",
+          "release/1.0.1",
+          "--target",
+          "main",
+          "--changelog",
+          "--check",
+          "--ack-final-changelog-source",
+          source_changelog_sha
+        )
+      expect(status).to be_success, stderr
+      expect(stdout).to include("Authoritative final 1.0.1 changelog is unchanged")
+
+      git(repo, "checkout", "release/1.0.1")
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n#### Fixed\n\n- Corrected release fix.\n"
+      )
+      commit_all(repo, "Correct final changelog")
+      git(repo, "checkout", "main")
+
+      _stdout, stderr, status =
+        run_script(
+          repo,
+          "--source",
+          "release/1.0.1",
+          "--target",
+          "main",
+          "--changelog",
+          "--check",
+          "--ack-final-changelog-source",
+          source_changelog_sha
+        )
+      expect(status.exitstatus).to eq(2)
+      expect(stderr).to include("current source CHANGELOG.md commit")
     end
   end
 
@@ -461,6 +535,39 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("SKIP #{prerelease_sha[0, 12]} Update Widget package pin to 2.0.0-rc.1 (#10)")
       expect(stdout).to include("prerelease package pin is superseded by later stable source commit")
       expect(stdout).not_to include("PICK #{prerelease_sha[0, 12]}")
+    end
+  end
+
+  it "requires manual inspection when a stable forward-port lacks cumulative prerelease state" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "package.txt", "widget=2.0.0-rc.1\nmode=new\n")
+      prerelease_sha = commit_all(repo, "Update Widget package pin to 2.0.0-rc.1 (#10)")
+      write_file(repo, "package.txt", "widget=2.0.0\nmode=new\n")
+      stable_sha = commit_all(repo, "Adopt stable Widget 2.0.0 (#11)")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "package.txt", "widget=2.0.0\nmode=old\n")
+      git(repo, "add", "package.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port stable Widget (#12)",
+        "-m",
+        "- cherry-picked the merged #11 squash commit with `git cherry-pick -x`\n\n" \
+        "(cherry picked from commit #{stable_sha})"
+      )
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+      expect(stdout).to include("MANUAL #{prerelease_sha[0, 12]}")
+      expect(stdout).to include("cumulative state of the prerelease commit's paths differs")
+      expect(stdout).not_to include("SKIP #{prerelease_sha[0, 12]}")
     end
   end
 
@@ -608,6 +715,13 @@ RSpec.describe "script/release-forward-port" do
       expect(git(repo, "status", "--porcelain")).to eq("")
 
       stdout, stderr, status = run_script(repo, "--source", "main", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(3)
+      expect(stdout).not_to include("CHECK PASSED")
+      expect(stderr).to include("a cherry-pick is already in progress")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "main", "--target", "main", "--changelog", "--check")
 
       expect(status.exitstatus).to eq(3)
       expect(stdout).not_to include("CHECK PASSED")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -335,6 +335,28 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "does not accept an authoritative changelog commit without the final version section" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n#### Fixed\n\n- Release fix.\n"
+      )
+      commit_all(repo, "Stamp final changelog")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [Unreleased]\n\n- Main-only note.\n")
+      commit_all(repo, "Record the final React on Rails 1.0.1 changelog (#999)")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+    end
+  end
+
   it "dry-runs release and target branches with unrelated root histories" do
     with_release_repo do |repo|
       git(repo, "checkout", "--orphan", "release/1.0.1")
@@ -712,6 +734,8 @@ RSpec.describe "script/release-forward-port" do
     with_release_repo do |repo|
       write_file(repo, "base-fix.txt", "main implementation\n")
       upstream_sha = commit_all(repo, "Fix prerelease retry ambiguity (#123)")
+      write_file(repo, "second-fix.txt", "second main implementation\n")
+      second_upstream_sha = commit_all(repo, "Fix follow-up retry ambiguity (#124)")
       write_file(repo, "review-fix.txt", "main review guard\n")
       git(repo, "add", "review-fix.txt")
       git(
@@ -727,12 +751,14 @@ RSpec.describe "script/release-forward-port" do
 
       git(repo, "checkout", "-b", "release/1.0.1", "#{upstream_sha}^")
       write_file(repo, "base-fix.txt", "release-adapted implementation\n")
+      write_file(repo, "second-fix.txt", "second release-adapted implementation\n")
       write_file(repo, "review-fix.txt", "release review guard\n")
-      git(repo, "add", "base-fix.txt", "review-fix.txt")
+      git(repo, "add", "base-fix.txt", "second-fix.txt", "review-fix.txt")
       release_sha = commit_all(
         repo,
         "Backport fail-closed prerelease retry (#456)\n\n" \
-        "Backports #123 and includes the reviewed post-pull downgrade guard."
+        "Backports #123 and includes the reviewed post-pull downgrade guard.\n\n" \
+        "Backports #124 to the release train."
       )
       git(repo, "checkout", "main")
 
@@ -743,12 +769,16 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("source commit identifies a live upstream PR already present on main")
       expect(stdout).not_to include("PICK #{release_sha[0, 12]} Backport fail-closed prerelease retry (#456)")
 
-      git(repo, "revert", "--no-edit", review_fix_sha)
-      stdout, stderr, status =
-        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+      [upstream_sha, second_upstream_sha, review_fix_sha].each do |required_sha|
+        git(repo, "revert", "--no-edit", required_sha)
+        revert_sha = git(repo, "rev-parse", "HEAD").strip
+        stdout, stderr, status =
+          run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
-      expect(status).to be_success, stderr
-      expect(stdout).to include("PICK #{release_sha[0, 12]} Backport fail-closed prerelease retry (#456)")
+        expect(status).to be_success, stderr
+        expect(stdout).to include("PICK #{release_sha[0, 12]} Backport fail-closed prerelease retry (#456)")
+        git(repo, "revert", "--no-edit", revert_sha)
+      end
     end
   end
 
@@ -756,27 +786,39 @@ RSpec.describe "script/release-forward-port" do
     with_release_repo do |repo|
       write_file(repo, "app.txt", "base\nunrelated main change\n")
       commit_all(repo, "Unrelated main feature (#123)")
+      write_file(repo, "other.txt", "other unrelated main change\n")
+      commit_all(repo, "Other unrelated main feature (#456)")
 
-      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
-      write_file(repo, "app.txt", "base\nunique release fix\n")
-      git(repo, "add", "app.txt")
-      git(
-        repo,
-        "commit",
-        "--no-gpg-sign",
-        "-m",
-        "Fix separate release regression (#456)",
-        "-m",
-        "This is not a backport from main PR #123.\nUnlike main PR #123, this fixes release-only behavior."
-      )
-      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~2")
+      negative_segments = [
+        "Backport the fix not from #123.",
+        "Backport this behavior, not from #123 but from #456.",
+        "- replaces the regex with code not already reviewed and merged in #456"
+      ]
+      release_fix_shas = negative_segments.each_with_index.map do |segment, index|
+        write_file(repo, "release-fix-#{index}.txt", "unique release fix #{index}\n")
+        git(repo, "add", "release-fix-#{index}.txt")
+        git(
+          repo,
+          "commit",
+          "--no-gpg-sign",
+          "-m",
+          "Fix separate release regression #{index} (#90#{index})",
+          "-m",
+          segment
+        )
+        git(repo, "rev-parse", "HEAD").strip
+      end
       git(repo, "checkout", "main")
 
       stdout, stderr, status =
         run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix separate release regression (#456)")
+      release_fix_shas.each_with_index do |release_fix_sha, index|
+        expected_pick = "PICK #{release_fix_sha[0, 12]} Fix separate release regression #{index} (#90#{index})"
+        expect(stdout).to include(expected_pick)
+      end
       expect(stdout).not_to include("source commit identifies a live upstream PR")
     end
   end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -491,12 +491,16 @@ RSpec.describe "script/release-forward-port" do
 
   it "uses source-body backport PR references to find exact target patches" do
     with_release_repo do |repo|
-      write_file(repo, "app.txt", "base\nmain fix\n")
-      write_file(repo, "main-only.txt", "combined target work\n")
+      write_file(repo, "app.txt", "top\nanchor\nbottom\n")
+      shared_base_sha = commit_all(repo, "Prepare shared source context")
+
+      write_file(repo, "app.txt", "top\nanchor\nmain bottom\n")
+      commit_all(repo, "Change adjacent target context")
+      write_file(repo, "app.txt", "top\nanchor\nmain fix\nmain bottom\n")
       commit_all(repo, "Fix release regression on main (#123)")
 
-      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
-      write_file(repo, "app.txt", "base\nmain fix\n")
+      git(repo, "checkout", "-b", "release/1.0.1", shared_base_sha)
+      write_file(repo, "app.txt", "top\nanchor\nmain fix\nbottom\n")
       git(repo, "add", "app.txt")
       git(
         repo,

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -362,6 +362,83 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips adapted release backports whose narrated upstream PR is live on target" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nnewer main fix\n")
+      commit_all(repo, "Fix release regression on main (#123)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nrelease-adapted fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regression (#456)",
+        "-m",
+        "Backports #123 to the release train with release-specific behavior preserved."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("source commit identifies a live upstream PR already present on main")
+      expect(stdout).not_to include("PICK #{release_fix_sha[0, 12]} Backport release regression (#456)")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nnewer main fix\n")
+    end
+  end
+
+  it "does not skip a narrated upstream PR after its target commit is reverted" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      commit_all(repo, "Fix release regression on main (#123)")
+      git(repo, "revert", "--no-edit", "HEAD")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~2")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regression (#456)",
+        "-m",
+        "Backports #123 to the release train."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Backport release regression (#456)")
+      expect(stdout).not_to include("source commit identifies a live upstream PR")
+    end
+  end
+
+  it "skips generated LLM artifact-only commits" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "llms-full.txt", "generated OSS docs\n")
+      write_file(repo, "llms-full-pro.txt", "generated Pro docs\n")
+      artifact_sha = commit_all(repo, "Regenerate release-branch llms artifacts")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{artifact_sha[0, 12]} Regenerate release-branch llms artifacts")
+      expect(stdout).to include("generated LLM artifact-only commit")
+    end
+  end
+
   it "skips no-footer cherry-picks after later target context changes" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -226,6 +226,17 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "distinguishes check verifier errors from an incomplete plan" do
+    with_release_repo do |repo|
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/missing", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(3)
+      expect(stderr).to include("source ref")
+      expect(stderr).not_to include("CHECK FAILED")
+    end
+  end
+
   it "accepts inspected manual items while checking the complete code plan" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
@@ -278,6 +289,49 @@ RSpec.describe "script/release-forward-port" do
 
       expect(status).to be_success, stderr
       expect(stdout).to include("CHECK PASSED")
+    end
+  end
+
+  it "accepts an unchanged dedicated final changelog PR as authoritative" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
+        "#### Changed\n\n- Intermediate prerelease behavior. (PR #100)\n" \
+        "- Final shipped behavior. (PR #101)\n"
+      )
+      commit_all(repo, "Stamp final changelog")
+      git(repo, "checkout", "main")
+
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
+        "#### Changed\n\n- Final shipped behavior, consolidated after review. (PR #101)\n"
+      )
+      authoritative_sha = commit_all(repo, "Record the final React on Rails 1.0.1 changelog (#999)")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("Authoritative final 1.0.1 changelog is unchanged")
+      expect(stdout).to include(authoritative_sha[0, 12])
+
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n#### Changed\n\n- Corrupted.\n"
+      )
+      commit_all(repo, "Rewrite final release notes")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
     end
   end
 
@@ -616,6 +670,117 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "recognizes a backport action that replaces code with an already-merged implementation" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain scanner fix\n")
+      target_sha = commit_all(repo, "Forward-port scanner fix to main (#4668)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nrelease-adapted scanner fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport safe scanner fix (#4671)",
+        "-m",
+        "During the forward-port in #4668, review found the unsafe release implementation.",
+        "-m",
+        "- replaces the release regex with the deterministic scanner already reviewed and merged in #4668"
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("source commit identifies a live upstream PR already present on main")
+      expect(stdout).not_to include("PICK #{release_fix_sha[0, 12]} Backport safe scanner fix (#4671)")
+
+      git(repo, "revert", "--no-edit", target_sha)
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Backport safe scanner fix (#4671)")
+    end
+  end
+
+  it "requires both the upstream PR and the separately forward-ported review fix for a composite backport" do
+    with_release_repo do |repo|
+      write_file(repo, "base-fix.txt", "main implementation\n")
+      upstream_sha = commit_all(repo, "Fix prerelease retry ambiguity (#123)")
+      write_file(repo, "review-fix.txt", "main review guard\n")
+      git(repo, "add", "review-fix.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Release: forward-port post-review guard (#999)",
+        "-m",
+        "Forward-port the review fix from release PR #456 so main has the same fail-closed behavior."
+      )
+      review_fix_sha = git(repo, "rev-parse", "HEAD").strip
+
+      git(repo, "checkout", "-b", "release/1.0.1", "#{upstream_sha}^")
+      write_file(repo, "base-fix.txt", "release-adapted implementation\n")
+      write_file(repo, "review-fix.txt", "release review guard\n")
+      git(repo, "add", "base-fix.txt", "review-fix.txt")
+      release_sha = commit_all(
+        repo,
+        "Backport fail-closed prerelease retry (#456)\n\n" \
+        "Backports #123 and includes the reviewed post-pull downgrade guard."
+      )
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("source commit identifies a live upstream PR already present on main")
+      expect(stdout).not_to include("PICK #{release_sha[0, 12]} Backport fail-closed prerelease retry (#456)")
+
+      git(repo, "revert", "--no-edit", review_fix_sha)
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_sha[0, 12]} Backport fail-closed prerelease retry (#456)")
+    end
+  end
+
+  it "does not trust negated or contrastive backport prose as provenance" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nunrelated main change\n")
+      commit_all(repo, "Unrelated main feature (#123)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nunique release fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Fix separate release regression (#456)",
+        "-m",
+        "This is not a backport from main PR #123.\nUnlike main PR #123, this fixes release-only behavior."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix separate release regression (#456)")
+      expect(stdout).not_to include("source commit identifies a live upstream PR")
+    end
+  end
+
   it "does not treat incidental merged-in references as forward-port provenance" do
     with_release_repo do |repo|
       write_file(repo, "app.txt", "base\noriginal main feature\n")
@@ -854,7 +1019,7 @@ RSpec.describe "script/release-forward-port" do
         "-m",
         "Forward-port release regression (#999)",
         "-m",
-        "Release PR #123 must be forward-ported with `git cherry-pick -x`.\n\n" \
+        "- cherry-picked release PR #123 with `git cherry-pick -x`\n\n" \
         "The conflict resolution preserves newer main behavior."
       )
 
@@ -865,6 +1030,42 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("source-bound forward-port narration")
       expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nnewer main fix\n")
+    end
+  end
+
+  it "recognizes wrapped exact-source provenance from a focused forward-port PR" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "base\nrelease-adapted fix\n")
+      fix_sha = commit_all(repo, "Fix release regression (#123)")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "app.txt", "base\nnewer main-compatible fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port release regression (#999)",
+        "-m",
+        "The commit retains `cherry-pick -x` provenance from source squash commit\n`#{fix_sha}`."
+      )
+      forward_port_sha = git(repo, "rev-parse", "HEAD").strip
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("source-bound forward-port narration")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
+
+      git(repo, "revert", "--no-edit", forward_port_sha)
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -508,6 +508,43 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "does not dedupe against an unbound active final section" do
+    with_release_repo do |repo|
+      final_changelog =
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
+        "#### Fixed\n\n- Final release fix. (PR #101)\n"
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "CHANGELOG.md", final_changelog)
+      source_changelog_sha = commit_all(repo, "Stamp final changelog")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "CHANGELOG.md", final_changelog)
+      commit_all(repo, "Record the final React on Rails 1.0.1 changelog (#999)")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+
+      stdout, stderr, status =
+        run_script(
+          repo,
+          "--source",
+          "release/1.0.1",
+          "--target",
+          "main",
+          "--changelog",
+          "--check",
+          "--ack-final-changelog-source",
+          source_changelog_sha
+        )
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("Authoritative final 1.0.1 changelog is unchanged")
+    end
+  end
+
   it "does not accept an authoritative changelog commit without the final version section" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
@@ -929,7 +966,7 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
-  it "skips adapted release backports whose narrated upstream PR is live on target" do
+  it "requires manual inspection for adapted release backports whose narrated upstream PR is live on target" do
     with_release_repo do |repo|
       write_file(repo, "app.txt", "base\nnewer main fix\n")
       commit_all(repo, "Fix release regression on main (#123)")
@@ -955,7 +992,8 @@ RSpec.describe "script/release-forward-port" do
         run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("source commit identifies a live upstream PR already present on main")
+      expect(stdout).to include("MANUAL #{release_fix_sha[0, 12]} Backport release regression (#456)")
+      expect(stdout).to include("does not prove whole-commit equivalence")
       expect(stdout).not_to include("PICK #{release_fix_sha[0, 12]} Backport release regression (#456)")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nnewer main fix\n")
     end
@@ -1049,7 +1087,8 @@ RSpec.describe "script/release-forward-port" do
         run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("source commit identifies a live upstream PR already present on main")
+      expect(stdout).to include("MANUAL #{release_fix_sha[0, 12]} Backport safe scanner fix (#4671)")
+      expect(stdout).to include("does not prove whole-commit equivalence")
       expect(stdout).not_to include("PICK #{release_fix_sha[0, 12]} Backport safe scanner fix (#4671)")
 
       git(repo, "revert", "--no-edit", target_sha)
@@ -1097,7 +1136,8 @@ RSpec.describe "script/release-forward-port" do
         run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("source commit identifies a live upstream PR already present on main")
+      expect(stdout).to include("MANUAL #{release_sha[0, 12]} Backport fail-closed prerelease retry (#456)")
+      expect(stdout).to include("does not prove whole-commit equivalence")
       expect(stdout).not_to include("PICK #{release_sha[0, 12]} Backport fail-closed prerelease retry (#456)")
 
       [upstream_sha, second_upstream_sha, review_fix_sha].each do |required_sha|

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -464,6 +464,37 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "preserves a scoped package name when a stable forward-port supersedes its prerelease pin" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "package.txt", "@scope/widget=2.0.0-rc.1\n")
+      prerelease_sha = commit_all(repo, "Update @scope/widget package pin to 2.0.0-rc.1 (#10)")
+      write_file(repo, "package.txt", "@scope/widget=2.0.0\n")
+      commit_all(repo, "Adopt stable @scope/widget 2.0.0 (#11)")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "package.txt", "@scope/widget=2.0.0\n")
+      git(repo, "add", "package.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port stable @scope/widget (#12)",
+        "-m",
+        "- cherry-picked the merged #11 squash commit with `git cherry-pick -x`"
+      )
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{prerelease_sha[0, 12]} Update @scope/widget package pin")
+      expect(stdout).to include("prerelease package pin is superseded by later stable source commit")
+      expect(stdout).not_to include("PICK #{prerelease_sha[0, 12]}")
+    end
+  end
+
   it "does not treat a different dependency at the same stable version as superseding a prerelease pin" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
@@ -555,6 +586,31 @@ RSpec.describe "script/release-forward-port" do
       expect(status).not_to be_success
       expect(stdout).to include("No commits found in main..main.")
       expect(stdout).not_to include("Nothing to cherry-pick")
+      expect(stderr).to include("a cherry-pick is already in progress")
+    end
+  end
+
+  it "rejects check mode while a real empty cherry-pick is in progress" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "duplicate-source")
+      write_file(repo, "app.txt", "base\nduplicate change\n")
+      duplicate_sha = commit_all(repo, "Apply duplicate change from source")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "app.txt", "base\nduplicate change\n")
+      commit_all(repo, "Apply duplicate change independently")
+
+      _stdout, _stderr, cherry_pick_status =
+        Open3.capture3(git_env, "git", "cherry-pick", duplicate_sha, chdir: repo)
+      expect(cherry_pick_status.exitstatus).to eq(1)
+      git_dir = git(repo, "rev-parse", "--git-dir").strip
+      expect(File).to exist(File.join(repo, git_dir, "CHERRY_PICK_HEAD"))
+      expect(git(repo, "status", "--porcelain")).to eq("")
+
+      stdout, stderr, status = run_script(repo, "--source", "main", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(3)
+      expect(stdout).not_to include("CHECK PASSED")
       expect(stderr).to include("a cherry-pick is already in progress")
     end
   end
@@ -675,7 +731,7 @@ RSpec.describe "script/release-forward-port" do
         "-m",
         "Backport release regression (#456)",
         "-m",
-        "Backport the fix from #123 after the release-only prerequisite in #789.",
+        "Backport the fix from #123 to the release train after the release-only prerequisite in #789.",
         "-m",
         "This is equivalent to main PR #123 with release-specific behavior preserved."
       )
@@ -793,32 +849,30 @@ RSpec.describe "script/release-forward-port" do
       negative_segments = [
         "Backport the fix not from #123.",
         "Backport this behavior, not from #123 but from #456.",
-        "- replaces the regex with code not already reviewed and merged in #456"
+        "- replaces the regex with code not already reviewed and merged in #456",
+        "Backport the fix that doesn't come from #123 to the release train.",
+        "Backport this behavior that isn’t from #123 to the release train.",
+        "- replaces the regex with code that wasn't already reviewed and merged in #456"
       ]
-      release_fix_shas = negative_segments.each_with_index.map do |segment, index|
-        write_file(repo, "release-fix-#{index}.txt", "unique release fix #{index}\n")
-        git(repo, "add", "release-fix-#{index}.txt")
-        git(
-          repo,
-          "commit",
-          "--no-gpg-sign",
-          "-m",
-          "Fix separate release regression #{index} (#90#{index})",
-          "-m",
-          segment
-        )
-        git(repo, "rev-parse", "HEAD").strip
-      end
+      write_file(repo, "release-fix.txt", "unique release fix\n")
+      git(repo, "add", "release-fix.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Fix separate release regression (#900)",
+        "-m",
+        negative_segments.join("\n\n")
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
       git(repo, "checkout", "main")
 
       stdout, stderr, status =
         run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
       expect(status).to be_success, stderr
-      release_fix_shas.each_with_index do |release_fix_sha, index|
-        expected_pick = "PICK #{release_fix_sha[0, 12]} Fix separate release regression #{index} (#90#{index})"
-        expect(stdout).to include(expected_pick)
-      end
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix separate release regression (#900)")
       expect(stdout).not_to include("source commit identifies a live upstream PR")
     end
   end
@@ -1089,7 +1143,7 @@ RSpec.describe "script/release-forward-port" do
         "commit",
         "--no-gpg-sign",
         "-m",
-        "Forward-port release regression (#999)",
+        "Integrate release regression (#999)",
         "-m",
         "The commit retains `cherry-pick -x` provenance from source squash commit\n`#{fix_sha}`."
       )
@@ -1127,7 +1181,7 @@ RSpec.describe "script/release-forward-port" do
         "-m",
         "Forward-port license metadata to main (#4668)",
         "-m",
-        "- forward-ports the reviewed licensing change from release\n" \
+        "- forward-ports the complete reviewed licensing change from release\n" \
         "PR #4660\n" \
         "- preserves newer mainline token handling"
       )
@@ -1138,6 +1192,36 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stdout).to include("source-bound forward-port narration")
       expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Publish accurate license metadata (#4660)")
+    end
+  end
+
+  it "does not trust negated target forward-port narration" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "license.txt", "release-only license behavior\n")
+      fix_sha = commit_all(repo, "Publish accurate license metadata (#4660)")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "other.txt", "unrelated main behavior\n")
+      git(repo, "add", "other.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port unrelated license work (#4668)",
+        "-m",
+        "- forward-ports no code from release PR #4660\n" \
+        "- forward-ports nothing from release PR #4660\n" \
+        "- forward-ports the reviewed change that wasn't from release PR #4660"
+      )
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Publish accurate license metadata (#4660)")
+      expect(stdout).not_to include("source-bound forward-port narration")
     end
   end
 
@@ -1634,7 +1718,8 @@ RSpec.describe "script/release-forward-port" do
         "-m",
         "Backport release regression fix",
         "-m",
-        "Cherry-picked main squash commit\n`#{main_fix_sha}` with `-x`."
+        "- Cherry-picked main squash commit\n`#{main_fix_sha}` with `-x`.\n" \
+        "- Preserves the release-specific conflict resolution."
       )
       release_fix_sha = git(repo, "rev-parse", "HEAD").strip
       git(repo, "checkout", "main")
@@ -1646,6 +1731,36 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("already forward-ported to main via cherry-pick -x evidence")
       expect(stdout).to include("Nothing to cherry-pick")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain fix\n")
+    end
+  end
+
+  it "does not trust negated narrated cherry-pick origins" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      main_fix_sha = commit_all(repo, "Fix release regression on main")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nunique release fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Fix separate release regression",
+        "-m",
+        "We never cherry-picked main squash commit `#{main_fix_sha}` with `-x`.\n\n" \
+        "This wasn't cherry-picked main commit `#{main_fix_sha}` with `-x`."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix separate release regression")
+      expect(stdout).not_to include("already forward-ported to main via cherry-pick -x evidence")
     end
   end
 
@@ -2603,7 +2718,7 @@ RSpec.describe "script/release-forward-port" do
       helper.send(:ensure_clean_worktree!)
     end.to raise_error(
       ReleaseForwardPort::GitError,
-      "a cherry-pick is already in progress; run git cherry-pick --continue or --abort first"
+      "a cherry-pick is already in progress; run git cherry-pick --continue, --skip, or --abort first"
     )
   end
 end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -143,6 +143,45 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "dry-runs release and target branches with unrelated root histories" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "--orphan", "release/1.0.1")
+      commit_all(repo, "Seed rewritten release history")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      fix_sha = commit_all(repo, "Fix release regression after history rewrite")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stderr).to eq("")
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression after history rewrite")
+      expect(stdout).to include("DRY RUN")
+    end
+  end
+
+  it "fails closed when shallow history prevents finding a merge base" do
+    with_release_repo do |repo|
+      main_sha = git(repo, "rev-parse", "main").strip
+      git(repo, "checkout", "--orphan", "release/1.0.1")
+      release_root_sha = commit_all(repo, "Seed shallow release history")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      commit_all(repo, "Fix release regression after shallow boundary")
+      git(repo, "checkout", "main")
+
+      git_dir = git(repo, "rev-parse", "--git-dir").strip
+      shallow_boundaries = [main_sha, release_root_sha].sort.join("\n")
+      File.write(File.join(repo, git_dir, "shallow"), "#{shallow_boundaries}\n")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).not_to be_success
+      expect(stderr).to include("repository history is shallow")
+      expect(stderr).to include("git fetch --unshallow")
+    end
+  end
+
   it "skips bare rc version bump subjects before version-drift checks" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -143,10 +143,149 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "applies only the selected source commit for a one-change forward-port PR" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "first.txt", "first release fix\n")
+      first_sha = commit_all(repo, "Fix first release regression (#101)")
+      write_file(repo, "second.txt", "second release fix\n")
+      second_sha = commit_all(repo, "Fix second release regression (#102)")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--only", first_sha)
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{first_sha[0, 12]} Fix first release regression (#101)")
+      expect(stdout).not_to include(second_sha[0, 12])
+      expect(File.read(File.join(repo, "first.txt"))).to eq("first release fix\n")
+      expect(File).not_to exist(File.join(repo, "second.txt"))
+    end
+  end
+
+  it "refuses to batch multiple source commits unless --all is explicit" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "first.txt", "first release fix\n")
+      first_sha = commit_all(repo, "Fix first release regression (#101)")
+      write_file(repo, "second.txt", "second release fix\n")
+      second_sha = commit_all(repo, "Fix second release regression (#102)")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to include("PICK #{first_sha[0, 12]}")
+      expect(stdout).to include("PICK #{second_sha[0, 12]}")
+      expect(stderr).to include("normal mode found 2 actionable commits")
+      expect(stderr).to include("--only SHA")
+      expect(File).not_to exist(File.join(repo, "first.txt"))
+      expect(File).not_to exist(File.join(repo, "second.txt"))
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--all")
+
+      expect(status).to be_success, stderr
+      expect(File.read(File.join(repo, "first.txt"))).to eq("first release fix\n")
+      expect(File.read(File.join(repo, "second.txt"))).to eq("second release fix\n")
+    end
+  end
+
+  it "rejects code selection flags in changelog mode" do
+    with_release_repo do |repo|
+      _stdout, stderr, status =
+        run_script(repo, "--source", "main", "--target", "main", "--changelog", "--only", "HEAD")
+
+      expect(status.exitstatus).to eq(2)
+      expect(stderr).to include("--only/--all select code commits and cannot be combined with --changelog")
+    end
+  end
+
+  it "checks whether the complete code forward-port plan is satisfied without changing the target" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(stderr).to include("CHECK FAILED")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\n")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--only", fix_sha)
+      expect(status).to be_success, stderr
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--check")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("CHECK PASSED")
+    end
+  end
+
+  it "accepts inspected manual items while checking the complete code plan" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(
+          repo,
+          "--source",
+          "release/1.0.1",
+          "--target",
+          "main",
+          "--check",
+          "--ack-manual",
+          stable_bump_sha
+        )
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("ACK-MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("CHECK PASSED")
+    end
+  end
+
+  it "checks whether release changelog reconciliation is complete" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n#### Fixed\n\n- Release fix.\n"
+      )
+      commit_all(repo, "Stamp final changelog")
+      git(repo, "checkout", "main")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog")
+      expect(status).to be_success, stderr
+      commit_all(repo, "Reconcile release changelog")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("CHECK PASSED")
+    end
+  end
+
   it "dry-runs release and target branches with unrelated root histories" do
     with_release_repo do |repo|
       git(repo, "checkout", "--orphan", "release/1.0.1")
-      commit_all(repo, "Seed rewritten release history")
+      write_file(repo, "release-seed-only.txt", "rewritten release root\n")
+      release_root_sha = commit_all(repo, "Seed rewritten release history")
       write_file(repo, "app.txt", "base\nrelease fix\n")
       fix_sha = commit_all(repo, "Fix release regression after history rewrite")
       git(repo, "checkout", "main")
@@ -155,8 +294,26 @@ RSpec.describe "script/release-forward-port" do
 
       expect(status).to be_success, stderr
       expect(stderr).to eq("")
+      expect(stdout).to include("MANUAL #{release_root_sha[0, 12]} Seed rewritten release history")
+      expect(stdout).to include("root commit from unrelated history")
+      expect(stdout).not_to include("PICK #{release_root_sha[0, 12]} Seed rewritten release history")
       expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression after history rewrite")
       expect(stdout).to include("DRY RUN")
+
+      stdout, stderr, status = run_script(
+        repo,
+        "--source",
+        "release/1.0.1",
+        "--target",
+        "main",
+        "--ack-manual",
+        release_root_sha
+      )
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("Cherry-picking #{fix_sha[0, 12]} Fix release regression after history rewrite")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+      expect(File).not_to exist(File.join(repo, "release-seed-only.txt"))
     end
   end
 
@@ -231,6 +388,37 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "does not treat a different dependency at the same stable version as superseding a prerelease pin" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "package.txt", "widget=2.0.0-rc.1\ngadget=1.0.0\n")
+      prerelease_sha = commit_all(repo, "Update Widget package pin to 2.0.0-rc.1 (#10)")
+      write_file(repo, "package.txt", "widget=2.0.0-rc.1\ngadget=2.0.0\n")
+      stable_sha = commit_all(repo, "Adopt stable Gadget 2.0.0 (#11)")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "package.txt", "widget=1.0.0\ngadget=2.0.0\n")
+      git(repo, "add", "package.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port stable Gadget (#12)",
+        "-m",
+        "- cherry-picked the merged #11 squash commit with `git cherry-pick -x`\n\n" \
+        "(cherry picked from commit #{stable_sha})"
+      )
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{prerelease_sha[0, 12]} Update Widget package pin to 2.0.0-rc.1 (#10)")
+      expect(stdout).not_to include("prerelease package pin is superseded")
+    end
+  end
+
   it "skips reverts of skipped rc version bump commits" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
@@ -243,7 +431,8 @@ RSpec.describe "script/release-forward-port" do
       git(repo, "checkout", "main")
       commit_count = git(repo, "rev-list", "--count", "main").strip
 
-      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
 
       expect(status).to be_success, stderr
       expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
@@ -410,7 +599,9 @@ RSpec.describe "script/release-forward-port" do
         "-m",
         "Backport release regression (#456)",
         "-m",
-        "Backports #123 to the release train with release-specific behavior preserved."
+        "Backport the fix from #123 after the release-only prerequisite in #789.",
+        "-m",
+        "This is equivalent to main PR #123 with release-specific behavior preserved."
       )
       release_fix_sha = git(repo, "rev-parse", "HEAD").strip
       git(repo, "checkout", "main")
@@ -422,6 +613,67 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("source commit identifies a live upstream PR already present on main")
       expect(stdout).not_to include("PICK #{release_fix_sha[0, 12]} Backport release regression (#456)")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nnewer main fix\n")
+    end
+  end
+
+  it "does not treat incidental merged-in references as forward-port provenance" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\noriginal main feature\n")
+      commit_all(repo, "Original feature (#123)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nseparate release fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Fix separate release regression (#456)",
+        "-m",
+        "Follow-up to behavior merged in #123; this adds a separate release fix."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix separate release regression (#456)")
+      expect(stdout).not_to include("source commit identifies a live upstream PR")
+    end
+  end
+
+  it "does not skip composite backports until every narrated upstream PR is live on target" do
+    with_release_repo do |repo|
+      write_file(repo, "first.txt", "first main fix\n")
+      commit_all(repo, "Fix first release regression on main (#123)")
+      write_file(repo, "second.txt", "second main fix\n")
+      commit_all(repo, "Fix second release regression on main (#124)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~2")
+      write_file(repo, "first.txt", "first release-adapted fix\n")
+      write_file(repo, "third.txt", "third release-only fix\n")
+      git(repo, "add", "first.txt", "third.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regressions (#456)",
+        "-m",
+        "Backports #123, #124, and #125 to the release train."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Backport release regressions (#456)")
+      expect(stdout).not_to include("source commit identifies a live upstream PR")
     end
   end
 
@@ -469,6 +721,23 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stdout).to include("SKIP #{artifact_sha[0, 12]} Regenerate release-branch llms artifacts")
       expect(stdout).to include("generated LLM artifact-only commit")
+    end
+  end
+
+  it "defers commits containing only changelog and generated LLM artifacts" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1.rc.1]\n- RC notes\n")
+      write_file(repo, "llms-full.txt", "generated release docs\n")
+      artifact_sha = commit_all(repo, "Stamp release docs and changelog")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{artifact_sha[0, 12]} Stamp release docs and changelog")
+      expect(stdout).to include("changelog/generated artifact-only commit")
     end
   end
 
@@ -593,9 +862,68 @@ RSpec.describe "script/release-forward-port" do
         run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("narrated cherry-pick -x evidence")
+      expect(stdout).to include("source-bound forward-port narration")
       expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nnewer main fix\n")
+    end
+  end
+
+  it "trusts a Forward-port commit whose action line names the release PR" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "license.txt", "release license behavior\n")
+      fix_sha = commit_all(repo, "Publish accurate license metadata (#4660)")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "license.txt", "conflict-adapted main license behavior\n")
+      git(repo, "add", "license.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port license metadata to main (#4668)",
+        "-m",
+        "- forward-ports the reviewed licensing change from release\n" \
+        "PR #4660\n" \
+        "- preserves newer mainline token handling"
+      )
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("source-bound forward-port narration")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Publish accurate license metadata (#4660)")
+    end
+  end
+
+  it "does not trust a narrated forward-port unless the narration names this source PR" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      fix_sha = commit_all(repo, "Fix release regression (#11)")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "other.txt", "different forward-port\n")
+      git(repo, "add", "other.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port a different regression (#999)",
+        "-m",
+        "This commit discusses release PR #11, but did not apply it.\n\n" \
+        "- cherry-picked release PR #12 with `git cherry-pick -x`"
+      )
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression (#11)")
+      expect(stdout).not_to include("source-bound forward-port narration")
     end
   end
 
@@ -630,6 +958,38 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stdout).to include("patch already exists on main according to target history")
       expect(stdout).not_to include("PICK #{release_fix_sha[0, 12]} Backport release regression (#456)")
+    end
+  end
+
+  it "does not trust zero-context provenance when the target patch differs" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "top\nanchor\nbottom\n")
+      shared_base_sha = commit_all(repo, "Prepare shared source context")
+
+      write_file(repo, "app.txt", "top\nanchor\ndifferent main fix\nbottom\n")
+      commit_all(repo, "Fix a different regression on main (#123)")
+
+      git(repo, "checkout", "-b", "release/1.0.1", shared_base_sha)
+      write_file(repo, "app.txt", "top\nanchor\nrelease fix\nbottom\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regression (#456)",
+        "-m",
+        "Source PR: #123"
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Backport release regression (#456)")
+      expect(stdout).not_to include("patch already exists on main according to target history")
     end
   end
 
@@ -816,7 +1176,8 @@ RSpec.describe "script/release-forward-port" do
       merge_sha = git(repo, "rev-parse", "HEAD").strip
       git(repo, "checkout", "main")
 
-      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--all")
 
       expect(status).not_to be_success
       expect(stdout).to include("PICK #{base_fix_sha[0, 12]} Fix release regression")
@@ -866,7 +1227,8 @@ RSpec.describe "script/release-forward-port" do
       write_file(repo, "conflict.txt", "main branch\n")
       commit_all(repo, "Change conflict on main")
 
-      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--all")
 
       expect(status).not_to be_success
       expect(stdout).to include("Cherry-picking")
@@ -1175,7 +1537,7 @@ RSpec.describe "script/release-forward-port" do
       git(repo, "checkout", "main")
 
       first_stdout, first_stderr, first_status =
-        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--all")
 
       expect(first_status).not_to be_success
       expect(first_stdout).to include("MANUAL #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")
@@ -1186,7 +1548,16 @@ RSpec.describe "script/release-forward-port" do
       expect(File).not_to exist(File.join(repo, "later.txt"))
 
       second_stdout, second_stderr, second_status =
-        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--ack-manual", release_revert_sha)
+        run_script(
+          repo,
+          "--source",
+          "release/1.0.1",
+          "--target",
+          "main",
+          "--all",
+          "--ack-manual",
+          release_revert_sha
+        )
 
       expect(second_status).to be_success, second_stderr
       expect(second_stdout).to include("ACK-MANUAL #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -345,6 +345,105 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "rejects authoritative final changelog state when a later RC section is reintroduced" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
+        "#### Fixed\n\n- Final release fix. (PR #101)\n"
+      )
+      source_changelog_sha = commit_all(repo, "Stamp final changelog")
+      git(repo, "checkout", "main")
+
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
+        "#### Fixed\n\n- Consolidated final release fix. (PR #101)\n"
+      )
+      git(repo, "add", "CHANGELOG.md")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Record the final React on Rails 1.0.1 changelog (#999)",
+        "-m",
+        "The final changelog records source CHANGELOG.md commit `#{source_changelog_sha}`."
+      )
+
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1.rc.1] - 2026-07-23\n\n" \
+        "#### Fixed\n\n- Reintroduced RC residue. (PR #101)\n\n" \
+        "### [1.0.1] - 2026-07-24\n\n#### Fixed\n\n- Consolidated final release fix. (PR #101)\n"
+      )
+      commit_all(repo, "Reintroduce RC changelog residue")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+    end
+  end
+
+  it "removes stale release entries reintroduced after an authoritative final changelog" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
+        "#### Changed\n\n- Intermediate prerelease behavior. (PR #100)\n" \
+        "- Final shipped behavior. (PR #101)\n"
+      )
+      source_changelog_sha = commit_all(repo, "Stamp final changelog")
+      git(repo, "checkout", "main")
+
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n### [1.0.1] - 2026-07-24\n\n" \
+        "#### Changed\n\n- Final shipped behavior, consolidated after review. (PR #101)\n"
+      )
+      git(repo, "add", "CHANGELOG.md")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Record the final React on Rails 1.0.1 changelog (#999)",
+        "-m",
+        "The final changelog records source CHANGELOG.md commit `#{source_changelog_sha}`."
+      )
+
+      write_file(
+        repo,
+        "CHANGELOG.md",
+        "# Change Log\n\n### [Unreleased]\n\n#### Changed\n\n" \
+        "- Intermediate prerelease behavior. (PR #100)\n\n" \
+        "### [1.0.1] - 2026-07-24\n\n#### Changed\n\n" \
+        "- Final shipped behavior, consolidated after review. (PR #101)\n"
+      )
+      commit_all(repo, "Reintroduce stale release entry")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog", "--check")
+      expect(status.exitstatus).to eq(1)
+      expect(stderr).to include("CHECK FAILED")
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--changelog")
+      expect(status).to be_success, stderr
+      expect(File.read(File.join(repo, "CHANGELOG.md"))).not_to include("Intermediate prerelease behavior")
+      expect(File.read(File.join(repo, "CHANGELOG.md"))).to include("consolidated after review")
+    end
+  end
+
   it "requires source-SHA provenance for a dedicated final changelog PR" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -198,6 +198,39 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips prerelease package pins superseded by a live stable forward-port" do
+    with_release_repo do |repo|
+      base_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "package.txt", "widget=2.0.0-rc.1\n")
+      prerelease_sha = commit_all(repo, "Update Widget package pin to 2.0.0-rc.1 (#10)")
+      write_file(repo, "package.txt", "widget=2.0.0\n")
+      commit_all(repo, "Adopt stable Widget 2.0.0 (#11)")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "package.txt", "widget=2.0.0\n")
+      git(repo, "add", "package.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port stable Widget (#12)",
+        "-m",
+        "- cherry-picked the merged #11 squash commit with `git cherry-pick -x`"
+      )
+      expect(git(repo, "merge-base", "release/1.0.1", "main").strip).to eq(base_sha)
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{prerelease_sha[0, 12]} Update Widget package pin to 2.0.0-rc.1 (#10)")
+      expect(stdout).to include("prerelease package pin is superseded by later stable source commit")
+      expect(stdout).not_to include("PICK #{prerelease_sha[0, 12]}")
+    end
+  end
+
   it "skips reverts of skipped rc version bump commits" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
@@ -586,7 +619,7 @@ RSpec.describe "script/release-forward-port" do
         "-m",
         "Backport release regression (#456)",
         "-m",
-        "Backports merged source PR #123 to the release train."
+        "Source PR: #123"
       )
       release_fix_sha = git(repo, "rev-parse", "HEAD").strip
       git(repo, "checkout", "main")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -840,6 +840,36 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips adapted backports that narrate their live target cherry-pick origin" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      main_fix_sha = commit_all(repo, "Fix release regression on main")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nrelease-adapted fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Backport release regression fix",
+        "-m",
+        "Cherry-picked main squash commit\n`#{main_fix_sha}` with `-x`."
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{release_fix_sha[0, 12]} Backport release regression fix")
+      expect(stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain fix\n")
+    end
+  end
+
   it "picks release commits cherry-picked from target merge commits that were later reverted" do
     with_release_repo do |repo|
       base_sha = git(repo, "rev-parse", "HEAD").strip

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -421,6 +421,27 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "ignores changelog differences when matching mixed commits to combined forward-ports" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1.rc.1]\n- Release wording\n")
+      fix_sha = commit_all(repo, "Fix release regression (#123)")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [Unreleased]\n- Mainline wording\n")
+      commit_all(repo, "Forward-port release fixes\n\nIncludes #123 with reconciled changelog wording")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
+    end
+  end
+
   it "does not trust a source-subject mention when the target patch differs" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -381,6 +381,43 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips source patches embedded in combined target commits that mention the source subject" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      write_file(repo, "main-only.txt", "combined target work\n")
+      commit_all(repo, "Forward-port release fixes\n\nIncludes: Fix release regression")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).to include("DRY RUN")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
+  it "does not trust a source-subject mention when the target patch differs" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      write_file(repo, "app.txt", "base\ndifferent target fix\n")
+      write_file(repo, "main-only.txt", "combined target work\n")
+      commit_all(repo, "Discuss release forward-port\n\nCandidate: Fix release regression")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(stdout).not_to include("patch already exists on main according to target history")
+    end
+  end
+
   it "skips no-footer target patches that rename the source path" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -459,6 +459,35 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "trusts a live target commit that narrates its conflict-resolved forward-port" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "base\nrelease-adapted fix\n")
+      fix_sha = commit_all(repo, "Fix release regression (#123)")
+      git(repo, "checkout", "main")
+
+      write_file(repo, "app.txt", "base\nnewer main fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Forward-port release regression (#999)",
+        "-m",
+        "- cherry-picked the merged #123 squash commit with `git cherry-pick -x`"
+      )
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("narrated cherry-pick -x evidence")
+      expect(stdout).not_to include("PICK #{fix_sha[0, 12]} Fix release regression (#123)")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nnewer main fix\n")
+    end
+  end
+
   it "skips no-footer target patches that rename the source path" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/script/release-finish
+++ b/script/release-finish
@@ -428,6 +428,16 @@ class ReleaseFinish
   def verify_main_after_delete!(remote, release_branch, checked_main_sha:, checked_source_sha:, recovery_ref:)
     fetch_remote!(remote)
     current_main_sha = git("rev-parse", "#{remote}/main").strip
+    recreated_source_sha = remote_branch_sha(remote, release_branch)
+    if recreated_source_sha
+      raise AbortError, <<~ERROR.strip
+        #{remote}/#{release_branch} reappeared during post-delete verification
+          checked: #{checked_source_sha}
+          current: #{recreated_source_sha}
+        The temporary recovery branch #{recovery_ref.delete_prefix('refs/heads/')} remains at the checked tip.
+        Re-run the code and changelog checks against the recreated source branch before removing recovery.
+      ERROR
+    end
 
     if current_main_sha == checked_main_sha
       run_or_print(*leased_recovery_delete_command(remote, checked_source_sha:, recovery_ref:))
@@ -447,6 +457,15 @@ class ReleaseFinish
       Restored #{release_branch} at #{checked_source_sha}.
       Re-run close-out against the new main tip; no release-branch commit was discarded.
     ERROR
+  end
+
+  def remote_branch_sha(remote, branch)
+    stdout, stderr, status =
+      capture_git("ls-remote", "--exit-code", "--heads", "--", remote, branch)
+    return stdout.split.first if status.success?
+    return if status.exitstatus == 2
+
+    raise GitError, git_error(["ls-remote", "--exit-code", "--heads", "--", remote, branch], stdout, stderr, status)
   end
 
   def leased_recovery_delete_command(remote, checked_source_sha:, recovery_ref:)

--- a/script/release-finish
+++ b/script/release-finish
@@ -31,6 +31,8 @@ class ReleaseFinish
   STABLE_VERSION = /\A\d+\.\d+\.\d+\z/
   SUBCOMMANDS = %w[promote close-out].freeze
   FORWARD_PORT_INCOMPLETE_STATUS = 1
+  CHERRY_PICK_IN_PROGRESS_MESSAGE =
+    "a cherry-pick is already in progress; run git cherry-pick --continue, --skip, or --abort first"
   # Resolve the sibling forward-port helper relative to this script so close-out
   # works regardless of the current directory (the runbook runs from repo root,
   # but the throwaway-repo tests run from a temp checkout).
@@ -412,9 +414,16 @@ class ReleaseFinish
   end
 
   def ensure_clean_worktree!
+    raise AbortError, CHERRY_PICK_IN_PROGRESS_MESSAGE if cherry_pick_in_progress?
+
     return if git("status", "--porcelain").strip.empty?
 
     raise AbortError, "working tree is not clean; commit, stash, or discard local changes before continuing"
+  end
+
+  def cherry_pick_in_progress?
+    git_dir = git("rev-parse", "--git-dir").strip
+    File.exist?(File.expand_path("CHERRY_PICK_HEAD", git_dir))
   end
 
   def ensure_tag_exists!(tag)

--- a/script/release-finish
+++ b/script/release-finish
@@ -30,6 +30,7 @@ require "open3"
 class ReleaseFinish
   STABLE_VERSION = /\A\d+\.\d+\.\d+\z/
   SUBCOMMANDS = %w[promote close-out].freeze
+  FORWARD_PORT_INCOMPLETE_STATUS = 1
   # Resolve the sibling forward-port helper relative to this script so close-out
   # works regardless of the current directory (the runbook runs from repo root,
   # but the throwaway-repo tests run from a temp checkout).
@@ -310,12 +311,12 @@ class ReleaseFinish
     puts "Code plan (every remaining PICK/MANUAL item needs its own source-change PR):"
     code_args = ["--source", source, "--target", "main", "--check"]
     @options.fetch(:ack_manual).each { |sha| code_args.push("--ack-manual", sha) }
-    code_complete = system(FORWARD_PORT_SCRIPT, *code_args)
+    code_complete = run_forward_port_check(*code_args)
 
     puts
     puts "Changelog plan (remaining reconciliation needs its own squash PR):"
     changelog_complete =
-      system(FORWARD_PORT_SCRIPT, "--source", source, "--target", "main", "--changelog", "--check")
+      run_forward_port_check("--source", source, "--target", "main", "--changelog", "--check")
 
     if code_complete && changelog_complete
       puts "\nAll source and changelog forward-port work is complete on main."
@@ -324,6 +325,17 @@ class ReleaseFinish
 
     puts "\nNext: follow the runbook's one-source-PR-at-a-time loop, then merge the release/changelog squash PR."
     false
+  end
+
+  def run_forward_port_check(*)
+    launched = system(FORWARD_PORT_SCRIPT, *)
+    status = Process.last_status
+    raise GitError, "could not launch #{FORWARD_PORT_SCRIPT}" if launched.nil? || status.nil?
+
+    return true if status.success?
+    return false if status.exitstatus == FORWARD_PORT_INCOMPLETE_STATUS
+
+    raise GitError, "#{FORWARD_PORT_SCRIPT} verification failed with status #{status.exitstatus}"
   end
 
   def delete_release_branch!(release_branch, remote)
@@ -336,7 +348,7 @@ class ReleaseFinish
     end
 
     # SAFETY: never delete the source branch unless the verified local main is
-    # already reachable from the remote main.
+    # still exactly the remote main checked by the completion gate.
     ensure_forward_port_durable_on_remote!(remote)
 
     confirm_outward!(
@@ -390,22 +402,11 @@ class ReleaseFinish
   end
 
   # SAFETY GATE for the branch delete: re-fetch and require the checked local
-  # main tip to be reachable from remote main. The plan checks above establish
-  # semantic completeness; this reachability check prevents an operator from
-  # validating unpushed local work and then deleting the source branch.
+  # main tip to still equal remote main. Any advancement, including a revert or
+  # changelog rewrite after the semantic checks, requires a fresh close-out run.
   def ensure_forward_port_durable_on_remote!(remote)
     fetch_remote!(remote)
-    remote_main = "#{remote}/main"
-    local_main = git("rev-parse", "main").strip
-    return if commit_reachable_from?(local_main, remote_main)
-
-    raise AbortError, <<~ERROR.strip
-      the forward-ported commits on local main are not yet on #{remote_main}.
-      Push main before deleting the source branch — its unique commits would
-      otherwise be lost (tags do not preserve the forward-port onto main):
-        git push   # or merge the forward-port PR into main
-      Then re-run: script/release-finish close-out #{@options.fetch(:version)}
-    ERROR
+    ensure_local_main_matches_remote!(remote)
   end
 
   def ensure_clean_worktree!

--- a/script/release-finish
+++ b/script/release-finish
@@ -394,9 +394,18 @@ class ReleaseFinish
       checked_main_sha:,
       checked_source_sha:
     )
-    run_or_print(
-      *leased_branch_delete_command(release_branch, remote, checked_source_sha:, recovery_ref:)
-    )
+    begin
+      run_or_print(
+        *leased_branch_delete_command(release_branch, remote, checked_source_sha:, recovery_ref:)
+      )
+    rescue GitError => e
+      raise AbortError, <<~ERROR.strip
+        The leased delete transaction could not be confirmed; its remote outcome is UNKNOWN.
+        Inspect #{remote}/#{release_branch} and #{recovery_ref.delete_prefix('refs/heads/')} before retrying.
+        A retained recovery branch at a conflicting tip intentionally rejects reuse until it is accounted for.
+        Git command failure: #{e.message}
+      ERROR
+    end
     verify_main_after_delete!(
       remote,
       release_branch,
@@ -426,9 +435,19 @@ class ReleaseFinish
   end
 
   def verify_main_after_delete!(remote, release_branch, checked_main_sha:, checked_source_sha:, recovery_ref:)
-    fetch_remote!(remote)
-    current_main_sha = git("rev-parse", "#{remote}/main").strip
-    recreated_source_sha = remote_branch_sha(remote, release_branch)
+    begin
+      fetch_remote!(remote)
+      current_main_sha = git("rev-parse", "#{remote}/main").strip
+      recreated_source_sha = remote_branch_sha(remote, release_branch)
+    rescue GitError => e
+      raise AbortError, <<~ERROR.strip
+        Post-delete verification did not complete.
+        The temporary recovery branch #{recovery_ref.delete_prefix('refs/heads/')} was created for the checked source tip.
+        Inspect #{remote}/main, #{remote}/#{release_branch}, and the recovery branch before retrying.
+        Git command failure: #{e.message}
+      ERROR
+    end
+
     if recreated_source_sha
       raise AbortError, <<~ERROR.strip
         #{remote}/#{release_branch} reappeared during post-delete verification

--- a/script/release-finish
+++ b/script/release-finish
@@ -369,18 +369,23 @@ class ReleaseFinish
 
   def delete_release_branch!(release_branch, remote, checked_main_sha:, checked_source_sha:)
     section "Delete the ephemeral branch #{release_branch} on #{remote} (tags are the durable record)"
+    recovery_ref = release_recovery_ref(release_branch, checked_source_sha)
 
     if @options[:dry_run]
-      puts "DRY RUN: would verify the checked source and main tips, then atomically delete with matching leases:"
+      puts "DRY RUN: would verify the checked source and main tips, then atomically move the release tip"
+      puts "to temporary recovery branch #{recovery_ref.delete_prefix('refs/heads/')} while deleting"
+      puts "with a source lease:"
       run_or_print(
-        *leased_branch_delete_command(release_branch, remote, checked_main_sha:, checked_source_sha:)
+        *leased_branch_delete_command(release_branch, remote, checked_source_sha:, recovery_ref:)
       )
+      puts "DRY RUN: would re-fetch #{remote}/main, restore #{release_branch} if main raced,"
+      puts "then remove the recovery branch."
       return
     end
 
     confirm_outward!(
       "Delete #{release_branch} on #{remote} now? Tags persist; this only removes the branch.",
-      "git push --atomic #{remote} <checked-main>:main :#{release_branch} (with matching leases)"
+      "git push --atomic #{remote} <checked-source>:#{recovery_ref} :#{release_branch} (with matching leases)"
     )
 
     ensure_forward_port_durable_on_remote!(
@@ -390,23 +395,90 @@ class ReleaseFinish
       checked_source_sha:
     )
     run_or_print(
-      *leased_branch_delete_command(release_branch, remote, checked_main_sha:, checked_source_sha:)
+      *leased_branch_delete_command(release_branch, remote, checked_source_sha:, recovery_ref:)
+    )
+    verify_main_after_delete!(
+      remote,
+      release_branch,
+      checked_main_sha:,
+      checked_source_sha:,
+      recovery_ref:
     )
   end
 
-  def leased_branch_delete_command(release_branch, remote, checked_main_sha:, checked_source_sha:)
-    main_ref = "refs/heads/main"
+  def release_recovery_ref(release_branch, checked_source_sha)
+    version = release_branch.delete_prefix("release/")
+    "refs/heads/release-finish-recovery/#{version}-#{checked_source_sha[0, 12]}"
+  end
+
+  def leased_branch_delete_command(release_branch, remote, checked_source_sha:, recovery_ref:)
     source_ref = "refs/heads/#{release_branch}"
     [
       "git",
       "push",
       "--atomic",
-      "--force-with-lease=#{main_ref}:#{checked_main_sha}",
       "--force-with-lease=#{source_ref}:#{checked_source_sha}",
+      "--force-with-lease=#{recovery_ref}:",
       remote,
-      "#{checked_main_sha}:#{main_ref}",
+      "#{checked_source_sha}:#{recovery_ref}",
       ":#{source_ref}"
     ]
+  end
+
+  def verify_main_after_delete!(remote, release_branch, checked_main_sha:, checked_source_sha:, recovery_ref:)
+    fetch_remote!(remote)
+    current_main_sha = git("rev-parse", "#{remote}/main").strip
+
+    if current_main_sha == checked_main_sha
+      run_or_print(*leased_recovery_delete_command(remote, checked_source_sha:, recovery_ref:))
+      return
+    end
+
+    restore_release_branch!(
+      remote,
+      release_branch,
+      checked_source_sha:,
+      recovery_ref:
+    )
+    raise AbortError, <<~ERROR.strip
+      #{remote}/main changed during the release-branch deletion
+        checked: #{checked_main_sha}
+        current: #{current_main_sha}
+      Restored #{release_branch} at #{checked_source_sha}.
+      Re-run close-out against the new main tip; no release-branch commit was discarded.
+    ERROR
+  end
+
+  def leased_recovery_delete_command(remote, checked_source_sha:, recovery_ref:)
+    [
+      "git",
+      "push",
+      "--force-with-lease=#{recovery_ref}:#{checked_source_sha}",
+      remote,
+      ":#{recovery_ref}"
+    ]
+  end
+
+  def restore_release_branch!(remote, release_branch, checked_source_sha:, recovery_ref:)
+    source_ref = "refs/heads/#{release_branch}"
+    command = [
+      "git",
+      "push",
+      "--atomic",
+      "--force-with-lease=#{source_ref}:",
+      "--force-with-lease=#{recovery_ref}:#{checked_source_sha}",
+      remote,
+      "#{checked_source_sha}:#{source_ref}",
+      ":#{recovery_ref}"
+    ]
+    run_or_print(*command)
+  rescue GitError => e
+    raise AbortError, <<~ERROR.strip
+      #{remote}/main changed during the release-branch deletion, and automatic restoration failed.
+      The checked release tip remains protected by #{recovery_ref} at #{checked_source_sha}.
+      Inspect #{remote}/#{release_branch} and restore it from that recovery branch before retrying.
+      Recovery command failure: #{e.message}
+    ERROR
   end
 
   # ---------------------------------------------------------------------------
@@ -453,8 +525,9 @@ class ReleaseFinish
   end
 
   # SAFETY GATE for the branch delete: re-fetch and require both checked tips to
-  # remain unchanged. The following atomic push repeats those expectations as
-  # leases, closing the final fetch-to-delete race for both refs.
+  # remain unchanged. The following atomic push leases the source and preserves
+  # its exact tip on a temporary remote recovery branch. A post-delete fetch then
+  # detects a main race and restores the source before aborting.
   def ensure_forward_port_durable_on_remote!(remote, release_branch, checked_main_sha:, checked_source_sha:)
     fetch_remote!(remote)
     ensure_local_main_matches_remote!(remote)

--- a/script/release-finish
+++ b/script/release-finish
@@ -50,6 +50,7 @@ class ReleaseFinish
       version: nil,
       rc_tag: nil,
       ack_manual: [],
+      ack_final_changelog_source: nil,
       remote: "origin"
     }
     @parser = build_parser
@@ -96,11 +97,16 @@ class ReleaseFinish
     raise UsageError, "too many arguments: #{argv.join(' ')}" unless argv.empty?
 
     validate_version!
-    if subcommand == "promote" && @options[:ack_manual].any?
-      raise UsageError, "--ack-manual applies only to close-out forward-port verification"
-    end
+    validate_subcommand_options!(subcommand)
 
     subcommand
+  end
+
+  def validate_subcommand_options!(subcommand)
+    return unless subcommand == "promote"
+    return if @options[:ack_manual].empty? && !@options[:ack_final_changelog_source]
+
+    raise UsageError, "forward-port acknowledgements apply only to close-out verification"
   end
 
   def validate_version!
@@ -124,9 +130,7 @@ class ReleaseFinish
       parser.on("--remote NAME", "Remote for fetch and branch deletion (default: origin)") do |remote|
         @options[:remote] = remote
       end
-      parser.on("--ack-manual SHA", "Acknowledge one inspected MANUAL forward-port item (repeatable)") do |sha|
-        @options[:ack_manual] << sha
-      end
+      add_forward_port_ack_options(parser)
       parser.on("--dry-run", "Preview the plan; still fetches remote refs needed for current-state checks") do
         @options[:dry_run] = true
       end
@@ -140,10 +144,23 @@ class ReleaseFinish
     end
   end
 
+  def add_forward_port_ack_options(parser)
+    parser.on("--ack-manual SHA", "Acknowledge one inspected MANUAL forward-port item (repeatable)") do |sha|
+      @options[:ack_manual] << sha
+    end
+    parser.on(
+      "--ack-final-changelog-source SHA",
+      "Acknowledge the current source CHANGELOG.md commit for a legacy authoritative changelog PR"
+    ) do |sha|
+      @options[:ack_final_changelog_source] = sha
+    end
+  end
+
   def usage_banner
     <<~BANNER
       Usage: script/release-finish promote   X.Y.Z [--rc-tag vX.Y.Z.rc.N] [--dry-run] [--yes]
-             script/release-finish close-out X.Y.Z [--remote origin] [--ack-manual SHA] [--dry-run] [--yes]
+             script/release-finish close-out X.Y.Z [--remote origin] [--ack-manual SHA]
+                                                  [--ack-final-changelog-source SHA] [--dry-run] [--yes]
 
       Orchestrates the release-train runbook steps 4 (promote) and 5 (close out).
 
@@ -285,6 +302,8 @@ class ReleaseFinish
 
     fetch_remote!(remote)
     ensure_local_main_matches_remote!(remote)
+    checked_main_sha = git("rev-parse", "#{remote}/main").strip
+    checked_source_sha = git("rev-parse", source).strip
 
     complete = forward_port_complete?(source)
     unless complete
@@ -302,7 +321,12 @@ class ReleaseFinish
       ERROR
     end
 
-    delete_release_branch!(release_branch, remote)
+    delete_release_branch!(
+      release_branch,
+      remote,
+      checked_main_sha:,
+      checked_source_sha:
+    )
 
     finish_dry_run_notice
     0
@@ -317,8 +341,11 @@ class ReleaseFinish
 
     puts
     puts "Changelog plan (remaining reconciliation needs its own squash PR):"
-    changelog_complete =
-      run_forward_port_check("--source", source, "--target", "main", "--changelog", "--check")
+    changelog_args = ["--source", source, "--target", "main", "--changelog", "--check"]
+    if (sha = @options[:ack_final_changelog_source])
+      changelog_args.push("--ack-final-changelog-source", sha)
+    end
+    changelog_complete = run_forward_port_check(*changelog_args)
 
     if code_complete && changelog_complete
       puts "\nAll source and changelog forward-port work is complete on main."
@@ -340,26 +367,46 @@ class ReleaseFinish
     raise GitError, "#{FORWARD_PORT_SCRIPT} verification failed with status #{status.exitstatus}"
   end
 
-  def delete_release_branch!(release_branch, remote)
+  def delete_release_branch!(release_branch, remote, checked_main_sha:, checked_source_sha:)
     section "Delete the ephemeral branch #{release_branch} on #{remote} (tags are the durable record)"
 
     if @options[:dry_run]
-      puts "DRY RUN: would verify the forward-ported commits are on #{remote}/main, then run:"
-      run_or_print("git", "push", remote, "--delete", release_branch)
+      puts "DRY RUN: would verify the checked source and main tips, then atomically delete with matching leases:"
+      run_or_print(
+        *leased_branch_delete_command(release_branch, remote, checked_main_sha:, checked_source_sha:)
+      )
       return
     end
 
     confirm_outward!(
       "Delete #{release_branch} on #{remote} now? Tags persist; this only removes the branch.",
-      "git push #{remote} --delete #{release_branch}"
+      "git push --atomic #{remote} <checked-main>:main :#{release_branch} (with matching leases)"
     )
 
-    # SAFETY: confirm first so an operator cannot leave this exact-main check
-    # stale while the prompt is open. Never delete the source branch unless the
-    # verified local main still exactly equals freshly fetched remote main.
-    ensure_forward_port_durable_on_remote!(remote)
+    ensure_forward_port_durable_on_remote!(
+      remote,
+      release_branch,
+      checked_main_sha:,
+      checked_source_sha:
+    )
+    run_or_print(
+      *leased_branch_delete_command(release_branch, remote, checked_main_sha:, checked_source_sha:)
+    )
+  end
 
-    run_or_print("git", "push", remote, "--delete", release_branch)
+  def leased_branch_delete_command(release_branch, remote, checked_main_sha:, checked_source_sha:)
+    main_ref = "refs/heads/main"
+    source_ref = "refs/heads/#{release_branch}"
+    [
+      "git",
+      "push",
+      "--atomic",
+      "--force-with-lease=#{main_ref}:#{checked_main_sha}",
+      "--force-with-lease=#{source_ref}:#{checked_source_sha}",
+      remote,
+      "#{checked_main_sha}:#{main_ref}",
+      ":#{source_ref}"
+    ]
   end
 
   # ---------------------------------------------------------------------------
@@ -405,12 +452,26 @@ class ReleaseFinish
     ERROR
   end
 
-  # SAFETY GATE for the branch delete: re-fetch and require the checked local
-  # main tip to still equal remote main. Any advancement, including a revert or
-  # changelog rewrite after the semantic checks, requires a fresh close-out run.
-  def ensure_forward_port_durable_on_remote!(remote)
+  # SAFETY GATE for the branch delete: re-fetch and require both checked tips to
+  # remain unchanged. The following atomic push repeats those expectations as
+  # leases, closing the final fetch-to-delete race for both refs.
+  def ensure_forward_port_durable_on_remote!(remote, release_branch, checked_main_sha:, checked_source_sha:)
     fetch_remote!(remote)
     ensure_local_main_matches_remote!(remote)
+    ensure_remote_ref_unchanged!("#{remote}/main", checked_main_sha)
+    ensure_remote_ref_unchanged!("#{remote}/#{release_branch}", checked_source_sha)
+  end
+
+  def ensure_remote_ref_unchanged!(ref, checked_sha)
+    current_sha = git("rev-parse", ref).strip
+    return if current_sha == checked_sha
+
+    raise AbortError, <<~ERROR.strip
+      #{ref} changed after the forward-port checks
+        checked: #{checked_sha}
+        current: #{current_sha}
+      Re-run close-out against the new tips; the release branch was not deleted.
+    ERROR
   end
 
   def ensure_clean_worktree!

--- a/script/release-finish
+++ b/script/release-finish
@@ -440,7 +440,12 @@ class ReleaseFinish
     end
 
     if current_main_sha == checked_main_sha
-      run_or_print(*leased_recovery_delete_command(remote, checked_source_sha:, recovery_ref:))
+      delete_recovery_if_source_absent!(
+        remote,
+        release_branch,
+        checked_source_sha:,
+        recovery_ref:
+      )
       return
     end
 
@@ -468,12 +473,33 @@ class ReleaseFinish
     raise GitError, git_error(["ls-remote", "--exit-code", "--heads", "--", remote, branch], stdout, stderr, status)
   end
 
-  def leased_recovery_delete_command(remote, checked_source_sha:, recovery_ref:)
+  def delete_recovery_if_source_absent!(remote, release_branch, checked_source_sha:, recovery_ref:)
+    run_or_print(
+      *leased_recovery_delete_command(
+        remote,
+        release_branch,
+        checked_source_sha:,
+        recovery_ref:
+      )
+    )
+  rescue GitError => e
+    raise AbortError, <<~ERROR.strip
+      Recovery cleanup was not confirmed while proving #{remote}/#{release_branch} remained absent.
+      Inspect #{remote}/#{release_branch} and #{recovery_ref.delete_prefix('refs/heads/')} before retrying.
+      Git command failure: #{e.message}
+    ERROR
+  end
+
+  def leased_recovery_delete_command(remote, release_branch, checked_source_sha:, recovery_ref:)
+    source_ref = "refs/heads/#{release_branch}"
     [
       "git",
       "push",
+      "--atomic",
+      "--force-with-lease=#{source_ref}:",
       "--force-with-lease=#{recovery_ref}:#{checked_source_sha}",
       remote,
+      ":#{source_ref}",
       ":#{recovery_ref}"
     ]
   end

--- a/script/release-finish
+++ b/script/release-finish
@@ -347,14 +347,16 @@ class ReleaseFinish
       return
     end
 
-    # SAFETY: never delete the source branch unless the verified local main is
-    # still exactly the remote main checked by the completion gate.
-    ensure_forward_port_durable_on_remote!(remote)
-
     confirm_outward!(
       "Delete #{release_branch} on #{remote} now? Tags persist; this only removes the branch.",
       "git push #{remote} --delete #{release_branch}"
     )
+
+    # SAFETY: confirm first so an operator cannot leave this exact-main check
+    # stale while the prompt is open. Never delete the source branch unless the
+    # verified local main still exactly equals freshly fetched remote main.
+    ensure_forward_port_durable_on_remote!(remote)
+
     run_or_print("git", "push", remote, "--delete", release_branch)
   end
 

--- a/script/release-finish
+++ b/script/release-finish
@@ -20,9 +20,9 @@ require "open3"
 #              the accepted RC tag, collapses the rc->stable CHANGELOG, then runs
 #              `bundle exec rake release[X.Y.Z]` (the rake guards enforce the
 #              dangerous tag/version safety; this script does not re-implement it).
-#   close-out  Step 5: forward-port remaining release-branch commits to main via
-#              `script/release-forward-port` (dry-run, then apply on confirmation),
-#              then delete the ephemeral release branch on origin.
+#   close-out  Step 5: verify the one-change forward-port PRs and the separate
+#              changelog/release PR are complete on main, then delete the
+#              ephemeral release branch on origin.
 #
 # The dangerous outward operations (`rake release`, `git push --delete`) are each
 # gated behind an explicit confirmation and are printed-only under --dry-run.
@@ -46,6 +46,7 @@ class ReleaseFinish
       assume_yes: false,
       version: nil,
       rc_tag: nil,
+      ack_manual: [],
       remote: "origin"
     }
     @parser = build_parser
@@ -92,6 +93,10 @@ class ReleaseFinish
     raise UsageError, "too many arguments: #{argv.join(' ')}" unless argv.empty?
 
     validate_version!
+    if subcommand == "promote" && @options[:ack_manual].any?
+      raise UsageError, "--ack-manual applies only to close-out forward-port verification"
+    end
+
     subcommand
   end
 
@@ -116,6 +121,9 @@ class ReleaseFinish
       parser.on("--remote NAME", "Remote for fetch and branch deletion (default: origin)") do |remote|
         @options[:remote] = remote
       end
+      parser.on("--ack-manual SHA", "Acknowledge one inspected MANUAL forward-port item (repeatable)") do |sha|
+        @options[:ack_manual] << sha
+      end
       parser.on("--dry-run", "Preview the plan; still fetches remote refs needed for current-state checks") do
         @options[:dry_run] = true
       end
@@ -132,14 +140,14 @@ class ReleaseFinish
   def usage_banner
     <<~BANNER
       Usage: script/release-finish promote   X.Y.Z [--rc-tag vX.Y.Z.rc.N] [--dry-run] [--yes]
-             script/release-finish close-out X.Y.Z [--remote origin] [--dry-run] [--yes]
+             script/release-finish close-out X.Y.Z [--remote origin] [--ack-manual SHA] [--dry-run] [--yes]
 
       Orchestrates the release-train runbook steps 4 (promote) and 5 (close out).
 
         promote    Verify the release/X.Y.Z tip equals the accepted RC tag, collapse the
                    rc->stable CHANGELOG, then run `bundle exec rake release[X.Y.Z]`.
-        close-out  Forward-port remaining commits to main via #{FORWARD_PORT_SCRIPT},
-                   then delete release/X.Y.Z on the remote.
+        close-out  Verify separate source and changelog forward-port PRs are complete
+                   on main, then delete release/X.Y.Z on the remote.
 
       The rake promotion guards enforce the dangerous tag/version safety; this script
       adds dry-run, confirmations, and on/at-release/clean-tree guards around them.
@@ -275,39 +283,47 @@ class ReleaseFinish
     fetch_remote!(remote)
     ensure_local_main_matches_remote!(remote)
 
-    forward_port_to_main!(source)
+    complete = forward_port_complete?(source)
+    unless complete
+      if @options[:dry_run]
+        puts "\nDRY RUN: close-out is blocked until the separate forward-port PRs above merge."
+        finish_dry_run_notice
+        return 0
+      end
+
+      raise AbortError, <<~ERROR.strip
+        release close-out is not complete on #{remote}/main.
+        Land each remaining source change in its own PR, then land the separate
+        changelog/release reconciliation as a squash PR. Re-run close-out only
+        after both checks pass; the release branch was not deleted.
+      ERROR
+    end
+
     delete_release_branch!(release_branch, remote)
 
     finish_dry_run_notice
     0
   end
 
-  def forward_port_to_main!(source)
-    section "Forward-port remaining #{source} commits to main"
-    # Always show the REAL plan: release-forward-port --dry-run is read-only (no
-    # checkout, no cherry-pick), so running it even under our own --dry-run gives
-    # the operator the actual forward-port preview rather than a bare command.
-    puts "Dry-run plan first (delegates to #{FORWARD_PORT_SCRIPT}; it skips rc bumps and already-ported fixes):"
-    unless system(FORWARD_PORT_SCRIPT, "--source", source, "--target", "main", "--dry-run")
-      raise GitError, "#{FORWARD_PORT_SCRIPT} --dry-run failed; cannot preview the forward-port plan"
+  def forward_port_complete?(source)
+    section "Verify separate forward-port PRs from #{source}"
+    puts "Code plan (every remaining PICK/MANUAL item needs its own source-change PR):"
+    code_args = ["--source", source, "--target", "main", "--check"]
+    @options.fetch(:ack_manual).each { |sha| code_args.push("--ack-manual", sha) }
+    code_complete = system(FORWARD_PORT_SCRIPT, *code_args)
+
+    puts
+    puts "Changelog plan (remaining reconciliation needs its own squash PR):"
+    changelog_complete =
+      system(FORWARD_PORT_SCRIPT, "--source", source, "--target", "main", "--changelog", "--check")
+
+    if code_complete && changelog_complete
+      puts "\nAll source and changelog forward-port work is complete on main."
+      return true
     end
 
-    if @options[:dry_run]
-      puts
-      puts "DRY RUN: the plan above is read-only; the apply step (forward-port without --dry-run) was skipped."
-      return
-    end
-
-    unless confirm?("Apply the forward-port plan above onto main?")
-      raise AbortError, "review the plan and re-run close-out when ready to forward-port"
-    end
-
-    forwarded = system(FORWARD_PORT_SCRIPT, "--source", source, "--target", "main")
-    return if forwarded
-
-    raise AbortError,
-          "#{FORWARD_PORT_SCRIPT} did not complete (conflict or MANUAL item). Resolve per the runbook, " \
-          "then re-run close-out; the helper is idempotent and the branch deletion below was not run."
+    puts "\nNext: follow the runbook's one-source-PR-at-a-time loop, then merge the release/changelog squash PR."
+    false
   end
 
   def delete_release_branch!(release_branch, remote)
@@ -319,11 +335,8 @@ class ReleaseFinish
       return
     end
 
-    # SAFETY: never delete the source branch while its forward-ported commits
-    # exist only on LOCAL main. close-out applies the cherry-picks locally but
-    # deliberately does not push main (main may be protected), so the operator
-    # must push first. Re-fetch and verify local main is now on origin/main
-    # before allowing the delete.
+    # SAFETY: never delete the source branch unless the verified local main is
+    # already reachable from the remote main.
     ensure_forward_port_durable_on_remote!(remote)
 
     confirm_outward!(
@@ -376,16 +389,10 @@ class ReleaseFinish
     ERROR
   end
 
-  # SAFETY GATE for the branch delete: the forward-port applies cherry-picks to
-  # LOCAL main but close-out never pushes main itself (main may be protected), so
-  # the operator must push (or merge the forward-port PR) first. Re-fetch and
-  # require local main — which carries those cherry-picks — to be reachable from
-  # the remote main. If the operator has not pushed, local main holds commits
-  # absent from #{remote}/main and this aborts, making it impossible to delete
-  # the source branch while its unique forward-ported commits exist only locally.
-  # (Cherry-picks get new SHAs, so this checks the pushed local-main tip, not the
-  # original release-branch commit identities, which are never ancestors of main
-  # under the trunk-based -x model.)
+  # SAFETY GATE for the branch delete: re-fetch and require the checked local
+  # main tip to be reachable from remote main. The plan checks above establish
+  # semantic completeness; this reachability check prevents an operator from
+  # validating unpushed local work and then deleting the source branch.
   def ensure_forward_port_durable_on_remote!(remote)
     fetch_remote!(remote)
     remote_main = "#{remote}/main"

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -618,6 +618,65 @@ test_close_out_aborts_if_remote_main_advances_after_checks() {
   fi
 }
 
+test_close_out_aborts_if_remote_main_advances_during_confirmation() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+
+  local runner="$PWD/../prompt-race-runner.rb"
+  local writer="$PWD/../prompt-race-writer"
+  local origin
+  origin="$(git remote get-url origin)"
+  cat > "$runner" <<'RUBY'
+require "pty"
+
+script, origin, writer = ARGV
+output = +""
+advanced = false
+status = nil
+
+PTY.spawn("ruby", script, "close-out", "1.0.0") do |read, write, pid|
+  begin
+    loop do
+      chunk = read.readpartial(1024)
+      output << chunk
+      next if advanced || !output.include?("Delete release/1.0.0 on origin now?")
+
+      abort "clone failed" unless system("git", "clone", "-q", origin, writer)
+      system("git", "-C", writer, "checkout", "-q", "main") || abort("checkout failed")
+      system("git", "-C", writer, "config", "user.email", "test@example.com") || abort("config failed")
+      system("git", "-C", writer, "config", "user.name", "Release Finish Prompt Race Test") || abort("config failed")
+      File.write(File.join(writer, "prompt-race.txt"), "remote advanced while confirmation was open\n")
+      system("git", "-C", writer, "add", "prompt-race.txt") || abort("add failed")
+      system("git", "-C", writer, "commit", "-qm", "Advance remote main during confirmation") ||
+        abort("commit failed")
+      system("git", "-C", writer, "push", "-q", "origin", "main") || abort("push failed")
+
+      advanced = true
+      write.write("y\n")
+    end
+  rescue EOFError, Errno::EIO
+    # PTYs report EIO at normal child exit on some platforms.
+  ensure
+    _waited_pid, status = Process.wait2(pid)
+  end
+end
+
+print output
+exit(status.exitstatus)
+RUBY
+
+  RF_OUT="$(ruby "$runner" "$RELEASE_FINISH" "$origin" "$writer" 2>&1)"
+  RF_STATUS=$?
+
+  assert_status 1 "$RF_STATUS" "close-out confirmation-window race status"
+  assert_contains "$RF_OUT" "Delete release/1.0.0 on origin now?" "close-out confirmation-window prompt"
+  assert_contains "$RF_OUT" "local main is not in sync with origin/main" "close-out confirmation-window race guard"
+  assert_not_contains "$RF_OUT" "git push origin --delete release/1.0.0" "close-out confirmation-window no delete"
+  if ! git ls-remote --heads "$origin" release/1.0.0 | grep -q release/1.0.0; then
+    fail "confirmation-window remote advancement deleted the release branch"
+  fi
+}
+
 # --- close-out: guard — not on main ----------------------------------------
 
 test_close_out_aborts_when_not_on_main() {
@@ -701,6 +760,7 @@ run_test test_close_out_propagates_verifier_errors
 run_test test_close_out_aborts_when_local_main_behind_origin
 run_test test_close_out_dry_run_fetches_before_main_sync_check
 run_test test_close_out_aborts_if_remote_main_advances_after_checks
+run_test test_close_out_aborts_if_remote_main_advances_during_confirmation
 run_test test_close_out_aborts_when_not_on_main
 run_test test_close_out_aborts_on_dirty_worktree
 run_test test_rejects_rc_version_argument

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -480,6 +480,37 @@ test_close_out_refuses_delete_when_changelog_pr_remains() {
   fi
 }
 
+test_close_out_refuses_mismatched_source_changelog_completion() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+
+  git checkout -q release/1.0.0
+  printf '# Change Log\n\n### [Unreleased]\n\n### [0.9.0]\n\n#### Fixed\n\n- Older release\n' > CHANGELOG.md
+  git add CHANGELOG.md
+  git commit -qm "Replace source with mismatched changelog section"
+  git push -q origin release/1.0.0
+
+  git checkout -q main
+  printf '# Change Log\n\n### [Unreleased]\n\n### [1.0.0.rc.1]\n\n#### Fixed\n\n- RC residue\n' > CHANGELOG.md
+  git add CHANGELOG.md
+  git commit -qm "Retain target RC residue"
+  git push -q origin main
+  git fetch -q origin
+
+  run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out mismatched-source status"
+  assert_contains "$RF_OUT" "no matching stable or prerelease 1.0.0 changelog section" \
+    "close-out mismatched-source explanation"
+  assert_contains "$RF_OUT" "release close-out is not complete on origin/main" \
+    "close-out mismatched-source completion gate"
+  assert_not_contains "$RF_OUT" "Delete the ephemeral branch" \
+    "close-out mismatched-source stops before delete"
+  if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "mismatched source changelog allowed release branch deletion"
+  fi
+}
+
 # --- close-out: refuse direct local application when forward-port PRs remain -
 
 # Close-out is now a completion gate, not an all-at-once mutator. When source or
@@ -813,6 +844,75 @@ test_close_out_restores_release_branch_if_main_races_during_delete() {
   fi
 }
 
+prepare_post_delete_source_recreation_wrapper() {
+  local origin_dir="$PWD/../origin.git"
+  local writer_dir="$PWD/../source-recreation-writer"
+  local wrapper_dir="$PWD/../source-recreation-bin"
+
+  git clone -q "$origin_dir" "$writer_dir"
+  git -C "$writer_dir" checkout -q release/1.0.0
+  git -C "$writer_dir" config user.email test@example.com
+  git -C "$writer_dir" config user.name "Release Finish Source Recreation Test"
+  printf 'source recreated after deletion\n' > "$writer_dir/recreated-source.txt"
+  git -C "$writer_dir" add recreated-source.txt
+  git -C "$writer_dir" commit -qm "Recreate release branch after deletion"
+  RECREATED_SOURCE_SHA="$(git -C "$writer_dir" rev-parse HEAD)"
+  git -C "$writer_dir" push -q origin HEAD:refs/heads/source-recreation-candidate
+  mkdir -p "$wrapper_dir"
+  REAL_GIT_BIN="$(command -v git)"
+  export REAL_GIT_BIN
+
+  cat > "$wrapper_dir/git" <<'WRAPPER'
+#!/usr/bin/env bash
+set -uo pipefail
+
+marker="$(dirname "$0")/source-recreation-fired"
+is_release_delete=false
+if [ "${1:-}" = "push" ]; then
+  for arg in "$@"; do
+    [ "$arg" = ":refs/heads/release/1.0.0" ] && is_release_delete=true
+  done
+fi
+
+if [ "$is_release_delete" = true ] && [ ! -e "$marker" ]; then
+  : > "$marker"
+  "$REAL_GIT_BIN" "$@"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    "$REAL_GIT_BIN" push -q origin \
+      refs/remotes/origin/source-recreation-candidate:refs/heads/release/1.0.0
+  fi
+  exit "$rc"
+fi
+
+exec "$REAL_GIT_BIN" "$@"
+WRAPPER
+  chmod +x "$wrapper_dir/git"
+  SOURCE_RECREATION_GIT_BIN="$wrapper_dir"
+}
+
+test_close_out_aborts_if_source_reappears_after_delete() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  local checked_source_sha recovery_ref
+  checked_source_sha="$(git rev-parse origin/release/1.0.0)"
+  recovery_ref="refs/heads/release-finish-recovery/1.0.0-${checked_source_sha:0:12}"
+  prepare_post_delete_source_recreation_wrapper
+
+  PATH="$SOURCE_RECREATION_GIT_BIN:$PATH" run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out source-recreation status"
+  assert_contains "$RF_OUT" "origin/release/1.0.0 reappeared during post-delete verification" \
+    "close-out source-recreation detection"
+  assert_contains "$RF_OUT" "temporary recovery branch" "close-out source-recreation recovery guidance"
+  assert_equal "$RECREATED_SOURCE_SHA" \
+    "$(git ls-remote "$PWD/../origin.git" refs/heads/release/1.0.0 | cut -f1)" \
+    "close-out source-recreation preserves new source"
+  assert_equal "$checked_source_sha" \
+    "$(git ls-remote "$PWD/../origin.git" "$recovery_ref" | cut -f1)" \
+    "close-out source-recreation retains checked recovery"
+}
+
 test_close_out_aborts_with_an_empty_cherry_pick_in_progress() {
   setup_release_repo
   git checkout -q main
@@ -929,6 +1029,7 @@ run_test test_close_out_dry_run_prints_plan_and_runs_nothing
 run_test test_close_out_dry_run_does_not_delete_branch
 run_test test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed
 run_test test_close_out_refuses_delete_when_changelog_pr_remains
+run_test test_close_out_refuses_mismatched_source_changelog_completion
 run_test test_close_out_refuses_delete_when_forward_port_prs_remain
 run_test test_close_out_propagates_verifier_errors
 run_test test_close_out_aborts_when_local_main_behind_origin
@@ -937,6 +1038,7 @@ run_test test_close_out_aborts_if_remote_main_advances_after_checks
 run_test test_close_out_aborts_if_source_advances_after_checks
 run_test test_close_out_aborts_if_remote_main_advances_during_confirmation
 run_test test_close_out_restores_release_branch_if_main_races_during_delete
+run_test test_close_out_aborts_if_source_reappears_after_delete
 run_test test_close_out_aborts_with_an_empty_cherry_pick_in_progress
 run_test test_close_out_aborts_when_not_on_main
 run_test test_close_out_aborts_on_dirty_worktree

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -386,7 +386,7 @@ test_close_out_dry_run_prints_plan_and_runs_nothing() {
   assert_contains "$RF_OUT" "Release forward-port plan" "close-out dry-run"
   assert_contains "$RF_OUT" "PICK" "close-out dry-run picks the fix"
   assert_contains "$RF_OUT" "close-out is blocked until the separate forward-port PRs above merge" "close-out dry-run"
-  assert_not_contains "$RF_OUT" "git push origin --delete release/1.0.0" "close-out dry-run"
+  assert_not_contains "$RF_OUT" "git push --atomic" "close-out dry-run"
   assert_contains "$RF_OUT" "no tags, pushes, releases, changelog changes, cherry-picks, or branch deletions were performed" "close-out dry-run"
 }
 
@@ -443,7 +443,11 @@ test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed() {
   # confirm_outward! with NO TTY (no "no TTY" abort, no prompt) and actually ran
   # the outward delete.
   assert_not_contains "$RF_OUT" "no TTY for confirmation" "close-out --yes should not stop on TTY"
-  assert_contains "$RF_OUT" "+ git push origin --delete release/1.0.0" "close-out --yes deleted branch"
+  assert_contains "$RF_OUT" "+ git push --atomic --force-with-lease=refs/heads/main:" \
+    "close-out --yes uses a checked main lease"
+  assert_contains "$RF_OUT" "--force-with-lease=refs/heads/release/1.0.0:" \
+    "close-out --yes uses a checked source lease"
+  assert_contains "$RF_OUT" ":refs/heads/release/1.0.0" "close-out --yes deleted branch"
   # The branch is actually gone from the (local bare) origin.
   if git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
     fail "close-out --yes did not delete the release branch on origin"
@@ -501,8 +505,8 @@ test_close_out_propagates_verifier_errors() {
   run_rf close-out 9.9.9 --dry-run
 
   assert_status 1 "$RF_STATUS" "close-out verifier-error status"
-  assert_contains "$RF_OUT" "source ref" "close-out verifier-error source"
-  assert_contains "$RF_OUT" "verification failed with status 3" "close-out verifier-error propagation"
+  assert_contains "$RF_OUT" "origin/release/9.9.9" "close-out verifier-error source"
+  assert_contains "$RF_OUT" "git rev-parse origin/release/9.9.9 failed" "close-out verifier-error propagation"
   assert_not_contains "$RF_OUT" "blocked until the separate forward-port PRs" \
     "close-out verifier errors are not ordinary pending work"
 }
@@ -601,6 +605,47 @@ WRAPPER
   RACE_RELEASE_FINISH="$wrapper_dir/release-finish"
 }
 
+prepare_post_check_source_advance_wrapper() {
+  local wrapper_dir="$PWD/../source-race-bin"
+  mkdir -p "$wrapper_dir"
+  cp "$RELEASE_FINISH" "$wrapper_dir/release-finish"
+  cp "$SCRIPT_DIR/release-forward-port" "$wrapper_dir/release-forward-port-real"
+
+  cat > "$wrapper_dir/release-forward-port" <<'WRAPPER'
+#!/usr/bin/env bash
+set -uo pipefail
+
+wrapper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$wrapper_dir/release-forward-port-real" "$@"
+rc=$?
+
+has_changelog=false
+has_check=false
+for arg in "$@"; do
+  [ "$arg" = "--changelog" ] && has_changelog=true
+  [ "$arg" = "--check" ] && has_check=true
+done
+
+marker="$wrapper_dir/source-advance-fired"
+if [ "$rc" -eq 0 ] && [ "$has_changelog" = true ] && [ "$has_check" = true ] && [ ! -e "$marker" ]; then
+  : > "$marker"
+  writer="$wrapper_dir/source-race-writer"
+  git clone -q "$(git remote get-url origin)" "$writer"
+  git -C "$writer" checkout -q release/1.0.0
+  git -C "$writer" config user.email test@example.com
+  git -C "$writer" config user.name "Release Finish Source Race Test"
+  printf 'late release correction\n' > "$writer/late-release.txt"
+  git -C "$writer" add late-release.txt
+  git -C "$writer" commit -qm "Advance release branch after checks"
+  git -C "$writer" push -q origin release/1.0.0
+fi
+
+exit "$rc"
+WRAPPER
+  chmod +x "$wrapper_dir/release-forward-port"
+  RACE_RELEASE_FINISH="$wrapper_dir/release-finish"
+}
+
 test_close_out_aborts_if_remote_main_advances_after_checks() {
   setup_release_repo
   push_forward_port_to_origin_main
@@ -612,9 +657,27 @@ test_close_out_aborts_if_remote_main_advances_after_checks() {
   assert_contains "$RF_OUT" "All source and changelog forward-port work is complete on main" \
     "close-out post-check race precondition"
   assert_contains "$RF_OUT" "local main is not in sync with origin/main" "close-out post-check race guard"
-  assert_not_contains "$RF_OUT" "git push origin --delete release/1.0.0" "close-out post-check race no delete"
+  assert_not_contains "$RF_OUT" "git push --atomic" "close-out post-check race no delete"
   if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
     fail "post-check remote advancement deleted the release branch"
+  fi
+}
+
+test_close_out_aborts_if_source_advances_after_checks() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  prepare_post_check_source_advance_wrapper
+
+  RELEASE_FINISH_UNDER_TEST="$RACE_RELEASE_FINISH" run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out source-race status"
+  assert_contains "$RF_OUT" "All source and changelog forward-port work is complete on main" \
+    "close-out source-race precondition"
+  assert_contains "$RF_OUT" "origin/release/1.0.0 changed after the forward-port checks" \
+    "close-out source-race guard"
+  assert_not_contains "$RF_OUT" "git push --atomic" "close-out source-race no delete"
+  if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "source advancement after checks deleted the release branch"
   fi
 }
 
@@ -671,7 +734,7 @@ RUBY
   assert_status 1 "$RF_STATUS" "close-out confirmation-window race status"
   assert_contains "$RF_OUT" "Delete release/1.0.0 on origin now?" "close-out confirmation-window prompt"
   assert_contains "$RF_OUT" "local main is not in sync with origin/main" "close-out confirmation-window race guard"
-  assert_not_contains "$RF_OUT" "git push origin --delete release/1.0.0" "close-out confirmation-window no delete"
+  assert_not_contains "$RF_OUT" "git push --atomic" "close-out confirmation-window no delete"
   if ! git ls-remote --heads "$origin" release/1.0.0 | grep -q release/1.0.0; then
     fail "confirmation-window remote advancement deleted the release branch"
   fi
@@ -798,6 +861,7 @@ run_test test_close_out_propagates_verifier_errors
 run_test test_close_out_aborts_when_local_main_behind_origin
 run_test test_close_out_dry_run_fetches_before_main_sync_check
 run_test test_close_out_aborts_if_remote_main_advances_after_checks
+run_test test_close_out_aborts_if_source_advances_after_checks
 run_test test_close_out_aborts_if_remote_main_advances_during_confirmation
 run_test test_close_out_aborts_with_an_empty_cherry_pick_in_progress
 run_test test_close_out_aborts_when_not_on_main

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -11,6 +11,11 @@
 
 set -uo pipefail
 
+# Test repositories must not inherit signing hooks or other machine-specific
+# Git behavior from the operator's global/system configuration.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RELEASE_FINISH="$SCRIPT_DIR/release-finish"
 
@@ -408,16 +413,37 @@ test_close_out_dry_run_does_not_delete_branch() {
 # so origin/main carries the cherry-pick. This is the precondition the durable
 # branch-delete gate requires. Leaves the checkout on a synced local main.
 push_forward_port_to_origin_main() {
-  git checkout -q main
-  git cherry-pick -x "$(git rev-parse release/1.0.0)" >/dev/null 2>&1
-  "$SCRIPT_DIR/release-forward-port" \
-    --source release/1.0.0 \
-    --target main \
-    --changelog >/dev/null
-  git add CHANGELOG.md
-  git commit -qm "Reconcile 1.0.0 release changelog on main"
-  git push -q origin main
-  git fetch -q origin
+  if ! git checkout -q main; then
+    fail "precondition: could not check out main"
+    return 1
+  fi
+  if ! git cherry-pick -x "$(git rev-parse release/1.0.0)" >/dev/null 2>&1; then
+    fail "precondition: forward-port cherry-pick failed"
+    return 1
+  fi
+  if ! "$SCRIPT_DIR/release-forward-port" \
+      --source release/1.0.0 \
+      --target main \
+      --changelog >/dev/null; then
+    fail "precondition: changelog reconciliation failed"
+    return 1
+  fi
+  if ! git add CHANGELOG.md; then
+    fail "precondition: could not stage changelog reconciliation"
+    return 1
+  fi
+  if ! git commit -qm "Reconcile 1.0.0 release changelog on main"; then
+    fail "precondition: changelog reconciliation produced nothing to commit"
+    return 1
+  fi
+  if ! git push -q origin main; then
+    fail "precondition: could not push forward-port fixture"
+    return 1
+  fi
+  if ! git fetch -q origin; then
+    fail "precondition: could not refresh forward-port fixture"
+    return 1
+  fi
 }
 
 # --- close-out: real apply (--yes, no TTY) deletes the branch ---------------
@@ -460,6 +486,30 @@ test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed() {
   fi
 }
 
+test_close_out_explains_a_conflicting_recovery_ref_rejection() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  local checked_source_sha conflicting_recovery_sha recovery_ref
+  checked_source_sha="$(git rev-parse origin/release/1.0.0)"
+  conflicting_recovery_sha="$(git rev-parse main)"
+  recovery_ref="refs/heads/release-finish-recovery/1.0.0-${checked_source_sha:0:12}"
+  git push -q origin "$conflicting_recovery_sha:$recovery_ref"
+
+  run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out preexisting-recovery status"
+  assert_contains "$RF_OUT" "leased delete transaction could not be confirmed" \
+    "close-out preexisting-recovery rejection"
+  assert_contains "$RF_OUT" "remote outcome is UNKNOWN" "close-out preexisting-recovery uncertainty"
+  assert_contains "$RF_OUT" "${recovery_ref#refs/heads/}" "close-out preexisting-recovery guidance"
+  assert_equal "$checked_source_sha" \
+    "$(git ls-remote "$PWD/../origin.git" refs/heads/release/1.0.0 | cut -f1)" \
+    "close-out preexisting-recovery preserves source"
+  assert_equal "$conflicting_recovery_sha" \
+    "$(git ls-remote "$PWD/../origin.git" "$recovery_ref" | cut -f1)" \
+    "close-out preexisting-recovery preserves recovery"
+}
+
 test_close_out_refuses_delete_when_changelog_pr_remains() {
   setup_release_repo
   git checkout -q main
@@ -474,7 +524,7 @@ test_close_out_refuses_delete_when_changelog_pr_remains() {
     "close-out changelog-incomplete code check"
   assert_contains "$RF_OUT" "CHECK FAILED: release changelog reconciliation still needs its own squash PR" \
     "close-out changelog-incomplete changelog check"
-  assert_not_contains "$RF_OUT" "git push origin --delete" "close-out changelog-incomplete must not delete"
+  assert_not_contains "$RF_OUT" "git push --atomic" "close-out changelog-incomplete must not delete"
   if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
     fail "completion gate deleted the release branch before the changelog PR"
   fi
@@ -527,7 +577,7 @@ test_close_out_refuses_delete_when_forward_port_prs_remain() {
   assert_contains "$RF_OUT" "release close-out is not complete on origin/main" "close-out incomplete message"
   assert_contains "$RF_OUT" "each remaining source change in its own PR" "close-out incomplete next step"
   assert_not_contains "$RF_OUT" "Forward-port complete" "close-out must not apply picks directly"
-  assert_not_contains "$RF_OUT" "git push origin --delete" "close-out incomplete must not delete"
+  assert_not_contains "$RF_OUT" "git push --atomic" "close-out incomplete must not delete"
   assert_equal "$main_before" "$(git rev-parse main)" "close-out incomplete main tip"
   # Critical: the branch still exists on origin (its unique commits are safe).
   if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
@@ -728,6 +778,7 @@ test_close_out_aborts_if_remote_main_advances_during_confirmation() {
   origin="$(git remote get-url origin)"
   cat > "$runner" <<'RUBY'
 require "pty"
+require "timeout"
 
 script, origin, writer = ARGV
 output = +""
@@ -736,24 +787,33 @@ status = nil
 
 PTY.spawn("ruby", script, "close-out", "1.0.0") do |read, write, pid|
   begin
-    loop do
-      chunk = read.readpartial(1024)
-      output << chunk
-      next if advanced || !output.include?("Delete release/1.0.0 on origin now?")
+    Timeout.timeout(120) do
+      loop do
+        chunk = read.readpartial(1024)
+        output << chunk
+        next if advanced || !output.include?("Delete release/1.0.0 on origin now?")
 
-      abort "clone failed" unless system("git", "clone", "-q", origin, writer)
-      system("git", "-C", writer, "checkout", "-q", "main") || abort("checkout failed")
-      system("git", "-C", writer, "config", "user.email", "test@example.com") || abort("config failed")
-      system("git", "-C", writer, "config", "user.name", "Release Finish Prompt Race Test") || abort("config failed")
-      File.write(File.join(writer, "prompt-race.txt"), "remote advanced while confirmation was open\n")
-      system("git", "-C", writer, "add", "prompt-race.txt") || abort("add failed")
-      system("git", "-C", writer, "commit", "-qm", "Advance remote main during confirmation") ||
-        abort("commit failed")
-      system("git", "-C", writer, "push", "-q", "origin", "main") || abort("push failed")
+        abort "clone failed" unless system("git", "clone", "-q", origin, writer)
+        system("git", "-C", writer, "checkout", "-q", "main") || abort("checkout failed")
+        system("git", "-C", writer, "config", "user.email", "test@example.com") || abort("config failed")
+        system("git", "-C", writer, "config", "user.name", "Release Finish Prompt Race Test") || abort("config failed")
+        File.write(File.join(writer, "prompt-race.txt"), "remote advanced while confirmation was open\n")
+        system("git", "-C", writer, "add", "prompt-race.txt") || abort("add failed")
+        system("git", "-C", writer, "commit", "-qm", "Advance remote main during confirmation") ||
+          abort("commit failed")
+        system("git", "-C", writer, "push", "-q", "origin", "main") || abort("push failed")
 
-      advanced = true
-      write.write("y\n")
+        advanced = true
+        write.write("y\n")
+      end
     end
+  rescue Timeout::Error
+    begin
+      Process.kill("TERM", pid)
+    rescue Errno::ESRCH
+      # The child exited at the timeout boundary.
+    end
+    warn "timed out waiting for the delete confirmation prompt"
   rescue EOFError, Errno::EIO
     # PTYs report EIO at normal child exit on some platforms.
   ensure
@@ -762,7 +822,7 @@ PTY.spawn("ruby", script, "close-out", "1.0.0") do |read, write, pid|
 end
 
 print output
-exit(status.exitstatus)
+exit(status&.exitstatus || 1)
 RUBY
 
   RF_OUT="$(ruby "$runner" "$RELEASE_FINISH" "$origin" "$writer" 2>&1)"
@@ -842,6 +902,55 @@ test_close_out_restores_release_branch_if_main_races_during_delete() {
       grep -q release-finish-recovery; then
     fail "close-out during-delete restoration left the temporary recovery branch on origin"
   fi
+}
+
+prepare_post_delete_verification_failure_wrapper() {
+  local wrapper_dir="$PWD/../verification-failure-bin"
+
+  mkdir -p "$wrapper_dir"
+  REAL_GIT_BIN="$(command -v git)"
+  export REAL_GIT_BIN
+
+  cat > "$wrapper_dir/git" <<'WRAPPER'
+#!/usr/bin/env bash
+set -uo pipefail
+
+marker="$(dirname "$0")/verification-failure-fired"
+if [ "$*" = "ls-remote --exit-code --heads -- origin release/1.0.0" ] && [ ! -e "$marker" ]; then
+  : > "$marker"
+  echo "simulated post-delete ls-remote failure" >&2
+  exit 128
+fi
+
+exec "$REAL_GIT_BIN" "$@"
+WRAPPER
+  chmod +x "$wrapper_dir/git"
+  VERIFICATION_FAILURE_GIT_BIN="$wrapper_dir"
+}
+
+test_close_out_retains_recovery_when_post_delete_verification_io_fails() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  local checked_source_sha recovery_ref
+  checked_source_sha="$(git rev-parse origin/release/1.0.0)"
+  recovery_ref="refs/heads/release-finish-recovery/1.0.0-${checked_source_sha:0:12}"
+  prepare_post_delete_verification_failure_wrapper
+
+  PATH="$VERIFICATION_FAILURE_GIT_BIN:$PATH" run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out post-delete verification-I/O status"
+  assert_contains "$RF_OUT" "Post-delete verification did not complete" \
+    "close-out post-delete verification-I/O explanation"
+  assert_contains "$RF_OUT" "${recovery_ref#refs/heads/}" \
+    "close-out post-delete verification-I/O recovery guidance"
+  assert_contains "$RF_OUT" "simulated post-delete ls-remote failure" \
+    "close-out post-delete verification-I/O cause"
+  if git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "post-delete verification-I/O failure unexpectedly restored the release branch"
+  fi
+  assert_equal "$checked_source_sha" \
+    "$(git ls-remote "$PWD/../origin.git" "$recovery_ref" | cut -f1)" \
+    "close-out post-delete verification-I/O retains checked recovery"
 }
 
 prepare_post_delete_source_recreation_wrapper() {
@@ -1095,6 +1204,7 @@ run_test test_promote_without_tty_and_without_yes_aborts_before_release
 run_test test_close_out_dry_run_prints_plan_and_runs_nothing
 run_test test_close_out_dry_run_does_not_delete_branch
 run_test test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed
+run_test test_close_out_explains_a_conflicting_recovery_ref_rejection
 run_test test_close_out_refuses_delete_when_changelog_pr_remains
 run_test test_close_out_refuses_mismatched_source_changelog_completion
 run_test test_close_out_refuses_delete_when_forward_port_prs_remain
@@ -1105,6 +1215,7 @@ run_test test_close_out_aborts_if_remote_main_advances_after_checks
 run_test test_close_out_aborts_if_source_advances_after_checks
 run_test test_close_out_aborts_if_remote_main_advances_during_confirmation
 run_test test_close_out_restores_release_branch_if_main_races_during_delete
+run_test test_close_out_retains_recovery_when_post_delete_verification_io_fails
 run_test test_close_out_aborts_if_source_reappears_after_delete
 run_test test_close_out_preserves_recovery_if_source_reappears_during_cleanup
 run_test test_close_out_aborts_with_an_empty_cherry_pick_in_progress

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -4,10 +4,10 @@
 # `bash script/release-finish-test.bash`.
 #
 # Every case runs against a throwaway `mktemp -d` git repo and exercises only the
-# dry-run output and the guard/abort paths. NOTHING here runs a real release,
-# branch deletion, or push: promote stops at the rake-release confirmation under
-# dry-run, and close-out only invokes the forward-port DRY-RUN plan plus printed
-# branch-deletion. The harness never adds a network remote.
+# dry-run output and the guard/abort paths. NOTHING here runs a real network
+# release or push: promote stops at the rake-release confirmation under dry-run.
+# Close-out tests use only a throwaway local bare remote when exercising the
+# final branch-deletion gate.
 
 set -uo pipefail
 
@@ -155,7 +155,7 @@ setup_release_repo() {
   mkdir -p react_on_rails/lib/react_on_rails
   printf 'module ReactOnRails\n  VERSION = "1.0.0"\nend\n' > react_on_rails/lib/react_on_rails/version.rb
   printf 'core\n' > app.txt
-  printf '## [Unreleased]\n\n## [1.0.0.rc.0]\n- Fix something\n' > CHANGELOG.md
+  printf '# Change Log\n\n### [Unreleased]\n\n### [1.0.0.rc.0]\n\n#### Fixed\n\n- Fix something\n' > CHANGELOG.md
   git add .
   git commit -qm "beta work"
   git push -q origin main
@@ -384,7 +384,8 @@ test_close_out_dry_run_prints_plan_and_runs_nothing() {
   # The real forward-port DRY-RUN plan is shown (it resolves origin/release/1.0.0).
   assert_contains "$RF_OUT" "Release forward-port plan" "close-out dry-run"
   assert_contains "$RF_OUT" "PICK" "close-out dry-run picks the fix"
-  assert_contains "$RF_OUT" 'DRY RUN: would run: git push origin --delete release/1.0.0' "close-out dry-run"
+  assert_contains "$RF_OUT" "close-out is blocked until the separate forward-port PRs above merge" "close-out dry-run"
+  assert_not_contains "$RF_OUT" "git push origin --delete release/1.0.0" "close-out dry-run"
   assert_contains "$RF_OUT" "no tags, pushes, releases, changelog changes, cherry-picks, or branch deletions were performed" "close-out dry-run"
 }
 
@@ -408,6 +409,12 @@ test_close_out_dry_run_does_not_delete_branch() {
 push_forward_port_to_origin_main() {
   git checkout -q main
   git cherry-pick -x "$(git rev-parse release/1.0.0)" >/dev/null 2>&1
+  "$SCRIPT_DIR/release-forward-port" \
+    --source release/1.0.0 \
+    --target main \
+    --changelog >/dev/null
+  git add CHANGELOG.md
+  git commit -qm "Reconcile 1.0.0 release changelog on main"
   git push -q origin main
   git fetch -q origin
 }
@@ -442,28 +449,47 @@ test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed() {
   fi
 }
 
-# --- close-out: P1 durability gate — refuse delete if main not pushed -------
-
-# #1: a single close-out run forward-ports the fix onto LOCAL main but never
-# pushes main itself. The fix now exists only locally, so the durable-delete gate
-# MUST abort before deleting the source branch (otherwise the commit is lost).
-# Local main starts in sync with origin/main, so the stale-main guard passes and
-# control reaches the durability gate the in-run cherry-pick triggers.
-test_close_out_refuses_delete_when_forward_port_only_local() {
+test_close_out_refuses_delete_when_changelog_pr_remains() {
   setup_release_repo
-  git checkout -q main   # local main == origin/main (synced by setup's fetch)
+  git checkout -q main
+  git cherry-pick -x "$(git rev-parse release/1.0.0)" >/dev/null 2>&1
+  git push -q origin main
+  git fetch -q origin
 
   run_rf close-out 1.0.0 --yes
 
-  assert_status 1 "$RF_STATUS" "close-out local-only status"
-  # The forward-port DID apply locally...
-  assert_contains "$RF_OUT" "Forward-port complete" "close-out local-only applied the pick"
-  # ...but the gate refused the delete because main was not pushed.
-  assert_contains "$RF_OUT" "not yet on origin/main" "close-out local-only message"
-  assert_not_contains "$RF_OUT" "git push origin --delete" "close-out local-only must not delete"
+  assert_status 1 "$RF_STATUS" "close-out changelog-incomplete status"
+  assert_contains "$RF_OUT" "CHECK PASSED: the release source has no remaining code forward-port work" \
+    "close-out changelog-incomplete code check"
+  assert_contains "$RF_OUT" "CHECK FAILED: release changelog reconciliation still needs its own squash PR" \
+    "close-out changelog-incomplete changelog check"
+  assert_not_contains "$RF_OUT" "git push origin --delete" "close-out changelog-incomplete must not delete"
+  if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "completion gate deleted the release branch before the changelog PR"
+  fi
+}
+
+# --- close-out: refuse direct local application when forward-port PRs remain -
+
+# Close-out is now a completion gate, not an all-at-once mutator. When source or
+# changelog work remains it must leave local main unchanged and refuse deletion.
+test_close_out_refuses_delete_when_forward_port_prs_remain() {
+  setup_release_repo
+  git checkout -q main   # local main == origin/main (synced by setup's fetch)
+  local main_before
+  main_before="$(git rev-parse main)"
+
+  run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out incomplete status"
+  assert_contains "$RF_OUT" "release close-out is not complete on origin/main" "close-out incomplete message"
+  assert_contains "$RF_OUT" "each remaining source change in its own PR" "close-out incomplete next step"
+  assert_not_contains "$RF_OUT" "Forward-port complete" "close-out must not apply picks directly"
+  assert_not_contains "$RF_OUT" "git push origin --delete" "close-out incomplete must not delete"
+  assert_equal "$main_before" "$(git rev-parse main)" "close-out incomplete main tip"
   # Critical: the branch still exists on origin (its unique commits are safe).
   if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
-    fail "durability gate deleted the release branch while commits were only local"
+    fail "completion gate deleted the release branch while PR work remained"
   fi
 }
 
@@ -598,7 +624,8 @@ run_test test_promote_without_tty_and_without_yes_aborts_before_release
 run_test test_close_out_dry_run_prints_plan_and_runs_nothing
 run_test test_close_out_dry_run_does_not_delete_branch
 run_test test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed
-run_test test_close_out_refuses_delete_when_forward_port_only_local
+run_test test_close_out_refuses_delete_when_changelog_pr_remains
+run_test test_close_out_refuses_delete_when_forward_port_prs_remain
 run_test test_close_out_aborts_when_local_main_behind_origin
 run_test test_close_out_dry_run_fetches_before_main_sync_check
 run_test test_close_out_aborts_when_not_on_main

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -913,6 +913,73 @@ test_close_out_aborts_if_source_reappears_after_delete() {
     "close-out source-recreation retains checked recovery"
 }
 
+prepare_cleanup_source_recreation_wrapper() {
+  local origin_dir="$PWD/../origin.git"
+  local writer_dir="$PWD/../cleanup-source-recreation-writer"
+  local wrapper_dir="$PWD/../cleanup-source-recreation-bin"
+
+  git clone -q "$origin_dir" "$writer_dir"
+  git -C "$writer_dir" checkout -q release/1.0.0
+  git -C "$writer_dir" config user.email test@example.com
+  git -C "$writer_dir" config user.name "Release Finish Cleanup Race Test"
+  printf 'source recreated during recovery cleanup\n' > "$writer_dir/cleanup-recreated-source.txt"
+  git -C "$writer_dir" add cleanup-recreated-source.txt
+  git -C "$writer_dir" commit -qm "Recreate release branch during recovery cleanup"
+  CLEANUP_RECREATED_SOURCE_SHA="$(git -C "$writer_dir" rev-parse HEAD)"
+  git -C "$writer_dir" push -q origin HEAD:refs/heads/cleanup-source-recreation-candidate
+  mkdir -p "$wrapper_dir"
+  REAL_GIT_BIN="$(command -v git)"
+  export REAL_GIT_BIN
+
+  cat > "$wrapper_dir/git" <<'WRAPPER'
+#!/usr/bin/env bash
+set -uo pipefail
+
+marker="$(dirname "$0")/cleanup-source-recreation-fired"
+has_source_absence_lease=false
+deletes_recovery=false
+if [ "${1:-}" = "push" ]; then
+  for arg in "$@"; do
+    [ "$arg" = "--force-with-lease=refs/heads/release/1.0.0:" ] && has_source_absence_lease=true
+    case "$arg" in
+      :refs/heads/release-finish-recovery/1.0.0-*) deletes_recovery=true ;;
+    esac
+  done
+fi
+
+if [ "$has_source_absence_lease" = true ] && [ "$deletes_recovery" = true ] && [ ! -e "$marker" ]; then
+  : > "$marker"
+  "$REAL_GIT_BIN" push -q origin \
+    refs/remotes/origin/cleanup-source-recreation-candidate:refs/heads/release/1.0.0
+fi
+
+exec "$REAL_GIT_BIN" "$@"
+WRAPPER
+  chmod +x "$wrapper_dir/git"
+  CLEANUP_SOURCE_RECREATION_GIT_BIN="$wrapper_dir"
+}
+
+test_close_out_preserves_recovery_if_source_reappears_during_cleanup() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  local checked_source_sha recovery_ref
+  checked_source_sha="$(git rev-parse origin/release/1.0.0)"
+  recovery_ref="refs/heads/release-finish-recovery/1.0.0-${checked_source_sha:0:12}"
+  prepare_cleanup_source_recreation_wrapper
+
+  PATH="$CLEANUP_SOURCE_RECREATION_GIT_BIN:$PATH" run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out cleanup-source-recreation status"
+  assert_contains "$RF_OUT" "Recovery cleanup was not confirmed" \
+    "close-out cleanup-source-recreation detection"
+  assert_equal "$CLEANUP_RECREATED_SOURCE_SHA" \
+    "$(git ls-remote "$PWD/../origin.git" refs/heads/release/1.0.0 | cut -f1)" \
+    "close-out cleanup-source-recreation preserves new source"
+  assert_equal "$checked_source_sha" \
+    "$(git ls-remote "$PWD/../origin.git" "$recovery_ref" | cut -f1)" \
+    "close-out cleanup-source-recreation retains checked recovery"
+}
+
 test_close_out_aborts_with_an_empty_cherry_pick_in_progress() {
   setup_release_repo
   git checkout -q main
@@ -1039,6 +1106,7 @@ run_test test_close_out_aborts_if_source_advances_after_checks
 run_test test_close_out_aborts_if_remote_main_advances_during_confirmation
 run_test test_close_out_restores_release_branch_if_main_races_during_delete
 run_test test_close_out_aborts_if_source_reappears_after_delete
+run_test test_close_out_preserves_recovery_if_source_reappears_during_cleanup
 run_test test_close_out_aborts_with_an_empty_cherry_pick_in_progress
 run_test test_close_out_aborts_when_not_on_main
 run_test test_close_out_aborts_on_dirty_worktree

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -177,7 +177,8 @@ setup_release_repo() {
 # Run release-finish with stdin closed (no TTY), capturing combined output.
 # Returns the exit status in RF_STATUS and output in RF_OUT.
 run_rf() {
-  RF_OUT="$(ruby "$RELEASE_FINISH" "$@" </dev/null 2>&1)"
+  local executable="${RELEASE_FINISH_UNDER_TEST:-$RELEASE_FINISH}"
+  RF_OUT="$(ruby "$executable" "$@" </dev/null 2>&1)"
   RF_STATUS=$?
 }
 
@@ -493,6 +494,19 @@ test_close_out_refuses_delete_when_forward_port_prs_remain() {
   fi
 }
 
+test_close_out_propagates_verifier_errors() {
+  setup_release_repo
+  git checkout -q main
+
+  run_rf close-out 9.9.9 --dry-run
+
+  assert_status 1 "$RF_STATUS" "close-out verifier-error status"
+  assert_contains "$RF_OUT" "source ref" "close-out verifier-error source"
+  assert_contains "$RF_OUT" "verification failed with status 3" "close-out verifier-error propagation"
+  assert_not_contains "$RF_OUT" "blocked until the separate forward-port PRs" \
+    "close-out verifier errors are not ordinary pending work"
+}
+
 # --- close-out: P1 stale-main guard ----------------------------------------
 
 # #2: local main behind origin/main must abort before forward-porting, so the
@@ -545,6 +559,63 @@ test_close_out_dry_run_fetches_before_main_sync_check() {
   assert_contains "$RF_OUT" "+ git fetch -- origin" "close-out dry-run stale-origin fetch"
   assert_contains "$RF_OUT" "local main is not in sync with origin/main" "close-out dry-run stale-origin message"
   assert_not_contains "$RF_OUT" "Release forward-port plan" "close-out stale-origin should stop before preview"
+}
+
+prepare_post_check_remote_revert_wrapper() {
+  local wrapper_dir="$PWD/../race-bin"
+  mkdir -p "$wrapper_dir"
+  cp "$RELEASE_FINISH" "$wrapper_dir/release-finish"
+  cp "$SCRIPT_DIR/release-forward-port" "$wrapper_dir/release-forward-port-real"
+
+  cat > "$wrapper_dir/release-forward-port" <<'WRAPPER'
+#!/usr/bin/env bash
+set -uo pipefail
+
+wrapper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$wrapper_dir/release-forward-port-real" "$@"
+rc=$?
+
+has_changelog=false
+has_check=false
+for arg in "$@"; do
+  [ "$arg" = "--changelog" ] && has_changelog=true
+  [ "$arg" = "--check" ] && has_check=true
+done
+
+marker="$wrapper_dir/remote-revert-fired"
+if [ "$rc" -eq 0 ] && [ "$has_changelog" = true ] && [ "$has_check" = true ] && [ ! -e "$marker" ]; then
+  : > "$marker"
+  writer="$wrapper_dir/origin-race-writer"
+  git clone -q "$(git remote get-url origin)" "$writer"
+  git -C "$writer" checkout -q main
+  git -C "$writer" config user.email test@example.com
+  git -C "$writer" config user.name "Release Finish Race Test"
+  forward_port_sha="$(git -C "$writer" log --format=%H --grep='Fix SSR regression' -n 1)"
+  git -C "$writer" revert --no-edit "$forward_port_sha" >/dev/null
+  git -C "$writer" push -q origin main
+fi
+
+exit "$rc"
+WRAPPER
+  chmod +x "$wrapper_dir/release-forward-port"
+  RACE_RELEASE_FINISH="$wrapper_dir/release-finish"
+}
+
+test_close_out_aborts_if_remote_main_advances_after_checks() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  prepare_post_check_remote_revert_wrapper
+
+  RELEASE_FINISH_UNDER_TEST="$RACE_RELEASE_FINISH" run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out post-check race status"
+  assert_contains "$RF_OUT" "All source and changelog forward-port work is complete on main" \
+    "close-out post-check race precondition"
+  assert_contains "$RF_OUT" "local main is not in sync with origin/main" "close-out post-check race guard"
+  assert_not_contains "$RF_OUT" "git push origin --delete release/1.0.0" "close-out post-check race no delete"
+  if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "post-check remote advancement deleted the release branch"
+  fi
 }
 
 # --- close-out: guard — not on main ----------------------------------------
@@ -626,8 +697,10 @@ run_test test_close_out_dry_run_does_not_delete_branch
 run_test test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed
 run_test test_close_out_refuses_delete_when_changelog_pr_remains
 run_test test_close_out_refuses_delete_when_forward_port_prs_remain
+run_test test_close_out_propagates_verifier_errors
 run_test test_close_out_aborts_when_local_main_behind_origin
 run_test test_close_out_dry_run_fetches_before_main_sync_check
+run_test test_close_out_aborts_if_remote_main_advances_after_checks
 run_test test_close_out_aborts_when_not_on_main
 run_test test_close_out_aborts_on_dirty_worktree
 run_test test_rejects_rc_version_argument

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -443,14 +443,20 @@ test_close_out_yes_non_dry_run_deletes_branch_when_forward_port_pushed() {
   # confirm_outward! with NO TTY (no "no TTY" abort, no prompt) and actually ran
   # the outward delete.
   assert_not_contains "$RF_OUT" "no TTY for confirmation" "close-out --yes should not stop on TTY"
-  assert_contains "$RF_OUT" "+ git push --atomic --force-with-lease=refs/heads/main:" \
-    "close-out --yes uses a checked main lease"
-  assert_contains "$RF_OUT" "--force-with-lease=refs/heads/release/1.0.0:" \
+  assert_contains "$RF_OUT" "+ git push --atomic --force-with-lease=refs/heads/release/1.0.0:" \
     "close-out --yes uses a checked source lease"
+  assert_contains "$RF_OUT" "--force-with-lease=refs/heads/release-finish-recovery/1.0.0-" \
+    "close-out --yes protects the source on a temporary recovery branch"
   assert_contains "$RF_OUT" ":refs/heads/release/1.0.0" "close-out --yes deleted branch"
+  assert_contains "$RF_OUT" ":refs/heads/release-finish-recovery/1.0.0-" \
+    "close-out --yes removed the temporary recovery branch"
   # The branch is actually gone from the (local bare) origin.
   if git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
     fail "close-out --yes did not delete the release branch on origin"
+  fi
+  if git ls-remote --heads "$PWD/../origin.git" "release-finish-recovery/*" |
+      grep -q release-finish-recovery; then
+    fail "close-out --yes left the temporary recovery branch on origin"
   fi
 }
 
@@ -740,6 +746,73 @@ RUBY
   fi
 }
 
+prepare_during_delete_main_race_wrapper() {
+  local origin_dir="$PWD/../origin.git"
+  local writer_dir="$PWD/../delete-race-writer"
+  local wrapper_dir="$PWD/../delete-race-bin"
+
+  git clone -q "$origin_dir" "$writer_dir"
+  git -C "$writer_dir" checkout -q main
+  git -C "$writer_dir" config user.email test@example.com
+  git -C "$writer_dir" config user.name "Release Finish Delete Race Test"
+  printf 'main advanced during branch deletion\n' > "$writer_dir/delete-race.txt"
+  git -C "$writer_dir" add delete-race.txt
+  git -C "$writer_dir" commit -qm "Advance main during branch deletion"
+  DELETE_RACE_MAIN_SHA="$(git -C "$writer_dir" rev-parse HEAD)"
+  git -C "$writer_dir" push -q origin HEAD:refs/heads/delete-race-candidate
+  mkdir -p "$wrapper_dir"
+  REAL_GIT_BIN="$(command -v git)"
+  export REAL_GIT_BIN
+
+  cat > "$wrapper_dir/git" <<'WRAPPER'
+#!/usr/bin/env bash
+set -uo pipefail
+
+marker="$(dirname "$0")/delete-race-fired"
+should_race=false
+if [ "${1:-}" = "push" ]; then
+  for arg in "$@"; do
+    [ "$arg" = ":refs/heads/release/1.0.0" ] && should_race=true
+  done
+fi
+
+if [ "$should_race" = true ] && [ ! -e "$marker" ]; then
+  : > "$marker"
+  "$REAL_GIT_BIN" push -q origin \
+    refs/remotes/origin/delete-race-candidate:refs/heads/main
+fi
+
+exec "$REAL_GIT_BIN" "$@"
+WRAPPER
+  chmod +x "$wrapper_dir/git"
+  DELETE_RACE_GIT_BIN="$wrapper_dir"
+}
+
+test_close_out_restores_release_branch_if_main_races_during_delete() {
+  setup_release_repo
+  push_forward_port_to_origin_main
+  local checked_source_sha
+  checked_source_sha="$(git rev-parse origin/release/1.0.0)"
+  prepare_during_delete_main_race_wrapper
+
+  PATH="$DELETE_RACE_GIT_BIN:$PATH" run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out during-delete main-race status"
+  assert_contains "$RF_OUT" "origin/main changed during the release-branch deletion" \
+    "close-out during-delete main-race detection"
+  assert_contains "$RF_OUT" "Restored release/1.0.0 at $checked_source_sha" \
+    "close-out during-delete source restoration"
+  assert_equal "$DELETE_RACE_MAIN_SHA" "$(git ls-remote "$PWD/../origin.git" refs/heads/main | cut -f1)" \
+    "close-out during-delete raced main tip"
+  assert_equal "$checked_source_sha" \
+    "$(git ls-remote "$PWD/../origin.git" refs/heads/release/1.0.0 | cut -f1)" \
+    "close-out during-delete restored source tip"
+  if git ls-remote --heads "$PWD/../origin.git" "release-finish-recovery/*" |
+      grep -q release-finish-recovery; then
+    fail "close-out during-delete restoration left the temporary recovery branch on origin"
+  fi
+}
+
 test_close_out_aborts_with_an_empty_cherry_pick_in_progress() {
   setup_release_repo
   git checkout -q main
@@ -863,6 +936,7 @@ run_test test_close_out_dry_run_fetches_before_main_sync_check
 run_test test_close_out_aborts_if_remote_main_advances_after_checks
 run_test test_close_out_aborts_if_source_advances_after_checks
 run_test test_close_out_aborts_if_remote_main_advances_during_confirmation
+run_test test_close_out_restores_release_branch_if_main_races_during_delete
 run_test test_close_out_aborts_with_an_empty_cherry_pick_in_progress
 run_test test_close_out_aborts_when_not_on_main
 run_test test_close_out_aborts_on_dirty_worktree

--- a/script/release-finish-test.bash
+++ b/script/release-finish-test.bash
@@ -677,6 +677,44 @@ RUBY
   fi
 }
 
+test_close_out_aborts_with_an_empty_cherry_pick_in_progress() {
+  setup_release_repo
+  git checkout -q main
+
+  git checkout -q -b duplicate-source
+  printf 'duplicate change\n' >> app.txt
+  git add app.txt
+  git commit -qm "Apply duplicate change from source"
+  local duplicate_sha
+  duplicate_sha="$(git rev-parse HEAD)"
+
+  git checkout -q main
+  printf 'duplicate change\n' >> app.txt
+  git add app.txt
+  git commit -qm "Apply duplicate change independently"
+
+  git cherry-pick "$duplicate_sha" >/dev/null 2>&1
+  local cherry_pick_status=$?
+  if [ "$cherry_pick_status" -eq 0 ]; then
+    fail "fixture invalid: duplicate cherry-pick unexpectedly succeeded"
+    return
+  fi
+  if [ ! -f "$(git rev-parse --git-path CHERRY_PICK_HEAD)" ]; then
+    fail "fixture invalid: duplicate cherry-pick did not leave CHERRY_PICK_HEAD"
+    return
+  fi
+  assert_equal "" "$(git status --porcelain)" "empty cherry-pick porcelain precondition"
+
+  run_rf close-out 1.0.0 --yes
+
+  assert_status 1 "$RF_STATUS" "close-out empty cherry-pick status"
+  assert_contains "$RF_OUT" "a cherry-pick is already in progress" "close-out empty cherry-pick guard"
+  assert_not_contains "$RF_OUT" "+ git fetch -- origin" "close-out empty cherry-pick stops before fetch"
+  if ! git ls-remote --heads "$PWD/../origin.git" release/1.0.0 | grep -q release/1.0.0; then
+    fail "empty cherry-pick state allowed deletion of the release branch"
+  fi
+}
+
 # --- close-out: guard — not on main ----------------------------------------
 
 test_close_out_aborts_when_not_on_main() {
@@ -761,6 +799,7 @@ run_test test_close_out_aborts_when_local_main_behind_origin
 run_test test_close_out_dry_run_fetches_before_main_sync_check
 run_test test_close_out_aborts_if_remote_main_advances_after_checks
 run_test test_close_out_aborts_if_remote_main_advances_during_confirmation
+run_test test_close_out_aborts_with_an_empty_cherry_pick_in_progress
 run_test test_close_out_aborts_when_not_on_main
 run_test test_close_out_aborts_on_dirty_worktree
 run_test test_rejects_rc_version_argument

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1510,8 +1510,16 @@ class ChangelogReconciler
     removed_sections = stray_rc_sections(target, base_version)
 
     target_entries = section_entries(find_unreleased(target))
-    seen_pr_numbers = target_entries.filter_map(&:pr_number).to_set
-    target_entry_texts = target_entries.to_set { |entry| normalize_text(entry.text) }
+    # De-duplicate against every section that will remain on main, not only the
+    # current [Unreleased]. A maintained release branch retains its stable
+    # section, whose entries may already live in main's history. Exclude RC
+    # sections being removed so their entries can still be re-homed before the
+    # section headers disappear.
+    retained_target_entries = target[:sections]
+                              .reject { |section| removed_sections.include?(section) }
+                              .flat_map { |section| section_entries(section) }
+    seen_pr_numbers = retained_target_entries.filter_map(&:pr_number).to_set
+    target_entry_texts = retained_target_entries.to_set { |entry| normalize_text(entry.text) }
 
     added, skipped = partition_source_entries(
       collect_source_entries(source, base_version),

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -30,6 +30,8 @@ class ReleaseForwardPort
   HUNKLESS_PATCH_ID_PREFIX = "__hunkless_patch__:"
   CHERRY_PICK_FOOTER_FORMAT = "(cherry picked from commit %s)"
   CHERRY_PICK_FOOTER_PATTERN = /\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/
+  NARRATED_CHERRY_PICK_PATTERN =
+    /cherry-picked\s+(?:main\s+)?(?:squash\s+)?commit\s+`?(?<sha>[0-9a-f]{40})`?\s+with\s+`?-x`?/i
   ASCII_WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, :manual, keyword_init: true) do
@@ -538,7 +540,7 @@ class ReleaseForwardPort
 
   def cherry_pick_origin(sha)
     body = git("log", "-1", "--format=%B", sha)
-    match = body.match(CHERRY_PICK_FOOTER_PATTERN)
+    match = body.match(CHERRY_PICK_FOOTER_PATTERN) || body.match(NARRATED_CHERRY_PICK_PATTERN)
     match && match[:sha]
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -32,6 +32,8 @@ class ReleaseForwardPort
   CHERRY_PICK_FOOTER_PATTERN = /\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/
   NARRATED_CHERRY_PICK_PATTERN =
     /cherry-picked\s+(?:main\s+)?(?:squash\s+)?commit\s+`?(?<sha>[0-9a-f]{40})`?\s+with\s+`?-x`?/i
+  NARRATED_FORWARD_PORT_PATTERN =
+    /^\s*-\s+cherry-picked\b.*\bwith\s+`?(?:git\s+)?cherry-pick\s+-x`?\s*$/i
   ASCII_WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, :manual, keyword_init: true) do
@@ -260,6 +262,9 @@ class ReleaseForwardPort
 
   def patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
     identity_candidates = target_history_source_identity_candidates(subject, target)
+    return "already forward-ported to #{target} via narrated cherry-pick -x evidence with no later target revert" if
+      identity_candidates.any? { |target_sha| narrated_forward_port_commit_live?(target_sha, target) }
+
     return patch_equivalent_skip_reason_message(target) if
       identity_candidates.any? &&
       patch_equivalent_commit_present_on_target?(sha, target, candidates: identity_candidates)
@@ -287,6 +292,11 @@ class ReleaseForwardPort
 
     @target_identity_mention_cache[cache_key] =
       git_lines("log", target, "--fixed-strings", "--grep", source_identity, "--format=%H")
+  end
+
+  def narrated_forward_port_commit_live?(sha, target)
+    body = git("log", "-1", "--format=%B", sha)
+    body.match?(NARRATED_FORWARD_PORT_PATTERN) && target_commit_live_on_target?(sha, target)
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -18,6 +18,10 @@ class ReleaseForwardPort
     \Abump\s+version\s+to\s+v?
     (?<version>\d+\.\d+\.\d+(?:(?:[.-])(?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?)?)\b
   /ix
+  PRERELEASE_PACKAGE_PIN_SUBJECT = /
+    \bpackage\s+pin\s+to\s+v?
+    (?<stable_version>\d+\.\d+\.\d+)[.-](?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?\b
+  /ix
   PRERELEASE_RANKS = {
     "dev" => 0,
     "test" => 1,
@@ -223,6 +227,8 @@ class ReleaseForwardPort
   end
 
   def build_plan(commits, target, target_version, patch_equivalent_commits)
+    @source_plan_commits = commits
+    @source_plan_positions = commits.each_with_index.to_h
     commits.map do |sha|
       subject = git("log", "-1", "--format=%s", sha).strip
       skip_decision = skip_reason(sha, subject, target, target_version, patch_equivalent_commits)
@@ -350,6 +356,9 @@ class ReleaseForwardPort
              "stale release output"
     end
 
+    superseded_pin_reason = superseded_prerelease_package_pin_reason(sha, subject, target)
+    return superseded_pin_reason if superseded_pin_reason
+
     return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}" if
       rc_version_bump?(subject)
 
@@ -365,6 +374,38 @@ class ReleaseForwardPort
 
   def rc_version_bump?(subject)
     subject.match?(RC_VERSION_BUMP_SUBJECT)
+  end
+
+  def superseded_prerelease_package_pin_reason(sha, subject, target)
+    match = subject.match(PRERELEASE_PACKAGE_PIN_SUBJECT)
+    return unless match
+
+    stable_sha = later_stable_package_pin_commit(sha, match[:stable_version], target)
+    return unless stable_sha
+
+    "prerelease package pin is superseded by later stable source commit #{stable_sha[0, 12]} already present on " \
+      "#{target}"
+  end
+
+  def later_stable_package_pin_commit(sha, stable_version, target)
+    position = @source_plan_positions&.fetch(sha, nil)
+    return unless position
+
+    superseded_paths = changed_paths_for_commit(sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
+    @source_plan_commits.drop(position + 1).find do |later_sha|
+      later_subject = subject_for_commit(later_sha).to_s
+      next unless later_subject.match?(/\bstable\b/i) && later_subject.include?(stable_version)
+
+      later_paths = changed_paths_for_commit(later_sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
+      (superseded_paths - later_paths).empty? && source_commit_provenance_present_on_target?(later_sha, target)
+    end
+  end
+
+  def source_commit_provenance_present_on_target?(sha, target)
+    subject = subject_for_commit(sha).to_s
+    source_narrated_pr_origin_on_target?(sha, target) ||
+      already_forward_ported_with_x?(sha, target) ||
+      !targeted_patch_equivalent_skip_reason(sha, subject, target).nil?
   end
 
   def merge_commit?(sha)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -28,6 +28,7 @@ class ReleaseForwardPort
   }.freeze
   EMPTY_PATCH_ID = "__empty_patch__"
   HUNKLESS_PATCH_ID_PREFIX = "__hunkless_patch__:"
+  GENERATED_LLM_FILES = %w[llms-full.txt llms-full-pro.txt].freeze
   CHERRY_PICK_FOOTER_FORMAT = "(cherry picked from commit %s)"
   CHERRY_PICK_FOOTER_PATTERN = /\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/
   NARRATED_CHERRY_PICK_PATTERN =
@@ -250,6 +251,9 @@ class ReleaseForwardPort
     return active_source_revert_skip_reason(subject, target, target_version) if
       source_standard_revert_on_target?(sha, target)
 
+    return "source commit identifies a live upstream PR already present on #{target}" if
+      source_narrated_pr_origin_on_target?(sha, target)
+
     return "already forward-ported to #{target} via cherry-pick -x evidence with no later target revert" if
       already_forward_ported_with_x?(sha, target)
 
@@ -336,8 +340,14 @@ class ReleaseForwardPort
   end
 
   def special_skip_reason(sha, subject, target, target_version)
-    if changed_paths_for_commit(sha) == [CHANGELOG_FILE]
+    changed_paths = changed_paths_for_commit(sha)
+    if changed_paths == [CHANGELOG_FILE]
       return "changelog-only commit; use --changelog reconciliation to re-home release entries under [Unreleased]"
+    end
+
+    if changed_paths.any? && (changed_paths - GENERATED_LLM_FILES).empty?
+      return "generated LLM artifact-only commit; regenerate from current target documentation instead of replaying " \
+             "stale release output"
     end
 
     return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}" if
@@ -487,6 +497,28 @@ class ReleaseForwardPort
   def source_cherry_pick_origin_reverted_on_target?(sha, target)
     origin_sha = cherry_pick_origin(sha)
     origin_sha && commit_on_target?(origin_sha, target) && !target_commit_live_on_target?(origin_sha, target)
+  end
+
+  def source_narrated_pr_origin_on_target?(sha, target)
+    subject = subject_for_commit(sha).to_s
+    release_pr_numbers = subject.scan(/#(\d+)/).flatten
+    body = git("log", "-1", "--format=%B", sha)
+    narrated_pr_numbers = body.each_line.flat_map do |line|
+      next [] unless line.match?(/\b(?:backports?|already\b.*merged\s+in|main\s+PR)\b/i)
+
+      line.scan(/#(\d+)/).flatten
+    end
+
+    (narrated_pr_numbers - release_pr_numbers).uniq.any? do |pr_number|
+      target_pr_commit_shas(pr_number, target).any? { |target_sha| target_commit_live_on_target?(target_sha, target) }
+    end
+  end
+
+  def target_pr_commit_shas(pr_number, target)
+    suffix = "(##{pr_number})"
+    target_history_commits_mentioning(suffix, target).select do |sha|
+      subject_for_commit(sha)&.end_with?(suffix)
+    end
   end
 
   def source_standard_revert_on_target?(sha, target)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -404,7 +404,9 @@ class ReleaseForwardPort
     targeted_reason = targeted_patch_equivalent_skip_reason(sha, subject, target)
     return targeted_reason if targeted_reason
 
-    return unless patch_equivalent_commits[sha] || target_has_renamed_source_paths?(target, sha)
+    return unless patch_equivalent_commits[sha] ||
+                  target_has_renamed_source_paths?(target, sha) ||
+                  generated_llm_artifact_changed?(sha)
     return unless patch_equivalent_commit_present_on_target?(sha, target)
 
     patch_equivalent_skip_reason_message(target)
@@ -977,7 +979,7 @@ class ReleaseForwardPort
   end
 
   def patch_equivalent_commit_present_on_target?(sha, target, candidates: nil, zero_context: false)
-    source_paths = changed_paths_for_commit(sha) - [CHANGELOG_FILE]
+    source_paths = changed_paths_for_commit(sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
     source_patch_id = patch_id_for_commit(sha, paths: source_paths, zero_context:)
 
     (candidates || patch_equivalent_target_candidates(sha, target)).any? do |target_sha|
@@ -1135,6 +1137,10 @@ class ReleaseForwardPort
   def changed_paths_for_commit(sha)
     @changed_paths_cache ||= {}
     @changed_paths_cache[sha] ||= git_lines("diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha)
+  end
+
+  def generated_llm_artifact_changed?(sha)
+    (changed_paths_for_commit(sha) & GENERATED_LLM_FILES).any?
   end
 
   def patch_id_for_commit(sha, target_to_source_paths: {}, paths: nil, zero_context: false)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -20,14 +20,14 @@ class ReleaseForwardPort
     (?<version>\d+\.\d+\.\d+(?:(?:[.-])(?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?)?)\b
   /ix
   PRERELEASE_PACKAGE_PIN_SUBJECT = %r{
-    \b(?<package>[A-Za-z0-9@._\/-]+)\s+package\s+pin\s+to\s+v?
+    (?<![A-Za-z0-9@._\/-])(?<package>[A-Za-z0-9@._\/-]+)\s+package\s+pin\s+to\s+v?
     (?<stable_version>\d+\.\d+\.\d+)[.-](?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?\b
   }ix
   PR_NUMBER_LIST_PATTERN = /#\d+(?:\s*,\s*#\d+)*(?:\s*,?\s+and\s+#\d+)?/i
   EXPLICIT_BACKPORT_PATTERN =
     /\A\s*backports?\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+(?:to|onto)\b/io
   FROM_BACKPORT_PATTERN =
-    /\A\s*backports?\s+(?:the|this|these)\b.*?\bfrom\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})/io
+    /\A\s*backports?\s+(?:the|this|these)\b.*?\bfrom\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+(?:to|onto)\b/io
   MERGED_REPLACEMENT_PATTERN = /
     \A\s*-\s+replaces?\b.*?\bwith\b.*?\balready\s+reviewed\s+and\s+merged\s+in\s+
     (?<prs>#{PR_NUMBER_LIST_PATTERN})
@@ -35,7 +35,12 @@ class ReleaseForwardPort
   COMPOSITE_BACKPORT_PATTERN =
     /\A\s*backports?\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+and\s+includes\s+the\s+reviewed\b/io
   PROVENANCE_NEGATION_PATTERN = /
-    \b(?:not|never|no|without|unlike|except(?:\s+for)?|rather\s+than|instead\s+of)\b
+    \b(?:
+      not|never|no|none|nothing|neither|nor|nowhere|cannot|without|unlike|
+      except(?:\s+for)?|rather\s+than|instead\s+of|other\s+than|
+      (?:ain|aren|can|couldn|didn|doesn|don|hadn|hasn|haven|isn|mightn|mustn|
+      needn|shan|shouldn|wasn|weren|won|wouldn)['’]?t
+    )\b
   /ix
   PRERELEASE_RANKS = {
     "dev" => 0,
@@ -49,13 +54,15 @@ class ReleaseForwardPort
   HUNKLESS_PATCH_ID_PREFIX = "__hunkless_patch__:"
   GENERATED_LLM_FILES = %w[llms-full.txt llms-full-pro.txt].freeze
   CHERRY_PICK_FOOTER_FORMAT = "(cherry picked from commit %s)"
-  CHERRY_PICK_FOOTER_PATTERN = /\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/
+  CHERRY_PICK_FOOTER_PATTERN = /^\(cherry picked from commit (?<sha>[0-9a-f]{40})\)$/
   NARRATED_CHERRY_PICK_PATTERN =
-    /cherry-picked\s+(?:main\s+)?(?:squash\s+)?commit\s+`?(?<sha>[0-9a-f]{40})`?\s+with\s+`?-x`?/i
+    /\A(?:-\s+)?cherry-picked\s+(?:main\s+)?(?:squash\s+)?commit\s+
+      `?(?<sha>[0-9a-f]{40})`?\s+with\s+`?-x`?\.?\z/ix
   NARRATED_FORWARD_PORT_PATTERN =
     /^\s*-\s+cherry-picked\b.*\bwith\s+`?(?:git\s+)?cherry-pick\s+-x`?\s*$/i
   NARRATED_SOURCE_PR_FORWARD_PORT_PATTERN =
-    /\A-\s+forward-ports?\b.*\b(?:release|source)\s+PR\s+#\d+/i
+    /\A-\s+forward-ports?\s+the\s+(?:complete\s+)?reviewed\b.*\bfrom\s+
+      (?:release|source)\s+PR\s+#\d+[.;]?\z/ix
   NARRATED_SOURCE_SHA_PROVENANCE_PATTERN = /
     \A(?:the|this)\s+(?:forward-port\s+)?commit\s+(?:retains|records)\s+
     `?(?:git\s+)?cherry-pick\s+-x`?\s+provenance\s+from\s+
@@ -139,7 +146,10 @@ class ReleaseForwardPort
 
     print_plan(source, target, target_version, plan)
 
-    return check_code_plan(plan) if @options[:check]
+    if @options[:check]
+      ensure_no_cherry_pick_in_progress!
+      return check_code_plan(plan)
+    end
 
     if @options[:dry_run]
       puts "\nDRY RUN: no branches were checked out and no commits were cherry-picked."
@@ -438,14 +448,12 @@ class ReleaseForwardPort
   def narrated_forward_port_commit_live?(sha, target, source_sha:, source_subject:)
     body = git("log", "-1", "--format=%B", sha)
     target_subject = subject_for_commit(sha)
-    exact_source_provenance = exact_source_sha_provenance?(body, target_subject, source_sha)
+    exact_source_provenance = exact_source_sha_provenance?(body, source_sha)
     narrated = source_pr_narration_present?(body, target_subject, source_sha, source_subject)
     (exact_source_provenance || narrated) && target_commit_live_on_target?(sha, target)
   end
 
-  def exact_source_sha_provenance?(body, target_subject, source_sha)
-    return false unless target_subject&.match?(/\AForward-port\b/i)
-
+  def exact_source_sha_provenance?(body, source_sha)
     body.split(/\n\s*\n/).any? do |paragraph|
       match = paragraph.gsub(/\s+/, " ").strip.match(NARRATED_SOURCE_SHA_PROVENANCE_PATTERN)
       match && source_sha.start_with?(match[:sha])
@@ -454,6 +462,8 @@ class ReleaseForwardPort
 
   def source_pr_narration_present?(body, target_subject, source_sha, source_subject)
     narration_segments = forward_port_narration_segments(body).select do |segment|
+      next false unless authoritative_provenance_segment?(segment)
+
       segment.match?(NARRATED_FORWARD_PORT_PATTERN) ||
         (target_subject&.match?(/\AForward-port\b/i) &&
           segment.match?(NARRATED_SOURCE_PR_FORWARD_PORT_PATTERN))
@@ -760,13 +770,18 @@ class ReleaseForwardPort
         next false unless subject_for_commit(target_sha)&.match?(/\bforward-port\b/i)
 
         body = git("log", "-1", "--format=%B", target_sha)
-        narrated = body.split(/\n\s*\n/).any? do |paragraph|
-          match = paragraph.gsub(/\s+/, " ").strip.match(NARRATED_REVIEW_FIX_FORWARD_PORT_PATTERN)
-          match && match[:pr] == pr_number
-        end
+        narrated = body.split(/\n\s*\n/).any? { |paragraph| narrated_review_fix_matches?(paragraph, pr_number) }
         narrated && target_commit_live_on_target?(target_sha, target)
       end
     end
+  end
+
+  def narrated_review_fix_matches?(paragraph, pr_number)
+    segment = paragraph.gsub(/\s+/, " ").strip
+    return false unless authoritative_provenance_segment?(segment)
+
+    match = segment.match(NARRATED_REVIEW_FIX_FORWARD_PORT_PATTERN)
+    match && match[:pr] == pr_number
   end
 
   def narrated_upstream_pr_numbers(body)
@@ -883,8 +898,17 @@ class ReleaseForwardPort
 
   def cherry_pick_origin(sha)
     body = git("log", "-1", "--format=%B", sha)
-    match = body.match(CHERRY_PICK_FOOTER_PATTERN) || body.match(NARRATED_CHERRY_PICK_PATTERN)
+    match = body.match(CHERRY_PICK_FOOTER_PATTERN) || narrated_cherry_pick_match(body)
     match && match[:sha]
+  end
+
+  def narrated_cherry_pick_match(body)
+    paragraph_segments = body.split(/\n\s*\n/).map { |paragraph| paragraph.gsub(/\s+/, " ").strip }
+    (paragraph_segments + forward_port_narration_segments(body)).uniq.filter_map do |segment|
+      next unless authoritative_provenance_segment?(segment)
+
+      segment.match(NARRATED_CHERRY_PICK_PATTERN)
+    end.first
   end
 
   def commit_on_target?(sha, target)
@@ -1347,7 +1371,7 @@ class ReleaseForwardPort
   def ensure_no_cherry_pick_in_progress!
     return unless cherry_pick_in_progress?
 
-    raise GitError, "a cherry-pick is already in progress; run git cherry-pick --continue or --abort first"
+    raise GitError, "a cherry-pick is already in progress; run git cherry-pick --continue, --skip, or --abort first"
   end
 
   def ensure_local_target_branch!(target)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -7,6 +7,7 @@ require "digest"
 
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
+  CHECK_ERROR_STATUS = 3
   VERSION_FILE = "react_on_rails/lib/react_on_rails/version.rb"
   CHANGELOG_FILE = "CHANGELOG.md"
   # Project convention is `X.Y.Z.rc.N`, but a release branch can still contain a
@@ -24,8 +25,15 @@ class ReleaseForwardPort
   }ix
   PR_NUMBER_LIST_PATTERN = /#\d+(?:\s*,\s*#\d+)*(?:\s*,?\s+and\s+#\d+)?/i
   EXPLICIT_BACKPORT_PATTERN =
-    /\bbackports?\s+(?:merged\s+)?(?:source\s+PR\s+)?(?<prs>#{PR_NUMBER_LIST_PATTERN})/io
-  FROM_BACKPORT_PATTERN = /\bbackports?\b.*?\bfrom\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})/io
+    /\A\s*backports?\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+(?:to|onto)\b/io
+  FROM_BACKPORT_PATTERN =
+    /\A\s*backports?\s+(?:the|this|these)\b.*?\bfrom\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})/io
+  MERGED_REPLACEMENT_PATTERN = /
+    \A\s*-\s+replaces?\b.*?\bwith\b.*?\balready\s+reviewed\s+and\s+merged\s+in\s+
+    (?<prs>#{PR_NUMBER_LIST_PATTERN})
+  /iox
+  COMPOSITE_BACKPORT_PATTERN =
+    /\A\s*backports?\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+and\s+includes\s+the\s+reviewed\b/io
   PRERELEASE_RANKS = {
     "dev" => 0,
     "test" => 1,
@@ -44,7 +52,14 @@ class ReleaseForwardPort
   NARRATED_FORWARD_PORT_PATTERN =
     /^\s*-\s+cherry-picked\b.*\bwith\s+`?(?:git\s+)?cherry-pick\s+-x`?\s*$/i
   NARRATED_SOURCE_PR_FORWARD_PORT_PATTERN =
-    /\bforward-ports?\b.*\b(?:release|source)\s+PR\s+#\d+/i
+    /\A-\s+forward-ports?\b.*\b(?:release|source)\s+PR\s+#\d+/i
+  NARRATED_SOURCE_SHA_PROVENANCE_PATTERN = /
+    \A(?:the|this)\s+(?:forward-port\s+)?commit\s+(?:retains|records)\s+
+    `?(?:git\s+)?cherry-pick\s+-x`?\s+provenance\s+from\s+
+    source(?:\s+squash)?\s+commit\s+`?(?<sha>[0-9a-f]{12,40})`?\.?\z
+  /ix
+  NARRATED_REVIEW_FIX_FORWARD_PORT_PATTERN =
+    /\Aforward-port\s+the\s+review\s+fix\s+from\s+release\s+PR\s+#(?<pr>\d+)\b/i
   ASCII_WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, :manual, keyword_init: true) do
@@ -100,7 +115,7 @@ class ReleaseForwardPort
     2
   rescue GitError => e
     warn "ERROR: #{e.message}"
-    1
+    @options[:check] ? CHECK_ERROR_STATUS : 1
   end
 
   private
@@ -369,7 +384,7 @@ class ReleaseForwardPort
   end
 
   def targeted_patch_equivalent_skip_reason(sha, subject, target)
-    identity_candidates = target_history_source_identity_candidates(subject, target)
+    identity_candidates = target_history_source_identity_candidates(sha, subject, target)
     return "already forward-ported to #{target} via source-bound forward-port narration with no later target revert" if
       identity_candidates.any? do |target_sha|
         narrated_forward_port_commit_live?(target_sha, target, source_sha: sha, source_subject: subject)
@@ -389,8 +404,8 @@ class ReleaseForwardPort
     "patch already exists on #{target} according to target history with no later standard revert"
   end
 
-  def target_history_source_identity_candidates(subject, target)
-    ([subject] + subject.scan(/#\d+/)).uniq.flat_map do |source_identity|
+  def target_history_source_identity_candidates(sha, subject, target)
+    ([sha, sha[0, 12], subject] + subject.scan(/#\d+/)).uniq.flat_map do |source_identity|
       target_history_commits_mentioning(source_identity, target)
     end.uniq
   end
@@ -420,16 +435,29 @@ class ReleaseForwardPort
   def narrated_forward_port_commit_live?(sha, target, source_sha:, source_subject:)
     body = git("log", "-1", "--format=%B", sha)
     target_subject = subject_for_commit(sha)
+    exact_source_provenance = exact_source_sha_provenance?(body, target_subject, source_sha)
+    narrated = source_pr_narration_present?(body, target_subject, source_sha, source_subject)
+    (exact_source_provenance || narrated) && target_commit_live_on_target?(sha, target)
+  end
+
+  def exact_source_sha_provenance?(body, target_subject, source_sha)
+    return false unless target_subject&.match?(/\AForward-port\b/i)
+
+    body.split(/\n\s*\n/).any? do |paragraph|
+      match = paragraph.gsub(/\s+/, " ").strip.match(NARRATED_SOURCE_SHA_PROVENANCE_PATTERN)
+      match && source_sha.start_with?(match[:sha])
+    end
+  end
+
+  def source_pr_narration_present?(body, target_subject, source_sha, source_subject)
     narration_segments = forward_port_narration_segments(body).select do |segment|
       segment.match?(NARRATED_FORWARD_PORT_PATTERN) ||
         (target_subject&.match?(/\AForward-port\b/i) &&
-          (segment.match?(/`git cherry-pick -x`/i) ||
-            segment.match?(NARRATED_SOURCE_PR_FORWARD_PORT_PATTERN)))
+          segment.match?(NARRATED_SOURCE_PR_FORWARD_PORT_PATTERN))
     end
-    narrated = narration_segments.any? do |segment|
+    narration_segments.any? do |segment|
       narrated_line_names_source?(segment, source_sha, source_subject)
     end
-    narrated && target_commit_live_on_target?(sha, target)
   end
 
   def forward_port_narration_segments(body)
@@ -696,22 +724,55 @@ class ReleaseForwardPort
     subject = subject_for_commit(sha).to_s
     release_pr_numbers = subject.scan(/#(\d+)/).flatten
     body = git("log", "-1", "--format=%B", sha)
+    composite_pr_numbers = composite_backport_pr_numbers(body)
+    if composite_pr_numbers.any?
+      return target_pr_numbers_live?(composite_pr_numbers, target) &&
+             review_fix_forward_ported_from_release_pr?(release_pr_numbers, target)
+    end
+
     narrated_pr_numbers = narrated_upstream_pr_numbers(body)
 
     upstream_pr_numbers = (narrated_pr_numbers - release_pr_numbers).uniq
-    upstream_pr_numbers.any? && upstream_pr_numbers.all? do |pr_number|
+    upstream_pr_numbers.any? && target_pr_numbers_live?(upstream_pr_numbers, target)
+  end
+
+  def composite_backport_pr_numbers(body)
+    forward_port_narration_segments(body).flat_map do |segment|
+      match = segment.match(COMPOSITE_BACKPORT_PATTERN)
+      match ? match[:prs].scan(/#(\d+)/).flatten : []
+    end.uniq
+  end
+
+  def target_pr_numbers_live?(pr_numbers, target)
+    pr_numbers.all? do |pr_number|
       target_pr_commit_shas(pr_number, target).any? { |target_sha| target_commit_live_on_target?(target_sha, target) }
     end
   end
 
-  def narrated_upstream_pr_numbers(body)
-    body.each_line.flat_map do |line|
-      numbers = line.scan(/\b(?:main|source)\s+PR\s+#(\d+)/i).flatten
+  def review_fix_forward_ported_from_release_pr?(release_pr_numbers, target)
+    release_pr_numbers.any? do |pr_number|
+      target_history_commits_mentioning("release PR ##{pr_number}", target).any? do |target_sha|
+        next false unless subject_for_commit(target_sha)&.match?(/\bforward-port\b/i)
 
-      explicit_backport = line.match(EXPLICIT_BACKPORT_PATTERN)
-      from_backport = line.match(FROM_BACKPORT_PATTERN)
+        body = git("log", "-1", "--format=%B", target_sha)
+        narrated = body.split(/\n\s*\n/).any? do |paragraph|
+          match = paragraph.gsub(/\s+/, " ").strip.match(NARRATED_REVIEW_FIX_FORWARD_PORT_PATTERN)
+          match && match[:pr] == pr_number
+        end
+        narrated && target_commit_live_on_target?(target_sha, target)
+      end
+    end
+  end
+
+  def narrated_upstream_pr_numbers(body)
+    forward_port_narration_segments(body).flat_map do |segment|
+      explicit_backport = segment.match(EXPLICIT_BACKPORT_PATTERN)
+      from_backport = segment.match(FROM_BACKPORT_PATTERN)
+      merged_replacement = segment.match(MERGED_REPLACEMENT_PATTERN)
+      numbers = []
       numbers.concat(explicit_backport[:prs].scan(/#(\d+)/).flatten) if explicit_backport
       numbers.concat(from_backport[:prs].scan(/#(\d+)/).flatten) if from_backport
+      numbers.concat(merged_replacement[:prs].scan(/#(\d+)/).flatten) if merged_replacement
       numbers
     end.uniq
   end
@@ -1301,6 +1362,10 @@ class ReleaseForwardPort
     target_changelog = changelog_at(target, label: "target")
 
     release_version = release_version_from_ref(source)
+    authoritative_sha =
+      authoritative_final_changelog_commit(source, target, target_changelog, release_version)
+    return finish_authoritative_changelog_plan(source, target, release_version, authoritative_sha) if authoritative_sha
+
     reconciler = ChangelogReconciler.new(source_changelog:, target_changelog:, release_version:)
     result = reconciler.reconcile
 
@@ -1331,6 +1396,61 @@ class ReleaseForwardPort
 
   def release_version_from_ref(ref)
     ref.match(%r{(?:\A|/)release/(?<version>\d+\.\d+\.\d+)\z})&.[](:version)
+  end
+
+  def authoritative_final_changelog_commit(source, target, target_changelog, release_version)
+    return unless release_version
+
+    source_time = git("show", "-s", "--format=%ct", source).to_i
+    subject_pattern =
+      /\ARecord the final React on Rails #{Regexp.escape(release_version)} changelog \(#\d+\)\z/
+    candidates =
+      git_lines(
+        "log",
+        target,
+        "--fixed-strings",
+        "--grep",
+        "final React on Rails #{release_version} changelog",
+        "--format=%H"
+      )
+
+    candidates.find do |sha|
+      next false unless subject_for_commit(sha)&.match?(subject_pattern)
+      next false unless changed_paths_for_commit(sha) == [CHANGELOG_FILE]
+      next false unless target_commit_live_on_target?(sha, target)
+      next false if git("show", "-s", "--format=%ct", sha).to_i < source_time
+
+      recorded_changelog = changelog_at(sha, label: "authoritative final changelog")
+      changelog_section(recorded_changelog, release_version) ==
+        changelog_section(target_changelog, release_version)
+    end
+  end
+
+  def changelog_section(changelog, version)
+    lines = changelog.lines
+    start_index = lines.index { |line| line.match?(/^### \[#{Regexp.escape(version)}\](?:\s|$)/) }
+    return unless start_index
+
+    end_index =
+      ((start_index + 1)...lines.length).find { |index| lines[index].match?(/^### \[/) } || lines.length
+    lines[start_index...end_index].join
+  end
+
+  def finish_authoritative_changelog_plan(source, target, release_version, authoritative_sha)
+    puts "Release forward-port CHANGELOG.md reconciliation plan"
+    puts "  source: #{source}"
+    puts "  target: #{target}"
+    puts
+    puts "Authoritative final #{release_version} changelog is unchanged on #{target}."
+    puts "  commit: #{authoritative_sha[0, 12]}"
+    puts "  superseded prerelease entries intentionally omitted by the dedicated final changelog PR"
+
+    if @options[:check]
+      puts "\nCHECK PASSED: the release changelog is already reconciled on the target."
+    else
+      puts "\nNothing to reconcile; the dedicated final changelog PR is authoritative."
+    end
+    0
   end
 
   def apply_changelog_reconciliation(target, result)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -257,29 +257,34 @@ class ReleaseForwardPort
   end
 
   def patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
-    candidate_signal =
-      patch_equivalent_commits[sha] ||
-      target_has_renamed_source_paths?(target, sha) ||
-      target_history_mentions_source_identity?(subject, target)
-    return unless candidate_signal
+    identity_candidates = target_history_source_identity_candidates(subject, target)
+    return patch_equivalent_skip_reason_message(target) if
+      identity_candidates.any? &&
+      patch_equivalent_commit_present_on_target?(sha, target, candidates: identity_candidates)
+
+    return unless patch_equivalent_commits[sha] || target_has_renamed_source_paths?(target, sha)
     return unless patch_equivalent_commit_present_on_target?(sha, target)
 
+    patch_equivalent_skip_reason_message(target)
+  end
+
+  def patch_equivalent_skip_reason_message(target)
     "patch already exists on #{target} according to target history with no later standard revert"
   end
 
-  def target_history_mentions_source_identity?(subject, target)
-    ([subject] + subject.scan(/#\d+/)).uniq.any? do |source_identity|
-      target_history_mentions?(source_identity, target)
-    end
+  def target_history_source_identity_candidates(subject, target)
+    ([subject] + subject.scan(/#\d+/)).uniq.flat_map do |source_identity|
+      target_history_commits_mentioning(source_identity, target)
+    end.uniq
   end
 
-  def target_history_mentions?(source_identity, target)
+  def target_history_commits_mentioning(source_identity, target)
     @target_identity_mention_cache ||= {}
     cache_key = [source_identity, target]
     return @target_identity_mention_cache.fetch(cache_key) if @target_identity_mention_cache.key?(cache_key)
 
     @target_identity_mention_cache[cache_key] =
-      git_lines("log", target, "--fixed-strings", "--grep", source_identity, "--format=%H", "-n", "1").any?
+      git_lines("log", target, "--fixed-strings", "--grep", source_identity, "--format=%H")
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)
@@ -569,10 +574,10 @@ class ReleaseForwardPort
     end.uniq
   end
 
-  def patch_equivalent_commit_present_on_target?(sha, target)
+  def patch_equivalent_commit_present_on_target?(sha, target, candidates: nil)
     source_patch_id = patch_id_for_commit(sha)
 
-    patch_equivalent_target_candidates(sha, target).any? do |target_sha|
+    (candidates || patch_equivalent_target_candidates(sha, target)).any? do |target_sha|
       patch_id_for_target_candidate(target_sha, sha) == source_patch_id &&
         target_commit_live_on_target?(target_sha, target)
     end

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -172,7 +172,8 @@ class ReleaseForwardPort
 
       Default mode forward-ports commits that are on a release branch but not on the target
       branch. The helper cherry-picks with -x, skips commits already forward-ported with -x
-      evidence or patches present in the target tree, and excludes RC version bump commits.
+      evidence or patches present in the target tree, and excludes RC version bump and
+      changelog-only commits.
 
       --changelog mode runs a separate CHANGELOG.md reconciliation pass instead of the
       cherry-pick loop: it collapses every release-branch entry (each rc.N section plus
@@ -272,6 +273,10 @@ class ReleaseForwardPort
   end
 
   def special_skip_reason(sha, subject, target, target_version)
+    if changed_paths_for_commit(sha) == [CHANGELOG_FILE]
+      return "changelog-only commit; use --changelog reconciliation to re-home release entries under [Unreleased]"
+    end
+
     return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}" if
       rc_version_bump?(subject)
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -657,12 +657,37 @@ class ReleaseForwardPort
     return @renamed_target_path_pairs_cache.fetch(cache_key) if @renamed_target_path_pairs_cache.key?(cache_key)
 
     source_paths = paths.to_h { |path| [path, true] }
-    rename_base_refs = [git("merge-base", first_parent, sha).strip, sha].uniq
+    rename_base_refs = [optional_merge_base(first_parent, sha), sha].compact.uniq
 
     @renamed_target_path_pairs_cache[cache_key] =
       rename_base_refs.flat_map do |from_ref|
         renamed_target_path_pairs_from_ref(from_ref, first_parent, source_paths)
       end.uniq
+  end
+
+  def optional_merge_base(left_ref, right_ref)
+    args = ["merge-base", left_ref, right_ref]
+    stdout, stderr, status = capture_git(*args)
+    return stdout.strip if status.success?
+
+    if status.exitstatus == 1 && stdout.empty? && stderr.empty?
+      raise UsageError, shallow_history_message(left_ref, right_ref) if shallow_repository?
+
+      return
+    end
+
+    raise GitError, git_error(args, stdout, stderr, status)
+  end
+
+  def shallow_repository?
+    git("rev-parse", "--is-shallow-repository").strip == "true"
+  end
+
+  def shallow_history_message(left_ref, right_ref)
+    <<~MESSAGE.chomp
+      cannot find a merge base between #{left_ref} and #{right_ref} because repository history is shallow;
+      run `git fetch --unshallow` (or deepen the relevant refs), then rerun the forward-port
+    MESSAGE
   end
 
   def renamed_target_path_pairs_from_ref(from_ref, first_parent, source_paths)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -18,10 +18,14 @@ class ReleaseForwardPort
     \Abump\s+version\s+to\s+v?
     (?<version>\d+\.\d+\.\d+(?:(?:[.-])(?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?)?)\b
   /ix
-  PRERELEASE_PACKAGE_PIN_SUBJECT = /
-    \bpackage\s+pin\s+to\s+v?
+  PRERELEASE_PACKAGE_PIN_SUBJECT = %r{
+    \b(?<package>[A-Za-z0-9@._\/-]+)\s+package\s+pin\s+to\s+v?
     (?<stable_version>\d+\.\d+\.\d+)[.-](?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?\b
-  /ix
+  }ix
+  PR_NUMBER_LIST_PATTERN = /#\d+(?:\s*,\s*#\d+)*(?:\s*,?\s+and\s+#\d+)?/i
+  EXPLICIT_BACKPORT_PATTERN =
+    /\bbackports?\s+(?:merged\s+)?(?:source\s+PR\s+)?(?<prs>#{PR_NUMBER_LIST_PATTERN})/io
+  FROM_BACKPORT_PATTERN = /\bbackports?\b.*?\bfrom\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})/io
   PRERELEASE_RANKS = {
     "dev" => 0,
     "test" => 1,
@@ -39,6 +43,8 @@ class ReleaseForwardPort
     /cherry-picked\s+(?:main\s+)?(?:squash\s+)?commit\s+`?(?<sha>[0-9a-f]{40})`?\s+with\s+`?-x`?/i
   NARRATED_FORWARD_PORT_PATTERN =
     /^\s*-\s+cherry-picked\b.*\bwith\s+`?(?:git\s+)?cherry-pick\s+-x`?\s*$/i
+  NARRATED_SOURCE_PR_FORWARD_PORT_PATTERN =
+    /\bforward-ports?\b.*\b(?:release|source)\s+PR\s+#\d+/i
   ASCII_WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, :manual, keyword_init: true) do
@@ -61,7 +67,10 @@ class ReleaseForwardPort
     @explicit_options = { source: false, target: false }
     @options = {
       dry_run: false,
+      check: false,
       ack_manual: [],
+      only: nil,
+      all: false,
       target: "main",
       changelog: false
     }
@@ -76,8 +85,10 @@ class ReleaseForwardPort
 
     verify_ref!(source, label: "source")
     verify_ref!(target, label: "target")
+    validate_mode_options!
+    normalize_selected_sha!
     normalize_acknowledged_manual_shas!
-    ensure_local_target_branch!(target) unless @options[:dry_run]
+    ensure_local_target_branch!(target) unless read_only_mode?
 
     return run_changelog_reconciliation(source, target) if @options[:changelog]
 
@@ -105,9 +116,12 @@ class ReleaseForwardPort
     # guard, so normal mode and dry-run report the same plan before refusing to
     # checkout or cherry-pick.
     plan = build_plan(commits, target, target_version, equiv_commits)
+    plan = selected_plan(plan, source, target)
     validate_acknowledged_manual_shas!(plan)
 
     print_plan(source, target, target_version, plan)
+
+    return check_code_plan(plan) if @options[:check]
 
     if @options[:dry_run]
       puts "\nDRY RUN: no branches were checked out and no commits were cherry-picked."
@@ -116,6 +130,7 @@ class ReleaseForwardPort
 
     return finish_no_action_plan(plan, target) unless actionable_plan?(plan)
 
+    enforce_single_forward_port!(plan)
     ensure_clean_worktree!
     checkout_target!(target)
     apply_plan(plan)
@@ -130,6 +145,16 @@ class ReleaseForwardPort
     end
 
     puts "\nNothing to cherry-pick."
+    0
+  end
+
+  def check_code_plan(plan)
+    if actionable_plan?(plan)
+      warn "CHECK FAILED: release source still has code or manual items that need their own forward-port PRs."
+      return 1
+    end
+
+    puts "\nCHECK PASSED: the release source has no remaining code forward-port work."
     0
   end
 
@@ -161,9 +186,7 @@ class ReleaseForwardPort
         @options[:target] = target
         @explicit_options[:target] = true
       end
-      parser.on("--dry-run", "Print the plan without checking out or cherry-picking") do
-        @options[:dry_run] = true
-      end
+      add_execution_options(parser)
       add_changelog_option(parser)
       add_ack_manual_option(parser)
       parser.on("-h", "--help", "Show this help") do
@@ -173,22 +196,42 @@ class ReleaseForwardPort
     end
   end
 
+  def add_execution_options(parser)
+    parser.on("--dry-run", "Print the plan without checking out or cherry-picking") do
+      @options[:dry_run] = true
+    end
+    parser.on("--check", "Exit nonzero unless the complete source plan is already satisfied") do
+      @options[:check] = true
+    end
+    parser.on("--only SHA", "Restrict the plan to one source commit for a one-change forward-port PR") do |sha|
+      @options[:only] = sha
+    end
+    parser.on("--all", "Apply every actionable commit (explicit batch override)") do
+      @options[:all] = true
+    end
+  end
+
   def usage_banner
     <<~BANNER
       Usage: script/release-forward-port --source release/X.Y.Z [--target main] [--dry-run]
+             script/release-forward-port --source release/X.Y.Z --check [--target main]
+             script/release-forward-port --source release/X.Y.Z --only SHA [--target main] [--dry-run]
              script/release-forward-port release/X.Y.Z [main] [--dry-run]
              script/release-forward-port --source release/X.Y.Z --changelog [--target main] [--dry-run]
 
       Default mode forward-ports commits that are on a release branch but not on the target
       branch. The helper cherry-picks with -x, skips commits already forward-ported with -x
       evidence or patches present in the target tree, and excludes RC version bump and
-      changelog-only commits.
+      changelog-only commits. Normal mode refuses to apply more than one actionable commit
+      unless --all is explicit; use --only SHA for one-change-at-a-time forward-port PRs.
+      --check evaluates the complete plan without changing the worktree and exits nonzero
+      while any code or manual item remains.
 
       --changelog mode runs a separate CHANGELOG.md reconciliation pass instead of the
       cherry-pick loop: it collapses every release-branch entry (each rc.N section plus
       [Unreleased]) into the target's [Unreleased] section, de-duplicates by PR number against
       the target's existing entries, and drops any RC-header section a prior cherry-pick left
-      on the target. The default cherry-pick behavior is unchanged for callers that omit the flag.
+      on the target. It is mutually exclusive with the --only and --all code-selection flags.
     BANNER
   end
 
@@ -211,6 +254,51 @@ class ReleaseForwardPort
     ) do |sha|
       @options[:ack_manual] << sha
     end
+  end
+
+  def validate_mode_options!
+    validate_read_only_options!
+    validate_code_selection_options!
+  end
+
+  def validate_read_only_options!
+    raise UsageError, "--check and --dry-run cannot be used together" if @options[:check] && @options[:dry_run]
+    return unless @options[:check] && code_selection_requested?
+
+    raise UsageError, "--check evaluates the complete plan and cannot be scoped with --only/--all"
+  end
+
+  def validate_code_selection_options!
+    raise UsageError, "--only and --all cannot be used together" if @options[:only] && @options[:all]
+    return unless @options[:changelog] && code_selection_requested?
+
+    raise UsageError, "--only/--all select code commits and cannot be combined with --changelog"
+  end
+
+  def code_selection_requested?
+    @options[:only] || @options[:all]
+  end
+
+  def normalize_selected_sha!
+    return unless @options[:only]
+
+    @selected_sha = git("rev-parse", "--verify", "#{@options[:only]}^{commit}").strip
+  rescue GitError => e
+    raise UsageError, "--only #{@options[:only].inspect} is not a commit: #{e.message}"
+  end
+
+  def selected_plan(plan, source, target)
+    return plan unless @selected_sha
+
+    entry = plan.find { |candidate| candidate.sha == @selected_sha }
+    return [entry] if entry
+
+    raise UsageError,
+          "--only #{@options[:only].inspect} is not in the current #{target}..#{source} plan; rerun --dry-run"
+  end
+
+  def read_only_mode?
+    @options[:dry_run] || @options[:check]
   end
 
   def source_only_commits(source, target)
@@ -282,8 +370,10 @@ class ReleaseForwardPort
 
   def targeted_patch_equivalent_skip_reason(sha, subject, target)
     identity_candidates = target_history_source_identity_candidates(subject, target)
-    return "already forward-ported to #{target} via narrated cherry-pick -x evidence with no later target revert" if
-      identity_candidates.any? { |target_sha| narrated_forward_port_commit_live?(target_sha, target) }
+    return "already forward-ported to #{target} via source-bound forward-port narration with no later target revert" if
+      identity_candidates.any? do |target_sha|
+        narrated_forward_port_commit_live?(target_sha, target, source_sha: sha, source_subject: subject)
+      end
 
     provenance_candidates = target_history_source_provenance_candidates(sha, target)
     return patch_equivalent_skip_reason_message(target) if
@@ -327,13 +417,48 @@ class ReleaseForwardPort
     end.uniq
   end
 
-  def narrated_forward_port_commit_live?(sha, target)
+  def narrated_forward_port_commit_live?(sha, target, source_sha:, source_subject:)
     body = git("log", "-1", "--format=%B", sha)
-    subject = subject_for_commit(sha)
-    narrated =
-      body.match?(NARRATED_FORWARD_PORT_PATTERN) ||
-      (subject&.match?(/\AForward-port\b/i) && body.match?(/`git cherry-pick -x`/i))
+    target_subject = subject_for_commit(sha)
+    narration_segments = forward_port_narration_segments(body).select do |segment|
+      segment.match?(NARRATED_FORWARD_PORT_PATTERN) ||
+        (target_subject&.match?(/\AForward-port\b/i) &&
+          (segment.match?(/`git cherry-pick -x`/i) ||
+            segment.match?(NARRATED_SOURCE_PR_FORWARD_PORT_PATTERN)))
+    end
+    narrated = narration_segments.any? do |segment|
+      narrated_line_names_source?(segment, source_sha, source_subject)
+    end
     narrated && target_commit_live_on_target?(sha, target)
+  end
+
+  def forward_port_narration_segments(body)
+    segments = []
+    current_bullet = nil
+
+    body.each_line do |line|
+      stripped = line.strip
+      if line.match?(/^\s*-\s+/)
+        segments << current_bullet if current_bullet
+        current_bullet = stripped
+      elsif current_bullet && !stripped.empty?
+        current_bullet = "#{current_bullet} #{stripped}"
+      else
+        segments << current_bullet if current_bullet
+        current_bullet = nil
+        segments << stripped unless stripped.empty?
+      end
+    end
+    segments << current_bullet if current_bullet
+    segments
+  end
+
+  def narrated_line_names_source?(line, source_sha, source_subject)
+    return true if line.include?(source_sha) || line.include?(source_sha[0, 12])
+
+    source_subject.scan(/#(\d+)/).flatten.any? do |pr_number|
+      line.match?(/(?<!\d)##{Regexp.escape(pr_number)}(?!\d)/)
+    end
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)
@@ -346,15 +471,12 @@ class ReleaseForwardPort
   end
 
   def special_skip_reason(sha, subject, target, target_version)
-    changed_paths = changed_paths_for_commit(sha)
-    if changed_paths == [CHANGELOG_FILE]
-      return "changelog-only commit; use --changelog reconciliation to re-home release entries under [Unreleased]"
-    end
+    root_reason = unrelated_root_commit_skip_reason(sha, target)
+    return root_reason if root_reason
 
-    if changed_paths.any? && (changed_paths - GENERATED_LLM_FILES).empty?
-      return "generated LLM artifact-only commit; regenerate from current target documentation instead of replaying " \
-             "stale release output"
-    end
+    changed_paths = changed_paths_for_commit(sha)
+    artifact_reason = generated_artifact_skip_reason(changed_paths)
+    return artifact_reason if artifact_reason
 
     superseded_pin_reason = superseded_prerelease_package_pin_reason(sha, subject, target)
     return superseded_pin_reason if superseded_pin_reason
@@ -372,6 +494,31 @@ class ReleaseForwardPort
       reverse_pick_revert_skip_reason(sha, target)
   end
 
+  def unrelated_root_commit_skip_reason(sha, target)
+    return unless root_commit?(sha)
+
+    manual_skip_reason(
+      "root commit from unrelated history; inspect the source seed manually instead of applying a full-repository " \
+      "snapshot onto #{target}"
+    )
+  end
+
+  def generated_artifact_skip_reason(changed_paths)
+    return "changelog-only commit; use --changelog reconciliation to re-home release entries under [Unreleased]" if
+      changed_paths == [CHANGELOG_FILE]
+
+    if changed_paths.any? && (changed_paths - GENERATED_LLM_FILES).empty?
+      return "generated LLM artifact-only commit; regenerate from current target documentation instead of replaying " \
+             "stale release output"
+    end
+
+    return unless changed_paths.include?(CHANGELOG_FILE) &&
+                  (changed_paths - [CHANGELOG_FILE] - GENERATED_LLM_FILES).empty?
+
+    "changelog/generated artifact-only commit; use --changelog reconciliation and regenerate LLM files " \
+      "from current target documentation"
+  end
+
   def rc_version_bump?(subject)
     subject.match?(RC_VERSION_BUMP_SUBJECT)
   end
@@ -380,14 +527,14 @@ class ReleaseForwardPort
     match = subject.match(PRERELEASE_PACKAGE_PIN_SUBJECT)
     return unless match
 
-    stable_sha = later_stable_package_pin_commit(sha, match[:stable_version], target)
+    stable_sha = later_stable_package_pin_commit(sha, match[:package], match[:stable_version], target)
     return unless stable_sha
 
     "prerelease package pin is superseded by later stable source commit #{stable_sha[0, 12]} already present on " \
       "#{target}"
   end
 
-  def later_stable_package_pin_commit(sha, stable_version, target)
+  def later_stable_package_pin_commit(sha, package, stable_version, target)
     position = @source_plan_positions&.fetch(sha, nil)
     return unless position
 
@@ -395,6 +542,7 @@ class ReleaseForwardPort
     @source_plan_commits.drop(position + 1).find do |later_sha|
       later_subject = subject_for_commit(later_sha).to_s
       next unless later_subject.match?(/\bstable\b/i) && later_subject.include?(stable_version)
+      next unless later_subject.match?(%r{(?<![A-Za-z0-9@._/-])#{Regexp.escape(package)}(?![A-Za-z0-9@._/-])}i)
 
       later_paths = changed_paths_for_commit(later_sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
       (superseded_paths - later_paths).empty? && source_commit_provenance_present_on_target?(later_sha, target)
@@ -410,6 +558,10 @@ class ReleaseForwardPort
 
   def merge_commit?(sha)
     git("rev-list", "--parents", "-n", "1", sha).split.length > 2
+  end
+
+  def root_commit?(sha)
+    git("rev-list", "--parents", "-n", "1", sha).split.length == 1
   end
 
   def manual_skip_reason?(reason)
@@ -544,15 +696,24 @@ class ReleaseForwardPort
     subject = subject_for_commit(sha).to_s
     release_pr_numbers = subject.scan(/#(\d+)/).flatten
     body = git("log", "-1", "--format=%B", sha)
-    narrated_pr_numbers = body.each_line.flat_map do |line|
-      next [] unless line.match?(/\b(?:backports?|already\b.*merged\s+in|main\s+PR)\b/i)
+    narrated_pr_numbers = narrated_upstream_pr_numbers(body)
 
-      line.scan(/#(\d+)/).flatten
-    end
-
-    (narrated_pr_numbers - release_pr_numbers).uniq.any? do |pr_number|
+    upstream_pr_numbers = (narrated_pr_numbers - release_pr_numbers).uniq
+    upstream_pr_numbers.any? && upstream_pr_numbers.all? do |pr_number|
       target_pr_commit_shas(pr_number, target).any? { |target_sha| target_commit_live_on_target?(target_sha, target) }
     end
+  end
+
+  def narrated_upstream_pr_numbers(body)
+    body.each_line.flat_map do |line|
+      numbers = line.scan(/\b(?:main|source)\s+PR\s+#(\d+)/i).flatten
+
+      explicit_backport = line.match(EXPLICIT_BACKPORT_PATTERN)
+      from_backport = line.match(FROM_BACKPORT_PATTERN)
+      numbers.concat(explicit_backport[:prs].scan(/#(\d+)/).flatten) if explicit_backport
+      numbers.concat(from_backport[:prs].scan(/#(\d+)/).flatten) if from_backport
+      numbers
+    end.uniq
   end
 
   def target_pr_commit_shas(pr_number, target)
@@ -844,7 +1005,7 @@ class ReleaseForwardPort
 
   def changed_paths_for_commit(sha)
     @changed_paths_cache ||= {}
-    @changed_paths_cache[sha] ||= git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+    @changed_paths_cache[sha] ||= git_lines("diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha)
   end
 
   def patch_id_for_commit(sha, target_to_source_paths: {}, paths: nil, zero_context: false)
@@ -1145,6 +1306,8 @@ class ReleaseForwardPort
 
     print_changelog_reconciliation_plan(source, target, result)
 
+    return check_changelog_plan(result) if @options[:check]
+
     if @options[:dry_run]
       puts "\nDRY RUN: CHANGELOG.md was not modified and no branch was checked out."
       return 0
@@ -1154,6 +1317,16 @@ class ReleaseForwardPort
   rescue ChangelogReconciler::ReconcileError => e
     # Map the reconciler's own error onto the shared GitError exit path.
     raise GitError, e.message
+  end
+
+  def check_changelog_plan(result)
+    if result.changed?
+      warn "CHECK FAILED: release changelog reconciliation still needs its own squash PR."
+      return 1
+    end
+
+    puts "\nCHECK PASSED: the release changelog is already reconciled on the target."
+    0
   end
 
   def release_version_from_ref(ref)
@@ -1171,8 +1344,9 @@ class ReleaseForwardPort
     # Write UTF-8 explicitly so the ⚠️-carrying changelog round-trips byte-for-byte
     # under a C/POSIX-locale runner where the default external encoding is US-ASCII.
     File.write(changelog_path, result.reconciled_changelog, encoding: Encoding::UTF_8)
-    puts "\nReconciled #{result.added_entries.length} entr#{result.added_entries.length == 1 ? 'y' : 'ies'} " \
-         "into #{CHANGELOG_FILE} [Unreleased] on #{target}."
+    puts "\nReconciled #{CHANGELOG_FILE} [Unreleased] on #{target}: " \
+         "#{changelog_count(result.added_entries.length, 'entry', 'entries')} added, " \
+         "#{changelog_count(result.removed_entries.length, 'stale entry', 'stale entries')} removed."
     puts "Review and commit #{CHANGELOG_FILE} (this mode does not commit)."
     0
   end
@@ -1184,6 +1358,7 @@ class ReleaseForwardPort
     puts
 
     print_changelog_added_entries(result)
+    print_changelog_removed_entries(result)
     print_changelog_removed_sections(result)
     print_changelog_already_present(result)
 
@@ -1209,6 +1384,14 @@ class ReleaseForwardPort
     result.removed_sections.each { |version| puts "  - ### [#{version}]" }
   end
 
+  def print_changelog_removed_entries(result)
+    return if result.removed_entries.empty?
+
+    puts
+    puts "Stale target [Unreleased] entries to DROP in favor of final release wording:"
+    result.removed_entries.each { |entry| puts indent_changelog_entry("-", entry) }
+  end
+
   def print_changelog_already_present(result)
     return if result.skipped_entries.empty?
 
@@ -1230,6 +1413,8 @@ class ReleaseForwardPort
       "#{changelog_count(result.added_entries.length, 'entry', 'entries')} to add",
       "#{changelog_count(result.skipped_entries.length, 'entry', 'entries')} already present"
     ]
+    parts << "#{changelog_count(result.removed_entries.length, 'stale entry', 'stale entries')} to drop" if
+      result.removed_entries.any?
     parts << "#{changelog_count(result.removed_sections.length, 'RC section', 'RC sections')} to drop" if
       result.removed_sections.any?
     "Summary: #{parts.join(', ')}."
@@ -1284,8 +1469,24 @@ class ReleaseForwardPort
     0
   end
 
+  def enforce_single_forward_port!(plan)
+    return if @options[:all]
+
+    actionable_entries = plan.select { |entry| actionable_entry?(entry) }
+    return if actionable_entries.length <= 1
+
+    shas = actionable_entries.map(&:short_sha).join(", ")
+    raise UsageError,
+          "normal mode found #{actionable_entries.length} actionable commits (#{shas}); " \
+          "create a fresh branch and rerun with --only SHA for one forward-port PR at a time"
+  end
+
   def actionable_plan?(plan)
-    plan.any? { |entry| entry.action == :pick || (entry.manual? && !acknowledged_manual_entry?(entry)) }
+    plan.any? { |entry| actionable_entry?(entry) }
+  end
+
+  def actionable_entry?(entry)
+    entry.action == :pick || (entry.manual? && !acknowledged_manual_entry?(entry))
   end
 
   def acknowledged_manual_entries?(plan)
@@ -1484,15 +1685,16 @@ class ChangelogReconciler
     :reconciled_changelog,
     :added_entries,
     :skipped_entries,
+    :removed_entries,
     :removed_sections,
     :original_changelog,
     keyword_init: true
   ) do
-    # Semantic change only: adding at least one entry or dropping at least one
+    # Semantic change only: adding/removing an entry or dropping at least one
     # stray RC section. Skipped (already-present) entries do not count, so the
     # reconciler never reformats the target's existing [Unreleased] for nothing.
     def changed?
-      added_entries.any? || removed_sections.any?
+      added_entries.any? || removed_entries.any? || removed_sections.any?
     end
   end
 
@@ -1509,11 +1711,12 @@ class ChangelogReconciler
     base_version = source_release_base_version(source)
     removed_sections = stray_rc_sections(target, base_version)
 
-    target_entries, added, skipped = reconcile_entries(target, source, removed_sections, base_version)
+    target_entries, added, skipped, removed_entries =
+      reconcile_entries(target, source, removed_sections, base_version)
 
     # Only re-render when there is a real change; otherwise return the target
     # changelog byte-for-byte so a no-op run never reflows existing entries.
-    reconciled = if added.any? || removed_sections.any?
+    reconciled = if added.any? || removed_entries.any? || removed_sections.any?
                    rebuild_changelog(target, target_entries + added, removed_sections)
                  else
                    @target_changelog
@@ -1523,6 +1726,7 @@ class ChangelogReconciler
       reconciled_changelog: reconciled,
       added_entries: added,
       skipped_entries: skipped,
+      removed_entries:,
       removed_sections: removed_sections.map { |section| section[:version] },
       original_changelog: @target_changelog
     )
@@ -1540,18 +1744,25 @@ class ChangelogReconciler
     # section, whose entries may already live in main's history. Exclude RC
     # sections being removed so their entries can still be re-homed before the
     # section headers disappear.
-    retained_target_entries = target[:sections]
-                              .reject { |section| removed_sections.include?(section) }
-                              .flat_map do |section|
-      entries = section_entries(section)
-      section[:version] == UNRELEASED ? entries.reject { |entry| replacement_prs.include?(entry.pr_number) } : entries
-    end
+    retained_target_entries = retained_target_entries(target, removed_sections, replacement_prs)
     seen_pr_numbers = retained_target_entries.filter_map(&:pr_number).to_set
     target_entry_texts = retained_target_entries.to_set { |entry| normalize_text(entry.text) }
 
     added, skipped = partition_source_entries(source_entries, seen_pr_numbers, target_entry_texts)
-    retained_unreleased_entries = target_entries.reject { |entry| replacement_prs.include?(entry.pr_number) }
-    [retained_unreleased_entries, added, skipped]
+    removed_entries = target_entries.select { |entry| replacement_prs.include?(entry.pr_number) }
+    retained_unreleased_entries = target_entries - removed_entries
+    [retained_unreleased_entries, added, skipped, removed_entries]
+  end
+
+  def retained_target_entries(target, removed_sections, replacement_prs)
+    target[:sections]
+      .reject { |section| removed_sections.include?(section) }
+      .flat_map do |section|
+        entries = section_entries(section)
+        next entries unless section[:version] == UNRELEASED
+
+        entries.reject { |entry| replacement_prs.include?(entry.pr_number) }
+      end
   end
 
   # Final stamping can consolidate an earlier entry with a follow-up PR while
@@ -1561,13 +1772,22 @@ class ChangelogReconciler
   def authoritative_replacement_pr_numbers(source, base_version, target_entries)
     stable_entries = stable_sections(source, base_version).flat_map { |section| section_entries(section) }
     stable_entries_by_pr = stable_entries.select(&:pr_number).group_by(&:pr_number)
+    target_entries_by_pr = target_entries.select(&:pr_number).group_by(&:pr_number)
 
-    target_entries.filter_map do |target_entry|
-      candidates = stable_entries_by_pr[target_entry.pr_number]
-      next unless candidates&.any? { |entry| normalize_text(entry.text) != normalize_text(target_entry.text) }
+    target_entries_by_pr.each_with_object(Set.new) do |(pr_number, entries), replacements|
+      stable_group = stable_entries_by_pr[pr_number]
+      replacements << pr_number if authoritative_entry_group?(stable_group, entries)
+    end
+  end
 
-      target_entry.pr_number
-    end.to_set
+  def authoritative_entry_group?(stable_group, target_group)
+    stable_group && entry_group_fingerprint(stable_group) != entry_group_fingerprint(target_group)
+  end
+
+  def entry_group_fingerprint(entries)
+    entries.map do |entry|
+      [normalize_heading_key(entry.heading), normalize_text(entry.text)]
+    end.sort
   end
 
   # Collapse every release-branch source section that belongs in main's

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -70,6 +70,7 @@ class ReleaseForwardPort
   /ix
   NARRATED_REVIEW_FIX_FORWARD_PORT_PATTERN =
     /\Aforward-port\s+the\s+review\s+fix\s+from\s+release\s+PR\s+#(?<pr>\d+)\b/i
+  SOURCE_PR_TRAILER_PATTERN = /\(#(?<pr>\d+)\)\z/
   ASCII_WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, :manual, keyword_init: true) do
@@ -510,9 +511,13 @@ class ReleaseForwardPort
   def narrated_line_names_source?(line, source_sha, source_subject)
     return true if line.include?(source_sha) || line.include?(source_sha[0, 12])
 
-    source_subject.scan(/#(\d+)/).flatten.any? do |pr_number|
-      line.match?(/(?<!\d)##{Regexp.escape(pr_number)}(?!\d)/)
-    end
+    source_pr_number = source_pr_number_from_subject(source_subject)
+    source_pr_number && line.match?(/(?<!\d)##{Regexp.escape(source_pr_number)}(?!\d)/)
+  end
+
+  def source_pr_number_from_subject(subject)
+    match = subject.to_s.match(SOURCE_PR_TRAILER_PATTERN)
+    match && match[:pr]
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)
@@ -762,7 +767,8 @@ class ReleaseForwardPort
 
   def source_narrated_pr_origin_on_target?(sha, target)
     subject = subject_for_commit(sha).to_s
-    release_pr_numbers = subject.scan(/#(\d+)/).flatten
+    release_pr_number = source_pr_number_from_subject(subject)
+    release_pr_numbers = release_pr_number ? [release_pr_number] : []
     body = git("log", "-1", "--format=%B", sha)
     composite_pr_numbers = composite_backport_pr_numbers(body)
     narrated_pr_numbers = narrated_upstream_pr_numbers(body)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -97,7 +97,8 @@ class ReleaseForwardPort
       only: nil,
       all: false,
       target: "main",
-      changelog: false
+      changelog: false,
+      ack_final_changelog_source: nil
     }
     @parser = build_parser
   end
@@ -113,7 +114,9 @@ class ReleaseForwardPort
     validate_mode_options!
     normalize_selected_sha!
     normalize_acknowledged_manual_shas!
+    normalize_acknowledged_changelog_source_sha!
     ensure_local_target_branch!(target) unless read_only_mode?
+    ensure_no_cherry_pick_in_progress! if @options[:check]
 
     return run_changelog_reconciliation(source, target) if @options[:changelog]
 
@@ -146,10 +149,7 @@ class ReleaseForwardPort
 
     print_plan(source, target, target_version, plan)
 
-    if @options[:check]
-      ensure_no_cherry_pick_in_progress!
-      return check_code_plan(plan)
-    end
+    return check_code_plan(plan) if @options[:check]
 
     if @options[:dry_run]
       puts "\nDRY RUN: no branches were checked out and no commits were cherry-picked."
@@ -217,6 +217,7 @@ class ReleaseForwardPort
       add_execution_options(parser)
       add_changelog_option(parser)
       add_ack_manual_option(parser)
+      add_ack_final_changelog_source_option(parser)
       parser.on("-h", "--help", "Show this help") do
         puts parser
         exit 0
@@ -284,6 +285,15 @@ class ReleaseForwardPort
     end
   end
 
+  def add_ack_final_changelog_source_option(parser)
+    parser.on(
+      "--ack-final-changelog-source SHA",
+      "Acknowledge the current source CHANGELOG.md commit for a legacy authoritative changelog PR"
+    ) do |sha|
+      @options[:ack_final_changelog_source] = sha
+    end
+  end
+
   def validate_mode_options!
     validate_read_only_options!
     validate_code_selection_options!
@@ -298,6 +308,9 @@ class ReleaseForwardPort
 
   def validate_code_selection_options!
     raise UsageError, "--only and --all cannot be used together" if @options[:only] && @options[:all]
+    if @options[:ack_final_changelog_source] && !@options[:changelog]
+      raise UsageError, "--ack-final-changelog-source requires --changelog"
+    end
     return unless @options[:changelog] && code_selection_requested?
 
     raise UsageError, "--only/--all select code commits and cannot be combined with --changelog"
@@ -571,6 +584,13 @@ class ReleaseForwardPort
     stable_sha = later_stable_package_pin_commit(sha, match[:package], match[:stable_version], target)
     return unless stable_sha
 
+    unless cumulative_prerelease_package_state_present_on_target?(sha, stable_sha, target)
+      return manual_skip_reason(
+        "later stable source commit #{stable_sha[0, 12]} is present on #{target}, but the cumulative state of the " \
+        "prerelease commit's paths differs; inspect those paths before acknowledging this supersession"
+      )
+    end
+
     "prerelease package pin is superseded by later stable source commit #{stable_sha[0, 12]} already present on " \
       "#{target}"
   end
@@ -588,6 +608,13 @@ class ReleaseForwardPort
       later_paths = changed_paths_for_commit(later_sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
       (superseded_paths - later_paths).empty? && source_commit_provenance_present_on_target?(later_sha, target)
     end
+  end
+
+  def cumulative_prerelease_package_state_present_on_target?(sha, stable_sha, target)
+    paths = changed_paths_for_commit(sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
+    return false if paths.empty?
+
+    !diff_changes_paths?(stable_sha, target, paths)
   end
 
   def source_commit_provenance_present_on_target?(sha, target)
@@ -1436,7 +1463,8 @@ class ReleaseForwardPort
   def authoritative_final_changelog_commit(source, target, target_changelog, release_version)
     return unless release_version
 
-    source_time = git("show", "-s", "--format=%ct", source).to_i
+    source_changelog_sha = latest_changelog_commit(source)
+    validate_acknowledged_changelog_source!(source_changelog_sha)
     subject_pattern =
       /\ARecord the final React on Rails #{Regexp.escape(release_version)} changelog \(#\d+\)\z/
     candidates =
@@ -1453,10 +1481,34 @@ class ReleaseForwardPort
       next false unless subject_for_commit(sha)&.match?(subject_pattern)
       next false unless changed_paths_for_commit(sha) == [CHANGELOG_FILE]
       next false unless target_commit_live_on_target?(sha, target)
-      next false if git("show", "-s", "--format=%ct", sha).to_i < source_time
+      next false unless authoritative_changelog_source_bound?(sha, source_changelog_sha)
 
       authoritative_changelog_section_unchanged?(sha, target_changelog, release_version)
     end
+  end
+
+  def latest_changelog_commit(source)
+    sha = git("log", "-1", "--format=%H", source, "--", CHANGELOG_FILE).strip
+    raise GitError, "#{source} has no #{CHANGELOG_FILE} history to bind the final changelog authority" if sha.empty?
+
+    sha
+  end
+
+  def authoritative_changelog_source_bound?(authoritative_sha, source_changelog_sha)
+    return true if @acknowledged_changelog_source_sha == source_changelog_sha
+
+    exact_sentence =
+      "The final changelog records source CHANGELOG.md commit `#{source_changelog_sha}`."
+    git("show", "-s", "--format=%B", authoritative_sha).lines.any? { |line| line.strip == exact_sentence }
+  end
+
+  def validate_acknowledged_changelog_source!(source_changelog_sha)
+    return unless @acknowledged_changelog_source_sha
+    return if @acknowledged_changelog_source_sha == source_changelog_sha
+
+    raise UsageError,
+          "--ack-final-changelog-source resolves to #{@acknowledged_changelog_source_sha}, but the current source " \
+          "CHANGELOG.md commit is #{source_changelog_sha}; inspect the newer changelog before acknowledging it"
   end
 
   def authoritative_changelog_section_unchanged?(sha, target_changelog, release_version)
@@ -1713,6 +1765,15 @@ class ReleaseForwardPort
     rescue GitError => e
       raise UsageError, "--ack-manual #{sha.inspect} is not a commit: #{e.message}"
     end.uniq
+  end
+
+  def normalize_acknowledged_changelog_source_sha!
+    sha = @options[:ack_final_changelog_source]
+    return unless sha
+
+    @acknowledged_changelog_source_sha = git("rev-parse", "--verify", "#{sha}^{commit}").strip
+  rescue GitError => e
+    raise UsageError, "--ack-final-changelog-source #{sha.inspect} is not a commit: #{e.message}"
   end
 
   def validate_acknowledged_manual_shas!(plan)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -265,6 +265,7 @@ class ReleaseForwardPort
     return "already forward-ported to #{target} via narrated cherry-pick -x evidence with no later target revert" if
       identity_candidates.any? { |target_sha| narrated_forward_port_commit_live?(target_sha, target) }
 
+    identity_candidates.concat(target_history_source_provenance_candidates(sha, target)).uniq!
     return patch_equivalent_skip_reason_message(target) if
       identity_candidates.any? &&
       patch_equivalent_commit_present_on_target?(sha, target, candidates: identity_candidates)
@@ -294,9 +295,26 @@ class ReleaseForwardPort
       git_lines("log", target, "--fixed-strings", "--grep", source_identity, "--format=%H")
   end
 
+  def target_history_source_provenance_candidates(sha, target)
+    body = git("log", "-1", "--format=%B", sha)
+    source_identities = body.each_line.filter_map do |line|
+      next unless line.match?(/\b(?:backports?|source\s+PR|main\s+PR|merged\s+in)\b/i)
+
+      line.scan(/#\d+/)
+    end.flatten.uniq
+
+    source_identities.flat_map do |source_identity|
+      target_history_commits_mentioning(source_identity, target)
+    end.uniq
+  end
+
   def narrated_forward_port_commit_live?(sha, target)
     body = git("log", "-1", "--format=%B", sha)
-    body.match?(NARRATED_FORWARD_PORT_PATTERN) && target_commit_live_on_target?(sha, target)
+    subject = subject_for_commit(sha)
+    narrated =
+      body.match?(NARRATED_FORWARD_PORT_PATTERN) ||
+      (subject&.match?(/\AForward-port\b/i) && body.match?(/`git cherry-pick -x`/i))
+    narrated && target_commit_live_on_target?(sha, target)
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1424,11 +1424,32 @@ class ReleaseForwardPort
     target_changelog = changelog_at(target, label: "target")
 
     release_version = release_version_from_ref(source)
-    authoritative_sha =
-      authoritative_final_changelog_commit(source, target, target_changelog, release_version)
-    return finish_authoritative_changelog_plan(source, target, release_version, authoritative_sha) if authoritative_sha
-
     reconciler = ChangelogReconciler.new(source_changelog:, target_changelog:, release_version:)
+    authoritative_sha =
+      authoritative_final_changelog_commit(
+        source,
+        target,
+        target_changelog,
+        release_version,
+        source_ready: reconciler.authoritative_source_ready?
+      )
+    if authoritative_sha
+      residue = reconciler.reconcile_authoritative_residue
+      unless residue.changed?
+        return finish_authoritative_changelog_plan(source, target, release_version, authoritative_sha)
+      end
+
+      print_changelog_reconciliation_plan(source, target, residue)
+      return check_changelog_plan(residue) if @options[:check]
+
+      if @options[:dry_run]
+        puts "\nDRY RUN: CHANGELOG.md was not modified and no branch was checked out."
+        return 0
+      end
+
+      return apply_changelog_reconciliation(target, residue)
+    end
+
     result = reconciler.reconcile
 
     print_changelog_reconciliation_plan(source, target, result)
@@ -1460,8 +1481,8 @@ class ReleaseForwardPort
     ref.match(%r{(?:\A|/)release/(?<version>\d+\.\d+\.\d+)\z})&.[](:version)
   end
 
-  def authoritative_final_changelog_commit(source, target, target_changelog, release_version)
-    return unless release_version
+  def authoritative_final_changelog_commit(source, target, target_changelog, release_version, source_ready:)
+    return unless release_version && source_ready
 
     source_changelog_sha = latest_changelog_commit(source)
     validate_acknowledged_changelog_source!(source_changelog_sha)
@@ -1476,15 +1497,27 @@ class ReleaseForwardPort
         "final React on Rails #{release_version} changelog",
         "--format=%H"
       )
+    context = {
+      target:,
+      target_changelog:,
+      release_version:,
+      source_changelog_sha:,
+      subject_pattern:
+    }
 
-    candidates.find do |sha|
-      next false unless subject_for_commit(sha)&.match?(subject_pattern)
-      next false unless changed_paths_for_commit(sha) == [CHANGELOG_FILE]
-      next false unless target_commit_live_on_target?(sha, target)
-      next false unless authoritative_changelog_source_bound?(sha, source_changelog_sha)
+    candidates.find { |sha| authoritative_changelog_candidate?(sha, context) }
+  end
 
-      authoritative_changelog_section_unchanged?(sha, target_changelog, release_version)
-    end
+  def authoritative_changelog_candidate?(sha, context)
+    subject_for_commit(sha)&.match?(context.fetch(:subject_pattern)) &&
+      changed_paths_for_commit(sha) == [CHANGELOG_FILE] &&
+      target_commit_live_on_target?(sha, context.fetch(:target)) &&
+      authoritative_changelog_source_bound?(sha, context.fetch(:source_changelog_sha)) &&
+      authoritative_changelog_section_unchanged?(
+        sha,
+        context.fetch(:target_changelog),
+        context.fetch(:release_version)
+      )
   end
 
   def latest_changelog_commit(source)
@@ -1952,7 +1985,59 @@ class ChangelogReconciler
     )
   end
 
+  # A dedicated final changelog PR may intentionally consolidate or omit
+  # prerelease wording, so its stable section is authoritative. It is only safe
+  # to use that fast path when the named release section exists on the source and
+  # the source has no later [Unreleased] entries.
+  def authoritative_source_ready?
+    return false unless @release_version
+
+    source = parse_sections(@source_changelog)
+    source_release_base_version(source) == @release_version &&
+      section_entries(find_unreleased(source)).empty?
+  end
+
+  # Even after a final changelog PR, a later mixed cherry-pick can reintroduce an
+  # RC section or duplicate one of the release entries under target [Unreleased].
+  # Remove only that residue; never re-add source wording that the authoritative
+  # final PR intentionally consolidated or omitted.
+  def reconcile_authoritative_residue
+    target = parse_sections(@target_changelog)
+    source = parse_sections(@source_changelog)
+    base_version = source_release_base_version(source)
+    removed_sections = stray_rc_sections(target, base_version)
+    target_entries, removed_entries = authoritative_residue_entries(target, source, base_version)
+    retained_entries = target_entries - removed_entries
+
+    reconciled = if removed_entries.any? || removed_sections.any?
+                   rebuild_changelog(target, retained_entries, removed_sections)
+                 else
+                   @target_changelog
+                 end
+
+    Result.new(
+      reconciled_changelog: reconciled,
+      added_entries: [],
+      skipped_entries: [],
+      removed_entries:,
+      removed_sections: removed_sections.map { |section| section[:version] },
+      original_changelog: @target_changelog
+    )
+  end
+
   private
+
+  def authoritative_residue_entries(target, source, base_version)
+    target_entries = section_entries(find_unreleased(target))
+    source_entries = stamped_source_entries(source, base_version)
+    source_pr_numbers = source_entries.filter_map(&:pr_number).to_set
+    source_texts = source_entries.to_set { |entry| normalize_text(entry.text) }
+    removed_entries = target_entries.select do |entry|
+      (entry.pr_number && source_pr_numbers.include?(entry.pr_number)) ||
+        source_texts.include?(normalize_text(entry.text))
+    end
+    [target_entries, removed_entries]
+  end
 
   def reconcile_entries(target, source, removed_sections, base_version)
     target_entries = section_entries(find_unreleased(target))
@@ -2016,10 +2101,18 @@ class ChangelogReconciler
   # active base version.
   def collect_source_entries(source, base_version)
     sections = [find_unreleased(source)].compact
-    sections += stable_sections(source, base_version)
-    sections += prerelease_sections(source, base_version)
+    sections += stamped_source_sections(source, base_version)
     blocks = sections.flat_map { |section| section_blocks(section[:body]) }
     entries_from_blocks(consolidate_blocks(blocks))
+  end
+
+  def stamped_source_entries(source, base_version)
+    blocks = stamped_source_sections(source, base_version).flat_map { |section| section_blocks(section[:body]) }
+    entries_from_blocks(consolidate_blocks(blocks))
+  end
+
+  def stamped_source_sections(source, base_version)
+    stable_sections(source, base_version) + prerelease_sections(source, base_version)
   end
 
   # Split the collapsed source entries into those to add to main's [Unreleased]
@@ -2120,7 +2213,13 @@ class ChangelogReconciler
   # For arbitrary source refs, retain the prerelease-section inference fallback.
   # Never infer from the target: an unrelated target RC section must stay intact.
   def source_release_base_version(source)
-    @release_version || highest_prerelease_base(source)
+    if @release_version
+      return @release_version if stamped_source_sections(source, @release_version).any?
+
+      return nil
+    end
+
+    highest_prerelease_base(source)
   end
 
   def highest_prerelease_base(parsed)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1139,7 +1139,8 @@ class ReleaseForwardPort
     source_changelog = changelog_at(source, label: "source")
     target_changelog = changelog_at(target, label: "target")
 
-    reconciler = ChangelogReconciler.new(source_changelog:, target_changelog:)
+    release_version = release_version_from_ref(source)
+    reconciler = ChangelogReconciler.new(source_changelog:, target_changelog:, release_version:)
     result = reconciler.reconcile
 
     print_changelog_reconciliation_plan(source, target, result)
@@ -1153,6 +1154,10 @@ class ReleaseForwardPort
   rescue ChangelogReconciler::ReconcileError => e
     # Map the reconciler's own error onto the shared GitError exit path.
     raise GitError, e.message
+  end
+
+  def release_version_from_ref(ref)
+    ref.match(%r{(?:\A|/)release/(?<version>\d+\.\d+\.\d+)\z})&.[](:version)
   end
 
   def apply_changelog_reconciliation(target, result)
@@ -1434,13 +1439,14 @@ end
 
 # Re-homes release-branch CHANGELOG.md entries into the target's [Unreleased]
 # section. On a release branch a fix's entry lives under an RC header
-# (### [17.0.0.rc.1]); on main it belongs under ### [Unreleased]. A plain
+# (### [17.0.0.rc.1]) or, after final stamping, the matching stable header
+# (### [17.0.0]); on main it belongs under ### [Unreleased]. A plain
 # cherry-pick -x of the fix commit drags the RC-header context and either
 # conflicts or lands the entry in the wrong section. This reconciler is the
 # changelog restructure half of the forward-port: it collapses every entry from
-# the release branch's rc.N sections plus its own [Unreleased] into the target's
-# [Unreleased], de-duplicated by PR number against the target's existing entries,
-# and drops any RC-header section a prior pick left on the target.
+# the release branch's matching stable/rc.N sections plus its own [Unreleased]
+# into the target's [Unreleased], de-duplicated by PR number against the target's
+# existing entries, and drops any RC-header section a prior pick left on the target.
 #
 # The parsing approach intentionally mirrors react_on_rails/rakelib/update_changelog.rake
 # (parse_changelog_sections / changelog_section_blocks / consolidate_changelog_blocks)
@@ -1490,9 +1496,10 @@ class ChangelogReconciler
     end
   end
 
-  def initialize(source_changelog:, target_changelog:)
+  def initialize(source_changelog:, target_changelog:, release_version: nil)
     @source_changelog = source_changelog
     @target_changelog = target_changelog
+    @release_version = release_version
   end
 
   def reconcile
@@ -1533,9 +1540,11 @@ class ChangelogReconciler
 
   # Collapse every release-branch source section that belongs in main's
   # [Unreleased]: the branch's own [Unreleased] first (so it wins "first seen"
-  # ordering), then each rc.N / prerelease section for the active base version.
+  # ordering), then the final stable section and each prerelease section for the
+  # active base version.
   def collect_source_entries(source, base_version)
     sections = [find_unreleased(source)].compact
+    sections += stable_sections(source, base_version)
     sections += prerelease_sections(source, base_version)
     blocks = sections.flat_map { |section| section_blocks(section[:body]) }
     entries_from_blocks(consolidate_blocks(blocks))
@@ -1634,14 +1643,12 @@ class ChangelogReconciler
     text.to_s.gsub(/\s+/, " ").strip
   end
 
-  # The active release line is defined by the SOURCE branch's prerelease sections.
-  # We must NOT fall back to the target's RC base: if the source has no prerelease
-  # sections, there is nothing to re-home and no basis to claim a target RC section
-  # belongs to this line, so the run is a clean no-op (handled by the empty-base
-  # guards in prerelease_sections / stray_rc_sections). Forward-porting from a
-  # non-prerelease ref such as release/16.6.0 must not reach into main's RC base.
+  # Prefer the version named by release/X.Y.Z. Final stamping removes RC headers,
+  # so the source ref is the durable way to identify the stable section to re-home.
+  # For arbitrary source refs, retain the prerelease-section inference fallback.
+  # Never infer from the target: an unrelated target RC section must stay intact.
   def source_release_base_version(source)
-    highest_prerelease_base(source)
+    @release_version || highest_prerelease_base(source)
   end
 
   def highest_prerelease_base(parsed)
@@ -1666,6 +1673,12 @@ class ChangelogReconciler
   # reconciliation must drop so entries live only under [Unreleased] on main.
   def stray_rc_sections(target, base_version)
     prerelease_sections(target, base_version)
+  end
+
+  def stable_sections(parsed, base_version)
+    return [] unless base_version
+
+    parsed[:sections].select { |section| section[:version] == base_version }
   end
 
   # Prerelease (rc.N / beta.N / ...) sections in `parsed` whose base equals

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -32,6 +32,9 @@ class ReleaseForwardPort
     \A\s*-\s+replaces?\b.*?\bwith\b.*?\balready\s+reviewed\s+and\s+merged\s+in\s+
     (?<prs>#{PR_NUMBER_LIST_PATTERN})
   /iox
+  EXPLICIT_EQUIVALENT_MAIN_PR_PATTERN = /
+    \A\s*this\s+is\s+equivalent\s+to\s+main\s+PR\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\b
+  /iox
   COMPOSITE_BACKPORT_PATTERN =
     /\A\s*backports?\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+and\s+includes\s+the\s+reviewed\b/io
   PROVENANCE_NEGATION_PATTERN = /
@@ -397,7 +400,19 @@ class ReleaseForwardPort
     # re-apply it even if git cherry reports a patch match.
     return if source_cherry_pick_origin_reverted_on_target?(sha, target)
 
-    patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
+    patch_or_narrated_manual_reason(sha, subject, target, patch_equivalent_commits)
+  end
+
+  def patch_or_narrated_manual_reason(sha, subject, target, patch_equivalent_commits)
+    patch_reason = patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
+    return patch_reason if patch_reason
+
+    return unless source_narrated_pr_reference_on_target?(sha, target)
+
+    manual_skip_reason(
+      "source commit names a live upstream PR on #{target}, but does not prove whole-commit equivalence; " \
+      "inspect its release-specific hunks before acknowledging it"
+    )
   end
 
   def patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
@@ -774,12 +789,31 @@ class ReleaseForwardPort
     body = git("log", "-1", "--format=%B", sha)
     composite_pr_numbers = composite_backport_pr_numbers(body)
     narrated_pr_numbers = narrated_upstream_pr_numbers(body)
-    upstream_pr_numbers = (composite_pr_numbers + narrated_pr_numbers - release_pr_numbers).uniq
     if composite_pr_numbers.any?
+      upstream_pr_numbers = (composite_pr_numbers + narrated_pr_numbers - release_pr_numbers).uniq
+      review_fix_shas = review_fix_forward_port_shas_from_release_pr(release_pr_numbers, target)
       return upstream_pr_numbers.any? &&
              target_pr_numbers_live?(upstream_pr_numbers, target) &&
-             review_fix_forward_ported_from_release_pr?(release_pr_numbers, target)
+             review_fix_shas.any? &&
+             source_paths_covered_by_target_commits?(
+               sha,
+               target_pr_commit_shas_for(upstream_pr_numbers, target) + review_fix_shas
+             )
     end
+
+    equivalent_pr_numbers = narrated_equivalent_upstream_pr_numbers(body) - release_pr_numbers
+    equivalent_pr_numbers.any? &&
+      target_pr_numbers_live?(equivalent_pr_numbers, target) &&
+      source_paths_covered_by_target_commits?(sha, target_pr_commit_shas_for(equivalent_pr_numbers, target))
+  end
+
+  def source_narrated_pr_reference_on_target?(sha, target)
+    release_pr_number = source_pr_number_from_subject(subject_for_commit(sha).to_s)
+    release_pr_numbers = release_pr_number ? [release_pr_number] : []
+    body = git("log", "-1", "--format=%B", sha)
+    return false if composite_backport_pr_numbers(body).any?
+
+    upstream_pr_numbers = narrated_upstream_pr_numbers(body) - release_pr_numbers
 
     upstream_pr_numbers.any? && target_pr_numbers_live?(upstream_pr_numbers, target)
   end
@@ -799,16 +833,31 @@ class ReleaseForwardPort
     end
   end
 
-  def review_fix_forward_ported_from_release_pr?(release_pr_numbers, target)
-    release_pr_numbers.any? do |pr_number|
-      target_history_commits_mentioning("release PR ##{pr_number}", target).any? do |target_sha|
+  def target_pr_commit_shas_for(pr_numbers, target)
+    pr_numbers.flat_map do |pr_number|
+      target_pr_commit_shas(pr_number, target).select do |target_sha|
+        target_commit_live_on_target?(target_sha, target)
+      end
+    end.uniq
+  end
+
+  def source_paths_covered_by_target_commits?(source_sha, target_shas)
+    source_paths = changed_paths_for_commit(source_sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
+    target_paths = target_shas.flat_map { |target_sha| changed_paths_for_commit(target_sha) }.uniq
+
+    source_paths.any? && (source_paths - target_paths).empty?
+  end
+
+  def review_fix_forward_port_shas_from_release_pr(release_pr_numbers, target)
+    release_pr_numbers.flat_map do |pr_number|
+      target_history_commits_mentioning("release PR ##{pr_number}", target).select do |target_sha|
         next false unless subject_for_commit(target_sha)&.match?(/\bforward-port\b/i)
 
         body = git("log", "-1", "--format=%B", target_sha)
         narrated = body.split(/\n\s*\n/).any? { |paragraph| narrated_review_fix_matches?(paragraph, pr_number) }
         narrated && target_commit_live_on_target?(target_sha, target)
       end
-    end
+    end.uniq
   end
 
   def narrated_review_fix_matches?(paragraph, pr_number)
@@ -829,6 +878,19 @@ class ReleaseForwardPort
       numbers = []
       numbers.concat(explicit_backport[:prs].scan(/#(\d+)/).flatten) if explicit_backport
       numbers.concat(from_backport[:prs].scan(/#(\d+)/).flatten) if from_backport
+      numbers.concat(merged_replacement[:prs].scan(/#(\d+)/).flatten) if merged_replacement
+      numbers
+    end.uniq
+  end
+
+  def narrated_equivalent_upstream_pr_numbers(body)
+    forward_port_narration_segments(body).flat_map do |segment|
+      next [] unless authoritative_provenance_segment?(segment)
+
+      explicit_equivalence = segment.match(EXPLICIT_EQUIVALENT_MAIN_PR_PATTERN)
+      merged_replacement = segment.match(MERGED_REPLACEMENT_PATTERN)
+      numbers = []
+      numbers.concat(explicit_equivalence[:prs].scan(/#(\d+)/).flatten) if explicit_equivalence
       numbers.concat(merged_replacement[:prs].scan(/#(\d+)/).flatten) if merged_replacement
       numbers
     end.uniq
@@ -1140,7 +1202,7 @@ class ReleaseForwardPort
   end
 
   def generated_llm_artifact_changed?(sha)
-    (changed_paths_for_commit(sha) & GENERATED_LLM_FILES).any?
+    changed_paths_for_commit(sha).intersect?(GENERATED_LLM_FILES)
   end
 
   def patch_id_for_commit(sha, target_to_source_paths: {}, paths: nil, zero_context: false)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1509,13 +1509,7 @@ class ChangelogReconciler
     base_version = source_release_base_version(source)
     removed_sections = stray_rc_sections(target, base_version)
 
-    target_entries = section_entries(find_unreleased(target))
-    # De-duplicate against every section that will remain on main, not only the
-    # current [Unreleased]. A maintained release branch retains its stable
-    # section, whose entries may already live in main's history. Exclude RC
-    # sections being removed so their entries can still be re-homed before the
-    # section headers disappear.
-    added, skipped = partition_source_against_retained_target(target, source, removed_sections, base_version)
+    target_entries, added, skipped = reconcile_entries(target, source, removed_sections, base_version)
 
     # Only re-render when there is a real change; otherwise return the target
     # changelog byte-for-byte so a no-op run never reflows existing entries.
@@ -1536,18 +1530,44 @@ class ChangelogReconciler
 
   private
 
-  def partition_source_against_retained_target(target, source, removed_sections, base_version)
+  def reconcile_entries(target, source, removed_sections, base_version)
+    target_entries = section_entries(find_unreleased(target))
+    source_entries = collect_source_entries(source, base_version)
+    replacement_prs = authoritative_replacement_pr_numbers(source, base_version, target_entries)
+
+    # De-duplicate against every section that will remain on main, not only the
+    # current [Unreleased]. A maintained release branch retains its stable
+    # section, whose entries may already live in main's history. Exclude RC
+    # sections being removed so their entries can still be re-homed before the
+    # section headers disappear.
     retained_target_entries = target[:sections]
                               .reject { |section| removed_sections.include?(section) }
-                              .flat_map { |section| section_entries(section) }
+                              .flat_map do |section|
+      entries = section_entries(section)
+      section[:version] == UNRELEASED ? entries.reject { |entry| replacement_prs.include?(entry.pr_number) } : entries
+    end
     seen_pr_numbers = retained_target_entries.filter_map(&:pr_number).to_set
     target_entry_texts = retained_target_entries.to_set { |entry| normalize_text(entry.text) }
 
-    partition_source_entries(
-      collect_source_entries(source, base_version),
-      seen_pr_numbers,
-      target_entry_texts
-    )
+    added, skipped = partition_source_entries(source_entries, seen_pr_numbers, target_entry_texts)
+    retained_unreleased_entries = target_entries.reject { |entry| replacement_prs.include?(entry.pr_number) }
+    [retained_unreleased_entries, added, skipped]
+  end
+
+  # Final stamping can consolidate an earlier entry with a follow-up PR while
+  # main still has narrower prerelease wording for that same own PR. The final
+  # stable entry is authoritative, so remove the narrower [Unreleased] copy and
+  # let the normal partition pass add the final wording and heading.
+  def authoritative_replacement_pr_numbers(source, base_version, target_entries)
+    stable_entries = stable_sections(source, base_version).flat_map { |section| section_entries(section) }
+    stable_entries_by_pr = stable_entries.select(&:pr_number).group_by(&:pr_number)
+
+    target_entries.filter_map do |target_entry|
+      candidates = stable_entries_by_pr[target_entry.pr_number]
+      next unless candidates&.any? { |entry| normalize_text(entry.text) != normalize_text(target_entry.text) }
+
+      target_entry.pr_number
+    end.to_set
   end
 
   # Collapse every release-branch source section that belongs in main's

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -34,6 +34,9 @@ class ReleaseForwardPort
   /iox
   COMPOSITE_BACKPORT_PATTERN =
     /\A\s*backports?\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+and\s+includes\s+the\s+reviewed\b/io
+  PROVENANCE_NEGATION_PATTERN = /
+    \b(?:not|never|no|without|unlike|except(?:\s+for)?|rather\s+than|instead\s+of)\b
+  /ix
   PRERELEASE_RANKS = {
     "dev" => 0,
     "test" => 1,
@@ -725,19 +728,21 @@ class ReleaseForwardPort
     release_pr_numbers = subject.scan(/#(\d+)/).flatten
     body = git("log", "-1", "--format=%B", sha)
     composite_pr_numbers = composite_backport_pr_numbers(body)
+    narrated_pr_numbers = narrated_upstream_pr_numbers(body)
+    upstream_pr_numbers = (composite_pr_numbers + narrated_pr_numbers - release_pr_numbers).uniq
     if composite_pr_numbers.any?
-      return target_pr_numbers_live?(composite_pr_numbers, target) &&
+      return upstream_pr_numbers.any? &&
+             target_pr_numbers_live?(upstream_pr_numbers, target) &&
              review_fix_forward_ported_from_release_pr?(release_pr_numbers, target)
     end
 
-    narrated_pr_numbers = narrated_upstream_pr_numbers(body)
-
-    upstream_pr_numbers = (narrated_pr_numbers - release_pr_numbers).uniq
     upstream_pr_numbers.any? && target_pr_numbers_live?(upstream_pr_numbers, target)
   end
 
   def composite_backport_pr_numbers(body)
     forward_port_narration_segments(body).flat_map do |segment|
+      next [] unless authoritative_provenance_segment?(segment)
+
       match = segment.match(COMPOSITE_BACKPORT_PATTERN)
       match ? match[:prs].scan(/#(\d+)/).flatten : []
     end.uniq
@@ -766,6 +771,8 @@ class ReleaseForwardPort
 
   def narrated_upstream_pr_numbers(body)
     forward_port_narration_segments(body).flat_map do |segment|
+      next [] unless authoritative_provenance_segment?(segment)
+
       explicit_backport = segment.match(EXPLICIT_BACKPORT_PATTERN)
       from_backport = segment.match(FROM_BACKPORT_PATTERN)
       merged_replacement = segment.match(MERGED_REPLACEMENT_PATTERN)
@@ -775,6 +782,10 @@ class ReleaseForwardPort
       numbers.concat(merged_replacement[:prs].scan(/#(\d+)/).flatten) if merged_replacement
       numbers
     end.uniq
+  end
+
+  def authoritative_provenance_segment?(segment)
+    !segment.match?(PROVENANCE_NEGATION_PATTERN)
   end
 
   def target_pr_commit_shas(pr_number, target)
@@ -1420,10 +1431,14 @@ class ReleaseForwardPort
       next false unless target_commit_live_on_target?(sha, target)
       next false if git("show", "-s", "--format=%ct", sha).to_i < source_time
 
-      recorded_changelog = changelog_at(sha, label: "authoritative final changelog")
-      changelog_section(recorded_changelog, release_version) ==
-        changelog_section(target_changelog, release_version)
+      authoritative_changelog_section_unchanged?(sha, target_changelog, release_version)
     end
+  end
+
+  def authoritative_changelog_section_unchanged?(sha, target_changelog, release_version)
+    recorded_changelog = changelog_at(sha, label: "authoritative final changelog")
+    recorded_section = changelog_section(recorded_changelog, release_version)
+    recorded_section && recorded_section == changelog_section(target_changelog, release_version)
   end
 
   def changelog_section(changelog, version)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -261,19 +261,28 @@ class ReleaseForwardPort
   end
 
   def patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
-    identity_candidates = target_history_source_identity_candidates(subject, target)
-    return "already forward-ported to #{target} via narrated cherry-pick -x evidence with no later target revert" if
-      identity_candidates.any? { |target_sha| narrated_forward_port_commit_live?(target_sha, target) }
-
-    identity_candidates.concat(target_history_source_provenance_candidates(sha, target)).uniq!
-    return patch_equivalent_skip_reason_message(target) if
-      identity_candidates.any? &&
-      patch_equivalent_commit_present_on_target?(sha, target, candidates: identity_candidates)
+    targeted_reason = targeted_patch_equivalent_skip_reason(sha, subject, target)
+    return targeted_reason if targeted_reason
 
     return unless patch_equivalent_commits[sha] || target_has_renamed_source_paths?(target, sha)
     return unless patch_equivalent_commit_present_on_target?(sha, target)
 
     patch_equivalent_skip_reason_message(target)
+  end
+
+  def targeted_patch_equivalent_skip_reason(sha, subject, target)
+    identity_candidates = target_history_source_identity_candidates(subject, target)
+    return "already forward-ported to #{target} via narrated cherry-pick -x evidence with no later target revert" if
+      identity_candidates.any? { |target_sha| narrated_forward_port_commit_live?(target_sha, target) }
+
+    provenance_candidates = target_history_source_provenance_candidates(sha, target)
+    return patch_equivalent_skip_reason_message(target) if
+      identity_candidates.any? &&
+      patch_equivalent_commit_present_on_target?(sha, target, candidates: identity_candidates)
+
+    patch_equivalent_skip_reason_message(target) if
+      provenance_candidates.any? &&
+      patch_equivalent_commit_present_on_target?(sha, target, candidates: provenance_candidates, zero_context: true)
   end
 
   def patch_equivalent_skip_reason_message(target)
@@ -604,12 +613,12 @@ class ReleaseForwardPort
     end.uniq
   end
 
-  def patch_equivalent_commit_present_on_target?(sha, target, candidates: nil)
+  def patch_equivalent_commit_present_on_target?(sha, target, candidates: nil, zero_context: false)
     source_paths = changed_paths_for_commit(sha) - [CHANGELOG_FILE]
-    source_patch_id = patch_id_for_commit(sha, paths: source_paths)
+    source_patch_id = patch_id_for_commit(sha, paths: source_paths, zero_context:)
 
     (candidates || patch_equivalent_target_candidates(sha, target)).any? do |target_sha|
-      patch_id_for_target_candidate(target_sha, sha, source_paths:) == source_patch_id &&
+      patch_id_for_target_candidate(target_sha, sha, source_paths:, zero_context:) == source_patch_id &&
         target_commit_live_on_target?(target_sha, target)
     end
   end
@@ -687,14 +696,15 @@ class ReleaseForwardPort
     (source_paths_for_target_diff(target, sha) - changed_paths_for_commit(sha)).any?
   end
 
-  def patch_id_for_target_candidate(target_sha, source_sha, source_paths: changed_paths_for_commit(source_sha))
+  def patch_id_for_target_candidate(target_sha, source_sha, source_paths: changed_paths_for_commit(source_sha),
+                                    zero_context: false)
     parents = git("rev-list", "--parents", "-n", "1", target_sha).split.drop(1)
-    return patch_id_for_commit(target_sha, paths: source_paths) if parents.empty?
+    return patch_id_for_commit(target_sha, paths: source_paths, zero_context:) if parents.empty?
 
     target_to_source_paths = target_to_source_path_map(target_sha, source_sha).select do |_target_path, source_path|
       source_paths.include?(source_path)
     end
-    patch_id_for_commit(target_sha, target_to_source_paths:, paths: target_to_source_paths.keys)
+    patch_id_for_commit(target_sha, target_to_source_paths:, paths: target_to_source_paths.keys, zero_context:)
   end
 
   def source_paths_for_target_diff(first_parent, sha)
@@ -764,7 +774,7 @@ class ReleaseForwardPort
     @changed_paths_cache[sha] ||= git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
   end
 
-  def patch_id_for_commit(sha, target_to_source_paths: {}, paths: nil)
+  def patch_id_for_commit(sha, target_to_source_paths: {}, paths: nil, zero_context: false)
     # git show --format= emits diff-only output. git patch-id still hashes the
     # hunk content and emits a commit field we discard; the first token is the
     # content hash used for comparisons.
@@ -776,6 +786,7 @@ class ReleaseForwardPort
       rename_detection_option(target_to_source_paths),
       sha
     ]
+    args << "--unified=0" if zero_context
     args.push("--", *paths) if paths
     patch = git(*args).b
     patch = normalize_patch_paths(patch, target_to_source_paths)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -260,20 +260,26 @@ class ReleaseForwardPort
     candidate_signal =
       patch_equivalent_commits[sha] ||
       target_has_renamed_source_paths?(target, sha) ||
-      target_history_mentions_source_subject?(subject, target)
+      target_history_mentions_source_identity?(subject, target)
     return unless candidate_signal
     return unless patch_equivalent_commit_present_on_target?(sha, target)
 
     "patch already exists on #{target} according to target history with no later standard revert"
   end
 
-  def target_history_mentions_source_subject?(subject, target)
-    @target_subject_mention_cache ||= {}
-    cache_key = [subject, target]
-    return @target_subject_mention_cache.fetch(cache_key) if @target_subject_mention_cache.key?(cache_key)
+  def target_history_mentions_source_identity?(subject, target)
+    ([subject] + subject.scan(/#\d+/)).uniq.any? do |source_identity|
+      target_history_mentions?(source_identity, target)
+    end
+  end
 
-    @target_subject_mention_cache[cache_key] =
-      git_lines("log", target, "--fixed-strings", "--grep", subject, "--format=%H", "-n", "1").any?
+  def target_history_mentions?(source_identity, target)
+    @target_identity_mention_cache ||= {}
+    cache_key = [source_identity, target]
+    return @target_identity_mention_cache.fetch(cache_key) if @target_identity_mention_cache.key?(cache_key)
+
+    @target_identity_mention_cache[cache_key] =
+      git_lines("log", target, "--fixed-strings", "--grep", source_identity, "--format=%H", "-n", "1").any?
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1515,17 +1515,7 @@ class ChangelogReconciler
     # section, whose entries may already live in main's history. Exclude RC
     # sections being removed so their entries can still be re-homed before the
     # section headers disappear.
-    retained_target_entries = target[:sections]
-                              .reject { |section| removed_sections.include?(section) }
-                              .flat_map { |section| section_entries(section) }
-    seen_pr_numbers = retained_target_entries.filter_map(&:pr_number).to_set
-    target_entry_texts = retained_target_entries.to_set { |entry| normalize_text(entry.text) }
-
-    added, skipped = partition_source_entries(
-      collect_source_entries(source, base_version),
-      seen_pr_numbers,
-      target_entry_texts
-    )
+    added, skipped = partition_source_against_retained_target(target, source, removed_sections, base_version)
 
     # Only re-render when there is a real change; otherwise return the target
     # changelog byte-for-byte so a no-op run never reflows existing entries.
@@ -1545,6 +1535,20 @@ class ChangelogReconciler
   end
 
   private
+
+  def partition_source_against_retained_target(target, source, removed_sections, base_version)
+    retained_target_entries = target[:sections]
+                              .reject { |section| removed_sections.include?(section) }
+                              .flat_map { |section| section_entries(section) }
+    seen_pr_numbers = retained_target_entries.filter_map(&:pr_number).to_set
+    target_entry_texts = retained_target_entries.to_set { |entry| normalize_text(entry.text) }
+
+    partition_source_entries(
+      collect_source_entries(source, base_version),
+      seen_pr_numbers,
+      target_entry_texts
+    )
+  end
 
   # Collapse every release-branch source section that belongs in main's
   # [Unreleased]: the branch's own [Unreleased] first (so it wins "first seen"

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -575,10 +575,11 @@ class ReleaseForwardPort
   end
 
   def patch_equivalent_commit_present_on_target?(sha, target, candidates: nil)
-    source_patch_id = patch_id_for_commit(sha)
+    source_paths = changed_paths_for_commit(sha) - [CHANGELOG_FILE]
+    source_patch_id = patch_id_for_commit(sha, paths: source_paths)
 
     (candidates || patch_equivalent_target_candidates(sha, target)).any? do |target_sha|
-      patch_id_for_target_candidate(target_sha, sha) == source_patch_id &&
+      patch_id_for_target_candidate(target_sha, sha, source_paths:) == source_patch_id &&
         target_commit_live_on_target?(target_sha, target)
     end
   end
@@ -656,11 +657,13 @@ class ReleaseForwardPort
     (source_paths_for_target_diff(target, sha) - changed_paths_for_commit(sha)).any?
   end
 
-  def patch_id_for_target_candidate(target_sha, source_sha)
+  def patch_id_for_target_candidate(target_sha, source_sha, source_paths: changed_paths_for_commit(source_sha))
     parents = git("rev-list", "--parents", "-n", "1", target_sha).split.drop(1)
-    return patch_id_for_commit(target_sha) if parents.empty?
+    return patch_id_for_commit(target_sha, paths: source_paths) if parents.empty?
 
-    target_to_source_paths = target_to_source_path_map(target_sha, source_sha)
+    target_to_source_paths = target_to_source_path_map(target_sha, source_sha).select do |_target_path, source_path|
+      source_paths.include?(source_path)
+    end
     patch_id_for_commit(target_sha, target_to_source_paths:, paths: target_to_source_paths.keys)
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -253,14 +253,27 @@ class ReleaseForwardPort
     # re-apply it even if git cherry reports a patch match.
     return if source_cherry_pick_origin_reverted_on_target?(sha, target)
 
-    patch_equivalent_skip_reason(sha, target, patch_equivalent_commits)
+    patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
   end
 
-  def patch_equivalent_skip_reason(sha, target, patch_equivalent_commits)
-    return unless patch_equivalent_commits[sha] || target_has_renamed_source_paths?(target, sha)
+  def patch_equivalent_skip_reason(sha, subject, target, patch_equivalent_commits)
+    candidate_signal =
+      patch_equivalent_commits[sha] ||
+      target_has_renamed_source_paths?(target, sha) ||
+      target_history_mentions_source_subject?(subject, target)
+    return unless candidate_signal
     return unless patch_equivalent_commit_present_on_target?(sha, target)
 
     "patch already exists on #{target} according to target history with no later standard revert"
+  end
+
+  def target_history_mentions_source_subject?(subject, target)
+    @target_subject_mention_cache ||= {}
+    cache_key = [subject, target]
+    return @target_subject_mention_cache.fetch(cache_key) if @target_subject_mention_cache.key?(cache_key)
+
+    @target_subject_mention_cache[cache_key] =
+      git_lines("log", target, "--fixed-strings", "--grep", subject, "--format=%H", "-n", "1").any?
   end
 
   def active_source_revert_skip_reason(subject, target, target_version)
@@ -637,7 +650,7 @@ class ReleaseForwardPort
     return patch_id_for_commit(target_sha) if parents.empty?
 
     target_to_source_paths = target_to_source_path_map(target_sha, source_sha)
-    patch_id_for_commit(target_sha, target_to_source_paths:)
+    patch_id_for_commit(target_sha, target_to_source_paths:, paths: target_to_source_paths.keys)
   end
 
   def source_paths_for_target_diff(first_parent, sha)
@@ -707,19 +720,20 @@ class ReleaseForwardPort
     @changed_paths_cache[sha] ||= git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
   end
 
-  def patch_id_for_commit(sha, target_to_source_paths: {})
+  def patch_id_for_commit(sha, target_to_source_paths: {}, paths: nil)
     # git show --format= emits diff-only output. git patch-id still hashes the
     # hunk content and emits a commit field we discard; the first token is the
     # content hash used for comparisons.
-    patch =
-      git(
-        "show",
-        "--no-ext-diff",
-        "--format=",
-        "--full-index",
-        rename_detection_option(target_to_source_paths),
-        sha
-      ).b
+    args = [
+      "show",
+      "--no-ext-diff",
+      "--format=",
+      "--full-index",
+      rename_detection_option(target_to_source_paths),
+      sha
+    ]
+    args.push("--", *paths) if paths
+    patch = git(*args).b
     patch = normalize_patch_paths(patch, target_to_source_paths)
     patch_id_for_patch(patch, sha)
   end

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -32,9 +32,6 @@ class ReleaseForwardPort
     \A\s*-\s+replaces?\b.*?\bwith\b.*?\balready\s+reviewed\s+and\s+merged\s+in\s+
     (?<prs>#{PR_NUMBER_LIST_PATTERN})
   /iox
-  EXPLICIT_EQUIVALENT_MAIN_PR_PATTERN = /
-    \A\s*this\s+is\s+equivalent\s+to\s+main\s+PR\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\b
-  /iox
   COMPOSITE_BACKPORT_PATTERN =
     /\A\s*backports?\s+(?<prs>#{PR_NUMBER_LIST_PATTERN})\s+and\s+includes\s+the\s+reviewed\b/io
   PROVENANCE_NEGATION_PATTERN = /
@@ -390,9 +387,6 @@ class ReleaseForwardPort
     return active_source_revert_skip_reason(subject, target, target_version) if
       source_standard_revert_on_target?(sha, target)
 
-    return "source commit identifies a live upstream PR already present on #{target}" if
-      source_narrated_pr_origin_on_target?(sha, target)
-
     return "already forward-ported to #{target} via cherry-pick -x evidence with no later target revert" if
       already_forward_ported_with_x?(sha, target)
 
@@ -641,8 +635,7 @@ class ReleaseForwardPort
 
   def source_commit_provenance_present_on_target?(sha, target)
     subject = subject_for_commit(sha).to_s
-    source_narrated_pr_origin_on_target?(sha, target) ||
-      already_forward_ported_with_x?(sha, target) ||
+    already_forward_ported_with_x?(sha, target) ||
       !targeted_patch_equivalent_skip_reason(sha, subject, target).nil?
   end
 
@@ -782,7 +775,7 @@ class ReleaseForwardPort
     origin_sha && commit_on_target?(origin_sha, target) && !target_commit_live_on_target?(origin_sha, target)
   end
 
-  def source_narrated_pr_origin_on_target?(sha, target)
+  def source_narrated_pr_reference_on_target?(sha, target)
     subject = subject_for_commit(sha).to_s
     release_pr_number = source_pr_number_from_subject(subject)
     release_pr_numbers = release_pr_number ? [release_pr_number] : []
@@ -794,26 +787,10 @@ class ReleaseForwardPort
       review_fix_shas = review_fix_forward_port_shas_from_release_pr(release_pr_numbers, target)
       return upstream_pr_numbers.any? &&
              target_pr_numbers_live?(upstream_pr_numbers, target) &&
-             review_fix_shas.any? &&
-             source_paths_covered_by_target_commits?(
-               sha,
-               target_pr_commit_shas_for(upstream_pr_numbers, target) + review_fix_shas
-             )
+             review_fix_shas.any?
     end
 
-    equivalent_pr_numbers = narrated_equivalent_upstream_pr_numbers(body) - release_pr_numbers
-    equivalent_pr_numbers.any? &&
-      target_pr_numbers_live?(equivalent_pr_numbers, target) &&
-      source_paths_covered_by_target_commits?(sha, target_pr_commit_shas_for(equivalent_pr_numbers, target))
-  end
-
-  def source_narrated_pr_reference_on_target?(sha, target)
-    release_pr_number = source_pr_number_from_subject(subject_for_commit(sha).to_s)
-    release_pr_numbers = release_pr_number ? [release_pr_number] : []
-    body = git("log", "-1", "--format=%B", sha)
-    return false if composite_backport_pr_numbers(body).any?
-
-    upstream_pr_numbers = narrated_upstream_pr_numbers(body) - release_pr_numbers
+    upstream_pr_numbers = narrated_pr_numbers - release_pr_numbers
 
     upstream_pr_numbers.any? && target_pr_numbers_live?(upstream_pr_numbers, target)
   end
@@ -831,21 +808,6 @@ class ReleaseForwardPort
     pr_numbers.all? do |pr_number|
       target_pr_commit_shas(pr_number, target).any? { |target_sha| target_commit_live_on_target?(target_sha, target) }
     end
-  end
-
-  def target_pr_commit_shas_for(pr_numbers, target)
-    pr_numbers.flat_map do |pr_number|
-      target_pr_commit_shas(pr_number, target).select do |target_sha|
-        target_commit_live_on_target?(target_sha, target)
-      end
-    end.uniq
-  end
-
-  def source_paths_covered_by_target_commits?(source_sha, target_shas)
-    source_paths = changed_paths_for_commit(source_sha) - [CHANGELOG_FILE] - GENERATED_LLM_FILES
-    target_paths = target_shas.flat_map { |target_sha| changed_paths_for_commit(target_sha) }.uniq
-
-    source_paths.any? && (source_paths - target_paths).empty?
   end
 
   def review_fix_forward_port_shas_from_release_pr(release_pr_numbers, target)
@@ -878,19 +840,6 @@ class ReleaseForwardPort
       numbers = []
       numbers.concat(explicit_backport[:prs].scan(/#(\d+)/).flatten) if explicit_backport
       numbers.concat(from_backport[:prs].scan(/#(\d+)/).flatten) if from_backport
-      numbers.concat(merged_replacement[:prs].scan(/#(\d+)/).flatten) if merged_replacement
-      numbers
-    end.uniq
-  end
-
-  def narrated_equivalent_upstream_pr_numbers(body)
-    forward_port_narration_segments(body).flat_map do |segment|
-      next [] unless authoritative_provenance_segment?(segment)
-
-      explicit_equivalence = segment.match(EXPLICIT_EQUIVALENT_MAIN_PR_PATTERN)
-      merged_replacement = segment.match(MERGED_REPLACEMENT_PATTERN)
-      numbers = []
-      numbers.concat(explicit_equivalence[:prs].scan(/#(\d+)/).flatten) if explicit_equivalence
       numbers.concat(merged_replacement[:prs].scan(/#(\d+)/).flatten) if merged_replacement
       numbers
     end.uniq
@@ -2132,7 +2081,14 @@ class ChangelogReconciler
     # section, whose entries may already live in main's history. Exclude RC
     # sections being removed so their entries can still be re-homed before the
     # section headers disappear.
-    retained_target_entries = retained_target_entries(target, removed_sections, replacement_prs)
+    retained_target_entries =
+      retained_target_entries(
+        target,
+        removed_sections,
+        replacement_prs,
+        base_version,
+        exclude_release_section: authoritative_source_ready?
+      )
     seen_pr_numbers = retained_target_entries.filter_map(&:pr_number).to_set
     target_entry_texts = retained_target_entries.to_set { |entry| normalize_text(entry.text) }
 
@@ -2142,15 +2098,17 @@ class ChangelogReconciler
     [retained_unreleased_entries, added, skipped, removed_entries]
   end
 
-  def retained_target_entries(target, removed_sections, replacement_prs)
-    target[:sections]
-      .reject { |section| removed_sections.include?(section) }
-      .flat_map do |section|
-        entries = section_entries(section)
-        next entries unless section[:version] == UNRELEASED
+  def retained_target_entries(target, removed_sections, replacement_prs, base_version, exclude_release_section:)
+    retained_sections = target[:sections].reject do |section|
+      removed_sections.include?(section) ||
+        (exclude_release_section && section[:version] == base_version)
+    end
+    retained_sections.flat_map do |section|
+      entries = section_entries(section)
+      next entries unless section[:version] == UNRELEASED
 
-        entries.reject { |entry| replacement_prs.include?(entry.pr_number) }
-      end
+      entries.reject { |entry| replacement_prs.include?(entry.pr_number) }
+    end
   end
 
   # Final stamping can consolidate an earlier entry with a follow-up PR while

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1425,6 +1425,8 @@ class ReleaseForwardPort
 
     release_version = release_version_from_ref(source)
     reconciler = ChangelogReconciler.new(source_changelog:, target_changelog:, release_version:)
+    return 1 if missing_source_release_section_check?(source, release_version, reconciler)
+
     authoritative_sha =
       authoritative_final_changelog_commit(
         source,
@@ -1439,19 +1441,17 @@ class ReleaseForwardPort
         return finish_authoritative_changelog_plan(source, target, release_version, authoritative_sha)
       end
 
-      print_changelog_reconciliation_plan(source, target, residue)
-      return check_changelog_plan(residue) if @options[:check]
-
-      if @options[:dry_run]
-        puts "\nDRY RUN: CHANGELOG.md was not modified and no branch was checked out."
-        return 0
-      end
-
-      return apply_changelog_reconciliation(target, residue)
+      return finish_changelog_reconciliation(source, target, residue)
     end
 
     result = reconciler.reconcile
+    finish_changelog_reconciliation(source, target, result)
+  rescue ChangelogReconciler::ReconcileError => e
+    # Map the reconciler's own error onto the shared GitError exit path.
+    raise GitError, e.message
+  end
 
+  def finish_changelog_reconciliation(source, target, result)
     print_changelog_reconciliation_plan(source, target, result)
 
     return check_changelog_plan(result) if @options[:check]
@@ -1462,9 +1462,14 @@ class ReleaseForwardPort
     end
 
     apply_changelog_reconciliation(target, result)
-  rescue ChangelogReconciler::ReconcileError => e
-    # Map the reconciler's own error onto the shared GitError exit path.
-    raise GitError, e.message
+  end
+
+  def missing_source_release_section_check?(source, release_version, reconciler)
+    return false unless @options[:check] && release_version
+    return false if reconciler.source_release_section_present?
+
+    warn "CHECK FAILED: #{source} has no matching stable or prerelease #{release_version} changelog section."
+    true
   end
 
   def check_changelog_plan(result)
@@ -1993,8 +1998,12 @@ class ChangelogReconciler
     return false unless @release_version
 
     source = parse_sections(@source_changelog)
-    source_release_base_version(source) == @release_version &&
+    source_release_section_present?(source) &&
       section_entries(find_unreleased(source)).empty?
+  end
+
+  def source_release_section_present?(source = parse_sections(@source_changelog))
+    source_release_base_version(source) == @release_version
   end
 
   # Even after a final changelog PR, a later mixed cherry-pick can reintroduce an

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -8,6 +8,11 @@
 
 set -uo pipefail
 
+# Test repositories must not inherit signing hooks or other machine-specific
+# Git behavior from the operator's global/system configuration.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FORWARD_PORT="$SCRIPT_DIR/release-forward-port"
 
@@ -62,7 +67,11 @@ run_test() {
   echo "-> $test_fn"
 
   local tmpdir before_failed had_errexit=false subshell_failures
-  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/release-forward-port-test.XXXXXX")"
+  if ! tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/release-forward-port-test.XXXXXX")" ||
+     [ -z "$tmpdir" ] || [ ! -d "$tmpdir" ]; then
+    fail "could not create an isolated temporary repository"
+    return
+  fi
   subshell_failures="$tmpdir/failures.log"
   : > "$subshell_failures"
   before_failed="$TESTS_FAILED"
@@ -108,6 +117,7 @@ init_repo() {
   git init -q -b main
   git config user.email test@example.com
   git config user.name "Forward Port Test"
+  git config commit.gpgsign false
 }
 
 commit_all() {
@@ -361,6 +371,207 @@ EOF
   assert_contains "$changelog" "PR 4490" "consolidated original PR kept"
   assert_not_contains "$changelog" "Narrow prerelease wording" "narrow target wording replaced"
   assert_contains "$changelog" "#### Breaking Changes" "final heading kept"
+}
+
+# If the canonical stable entry is already retained in target history, stale
+# same-PR wording under [Unreleased] still needs to be removed. That removal is
+# a semantic change even though there is no canonical entry left to add.
+test_stale_unreleased_copy_is_removed_when_canonical_entry_is_in_history() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Changed
+
+- **Stale prerelease wording**: obsolete copy. $(pr_link 123) by [a](https://github.com/a).
+
+### [17.0.0] - 2026-07-16
+
+#### Breaking Changes
+
+- **Canonical final wording**: released guidance. $(pr_link 123) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Breaking Changes
+
+- **Canonical final wording**: released guidance. $(pr_link 123) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out changelog
+  out="$(run_changelog release/17.0.0)"
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$out" "1 stale entry to drop" "stale removal counted"
+  assert_not_contains "$changelog" "Stale prerelease wording" "stale copy removed"
+  assert_contains "$changelog" "Canonical final wording" "canonical history retained"
+}
+
+# A final-stable source is authoritative over matching target RC sections.
+# Target-only RC notes can describe prerelease pins or experiments deliberately
+# removed before final, so drop them with the obsolete RC header.
+test_target_only_rc_entries_are_discarded_with_section() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.1] - 2026-07-01
+
+#### Fixed
+
+- **Target-only RC note**: prerelease-only behavior. $(pr_link 999) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Fixed
+
+- **Canonical final fix**: release entry. $(pr_link 123) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  run_changelog release/17.0.0 >/dev/null
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_not_contains "$changelog" "Target-only RC note" "target RC note discarded"
+  assert_contains "$changelog" "Canonical final fix" "source stable entry re-homed"
+  assert_not_contains "$changelog" "### [17.0.0.rc.1]" "target RC header removed"
+}
+
+# Stable changelogs can contain several distinct entries with the same own PR.
+# If main already has every exact entry, sibling wording must not make the
+# reconciler replace and reorder the whole PR group on every run.
+test_exact_same_pr_group_is_idempotent() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Added
+
+- **First feature**: first final entry. $(pr_link 3320) by [a](https://github.com/a).
+- **Second feature**: second final entry. $(pr_link 3320) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Added
+
+- **First feature**: first final entry. $(pr_link 3320) by [a](https://github.com/a).
+- **Second feature**: second final entry. $(pr_link 3320) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+  local before
+  before="$(cat CHANGELOG.md)"
+
+  local out
+  out="$(run_changelog release/17.0.0)"
+  assert_contains "$out" "0 entries to add" "exact same-PR group is a no-op"
+  assert_contains "$out" "2 entries already present" "both exact entries counted"
+  [ "$(cat CHANGELOG.md)" = "$before" ] || fail "exact same-PR group changed CHANGELOG.md"
+}
+
+# A partial target copy of a same-PR group must not suppress a canonical sibling
+# from the stable source.
+test_partial_same_pr_group_restores_missing_sibling() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Added
+
+- **First feature**: first final entry. $(pr_link 3320) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Added
+
+- **First feature**: first final entry. $(pr_link 3320) by [a](https://github.com/a).
+- **Second feature**: second final entry. $(pr_link 3320) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+  run_changelog release/17.0.0 >/dev/null
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "First feature" "existing same-PR sibling retained"
+  assert_contains "$changelog" "Second feature" "missing same-PR sibling restored"
+  [ "$(grep -c "First feature" CHANGELOG.md)" -eq 1 ] || fail "expected one first feature entry"
+  [ "$(grep -c "Second feature" CHANGELOG.md)" -eq 1 ] || fail "expected one second feature entry"
+}
+
+# Stable headings are part of the canonical entry identity. Identical prose
+# under the wrong heading must move to the stable source heading.
+test_stable_heading_replaces_matching_text_under_wrong_heading() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Changed
+
+- **Canonical fix**: final wording. $(pr_link 123) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Fixed
+
+- **Canonical fix**: final wording. $(pr_link 123) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+  run_changelog release/17.0.0 >/dev/null
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "#### Fixed" "stable heading restored"
+  assert_not_contains "$changelog" "#### Changed" "stale heading removed"
 }
 
 # Multiple distinct entries that share one PR number are all carried over (the
@@ -1008,6 +1219,11 @@ run_test test_collapses_rc_sections_and_branch_unreleased_into_main_unreleased
 run_test test_dry_run_previews_without_writing
 run_test test_dedupes_by_pr_number_even_with_different_prose
 run_test test_final_stable_wording_replaces_target_unreleased_copy
+run_test test_stale_unreleased_copy_is_removed_when_canonical_entry_is_in_history
+run_test test_target_only_rc_entries_are_discarded_with_section
+run_test test_exact_same_pr_group_is_idempotent
+run_test test_partial_same_pr_group_restores_missing_sibling
+run_test test_stable_heading_replaces_matching_text_under_wrong_heading
 run_test test_multiple_entries_same_new_pr_all_carry_over
 run_test test_entries_regroup_under_headings_in_order
 run_test test_second_run_is_noop

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -750,6 +750,47 @@ EOF
   [ "$before" = "$after" ] || fail "no-op run must not modify CHANGELOG.md"
 }
 
+# A release/X.Y.Z ref with no matching stable or prerelease source section must
+# not infer X.Y.Z from the branch name and delete the target's only RC notes.
+test_mismatched_source_section_does_not_drop_target_rc() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [1.0.1.rc.1] - 2026-07-20
+
+#### Fixed
+
+- **Only RC copy**: must remain. $(pr_link 101) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [1.0.0] - 2026-06-01
+
+#### Fixed
+
+- **Older stable**: unrelated. $(pr_link 100) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md "release/1.0.1"
+
+  local before out after
+  before="$(cat CHANGELOG.md)"
+  out="$(run_changelog release/1.0.1)"
+  after="$(cat CHANGELOG.md)"
+  assert_not_contains "$out" "RC-header sections to DROP" "mismatched source does not authorize RC removal"
+  assert_contains "$after" "### [1.0.1.rc.1]" "target RC section preserved"
+  assert_contains "$after" "Only RC copy" "target RC entry preserved"
+  [ "$before" = "$after" ] || fail "mismatched source section must not modify CHANGELOG.md"
+}
+
 # Multi-line entries (continuation/detail lines and nested bullets) are carried
 # over intact, not truncated to the first line.
 test_multiline_entry_preserved() {
@@ -1228,6 +1269,7 @@ run_test test_multiple_entries_same_new_pr_all_carry_over
 run_test test_entries_regroup_under_headings_in_order
 run_test test_second_run_is_noop
 run_test test_no_release_entries_is_clean_noop
+run_test test_mismatched_source_section_does_not_drop_target_rc
 run_test test_multiline_entry_preserved
 run_test test_hash_shorthand_pr_reference_dedupes
 run_test test_empty_main_unreleased_receives_entries

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -716,6 +716,45 @@ EOF
   assert_contains "$changelog" "Backport on 16.6 branch" "backport written under unreleased"
 }
 
+# Final stamping collapses the active RC sections into ### [X.Y.Z]. The
+# reconciler must still move those final entries to main's [Unreleased].
+test_final_stable_section_rehomes_into_main_unreleased() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Existing main fix**: here. $(pr_link 100) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Added
+
+- **Final release feature**: shipped. $(pr_link 999) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out
+  out="$(run_changelog release/17.0.0)"
+  assert_contains "$out" "Final release feature" "final entry planned"
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "Final release feature" "final entry re-homed"
+  assert_not_contains "$changelog" "### [17.0.0]" "final header not copied"
+}
+
 # De-duplication keys on the entry's OWN PR (the "[PR NNNN](...) by [author]"
 # trailer), not on a PR it merely references. An entry that references PR 4227 but
 # is itself PR 4234 must dedupe against main's PR 4234, and must NOT dedupe against
@@ -833,6 +872,7 @@ run_test test_hash_shorthand_pr_reference_dedupes
 run_test test_empty_main_unreleased_receives_entries
 run_test test_target_without_unreleased_errors_clearly
 run_test test_non_prerelease_source_does_not_touch_target_rc_section
+run_test test_final_stable_section_rehomes_into_main_unreleased
 run_test test_dedupes_on_own_pr_trailer_not_referenced_pr
 run_test test_utf8_changelog_parses_and_round_trips_under_ascii_locale
 run_test test_default_mode_unchanged_without_flag

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -322,6 +322,47 @@ EOF
   assert_not_contains "$(cat CHANGELOG.md)" "Original branch wording" "branch wording skipped"
 }
 
+# Final stamping can consolidate an earlier entry with a follow-up PR and move
+# it to a different heading. The final stable wording is authoritative: replace
+# a narrower target [Unreleased] entry with the same own PR instead of skipping
+# the final entry merely because that PR number is already present.
+test_final_stable_wording_replaces_target_unreleased_copy() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Changed
+
+- **Narrow prerelease wording**: only the follow-up. $(pr_link 4670) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Breaking Changes
+
+- **Canonical final wording**: covers the original [PR 4490](https://github.com/shakacode/react_on_rails/pull/4490) and the follow-up. $(pr_link 4670) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  run_changelog release/17.0.0 >/dev/null
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "Canonical final wording" "final stable wording kept"
+  assert_contains "$changelog" "PR 4490" "consolidated original PR kept"
+  assert_not_contains "$changelog" "Narrow prerelease wording" "narrow target wording replaced"
+  assert_contains "$changelog" "#### Breaking Changes" "final heading kept"
+}
+
 # Multiple distinct entries that share one PR number are all carried over (the
 # dedup key is "PR already on main", not "PR seen once"); two entries from the
 # same new PR both land.
@@ -966,6 +1007,7 @@ test_missing_source_changelog_errors_clearly() {
 run_test test_collapses_rc_sections_and_branch_unreleased_into_main_unreleased
 run_test test_dry_run_previews_without_writing
 run_test test_dedupes_by_pr_number_even_with_different_prose
+run_test test_final_stable_wording_replaces_target_unreleased_copy
 run_test test_multiple_entries_same_new_pr_all_carry_over
 run_test test_entries_regroup_under_headings_in_order
 run_test test_second_run_is_noop

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -789,6 +789,16 @@ EOF
   assert_contains "$after" "### [1.0.1.rc.1]" "target RC section preserved"
   assert_contains "$after" "Only RC copy" "target RC entry preserved"
   [ "$before" = "$after" ] || fail "mismatched source section must not modify CHANGELOG.md"
+
+  local check_out check_rc
+  set +e
+  check_out="$(run_changelog release/1.0.1 --check 2>&1)"
+  check_rc=$?
+  set -e
+  [ "$check_rc" -eq 1 ] || fail "mismatched source check should report incomplete, got $check_rc"
+  assert_contains "$check_out" "CHECK FAILED" "mismatched source check fails closed"
+  assert_contains "$check_out" "no matching stable or prerelease 1.0.1 changelog section" \
+    "mismatched source check explains missing section"
 }
 
 # Multi-line entries (continuation/detail lines and nested bullets) are carried

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -755,6 +755,58 @@ EOF
   assert_not_contains "$changelog" "### [17.0.0]" "final header not copied"
 }
 
+# A maintained release branch retains its original stable section after main has
+# already stamped those entries into history. A later branch fix must not pull
+# the entire historical release back into main's current [Unreleased].
+test_final_stable_section_dedupes_against_target_history() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Changed
+
+- **Current main work**: still unreleased. $(pr_link 1100) by [a](https://github.com/a).
+
+### [17.0.0] - 2026-07-16
+
+#### Added
+
+- **Original stable feature**: already shipped. $(pr_link 999) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Post-release branch fix**: newly forward-ported. $(pr_link 1200) by [a](https://github.com/a).
+
+### [17.0.0] - 2026-07-16
+
+#### Added
+
+- **Original stable feature**: already shipped. $(pr_link 999) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out
+  out="$(run_changelog release/17.0.0)"
+  assert_contains "$out" "1 entry to add, 1 entry already present" "historical dedupe summary"
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "Post-release branch fix" "new branch fix re-homed"
+  local occurrences
+  occurrences="$(grep -c "Original stable feature" CHANGELOG.md)"
+  [ "$occurrences" -eq 1 ] || fail "expected 1 historical stable entry, got $occurrences"
+}
+
 # De-duplication keys on the entry's OWN PR (the "[PR NNNN](...) by [author]"
 # trailer), not on a PR it merely references. An entry that references PR 4227 but
 # is itself PR 4234 must dedupe against main's PR 4234, and must NOT dedupe against
@@ -873,6 +925,7 @@ run_test test_empty_main_unreleased_receives_entries
 run_test test_target_without_unreleased_errors_clearly
 run_test test_non_prerelease_source_does_not_touch_target_rc_section
 run_test test_final_stable_section_rehomes_into_main_unreleased
+run_test test_final_stable_section_dedupes_against_target_history
 run_test test_dedupes_on_own_pr_trailer_not_referenced_pr
 run_test test_utf8_changelog_parses_and_round_trips_under_ascii_locale
 run_test test_default_mode_unchanged_without_flag

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -755,6 +755,57 @@ EOF
   assert_not_contains "$changelog" "### [17.0.0]" "final header not copied"
 }
 
+# The final release section is authoritative over transient target RC wording.
+# When both describe the same shipped PR, re-home the final wording and discard
+# the RC copy along with its header. Target-only RC entries are intentionally not
+# carried forward because they can describe experiments removed before final or
+# dependency pins superseded later in the release train.
+test_final_source_wording_replaces_target_rc_copy() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Current main fix**: still unreleased. $(pr_link 100) by [a](https://github.com/a).
+
+### [17.0.0.rc.6] - 2026-07-10
+
+#### Fixed
+
+- **Render helpers no longer mutate caller-supplied option hashes**: RC wording. $(pr_link 4396) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0] - 2026-07-16
+
+#### Added
+
+- **Final release feature**: shipped. $(pr_link 999) by [a](https://github.com/a).
+
+#### Fixed
+
+- **create_render_options no longer mutates the caller options hash**: final wording. $(pr_link 4396) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  run_changelog release/17.0.0 >/dev/null
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "create_render_options no longer mutates" "final source wording re-homed"
+  assert_not_contains "$changelog" "Render helpers no longer mutate" "target rc wording discarded"
+  assert_not_contains "$changelog" "### [17.0.0.rc.6]" "target rc header removed"
+}
+
 # A maintained release branch retains its original stable section after main has
 # already stamped those entries into history. A later branch fix must not pull
 # the entire historical release back into main's current [Unreleased].
@@ -925,6 +976,7 @@ run_test test_empty_main_unreleased_receives_entries
 run_test test_target_without_unreleased_errors_clearly
 run_test test_non_prerelease_source_does_not_touch_target_rc_section
 run_test test_final_stable_section_rehomes_into_main_unreleased
+run_test test_final_source_wording_replaces_target_rc_copy
 run_test test_final_stable_section_dedupes_against_target_history
 run_test test_dedupes_on_own_pr_trailer_not_referenced_pr
 run_test test_utf8_changelog_parses_and_round_trips_under_ascii_locale


### PR DESCRIPTION
## Why

The React on Rails 17.0.0 close-out exposed a process gap: release commits that
were not yet on `main` were collected into one large forward-port PR (#4734),
while already-landed changes, release-only metadata, and changelog authority
were mixed into the same review surface.

This PR makes the intended policy executable:

- squash changelog/release PRs;
- forward-port each missing non-release source change in its own PR;
- skip changes already represented on `main`;
- keep the final changelog as a separately acknowledged authority;
- fail closed when source provenance is ambiguous;
- make release-branch deletion atomic, recoverable, and race-aware.

## Implementation

- Reworks `script/release-forward-port` around one-source-change planning,
  provenance/equivalence checks, `--only`, `--all`, `--check`,
  `--ack-manual`, and authoritative changelog handling.
- Strengthens `script/release-finish` with pre-delete durability checks,
  atomic recovery-ref creation, source/main race detection, leased cleanup,
  and automatic restoration when final verification fails.
- Adds exhaustive Ruby and shell regression coverage for provenance,
  incomplete changelogs, branch recreation, main advancement, stale leases,
  recovery cleanup, and operator confirmation boundaries.
- Updates the release-train runbook and agent policy to document the
  one-change-at-a-time close-out contract.

## Process-gap disposition

- **Mechanism target:** `script`
- **Motivating miss:** combined PR #4734 obscured which release commits were
  already on `main`, which needed individual review, and which were release
  metadata only.
- **Replay evidence:** the corrected flow produced the separate changelog PR
  #4742 and source-change PRs #4781 and #4782, while recognizing #4668 as the
  already-merged equivalent of release source #4660. The live
  `release/17.0.0` check reports 0 picks, 34 skips, and 2 explicit manual
  acknowledgements.
- **Non-goal:** this PR does not forward-port product code, restamp the
  17.0.0 changelog, or change released package versions.

## Verification

- `bash script/release-forward-port-test.bash` — 26/26 passed
- `bash script/release-finish-test.bash` — 36/36 passed
- `bundle exec rspec spec/react_on_rails/release_forward_port_script_spec.rb`
  from `react_on_rails/` — 109 examples, 0 failures
- OSS RuboCop — 243 files inspected, 0 offenses; targeted RuboCop also passed
  after the final provenance regression edit
- Ruby syntax, Bash syntax, ShellCheck, Prettier, diff checks, and
  `script/check-docs-sidebar` passed
- Live `release/17.0.0` code completeness check passed with the two documented
  manual acknowledgements
- Live authoritative changelog check passed against source commit
  `44d25171e7fc2eb86d7ccba622862b2a371aae60`

## Review receipt

- The primary pre-push review found a P1 false provenance-skip case involving
  incidental PR numbers in source titles; the implementation and two distinct-
  identity regressions were added before this final candidate.
- The primary reviewer then degraded by recursively launching itself during the
  final-verdict rerun.
- Independent exact-head review at
  `1eb3cbde4e0ebf9da88a06828479218079c15e58` returned `MERGE_READY` with no
  P0-P3 findings.
- The final simplify gate timed out without source edits; its temporary
  comparison artifacts were removed and the reviewed head remained unchanged.
- Strict untrusted-input preflight passed; the only suspicious-text heuristic
  was acknowledged after confirming it was ordinary changelog prose.

## Changelog

`not_user_visible` — internal maintainer tooling, tests, and contributor docs.

This tooling/process PR should be squash merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plan-check mode for forward-port operations with scoped selection, explicit acknowledgements for inspected manual items, and stronger changelog reconciliation validation.
  * Extended release close-out to require forward-port and changelog completion before proceeding.
* **Bug Fixes**
  * Blocked release close-out during active cherry-picks and until all required code/changelog forward-port work is finished.
  * Improved safety for ephemeral release-branch deletion with atomic, lease-based race handling and recovery.
* **Documentation**
  * Updated release automation runbooks and close-out guidance with safer sequencing and queue-based forward-port workflows.
* **Tests**
  * Expanded coverage for CLI edge cases, changelog reconciliation completion/deduping, and race-condition close-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->