### PR TITLE
Forward-port gh include mixed framing from #4684

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -5871,13 +5871,30 @@ def gh_included_response_parts(output)
   output = normalized_utf8_output(output)
   return [nil, nil, nil] unless output
 
-  newline = gh_included_response_newline(output)
-  return [nil, nil, nil] unless newline && valid_gh_included_response_bytes?(output)
+  status_line_parts = gh_included_response_status_line_parts(output)
+  return [nil, nil, nil] unless status_line_parts && valid_gh_included_response_bytes?(output)
 
-  header_block, body, *trailing_sections = output.split("#{newline}#{newline}", -1)
-  return [nil, nil, nil] unless trailing_sections.empty? && header_block && body
+  status_line, status_newline, remainder = status_line_parts
+  newline = gh_included_response_newline(remainder)
+  # gh writes the status line with the platform newline, then writes HTTP
+  # headers with CRLF. Accept that CLI byte shape while continuing
+  # to reject the inverse or arbitrarily mixed framing.
+  return [nil, nil, nil] unless compatible_gh_included_response_newlines?(status_newline, newline)
 
-  [header_block, body, newline]
+  headers, body, *trailing_sections = remainder.split("#{newline}#{newline}", -1)
+  return [nil, nil, nil] unless trailing_sections.empty? && headers && body
+
+  [[status_line, headers].join(newline), body, newline]
+end
+
+def gh_included_response_status_line_parts(output)
+  output.match(/\A([^\r\n]+)(\r?\n)(.*)\z/m)&.captures
+end
+
+def compatible_gh_included_response_newlines?(status_newline, header_newline)
+  return false unless header_newline
+
+  status_newline == header_newline || (status_newline == "\n" && header_newline == "\r\n")
 end
 
 def gh_included_response_newline(output)

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -5881,10 +5881,24 @@ def gh_included_response_parts(output)
   # to reject the inverse or arbitrarily mixed framing.
   return [nil, nil, nil] unless compatible_gh_included_response_newlines?(status_newline, newline)
 
-  headers, body, *trailing_sections = remainder.split("#{newline}#{newline}", -1)
-  return [nil, nil, nil] unless trailing_sections.empty? && headers && body
+  headers, body = gh_included_response_headers_and_body(remainder, newline:)
+  return [nil, nil, nil] unless headers && body
 
-  [[status_line, headers].join(newline), body, newline]
+  header_block = headers.empty? ? status_line : [status_line, headers].join(newline)
+  [header_block, body, newline]
+end
+
+def gh_included_response_headers_and_body(remainder, newline:)
+  separator = "#{newline}#{newline}"
+  if remainder.start_with?(newline)
+    body = remainder.delete_prefix(newline)
+    return if body.include?(separator)
+
+    return ["", body]
+  end
+
+  headers, body, *trailing_sections = remainder.split(separator, -1)
+  [headers, body] if trailing_sections.empty? && headers && body
 end
 
 def gh_included_response_status_line_parts(output)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -17305,6 +17305,16 @@ RSpec.describe "release.rake helper methods" do
   end
 
   describe "#gh_included_json_response" do
+    it "parses the mixed status and header newlines emitted by gh api --include" do
+      response = "HTTP/2.0 404 Not Found\nContent-Type: application/json\r\n\r\n" \
+                 '{"message":"Branch not protected"}'
+
+      expect(gh_included_json_response(response)).to eq(
+        status: 404,
+        body: { "message" => "Branch not protected" }
+      )
+    end
+
     it "rejects mixed newline framing and HTTP control bytes" do
       mixed_newlines = "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\n\n" \
                        '{"message":"Branch not protected"}'

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -17315,6 +17315,16 @@ RSpec.describe "release.rake helper methods" do
       )
     end
 
+    it "parses an included response without HTTP headers" do
+      response = "HTTP/2.0 404 Not Found\r\n\r\n" \
+                 '{"message":"Branch not protected"}'
+
+      expect(gh_included_json_response(response)).to eq(
+        status: 404,
+        body: { "message" => "Branch not protected" }
+      )
+    end
+
     it "rejects mixed newline framing and HTTP control bytes" do
       mixed_newlines = "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\n\n" \
                        '{"message":"Branch not protected"}'


### PR DESCRIPTION
## Why

The React on Rails 17.0.0 release branch taught strict branch-protection discovery to accept the mixed newline framing emitted by `gh api --include`: an LF status line followed by CRLF-delimited HTTP headers. That small compatibility fix from #4684 was the only source change still absent from `main`.

Without it, a valid GitHub 404 response can be rejected as malformed, leaving required-check discovery unknown during exact-HEAD release recovery.

## What changed

- Parse the HTTP status line separately from the included header block.
- Accept LF-status/CRLF-header framing while continuing to reject the inverse and arbitrary mixed framing.
- Preserve valid `gh --include` responses whose HTTP header section is empty.
- Add a focused regression example for the real `gh api --include` byte shape.

This deliberately ports only the missing framing fix. The other #4684 changes are already on `main` or superseded by the reviewed release-closeout tooling.

The commit retains `cherry-pick -x` provenance from source squash commit `8601d96357b61b9818055a41ead46ed26d51bcbe`.

## Verification

- Red/green regression: the new example failed before the parser change and passed afterward.
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb` — 745 examples, 0 failures.
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/configuration_spec.rb` — 52 examples, 0 failures.
- `bundle exec rubocop rakelib/release.rake react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb` — no offenses.
- `pnpm start format.listDifferent` — clean.
- Optimized validation also passed dependency install, docs sidebar, RuboCop, package build, ESLint, Prettier, and TypeScript checks.
- `codex review --uncommitted` — no actionable findings.

## Validation limitation

The optimized validator selected the entire gem suite. That aggregate run exposed pre-existing order-dependent failures across unrelated configuration/dev specs; a representative affected spec passes standalone. The aggregate run was stopped after that diagnosis. Hosted current-head CI remains required before merge.

## Changelog

`not_user_visible` — release-safety tooling compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of GitHub API responses when the status line and headers use mixed newline formats.
  * Added stricter validation for response framing to reliably separate status, headers, and body content.
  * Ensured included responses without additional headers (e.g., error responses) are still parsed correctly.
* **Tests**
  * Added RSpec coverage for mixed newline formatting and headerless included responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->