### PR TITLE
Cover the rspack CSS SSR generator fixes and de-duplicate the loader path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,15 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   [PR 4579](https://github.com/shakacode/react_on_rails/pull/4579) by
   [alexeyr-ci2](https://github.com/alexeyr-ci2).
 
+- **Generated `serverWebpackConfig.js` shares a single loader-path helper**: New installs emit one
+  `getLoaderPath(item)` function instead of repeating the same loader-path expression in four places, and a
+  standalone Pro upgrade now writes the same `extractLoader` source text that a fresh `--pro` install renders
+  instead of an equivalent variant. Behavior is unchanged, but regenerating
+  `config/webpack/serverWebpackConfig.js` produces a smaller, deduplicated file. Fixes
+  [Issue 4786](https://github.com/shakacode/react_on_rails/issues/4786).
+  [PR 4788](https://github.com/shakacode/react_on_rails/pull/4788) by
+  [justin808](https://github.com/justin808).
+
 ### [17.0.0] - 2026-07-16
 
 #### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,15 +244,6 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   [PR 4579](https://github.com/shakacode/react_on_rails/pull/4579) by
   [alexeyr-ci2](https://github.com/alexeyr-ci2).
 
-- **Generated `serverWebpackConfig.js` shares a single loader-path helper**: New installs emit one
-  `getLoaderPath(item)` function instead of repeating the same loader-path expression in four places, and a
-  standalone Pro upgrade now writes the same `extractLoader` source text that a fresh `--pro` install renders
-  instead of an equivalent variant. Behavior is unchanged, but regenerating
-  `config/webpack/serverWebpackConfig.js` produces a smaller, deduplicated file. Fixes
-  [Issue 4786](https://github.com/shakacode/react_on_rails/issues/4786).
-  [PR 4788](https://github.com/shakacode/react_on_rails/pull/4788) by
-  [justin808](https://github.com/justin808).
-
 ### [17.0.0] - 2026-07-16
 
 #### Breaking Changes

--- a/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
+++ b/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
@@ -59,6 +59,12 @@ module ReactOnRails
       BUNDLER_REQUIRE_PATTERN =
         %r{(const bundler = config\.assets_bundler.*\n.*require\('@rspack/core'\).*\n.*: require\('webpack'\);)}
 
+      # Matches any declaration of the getLoaderPath symbol, however it is written. The
+      # emitted extractLoader calls getLoaderPath, so we must never add a second
+      # declaration: `function` next to an existing `const` is a SyntaxError, not a
+      # silent shadow, and the generated config would fail to parse in Node.
+      GET_LOADER_PATH_DECLARATION = /(?:function\s+getLoaderPath\s*\(|(?:const|let|var)\s+getLoaderPath\s*=)/
+
       # Main entry point for Pro setup.
       # Orchestrates creation of all Pro-related files and configuration.
       #
@@ -518,9 +524,15 @@ module ReactOnRails
           # Config rendered by the current base template: append extractLoader directly after
           # the shared getLoaderPath helper so the result matches the template's Pro output.
           gsub_file(webpack_config, GET_LOADER_PATH_JS, "#{GET_LOADER_PATH_JS}\n#{EXTRACT_LOADER_JS}")
+        elsif content.match?(GET_LOADER_PATH_DECLARATION)
+          # The app already declares getLoaderPath but has customized it (reformatted, recommented,
+          # or rewritten as an arrow function). Reuse whatever is there and emit extractLoader only.
+          # Emitting our own copy would redeclare the identifier, which is a SyntaxError next to an
+          # existing const/let and silent shadowing next to another function declaration.
+          gsub_file(webpack_config, BUNDLER_REQUIRE_PATTERN, "\\1\n\n#{EXTRACT_LOADER_JS}".chomp)
         else
-          # Base config generated before getLoaderPath existed (or one whose helper was edited):
-          # emit both helpers after the bundler require so extractLoader's dependency is present.
+          # Base config generated before getLoaderPath existed: emit both helpers after the
+          # bundler require so extractLoader's dependency is present.
           gsub_file(
             webpack_config,
             BUNDLER_REQUIRE_PATTERN,

--- a/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
+++ b/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
@@ -33,6 +33,32 @@ module ReactOnRails
       AUTO_INSTALL_TIMEOUT = 120
       TERMINATION_GRACE_PERIOD = 5
 
+      # Loader helpers emitted by
+      # templates/base/base/config/webpack/serverWebpackConfig.js.tt.
+      #
+      # Keep both blocks byte-identical to that template: a fresh `--pro` install renders
+      # the template while a standalone Pro upgrade patches an existing base config, and
+      # the two must produce the same source text so drift is detectable (issue #4786).
+      GET_LOADER_PATH_JS = <<~JS
+        // Normalizes an entry of a webpack/rspack `rule.use` array to its loader path.
+        // Entries may be a bare string, a `{ loader, options }` object, or null.
+        function getLoaderPath(item) {
+          if (typeof item === 'string') return item;
+          if (item && typeof item.loader === 'string') return item.loader;
+          return '';
+        }
+      JS
+
+      EXTRACT_LOADER_JS = <<~JS
+        function extractLoader(rule, loaderName) {
+          if (!Array.isArray(rule.use)) return null;
+          return rule.use.find((item) => getLoaderPath(item).includes(loaderName));
+        }
+      JS
+
+      BUNDLER_REQUIRE_PATTERN =
+        %r{(const bundler = config\.assets_bundler.*\n.*require\('@rspack/core'\).*\n.*: require\('webpack'\);)}
+
       # Main entry point for Pro setup.
       # Orchestrates creation of all Pro-related files and configuration.
       #
@@ -488,25 +514,19 @@ module ReactOnRails
         # Skip if extractLoader already exists
         return if content.include?("function extractLoader")
 
-        extract_loader_code = <<~JS.chomp
-
-
-          function extractLoader(rule, loaderName) {
-            if (!Array.isArray(rule.use)) return null;
-            return rule.use.find((item) => {
-              if (!item) return false;
-              const testValue = typeof item === 'string' ? item : (typeof item.loader === 'string' ? item.loader : '');
-              return testValue.includes(loaderName);
-            });
-          }
-        JS
-
-        # Insert after bundler require line
-        gsub_file(
-          webpack_config,
-          %r{(const bundler = config\.assets_bundler.*\n.*require\('@rspack/core'\).*\n.*: require\('webpack'\);)},
-          "\\1#{extract_loader_code}"
-        )
+        if content.include?(GET_LOADER_PATH_JS)
+          # Config rendered by the current base template: append extractLoader directly after
+          # the shared getLoaderPath helper so the result matches the template's Pro output.
+          gsub_file(webpack_config, GET_LOADER_PATH_JS, "#{GET_LOADER_PATH_JS}\n#{EXTRACT_LOADER_JS}")
+        else
+          # Base config generated before getLoaderPath existed (or one whose helper was edited):
+          # emit both helpers after the bundler require so extractLoader's dependency is present.
+          gsub_file(
+            webpack_config,
+            BUNDLER_REQUIRE_PATTERN,
+            "\\1\n\n#{GET_LOADER_PATH_JS}\n#{EXTRACT_LOADER_JS}".chomp
+          )
+        end
       end
 
       def add_babel_ssr_caller_to_server_config(webpack_config, content)

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
@@ -17,18 +17,18 @@ const rscClientReferences = {
 };
 <% end -%>
 
+// Normalizes an entry of a webpack/rspack `rule.use` array to its loader path.
+// Entries may be a bare string, a `{ loader, options }` object, or null.
+function getLoaderPath(item) {
+  if (typeof item === 'string') return item;
+  if (item && typeof item.loader === 'string') return item.loader;
+  return '';
+}
+
 <% if use_pro? -%>
 function extractLoader(rule, loaderName) {
   if (!Array.isArray(rule.use)) return null;
-  return rule.use.find((item) => {
-    let testValue = '';
-    if (typeof item === 'string') {
-      testValue = item;
-    } else if (item && typeof item.loader === 'string') {
-      testValue = item.loader;
-    }
-    return testValue.includes(loaderName);
-  });
+  return rule.use.find((item) => getLoaderPath(item).includes(loaderName));
 }
 
 <% end -%>
@@ -63,15 +63,10 @@ const configureServer = () => {
   serverWebpackConfig.module.rules.forEach((loader) => {
     if (loader.use && loader.use.filter) {
       loader.use = loader.use.filter((item) => {
-        let testValue = '';
-        if (typeof item === 'string') {
-          testValue = item;
-        } else if (item && typeof item.loader === 'string') {
-          testValue = item.loader;
-        }
+        const loaderPath = getLoaderPath(item);
         return !(
-          testValue.includes('mini-css-extract-plugin') ||
-          testValue.includes('cssExtractLoader') // Rspack uses this path
+          loaderPath.includes('mini-css-extract-plugin') ||
+          loaderPath.includes('cssExtractLoader') // Rspack uses this path
         );
       });
     }
@@ -162,29 +157,14 @@ const configureServer = () => {
     if (Array.isArray(rule.use)) {
       // remove the mini-css-extract-plugin and style-loader
       rule.use = rule.use.filter((item) => {
-        let testValue = '';
-        if (typeof item === 'string') {
-          testValue = item;
-        } else if (item && typeof item.loader === 'string') {
-          testValue = item.loader;
-        }
+        const loaderPath = getLoaderPath(item);
         return !(
-          testValue.includes('mini-css-extract-plugin') ||
-          testValue.includes('cssExtractLoader') || // Rspack uses this path
-          testValue === 'style-loader'
+          loaderPath.includes('mini-css-extract-plugin') ||
+          loaderPath.includes('cssExtractLoader') || // Rspack uses this path
+          loaderPath === 'style-loader'
         );
       });
-      const cssLoader = rule.use.find((item) => {
-        let testValue = '';
-
-        if (typeof item === 'string') {
-          testValue = item;
-        } else if (item && typeof item.loader === 'string') {
-          testValue = item.loader;
-        }
-
-        return testValue.includes('css-loader');
-      });
+      const cssLoader = rule.use.find((item) => getLoaderPath(item).includes('css-loader'));
       if (cssLoader && cssLoader.options && cssLoader.options.modules) {
         cssLoader.options.modules = {
           ...(typeof cssLoader.options.modules === 'object' ? cssLoader.options.modules : {}),

--- a/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
@@ -23,6 +23,54 @@ RSpec.describe ReactOnRails::Generators::BaseGenerator, type: :generator do
     end
   end
 
+  # Regression coverage for PR #2489, which fixed two rspack SSR bugs in the generated
+  # serverWebpackConfig.js and shipped without any assertions (issue #4786). These render
+  # the real template rather than a hand-maintained copy, so a revert in the template is red.
+  describe "rendered serverWebpackConfig.js.tt" do
+    let(:destination) { File.expand_path("../dummy-for-generators", __dir__) }
+
+    def render_server_webpack_config(options = {})
+      described_class.new([], options, { destination_root: destination })
+                     .send(:rendered_template_for_cleanup, "base/base/config/webpack/serverWebpackConfig.js.tt")
+    end
+
+    it "drops rspack's cssExtractLoader from the server bundle, not just mini-css-extract-plugin" do
+      # rspack routes CSS extraction through cssExtractLoader. Matching only
+      # mini-css-extract-plugin leaked CSS extraction into the server bundle.
+      content = render_server_webpack_config
+
+      expect(content.scan("loaderPath.includes('cssExtractLoader')").size).to eq(2)
+      expect(content.scan("loaderPath.includes('mini-css-extract-plugin')").size).to eq(2)
+    end
+
+    it "merges exportOnlyLocals into existing CSS module options instead of replacing them" do
+      # Shakapacker's getStyleRule.js already sets `modules: { auto: true, ... }`.
+      # Overwriting the whole object dropped those settings from the server build.
+      content = render_server_webpack_config
+
+      expect(content).to include(
+        "...(typeof cssLoader.options.modules === 'object' ? cssLoader.options.modules : {})"
+      )
+      expect(content).to include("exportOnlyLocals: true")
+    end
+
+    it "resolves every rule.use entry through a single shared getLoaderPath helper" do
+      content = render_server_webpack_config(pro: true)
+
+      expect(content.scan("function getLoaderPath(item) {").size).to eq(1)
+      expect(content.scan("getLoaderPath(item)").size).to eq(5)
+    end
+
+    it "emits the loader helpers that the standalone Pro upgrade also writes" do
+      # ProSetup patches an existing base config instead of rendering this template, so the
+      # two paths drift silently unless the emitted source text is asserted to be identical.
+      content = render_server_webpack_config(pro: true)
+
+      expect(content).to include(ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_JS)
+      expect(content).to include(ReactOnRails::Generators::ProSetup::EXTRACT_LOADER_JS)
+    end
+  end
+
   describe "#generate_new_app_home_page?" do
     it "returns false without calling add_root_route when --new-app is disabled" do
       base_generator = described_class.new

--- a/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
@@ -1671,6 +1671,25 @@ describe ProGenerator, type: :generator do
         end
       end
 
+      it "emits the same extractLoader source text as a fresh Pro install renders" do
+        # A fresh `rails g react_on_rails:install --pro` renders the template while this
+        # standalone upgrade patches an existing base config. Both must produce identical
+        # source text so the two paths cannot drift unnoticed (issue #4786).
+        assert_file "config/webpack/serverWebpackConfig.js" do |content|
+          expect(content).to include(ReactOnRails::Generators::ProSetup::EXTRACT_LOADER_JS)
+        end
+      end
+
+      it "reuses the getLoaderPath helper already present in the base config" do
+        assert_file "config/webpack/serverWebpackConfig.js" do |content|
+          expect(content).to include(ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_JS)
+          expect(content.scan("function getLoaderPath(item) {").size).to eq(1)
+          expect(content).to match(
+            /function getLoaderPath\(item\) \{.*?\n\}\n\nfunction extractLoader\(rule, loaderName\) \{/m
+          )
+        end
+      end
+
       it "enables libraryTarget commonjs2" do
         assert_file "config/webpack/serverWebpackConfig.js" do |content|
           expect(content).to include("libraryTarget: 'commonjs2',")
@@ -1710,6 +1729,39 @@ describe ProGenerator, type: :generator do
           expect(content).to include("{ default: serverWebpackConfig }")
           expect(content).not_to match(/^const serverWebpackConfig = require/)
         end
+      end
+    end
+  end
+
+  # Upgrade path for apps installed before the shared getLoaderPath helper existed:
+  # the emitted extractLoader calls it, so ProSetup must supply it too.
+  context "when prerequisites are met on a base install predating the getLoaderPath helper" do
+    before do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_existing_file("Gemfile", <<~RUBY)
+        source "https://rubygems.org"
+        gem "react_on_rails_pro"
+      RUBY
+      simulate_npm_files(package_json: true)
+      simulate_existing_file("config/initializers/react_on_rails.rb", "ReactOnRails.configure {}")
+      simulate_existing_file("Procfile.dev", "rails: bin/rails s\n")
+      simulate_legacy_base_webpack_files
+      allow(Gem).to receive(:loaded_specs).and_return({ "react_on_rails_pro" => double })
+
+      Dir.chdir(destination_root) do
+        run_generator(["--force"])
+      end
+    end
+
+    it "adds getLoaderPath alongside extractLoader so the emitted helper call resolves" do
+      assert_file "config/webpack/serverWebpackConfig.js" do |content|
+        expect(content).to include(ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_JS)
+        expect(content).to include(ReactOnRails::Generators::ProSetup::EXTRACT_LOADER_JS)
+        expect(content.scan("function getLoaderPath(item) {").size).to eq(1)
+        expect(content).to match(
+          /function getLoaderPath\(item\) \{.*?\n\}\n\nfunction extractLoader\(rule, loaderName\) \{/m
+        )
       end
     end
   end

--- a/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
@@ -1733,6 +1733,40 @@ describe ProGenerator, type: :generator do
     end
   end
 
+  # Upgrade path for apps that already declare getLoaderPath but have customized it. Redeclaring
+  # the identifier would be a SyntaxError next to the app's const, so the transform must reuse it.
+  context "when prerequisites are met on a base install with a customized getLoaderPath helper" do
+    before do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_existing_file("Gemfile", <<~RUBY)
+        source "https://rubygems.org"
+        gem "react_on_rails_pro"
+      RUBY
+      simulate_npm_files(package_json: true)
+      simulate_existing_file("config/initializers/react_on_rails.rb", "ReactOnRails.configure {}")
+      simulate_existing_file("Procfile.dev", "rails: bin/rails s\n")
+      simulate_customized_base_webpack_files
+      allow(Gem).to receive(:loaded_specs).and_return({ "react_on_rails_pro" => double })
+
+      Dir.chdir(destination_root) do
+        run_generator(["--force"])
+      end
+    end
+
+    it "reuses the customized helper instead of emitting a second getLoaderPath declaration" do
+      assert_file "config/webpack/serverWebpackConfig.js" do |content|
+        # Counted via the declaration matcher, so a redeclaration is caught whether it is
+        # emitted as `function getLoaderPath(` or as `const getLoaderPath =`.
+        declarations = content.scan(ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_DECLARATION)
+        expect(declarations.size).to eq(1)
+        expect(content).to include("const getLoaderPath = (item) =>")
+        expect(content).not_to include(ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_JS)
+        expect(content).to include(ReactOnRails::Generators::ProSetup::EXTRACT_LOADER_JS)
+      end
+    end
+  end
+
   # Upgrade path for apps installed before the shared getLoaderPath helper existed:
   # the emitted extractLoader calls it, so ProSetup must supply it too.
   context "when prerequisites are met on a base install predating the getLoaderPath helper" do

--- a/react_on_rails/spec/react_on_rails/support/generator_spec_helper.rb
+++ b/react_on_rails/spec/react_on_rails/support/generator_spec_helper.rb
@@ -200,6 +200,16 @@ def simulate_base_webpack_files
                          server_client_or_both_content(destructured_import: false))
 end
 
+# Simulates a base install produced before the shared getLoaderPath helper existed.
+# Used to verify the Pro upgrade still emits a self-consistent serverWebpackConfig.js
+# when the file it patches has no helper to hang extractLoader off of.
+def simulate_legacy_base_webpack_files
+  simulate_existing_file("config/webpack/serverWebpackConfig.js",
+                         legacy_base_server_webpack_content_pre_get_loader_path)
+  simulate_existing_file("config/webpack/ServerClientOrBoth.js",
+                         server_client_or_both_content(destructured_import: false))
+end
+
 # Simulates Pro-transformed webpack configs (after Pro generator, before RSC).
 # Contains extractLoader, object exports, destructured imports — all RSC patterns target these.
 # Used by RSC generator tests to verify standalone upgrade transforms.
@@ -277,6 +287,67 @@ def base_server_webpack_content
       ? require('@rspack/core')
       : require('webpack');
 
+    // Normalizes an entry of a webpack/rspack `rule.use` array to its loader path.
+    // Entries may be a bare string, a `{ loader, options }` object, or null.
+    function getLoaderPath(item) {
+      if (typeof item === 'string') return item;
+      if (item && typeof item.loader === 'string') return item.loader;
+      return '';
+    }
+
+    const configureServer = () => {
+      const serverWebpackConfig = commonWebpackConfig();
+
+      serverWebpackConfig.output = {
+        filename: 'server-bundle.js',
+        globalObject: 'this',
+        // If using the React on Rails Pro node server renderer, uncomment the next line
+        // libraryTarget: 'commonjs2',
+        path: serverBundleOutputPath,
+      };
+
+      serverWebpackConfig.plugins.unshift(new bundler.optimize.LimitChunkCountPlugin({ maxChunks: 1 }));
+
+      const rules = serverWebpackConfig.module.rules;
+      rules.forEach((rule) => {
+        if (Array.isArray(rule.use)) {
+          const cssLoader = rule.use.find((item) => getLoaderPath(item).includes('css-loader'));
+          if (cssLoader && cssLoader.options && cssLoader.options.modules) {
+            cssLoader.options.modules = {
+              ...(typeof cssLoader.options.modules === 'object' ? cssLoader.options.modules : {}),
+              exportOnlyLocals: true,
+            };
+          }
+        }
+      });
+
+      serverWebpackConfig.devtool = process.env.NODE_ENV === 'production' ? false : 'cheap-module-source-map';
+
+      // If using the default 'web', then libraries like Emotion and loadable-components
+      // break with SSR. The fix is to use a node renderer and change the target.
+      // If using the React on Rails Pro node server renderer, uncomment the next line
+      // serverWebpackConfig.target = 'node'
+
+      return serverWebpackConfig;
+    };
+
+    module.exports = configureServer;
+  JS
+end
+
+# A base install generated before the shared getLoaderPath helper was extracted.
+# Kept deliberately stale so the standalone Pro upgrade path stays covered for apps
+# installed with an older React on Rails, where extractLoader cannot assume the
+# helper already exists in the file it is patching.
+def legacy_base_server_webpack_content_pre_get_loader_path
+  <<~JS
+    const { merge, config } = require('shakapacker');
+    const commonWebpackConfig = require('./commonWebpackConfig');
+
+    const bundler = config.assets_bundler === 'rspack'
+      ? require('@rspack/core')
+      : require('webpack');
+
     const configureServer = () => {
       const serverWebpackConfig = commonWebpackConfig();
 
@@ -334,12 +405,17 @@ def pro_server_webpack_content
       ? require('@rspack/core')
       : require('webpack');
 
+    // Normalizes an entry of a webpack/rspack `rule.use` array to its loader path.
+    // Entries may be a bare string, a `{ loader, options }` object, or null.
+    function getLoaderPath(item) {
+      if (typeof item === 'string') return item;
+      if (item && typeof item.loader === 'string') return item.loader;
+      return '';
+    }
+
     function extractLoader(rule, loaderName) {
       if (!Array.isArray(rule.use)) return null;
-      return rule.use.find((item) => {
-        const testValue = typeof item === 'string' ? item : item.loader;
-        return testValue && testValue.includes(loaderName);
-      });
+      return rule.use.find((item) => getLoaderPath(item).includes(loaderName));
     }
 
     const configureServer = () => {

--- a/react_on_rails/spec/react_on_rails/support/generator_spec_helper.rb
+++ b/react_on_rails/spec/react_on_rails/support/generator_spec_helper.rb
@@ -210,6 +210,14 @@ def simulate_legacy_base_webpack_files
                          server_client_or_both_content(destructured_import: false))
 end
 
+# Simulates a base install whose getLoaderPath helper the app owner has rewritten.
+# Used to verify the Pro upgrade reuses an existing declaration instead of redeclaring it.
+def simulate_customized_base_webpack_files
+  simulate_existing_file("config/webpack/serverWebpackConfig.js", customized_base_server_webpack_content)
+  simulate_existing_file("config/webpack/ServerClientOrBoth.js",
+                         server_client_or_both_content(destructured_import: false))
+end
+
 # Simulates Pro-transformed webpack configs (after Pro generator, before RSC).
 # Contains extractLoader, object exports, destructured imports — all RSC patterns target these.
 # Used by RSC generator tests to verify standalone upgrade transforms.
@@ -333,6 +341,20 @@ def base_server_webpack_content
 
     module.exports = configureServer;
   JS
+end
+
+# A base install whose getLoaderPath helper has been customized by the app owner.
+# Declared as a const arrow function rather than the template's function declaration, so a
+# second emitted `function getLoaderPath` would be a SyntaxError (identifier already declared),
+# not silent shadowing. The Pro upgrade must reuse this declaration.
+def customized_base_server_webpack_content
+  base_server_webpack_content.sub(
+    ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_JS,
+    <<~JS
+      // Project-specific loader path normalization.
+      const getLoaderPath = (item) => (typeof item === 'string' ? item : (item && item.loader) || '');
+    JS
+  )
 end
 
 # A base install generated before the shared getLoaderPath helper was extracted.


### PR DESCRIPTION
Fixes #4786

PR #2489 fixed two real rspack SSR bugs in the generated `serverWebpackConfig.js` and shipped with zero assertions. Reverting either fix left the whole suite green. This adds the missing coverage, refreshes a stale Pro fixture, and removes the loader-path duplication that made the two generator paths drift silently.

## What changed

**1. Generator assertions for both #2489 fixes** (`spec/react_on_rails/generators/base_generator_spec.rb`)

The new examples render the real template through `BaseGenerator#rendered_template_for_cleanup` rather than asserting against a hand-maintained copy, so a revert in the template is red:

- rspack's `cssExtractLoader` is filtered out of the server bundle in both style-rule passes, alongside `mini-css-extract-plugin`.
- `exportOnlyLocals` is merged into existing CSS module options via the object spread instead of replacing them.
- Every `rule.use` entry resolves through one shared helper.
- The template emits the same loader-helper source text that the standalone Pro upgrade writes.

**2. Refreshed the stale Pro fixture** (`spec/react_on_rails/support/generator_spec_helper.rb`)

`pro_server_webpack_content` still carried the pre-#2489 `extractLoader` body while claiming to simulate a current Pro-transformed install. It now carries the post-fix body. `base_server_webpack_content` was stale in the same way and now matches what the current base template emits.

A deliberately-stale variant is kept under a name that says so: `legacy_base_server_webpack_content_pre_get_loader_path`, used by a new `pro_generator_spec` context that covers upgrading an app installed before the shared helper existed.

**3. De-duplicated the loader-path block**

The template had four copies of the same six-line loader-path expression. They collapse into one `getLoaderPath(item)` helper, emitted for every install (Pro and non-Pro).

`pro_setup.rb` emitted a *different but semantically equivalent* `extractLoader` body (ternary form) than the template (if/else form), so a fresh install and a standalone Pro upgrade produced different source text for the same function — and no test could detect the drift, because both satisfied the existing `include("function extractLoader(rule, loaderName)")` assertion. Both paths now emit from the same `ProSetup::GET_LOADER_PATH_JS` / `ProSetup::EXTRACT_LOADER_JS` constants, and specs on both sides assert against those constants, so drift in either direction is red.

The Pro upgrade appends `extractLoader` directly after the existing `getLoaderPath` helper (matching template output byte-for-byte). For a base config generated before the helper existed, it emits both helpers so the emitted `getLoaderPath(item)` call always resolves.

**Out of scope, unchanged:** the `if (cssLoader && cssLoader.options && cssLoader.options.modules)` guard. Issue #4786 explains why it is correct.

## Revert-and-fail evidence

Every new assertion was proven non-vacuous: the corresponding line was removed from the template (or from `pro_setup.rb`), the spec was run to capture red, then restored. The reverted state is not committed — `git diff --stat` was checked after each case.

Base-spec command:
`(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/base_generator_spec.rb -e "<example>")`
Pro-spec command:
`(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/pro_generator_spec.rb -e "<example>")`

| # | Assertion | Revert applied | Red output |
|---|-----------|----------------|------------|
| 1 | drops rspack's cssExtractLoader from the server bundle | removed the `cssExtractLoader` line from style-rule filter #1 | `expect(content.scan("loaderPath.includes('cssExtractLoader')").size).to eq(2)` → `expected: 2, got: 1` |
| 2 | merges exportOnlyLocals into existing CSS module options | removed the `...(typeof cssLoader.options.modules === 'object' ? ... : {})` spread | `Failure/Error: expect(content).to include("...(typeof cssLoader.options.modules === 'object' ? cssLoader.options.modules : {})")` |
| 3 | resolves every rule.use entry through a single shared getLoaderPath helper | re-inlined one call site to `item.loader.includes('css-loader')` | `expect(content.scan("getLoaderPath(item)").size).to eq(5)` → `expected: 5, got: 4` |
| 4a | emits the loader helpers that the standalone Pro upgrade also writes | changed the template helper's `return '';` to `return null;` | `Failure/Error: expect(content).to include(ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_JS)` |
| 4b | (same assertion, other drift direction) | drifted `ProSetup::EXTRACT_LOADER_JS` to the pre-fix ternary body | `Failure/Error: expect(content).to include(ReactOnRails::Generators::ProSetup::EXTRACT_LOADER_JS)` |
| 5 | emits the same extractLoader source text as a fresh Pro install renders | hardcoded the pre-#4786 ternary body in `add_extract_loader_to_server_config` | `Failure/Error: expect(content).to include(ReactOnRails::Generators::ProSetup::EXTRACT_LOADER_JS)` → `1 example, 1 failure` |
| 6 | reuses the getLoaderPath helper already present in the base config | forced the legacy insertion branch (`if content.include?(GET_LOADER_PATH_JS)` → `if false`) | `expect(content.scan("function getLoaderPath(item) {").size).to eq(1)` → `expected: 1, got: 2` |
| 7 | adds getLoaderPath alongside extractLoader so the emitted helper call resolves | legacy branch emits `extractLoader` without `getLoaderPath` | `Failure/Error: expect(content).to include(ReactOnRails::Generators::ProSetup::GET_LOADER_PATH_JS)` |

## Validation

```
(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)
→ 243 files inspected, no offenses detected

(cd react_on_rails && bundle exec rspec \
   spec/react_on_rails/generators/base_generator_spec.rb \
   spec/react_on_rails/generators/pro_generator_spec.rb \
   spec/react_on_rails/generators/rsc_generator_spec.rb \
   spec/react_on_rails/generators/install_generator_spec.rb)
→ 1031 examples, 0 failures (27 minutes 29 seconds)
```

These four specs share `spec/react_on_rails/dummy-for-generators` as their destination and must be run **serially** — a parallel run silently corrupts the destination mid-flight and produces false greens. The result above is from a single serial process at head `9fd7c089e`.

`rsc_generator_spec` and `install_generator_spec` are included because they consume the changed fixtures (`pro_server_webpack_content`, `base_server_webpack_content`) and the changed `pro_setup.rb` transform.

## Review follow-up: customized `getLoaderPath` was redeclared

A review finding on `pro_setup.rb` was confirmed and fixed in `9fd7c089e`.

`add_extract_loader_to_server_config` picked its insertion branch with a byte-for-byte comparison against the template helper text. An app that already declared `getLoaderPath` but had edited it at all — reformatted, recommented, or rewritten as an arrow function — failed that check and fell through to the fallback branch, which emitted a **second** declaration. Two `function` declarations shadow silently; a `function` declaration next to an existing `const`/`let` is a hard `SyntaxError: Identifier 'getLoaderPath' has already been declared`, so the generated config would not parse in Node.

The symbol is now detected independently of its source text via `ProSetup::GET_LOADER_PATH_DECLARATION`, giving three cases:

1. exact template text present → append `extractLoader` right after it (output still matches a fresh `--pro` install byte-for-byte);
2. some other `getLoaderPath` declaration present (`function`, `const`, `let`, `var`, arrow) → emit **only** `extractLoader`, reusing the app's helper;
3. no `getLoaderPath` at all → emit both after the bundler require.

New spec: `pro_generator_spec.rb`, "reuses the customized helper instead of emitting a second getLoaderPath declaration", driven by a base fixture whose helper is `const getLoaderPath = (item) => ...`. It counts declarations through the shared matcher, so a redeclaration is caught in either the `function` or the `const` form.

Red before the fix (with the new `elsif` branch removed):

```
(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/pro_generator_spec.rb \
  -e "reuses the customized helper instead of emitting a second getLoaderPath declaration")
→ Failure/Error: expect(declarations.size).to eq(1)
    expected: 1
         got: 2
  1 example, 1 failure
```

Green after:

```
→ 1 example, 0 failures
```

## Codex Decision Log

- **The three dummy-app `serverWebpackConfig.js` copies were left untouched.** Issue #4786 states their duplication is by design — they stand in for real user apps. They are checked-in applications, not generator output, and there is no task that regenerates them. Leaving them on the pre-dedupe (behaviorally identical) form also keeps runtime coverage of the shape that existing user apps actually have. Golden-output fixtures for the generator (issue #4787) are derived from the template, not from these apps, so nothing downstream depends on them matching.
- **`getLoaderPath` is emitted for every install, not just Pro.** The non-Pro path uses it in three places, so gating it behind `use_pro?` would leave the duplication in place for the majority of installs.
- **`pro_setup.rb` keeps a fallback insertion branch.** Anchoring solely on `getLoaderPath` would silently skip the transform for apps generated before this change. The fallback emits both helpers after the bundler require, producing text identical to a fresh non-RSC Pro install.
- **The assertions target rendered template output rather than a full generator run.** `rendered_template_for_cleanup` is the same seam `install_generator_spec` already uses for stock webpack templates; it is exact and runs in milliseconds instead of ~15s per example.
- **The CHANGELOG entry was added, then removed in 0eb4ef58e.** It was flagged as borderline when added, and CodeRabbit independently called it out. `AGENTS.md` and `.claude/docs/changelog-guidelines.md` both exclude refactoring and test-only changes, and the entry stated outright that behavior is unchanged. No released behavior changes for any user here; the only difference is cosmetic source text in a regenerated config. Merge-ledger classification for this PR is `not_user_visible`.
- **`GET_LOADER_PATH_DECLARATION` is a text-level regex, and a commented-out declaration with no live one would match it.** That case skips emitting the helper and yields a `ReferenceError` at build time rather than the `SyntaxError` this PR removed. Distinguishing it properly needs real JS parsing, which is out of proportion to a user who comments out their helper while leaving the calls in place. Recorded here rather than hardened.

## Confidence note

**High** for the coverage and the fixture refresh: every new assertion has direct revert-and-fail evidence, and the four affected generator specs pass in full.

**Medium-high** for the de-duplication. It changes text a user sees in a newly generated file, and it changes the source `pro_setup.rb` writes during a standalone Pro upgrade. The change is behavior-preserving by inspection and both upgrade branches (current base install, pre-helper base install) have dedicated specs, but nothing here executes the generated webpack config against a real rspack or webpack build.

Review threads: all five current-head threads (chatgpt-codex-connector, claude x2, copilot-pull-request-reviewer, coderabbitai) converged on two findings, both addressed and resolved in-thread. `copilot-pull-request-reviewer` is not in `.agents/trusted-github-actors.yml`, so its comment was treated as corroborating metadata only, not as actionable review authority, and is queued for maintainer trust triage.

UNKNOWNs:

- Whether the maintainer would prefer the three dummy-app `serverWebpackConfig.js` copies regenerated to match. I left them alone for the reasons in the Decision Log; happy to update them if that call goes the other way.
- The heavier `rake run_rspec:gen_*` example-generation tasks were not run locally. Hosted CI covers them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated server webpack configuration by consolidating loader handling around a shared `getLoaderPath` helper.
  * Fixed standalone Pro upgrades so generated `extractLoader` matches fresh installs.
  * Improved upgrade compatibility for apps with customized or legacy webpack configurations.
  * Corrected server-side CSS loader filtering while preserving existing CSS module options.
* **Tests**
  * Added regression coverage for server webpack template output and multiple upgrade scenarios.
* **Documentation**
  * Updated the changelog with the webpack configuration improvements and issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
