### PR TITLE
Fix OSS npm package license metadata

### DIFF
--- a/packages/react-on-rails/LICENSE.md
+++ b/packages/react-on-rails/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2017, 2018 Justin Gordon and ShakaCode
+Copyright (c) 2015–2025 ShakaCode, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -8,7 +8,8 @@
     "build": "pnpm run clean && tsc",
     "build-watch": "pnpm run clean && tsc --watch",
     "clean": "rm -rf ./lib",
-    "test": "jest tests",
+    "test": "pnpm run test:package-license && jest tests",
+    "test:package-license": "node scripts/check-package-license.mjs",
     "type-check": "tsc --noEmit --noErrorTruncation",
     "prepare": "[ -f lib/ReactOnRails.full.js ] || (rm -rf ./lib && tsc)",
     "prepublishOnly": "pnpm run build"
@@ -27,7 +28,7 @@
     "Rails"
   ],
   "author": "justin@shakacode.com",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "exports": {
     ".": {
       "default": "./lib/ReactOnRails.full.js"
@@ -78,6 +79,7 @@
     "react-dom": ">= 16"
   },
   "files": [
+    "LICENSE.md",
     "README.md",
     "lib/**/*.js",
     "lib/**/*.cjs",

--- a/packages/react-on-rails/scripts/check-package-license.mjs
+++ b/packages/react-on-rails/scripts/check-package-license.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const expectedOssMitLicense = `Copyright (c) 2017, 2018 Justin Gordon and ShakaCode
+Copyright (c) 2015–2025 ShakaCode, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+
+const readPackedFile = (tarballPath, packedPath) =>
+  execFileSync('tar', ['-xOzf', tarballPath, packedPath], { encoding: 'utf8' });
+
+const temporaryDirectory = mkdtempSync(join(tmpdir(), 'react-on-rails-license-'));
+
+try {
+  execFileSync('pnpm', ['pack', '--pack-destination', temporaryDirectory], { stdio: 'inherit' });
+
+  const [tarball] = readdirSync(temporaryDirectory).filter((file) => file.endsWith('.tgz'));
+  assert.ok(tarball, 'pnpm pack should produce a tarball');
+
+  const tarballPath = join(temporaryDirectory, tarball);
+  const packedPackage = JSON.parse(readPackedFile(tarballPath, 'package/package.json'));
+  const packedLicense = readPackedFile(tarballPath, 'package/LICENSE.md');
+
+  assert.equal(packedPackage.license, 'MIT');
+  assert.equal(packedLicense, expectedOssMitLicense);
+  assert.doesNotMatch(packedLicense, /React on Rails Pro|subscription|commercial/i);
+} finally {
+  rmSync(temporaryDirectory, { force: true, recursive: true });
+}


### PR DESCRIPTION
## Why

The published open-source `react-on-rails@17.0.0` npm artifact reports
`SEE LICENSE IN LICENSE.md`, even though React on Rails OSS is MIT-licensed.
Its packed license was inherited from the monorepo root and also described the
separately licensed Pro code, making the OSS package metadata ambiguous.

This was reported in the
[ShakaCode Slack thread](https://shakacode.slack.com/archives/C5URG8NV7/p1784985435194039?thread_ts=1783988708.830839&cid=C5URG8NV7)
and reproduced from the real npm tarball. npm versions are immutable, so a new
17.x patch artifact is required.

## What changed

- Declare the OSS npm package license as `MIT`.
- Pack a package-local MIT-only `LICENSE.md`.
- Add a regression guard that creates the real `pnpm pack` tarball and checks:
  - packed `package.json` reports `MIT`;
  - `package/LICENSE.md` exists and matches the approved MIT text;
  - no Pro, commercial, or subscription wording is present.
- Run the packed-artifact guard through the existing OSS package test command.

The private workspace metadata and both Pro package license contracts are
unchanged.

## Release scope

This PR targets `release/17.0.1`, cut from the immutable `v17.0.0` tag, so the
patch cannot pick up unrelated unreleased work from `main`. After merge, the
release-train changelog flow will stamp `17.0.1.rc.0`; the fix will also be
forward-ported to `main`.

## Verification

- TDD red: the original real tarball reported
  `SEE LICENSE IN LICENSE.md` and had no package-local license.
- `pnpm --filter react-on-rails run test:package-license`
- `pnpm --filter react-on-rails run test` — 26 suites / 361 tests
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- `.agents/bin/validate --changed`
- Independent Sol/xhigh QA reproduced the tarball inspection on Node 20.19.0
  and Node 22, confirmed exact MIT metadata/content, clean lifecycle behavior,
  unchanged root/Pro license files, and a clean worktree.

## Process gap disposition

- Mechanism target: `script`
- Motivating miss: package workspace migration allowed the OSS package to
  inherit ambiguous monorepo license material.
- Replay evidence: the guard fails against the v17.0.0 packed artifact and
  passes against this exact head.
- Non-goal: changing the monorepo root license or any Pro licensing terms.

## Churn

None. The change is limited to three OSS npm package files.
