### PR TITLE
Update changelog for 17.0.1.rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.0.1.rc.0] - 2026-07-26
+
+#### Fixed
+
+- **Corrected the OSS npm package license metadata and packed license**: `react-on-rails` now declares
+  `MIT`, includes a package-local MIT license in the published tarball, and verifies the packed
+  artifact cannot inherit React on Rails Pro commercial terms.
+  [PR 4792](https://github.com/shakacode/react_on_rails/pull/4792) by
+  [justin808](https://github.com/justin808).
+
 ### [17.0.0] - 2026-07-16
 
 #### Breaking Changes
@@ -2759,7 +2769,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.1.rc.0...main
+[17.0.1.rc.0]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...v17.0.1.rc.0
 [17.0.0]: https://github.com/shakacode/react_on_rails/compare/v16.6.0...v17.0.0
 [16.6.0]: https://github.com/shakacode/react_on_rails/compare/v16.5.1...v16.6.0
 [16.5.1]: https://github.com/shakacode/react_on_rails/compare/v16.5.0...v16.5.1


### PR DESCRIPTION
## Why

Prepare the first 17.0.1 release candidate containing the OSS npm license correction from #4792. The published `react-on-rails` package needs a new immutable version before npm consumers can receive the corrected MIT metadata and package-local license.

## What changed

- Added the user-visible fix under `17.0.1.rc.0`.
- Stamped the release-candidate header and compare links with the repository task.
- Kept the change limited to `CHANGELOG.md`; the release task remains responsible for version files, tags, and publication.

## Verification

- `bundle exec rake 'update_changelog[17.0.1.rc.0]'`
- `pnpm exec prettier --check CHANGELOG.md`
- `git diff --check`
- Pre-commit Markdown link and formatting hooks
- Pre-push RuboCop and online Markdown link hooks

## Review coverage

- Claude and Greptile both produced clean current-head reviews.
- CodeRabbit was configured but skipped its review because the target is the non-default `release/17.0.1` branch. This degraded route is acknowledged; the two independent working review systems still satisfy the current-head coverage floor.

## Release scope

Targets `release/17.0.1`. After merge, the release task will run its CI and ShakaPerf gates before publishing `17.0.1.rc.0`.
