### PR TITLE
Forward-port OSS npm license metadata fix

### DIFF
--- a/docs/DIRECTORY_LICENSING.md
+++ b/docs/DIRECTORY_LICENSING.md
@@ -47,7 +47,7 @@ react_on_rails/ (monorepo root)
    - `react_on_rails_pro/react_on_rails_pro.gemspec`: `s.license = "LicenseRef-LICENSE"`
 
 2. **Package.json Files**:
-   - `packages/react-on-rails/package.json`: `"license": "SEE LICENSE IN LICENSE.md"` (MIT)
+   - `packages/react-on-rails/package.json`: `"license": "MIT"` with a package-local `LICENSE.md`
    - `packages/react-on-rails-pro/package.json`: `"license": "SEE LICENSE IN LICENSE.md"`
    - `packages/react-on-rails-pro-node-renderer/package.json`: `"license": "SEE LICENSE IN LICENSE.md"`
 

--- a/packages/react-on-rails/LICENSE.md
+++ b/packages/react-on-rails/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2017, 2018 Justin Gordon and ShakaCode
+Copyright (c) 2015–2025 ShakaCode, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -8,7 +8,8 @@
     "build": "pnpm run clean && tsc",
     "build-watch": "pnpm run clean && tsc --watch",
     "clean": "rm -rf ./lib",
-    "test": "jest tests",
+    "test": "pnpm run test:package-license && jest tests",
+    "test:package-license": "node scripts/check-package-license.mjs",
     "type-check": "tsc --noEmit --noErrorTruncation",
     "prepare": "[ -f lib/ReactOnRails.full.js ] || (rm -rf ./lib && tsc)",
     "prepublishOnly": "pnpm run build"
@@ -27,7 +28,7 @@
     "Rails"
   ],
   "author": "justin@shakacode.com",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "exports": {
     ".": {
       "default": "./lib/ReactOnRails.full.js"
@@ -78,6 +79,7 @@
     "react-dom": ">= 16"
   },
   "files": [
+    "LICENSE.md",
     "README.md",
     "lib/**/*.js",
     "lib/**/*.cjs",

--- a/packages/react-on-rails/scripts/check-package-license.mjs
+++ b/packages/react-on-rails/scripts/check-package-license.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const expectedOssMitLicense = `Copyright (c) 2017, 2018 Justin Gordon and ShakaCode
+Copyright (c) 2015–2025 ShakaCode, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+
+const readPackedFile = (tarballPath, packedPath) =>
+  execFileSync('tar', ['-xOzf', tarballPath, packedPath], { encoding: 'utf8' });
+
+const temporaryDirectory = mkdtempSync(join(tmpdir(), 'react-on-rails-license-'));
+
+try {
+  execFileSync('pnpm', ['pack', '--pack-destination', temporaryDirectory], { stdio: 'inherit' });
+
+  const [tarball] = readdirSync(temporaryDirectory).filter((file) => file.endsWith('.tgz'));
+  assert.ok(tarball, 'pnpm pack should produce a tarball');
+
+  const tarballPath = join(temporaryDirectory, tarball);
+  const packedPackage = JSON.parse(readPackedFile(tarballPath, 'package/package.json'));
+  const packedLicense = readPackedFile(tarballPath, 'package/LICENSE.md');
+
+  assert.equal(packedPackage.license, 'MIT');
+  assert.equal(packedLicense, expectedOssMitLicense);
+  assert.doesNotMatch(packedLicense, /React on Rails Pro|subscription|commercial/i);
+} finally {
+  rmSync(temporaryDirectory, { force: true, recursive: true });
+}


### PR DESCRIPTION
## Why

Forward-port the OSS npm license correction from the `release/17.0.1` train so `main` does not regress after the ephemeral release branch is removed.

Release-branch source: #4792 (`e9567c207e9c30ac9b956a1ed4306a4381e584cc`).

## What changed

- Cherry-picked the release fix with `-x`.
- Declares `react-on-rails` as MIT and includes the package-local MIT license.
- Keeps the real packed-artifact license guard on the ongoing development line.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter react-on-rails test` — 27 suites, 367 tests
- `pnpm exec eslint packages/react-on-rails/scripts/check-package-license.mjs`
- `pnpm exec prettier --check packages/react-on-rails/package.json packages/react-on-rails/LICENSE.md packages/react-on-rails/scripts/check-package-license.mjs`
- `git diff --check origin/main...HEAD`
- Pre-push hooks

## Changelog

The release entry is handled by the dedicated `17.0.1.rc.0` changelog PR against `release/17.0.1`; its release closeout will be forward-ported separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated licensing docs to explicitly declare the package as MIT and reference the included license file.
  * Added/updated MIT license text with copyright spanning 2015–2025.
* **Chores**
  * Ensure the package publishes the MIT `LICENSE.md`.
  * Added an automated license/package compliance check that runs before tests, verifying license text and package contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- merge-qualification:v1 -->
## Merge qualification

- Release mode / phase: `development` / `beta`; beta gate satisfied.
- Labels: `ready-for-hosted-ci` — optimized hosted CI completed for the current head.
- Changelog classification: `deferred_to_update_changelog` — release-branch entry is already published and final closeout will be reconciled separately.
- Current-head review coverage: Claude and CodeRabbit working (2 systems).
- Degraded review coverage: Copilot quota exhausted; Greptile and Codex produced no current-head artifact after the docs follow-up commit. Their older-head output is advisory only.

Confidence note:
- Validated: `pnpm install --frozen-lockfile`; `pnpm --filter react-on-rails test` (27 suites / 367 tests); focused artifact guard (0.45s); ESLint; Prettier; `git diff --check origin/main...HEAD`; pre-push hooks.
- Evidence: current-head required and optimized hosted checks passed; Claude and CodeRabbit found no confirmed blocker; all five review threads were replied to and resolved.
- UNKNOWN: none affecting merge safety.
- Residual risk: none beyond normal package-metadata rollout; the public RC tarball independently verifies MIT metadata and the packaged license.