### PR TITLE
Align 17.0.1 licensing docs with npm metadata

### DIFF
--- a/docs/DIRECTORY_LICENSING.md
+++ b/docs/DIRECTORY_LICENSING.md
@@ -47,7 +47,7 @@ react_on_rails/ (monorepo root)
    - `react_on_rails_pro/react_on_rails_pro.gemspec`: `s.license = "LicenseRef-LICENSE"`
 
 2. **Package.json Files**:
-   - `packages/react-on-rails/package.json`: `"license": "SEE LICENSE IN LICENSE.md"` (MIT)
+   - `packages/react-on-rails/package.json`: `"license": "MIT"` with a package-local `LICENSE.md`
    - `packages/react-on-rails-pro/package.json`: `"license": "SEE LICENSE IN LICENSE.md"`
    - `packages/react-on-rails-pro-node-renderer/package.json`: `"license": "SEE LICENSE IN LICENSE.md"`
 


### PR DESCRIPTION
## Why

The 17.0.1 license fix changes the OSS npm package metadata to `MIT`, but the repository’s directory-licensing guide still documents the old `SEE LICENSE IN LICENSE.md` field. That contradiction was found during the `main` forward-port review and should be corrected before publishing the release candidate.

## What changed

- Document the OSS `react-on-rails` npm package as `MIT` with its package-local `LICENSE.md`.
- Leave both Pro package entries unchanged.
- Cherry-pick the documentation correction from the `main` forward-port work with `-x`.

## Verification

- `pnpm exec prettier --check docs/DIRECTORY_LICENSING.md`
- `git diff --check origin/release/17.0.1...HEAD`
- Pre-push RuboCop and online Markdown link hooks

## Review coverage

- Claude and Greptile both produced clean current-head reviews.
- CodeRabbit was configured but skipped its review because the target is the non-default `release/17.0.1` branch. This degraded route is acknowledged; the two independent working review systems still satisfy the current-head coverage floor.

## Scope

Documentation-only release stabilizer for `release/17.0.1`; no package or runtime code changes.
