### PR TITLE
Finalize changelog for React on Rails 17.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
-### [17.0.1.rc.0] - 2026-07-26
+### [17.0.1] - 2026-07-26
 
 #### Fixed
 
@@ -2769,8 +2769,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.1.rc.0...main
-[17.0.1.rc.0]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...v17.0.1.rc.0
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.1...main
+[17.0.1]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...v17.0.1
 [17.0.0]: https://github.com/shakacode/react_on_rails/compare/v16.6.0...v17.0.0
 [16.6.0]: https://github.com/shakacode/react_on_rails/compare/v16.5.1...v16.6.0
 [16.5.1]: https://github.com/shakacode/react_on_rails/compare/v16.5.0...v16.5.1


### PR DESCRIPTION
## Why

Prepare the accepted `v17.0.1.rc.0` candidate for stable promotion without re-cutting from `main`. This patch release corrects the open-source `react-on-rails` npm license metadata and packed MIT license.

## What changed

- Collapse the `17.0.1.rc.0` changelog section into stable `17.0.1`.
- Update compare links to `v17.0.1` while keeping `Unreleased` anchored to `main`.
- Leave all runtime source and version artifacts unchanged; the release task owns the final coordinated version bump.

## Validation

- `bundle exec rake "update_changelog[release]"`
- `pnpm exec prettier --check CHANGELOG.md`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `script/ci-changes-detector origin/release/17.0.1` → documentation-only; no hosted CI expansion recommended
- Pre-push RuboCop and online Markdown link checks passed
- Fresh ready-state checks on current head: required PR gate, Claude review, Greptile review, and selected CI all passed; CodeRabbit explicitly skipped because automatic reviews are disabled for non-default base branches
- Strict `script/pr-merge-ledger` with `changelog_present`: `complete_allowed: true`

## Release gate

- Tracker: #4806 (`final-release`, GO)
- Accepted candidate: `v17.0.1.rc.0` at `ba1bb13931345ef41d010061d5abf57e0c27697a`
- Maintainer decision: Justin explicitly authorized final promotion on 2026-07-28
- Published standard starter and Pro + RSC TypeScript starter gates passed using the repository-declared `pnpm@10.33.4`
- Tracker #4806 records the exact-tag CI/artifact evidence and the narrow package-only demo-fleet waiver

No runtime Ruby/JavaScript, generator, RSC, or Pro behavior differs from 17.0.0. The exploratory pnpm 11 ignored-builds result is outside the generated repository's declared pnpm 10 toolchain and is not represented as passing.

Labels: none — changelog-only release metadata; required checks plus the final-release audit apply.
