### PR TITLE
Scope GitHub release commands to the origin repository

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -6886,21 +6886,23 @@ def publish_or_update_github_release(monorepo_root:, release_context:, dry_run:)
     return
   end
 
+  repo_slug = github_repo_slug(monorepo_root)
+
   Tempfile.create(["react-on-rails-release-notes-", ".md"]) do |tmp|
     tmp.write(release_context[:notes])
     tmp.flush
 
-    release_exists = system("gh", "release", "view", release_context[:tag], chdir: monorepo_root, out: File::NULL,
-                                                                            err: File::NULL)
+    release_exists = system("gh", "release", "view", release_context[:tag], "--repo", repo_slug,
+                            chdir: monorepo_root, out: File::NULL, err: File::NULL)
     abort "❌ Unable to run `gh`. Ensure GitHub CLI is installed and on PATH." if release_exists.nil?
 
     release_command = if release_exists
-                        ["gh", "release", "edit", release_context[:tag], "--title", release_context[:title],
-                         "--notes-file", tmp.path,
+                        ["gh", "release", "edit", release_context[:tag], "--repo", repo_slug,
+                         "--title", release_context[:title], "--notes-file", tmp.path,
                          "--prerelease=#{release_context[:prerelease]}"]
                       else
-                        command = ["gh", "release", "create", release_context[:tag], "--verify-tag", "--title",
-                                   release_context[:title],
+                        command = ["gh", "release", "create", release_context[:tag], "--repo", repo_slug,
+                                   "--verify-tag", "--title", release_context[:title],
                                    "--notes-file", tmp.path]
                         command << "--prerelease" if release_context[:prerelease]
                         command

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -664,6 +664,37 @@ RSpec.describe "release.rake helper methods" do
   end
 
   describe "#publish_or_update_github_release" do
+    it "scopes GitHub release commands to the origin repository" do
+      release_context = {
+        notes: "#### Fixed\n\n- Release fix",
+        prerelease: false,
+        tag: "v17.0.0",
+        title: "v17.0.0"
+      }
+      allow(self).to receive(:ensure_git_tag_exists!)
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
+      allow(self).to receive(:system).and_return(false, true, true, true)
+
+      2.times do
+        publish_or_update_github_release(monorepo_root: "/tmp/repo", release_context:, dry_run: false)
+      end
+
+      expect(self).to have_received(:system)
+        .with(
+          "gh", "release", "view", "v17.0.0", "--repo", "shakacode/react_on_rails",
+          chdir: "/tmp/repo", out: File::NULL, err: File::NULL
+        ).twice
+      expect(self).to have_received(:system).with(
+        "gh", "release", "create", "v17.0.0", "--repo", "shakacode/react_on_rails", "--verify-tag",
+        "--title", "v17.0.0", "--notes-file", a_string_ending_with(".md"), chdir: "/tmp/repo"
+      )
+      expect(self).to have_received(:system).with(
+        "gh", "release", "edit", "v17.0.0", "--repo", "shakacode/react_on_rails",
+        "--title", "v17.0.0", "--notes-file", a_string_ending_with(".md"), "--prerelease=false",
+        chdir: "/tmp/repo"
+      )
+    end
+
     it "reports the GitHub-only recovery command when publication fails" do
       release_context = {
         notes: "#### Fixed\n\n- Release fix",
@@ -672,6 +703,7 @@ RSpec.describe "release.rake helper methods" do
         title: "v17.0.0"
       }
       allow(self).to receive(:ensure_git_tag_exists!)
+      allow(self).to receive(:github_repo_slug).with("/tmp/repo").and_return("shakacode/react_on_rails")
       allow(self).to receive(:system).and_return(false, false)
 
       expect do


### PR DESCRIPTION
## Why

`gh release` could not select a repository in checkouts with multiple remotes, so an otherwise successful release stopped at GitHub release creation.

## Change

Pass the canonical origin repository to every `gh release view/create/edit` command and cover both create and edit paths.

## Validation

- Focused RSpec: 2 examples, 0 failures
- RuboCop: 2 files, no offenses
- Pre-commit and pre-push hooks: passed
- [Optimized hosted CI](https://github.com/shakacode/react_on_rails/pull/4803#issuecomment-5082481123): all 9 workflows passed for `69a27493b6bd`
- Claude, CodeRabbit, and Greptile: no actionable findings; 0 review threads

No changelog: internal release tooling only.

## Confidence note

- Release-mode gate: development; standard merge qualification satisfied
- Validated: focused regression test, Ruby lint, repository hooks, and exact-head hosted CI
- Evidence: checks and reviews above
- UNKNOWN: none
- Residual risk: none
