### PR TITLE
[Pro] Prevent caching RSC renders with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   component HTML and static RSC HTML now skip cache writes when any streamed chunk reports
   `hasErrors: true`; clean renders remain cacheable. Fixes
   [Issue 4723](https://github.com/shakacode/react_on_rails/issues/4723).
+  [PR 4804](https://github.com/shakacode/react_on_rails/pull/4804) by
+  [justin808](https://github.com/justin808).
 
 - **Stopped Doctor from warning when a layout uses only one pack helper**: `rake react_on_rails:doctor`
   no longer emits `⚠️ <layout>: has javascript_pack_tag but missing stylesheet_pack_tag` (or its mirror)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   [PR 4722](https://github.com/shakacode/react_on_rails/pull/4722) by
   [justin808](https://github.com/justin808).
 
+- **[Pro]** **Buffered and static RSC caches no longer persist error-containing renders**: Buffered
+  component HTML and static RSC HTML now skip cache writes when any streamed chunk reports
+  `hasErrors: true`; clean renders remain cacheable. Fixes
+  [Issue 4723](https://github.com/shakacode/react_on_rails/issues/4723).
+
 - **Stopped Doctor from warning when a layout uses only one pack helper**: `rake react_on_rails:doctor`
   no longer emits `⚠️ <layout>: has javascript_pack_tag but missing stylesheet_pack_tag` (or its mirror)
   based purely on helper asymmetry. A JavaScript-only Shakapacker entrypoint, a CSS-only pack, and a

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -493,7 +493,7 @@ module ReactOnRailsProHelper
     cache_hit = true
     cache_write_skipped = false
     uncached_result = nil
-    fetch_options = cache_write_if ? cache_write_options.merge(skip_nil: true) : cache_write_options
+    fetch_options = cache_write_if ? (cache_write_options || {}).merge(skip_nil: true) : cache_write_options
     result = Rails.cache.fetch(cache_key, fetch_options) do
       cache_hit = false
       rendered_result = yield

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -492,18 +492,17 @@ module ReactOnRailsProHelper
   def fetch_cache_entry(cache_key, cache_write_options, cache_write_if:)
     cache_hit = true
     cache_write_skipped = false
-    uncached_result = nil
-    fetch_options = cache_write_if ? (cache_write_options || {}).merge(skip_nil: true) : cache_write_options
-    result = Rails.cache.fetch(cache_key, fetch_options) do
-      cache_hit = false
-      rendered_result = yield
-      next rendered_result unless cache_write_if && !cache_write_if.call
+    skip_cache_write = Object.new
+    result = catch(skip_cache_write) do
+      Rails.cache.fetch(cache_key, cache_write_options) do
+        cache_hit = false
+        rendered_result = yield
+        next rendered_result unless cache_write_if && !cache_write_if.call
 
-      cache_write_skipped = true
-      uncached_result = rendered_result
-      nil
+        cache_write_skipped = true
+        throw(skip_cache_write, rendered_result)
+      end
     end
-    result = uncached_result if cache_write_skipped
 
     [result, cache_hit, cache_write_skipped]
   end

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -180,10 +180,11 @@ module ReactOnRailsProHelper
     end
 
     on_complete = options.delete(:on_complete)
+    on_chunk_errors = options.delete(:on_chunk_errors)
     collect_chunks = on_complete.respond_to?(:call)
     buffer = collect_chunks ? [] : +""
 
-    internal_stream_react_component(component_name, options).each_chunk do |chunk|
+    internal_stream_react_component(component_name, options, on_chunk_errors:).each_chunk do |chunk|
       buffer << chunk.to_s
     end
 
@@ -335,13 +336,12 @@ module ReactOnRailsProHelper
         prerender: true
       )
 
-      cached_result = fetch_react_component(component_name, cache_options) do
-        options = render_options.merge(
-          props: yield,
-          skip_prerender_cache: true
-        )
-        buffered_stream_react_component(component_name, options)
-      end
+      cached_result = render_cached_buffered_stream_react_component(
+        component_name,
+        cache_options,
+        render_options,
+        &block
+      )
       cached_result.html_safe
     end
   end
@@ -449,28 +449,63 @@ module ReactOnRailsProHelper
 
   private
 
-  def fetch_react_component(component_name, options)
+  def render_cached_buffered_stream_react_component(component_name, cache_options, render_options)
+    stream_has_errors = false
+    fetch_react_component(component_name, cache_options, cache_write_if: -> { !stream_has_errors }) do
+      options = render_options.merge(
+        props: yield,
+        skip_prerender_cache: true,
+        on_chunk_errors: ->(chunk_has_errors) { stream_has_errors ||= chunk_has_errors == true }
+      )
+      buffered_stream_react_component(component_name, options)
+    end
+  end
+
+  def fetch_react_component(component_name, options, cache_write_if: nil)
     return yield unless ReactOnRailsPro::Cache.use_cache?(options)
 
     cache_key = ReactOnRailsPro::Cache.react_component_cache_key(component_name, options)
     Rails.logger.debug { "React on Rails Pro cache_key is #{cache_key.inspect}" }
-    cache_options = ReactOnRailsPro::Cache.cache_write_options(options[:cache_options])
+    cache_write_options = ReactOnRailsPro::Cache.cache_write_options(options[:cache_options])
     if ReactOnRailsPro::Cache.cache_write_expired?(options[:cache_options])
       return add_component_cache_metadata(yield, cache_key, false)
     end
 
-    cache_hit = true
     normalized_cache_tags = []
-    result = Rails.cache.fetch(cache_key, cache_options) do
-      cache_hit = false
+    result, cache_hit, cache_write_skipped = fetch_cache_entry(
+      cache_key,
+      cache_write_options,
+      cache_write_if:
+    ) do
       normalized_cache_tags = ReactOnRailsPro::Cache.normalize_tags(options[:cache_tags])
       yield
     end
-    ReactOnRailsPro::Cache.register_normalized_tags(normalized_cache_tags, cache_key, cache_options) unless cache_hit
+    unless cache_hit || cache_write_skipped
+      ReactOnRailsPro::Cache.register_normalized_tags(normalized_cache_tags, cache_key, cache_write_options)
+    end
     load_pack_for_cached_react_component(component_name, options) if cache_hit
     result = normalize_cached_pro_attribution(result) if cache_hit
 
     add_component_cache_metadata(result, cache_key, cache_hit)
+  end
+
+  def fetch_cache_entry(cache_key, cache_write_options, cache_write_if:)
+    cache_hit = true
+    cache_write_skipped = false
+    uncached_result = nil
+    fetch_options = cache_write_if ? cache_write_options.merge(skip_nil: true) : cache_write_options
+    result = Rails.cache.fetch(cache_key, fetch_options) do
+      cache_hit = false
+      rendered_result = yield
+      next rendered_result unless cache_write_if && !cache_write_if.call
+
+      cache_write_skipped = true
+      uncached_result = rendered_result
+      nil
+    end
+    result = uncached_result if cache_write_skipped
+
+    [result, cache_hit, cache_write_skipped]
   end
 
   def normalize_cached_pro_attribution(result)
@@ -604,21 +639,30 @@ module ReactOnRailsProHelper
   end
 
   def render_cached_static_rsc_component(component_name, cache_options, render_options, diagnostics_context, &block)
+    stream_has_errors = false
     fetch_static_rsc_component(
       component_name,
       cache_options,
       render_options,
       diagnostics_context[:cache],
-      diagnostics_enabled: static_rsc_render_diagnostics_enabled?(diagnostics_context[:config])
+      diagnostics_enabled: static_rsc_render_diagnostics_enabled?(diagnostics_context[:config]),
+      cache_write_if: -> { !stream_has_errors }
     ) do
-      static_rsc_component_cache_miss_html(component_name, render_options, diagnostics_context, &block)
+      static_rsc_component_cache_miss_html(
+        component_name,
+        render_options,
+        diagnostics_context,
+        on_chunk_errors: ->(chunk_has_errors) { stream_has_errors ||= chunk_has_errors == true },
+        &block
+      )
     end
   end
 
-  def static_rsc_component_cache_miss_html(component_name, render_options, diagnostics_context)
+  def static_rsc_component_cache_miss_html(component_name, render_options, diagnostics_context, on_chunk_errors:)
     options = render_options.merge(
       props: yield,
-      skip_prerender_cache: true
+      skip_prerender_cache: true,
+      on_chunk_errors:
     )
     strip_static_rsc_payload_scripts(
       buffered_stream_react_component(component_name, options),
@@ -632,6 +676,7 @@ module ReactOnRailsProHelper
     render_options,
     cache_diagnostics,
     diagnostics_enabled:,
+    cache_write_if:,
     &
   )
     cache_enabled = ReactOnRailsPro::Cache.use_cache?(cache_options)
@@ -657,6 +702,7 @@ module ReactOnRailsProHelper
       render_options,
       cache_diagnostics,
       cache_key,
+      cache_write_if:,
       &
     )
   end
@@ -666,18 +712,21 @@ module ReactOnRailsProHelper
     cache_options,
     render_options,
     cache_diagnostics,
-    cache_key
+    cache_key,
+    cache_write_if:
   )
     cache_write_options = ReactOnRailsPro::Cache.cache_write_options(cache_options[:cache_options])
-    cache_hit = true
     normalized_cache_tags = []
-    result = Rails.cache.fetch(cache_key, cache_write_options) do
-      cache_hit = false
+    result, cache_hit, cache_write_skipped = fetch_cache_entry(
+      cache_key,
+      cache_write_options,
+      cache_write_if:
+    ) do
       normalized_cache_tags = ReactOnRailsPro::Cache.normalize_tags(cache_options[:cache_tags])
       yield
     end
 
-    unless cache_hit
+    unless cache_hit || cache_write_skipped
       ReactOnRailsPro::Cache.register_normalized_tags(normalized_cache_tags, cache_key, cache_write_options)
     end
     load_pack_for_cached_react_component(component_name, render_options) if cache_hit

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -856,6 +856,12 @@ describe ReactOnRailsProHelper do
       )
     end
 
+    def simulate_cache_store_ignoring_skip_nil
+      allow(Rails.cache).to receive(:fetch).and_wrap_original do |original, key, options = nil, &fetch_block|
+        original.call(key, options&.except(:skip_nil), &fetch_block)
+      end
+    end
+
     it "redacts parser failures from the StreamRequest helper wrapper" do
       stub_pro_bundle_hashes
       malformed_payloads = [
@@ -2042,6 +2048,111 @@ describe ReactOnRailsProHelper do
       end
     end
 
+    describe "#fetch_cache_entry", :caching do
+      around do |example|
+        Rails.cache.clear
+        example.run
+      ensure
+        Rails.cache.clear
+      end
+
+      it "returns a rejected nil result and leaves no cache entry" do
+        cache_key = "rejected-nil-#{SecureRandom.hex(4)}"
+        simulate_cache_store_ignoring_skip_nil
+
+        result = send(:fetch_cache_entry, cache_key, nil, cache_write_if: -> { false }) { nil }
+
+        expect(result).to eq([nil, false, true])
+        expect(Rails.cache.exist?(cache_key)).to be(false)
+      end
+
+      it "preserves ordinary nil cache writes without a rejection predicate" do
+        cache_key = "ordinary-nil-#{SecureRandom.hex(4)}"
+
+        result = send(:fetch_cache_entry, cache_key, nil, cache_write_if: nil) { nil }
+
+        expect(result).to eq([nil, false, false])
+        expect(Rails.cache.exist?(cache_key)).to be(true)
+      end
+
+      it "keeps nested rejected cache fetches isolated" do
+        outer_key = "rejected-outer-#{SecureRandom.hex(4)}"
+        inner_key = "rejected-inner-#{SecureRandom.hex(4)}"
+        inner_result = nil
+        simulate_cache_store_ignoring_skip_nil
+
+        outer_result = send(:fetch_cache_entry, outer_key, nil, cache_write_if: -> { false }) do
+          inner_result = send(:fetch_cache_entry, inner_key, nil, cache_write_if: -> { false }) do
+            "inner rejected"
+          end
+          "outer rejected"
+        end
+
+        expect(inner_result).to eq(["inner rejected", false, true])
+        expect(outer_result).to eq(["outer rejected", false, true])
+        expect(Rails.cache.exist?(inner_key)).to be(false)
+        expect(Rails.cache.exist?(outer_key)).to be(false)
+      end
+
+      it "emits cache generation without a cache write for rejected misses" do
+        cache_key = "rejected-notifications-#{SecureRandom.hex(4)}"
+        notifications = []
+        simulate_cache_store_ignoring_skip_nil
+        subscriber = ActiveSupport::Notifications.subscribe(
+          /cache_(?:generate|write)\.active_support/
+        ) do |event_name, _started, _finished, _event_id, payload|
+          notifications << event_name if payload[:key] == cache_key
+        end
+
+        result = send(:fetch_cache_entry, cache_key, nil, cache_write_if: -> { false }) { "rejected" }
+
+        expect(result).to eq(["rejected", false, true])
+        expect(notifications).to include("cache_generate.active_support")
+        expect(notifications).not_to include("cache_write.active_support")
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+
+      it "does not register cache tags for rejected misses" do
+        options = {
+          cache_key: "rejected-tags-#{SecureRandom.hex(4)}",
+          cache_tags: ["rejected-tag"],
+          prerender: false
+        }
+        expected_cache_key = ReactOnRailsPro::Cache.react_component_cache_key(component_name, options)
+        simulate_cache_store_ignoring_skip_nil
+        allow(ReactOnRailsPro::Cache).to receive(:register_normalized_tags)
+
+        result = send(:fetch_react_component, component_name, options, cache_write_if: -> { false }) do
+          "rejected"
+        end
+
+        expect(result).to eq("rejected")
+        expect(Rails.cache.exist?(expected_cache_key)).to be(false)
+        expect(ReactOnRailsPro::Cache).not_to have_received(:register_normalized_tags)
+      end
+
+      it "preserves the stale race-condition entry while rejecting the fresh result" do
+        cache_key = "rejected-race-condition-#{SecureRandom.hex(4)}"
+        started_at = Time.now
+        Rails.cache.write(cache_key, "stale", expires_in: 1)
+        allow(Time).to receive(:now).and_return(started_at + 2)
+        simulate_cache_store_ignoring_skip_nil
+
+        result = send(
+          :fetch_cache_entry,
+          cache_key,
+          { race_condition_ttl: 5 },
+          cache_write_if: -> { false }
+        ) { "fresh error" }
+
+        expect(result).to eq(["fresh error", false, true])
+        expect(Rails.cache.read(cache_key)).to eq("stale")
+        allow(Time).to receive(:now).and_return(started_at + 8)
+        expect(Rails.cache.exist?(cache_key)).to be(false)
+      end
+    end
+
     describe "#cached_buffered_stream_react_component", :caching do
       around do |example|
         Rails.cache.clear
@@ -2109,6 +2220,8 @@ describe ReactOnRailsProHelper do
         expected_cache_key = nil
         result = nil
 
+        simulate_cache_store_ignoring_skip_nil
+
         Sync do
           mock_request_and_response(error_chunks)
           expected_cache_key = ReactOnRailsPro::Cache.react_component_cache_key(
@@ -2119,8 +2232,7 @@ describe ReactOnRailsProHelper do
           result = cached_buffered_stream_react_component(
             component_name,
             cache_key: user_cache_key,
-            id: "#{component_name}-react-component-0",
-            cache_options: { expires_in: 60 }
+            id: "#{component_name}-react-component-0"
           ) do
             props
           end
@@ -2128,7 +2240,7 @@ describe ReactOnRailsProHelper do
 
         expect(result).to include("broken boundary")
         expect(chunks_read.count).to eq(error_chunks.count)
-        expect(Rails.cache.read(expected_cache_key)).to be_nil
+        expect(Rails.cache.exist?(expected_cache_key)).to be(false)
       end
 
       it "respects explicit auto_load_bundle false on cache misses" do
@@ -2374,6 +2486,8 @@ describe ReactOnRailsProHelper do
         expected_cache_key = nil
         result = nil
 
+        simulate_cache_store_ignoring_skip_nil
+
         Sync do
           mock_request_and_response(error_chunks)
           expected_cache_key = ReactOnRailsPro::Cache.react_component_cache_key(
@@ -2384,8 +2498,7 @@ describe ReactOnRailsProHelper do
           result = cached_static_rsc_component(
             component_name,
             cache_key: user_cache_key,
-            id: "#{component_name}-react-component-0",
-            cache_options: { expires_in: 60 }
+            id: "#{component_name}-react-component-0"
           ) do
             props
           end
@@ -2393,7 +2506,7 @@ describe ReactOnRailsProHelper do
 
         expect(result).to include("broken boundary")
         expect(chunks_read.count).to eq(error_chunks.count)
-        expect(Rails.cache.read(expected_cache_key)).to be_nil
+        expect(Rails.cache.exist?(expected_cache_key)).to be(false)
       end
 
       it "replaces cached static RSC attribution once per request" do

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -2073,8 +2073,7 @@ describe ReactOnRailsProHelper do
               component_name,
               cache_key: ["buffered-stream-cache-spec", component_name],
               id: "#{component_name}-react-component-0",
-              trace: true,
-              cache_options: { expires_in: 60 }
+              trace: true
             ) do
               props_calls += 1
               props
@@ -2439,8 +2438,7 @@ describe ReactOnRailsProHelper do
           result = cached_static_rsc_component(
             component_name,
             cache_key: ["static-rsc-cache-spec", component_name],
-            id: "#{component_name}-react-component-0",
-            cache_options: { expires_in: 60 }
+            id: "#{component_name}-react-component-0"
           ) do
             props_calls += 1
             props

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -2099,6 +2099,39 @@ describe ReactOnRailsProHelper do
         expect(chunks_read.count).to eq(chunks.count)
       end
 
+      it "does not cache a buffered render when any chunk reports errors" do
+        error_chunks = [
+          { html: "<div>Chunk 1: shell ok</div>", consoleReplayScript: "",
+            hasErrors: false, isShellReady: true },
+          { html: "<div>Chunk 2: broken boundary</div>", consoleReplayScript: "",
+            hasErrors: true, isShellReady: true }
+        ]
+        user_cache_key = ["buffered-stream-cache-errors", component_name]
+        expected_cache_key = nil
+        result = nil
+
+        Sync do
+          mock_request_and_response(error_chunks)
+          expected_cache_key = ReactOnRailsPro::Cache.react_component_cache_key(
+            component_name,
+            cache_key: ["buffered_stream_react_component", user_cache_key],
+            prerender: true
+          )
+          result = cached_buffered_stream_react_component(
+            component_name,
+            cache_key: user_cache_key,
+            id: "#{component_name}-react-component-0",
+            cache_options: { expires_in: 60 }
+          ) do
+            props
+          end
+        end
+
+        expect(result).to include("broken boundary")
+        expect(chunks_read.count).to eq(error_chunks.count)
+        expect(Rails.cache.read(expected_cache_key)).to be_nil
+      end
+
       it "respects explicit auto_load_bundle false on cache misses" do
         original_auto_load_bundle = ReactOnRails.configuration.auto_load_bundle
         ReactOnRails.configuration.auto_load_bundle = true
@@ -2329,6 +2362,39 @@ describe ReactOnRailsProHelper do
           <script>window.ReactOnRailsReveal && window.ReactOnRailsReveal("#{component_name}")</script>
           <script src="/packs/generated/PublicPageClientEffects.js"></script>
         HTML
+      end
+
+      it "does not cache static RSC HTML when any chunk reports errors" do
+        error_chunks = [
+          { html: "<div>Chunk 1: shell ok</div>", consoleReplayScript: "",
+            hasErrors: false, isShellReady: true },
+          { html: "<div>Chunk 2: broken boundary</div>", consoleReplayScript: "",
+            hasErrors: true, isShellReady: true }
+        ]
+        user_cache_key = ["static-rsc-cache-errors", component_name]
+        expected_cache_key = nil
+        result = nil
+
+        Sync do
+          mock_request_and_response(error_chunks)
+          expected_cache_key = ReactOnRailsPro::Cache.react_component_cache_key(
+            component_name,
+            cache_key: ["static_rsc_component", user_cache_key],
+            prerender: true
+          )
+          result = cached_static_rsc_component(
+            component_name,
+            cache_key: user_cache_key,
+            id: "#{component_name}-react-component-0",
+            cache_options: { expires_in: 60 }
+          ) do
+            props
+          end
+        end
+
+        expect(result).to include("broken boundary")
+        expect(chunks_read.count).to eq(error_chunks.count)
+        expect(Rails.cache.read(expected_cache_key)).to be_nil
       end
 
       it "replaces cached static RSC attribution once per request" do


### PR DESCRIPTION
## Why

Buffered and static RSC helpers could persist an error-containing render in `Rails.cache`, allowing a later request to receive that rejected output as a cache hit. This closes #4723 while preserving caching for clean renders.

## What changed

- Propagate per-chunk `hasErrors` metadata through both buffered and static RSC render paths.
- Return rejected render output to the current caller while exiting `Rails.cache.fetch` before its write step.
- Preserve cache-hit metadata, tag registration rules, normal `nil` caching, and `race_condition_ttl` behavior.
- Add focused regression coverage for rejected and clean renders, cache hits, default cache options, nested fetches, notifications, tags, and race handling.

The cache-write bypass uses Ruby's uniquely scoped `catch`/`throw` control flow instead of `skip_nil`, because React on Rails Pro still supports ActiveSupport versions whose cache implementation predates `skip_nil`.

## Verification

- Focused Pro helper matrix: 10 examples, 0 failures.
- Rails 5.2 compatibility simulation (cache store ignores `skip_nil`): rejected buffered/static renders were returned and no cache entry was written.
- Current ActiveSupport executable checks: clean misses write, hits remain hits, rejected renders do not write, and ordinary `nil` behavior is unchanged.
- Targeted Pro RuboCop: 2 files, 0 offenses.
- Ruby syntax, `git diff --check`, Pro license-header audit, and commit hooks passed.
- Independent `codex review --base origin/main`: no actionable findings.

The broad helper spec currently has 23 unrelated failures because this checkout does not contain `react_on_rails_pro/spec/dummy/ssr-generated/server-bundle.js`; focused tests that do not depend on that generated bundle pass.

## Churn and scope

This PR changes only the Pro helper, its focused dummy-app helper spec, and the changelog. No package, generator, or public API changes are included.

Fixes #4723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented buffered React component rendering and static RSC caching from saving results when any streamed chunk reports errors.
  - Ensured error-free renders continue to be cached.
  - Improved conditional cache write behavior and avoided recording cache metadata for rejected cache misses.

- **Tests**
  - Added helper coverage and regression specs validating conditional cache entry acceptance/rejection and the new “no cache on chunk errors” behavior for buffered and static RSC paths.

- **Documentation**
  - Added an unreleased changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->