### PR TITLE
Agents: bind fleet closeout to generated pack

### DIFF
--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -70,6 +70,7 @@ module FleetValidation
     end
 
     def write_pack(output_dir)
+      output_dir = File.expand_path(output_dir)
       @lifecycle.validate_existing_ledger(File.join(output_dir, "result-ledger.json"))
       FileUtils.mkdir_p(output_dir)
       clear_generated_prompts(output_dir)

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts.rb
@@ -86,7 +86,7 @@ module FleetValidation
         rendered_prompts << [assignment.fetch(:machine), relative_path, assignment]
       end
 
-      File.write(File.join(output_dir, "INDEX.md"), render_index(rendered_prompts))
+      File.write(File.join(output_dir, "INDEX.md"), render_index(rendered_prompts, output_dir))
       @lifecycle.write_artifacts(output_dir)
     end
 
@@ -282,7 +282,7 @@ module FleetValidation
       (["## Machine allocation", ""] + rows).join("\n")
     end
 
-    def render_index(rendered_prompts)
+    def render_index(rendered_prompts, output_dir)
       rows = rendered_prompts.map do |machine, path, assignment|
         targets = assignment.fetch(:targets).map { |target| target.fetch("name") }.join("; ")
         "| #{machine} | [#{File.basename(path)}](#{path}) | #{targets} |"
@@ -307,19 +307,20 @@ module FleetValidation
            comment, never from `result-ledger.json`, before running:
 
            ```bash
+           PACK_DIR=#{Shellwords.escape(output_dir)}
            EXPECTED_CANDIDATE=RESOLVED_CANDIDATE_TAG
            EXPECTED_CANDIDATE_COMMIT=RESOLVED_CANDIDATE_COMMIT
            EXPECTED_POLICY_COMMIT=FULL_POLICY_COMMIT_SHA
            EXPECTED_TRACKER_MODE=INITIAL_TRACKER_MODE
-           ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
-             --ledger result-ledger.json \
+           bundle exec ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb \
+             --ledger "$PACK_DIR/result-ledger.json" \
              --expected-pack-id #{Shellwords.escape(@pack_id)} \
              --expected-release-selector #{Shellwords.escape(@release_selector)} \
              --expected-candidate "$EXPECTED_CANDIDATE" \
              --expected-candidate-commit "$EXPECTED_CANDIDATE_COMMIT" \
              --expected-policy-commit "$EXPECTED_POLICY_COMMIT" \
              --expected-tracker-mode "$EXPECTED_TRACKER_MODE" \
-             --render-tracker tracker-closeout.md
+             --render-tracker "$PACK_DIR/tracker-closeout.md"
            ```
 
         This layout runs at most

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -3289,6 +3289,22 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_index_closeout_command_anchors_a_relative_output_directory
+    Dir.mktmpdir do |root|
+      relative_output_dir = "fleet pack"
+      output_dir = File.join(File.realpath(root), relative_output_dir)
+      launch_dir = File.join(root, "closeout")
+      FileUtils.mkdir_p(launch_dir)
+
+      Dir.chdir(root) { build_generator.write_pack(relative_output_dir) }
+      index = File.read(File.join(output_dir, "INDEX.md"))
+      assignment = index.lines.find { |line| line.strip.start_with?("PACK_DIR=") }.strip
+      pack_dir = Shellwords.split(assignment.delete_prefix("PACK_DIR=")).fetch(0)
+
+      assert_equal output_dir, File.expand_path(pack_dir, launch_dir)
+    end
+  end
+
   def test_core_matrix_gate_is_always_assigned_to_coordinator_one
     (4..8).each do |prompt_count|
       generator = build_generator(prompt_count:)

--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -3276,6 +3276,19 @@ class FleetValidationGeneratorTest < Minitest::Test
     end
   end
 
+  def test_index_closeout_command_targets_the_generated_pack_directory
+    Dir.mktmpdir do |root|
+      output_dir = File.join(root, "fleet pack")
+      build_generator.write_pack(output_dir)
+      index = File.read(File.join(output_dir, "INDEX.md"))
+
+      assert_includes index, "PACK_DIR=#{Shellwords.escape(output_dir)}"
+      assert_includes index, "bundle exec ruby .agents/skills/run-fleet-validation/scripts/validate_ledger.rb"
+      assert_includes index, '--ledger "$PACK_DIR/result-ledger.json"'
+      assert_includes index, '--render-tracker "$PACK_DIR/tracker-closeout.md"'
+    end
+  end
+
   def test_core_matrix_gate_is_always_assigned_to_coordinator_one
     (4..8).each do |prompt_count|
       generator = build_generator(prompt_count:)


### PR DESCRIPTION
## Why

Fleet closeout is the release-safety boundary that validates the durable result ledger and renders the tracker disposition. The generated `INDEX.md` previously invoked the validator from the repository root but passed bare `result-ledger.json` and `tracker-closeout.md` paths. That made the command depend on the operator's current directory and could validate or write an unrelated file instead of the selected fleet pack.

This branch was refreshed from current `origin/main`. Its four historical local commits were already merged byte-for-byte as squash commit `5121928ca` in #4694, so they were not replayed as duplicate history; the current-main implementation and later lifecycle hardening were reviewed semantically instead.

## What changed

- Thread the generated output directory into the launch-index renderer.
- Normalize the output directory at pack generation, then emit a shell-escaped absolute `PACK_DIR` and bind both `--ledger` and `--render-tracker` to that exact directory.
- Run the validator through `bundle exec ruby`, matching the documented repository workflow.
- Add regressions for an output path with spaces and for relative generation followed by closeout from another working directory.

## Release-safety rationale

The independent checker still receives pack ID, selector, candidate/tag commit, policy commit, and tracker mode from external launch evidence. This change does not relax schema or semantic validation. It removes ambient-CWD ambiguity so a successful closeout necessarily reads the intended pack ledger and writes the tracker matrix beside it, reducing the risk of false promotion evidence.

## Verification

- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb` — 166 runs, 670 assertions
- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_lifecycle.rb` — pass
- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/fleet_health_test.rb` — 73 runs, 393 assertions
- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/replay_rc12_fleet_health.rb` — pass
- `bundle exec rubocop --config .agents/.rubocop.yml .agents/skills/run-fleet-validation/scripts/generate_prompts.rb .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb` — no offenses
- CI-equivalent OSS RuboCop — 247 files, no offenses
- skill quick validator — valid
- `.agents/bin/validate --changed` — pass
- pre-push branch lint — pass
- independent Sol/xhigh exact-head checker — clean, no outstanding findings
- current-head Claude review — clean overall; documentation suggestion verified against the existing skill and declined with evidence
- current-head CodeRabbit review — approved, no actionable comments

## Review-system coverage

Current head: `8fc13ee7693955223b95628757077910c654fe07`.

- Working: Claude review, CodeRabbit, and the independent Codex Sol/xhigh checker.
- Degraded: Copilot was quota-limited; Greptile did not emit a fresh-head artifact after the fix. Greptile's old-head P1 finding was fixed, replied to, and resolved; both current-head working reviewers and the independent checker found no blocker.
- Coverage floor: satisfied with at least two independent working systems. All review threads are resolved and exact-head required checks are complete.

## Churn and scope

- Two implementation commits: the original closeout hardening and one batched review-fix commit for relative output directories.
- No changelog entry: this hardens internal contributor release tooling and does not change product behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated validation/closeout instructions to reliably reference the correct pack output directory by normalizing and using an absolute path.
  * Updated closeout commands so ledger and tracker arguments point to pack-scoped files.
* **Tests**
  * Added/expanded test coverage to verify generated closeout commands use the correct `PACK_DIR` value for both absolute and relative output locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- completed-batch-audit-summary:start -->
## Completed-batch audit

**Status:** Clean — no outstanding findings or follow-ups. [Durable receipt](https://github.com/shakacode/react_on_rails/pull/4805#issuecomment-5086990940).
<!-- completed-batch-audit-summary:end -->
