### PR TITLE
Agents: trust Copilot review identities

### DIFF
--- a/.agents/agent-workflow-drift.yml
+++ b/.agents/agent-workflow-drift.yml
@@ -118,9 +118,10 @@ files:
 - source: skills/pr-batch/bin/dispatcher-capability-preflight-test.rb
   consumer: ".agents/skills/pr-batch/bin/dispatcher-capability-preflight-test.rb"
   mode: identical
-# Count disposition: the pull request 182 pin alone would classify these two files
-# as identical. Retaining the merged pull request 198 cancellation guardrail
-# honestly reclassifies them as overlays, yielding 26 identical and 16 overlays.
+# Count disposition: the pull request 182 pin alone would classify these four files
+# as identical. Retaining the merged pull request 198 cancellation guardrail and
+# pull request 270 canonical bot resolution honestly reclassifies them as overlays,
+# yielding 24 identical and 18 overlays.
 - source: skills/pr-batch/bin/pr-ci-readiness
   consumer: ".agents/skills/pr-batch/bin/pr-ci-readiness"
   mode: overlay
@@ -139,10 +140,20 @@ files:
   consumer_sha256: c4d8ef00f739e307054d2298629a971efa916ed148b432c4ddf6a071505219d8
 - source: skills/pr-batch/bin/pr-security-preflight
   consumer: ".agents/skills/pr-batch/bin/pr-security-preflight"
-  mode: identical
+  mode: overlay
+  reason: React on Rails keeps merged agent-workflows pull requests 201 trust-config provenance
+    and 270 canonical-node bot identity resolution ahead of the global source pin.
+  consumer_mode: '100755'
+  source_sha256: 9853bc0f8e0ae512ad54a3bc926c7ee871c3878590717f623fe269a1acaf0da0
+  consumer_sha256: 0f2dd2e81899a04f7b3a0a5dcf8dd90e4b7a4b5a6e8cccbf521ec64f5e1bbcc8
 - source: skills/pr-batch/bin/pr-security-preflight-test.rb
   consumer: ".agents/skills/pr-batch/bin/pr-security-preflight-test.rb"
-  mode: identical
+  mode: overlay
+  reason: React on Rails keeps merged agent-workflows pull requests 201 trust-config provenance
+    and 270 canonical-node bot identity regression coverage ahead of the global source pin.
+  consumer_mode: '100755'
+  source_sha256: e0e4978e46030c9a91bfafde07a7837d1b6e72beb970ac1654e2d9236cbe1c19
+  consumer_sha256: b8753b6f9a19e86cfae1a2ebacc3e6d971f9f30a1420875eff92f166a3920396
 - source: skills/pr-batch/lib/git_probe_env.rb
   consumer: ".agents/skills/pr-batch/lib/git_probe_env.rb"
   mode: identical

--- a/.agents/skills/pr-batch/bin/pr-security-preflight
+++ b/.agents/skills/pr-batch/bin/pr-security-preflight
@@ -248,24 +248,26 @@ def resolved_trust_config(explicit_path, repo:, github_host:)
     expanded = File.expand_path(explicit_path)
     abort "Trust config not found: #{expanded}" unless File.exist?(expanded)
 
-    return { path: expanded, global: trust_config_global?(expanded, repo, github_host:) }
+    return { path: expanded, global: trust_config_global?(expanded, repo, github_host:), source: "explicit" }
   end
 
   repo_path = repo_trust_config_path
-  return { path: repo_path, global: trust_config_global?(repo_path, repo, github_host:) } if File.exist?(repo_path)
+  if File.exist?(repo_path)
+    return { path: repo_path, global: trust_config_global?(repo_path, repo, github_host:), source: "repo-local" }
+  end
 
   env_path = ENV[USER_TRUST_CONFIG_ENV].to_s
   unless env_path.empty?
     expanded_env_path = File.expand_path(env_path)
     abort "#{USER_TRUST_CONFIG_ENV} points to a missing trust config: #{expanded_env_path}" unless File.exist?(expanded_env_path)
 
-    return { path: expanded_env_path, global: true }
+    return { path: expanded_env_path, global: true, source: "env" }
   end
 
   home_path = File.expand_path(HOME_TRUST_CONFIG)
-  return { path: home_path, global: true } if File.exist?(home_path)
+  return { path: home_path, global: true, source: "user-global" } if File.exist?(home_path)
 
-  { path: PACKAGED_TRUST_CONFIG, global: false }
+  { path: PACKAGED_TRUST_CONFIG, global: false, source: "packaged-fallback" }
 end
 
 def repo_trust_config_path
@@ -981,9 +983,19 @@ def high_risk_files(files)
 end
 
 PARTICIPANT_NODES_FRAGMENT = <<~GRAPHQL
+  id
   login
   url
   __typename
+GRAPHQL
+
+CANONICAL_BOT_QUERY = <<~GRAPHQL
+  query CanonicalBot($id:ID!) {
+    node(id:$id) {
+      __typename
+      ... on Bot { login }
+    }
+  }
 GRAPHQL
 
 PR_TIMELINE_NODES_FRAGMENT = <<~GRAPHQL
@@ -1250,11 +1262,36 @@ def participant_logins_and_unknown_count(target)
     if login.to_s.empty?
       unknown_count += 1
     else
-      participants << login
+      participants << [login, participant&.[]("id")]
     end
   end
 
   { participants:, unknown_count: }
+end
+
+def canonical_bot_login(node_id, canonical_bot_cache)
+  return if node_id.to_s.empty?
+
+  canonical_bot_cache.fetch(node_id) do
+    payload = run_gh_json("api", "graphql", "-f", "id=#{node_id}", "-f", "query=#{CANONICAL_BOT_QUERY}")
+    node = payload.dig("data", "node")
+    canonical_bot_cache[node_id] = if node.is_a?(Hash) && node["__typename"] == "Bot"
+                                     node["login"]
+                                   end
+  end
+rescue StandardError => e
+  warn "WARN: could not resolve canonical bot identity for node #{node_id}: #{e.message.lines.first&.strip}"
+  canonical_bot_cache[node_id] = nil
+end
+
+def trusted_bare_bot_participant?(login, node_id, trust_config, canonical_bot_cache)
+  trusted_bots = trust_config.fetch(:trusted_bots)
+  return false unless trusted_bots.include?(normalized_login(login))
+
+  canonical_login = canonical_bot_login(node_id, canonical_bot_cache)
+  return false if canonical_login.to_s.empty?
+
+  trusted_bots.include?(normalized_bot_login(canonical_login))
 end
 
 def unknown_participant_findings(unknown_count)
@@ -1269,15 +1306,16 @@ def unknown_participant_findings(unknown_count)
   }]
 end
 
-def participant_findings(repo:, target:, visible:, permission_cache:, trust_config:, team_cache:)
+def participant_findings(repo:, target:, visible:, permission_cache:, trust_config:, team_cache:, canonical_bot_cache:)
   participant_data = participant_logins_and_unknown_count(target)
   findings = unknown_participant_findings(participant_data.fetch(:unknown_count))
   source_logins = target_source_actor_logins(target)
 
-  participant_data.fetch(:participants).each do |login|
+  participant_data.fetch(:participants).each do |login, node_id|
     # Trusted bots cannot delete comments, so a hidden bot participant does not
     # carry the same prompt-injection risk as a hidden human.
     next if trusted_bot?(login, trust_config)
+    next if trusted_bare_bot_participant?(login, node_id, trust_config, canonical_bot_cache)
 
     hidden = !visible.include?(login)
     if trusted_metadata_bot?(login, trust_config) && !hidden && !source_logins.include?(login)
@@ -1303,7 +1341,7 @@ def participant_findings(repo:, target:, visible:, permission_cache:, trust_conf
 end
 
 def scan_target(repo:, owner:, name:, number:, pr_query:, issue_query:, include_reactions:, permission_cache:,
-                trust_config:, team_cache:)
+                trust_config:, team_cache:, canonical_bot_cache:)
   issue = issue_payload(repo, number)
   target_is_pr = issue.key?("pull_request")
   graph_field = target_is_pr ? "pullRequest" : "issue"
@@ -1349,7 +1387,15 @@ def scan_target(repo:, owner:, name:, number:, pr_query:, issue_query:, include_
     files:,
     number:,
     graph_coverage_findings: graph_coverage_findings(target, include_target_author: target_is_pr),
-    participant_findings: participant_findings(repo:, target:, visible:, permission_cache:, trust_config:, team_cache:),
+    participant_findings: participant_findings(
+      repo:,
+      target:,
+      visible:,
+      permission_cache:,
+      trust_config:,
+      team_cache:,
+      canonical_bot_cache:
+    ),
     risky_files: high_risk_files(files),
     suspicious: suspicious_findings.fetch(:suspicious),
     suspicious_warnings: suspicious_findings.fetch(:suspicious_warnings),
@@ -1611,7 +1657,14 @@ overall_blockers = []
 acknowledged_findings = []
 permission_cache = {}
 team_cache = {}
-trust_config = load_trust_config(**resolved_trust_config(options.fetch(:trust_config), repo:, github_host:))
+canonical_bot_cache = {}
+trust_config_resolution = resolved_trust_config(options.fetch(:trust_config), repo:, github_host:)
+puts "Trust config: #{trust_config_resolution.fetch(:path)}"
+puts "Trust config source: #{trust_config_resolution.fetch(:source)}"
+trust_config = load_trust_config(
+  path: trust_config_resolution.fetch(:path),
+  global: trust_config_resolution.fetch(:global)
+)
 
 ARGV.each do |arg|
   number = Integer(arg, exception: false)
@@ -1627,7 +1680,8 @@ ARGV.each do |arg|
     include_reactions: options[:include_reactions],
     permission_cache:,
     trust_config:,
-    team_cache:
+    team_cache:,
+    canonical_bot_cache:
   )
   print_scan_result(
     result,

--- a/.agents/skills/pr-batch/bin/pr-security-preflight-test.rb
+++ b/.agents/skills/pr-batch/bin/pr-security-preflight-test.rb
@@ -35,6 +35,7 @@ class PrSecurityPreflightTest < Minitest::Test
       )
 
       assert status.success?, out
+      assert_trust_config_evidence(out, path: global_config, source: "env")
       assert_includes out, "SECURITY_PREFLIGHT_OK"
       refute_includes out, "SECURITY_PREFLIGHT_BLOCKED"
     end
@@ -1097,6 +1098,7 @@ class PrSecurityPreflightTest < Minitest::Test
       )
 
       refute status.success?, out
+      assert_trust_config_evidence(out, path: explicit_config, source: "explicit")
       assert_includes out, "SECURITY_PREFLIGHT_BLOCKED"
       assert_includes out, "not in trusted actor allowlist"
     end
@@ -1182,6 +1184,7 @@ class PrSecurityPreflightTest < Minitest::Test
       )
 
       assert status.success?, out
+      assert_trust_config_evidence(out, path: File.realpath(repo_config), source: "repo-local")
       assert_includes out, "SECURITY_PREFLIGHT_OK"
       refute_includes out, "SECURITY_PREFLIGHT_BLOCKED"
     end
@@ -1294,6 +1297,7 @@ class PrSecurityPreflightTest < Minitest::Test
       )
 
       assert status.success?, out
+      assert_trust_config_evidence(out, path: home_config, source: "user-global")
       assert_includes out, "SECURITY_PREFLIGHT_OK"
       refute_includes out, "SECURITY_PREFLIGHT_BLOCKED"
     end
@@ -1315,6 +1319,11 @@ class PrSecurityPreflightTest < Minitest::Test
       )
 
       refute status.success?, out
+      assert_trust_config_evidence(
+        out,
+        path: File.expand_path("../trusted-github-actors.yml", __dir__),
+        source: "packaged-fallback"
+      )
       assert_includes out, "SECURITY_PREFLIGHT_BLOCKED"
       assert_includes out, "not in trusted actor allowlist"
     end
@@ -2048,12 +2057,39 @@ class PrSecurityPreflightTest < Minitest::Test
     end
   end
 
-  def test_human_login_matching_bot_base_name_is_not_trusted_as_bot
-    with_fake_gh("human-bot-basename-participant") do |env, trust_config_path, _log_path|
+  def test_bare_bot_alias_resolves_canonical_bot_identity
+    with_fake_gh("canonical-bare-bot-alias-participant") do |env, trust_config_path, _log_path|
       File.write(trust_config_path, <<~YAML)
         trusted_users: []
         trusted_bots:
-          - claude
+          - copilot
+          - copilot-pull-request-reviewer
+        trusted_teams: []
+      YAML
+
+      out, status = run_script(
+        env,
+        "--repo",
+        "owner/repo",
+        "--trust-config",
+        trust_config_path,
+        "--strict-trust",
+        "123"
+      )
+
+      assert status.success?, out
+      assert_includes out, "SECURITY_PREFLIGHT_OK"
+      assert_includes out, "Untrusted or hidden participant findings: none"
+    end
+  end
+
+  def test_bare_bot_alias_rejects_mismatched_canonical_bot_identity
+    with_fake_gh("canonical-bot-mismatch-participant") do |env, trust_config_path, _log_path|
+      File.write(trust_config_path, <<~YAML)
+        trusted_users: []
+        trusted_bots:
+          - copilot
+          - copilot-pull-request-reviewer
         trusted_teams: []
       YAML
 
@@ -2070,8 +2106,150 @@ class PrSecurityPreflightTest < Minitest::Test
       refute status.success?, out
       assert_equal 2, status.exitstatus
       assert_includes out, "SECURITY_PREFLIGHT_BLOCKED"
-      assert_includes out, "claude: no visible comment/review/commit/reaction trail"
+      assert_includes out, "Copilot: no visible comment/review/commit/reaction trail"
       assert_includes out, "not in trusted actor allowlist"
+    end
+  end
+
+  def test_bare_bot_alias_fails_closed_when_canonical_lookup_fails
+    with_fake_gh("canonical-bot-query-failure-participant") do |env, trust_config_path, _log_path|
+      File.write(trust_config_path, <<~YAML)
+        trusted_users: []
+        trusted_bots:
+          - copilot
+          - copilot-pull-request-reviewer
+        trusted_teams: []
+      YAML
+
+      out, status = run_script(
+        env,
+        "--repo",
+        "owner/repo",
+        "--trust-config",
+        trust_config_path,
+        "--strict-trust",
+        "123"
+      )
+
+      refute status.success?, out
+      assert_equal 2, status.exitstatus
+      assert_includes out, "WARN: could not resolve canonical bot identity for node BOT_kgDOCnlnWA"
+      assert_includes out, "SECURITY_PREFLIGHT_BLOCKED"
+      assert_includes out, "Copilot: no visible comment/review/commit/reaction trail"
+      assert_includes out, "not in trusted actor allowlist"
+    end
+  end
+
+  def test_bare_bot_alias_without_node_id_fails_closed_without_lookup
+    with_fake_gh("bare-bot-missing-id-participant") do |env, trust_config_path, log_path|
+      File.write(trust_config_path, <<~YAML)
+        trusted_users: []
+        trusted_bots:
+          - copilot
+          - copilot-pull-request-reviewer
+        trusted_teams: []
+      YAML
+
+      out, status = run_script(
+        env,
+        "--repo",
+        "owner/repo",
+        "--trust-config",
+        trust_config_path,
+        "--strict-trust",
+        "123"
+      )
+
+      refute status.success?, out
+      assert_equal 2, status.exitstatus
+      assert_includes out, "SECURITY_PREFLIGHT_BLOCKED"
+      assert_includes out, "Copilot: no visible comment/review/commit/reaction trail"
+      assert_equal 0, canonical_bot_query_call_count(log_path)
+    end
+  end
+
+  def test_bare_bot_aliases_share_canonical_node_cache
+    with_fake_gh("cached-bare-bot-alias-participants") do |env, trust_config_path, log_path|
+      File.write(trust_config_path, <<~YAML)
+        trusted_users: []
+        trusted_bots:
+          - copilot
+          - copilot-alias
+          - copilot-pull-request-reviewer
+        trusted_teams: []
+      YAML
+
+      out, status = run_script(
+        env,
+        "--repo",
+        "owner/repo",
+        "--trust-config",
+        trust_config_path,
+        "--strict-trust",
+        "123"
+      )
+
+      assert status.success?, out
+      assert_includes out, "SECURITY_PREFLIGHT_OK"
+      assert_includes out, "Untrusted or hidden participant findings: none"
+      assert_equal 1, canonical_bot_query_call_count(log_path)
+    end
+  end
+
+  def test_human_login_matching_bot_base_name_is_not_trusted_as_bot
+    with_fake_gh("human-bot-basename-participant") do |env, trust_config_path, log_path|
+      File.write(trust_config_path, <<~YAML)
+        trusted_users: []
+        trusted_bots:
+          - copilot
+        trusted_teams: []
+      YAML
+
+      out, status = run_script(
+        env,
+        "--repo",
+        "owner/repo",
+        "--trust-config",
+        trust_config_path,
+        "--strict-trust",
+        "123"
+      )
+
+      refute status.success?, out
+      assert_equal 2, status.exitstatus
+      assert_includes out, "SECURITY_PREFLIGHT_BLOCKED"
+      assert_includes out, "Copilot: no visible comment/review/commit/reaction trail"
+      assert_includes out, "not in trusted actor allowlist"
+      assert_equal 1, canonical_bot_query_call_count(log_path)
+    end
+  end
+
+  def test_blank_trusted_bot_entry_does_not_trust_human_canonical_node
+    with_fake_gh("human-bot-basename-participant") do |env, trust_config_path, log_path|
+      File.write(trust_config_path, <<~YAML)
+        trusted_users: []
+        trusted_bots:
+          - copilot
+          - null
+        trusted_teams: []
+      YAML
+
+      out, status = run_script(
+        env,
+        "--repo",
+        "owner/repo",
+        "--trust-config",
+        trust_config_path,
+        "--strict-trust",
+        "123"
+      )
+
+      refute status.success?, out
+      assert_equal 2, status.exitstatus
+      assert_includes out, "SECURITY_PREFLIGHT_BLOCKED"
+      assert_includes out, "Copilot: no visible comment/review/commit/reaction trail"
+      assert_includes out, "not in trusted actor allowlist"
+      assert_equal 1, canonical_bot_query_call_count(log_path)
     end
   end
 
@@ -2287,6 +2465,12 @@ class PrSecurityPreflightTest < Minitest::Test
 
   private
 
+  def assert_trust_config_evidence(out, path:, source:)
+    lines = out.lines.map(&:chomp)
+    assert_includes lines, "Trust config: #{File.expand_path(path)}"
+    assert_includes lines, "Trust config source: #{source}"
+  end
+
   def run_script(env, *args, chdir: nil, clear_git_env: true)
     options = {}
     options[:chdir] = chdir if chdir
@@ -2383,6 +2567,10 @@ class PrSecurityPreflightTest < Minitest::Test
 
   def graphql_call_count(log_path)
     File.readlines(log_path).count { |line| line.start_with?("api graphql") }
+  end
+
+  def canonical_bot_query_call_count(log_path)
+    File.readlines(log_path).count { |line| line.include?("query CanonicalBot") }
   end
 
   def fake_gh_script(log_path)
@@ -2515,7 +2703,11 @@ class PrSecurityPreflightTest < Minitest::Test
 
       mode_uses_issue_author_payload() {
         case "$1" in
-          reaction-only-participant|trusted-hidden-participant|trusted-bot-participant|human-bot-basename-participant|\
+          reaction-only-participant|trusted-hidden-participant|trusted-bot-participant|\
+          canonical-bare-bot-alias-participant|canonical-bot-mismatch-participant|\
+          canonical-bot-query-failure-participant|\
+          bare-bot-missing-id-participant|cached-bare-bot-alias-participants|\
+          human-bot-basename-participant|\
           paginated-timeline|paginated-timeline-missing-page-info|paginated-timeline-page-fetch-failure|\
           paginated-timeline-cursor-cycle|paginated-timeline-partial-error|paginated-participants)
             return 0
@@ -2618,6 +2810,27 @@ class PrSecurityPreflightTest < Minitest::Test
       {"data":{"repository":{"issue":{"number":${number},"title":"Maintainer target ${number}","url":"https://github.com/acme/widgets/issues/${number}","author":{"login":"maintainer-login"},"participants":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"login":"maintainer-login","url":"https://github.com/maintainer-login","__typename":"User"}]},"timelineItems":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"__typename":"IssueComment","author":{"login":"maintainer-login"}}]}}}}}
       JSON
             exit 0
+          fi
+        elif [[ "$*" == *"query CanonicalBot"* ]]; then
+          if [ "$mode" = "canonical-bare-bot-alias-participant" ] ||
+             [ "$mode" = "cached-bare-bot-alias-participants" ]; then
+            cat <<'JSON'
+      {"data":{"node":{"id":"BOT_kgDOCnlnWA","__typename":"Bot","login":"copilot-pull-request-reviewer"}}}
+      JSON
+          elif [ "$mode" = "canonical-bot-mismatch-participant" ]; then
+            cat <<'JSON'
+      {"data":{"node":{"id":"BOT_kgDOCnlnWA","__typename":"Bot","login":"other-reviewer"}}}
+      JSON
+          elif [ "$mode" = "canonical-bot-query-failure-participant" ]; then
+            printf 'simulated canonical node lookup failure\\n' >&2
+            exit 1
+          elif [ "$mode" = "human-bot-basename-participant" ]; then
+            cat <<'JSON'
+      {"data":{"node":{"id":"U_kgDOCnlnWA","__typename":"User"}}}
+      JSON
+          else
+            printf 'unexpected canonical bot lookup for mode: %s\\n' "$mode" >&2
+            exit 1
           fi
         elif [[ "$*" == *"reviewThreads"* ]]; then
           if [ "$mode" = "resolved-trusted-bot-review-comment" ] || [ "$mode" = "resolved-metadata-bot-warning-review-comment" ]; then
@@ -2747,9 +2960,23 @@ class PrSecurityPreflightTest < Minitest::Test
           cat <<'JSON'
       {"data":{"repository":{"issue":{"number":123,"title":"Test issue","url":"https://github.com/owner/repo/issues/123","author":{"login":"issue-author"},"participants":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"login":"coderabbitai[bot]","url":"https://github.com/apps/coderabbitai","__typename":"Bot"}]},"timelineItems":{"totalCount":0,"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}
       JSON
+        elif [ "$mode" = "canonical-bare-bot-alias-participant" ] ||
+             [ "$mode" = "canonical-bot-mismatch-participant" ] ||
+             [ "$mode" = "canonical-bot-query-failure-participant" ]; then
+          cat <<'JSON'
+      {"data":{"repository":{"issue":{"number":123,"title":"Test issue","url":"https://github.com/owner/repo/issues/123","author":{"login":"issue-author"},"participants":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"id":"BOT_kgDOCnlnWA","login":"Copilot","url":"https://github.com/apps/github-copilot-code-review","__typename":"User"}]},"timelineItems":{"totalCount":0,"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}
+      JSON
+        elif [ "$mode" = "bare-bot-missing-id-participant" ]; then
+          cat <<'JSON'
+      {"data":{"repository":{"issue":{"number":123,"title":"Test issue","url":"https://github.com/owner/repo/issues/123","author":{"login":"issue-author"},"participants":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"login":"Copilot","url":"https://github.com/apps/github-copilot-code-review","__typename":"User"}]},"timelineItems":{"totalCount":0,"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}
+      JSON
+        elif [ "$mode" = "cached-bare-bot-alias-participants" ]; then
+          cat <<'JSON'
+      {"data":{"repository":{"issue":{"number":123,"title":"Test issue","url":"https://github.com/owner/repo/issues/123","author":{"login":"issue-author"},"participants":{"totalCount":2,"pageInfo":{"hasNextPage":false},"nodes":[{"id":"BOT_kgDOCnlnWA","login":"Copilot","url":"https://github.com/apps/github-copilot-code-review","__typename":"User"},{"id":"BOT_kgDOCnlnWA","login":"Copilot-Alias","url":"https://github.com/apps/github-copilot-code-review","__typename":"User"}]},"timelineItems":{"totalCount":0,"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}
+      JSON
         elif [ "$mode" = "human-bot-basename-participant" ]; then
           cat <<'JSON'
-      {"data":{"repository":{"issue":{"number":123,"title":"Test issue","url":"https://github.com/owner/repo/issues/123","author":{"login":"issue-author"},"participants":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"login":"claude","url":"https://github.com/claude","__typename":"User"}]},"timelineItems":{"totalCount":0,"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}
+      {"data":{"repository":{"issue":{"number":123,"title":"Test issue","url":"https://github.com/owner/repo/issues/123","author":{"login":"issue-author"},"participants":{"totalCount":1,"pageInfo":{"hasNextPage":false},"nodes":[{"id":"U_kgDOCnlnWA","login":"Copilot","url":"https://github.com/Copilot","__typename":"User"}]},"timelineItems":{"totalCount":0,"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}
       JSON
         elif [ "$mode" = "metadata-bot-comment" ]; then
           cat <<'JSON'

--- a/.agents/trusted-github-actors.yml
+++ b/.agents/trusted-github-actors.yml
@@ -12,6 +12,8 @@ trusted_bots:
   - chatgpt-codex-connector
   - claude
   - coderabbitai
+  - copilot
+  - copilot-pull-request-reviewer
   - cursor
   - dependabot
   - greptile-apps


### PR DESCRIPTION
## Why

React on Rails strict GitHub trust currently blocks Copilot review evidence because GitHub exposes the pull-request participant as a bare, User-shaped `Copilot` alias while review records use the canonical `copilot-pull-request-reviewer[bot]` identity.

This consumes the fail-closed canonical-node resolution merged in shakacode/agent-workflows#270 and explicitly allowlists both identities. A human account with a matching name still cannot inherit bot trust: both the configured alias and the canonical GraphQL `Bot` login must match.

## What changed

- Allow `copilot` and `copilot-pull-request-reviewer` as actionable trusted bots.
- Pin the exact merged preflight helper and regression tests from agent-workflows#270.
- Record the two files as reviewed drift overlays while retaining the repository's global Agent Workflows source revision, avoiding unrelated workflow drift.
- Leave trusted users and metadata-only actors unchanged.

## Security evidence

- Before: strict preflight on react_on_rails#4804 exited 2, blocked by the hidden User-shaped `Copilot` participant and canonical Copilot review author.
- After: the same live strict preflight exits 0 with `SECURITY_PREFLIGHT_OK` and no acknowledgement.
- Missing IDs, failed lookups, human nodes, canonical mismatches, null/blank identities, and malformed responses remain fail-closed.
- No GitHub node ID is hardcoded.

## Validation

- Focused identity tests: 7 runs, 54 assertions.
- Full preflight suite: 108 runs, 913 assertions.
- Other affected pinned-helper suites: 14/81, 54/476, and 66/234.
- Drift manifest: 42 mapped, 4 excluded; 24 identical, 18 expected overlays, 0 unexpected drift.
- Agent workflow seam doctor: PASS.
- `.agents/bin/validate --changed`: PASS.
- CI-equivalent OSS RuboCop: 244 files, no offenses.
- Focused agent RuboCop, Prettier, pre-commit hooks, and committed diff checks: PASS.
- Pinned helper/test bytes match agent-workflows merge commit `7ef1dcad43980ac6fcb9008ddc3bc27e643b1f51` exactly.

Changelog: release-process/internal workflow policy; no product changelog entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved security preflight checks by recognizing trusted bot aliases through canonical identities.
  - Added clearer reporting of which trust configuration is being used.
  - Added support for additional trusted Copilot bot identities.

- **Bug Fixes**
  - Prevented mismatched, unresolved, or incomplete bot identities from being trusted incorrectly.
  - Improved handling and caching of canonical bot lookups.

- **Tests**
  - Expanded coverage for trust configuration selection, bot identity validation, lookup failures, and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->