### PR TITLE
Handle selector metacharacters in renderComponent DOM IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   [PR 4804](https://github.com/shakacode/react_on_rails/pull/4804) by
   [justin808](https://github.com/justin808).
 
+- **`renderComponent` now handles DOM IDs containing selector metacharacters**: Component payloads are
+  matched by their exact `data-dom-id` attribute value, so valid IDs containing quotes, backslashes,
+  hashes, periods, or brackets no longer throw selector errors or fail to render. Fixes
+  [Issue 4585](https://github.com/shakacode/react_on_rails/issues/4585).
+  [PR 4808](https://github.com/shakacode/react_on_rails/pull/4808) by
+  [justin808](https://github.com/justin808).
+
 - **Stopped Doctor from warning when a layout uses only one pack helper**: `rake react_on_rails:doctor`
   no longer emits `⚠️ <layout>: has javascript_pack_tag but missing stylesheet_pack_tag` (or its mirror)
   based purely on helper asymmetry. A JavaScript-only Shakapacker entrypoint, a CSS-only pack, and a

--- a/packages/react-on-rails/src/ClientRenderer.ts
+++ b/packages/react-on-rails/src/ClientRenderer.ts
@@ -519,8 +519,15 @@ export function renderComponent(domId: string): void {
   // Initialize stores first
   forEachStore(railsContext);
 
-  // Find the element with the matching data-dom-id
-  const el = document.querySelector(`[data-dom-id="${domId}"]`);
+  // Compare attribute values directly so valid DOM IDs do not need CSS-selector escaping.
+  let el: Element | null = null;
+  const componentElements = document.querySelectorAll('[data-dom-id]');
+  for (let index = 0; index < componentElements.length; index += 1) {
+    if (componentElements[index].getAttribute('data-dom-id') === domId) {
+      el = componentElements[index];
+      break;
+    }
+  }
   if (!el) return;
 
   renderElement(el, railsContext);

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -115,6 +115,31 @@ describe('ClientRenderer', () => {
       expect(targetNode.innerHTML).toContain('Rendered:');
     });
 
+    it.each(['component"quoted', 'component\\backslash', 'component#selector.metachar[one]'])(
+      'renders a component whose DOM ID contains selector metacharacters: %s',
+      (domId) => {
+        setupRailsContext();
+
+        const TestComponent: React.FC<{ message: string }> = ({ message }) =>
+          React.createElement('div', null, `Hello, ${message}!`);
+        ComponentRegistry.register({ TestComponent });
+
+        const componentElement = document.createElement('div');
+        componentElement.className = 'js-react-on-rails-component';
+        componentElement.setAttribute('data-component-name', 'TestComponent');
+        componentElement.setAttribute('data-dom-id', domId);
+        componentElement.textContent = JSON.stringify({ message: 'World' });
+        document.body.appendChild(componentElement);
+
+        const targetNode = document.createElement('div');
+        targetNode.id = domId;
+        document.body.appendChild(targetNode);
+
+        expect(() => renderComponent(domId)).not.toThrow();
+        expect(targetNode.innerHTML).toContain('Rendered:');
+      },
+    );
+
     it('handles missing Rails context gracefully', () => {
       // Don't setup Rails context - should return early without error
       renderComponent('test-component');


### PR DESCRIPTION
## Why

`renderComponent(domId)` interpolated the ID into a CSS attribute selector. Valid DOM IDs containing quotes, backslashes, or selector metacharacters could therefore throw a selector syntax error or fail to locate their component payload.

## What changed

- Locate component payload elements with a static `[data-dom-id]` selector.
- Compare each `data-dom-id` attribute value directly with the requested ID.
- Add focused coverage for quote, backslash, and combined selector-metacharacter IDs.

Fixes #4585.

## Test plan

- `pnpm --filter react-on-rails exec jest tests/ClientRenderer.test.ts --runInBand` (44 tests)
- `pnpm --dir react_on_rails/spec/dummy run build:test`
- `(cd react_on_rails && bundle exec rake run_rspec:dummy)` (389 examples, 0 failures, 1 pending)
- `bin/ci-local --changed` completed every earlier selected stage; its dummy-app stage initially lacked the generated test manifest, which the explicit build plus full dummy suite verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed component rendering for DOM IDs containing special characters such as quotes, backslashes, hashes, periods, or brackets.
  * Prevented selector-related errors and render failures when using these IDs.

* **Tests**
  * Added coverage for rendering components with complex DOM IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->