### PR TITLE
Forward-port the 17.0.1 changelog section to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,16 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
   [PR 4579](https://github.com/shakacode/react_on_rails/pull/4579) by
   [alexeyr-ci2](https://github.com/alexeyr-ci2).
 
+### [17.0.1] - 2026-07-26
+
+#### Fixed
+
+- **Corrected the OSS npm package license metadata and packed license**: `react-on-rails` now declares
+  `MIT`, includes a package-local MIT license in the published tarball, and verifies the packed
+  artifact cannot inherit React on Rails Pro commercial terms.
+  [PR 4792](https://github.com/shakacode/react_on_rails/pull/4792) by
+  [justin808](https://github.com/justin808).
+
 ### [17.0.0] - 2026-07-16
 
 #### Breaking Changes
@@ -3005,7 +3015,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.1...main
+[17.0.1]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...v17.0.1
 [17.0.0]: https://github.com/shakacode/react_on_rails/compare/v16.6.0...v17.0.0
 [16.6.0]: https://github.com/shakacode/react_on_rails/compare/v16.5.1...v16.6.0
 [16.5.1]: https://github.com/shakacode/react_on_rails/compare/v16.5.0...v16.5.1


### PR DESCRIPTION
Fixes #4813

## What changed and why

`main`'s `CHANGELOG.md` skipped from `[Unreleased]` straight to `[17.0.0]` because the
17.0.1 release-reconciliation PR onto `main` was never opened (v17.0.1 shipped from
`release/17.0.1`, tag `v17.0.1` = `88c0de5b8994d7ed9bcd2cc2405d2e520e1bf20a`, but that
work never landed on `main`). This PR is pure changelog bookkeeping:

- Copied the `### [17.0.1] - 2026-07-26` section **verbatim** from
  `origin/release/17.0.1:CHANGELOG.md` (the OSS `react-on-rails` npm MIT license
  correction, PR #4792) and placed it between `[Unreleased]` and `[17.0.0] - 2026-07-16`.
- Added the `[17.0.1]` compare link in sorted position, right above `[17.0.0]`.
- Corrected the stale `[unreleased]` compare link (`v17.0.0...main` →
  `v17.0.1...main`), matching the precedent `release/17.0.1`'s own CHANGELOG.md already
  set for that link when it bumped.
- No `[Unreleased]` entries were moved: main's `[Unreleased]` block does **not** already
  contain the 17.0.1 entry (verified below), so nothing needed relocating.

## Evidence

Version headers before/after (`grep -n '^### \[' CHANGELOG.md | head`):

Before (base `822b4c30`):
```
25:### [Unreleased]
261:### [17.0.0] - 2026-07-16
931:### [16.6.0] - 2026-04-09
```

After:
```
25:### [Unreleased]
261:### [17.0.1] - 2026-07-26
271:### [17.0.0] - 2026-07-16
941:### [16.6.0] - 2026-04-09
```

Prettier:
```
$ pnpm exec prettier --check CHANGELOG.md
Checking formatting...
All matched files use Prettier code style!
```

`git diff --stat` against base `822b4c30bc3764a08454a7e891834b2699921a03`:
```
 CHANGELOG.md | 13 ++++++++++++-
 1 file changed, 12 insertions(+), 1 deletion(-)
```
**No runtime source in this diff** — only `CHANGELOG.md` is touched.

Verbatim-insertion check: diffed the inserted `### [17.0.1]` section (headers through
the PR #4792 entry) against the same range in `origin/release/17.0.1:CHANGELOG.md` —
identical, zero-line diff.

Tag verification:
- `v17.0.1` = `88c0de5b8994d7ed9bcd2cc2405d2e520e1bf20a` (matches the issue and envelope).
- `v17.0.0` = `d2e64e4043bcd22ea9e81c44d14f234cf3c361a5` (used by the pre-existing
  `[17.0.0]` compare link, confirmed unchanged).

Already-shipped `[Unreleased]` entries: **none found**. Searched main's `[Unreleased]`
block for the PR #4792 / "OSS npm package license metadata" text — no match. (An
unrelated `[Pro] Configurable license-token secret sources` entry, PR #4552, also
mentions "license" but is a different, still-unreleased feature — not the 17.0.1 fix.)

Pre-commit/pre-push hooks (lefthook) ran clean: `trailing-newlines`, `markdown-links`,
`prettier` on commit; `branch-lint`, `markdown-links` on push.

## Labels: none

Docs/changelog-only change; no code labels apply.

## Codex Decision Log

**Question:** The envelope's worked example only called out fixing the `[17.0.0]`
compare link and adding `[17.0.1]`. Main also has a stale `[unreleased]: ...v17.0.0...main`
link at the bottom of the file that logically should advance to `v17.0.1...main` now that
`[Unreleased]` sits after `[17.0.1]` in the document structure. Is that in scope?

**Decision:** Fixed it as part of this PR.

**Why:** It's the same file, the same "fix link references at the bottom of the file"
instruction, a one-line mechanical correction, and `release/17.0.1`'s own CHANGELOG.md
already made the identical correction (`[unreleased]: ...v17.0.1...main`) when it
bumped — so this brings main in line with the established precedent rather than
introducing a new convention.

**What a maintainer may want to revisit:** If this single extra line is considered
out of the tightly-scoped envelope, it can be reverted with a one-line diff; everything
else in this PR is independent of it.

Confidence note:
- Validated: `git fetch --prune origin main release/17.0.1`; `git rev-parse v17.0.1`
  and `v17.0.0` (both resolved and match expected SHAs); `pnpm install --prefer-offline`
  (succeeded, required for the prettier pre-commit hook); `pnpm exec prettier --check
  CHANGELOG.md` (pass, both before commit and after final edit); `git diff --stat`
  against pinned base SHA (CHANGELOG.md only, 12 insertions/1 deletion); manual diff of
  the inserted `[17.0.1]` section against `origin/release/17.0.1:CHANGELOG.md` (identical);
  grep of main's `[Unreleased]` block for PR 4792 / license text (no match — nothing to
  move); `agent-coord status --target 4813` checked twice (before editing and
  immediately before push) — claim holder `maker-lane-4813-changelog-171` confirmed
  both times; `git commit` and `git push` ran with lefthook pre-commit/pre-push hooks,
  all green.
- Evidence: inline command output above; issue body fetched via
  `gh issue view 4813 --repo shakacode/react_on_rails --json title,body,state,labels`
  (matches this envelope's framing exactly, no discrepancies).
- UNKNOWN: none.
- Residual risk: none — single-file, additive changelog change; no runtime source
  touched; verbatim-copy verified byte-for-byte against the release branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected open-source package license metadata.
  - Ensured package distributions do not inherit commercial licensing terms.

- **Documentation**
  - Added release notes for version 17.0.1.
  - Updated changelog comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Merge qualifications (coordinator)

**Release gate applied: `beta`.** Target branch is `main`, whose release phase is `beta` per
`AGENTS.md` -> Release-Train Branching And Phase Gating. The `beta` row requires the lowest
gate: confidence note + green required checks. Both are satisfied — the confidence note is
above, and `required-pr-gate` passed with zero failing checks at head
`d7555e71058b0431187bdd410aa035611c2f3ef9`.

**Release mode: `development`.** The only open release tracker is #4806, whose final release
target is 17.0.1 — already shipped (tag `v17.0.1` = `88c0de5b8994d7ed9bcd2cc2405d2e520e1bf20a`).
Per `AGENTS.md`, an unrelated final-release target does not block work whose own target is
clear; this PR targets `main` on the 17.1 line, for which no tracker exists, so `development`
applies. The accelerated-RC confidence block is therefore not required.

**Merge ledger:** `script/pr-merge-ledger 4814 --strict --changelog-classification not_user_visible`
-> `complete_allowed: true`, zero violations, zero unknown fields, CI verdict `READY`, zero
unresolved current-head review threads, no `changes_requested`.

**Changelog classification: `not_user_visible`.** Supplied explicitly by the coordinator.
Release-reconciliation bookkeeping is `release-process` per the `AGENTS.md` taxonomy and
introduces no user-visible behavior needing its own `[Unreleased]` entry.

**Coordinator verification (independent of the authoring worker):** re-extracted the
`[17.0.1]` section from both `origin/release/17.0.1` and this PR head and diffed them
(identical); confirmed `CHANGELOG.md` is the only changed path; confirmed `v17.0.0` and
`v17.0.1` both resolve; independently confirmed main's `[Unreleased]` never contained the
shipped PR 4792 entry, so the "move not copy" requirement was vacuous here.

**UNKNOWN carried forward:** the installed Agent Workflows pack ships an
`autonomous-merge-eligibility` gate that this repository has not adopted — none of its
required runtime-trust paths (`.agents/skills/pr-batch/bin/autonomous-merge-eligibility`,
`.agents/skills/pr-batch/lib/autonomous_merge_decision.rb`,
`.agents/bin/agent_doctor/autonomous_merge_policy.rb`, and the calibration fixture) exist in
`origin/main`, so its runtime-trust binding cannot verify here by construction. This merge
therefore rests on the repository's own adopted contract (`AGENTS.md` phase gate +
`script/pr-merge-ledger --strict`), not on that helper. Recorded rather than silently skipped.

Batch: `ror-a-17-1-wave-a-20260729`, lane `lane-4813-changelog-171`. `merge_authority: auto_merge_when_gates_pass`.
