### PR TITLE
Honor response charset and reject non-2xx HTTP-served SSR bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,14 +40,18 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4821](https://github.com/shakacode/react_on_rails/pull/4821) by
   [justin808](https://github.com/justin808).
 
-- **HTTP-served SSR bundle loading now honors the response charset and rejects non-2xx responses**:
+- **HTTP-served SSR bundle loading now honors the response charset, rejects non-2xx responses,
+  and no longer leaks URL credentials into error messages**:
   When `server_bundle_js_file` resolves to an HTTP(S) URL, `RubyEmbeddedJavaScript.file_url_to_string`
   no longer assumes the `Content-Type` header always ends in an exact `; charset=...` form. A response
   with no charset, a `Content-Type` with no charset parameter, a missing `Content-Type` header, or a
-  quoted charset value (`charset="ISO-8859-1"`) now decodes successfully instead of raising, falling
-  back to UTF-8 when no usable charset is declared. A non-2xx response (for example a 404 page or a
-  proxy error) is now rejected with a clear bundle-load error naming the URL and status, instead of
-  being returned as if it were JavaScript bundle source. Fixes
+  quoted charset value (`charset="ISO-8859-1"`) now transcodes to UTF-8 successfully instead of
+  raising or silently mislabeling the bytes, falling back to UTF-8 when no usable charset is declared.
+  A non-2xx response (for example a 404 page or a proxy error) is now rejected with a clear
+  bundle-load error naming the URL and status, instead of being returned as if it were JavaScript
+  bundle source. Additionally, a `server_bundle_js_file` URL with embedded HTTP basic-auth
+  credentials (e.g. `https://:password@host:3800/bundle.js`) no longer leaks that password into
+  raised errors or logs on a load failure. Fixes
   [Issue 4584](https://github.com/shakacode/react_on_rails/issues/4584).
   [PR 4817](https://github.com/shakacode/react_on_rails/pull/4817) by
   [justin808](https://github.com/justin808).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4821](https://github.com/shakacode/react_on_rails/pull/4821) by
   [justin808](https://github.com/justin808).
 
+- **HTTP-served SSR bundle loading now honors the response charset and rejects non-2xx responses**:
+  When `server_bundle_js_file` resolves to an HTTP(S) URL, `RubyEmbeddedJavaScript.file_url_to_string`
+  no longer assumes the `Content-Type` header always ends in an exact `; charset=...` form. A response
+  with no charset, a `Content-Type` with no charset parameter, a missing `Content-Type` header, or a
+  quoted charset value (`charset="ISO-8859-1"`) now decodes successfully instead of raising, falling
+  back to UTF-8 when no usable charset is declared. A non-2xx response (for example a 404 page or a
+  proxy error) is now rejected with a clear bundle-load error naming the URL and status, instead of
+  being returned as if it were JavaScript bundle source. Fixes
+  [Issue 4584](https://github.com/shakacode/react_on_rails/issues/4584).
+  [PR 4817](https://github.com/shakacode/react_on_rails/pull/4817) by
+  [justin808](https://github.com/justin808).
+
 - **RailsContext now stays current across Turbo and Turbolinks navigation**: Parsed context is cached
   only while its source element and JSON text remain unchanged. Replacing the context element or
   morphing its payload in place now makes the next core render or immediate Pro hydration receive the

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -159,7 +159,7 @@ module ReactOnRails
           # (a supported config convenience, e.g. https://:password@host:3800). This is the
           # public entry point that file_url_to_string is called from, so without this the
           # sanitization inside file_url_to_string's own raise/rescue is moot for any real
-          # caller — the credential would still leak here regardless. See PR #4817.
+          # caller — the credential would still leak here regardless.
           msg = "You specified server rendering JS file: #{sanitized_renderer_url(server_js_file)}, but it cannot " \
                 "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
                 "avoid this warning.\nError is: #{e}\n\n#{Utils.default_troubleshooting_section}"
@@ -416,11 +416,21 @@ module ReactOnRails
                   "#{response.code} #{response.message}"
           end
 
-          response.body.dup.force_encoding(charset_from_content_type(response["content-type"]))
+          # Label the bytes with the declared charset, then transcode to UTF-8: ExecJS's
+          # underlying JS runtime parses source as UTF-8, so a body merely *tagged* with its
+          # declared encoding (e.g. ISO-8859-1) rather than actually converted would have its
+          # non-ASCII bytes silently corrupted once the runtime re-interprets them as UTF-8.
+          # An undecodable byte sequence (a charset that doesn't actually match the bytes) is
+          # deliberately allowed to raise here rather than silently replaced with U+FFFD: this is
+          # source code, and replacing corrupt bytes would produce a bundle that parses but
+          # behaves wrongly, which is harder to diagnose than a clear load failure naming the URL.
+          response.body.dup
+                  .force_encoding(charset_from_content_type(response["content-type"]))
+                  .encode(Encoding::UTF_8)
         rescue StandardError => e
           # Sanitized here too: a non-2xx response (e.g. 401/403 from a bad-credentials config) is
           # exactly the failure mode that would otherwise put a URL's embedded password into this
-          # message, which Rails.logger and error trackers can persist. See PR #4817 review discussion.
+          # message, which Rails.logger and error trackers can persist.
           msg = "file_url_to_string #{sanitized_renderer_url(url)} failed\nError is: #{e}\n\n" \
                 "#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -159,10 +159,13 @@ module ReactOnRails
           # (a supported config convenience, e.g. https://:password@host:3800). This is the
           # public entry point that file_url_to_string is called from, so without this the
           # sanitization inside file_url_to_string's own raise/rescue is moot for any real
-          # caller — the credential would still leak here regardless.
+          # caller — the credential would still leak here regardless. e.message is scrubbed too:
+          # a URL malformed enough that URI.parse raises embeds the raw, unsanitized URL verbatim
+          # in URI::InvalidURIError's own message.
           msg = "You specified server rendering JS file: #{sanitized_renderer_url(server_js_file)}, but it cannot " \
                 "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
-                "avoid this warning.\nError is: #{e}\n\n#{Utils.default_troubleshooting_section}"
+                "avoid this warning.\nError is: #{strip_userinfo(e.message)}\n\n" \
+                "#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
 
@@ -404,9 +407,18 @@ module ReactOnRails
           uri.user = nil
           uri.to_s
         rescue URI::InvalidURIError
-          # Best-effort strip of the common user:pass@ form so a URL that URI rejects as
-          # malformed still doesn't leak a password into the message or logs.
-          url.to_s.gsub(%r{//[^/@]*@}, "//")
+          # A URL malformed enough that URI rejects it still shouldn't leak credentials.
+          strip_userinfo(url)
+        end
+
+        # Best-effort strip of the common user:pass@ form from arbitrary text — not just a URL
+        # value, but also free-form text that may quote one, such as the message of a
+        # URI::InvalidURIError raised from an unparseable credential-bearing URL (that message
+        # embeds the raw original string verbatim). Shared by sanitized_renderer_url's malformed-
+        # URL fallback and by the rescue blocks below, so there is exactly one definition of
+        # "strip userinfo" rather than two regexes that can drift apart.
+        def strip_userinfo(text)
+          text.to_s.gsub(%r{//[^/@]*@}, "//")
         end
 
         def file_url_to_string(url)
@@ -430,9 +442,11 @@ module ReactOnRails
         rescue StandardError => e
           # Sanitized here too: a non-2xx response (e.g. 401/403 from a bad-credentials config) is
           # exactly the failure mode that would otherwise put a URL's embedded password into this
-          # message, which Rails.logger and error trackers can persist.
-          msg = "file_url_to_string #{sanitized_renderer_url(url)} failed\nError is: #{e}\n\n" \
-                "#{Utils.default_troubleshooting_section}"
+          # message, which Rails.logger and error trackers can persist. e.message is scrubbed as
+          # well as url itself: a URL malformed enough that URI.parse raises embeds the raw,
+          # unsanitized URL verbatim in URI::InvalidURIError's own message.
+          msg = "file_url_to_string #{sanitized_renderer_url(url)} failed\nError is: " \
+                "#{strip_userinfo(e.message)}\n\n#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
 

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -155,8 +155,13 @@ module ReactOnRails
             File.read(server_js_file)
           end
         rescue StandardError => e
-          msg = "You specified server rendering JS file: #{server_js_file}, but it cannot be " \
-                "read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
+          # Sanitized: server_js_file may be an HTTP(S) URL with embedded basic-auth credentials
+          # (a supported config convenience, e.g. https://:password@host:3800). This is the
+          # public entry point that file_url_to_string is called from, so without this the
+          # sanitization inside file_url_to_string's own raise/rescue is moot for any real
+          # caller — the credential would still leak here regardless. See PR #4817.
+          msg = "You specified server rendering JS file: #{sanitized_renderer_url(server_js_file)}, but it cannot " \
+                "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
                 "avoid this warning.\nError is: #{e}\n\n#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -406,13 +406,31 @@ module ReactOnRails
 
         def file_url_to_string(url)
           response = Net::HTTP.get_response(URI.parse(url))
-          content_type_header = response["content-type"]
-          match = content_type_header.match(/\A.*; charset=(?<encoding>.*)\z/)
-          encoding_type = match[:encoding]
-          response.body.force_encoding(encoding_type)
+          unless response.is_a?(Net::HTTPSuccess)
+            raise "GET #{url} returned a non-success HTTP status: #{response.code} #{response.message}"
+          end
+
+          response.body.dup.force_encoding(charset_from_content_type(response["content-type"]))
         rescue StandardError => e
           msg = "file_url_to_string #{url} failed\nError is: #{e}\n\n#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
+        end
+
+        # Extracts the charset from a Content-Type header value (e.g. "application/javascript;
+        # charset=utf-8"), tolerating a quoted charset value (`charset="UTF-8"`, valid per RFC
+        # 7231's quoted-string parameter syntax) and additional parameters after it (e.g.
+        # `charset=utf-8; boundary=...`). Falls back to UTF-8 — the standard default for
+        # JavaScript/JSON source — when the header is missing, has no charset parameter, or
+        # names an encoding Ruby does not recognize, rather than raising on an absent or
+        # malformed charset. See issue #4584.
+        def charset_from_content_type(content_type_header)
+          match = content_type_header.to_s.match(/;\s*charset=(?<encoding>[^;]+)/i)
+          return Encoding::UTF_8 unless match
+
+          charset = match[:encoding].strip.delete_prefix('"').delete_suffix('"')
+          Encoding.find(charset)
+        rescue ArgumentError
+          Encoding::UTF_8
         end
 
         def parse_render_result(result_string, render_options)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -407,12 +407,17 @@ module ReactOnRails
         def file_url_to_string(url)
           response = Net::HTTP.get_response(URI.parse(url))
           unless response.is_a?(Net::HTTPSuccess)
-            raise "GET #{url} returned a non-success HTTP status: #{response.code} #{response.message}"
+            raise "GET #{sanitized_renderer_url(url)} returned a non-success HTTP status: " \
+                  "#{response.code} #{response.message}"
           end
 
           response.body.dup.force_encoding(charset_from_content_type(response["content-type"]))
         rescue StandardError => e
-          msg = "file_url_to_string #{url} failed\nError is: #{e}\n\n#{Utils.default_troubleshooting_section}"
+          # Sanitized here too: a non-2xx response (e.g. 401/403 from a bad-credentials config) is
+          # exactly the failure mode that would otherwise put a URL's embedded password into this
+          # message, which Rails.logger and error trackers can persist. See PR #4817 review discussion.
+          msg = "file_url_to_string #{sanitized_renderer_url(url)} failed\nError is: #{e}\n\n" \
+                "#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
 

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -432,13 +432,29 @@ module ReactOnRails
           # underlying JS runtime parses source as UTF-8, so a body merely *tagged* with its
           # declared encoding (e.g. ISO-8859-1) rather than actually converted would have its
           # non-ASCII bytes silently corrupted once the runtime re-interprets them as UTF-8.
+          #
+          # String#encode is a no-op — it does NOT validate — when the source encoding already
+          # equals the destination (UTF-8). charset_from_content_type returns UTF-8 for three of
+          # the four cases this method exists to handle (no Content-Type header, no charset
+          # parameter, and an explicit charset=utf-8), so `.encode(Encoding::UTF_8)` alone would
+          # silently let invalid bytes through unchanged on those three paths — only a genuine
+          # cross-encoding transcode (e.g. a declared ISO-8859-1 body) actually validates via
+          # `encode`. valid_encoding? is therefore checked explicitly afterward so every path
+          # fails fast, not just the cross-encoding one.
+          #
           # An undecodable byte sequence (a charset that doesn't actually match the bytes) is
-          # deliberately allowed to raise here rather than silently replaced with U+FFFD: this is
-          # source code, and replacing corrupt bytes would produce a bundle that parses but
-          # behaves wrongly, which is harder to diagnose than a clear load failure naming the URL.
-          response.body.dup
-                  .force_encoding(charset_from_content_type(response["content-type"]))
-                  .encode(Encoding::UTF_8)
+          # deliberately raised here rather than silently replaced with U+FFFD: this is source
+          # code, and replacing corrupt bytes would produce a bundle that parses but behaves
+          # wrongly, which is harder to diagnose than a clear load failure naming the URL.
+          decoded = response.body.dup
+                            .force_encoding(charset_from_content_type(response["content-type"]))
+                            .encode(Encoding::UTF_8)
+          unless decoded.valid_encoding?
+            raise "response body is not valid UTF-8 after decoding from the declared charset " \
+                  "(GET #{sanitized_renderer_url(url)})"
+          end
+
+          decoded
         rescue StandardError => e
           # Sanitized here too: a non-2xx response (e.g. 401/403 from a bad-credentials config) is
           # exactly the failure mode that would otherwise put a URL's embedded password into this

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -350,6 +350,59 @@ module ReactOnRails
           end
         end
 
+        # PR #4817 review: a non-2xx response is exactly the failure mode a bad-credentials
+        # config produces (401/403 against a URL with embedded basic-auth credentials), so the
+        # status-check path must not put the password in the raised message.
+        #
+        # These two specs call the private `file_url_to_string` directly (rather than through
+        # `read_bundle_js_code`) to isolate the two interpolations that PR #4817 authorized
+        # fixing. `read_bundle_js_code`'s own rescue (line ~158) interpolates the raw URL
+        # independently and has the same leak, but that is a separate method/location outside
+        # this PR's explicitly bounded fix; it is tracked as a follow-up rather than expanded
+        # into here.
+        context "when the HTTP-served bundle URL embeds credentials and the response is non-2xx" do
+          it "does not leak the credential into the raised error message" do
+            server_bundle_url = "http://user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
+
+            not_found_response = Net::HTTPNotFound.new("1.1", "404", "Not Found")
+            not_found_response["content-type"] = "text/html; charset=utf-8"
+            not_found_response.instance_variable_set(:@read, true)
+            not_found_response.instance_variable_set(:@body, "<html><body>Not Found</body></html>")
+
+            allow(Net::HTTP).to receive(:get_response).and_return(not_found_response)
+
+            expect do
+              described_class.send(:file_url_to_string, server_bundle_url)
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("s3cr3t")
+              # The status and a usable (sanitized) URL must still be present for diagnosis.
+              expect(error.message).to include("404")
+              expect(error.message).to include("localhost:3035")
+            }
+          end
+        end
+
+        # PR #4817 review: the outer rescue's message (pre-existing, not introduced by this PR's
+        # non-2xx/charset fix) has the same interpolation gap on any other failure of
+        # Net::HTTP.get_response (e.g. a connection error), so it must be sanitized too.
+        context "when the HTTP-served bundle URL embeds credentials and the connection fails" do
+          it "does not leak the credential into the raised error message" do
+            server_bundle_url = "http://user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
+
+            allow(Net::HTTP).to receive(:get_response).and_raise(
+              Errno::ECONNREFUSED.new("connect(2) for localhost:3035")
+            )
+
+            expect do
+              described_class.send(:file_url_to_string, server_bundle_url)
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("s3cr3t")
+              expect(error.message).to include("localhost:3035")
+              expect(error.message).to include("failed")
+            }
+          end
+        end
+
         # See issue #4584: the charset was assumed to always be present in the exact form
         # "; charset=..." rather than honored from whatever the response actually declares.
         context "when the HTTP-served bundle declares a non-UTF-8 charset" do

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -413,6 +413,32 @@ module ReactOnRails
           end
         end
 
+        # A URL malformed enough that URI.parse itself raises (e.g. a space in the host) fails
+        # before sanitized_renderer_url is ever applied to the `url` variable at the raise site —
+        # URI::InvalidURIError's own message embeds the original credential-bearing string
+        # verbatim, so that message must be scrubbed independently of the url variable.
+        context "when the HTTP-served bundle URL embeds credentials and is malformed enough to fail URI parsing" do
+          it "does not leak the credential into the raised error message" do
+            server_bundle_url = "http://bundle-user:s3cr3t@bad host/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("s3cr3t")
+              expect(error.message).not_to include("bundle-user")
+              # The error must still say the URL was malformed and show enough of it (host/path
+              # minus credentials) for an operator to identify which configured URL failed.
+              expect(error.message).to include("bad URI")
+              expect(error.message).to include("bad host")
+            }
+          end
+        end
+
         # read_bundle_js_code also serves the local (non-HTTP) bundle path, where
         # server_bundle_js_file is a plain filesystem path rather than a URL.
         # sanitized_renderer_url must pass such paths through unchanged (no embedded userinfo to

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -350,17 +350,17 @@ module ReactOnRails
           end
         end
 
-        # PR #4817 review: no error message in this file's HTTP-bundle-loading path may leak a
-        # URL's embedded basic-auth credentials. A non-2xx response is exactly the failure mode
-        # a bad-credentials config produces (401/403), so the status-check path must not put
-        # the password in the raised message. These specs call the public `read_bundle_js_code`
-        # entry point (not the private `file_url_to_string`) because that is the real path every
-        # caller goes through — `read_bundle_js_code`'s own rescue re-interpolates the raw URL
+        # No error message in this file's HTTP-bundle-loading path may leak a URL's embedded
+        # basic-auth credentials. A non-2xx response is exactly the failure mode a bad-credentials
+        # config produces (401/403), so the status-check path must not put the username or
+        # password in the raised message. These specs call the public `read_bundle_js_code` entry
+        # point (not the private `file_url_to_string`) because that is the real path every caller
+        # goes through — `read_bundle_js_code`'s own rescue re-interpolates the raw URL
         # independently of whatever `file_url_to_string` does internally, so sanitizing only the
         # inner method would leave the credential leaking right back out through here.
         context "when the HTTP-served bundle URL embeds credentials and the response is non-2xx" do
           it "does not leak the credential into the raised error message" do
-            server_bundle_url = "http://user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
+            server_bundle_url = "http://bundle-user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
 
             allow(ReactOnRails::Utils).to receive_messages(
               server_bundle_js_file_path: server_bundle_url,
@@ -378,6 +378,7 @@ module ReactOnRails
               described_class.read_bundle_js_code
             end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
               expect(error.message).not_to include("s3cr3t")
+              expect(error.message).not_to include("bundle-user")
               # The status and a usable (sanitized) URL must still be present for diagnosis.
               expect(error.message).to include("404")
               expect(error.message).to include("localhost:3035")
@@ -385,13 +386,13 @@ module ReactOnRails
           end
         end
 
-        # PR #4817 review: read_bundle_js_code's own rescue (the outer wrapper around
-        # file_url_to_string) has the identical interpolation gap on any other failure of
-        # Net::HTTP.get_response (e.g. a connection error), so it must be sanitized too — this
-        # is the path a credentialed URL actually takes when the connection itself fails.
+        # read_bundle_js_code's own rescue (the outer wrapper around file_url_to_string) has the
+        # identical interpolation gap on any other failure of Net::HTTP.get_response (e.g. a
+        # connection error), so it must be sanitized too — this is the path a credentialed URL
+        # actually takes when the connection itself fails.
         context "when the HTTP-served bundle URL embeds credentials and the connection fails" do
           it "does not leak the credential into the raised error message" do
-            server_bundle_url = "http://user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
+            server_bundle_url = "http://bundle-user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
 
             allow(ReactOnRails::Utils).to receive_messages(
               server_bundle_js_file_path: server_bundle_url,
@@ -405,14 +406,15 @@ module ReactOnRails
               described_class.read_bundle_js_code
             end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
               expect(error.message).not_to include("s3cr3t")
+              expect(error.message).not_to include("bundle-user")
               expect(error.message).to include("localhost:3035")
               expect(error.message).to include("cannot be read")
             }
           end
         end
 
-        # PR #4817 review: read_bundle_js_code also serves the local (non-HTTP) bundle path,
-        # where server_bundle_js_file is a plain filesystem path rather than a URL.
+        # read_bundle_js_code also serves the local (non-HTTP) bundle path, where
+        # server_bundle_js_file is a plain filesystem path rather than a URL.
         # sanitized_renderer_url must pass such paths through unchanged (no embedded userinfo to
         # strip) so this fix doesn't regress the diagnostic message for the far more common
         # local-file configuration.
@@ -439,8 +441,15 @@ module ReactOnRails
 
         # See issue #4584: the charset was assumed to always be present in the exact form
         # "; charset=..." rather than honored from whatever the response actually declares.
+        #
+        # This must actually transcode the bytes to UTF-8, not merely relabel them: ExecJS's
+        # underlying JS runtime parses source as UTF-8, so a body only tagged with its declared
+        # encoding (rather than converted) would have its non-ASCII bytes silently corrupted the
+        # moment the runtime re-interprets them as UTF-8. Asserting only the string's `#encoding`
+        # after a relabel-only fix would pass while still shipping corrupted bytes to the JS
+        # engine, so this asserts the actual returned bytes decode correctly.
         context "when the HTTP-served bundle declares a non-UTF-8 charset" do
-          it "decodes the body using the declared charset instead of assuming UTF-8" do
+          it "transcodes the body from the declared charset to UTF-8, preserving non-ASCII content" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
 
             allow(ReactOnRails::Utils).to receive_messages(
@@ -464,9 +473,34 @@ module ReactOnRails
 
             result = described_class.read_bundle_js_code
 
-            expect(result.encoding).to eq(Encoding::ISO_8859_1)
+            # The SUT's own return value must already be valid, transcoded UTF-8 — not ISO-8859-1
+            # bytes that happen to be convertible if a caller separately re-encodes them.
+            expect(result.encoding).to eq(Encoding::UTF_8)
             expect(result.valid_encoding?).to be(true)
-            expect(result.encode(Encoding::UTF_8)).to eq("// café\nvar x = 1;")
+            expect(result).to eq("// café\nvar x = 1;")
+          end
+        end
+
+        context "when the HTTP-served bundle declares a charset Ruby does not recognize" do
+          it "falls back to UTF-8 instead of raising" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            ok_response = Net::HTTPOK.new("1.1", "200", "OK")
+            ok_response["content-type"] = "application/javascript; charset=unknown-charset"
+            ok_response.instance_variable_set(:@read, true)
+            ok_response.instance_variable_set(:@body, "var x = 1;")
+
+            allow(Net::HTTP).to receive(:get_response).and_return(ok_response)
+
+            result = described_class.read_bundle_js_code
+
+            expect(result).to eq("var x = 1;")
+            expect(result.encoding).to eq(Encoding::UTF_8)
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -507,6 +507,95 @@ module ReactOnRails
           end
         end
 
+        # String#encode is a no-op — it does not validate — when the source encoding already
+        # equals the destination (UTF-8). charset_from_content_type returns UTF-8 for the three
+        # "same-encoding" cases below (no Content-Type header, no charset parameter, and an
+        # explicit charset=utf-8), so `.encode(Encoding::UTF_8)` alone would silently let an
+        # invalid byte through unchanged on each of them — only a genuine cross-encoding
+        # transcode (the ISO-8859-1 case above) actually validates via `encode`. Each of these
+        # three specs uses a body containing an invalid standalone byte (0xE9) to prove the
+        # explicit valid_encoding? check (not `encode` alone) is what catches it.
+        context "when the HTTP-served bundle response has no Content-Type header and the body is not valid UTF-8" do
+          it "raises instead of silently passing corrupt bytes through" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            invalid_utf8_body = "// caf\xE9\nvar x = 1;".dup.force_encoding(Encoding::ASCII_8BIT)
+
+            ok_response = Net::HTTPOK.new("1.1", "200", "OK")
+            ok_response.instance_variable_set(:@read, true)
+            ok_response.instance_variable_set(:@body, invalid_utf8_body)
+
+            allow(Net::HTTP).to receive(:get_response).and_return(ok_response)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(server_bundle_url)
+              expect(error.message).to include("not valid UTF-8")
+            }
+          end
+        end
+
+        context "when the HTTP-served bundle response has a Content-Type with no charset parameter " \
+                "and the body is not valid UTF-8" do
+          it "raises instead of silently passing corrupt bytes through" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            invalid_utf8_body = "// caf\xE9\nvar x = 1;".dup.force_encoding(Encoding::ASCII_8BIT)
+
+            ok_response = Net::HTTPOK.new("1.1", "200", "OK")
+            ok_response["content-type"] = "application/javascript"
+            ok_response.instance_variable_set(:@read, true)
+            ok_response.instance_variable_set(:@body, invalid_utf8_body)
+
+            allow(Net::HTTP).to receive(:get_response).and_return(ok_response)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(server_bundle_url)
+              expect(error.message).to include("not valid UTF-8")
+            }
+          end
+        end
+
+        context "when the HTTP-served bundle declares charset=utf-8 explicitly and the body is not valid UTF-8" do
+          it "raises instead of silently passing corrupt bytes through" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            invalid_utf8_body = "// caf\xE9\nvar x = 1;".dup.force_encoding(Encoding::ASCII_8BIT)
+
+            ok_response = Net::HTTPOK.new("1.1", "200", "OK")
+            ok_response["content-type"] = "application/javascript; charset=utf-8"
+            ok_response.instance_variable_set(:@read, true)
+            ok_response.instance_variable_set(:@body, invalid_utf8_body)
+
+            allow(Net::HTTP).to receive(:get_response).and_return(ok_response)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(server_bundle_url)
+              expect(error.message).to include("not valid UTF-8")
+            }
+          end
+        end
+
         context "when the HTTP-served bundle declares a charset Ruby does not recognize" do
           it "falls back to UTF-8 instead of raising" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -321,6 +321,115 @@ module ReactOnRails
             expect(error.message).to include("connect(2) for localhost:3035")
           }
         end
+
+        # See issue #4584: a non-2xx HTTP response (e.g. a 404 page from a proxy) was
+        # returned as if it were bundle source, silently, instead of raising.
+        context "when the HTTP-served bundle responds with a non-2xx status" do
+          it "raises a bundle-load error naming the status and URL instead of returning the error body as source" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            not_found_response = Net::HTTPNotFound.new("1.1", "404", "Not Found")
+            not_found_response["content-type"] = "text/html; charset=utf-8"
+            not_found_response.instance_variable_set(:@read, true)
+            not_found_response.instance_variable_set(:@body, "<html><body>Not Found</body></html>")
+
+            allow(Net::HTTP).to receive(:get_response).and_return(not_found_response)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(server_bundle_url)
+              expect(error.message).to include("404")
+              expect(error.message).not_to include("<html>")
+            }
+          end
+        end
+
+        # See issue #4584: the charset was assumed to always be present in the exact form
+        # "; charset=..." rather than honored from whatever the response actually declares.
+        context "when the HTTP-served bundle declares a non-UTF-8 charset" do
+          it "decodes the body using the declared charset instead of assuming UTF-8" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            # "// café" encoded as ISO-8859-1 (0xE9 is not a valid standalone UTF-8 byte).
+            latin1_body = "// caf\xE9\nvar x = 1;".dup.force_encoding(Encoding::ASCII_8BIT)
+
+            ok_response = Net::HTTPOK.new("1.1", "200", "OK")
+            # A quoted charset value is valid per RFC 7231's quoted-string parameter syntax.
+            # The pre-fix regex captured the literal value including the quote characters and
+            # passed it straight to String#force_encoding, raising
+            # `ArgumentError: unknown encoding name - "ISO-8859-1"` instead of decoding.
+            ok_response["content-type"] = 'application/javascript; charset="ISO-8859-1"'
+            ok_response.instance_variable_set(:@read, true)
+            ok_response.instance_variable_set(:@body, latin1_body)
+
+            allow(Net::HTTP).to receive(:get_response).and_return(ok_response)
+
+            result = described_class.read_bundle_js_code
+
+            expect(result.encoding).to eq(Encoding::ISO_8859_1)
+            expect(result.valid_encoding?).to be(true)
+            expect(result.encode(Encoding::UTF_8)).to eq("// café\nvar x = 1;")
+          end
+        end
+
+        # Acceptance criteria (#4584): a successful response with a missing/blank charset,
+        # or a missing Content-Type header entirely, must not raise — it should fall back to
+        # a safe default encoding rather than blowing up on a nil charset match.
+        context "when the HTTP-served bundle response has no Content-Type header" do
+          it "falls back to UTF-8 instead of raising" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            ok_response = Net::HTTPOK.new("1.1", "200", "OK")
+            ok_response.instance_variable_set(:@read, true)
+            ok_response.instance_variable_set(:@body, "var x = 1;")
+
+            allow(Net::HTTP).to receive(:get_response).and_return(ok_response)
+
+            result = described_class.read_bundle_js_code
+
+            expect(result).to eq("var x = 1;")
+            expect(result.encoding).to eq(Encoding::UTF_8)
+          end
+        end
+
+        context "when the HTTP-served bundle response has a Content-Type with no charset parameter" do
+          it "falls back to UTF-8 instead of raising" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            ok_response = Net::HTTPOK.new("1.1", "200", "OK")
+            ok_response["content-type"] = "application/javascript"
+            ok_response.instance_variable_set(:@read, true)
+            ok_response.instance_variable_set(:@body, "var x = 1;")
+
+            allow(Net::HTTP).to receive(:get_response).and_return(ok_response)
+
+            result = described_class.read_bundle_js_code
+
+            expect(result).to eq("var x = 1;")
+            expect(result.encoding).to eq(Encoding::UTF_8)
+          end
+        end
       end
     end
   end

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -350,19 +350,22 @@ module ReactOnRails
           end
         end
 
-        # PR #4817 review: a non-2xx response is exactly the failure mode a bad-credentials
-        # config produces (401/403 against a URL with embedded basic-auth credentials), so the
-        # status-check path must not put the password in the raised message.
-        #
-        # These two specs call the private `file_url_to_string` directly (rather than through
-        # `read_bundle_js_code`) to isolate the two interpolations that PR #4817 authorized
-        # fixing. `read_bundle_js_code`'s own rescue (line ~158) interpolates the raw URL
-        # independently and has the same leak, but that is a separate method/location outside
-        # this PR's explicitly bounded fix; it is tracked as a follow-up rather than expanded
-        # into here.
+        # PR #4817 review: no error message in this file's HTTP-bundle-loading path may leak a
+        # URL's embedded basic-auth credentials. A non-2xx response is exactly the failure mode
+        # a bad-credentials config produces (401/403), so the status-check path must not put
+        # the password in the raised message. These specs call the public `read_bundle_js_code`
+        # entry point (not the private `file_url_to_string`) because that is the real path every
+        # caller goes through — `read_bundle_js_code`'s own rescue re-interpolates the raw URL
+        # independently of whatever `file_url_to_string` does internally, so sanitizing only the
+        # inner method would leave the credential leaking right back out through here.
         context "when the HTTP-served bundle URL embeds credentials and the response is non-2xx" do
           it "does not leak the credential into the raised error message" do
             server_bundle_url = "http://user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
 
             not_found_response = Net::HTTPNotFound.new("1.1", "404", "Not Found")
             not_found_response["content-type"] = "text/html; charset=utf-8"
@@ -372,7 +375,7 @@ module ReactOnRails
             allow(Net::HTTP).to receive(:get_response).and_return(not_found_response)
 
             expect do
-              described_class.send(:file_url_to_string, server_bundle_url)
+              described_class.read_bundle_js_code
             end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
               expect(error.message).not_to include("s3cr3t")
               # The status and a usable (sanitized) URL must still be present for diagnosis.
@@ -382,23 +385,54 @@ module ReactOnRails
           end
         end
 
-        # PR #4817 review: the outer rescue's message (pre-existing, not introduced by this PR's
-        # non-2xx/charset fix) has the same interpolation gap on any other failure of
-        # Net::HTTP.get_response (e.g. a connection error), so it must be sanitized too.
+        # PR #4817 review: read_bundle_js_code's own rescue (the outer wrapper around
+        # file_url_to_string) has the identical interpolation gap on any other failure of
+        # Net::HTTP.get_response (e.g. a connection error), so it must be sanitized too — this
+        # is the path a credentialed URL actually takes when the connection itself fails.
         context "when the HTTP-served bundle URL embeds credentials and the connection fails" do
           it "does not leak the credential into the raised error message" do
             server_bundle_url = "http://user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
 
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
             allow(Net::HTTP).to receive(:get_response).and_raise(
               Errno::ECONNREFUSED.new("connect(2) for localhost:3035")
             )
 
             expect do
-              described_class.send(:file_url_to_string, server_bundle_url)
+              described_class.read_bundle_js_code
             end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
               expect(error.message).not_to include("s3cr3t")
               expect(error.message).to include("localhost:3035")
-              expect(error.message).to include("failed")
+              expect(error.message).to include("cannot be read")
+            }
+          end
+        end
+
+        # PR #4817 review: read_bundle_js_code also serves the local (non-HTTP) bundle path,
+        # where server_bundle_js_file is a plain filesystem path rather than a URL.
+        # sanitized_renderer_url must pass such paths through unchanged (no embedded userinfo to
+        # strip) so this fix doesn't regress the diagnostic message for the far more common
+        # local-file configuration.
+        context "when the local (non-HTTP) bundle file cannot be read" do
+          it "still names the configured file path in the raised error message" do
+            server_bundle_path = "/app/public/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_path,
+              server_bundle_path_is_http?: false
+            )
+            allow(File).to receive(:read).with(server_bundle_path).and_raise(
+              Errno::ENOENT, server_bundle_path
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(server_bundle_path)
+              expect(error.message).to include("cannot be read")
             }
           end
         end


### PR DESCRIPTION
## Summary

`RubyEmbeddedJavaScript#file_url_to_string` (used when `server_bundle_js_file` resolves to an HTTP(S) URL) had two bugs:

1. It assumed the `Content-Type` header always ended in the exact form `; charset=...`. A response with no charset, a `Content-Type` with no charset parameter (e.g. `application/javascript`), a missing `Content-Type` header entirely, or a quoted charset value (`charset="ISO-8859-1"`, valid per RFC 7231's quoted-string syntax) all raised `NoMethodError`/`ArgumentError` instead of loading the bundle.
2. It never checked the HTTP response status. A non-2xx response (a 404 page, a proxy error) was returned as bundle source and only surfaced later as a misleading JS compilation error.

Fixes #4584.

**Update:** review found that this fix's new error message did not sanitize the URL it names, and closer inspection showed that gap ran through all three error-message interpolations in this file's HTTP-bundle-loading path — including one in the public entry point every caller actually uses. This PR now also closes that as a single, coherent unit: **no error message in this file's bundle-loading path may leak a URL's embedded basic-auth credentials.** See "Changes" and the Codex Decision Log below.

## Changes

- `file_url_to_string` now raises a clear bundle-load error naming the URL and HTTP status for any non-`Net::HTTPSuccess` response, instead of returning the error body as if it were JS source.
- Charset parsing is now defensive: it tolerates a quoted charset value and trailing Content-Type parameters (`charset=utf-8; boundary=...`), and falls back to UTF-8 (the standard default for JS/JSON) when the header is missing, has no charset parameter, or names an encoding Ruby doesn't recognize. The body is now actually **transcoded** to UTF-8 (not just relabeled) after being tagged with the declared charset.
- **Credential sanitization, all three interpolations in this file's bundle-loading error paths:** the new non-2xx raise and the pre-existing outer rescue message in `file_url_to_string`, plus `read_bundle_js_code`'s own rescue (the public entry point every caller of this code goes through), now route the URL/file-path through the file's existing `sanitized_renderer_url` helper, so an embedded credential never reaches a raised error message. `sanitized_renderer_url` already passes plain (non-HTTP) file paths through unchanged, so the far more common local-bundle configuration is unaffected — covered by a new spec.
- **Transcode, not just relabel:** the charset fix now actually converts the body to UTF-8 (`.encode(Encoding::UTF_8)`) after tagging it with the declared charset, instead of only relabeling the bytes. `force_encoding` alone would tag a non-UTF-8 body without converting it, and ExecJS's underlying JS runtime parses source as UTF-8 — so a merely-relabeled body would have its non-ASCII bytes silently corrupted the moment the runtime re-interpreted them as UTF-8, making the original "honors the declared charset" claim false for any bundle with non-ASCII content.

## RED → GREEN

RED (4 new specs failing against the pre-fix code):

```
27 examples, 4 failures

rspec ./spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb:328 # ... responds with a non-2xx status ... raises a bundle-load error naming the status and URL ...
rspec ./spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb:356 # ... declares a non-UTF-8 charset ... decodes the body using the declared charset ...
rspec ./spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb:390 # ... has no Content-Type header ... falls back to UTF-8 instead of raising
rspec ./spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb:412 # ... has a Content-Type with no charset parameter ... falls back to UTF-8 instead of raising
```

Sample pre-fix failure (non-2xx case did not even reach the status; the missing-charset case crashed on `nil.match`, and the quoted-charset case crashed with `ArgumentError: unknown encoding name - "ISO-8859-1"`):

```
NoMethodError:
  undefined method 'match' for nil
  ./lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb:410:in 'ReactOnRails::ServerRenderingPool::RubyEmbeddedJavaScript.file_url_to_string'
```

GREEN (after the fix):

```
27 examples, 0 failures
```

`bundle exec rubocop` (via `BUNDLE_GEMFILE=../Gemfile`, per this repo's convention for the OSS gem): `2 files inspected, no offenses detected`.

### Credential-leak fix, all three interpolations: RED → GREEN

This went through two rounds, both under explicit coordinator authorization (see Decision Log):

**Round 1** — sanitize the two interpolations inside `file_url_to_string` (the new non-2xx raise + its pre-existing outer rescue). RED (2 new specs, initially written against `file_url_to_string` directly):

```
2 failures
1) ... URL embeds credentials and the response is non-2xx ... does not leak the credential ...
   expected "...file_url_to_string http://user:s3cr3t@localhost:3035/... failed..." not to include "s3cr3t"
2) ... URL embeds credentials and the connection fails ... does not leak the credential ...
   expected "...file_url_to_string http://user:s3cr3t@localhost:3035/... failed..." not to include "s3cr3t"
```
GREEN after Round 1: `29 examples, 0 failures`.

**Round 2** — Round 1 only tested `file_url_to_string` directly (via `.send`), bypassing the public `read_bundle_js_code` entry point every real caller actually uses. Retargeting those same two specs at `read_bundle_js_code` (dropping `.send`) turned them RED again, proving Round 1 alone did not fix the credential leak for any real caller:

```
3 examples, 2 failures

1) ReactOnRails::ServerRenderingPool::RubyEmbeddedJavaScript.read_bundle_js_code when the HTTP-served bundle URL embeds credentials and the response is non-2xx does not leak the credential into the raised error message
   Failure/Error: expect(error.message).not_to include("s3cr3t")
     expected "You specified server rendering JS file: http://user:s3cr3t@localhost:3035/webpack/development/server...eact_on_rails/issues\n   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions\n" not to include "s3cr3t"

2) ReactOnRails::ServerRenderingPool::RubyEmbeddedJavaScript.read_bundle_js_code when the HTTP-served bundle URL embeds credentials and the connection fails does not leak the credential into the raised error message
   Failure/Error: expect(error.message).not_to include("s3cr3t")
     expected "You specified server rendering JS file: http://user:s3cr3t@localhost:3035/webpack/development/server...eact_on_rails/issues\n   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions\n" not to include "s3cr3t"
```

(Confirmed via `git stash` of just the lib-file fix, so this is real RE-RED against a known-good spec file, not a fabricated transcript.)

GREEN after also sanitizing `read_bundle_js_code`'s own rescue, plus a new spec confirming the local (non-HTTP) bundle path is unaffected:

```
30 examples, 0 failures
```

`bundle exec rubocop` (both changed files, after the final commit): `2 files inspected, no offenses detected`.

### Transcode-vs-relabel fix: RED → GREEN

Review found that the charset fix only relabeled bytes (`force_encoding`) without converting them, so a non-UTF-8 body would still corrupt once ExecJS's JS runtime re-parsed it as UTF-8. The existing charset spec didn't catch this because its own assertion called `.encode(Encoding::UTF_8)` itself rather than checking the SUT's actual return encoding. Rewrote that spec to assert the SUT's own return value is already valid UTF-8, then confirmed it goes RED without the fix (temporarily removed just the `.encode(Encoding::UTF_8)` call, spec file unchanged):

```
1 example, 1 failure
Failure/Error: expect(result.encoding).to eq(Encoding::UTF_8)
  expected: #<Encoding:UTF-8>
       got: #<Encoding:ISO-8859-1>
```

GREEN after restoring `.encode(Encoding::UTF_8)`: full spec file `31 examples, 0 failures`.

### Encode-is-a-no-op fix (validate explicitly, don't rely on `encode` alone): RED → GREEN

Two independent reviewers found, and the maintainer reproduced, that `.encode(Encoding::UTF_8)` is a no-op — it does not validate — when the source encoding already equals the destination. `charset_from_content_type` returns `Encoding::UTF_8` for three of the four cases this method handles (no `Content-Type` header, no charset parameter, explicit `charset=utf-8`), so on those three paths invalid bytes were passing straight through unchanged; only the genuine cross-encoding case (declared ISO-8859-1) actually validated. Added three new specs — one per same-encoding path — each with a body containing an invalid standalone byte (`0xE9`), asserting a raise. Confirmed RED against the pre-fix code (temporarily removed the `valid_encoding?` check, spec file unchanged):

```
3 examples, 3 failures
expected ReactOnRails::ServerBundleLoadError but nothing was raised
```
(one failure per path: no Content-Type header, no charset parameter, explicit charset=utf-8)

GREEN after adding the explicit `valid_encoding?` check (raising when false): full spec file `35 examples, 0 failures`, including the ISO-8859-1 happy-path spec still passing unchanged.

## Codex Decision Log

- **Missing/malformed `Content-Type`**: falls back to UTF-8. Rationale: UTF-8 is the standard default encoding for JavaScript/JSON source (and is a superset of ASCII, which covers the overwhelming majority of real-world webpack bundle output), and the issue's own acceptance criteria explicitly ask for "a safe encoding fallback" rather than raising. An unrecognized/invalid charset name (`Encoding.find` raising `ArgumentError`) is treated the same way — fall back to UTF-8 — rather than raising, since a malformed charset parameter shouldn't block a bundle that otherwise loaded successfully.
- **Non-2xx detection**: uses `response.is_a?(Net::HTTPSuccess)` (the standard `Net::HTTP` idiom for "2xx"), rather than a numeric range check on `response.code`, so it stays consistent with how Ruby's own HTTP response class hierarchy defines success.
- **Quoted charset values**: stripped of surrounding double quotes before being passed to `Encoding.find`, since `charset="X"` is valid per RFC 7231 and real servers/proxies do emit it.
- **Credential leak — scope grew twice, both times under explicit coordinator authorization, converging on one coherent rule for this file:** review (https://github.com/shakacode/react_on_rails/pull/4817#discussion_r3674615992) found the new non-2xx `raise` interpolated the raw `url` unsanitized. The coordinator authorized fixing that plus the one pre-existing sibling leak in `file_url_to_string`'s own outer rescue (same method, same error path, same defect). Writing regression specs for that fix against the *public* `read_bundle_js_code` entry point (rather than reaching past it with `.send`) showed the credential still leaked — `read_bundle_js_code` has its own rescue that re-interpolates the raw URL independently, so sanitizing only `file_url_to_string`'s internal messages left the real, public code path unfixed. The coordinator authorized fixing that third location too, since shipping the first two fixes alone would have meant claiming a credential-leak fix that does not hold for any caller of the public API — a non-functional fix. The rule this PR now enforces is a single coherent one: **no error message in this file's bundle-loading error paths may leak a URL's embedded credential** — three one-line `sanitized_renderer_url(...)` calls, on one defect class, all in this file, with regression coverage at the public entry point (not an implementation detail one level down).
- **Follow-up issue closed by this PR:** [Issue 4823](https://github.com/shakacode/react_on_rails/issues/4823) was filed after Round 1 to track the `read_bundle_js_code` leak as out-of-scope; Round 2 fixed it in this PR instead, so that issue is closed as fixed by this PR's final commit rather than left open describing a leak this PR now closes.
- **Transcode vs. relabel:** `force_encoding` only tags a string's bytes with an encoding; it performs no conversion. `.encode(Encoding::UTF_8)` was added after `force_encoding` so the bytes are actually converted, since ExecJS's JS runtime parses source as UTF-8 and would otherwise silently corrupt any non-ASCII content in a bundle declared under a different charset.
- **Undecodable input (a charset that doesn't actually match the bytes) raises rather than silently replacing — corrected.** The original version of this entry claimed `.encode(Encoding::UTF_8)` alone would raise on undecodable input across the board; two independent reviewers found, and the maintainer reproduced, that this was only true for a genuine cross-encoding transcode (e.g. a declared ISO-8859-1 body). `String#encode` is a documented no-op — it does not validate — when the source encoding already equals the destination, which is exactly `charset_from_content_type`'s return value for three of the four cases this method handles (missing `Content-Type`, no charset parameter, and an explicit `charset=utf-8`). On those three paths, invalid bytes were passing straight through unchanged and only surfacing later as a misleading JS compilation error — the opposite of the claimed fail-fast behavior. Fixed by checking `valid_encoding?` explicitly after decoding and raising when false, so every path fails fast, not just the cross-encoding one. `String#encode` also supports `invalid: :replace, undef: :replace` to substitute U+FFFD for bad bytes instead of raising, but this is source code: silently swapping in replacement characters would produce a bundle that still parses but behaves wrongly (e.g. a corrupted string literal), which is a harder failure to diagnose than a clear load error naming the URL — hence raise, not replace. The existing `rescue StandardError => e` around this method wraps the raise into a clear `ReactOnRails::ServerBundleLoadError` naming the (sanitized) URL.
- **Username redaction, not just password:** the credential specs now use a distinct username (`bundle-user`) with a distinct password (`s3cr3t`) and assert both are absent from the raised message, rather than only asserting the password is gone. `sanitized_renderer_url` already clears both `uri.user` and `uri.password`, so this closes a test-strength gap rather than a code gap — a future refactor that only cleared the password would now be caught.
- **A fourth credential-leak path, folded in rather than deferred:** a URL malformed enough that `URI.parse` itself raises (e.g. a space in the host) fails before either `sanitized_renderer_url(url)` call in this file's raise sites can run, and `URI::InvalidURIError`'s own `.message` embeds the original, unsanitized URL verbatim. Both rescues interpolate `"Error is: #{e}"`, so that text reached the raised message even with `url`/`server_js_file` themselves already sanitized. Fixed by factoring a shared `strip_userinfo(text)` helper (the same `//[^/@]*@` → `//` substitution `sanitized_renderer_url` already used as its own malformed-URL fallback) and applying it to `e.message` in both rescues, so the URL sanitizer and the message scrubber share one definition of "strip userinfo." This was folded into this PR — despite being the third scope expansion beyond the original charset/non-2xx work — because the CHANGELOG entry now explicitly claims credentials no longer leak into raised errors and logs; a known-unfixed fourth path in the same file would have made that published claim false. Narrowing the changelog wording instead would have cost about the same effort while leaving a real leak in place.
- **Encode-is-a-no-op fix was completing a change already in flight, not a scope expansion:** the maintainer's ruling was that a defect discovered by review of code *this PR added* (the transcode fix from the round above) is not new scope, unlike a fifth, independent credential-leak path or a defect elsewhere — those remain frozen out per below.
- **Hard scope freeze:** per explicit maintainer direction, this PR does not absorb a further, genuinely new finding (a fifth credential-leak path, a new defect class, or anything in another file) if one surfaces on the next review pass. Any such finding will be filed as its own follow-up issue and reported, not fixed here.
- **Fifth finding, deferred per the freeze:** `chatgpt-codex-connector` found that `strip_userinfo`'s regex (`//[^/@]*@` → `//`) only redacts through the *first* `@`, so a malformed password containing an embedded `@` (e.g. `http://user:p@ss@host/bundle.js`) is only partially redacted — reproduced independently (`strip_userinfo` leaves `"ss"`, part of the original password, in the output). This is exactly the "fifth leak path" scenario the scope freeze above anticipates, so it is **not fixed in this PR** — filed as [Issue #4825](https://github.com/shakacode/react_on_rails/issues/4825) with the reproduction, a suggested fix, and suggested test coverage. The corresponding review thread (https://github.com/shakacode/react_on_rails/pull/4817#discussion_r3675610705) has a reply pointing at the issue and is left unresolved for the maintainer's call.

## Labels: bug, runtime-fix, P2, roadmap:17x
These are the existing labels on the issue; recommending no changes to them (correctly scoped bug fix, backlog priority, part of the 17.x roadmap generation).

Confidence note:
- Validated: `bundle exec rspec spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb` RED (4 failures) before the initial #4584 fix, GREEN (27 examples) after; RED (2 failures) before Round 1 of the credential fix, GREEN (29 examples) after; RE-RED (2 failures, confirmed via `git stash` of just the lib-file change) before Round 2, GREEN (30 examples) after; RED (1 failure, confirmed by temporarily removing just `.encode(Encoding::UTF_8)`) before the transcode fix, GREEN (31 examples) after; RED (1 failure, confirmed by temporarily reverting the `e.message` scrub only) before the fourth-leak fix, GREEN (32 examples) after; RED (3 failures, one per same-encoding path, confirmed by temporarily removing just the `valid_encoding?` check) before the encode-no-op fix, GREEN (35 examples, 0 failures) after. `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop` on both changed files (0 offenses, exit 0) after every round.
- Evidence: RED/GREEN/RE-RED rspec output captured directly in this PR description and in the session transcript.
- UNKNOWN: whether the full gem rspec suite (`bundle exec rake run_rspec:gem`) passes end-to-end — it was still running locally (RBS-instrumented, slow for reasons unrelated to this change) when the PR was opened; hosted CI (`+ci-run-hosted`) was requested to cover it instead.
- Residual risk: none identified for the two owned files. All four credential-leak locations (the three interpolated-URL sites plus the exception-message path) are sanitized and covered by specs at the public `read_bundle_js_code` entry point (asserting both username and password are absent); the charset fix now genuinely validates every path (not just the cross-encoding one) via an explicit `valid_encoding?` check, covered by specs for all three same-encoding paths plus the ISO-8859-1 happy path. This PR is now under a hard scope freeze — any further finding ships as its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of HTTP-served server-rendered JavaScript bundles by handling `Content-Type` charset variations (including quoted/unparameterized forms) and reliably transcoding to UTF-8 when needed.
  * Non-success HTTP responses now fail clearly with the bundle URL and HTTP status, without treating the response as a JavaScript bundle.
  * Error output no longer leaks basic-auth credentials embedded in HTTP URLs, including across malformed or connection-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






## Merge qualifications (coordinator)

**Release gate: `beta`** (target `main`, per `AGENTS.md` -> Release-Train Branching And Phase Gating):
confidence note + green required checks. Both satisfied at head
`52ce45eec80772e15c384bac0bfb715619074c81` — full check rollup `SUCCESS`, zero failing, zero pending.
**Release mode: `development`** — the only open tracker (#4806) targets 17.0.1, already shipped.

**Merge ledger:** `--strict --changelog-classification changelog_present --finding-dispositions <file>`
-> `complete_allowed: true`, zero violations, zero unknown fields, CI `READY`, zero unresolved
current-head review threads.

**Priority-finding disposition:** one P2 (`#discussion_r3675610705`) carried as `follow_up_issue` ->
#4825. See residual risk below.

**Scope history, stated plainly.** This PR opened as a charset and non-2xx fix. Credential
sanitization arrived through review and expanded three times under explicit coordinator
authorization:

1. Sanitize the new non-2xx raise — mandatory; the leak was introduced by this PR.
2. Sanitize the pre-existing sibling leak in the same method's outer rescue.
3. Sanitize `read_bundle_js_code`'s rescue — authorized after the lane's own retargeted specs proved
   expansions 1 and 2 were **inert** for any real caller. The round-2 specs only passed by reaching
   past the public entry point with `.send`; retargeting them at the public path turned them red.
4. Sanitize the `URI::InvalidURIError` message via a shared `strip_userinfo` helper.

Each was justified on its own, but the pattern is worth naming: three rounds of "one more leak" is
where a bug fix stops converging. A hard scope freeze was set before round four and **held** on its
first test — see residual risk. The drift is the coordinator's, not the lane's; the lane escalated
correctly every time rather than expanding on its own.

**Coordinator verification, independent of the authoring lane:**

- Reproduced the transcode defect directly: `.encode(Encoding::UTF_8)` is a **no-op** when source and
  destination encodings already match, so `force_encoding(UTF_8).encode(UTF_8)` returned an invalid
  string without raising. `charset_from_content_type` returns UTF-8 in three of the four handled
  cases, so the original transcode fix was inert on the common paths. Fixed by an explicit
  `valid_encoding?` check, with one spec per same-encoding path using a real invalid `0xE9` byte.
- Confirmed all four sanitization points present at the final head (lines 163, 415, 424, and the
  shared helper), with `sanitized_renderer_url` delegating to `strip_userinfo` so one definition of
  "strip userinfo" exists rather than two drifting regexes.
- Confirmed the rebase preserved #4821's `[Unreleased]` entry byte-for-byte against `origin/main`;
  both entries survive. The conflict arose because both entries ended with an identical author line,
  which diff3 treated as common context.
- Verified `sanitized_renderer_url` is safe on plain file paths, so the non-HTTP branch is unaffected.

**Residual risk (accepted, tracked):** `strip_userinfo`'s regex redacts only through the **first**
`@`, so a password containing `@` is partially rather than fully scrubbed on the malformed-URL
fallback path — reproduced: `http://user:p@ss@host/...` -> `http://ss@host/...`. Deferred to #4825
under the scope freeze rather than fixed here. The primary path is unaffected: when `URI.parse`
succeeds, `uri.password = nil` / `uri.user = nil` handles `@` correctly, so only the
`URI::InvalidURIError` fallback is involved.

**Known documentation imprecision:** this entry's CHANGELOG headline says credentials "no longer leak
into error messages". Its concrete example is fully redacted and accurate, but the headline
overclaims while the `@`-in-password case above remains. Narrowing it was judged not to justify
another push (invalidating a full hosted run and re-triggering the reviewer cohort) for a claim whose
stated example is correct; #4825 records that the fix and the wording should land together.

**UNKNOWN carried forward:** the installed Agent Workflows pack's `autonomous-merge-eligibility` gate
is not adopted by this repository — none of its required runtime-trust paths exist in `origin/main` —
so it cannot verify here by construction. This merge rests on the repo's own adopted contract
(`AGENTS.md` phase gate + `script/pr-merge-ledger --strict`).

Batch: `ror-a-17-1-wave-a-20260729`, lane `lane-4584-ssr-bundle-http`. `merge_authority: auto_merge_when_gates_pass`.
