### PR TITLE
Fix ci-required base ref for PR merge-ref checkouts

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -125,13 +125,12 @@ jobs:
         env:
           PULL_REQUEST_BASE_SHA: ${{ github.event.inputs.pull_request_base_sha || '' }}
           PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-          EVENT_BASE_REF: >-
-            ${{
-              github.event.pull_request.base.sha ||
-              github.event.merge_group.base_sha ||
-              github.event.before ||
-              'origin/main'
-            }}
+          # Keep this expression on one line. It is the merge-queue base-ref
+          # contract asserted by react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb,
+          # which matches the raw file text, and a folded scalar would preserve
+          # the newlines rather than fold them (the continuation lines are more
+          # indented than the first).
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # For pull_request events actions/checkout resolves refs/pull/<n>/merge,
           # so HEAD is the PR head merged into the CURRENT base tip. By contrast

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -160,22 +160,33 @@ jobs:
             # parents[0] = HEAD, [1] = first parent (base side), [2] = second parent (PR head)
             if [ "${#parents[@]}" -eq 3 ]; then
               if [ -n "${PULL_REQUEST_HEAD_SHA}" ] && [ "${parents[2]}" != "${PULL_REQUEST_HEAD_SHA}" ]; then
-                # The merge ref describes an OLDER PR head. Mind the direction of
-                # the error here: a stale event base can only ADD base-branch
-                # commits to the diff, which over-selects suites and merely wastes
-                # runner minutes. Classifying from a stale merge ref's first parent
-                # instead OMITS changes that exist in the current head, which can
-                # flip run_generators to false and let this required gate pass
-                # without the hosted run those changes needed. Narrowing is the
-                # unsafe direction, so once staleness is detected, fall back to the
-                # event base rather than trusting a base proven to describe the
-                # wrong head.
-                echo "::warning::Checked-out merge commit's second parent (${parents[2]}) is not the current PR head (${PULL_REQUEST_HEAD_SHA}); GitHub's merge ref is stale. Falling back to ${base_ref} so the classification cannot omit changes present in the current head."
-                base_source="event payload (merge ref stale)"
-              else
-                base_ref="${parents[1]}"
-                base_source="PR merge commit first parent"
+                # Fail closed: this is the one state where no base can save us.
+                #
+                # Mind the direction of the error. A stale base only ADDS
+                # base-branch commits to the diff, over-selecting suites and
+                # wasting runner minutes, which is survivable. Missing changes is
+                # not: run_generators can come back false and this required gate
+                # can pass without the hosted run those changes needed.
+                #
+                # When the merge ref is stale, HEAD's TREE does not contain the
+                # current head's changes at all, so every base is diffed against a
+                # tree that is already missing them. Choosing a wider base cannot
+                # recover a file that is not in HEAD. The only honest outcomes are
+                # to classify the reported head instead (a network fetch plus a
+                # tree that no longer matches the rest of this job) or to refuse to
+                # classify. A required gate should refuse.
+                #
+                # This is a genuinely different situation from the single-parent
+                # branch below, which continues with a warning. There, HEAD is the
+                # real PR head, so a wide base still yields a complete diff. Here it
+                # does not. The condition is a race against GitHub recomputing
+                # refs/pull/<n>/merge, so a re-run clears it.
+                echo "::error::Checked-out merge commit's second parent (${parents[2]}) is not the PR head reported by this event (${PULL_REQUEST_HEAD_SHA}). GitHub's merge ref is stale, so HEAD's tree cannot contain the current head's changes and no diff base can produce a trustworthy classification. Re-run this job so GitHub recomputes refs/pull/<n>/merge, or push to the branch again."
+                exit 1
               fi
+
+              base_ref="${parents[1]}"
+              base_source="PR merge commit first parent"
             else
               # bundle-size.yml hard-fails on an unexpected merge structure. This gate
               # runs on every PR, so it warns instead: a new hard-fail path here would

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -213,7 +213,16 @@ jobs:
             # case this output exists to expose. sed is used rather than head
             # because sed reads its input to the end, so nothing can close the
             # pipe early.
-            changed_files="$(git diff --name-only "$diff_base" HEAD)"
+            # The explicit || guard is required: bash `set -e` does NOT fire on a
+            # failed command substitution in an assignment, so without it a failing
+            # git diff would silently yield an empty list that reads as "nothing
+            # changed" -- the same under-selection direction this step guards
+            # against elsewhere. script/ci-changes-detector guards its own diff the
+            # same way for the same reason; do not "simplify" this away.
+            changed_files="$(git diff --name-only "$diff_base" HEAD)" || {
+              echo "::error::git diff failed for ${diff_base}..HEAD while listing changed files."
+              exit 1
+            }
 
             if [ -z "$changed_files" ]; then
               echo "Changed files the classification was computed from: none"

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -124,12 +124,66 @@ jobs:
         id: changes
         env:
           PULL_REQUEST_BASE_SHA: ${{ github.event.inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: >-
+            ${{
+              github.event.pull_request.base.sha ||
+              github.event.merge_group.base_sha ||
+              github.event.before ||
+              'origin/main'
+            }}
         run: |
-          base_ref="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
+          # For pull_request events actions/checkout resolves refs/pull/<n>/merge,
+          # so HEAD is the PR head merged into the CURRENT base tip. By contrast
+          # github.event.pull_request.base.sha is only refreshed when the PR is
+          # opened or synchronized, so on a branch that has not been pushed for a
+          # while it lags HEAD's own base parent. Diffing from that stale SHA folds
+          # every base-branch commit in between into the changed-file set, which is
+          # how a docs-only PR gets classified as a generator change and is then
+          # told to spend a hosted CI run it does not need (#4756).
+          #
+          # The merge commit's FIRST PARENT is the base commit the merge was
+          # actually computed against, so it is the only base that yields this PR's
+          # own diff. It is also always present locally (it is a parent of HEAD), so
+          # it cannot fall outside the shallow fetch window. bundle-size.yml derives
+          # its size baseline from the same first parent for the same reason.
+          base_ref="${EVENT_BASE_REF}"
+          base_source="event payload"
+
           if [ -n "${PULL_REQUEST_BASE_SHA}" ]; then
             base_ref="${PULL_REQUEST_BASE_SHA}"
+            base_source="workflow_dispatch input"
+          elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            parent_line="$(git rev-list --parents -n 1 HEAD 2>/dev/null || true)"
+            read -ra parents <<< "$parent_line"
+            # parents[0] = HEAD, [1] = first parent (base side), [2] = second parent (PR head)
+            if [ "${#parents[@]}" -eq 3 ]; then
+              base_ref="${parents[1]}"
+              base_source="PR merge commit first parent"
+
+              if [ -n "${PULL_REQUEST_HEAD_SHA}" ] && [ "${parents[2]}" != "${PULL_REQUEST_HEAD_SHA}" ]; then
+                echo "::warning::Checked-out merge commit's second parent (${parents[2]}) is not the current PR head (${PULL_REQUEST_HEAD_SHA}); GitHub's merge ref is stale, so this classification describes an older head."
+              fi
+            else
+              # bundle-size.yml hard-fails on an unexpected merge structure. This gate
+              # runs on every PR, so it warns instead: a new hard-fail path here would
+              # block more PRs than the misclassification it guards against. The
+              # changed-file list printed below makes a widened diff obvious anyway.
+              echo "::warning::HEAD is not the expected two-parent PR merge commit, so the changed-file classification is computed from ${base_ref} and may include base-branch drift. If this PR is routed to suites it does not touch, rebase it on its base branch."
+            fi
           fi
+
+          echo "Diff base: ${base_ref} (source: ${base_source})"
+
           script/ci-changes-detector "$base_ref"
+
+          # Show the exact file set behind the classification above so a widened
+          # diff is visible at a glance. The detector has already fetched and
+          # deepened as needed, so these calls add no network work.
+          if diff_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)"; then
+            echo "Changed files the classification was computed from (first 50):"
+            git diff --name-only "$diff_base" HEAD | head -50
+          fi
 
       - name: Enforce hosted CI for generator changes
         env:

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -213,12 +213,14 @@ jobs:
             # case this output exists to expose. sed is used rather than head
             # because sed reads its input to the end, so nothing can close the
             # pipe early.
-            # The explicit || guard is required: bash `set -e` does NOT fire on a
-            # failed command substitution in an assignment, so without it a failing
-            # git diff would silently yield an empty list that reads as "nothing
-            # changed" -- the same under-selection direction this step guards
-            # against elsewhere. script/ci-changes-detector guards its own diff the
-            # same way for the same reason; do not "simplify" this away.
+            # The || guard is for the diagnostic, not for control flow. `set -e`
+            # DOES abort on a failed command substitution in a plain assignment
+            # (the masking people remember applies to declaration assignments such
+            # as `local x=$(false)`, not to this one), so the step would fail here
+            # either way. Without the guard it fails with a bare non-zero exit and
+            # git's own stderr; with it, the log names which refs the diff was
+            # between. Keep it for that message, not because the failure would
+            # otherwise pass unnoticed.
             changed_files="$(git diff --name-only "$diff_base" HEAD)" || {
               echo "::error::git diff failed for ${diff_base}..HEAD while listing changed files."
               exit 1

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -87,6 +87,7 @@ jobs:
             bin/ci-rerun-failures \
             bin/request-hosted-ci \
             script/ci-changes-detector \
+            script/ci-required-diff-base-test.bash \
             script/ci-required-hosted-gate
           do
             bash -n "$script"
@@ -96,6 +97,7 @@ jobs:
       - name: Run CI gate tests
         run: |
           bash script/ci-required-hosted-gate-test.bash
+          bash script/ci-required-diff-base-test.bash
           bash script/lint-mirrored-blocks-test.bash
           ruby script/ci_required_merge_group_gate_test.rb
           node --test .github/workflows/ci-commands.test.cjs
@@ -157,11 +159,22 @@ jobs:
             read -ra parents <<< "$parent_line"
             # parents[0] = HEAD, [1] = first parent (base side), [2] = second parent (PR head)
             if [ "${#parents[@]}" -eq 3 ]; then
-              base_ref="${parents[1]}"
-              base_source="PR merge commit first parent"
-
               if [ -n "${PULL_REQUEST_HEAD_SHA}" ] && [ "${parents[2]}" != "${PULL_REQUEST_HEAD_SHA}" ]; then
-                echo "::warning::Checked-out merge commit's second parent (${parents[2]}) is not the current PR head (${PULL_REQUEST_HEAD_SHA}); GitHub's merge ref is stale, so this classification describes an older head."
+                # The merge ref describes an OLDER PR head. Mind the direction of
+                # the error here: a stale event base can only ADD base-branch
+                # commits to the diff, which over-selects suites and merely wastes
+                # runner minutes. Classifying from a stale merge ref's first parent
+                # instead OMITS changes that exist in the current head, which can
+                # flip run_generators to false and let this required gate pass
+                # without the hosted run those changes needed. Narrowing is the
+                # unsafe direction, so once staleness is detected, fall back to the
+                # event base rather than trusting a base proven to describe the
+                # wrong head.
+                echo "::warning::Checked-out merge commit's second parent (${parents[2]}) is not the current PR head (${PULL_REQUEST_HEAD_SHA}); GitHub's merge ref is stale. Falling back to ${base_ref} so the classification cannot omit changes present in the current head."
+                base_source="event payload (merge ref stale)"
+              else
+                base_ref="${parents[1]}"
+                base_source="PR merge commit first parent"
               fi
             else
               # bundle-size.yml hard-fails on an unexpected merge structure. This gate
@@ -180,8 +193,24 @@ jobs:
           # diff is visible at a glance. The detector has already fetched and
           # deepened as needed, so these calls add no network work.
           if diff_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)"; then
-            echo "Changed files the classification was computed from (first 50):"
-            git diff --name-only "$diff_base" HEAD | head -50
+            # Capture the whole stream before truncating. Piping git diff straight
+            # into `head -50` lets head close the read end once it has its 50
+            # lines; git then takes SIGPIPE and exits 141, and because Actions runs
+            # run: steps under `bash --noprofile --norc -eo pipefail`, pipefail
+            # promotes that 141 to the pipeline's status and set -e fails this
+            # required gate. It would fire on large diffs, meaning the widened-diff
+            # case this output exists to expose. sed is used rather than head
+            # because sed reads its input to the end, so nothing can close the
+            # pipe early.
+            changed_files="$(git diff --name-only "$diff_base" HEAD)"
+
+            if [ -z "$changed_files" ]; then
+              echo "Changed files the classification was computed from: none"
+            else
+              changed_total="$(printf '%s\n' "$changed_files" | wc -l | tr -d ' ')"
+              echo "Changed files the classification was computed from (${changed_total} total, showing up to 50):"
+              printf '%s\n' "$changed_files" | sed -n '1,50p'
+            fi
           fi
 
       - name: Enforce hosted CI for generator changes

--- a/script/ci-required-diff-base-test.bash
+++ b/script/ci-required-diff-base-test.bash
@@ -262,10 +262,13 @@ fi
 # changed_files assignment. Exercising it needs a git that fails only on
 # `diff --name-only`, and injecting one via PATH does not survive into the child
 # shell in every developer environment, so a case for it would pass or fail for
-# reasons unrelated to the guard. The guard mirrors the one in
-# script/ci-changes-detector, which is likewise enforced by comment rather than
-# by test. Tracked with the extraction work in #4824, where the logic moves into
-# script/ and the guard becomes directly callable.
+# reasons unrelated to the guard.
+#
+# The stakes are lower than they look: `set -e` aborts on a failed command
+# substitution in a plain assignment on its own, so the guard supplies a better
+# message rather than the only failure. Tracked with the extraction work in
+# #4824, where the logic moves into script/ and the guard becomes directly
+# callable.
 
 echo
 if [ "$TESTS_FAILED" -ne 0 ]; then

--- a/script/ci-required-diff-base-test.bash
+++ b/script/ci-required-diff-base-test.bash
@@ -258,6 +258,15 @@ if [ "$printed_files" -ne 50 ]; then
   fail "large changed-file list: expected 50 printed paths, got $printed_files"
 fi
 
+# NOT COVERED HERE: the `|| { echo ::error::; exit 1; }` guard on the
+# changed_files assignment. Exercising it needs a git that fails only on
+# `diff --name-only`, and injecting one via PATH does not survive into the child
+# shell in every developer environment, so a case for it would pass or fail for
+# reasons unrelated to the guard. The guard mirrors the one in
+# script/ci-changes-detector, which is likewise enforced by comment rather than
+# by test. Tracked with the extraction work in #4824, where the logic moves into
+# script/ and the guard becomes directly callable.
+
 echo
 if [ "$TESTS_FAILED" -ne 0 ]; then
   echo "$TESTS_FAILED of $TESTS_RUN diff-base tests failed" >&2

--- a/script/ci-required-diff-base-test.bash
+++ b/script/ci-required-diff-base-test.bash
@@ -135,6 +135,16 @@ git -C "$REPO" -c user.name=ci-test -c user.email=ci-test@example.com \
   merge -q --no-ff -m "Merge docs into main" "$PR_HEAD"
 MERGE_REF="$(git -C "$REPO" rev-parse HEAD)"
 
+# A newer PR head that landed after the merge ref was computed. Nothing merges it,
+# so MERGE_REF's tree cannot contain its file. This is the stale-merge-ref race:
+# the event reports this head while the checkout still holds the older merge.
+git -C "$REPO" checkout -q docs
+echo "added later" > "$REPO/added-after-merge-ref.txt"
+git -C "$REPO" add added-after-merge-ref.txt
+git_commit -m "Change present only in the newer PR head"
+NEW_PR_HEAD="$(git -C "$REPO" rev-parse HEAD)"
+git -C "$REPO" checkout -q main
+
 # A second merge ref carrying a large changed-file list, for the truncation case.
 # The names are long on purpose: the whole list has to exceed the 64KB pipe buffer
 # for an early-closing reader to be able to break the step.
@@ -188,17 +198,30 @@ assert_contains "$LAST_OUTPUT" "docs.md" "current merge ref"
 # The whole point of the fix: main's own drift must not enter the diff.
 assert_not_contains "$LAST_OUTPUT" "newer.txt" "current merge ref"
 
-# Regression guard for the under-selection hazard. A stale merge ref describes an
-# older head, so its first parent can OMIT changes that exist in the current head
-# and let this gate pass without the hosted run they need. Falling back to the
-# event base can only widen, which is the safe direction.
-run_case "stale merge ref falls back to the event base" \
-  "$MERGE_REF" pull_request "" "0000000000000000000000000000000000000000" "$OLD_MAIN"
-assert_rc 0 "stale merge ref"
-assert_contains "$LAST_OUTPUT" "Diff base: $OLD_MAIN (source: event payload (merge ref stale))" "stale merge ref"
-assert_contains "$LAST_OUTPUT" "DETECTOR_BASE=$OLD_MAIN" "stale merge ref"
-assert_contains "$LAST_OUTPUT" "merge ref is stale" "stale merge ref"
-assert_not_contains "$LAST_OUTPUT" "source: PR merge commit first parent" "stale merge ref"
+# Regression guard for the under-selection hazard, which is the sharpest edge in
+# this step. When the merge ref is stale, HEAD's tree does not contain the current
+# head's changes, so NO choice of base can classify them: every base is diffed
+# against a tree that is already missing them. Widening the base does not help.
+# The step must refuse to classify rather than emit a confident, incomplete answer
+# that could let a generator change through this required gate.
+#
+# NEW_PR_HEAD below is deliberately not reachable from MERGE_REF, which is exactly
+# the shape of the race this guards against.
+run_case "stale merge ref fails closed" \
+  "$MERGE_REF" pull_request "" "$NEW_PR_HEAD" "$OLD_MAIN"
+assert_rc 1 "stale merge ref"
+assert_contains "$LAST_OUTPUT" "::error::" "stale merge ref"
+assert_contains "$LAST_OUTPUT" "GitHub's merge ref is stale" "stale merge ref"
+assert_contains "$LAST_OUTPUT" "Re-run this job" "stale merge ref"
+# It must not hand any base to the detector once it knows the tree is wrong.
+assert_not_contains "$LAST_OUTPUT" "DETECTOR_BASE=" "stale merge ref"
+
+# Demonstrates WHY widening the base is not a fix: the file added in the current
+# head simply is not in HEAD's tree, so it cannot appear in any diff taken here.
+missing_from_stale_head="$(git -C "$REPO" diff --name-only "$OLD_MAIN" "$MERGE_REF" | grep -c 'added-after-merge-ref.txt')"
+if [ "$missing_from_stale_head" -ne 0 ]; then
+  fail "stale merge ref: expected the newer head's file to be absent from the widest diff against the stale HEAD"
+fi
 
 # A single-parent HEAD must never take HEAD^1: there it is the PR's own previous
 # commit rather than the base branch. Unlike the stale-merge-ref case there is no

--- a/script/ci-required-diff-base-test.bash
+++ b/script/ci-required-diff-base-test.bash
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Test harness for the diff-base selection in the "Run changed-files detector"
+# step of .github/workflows/ci-required.yml.
+#
+# Run: bash script/ci-required-diff-base-test.bash
+# CI invokes it from the "Run CI gate tests" step of the same workflow.
+#
+# The step body is extracted from the committed workflow with a YAML parser and
+# executed against a synthetic repository, so the logic under test is exactly the
+# logic that ships. That matters because this branching decides which suites run
+# for every PR, and it lives inline in YAML rather than in script/.
+#
+# script/ci-changes-detector is stubbed here. Its own behavior is covered by
+# script/ci-changes-detector-test.bash; what this harness pins down is which base
+# ref the step hands it, and that the step survives a large changed-file list.
+#
+# Cases are run under `bash --noprofile --norc -eo pipefail`, the exact shell
+# GitHub Actions uses for run: steps. The pipefail part is load-bearing: it is
+# what turned a truncating pipe into a hard failure of this required gate.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/ci-required.yml"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+FAILURES=()
+
+LAST_OUTPUT=""
+LAST_RC=0
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$message")
+  echo "  FAIL: $message" >&2
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  case "$haystack" in
+    *"$needle"*) ;;
+    *) fail "$label: expected '$needle' in: $haystack" ;;
+  esac
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  case "$haystack" in
+    *"$needle"*) fail "$label: did not expect '$needle' in: $haystack" ;;
+    *) ;;
+  esac
+}
+
+assert_rc() {
+  local expected="$1"
+  local label="$2"
+
+  if [ "$LAST_RC" -ne "$expected" ]; then
+    fail "$label: expected exit $expected, got $LAST_RC. Output: $LAST_OUTPUT"
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+STEP="$WORKDIR/step.sh"
+REPO="$WORKDIR/repo"
+
+# Extract the step body. A rename of the step name is a real breakage of this
+# harness, so fail loudly rather than silently testing nothing.
+if ! ruby -ryaml -e '
+  workflow = YAML.safe_load_file(ARGV[0], permitted_classes: [], aliases: false)
+  steps = workflow.fetch("jobs").fetch("required-pr-gate").fetch("steps")
+  step = steps.find { |candidate| candidate["name"] == "Run changed-files detector" }
+  abort "step \"Run changed-files detector\" not found in #{ARGV[0]}" if step.nil?
+  File.write(ARGV[1], step.fetch("run"))
+' "$WORKFLOW" "$STEP"; then
+  echo "FAIL: could not extract the step body from $WORKFLOW" >&2
+  exit 1
+fi
+
+git init -q "$REPO"
+mkdir -p "$REPO/script"
+
+cat > "$REPO/script/ci-changes-detector" <<'STUB'
+#!/usr/bin/env bash
+# Stub standing in for the real detector: record the base ref it was handed.
+echo "DETECTOR_BASE=$1"
+STUB
+chmod +x "$REPO/script/ci-changes-detector"
+
+git_commit() {
+  git -C "$REPO" -c user.name=ci-test -c user.email=ci-test@example.com \
+    commit -q --no-verify "$@"
+}
+
+git -C "$REPO" checkout -q -b main
+git -C "$REPO" add script/ci-changes-detector
+git_commit -m "Add detector stub"
+
+echo "old" > "$REPO/older.txt"
+git -C "$REPO" add older.txt
+git_commit -m "Older main commit"
+OLD_MAIN="$(git -C "$REPO" rev-parse HEAD)"
+
+echo "new" > "$REPO/newer.txt"
+git -C "$REPO" add newer.txt
+git_commit -m "Newer main commit"
+MAIN_TIP="$(git -C "$REPO" rev-parse HEAD)"
+
+# A docs-only PR branch, cut from the OLDER main commit. OLD_MAIN stands in for a
+# pull_request.base.sha that has gone stale while main moved on.
+git -C "$REPO" checkout -q -b docs "$OLD_MAIN"
+echo "docs" > "$REPO/docs.md"
+git -C "$REPO" add docs.md
+git_commit -m "Docs-only change"
+PR_HEAD="$(git -C "$REPO" rev-parse HEAD)"
+
+# Stand-in for refs/pull/<n>/merge: first parent is the base side, second is the
+# PR head. This is the shape actions/checkout puts in HEAD for pull_request.
+git -C "$REPO" checkout -q main
+git -C "$REPO" -c user.name=ci-test -c user.email=ci-test@example.com \
+  merge -q --no-ff -m "Merge docs into main" "$PR_HEAD"
+MERGE_REF="$(git -C "$REPO" rev-parse HEAD)"
+
+# A second merge ref carrying a large changed-file list, for the truncation case.
+# The names are long on purpose: the whole list has to exceed the 64KB pipe buffer
+# for an early-closing reader to be able to break the step.
+git -C "$REPO" checkout -q -b big "$MERGE_REF"
+mkdir -p "$REPO/bigdir"
+long_name="a-deliberately-long-path-segment-to-exceed-the-pipe-buffer-quickly"
+seq 1 3000 | while read -r index; do
+  printf '%s/bigdir/%s-%05d.txt\n' "$REPO" "$long_name" "$index"
+done | xargs touch
+git -C "$REPO" add -A
+git_commit -m "Large changed-file list"
+BIG_HEAD="$(git -C "$REPO" rev-parse HEAD)"
+
+git -C "$REPO" checkout -q main
+git -C "$REPO" -c user.name=ci-test -c user.email=ci-test@example.com \
+  merge -q --no-ff -m "Merge big into main" "$BIG_HEAD"
+BIG_MERGE_REF="$(git -C "$REPO" rev-parse HEAD)"
+
+run_case() {
+  local name="$1"
+  local head="$2"
+  local event_name="$3"
+  local dispatch_base_sha="$4"
+  local pr_head_sha="$5"
+  local event_base_ref="$6"
+
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $name"
+
+  git -C "$REPO" checkout -q --detach "$head"
+
+  LAST_OUTPUT="$(
+    cd "$REPO" || exit 1
+    CI=1 \
+      GITHUB_EVENT_NAME="$event_name" \
+      GITHUB_OUTPUT="$WORKDIR/github-output.txt" \
+      PULL_REQUEST_BASE_SHA="$dispatch_base_sha" \
+      PULL_REQUEST_HEAD_SHA="$pr_head_sha" \
+      EVENT_BASE_REF="$event_base_ref" \
+      bash --noprofile --norc -eo pipefail "$STEP" 2>&1
+  )"
+  LAST_RC=$?
+}
+
+run_case "current merge ref uses the first parent" \
+  "$MERGE_REF" pull_request "" "$PR_HEAD" "$OLD_MAIN"
+assert_rc 0 "current merge ref"
+assert_contains "$LAST_OUTPUT" "Diff base: $MAIN_TIP (source: PR merge commit first parent)" "current merge ref"
+assert_contains "$LAST_OUTPUT" "DETECTOR_BASE=$MAIN_TIP" "current merge ref"
+assert_contains "$LAST_OUTPUT" "docs.md" "current merge ref"
+# The whole point of the fix: main's own drift must not enter the diff.
+assert_not_contains "$LAST_OUTPUT" "newer.txt" "current merge ref"
+
+# Regression guard for the under-selection hazard. A stale merge ref describes an
+# older head, so its first parent can OMIT changes that exist in the current head
+# and let this gate pass without the hosted run they need. Falling back to the
+# event base can only widen, which is the safe direction.
+run_case "stale merge ref falls back to the event base" \
+  "$MERGE_REF" pull_request "" "0000000000000000000000000000000000000000" "$OLD_MAIN"
+assert_rc 0 "stale merge ref"
+assert_contains "$LAST_OUTPUT" "Diff base: $OLD_MAIN (source: event payload (merge ref stale))" "stale merge ref"
+assert_contains "$LAST_OUTPUT" "DETECTOR_BASE=$OLD_MAIN" "stale merge ref"
+assert_contains "$LAST_OUTPUT" "merge ref is stale" "stale merge ref"
+assert_not_contains "$LAST_OUTPUT" "source: PR merge commit first parent" "stale merge ref"
+
+# A single-parent HEAD must never take HEAD^1: there it is the PR's own previous
+# commit rather than the base branch. Unlike the stale-merge-ref case there is no
+# better base available, so warn and continue.
+run_case "single-parent HEAD keeps the event base" \
+  "$PR_HEAD" pull_request "" "$PR_HEAD" "$OLD_MAIN"
+assert_rc 0 "single-parent HEAD"
+assert_contains "$LAST_OUTPUT" "Diff base: $OLD_MAIN (source: event payload)" "single-parent HEAD"
+assert_contains "$LAST_OUTPUT" "not the expected two-parent PR merge commit" "single-parent HEAD"
+
+run_case "workflow_dispatch input wins" \
+  "$MERGE_REF" workflow_dispatch "$OLD_MAIN" "$PR_HEAD" "$MAIN_TIP"
+assert_rc 0 "workflow_dispatch input"
+assert_contains "$LAST_OUTPUT" "Diff base: $OLD_MAIN (source: workflow_dispatch input)" "workflow_dispatch input"
+
+# merge_group must keep diffing from the merge queue base SHA it is handed. This
+# mirrors the contract asserted in
+# react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb.
+run_case "merge_group keeps the event base" \
+  "$MERGE_REF" merge_group "" "" "$OLD_MAIN"
+assert_rc 0 "merge_group"
+assert_contains "$LAST_OUTPUT" "Diff base: $OLD_MAIN (source: event payload)" "merge_group"
+assert_not_contains "$LAST_OUTPUT" "source: PR merge commit first parent" "merge_group"
+
+# Regression guard for the truncation pipe. Under pipefail an early-closing reader
+# makes git exit 141 and takes the whole required gate down with it.
+run_case "large changed-file list does not abort the step" \
+  "$BIG_MERGE_REF" pull_request "" "$BIG_HEAD" "$OLD_MAIN"
+assert_rc 0 "large changed-file list"
+assert_contains "$LAST_OUTPUT" "3000 total, showing up to 50" "large changed-file list"
+
+printed_files="$(printf '%s\n' "$LAST_OUTPUT" | grep -c "bigdir/${long_name}-")"
+if [ "$printed_files" -ne 50 ]; then
+  fail "large changed-file list: expected 50 printed paths, got $printed_files"
+fi
+
+echo
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  echo "$TESTS_FAILED of $TESTS_RUN diff-base tests failed" >&2
+  for failure in "${FAILURES[@]}"; do
+    echo "  - $failure" >&2
+  done
+  exit 1
+fi
+
+echo "$TESTS_RUN diff-base tests passed"


### PR DESCRIPTION
Fixes #4756

## Correcting the record first

#4756 is titled and framed around a "shallow merge-base fallback": `fetch-depth: 50` too small, merge base unresolvable, fallback widens the diff. **Fetch depth was never the cause.** I reproduced the bug on a full, unshallow clone, which by itself rules depth out.

Three pieces of evidence from the run the issue cites:

1. The failing run checked out `refs/remotes/pull/4739/merge` = `ed86829364509ac3e4e3782e52f44300d11e0f17`. So `HEAD` was GitHub's PR **merge commit**, not the PR head. Its parents are `613c6c2a` (base side) and `bf4711c1` (PR head side).
2. The workflow passed `github.event.pull_request.base.sha` = `18bdc4f8`, dated `2026-07-18T08:06:09Z`. The run was at `23:33Z`, so the base SHA was about 15 hours behind the merge commit's own base parent. `merge-base(18bdc4f8, HEAD) = 18bdc4f8` is the **correct** answer for those inputs. The inputs were wrong, not the merge-base resolution.
3. The log contains zero `Deepening shallow history` lines. The deepen loop never ran. `script/lib/git-diff-base` already deepens 50 → 100 → ... → `--unshallow` and hard-fails with an explicit diagnostic when a base is genuinely unreachable, so the "deepen or fail closed" half of the request is already implemented upstream.

The clincher: the post-rebase **passing** run used base `613c6c2a`, which is exactly `HEAD^1` of the failing run's merge commit. Had the failing run used `HEAD^1`, it would have classified documentation-only with no rebase and no hosted CI.

## Root cause

For `pull_request` events `actions/checkout` resolves `refs/pull/<n>/merge`, so `HEAD` is the PR head merged into the **current** base tip. `github.event.pull_request.base.sha` is a different commit: it only refreshes when the PR is opened or synchronized. On a branch that has not been pushed for a while the two drift apart, and diffing from the stale SHA folds every base-branch commit in between into the changed-file set. A one-file docs-only PR then looks like it touched generators.

## The fix

Take the base from the merge commit's **first parent**, which is the exact commit the merge was computed against, guarded on `HEAD` having exactly two parents.

`.github/workflows/bundle-size.yml:82-99` already derives its size baseline from the same first parent, with the same documented reasoning. This follows that precedent rather than inventing a mechanism.

`fetch-depth` stays at 50. The first parent is a parent of `HEAD`, so it can never fall outside the shallow window, and widening the fetch would slow every run for no benefit.

## Reproduction

A docs-only branch, a simulated `refs/pull/N/merge` (first parent = main tip, second parent = PR head), and a stale `base.sha` standing in for the 15-hour lag. Run on a **full clone** (`git rev-parse --is-shallow-repository` = `false`).

```
HEAD (merge ref)  : 0e95f13df4cbfe18b77e5c596ca734efaf51832e
HEAD^1 (base side): 822b4c30bc3764a08454a7e891834b2699921a03
HEAD^2 (PR head)  : 6299aaeb2045a6c0347837528a841351becece9e
stale base.sha    : 1c12dbbb91eeb97cf006ce39c02621e98502a98c
PR touches        : internal/planning/REPRO_4756.md
```

### BEFORE: base = stale `pull_request.base.sha`

```
Base: 1c12dbbb91eeb97cf006ce39c02621e98502a98c | Current: HEAD | Merge base: 1c12dbbb91eeb97cf006ce39c02621e98502a98c

Changed file categories:
  • JavaScript/TypeScript code
  • RSpec tests
  • Generators
  • React on Rails Pro Ruby core source code
  • React on Rails Pro Dummy app
  • CI infrastructure (full test suite, no benchmarks)
  • Uncategorized changes (running full suite for safety)

---- GITHUB_OUTPUT flags:
docs_only=false
non_runtime_only=false
run_js_tests=true
run_generators=true
```

That `run_generators=true` is what fails `required-pr-gate` and tells the author to spend a hosted CI run.

### AFTER: same stale `base.sha` in the environment, fix applied

This is not a hand-written recreation. The step's `run:` body was extracted straight out of the committed `.github/workflows/ci-required.yml` with a YAML parser and executed, so what is tested is exactly what ships.

```
Diff base: 822b4c30bc3764a08454a7e891834b2699921a03 (source: PR merge commit first parent)
=== CI Changes Analysis ===
Base: 822b4c30bc3764a08454a7e891834b2699921a03 | Current: HEAD | Merge base: 822b4c30bc3764a08454a7e891834b2699921a03

✓ Documentation-only changes

Recommended CI jobs: NONE (skip CI)
Changed files the classification was computed from (first 50):
internal/planning/REPRO_4756.md

---- GITHUB_OUTPUT flags:
docs_only=true
non_runtime_only=true
run_js_tests=false
run_generators=false
```

### Branch matrix

This is now a committed test rather than a one-off: `script/ci-required-diff-base-test.bash`, wired into this workflow's own `Run CI gate tests` step. It extracts the step body from the committed YAML with a YAML parser and runs it against a synthetic repository under `bash --noprofile --norc -eo pipefail`, the exact shell Actions uses.

```
-> current merge ref uses the first parent
-> stale merge ref fails closed
-> single-parent HEAD keeps the event base
-> workflow_dispatch input wins
-> merge_group keeps the event base
-> large changed-file list does not abort the step

6 diff-base tests passed
```

Two cases carry most of the weight. A single-parent `HEAD` must never take `HEAD^1`, because there it is the PR's own previous commit rather than the base branch. And a *stale* merge ref must not use its first parent at all, because that base describes an older head and would narrow the diff (decision log item 6).

**The harness is a real guard, not a rubber stamp.** Reverting each fix makes it fail:

```
# with `git diff --name-only | head -50` restored
FAIL: large changed-file list: expected exit 0, got 141
2 of 6 diff-base tests failed

# with the stale-merge-ref guard removed
FAIL: stale merge ref: expected exit 1, got 0.
      Output: Diff base: 268edd42... (source: PR merge commit first parent)
FAIL: stale merge ref: did not expect 'DETECTOR_BASE=' in: ...
```

141 is the SIGPIPE exit the reviewers predicted.

The stale-merge-ref case also asserts directly that the newer head's file is absent from the widest possible diff against the stale `HEAD`. That assertion is the evidence for decision log item 6: it is why no choice of base could have fixed this, and why the step refuses instead.

## The fix is not total, by design

There is **one** fallback path that lands on `EVENT_BASE_REF` — the stale `github.event.pull_request.base.sha`. **On that path the original over-selection can still occur**, so a stale docs-only PR in that state still gets a wide classification.

That is deliberate. A stale event base can only *widen* the diff, which wastes runner minutes; it cannot let an unverified change through. The second abnormal state does not fall back at all — it fails the gate, because widening the base cannot repair a `HEAD` that is missing the current head's changes. Neither state is silent: the fallback path emits a `::warning::` annotation plus the printed changed-file list, and the fail-closed path emits `::error::` and exits non-zero.

- **Single-parent HEAD** (GitHub produced no merge ref, in practice a PR conflicting with its base): no better base exists, so warn and continue. Decision log item 1.
- **Stale merge ref** (second parent is not the current PR head): does **not** fall back — it fails the gate. `HEAD`'s tree is missing the current head's changes, so no base can produce a trustworthy classification. Decision log item 6.

## Scope

Two files: `.github/workflows/ci-required.yml` and the new `script/ci-required-diff-base-test.bash`.

Nine other hosted workflows feed the detector the same stale `base.sha` and have the same latent misrouting — tracked in #4818. Moving this step's logic out of YAML into `script/` is tracked in #4824. Neither is widened into this PR.

## Post-merge exercise

Required by `.github/read-me.md` for semantic `.github/workflows/**` changes: #4820.

The stale-base path cannot be exercised from this branch, because a freshly pushed PR always has a current `base.sha`, so this PR's own run only covers the case where old and new logic agree. #4820 specifies the throwaway stale docs-only PR, the expected step-log evidence, and the cleanup.

## Changelog

**No changelog entry applies.** `CHANGELOG.md` is user-visible changes only per the repo seam in `.agents/agent-workflow.yml`. This is internal CI plumbing with no effect on the published gem or npm package.

## Labels

`Labels: ci-tooling` because the change is confined to CI workflow suite-routing logic and ships no runtime code.

## Codex Decision Log

1. **Warn instead of hard-fail when `HEAD` is not a two-parent merge commit.** `bundle-size.yml` hard-fails with `::error::` in the equivalent situation; this deliberately diverges. GitHub does not produce a merge ref for a PR that conflicts with its base, so a single-parent `HEAD` on a `pull_request` event is a real, reachable state rather than a can't-happen. `ci-required` is the required gate on every PR, so hard-failing there would block the gate on every conflicted PR, which is strictly worse than the misclassification it guards against, and a conflicted PR cannot merge anyway. `bundle-size.yml` can afford `::error::` precisely because it is advisory and this gate is not. Please do not "fix" this back to a hard fail without that asymmetry in mind.
2. **`fetch-depth` left at 50.** The issue suggested deepening. The first parent is a parent of `HEAD` and therefore always in the clone, so deepening buys nothing and would slow every PR.
3. **`script/ci-changes-detector` untouched.** The issue suggested changing the detector. The detector's merge-base resolution is correct; only its input was wrong. Fixing the input keeps the blast radius to one file.
4. ~~**Stale merge ref warns but still uses the first parent.**~~ **Reversed in review — this was wrong.** See item 6.
5. **`internal/planning/CONTEXT.md` not modified,** although it was in scope for this lane. That file is a product-strategy glossary (Language / Relationships / Example dialogue / Flagged ambiguities) and documents no CI decisions, so adding one would have meant inventing a new section style in a tightly scoped document. CI routing behavior is documented in `.github/read-me.md` and decisions in `internal/adr/`, neither of which was in scope. The decision record lives in this PR body and in the inline comments on the changed step.
6. **A stale merge ref fails closed. This is the subtle one, and it took two corrections to get right — read the direction of the error, and then read which half of the diff it applies to.**

   First correction (from Greptile): my original code only warned and kept classifying from the stale merge ref's first parent. Compare which way each base can be wrong:
   - A stale **event base** can only **add** base-branch commits to the diff. Over-selects suites, wastes runner minutes. Safe direction, and why #4818 is a cost problem rather than a correctness hole.
   - A stale **merge ref's first parent** describes an **older head**, so changes in the current head get **omitted**. `run_generators` can come back false and this required gate can pass without the hosted run those changes needed. Unsafe direction.

   So I switched to falling back to `EVENT_BASE_REF`. **That was still wrong**, and this is the part a future reader will most likely get wrong too, because I did and so did the reviewer who proposed it.

   Second correction (from Codex): **widening the base does not fix under-selection, because the base is only half of the diff.** The detector diffs the chosen base against `HEAD`. When the merge ref is stale, `HEAD`'s *tree* does not contain the current head's changes at all. Changing the base changes what we diff *from*; it does nothing about what we diff *to*. A file added in the newer head stays invisible no matter how wide the base is. There is no base that repairs a tree which is already missing the changes.

   That leaves two honest options: fetch and classify the reported head (a network fetch, and then the classified tree no longer matches what the rest of the job checked out), or refuse to classify. **A required gate should refuse.** The step now exits 1 with a message saying to re-run so GitHub recomputes `refs/pull/<n>/merge`, or push again — the condition is a race against that recomputation, so a re-run clears it.

   A third option, emitting a maximal conservative classification instead of failing, was rejected on evidence rather than taste. It does not avoid a red gate, and it makes the failure misleading:

   ```
   $ RUN_GENERATORS=true SHOULD_RUN_HOSTED_CI=false bash script/ci-required-hosted-gate
   Generator changes require hosted CI before merge.
   Comment +ci-run-hosted on the PR, or add the ready-for-hosted-ci label...
   EXIT: 1
   ```

   That is the exact wrong-remedy message #4756 exists to eliminate, and it would route someone to spend a full hosted run over a transient merge-ref race. Same availability cost, worse diagnosis.

   Note the asymmetry with item 1, which still stands: on a **single-parent** HEAD we warn and continue, because `HEAD` is the real PR head there and a wide base still yields a complete diff. Positive proof that the checkout is wrong is what separates the two cases.
7. **The changed-file list is captured before truncation, and truncated with `sed` rather than `head`.** Two reviewers independently found that `git diff --name-only | head -50` breaks under the Actions shell (`bash --noprofile --norc -eo pipefail`): `head` closes the read end, `git` takes SIGPIPE and exits 141, `pipefail` promotes it, `set -e` fails the gate. It would fire on large diffs — the widened-diff case this output exists to expose — so a cosmetic diagnostic could have taken down the required gate exactly when it had something to show. `sed -n '1,50p'` reads its input to the end, so nothing closes early. `mapfile` with an array slice reads better but needs bash 4+, and this repo's `*-test.bash` harnesses run on macOS where `/bin/bash` is 3.2.
8. **The changed-file assignment is guarded — for the diagnostic, not for control flow.** I first justified this guard by claiming `set -e` does not fire on a failed command substitution in an assignment. **That was wrong**, and CodeRabbit caught it. The masking applies to *declaration* assignments, not plain ones:

   ```
   $ bash -c 'set -e; x=$(false); echo REACHED'
   exit=1          # REACHED never printed

   $ bash -c 'set -e; f(){ local x=$(false); echo REACHED; }; f'
   REACHED
   exit=0
   ```

   So the step aborts on a failed `git diff` with or without the guard, and the "empty list reads as nothing changed" scenario I described could not occur. The guard stays because it names which refs the diff was between instead of dying with a bare non-zero exit and git's stderr — a real improvement, just not the one I claimed. Corrected in e0c835ac3; every line of that commit's diff is a comment.

   `script/ci-changes-detector` carries the same inaccurate claim, which is where I copied it from. Deliberately not corrected here (it would pull an unrelated file into a two-file PR); recorded on #4824 so the extraction fixes both, since the bad reasoning has already propagated once.
9. **Two plausible shell claims in this PR were wrong, and CI could not have caught either.** Worth stating plainly for whoever maintains this next. The first: that widening the diff base fixes under-selection — false, because the base is only half the diff and `HEAD`'s tree was the broken half (item 6). The second: the `set -e` claim above. Both survived a fully green hosted matrix, because neither is observable from a passing test — the code did the right thing for a misstated reason, or the failure mode was unreachable. Both were caught by review. The committed harness in item 10 raises the floor for *behavior*, but reasoning stated in comments still needs a reader.
10. **Test harness committed; extracting the step into `script/` deferred.** Review correctly noted that every other piece of CI-selection logic here pairs with a companion test, and this branching had none. `script/ci-required-diff-base-test.bash` now covers it, and is wired into this workflow's own `Run CI gate tests` step. The structural half — moving the logic out of YAML into `script/` — is deliberately not done here: refactoring a required gate is a larger change than the bug fix that surfaced it. Filed as #4824, proposed alongside #4818 since that issue would otherwise paste the same shape into nine more workflows.

## Confidence note

- **Validated:**
  - `bash script/ci-required-diff-base-test.bash`: `6 diff-base tests passed`. Also confirmed to fail when each fix is reverted (output above), so it is a real guard.
  - `RUN_GENERATORS=true SHOULD_RUN_HOSTED_CI=false bash script/ci-required-hosted-gate` exits 1 with the generator message. This is the evidence behind rejecting the maximal-classification alternative in decision log item 6.
  - `bash -n script/ci-required-diff-base-test.bash`: syntax OK. `shellcheck -S warning`: clean.
  - `bundle exec rspec spec/react_on_rails/ruby_version_support_spec.rb`: `7 examples, 0 failures`, including the merge-queue base-SHA guard this PR previously broke.
  - `SHELLCHECK_OPTS="-S warning" actionlint` repo-wide, exit 0 (also run against the committed file alone, exit 0). This is the same invocation `.github/workflows/actionlint.yml` uses.
  - `ruby -e "... YAML.safe_load_file ..."` over all workflows: `all workflow YAML parsed OK`. This is the gate's own "Validate workflow YAML" step.
  - `node .github/workflows/hosted-ci-safety.test.cjs`: `hosted CI workflow safety tests passed`. This test asserts against `ci-required.yml` directly.
  - `ruby bin/lint-mirrored-blocks`: 2 `MIRROR OF:` markers across 1 pair, 10 `MIRROR VALUES OF:` markers across 5 pairs, exit 0.
  - `bash script/ci-required-hosted-gate-test.bash`: 7 tests passed.
  - `ruby script/ci_required_merge_group_gate_test.rb`: 11 tests passed.
  - `ruby script/pr_merge_ledger_test.rb`: 254 runs, 0 failures.
  - `ruby .agents/bin/agent_workflow_drift_manifest_test_test.rb`: 11 runs, 0 failures.
  - `ruby .agents/skills/pr-batch/bin/pr-ci-readiness-test.rb`: 66 runs, 0 failures.
  - `node --test .github/workflows/ci-commands.test.cjs`: 49 pass, 0 fail.
  - Reproduction and all four selection branches, run against the step body extracted from the committed YAML (output above).
  - **Observed on a real GitHub-hosted runner.** `pull_request` workflows run from the PR branch, so this PR's own `ci-required` run already executed the new step. From run 30455776751:

    ```
    Diff base: 822b4c30bc3764a08454a7e891834b2699921a03 (source: PR merge commit first parent)
    Base: 822b4c30bc3764a08454a7e891834b2699921a03 | Current: HEAD | Merge base: 822b4c30bc3764a08454a7e891834b2699921a03
    Changed files the classification was computed from (first 50):
    .github/workflows/ci-required.yml
    ```

    The two-parent detection, the first-parent selection, and the new changed-file listing all work on `ubuntu-latest` with the runner's real shallow checkout.
  - Hosted `actionlint` and `zizmor` checks both pass on this PR.
- **Evidence:** failing run https://github.com/shakacode/react_on_rails/actions/runs/29665416514/job/88134918712, passing post-rebase run https://github.com/shakacode/react_on_rails/actions/runs/29665576745/job/88135331590, this PR's hosted run https://github.com/shakacode/react_on_rails/actions/runs/30455776751, plus the inline output above.
- **UNKNOWN:**
  - No Ruby changed, so `bundle exec rubocop` was not run. Nothing in the diff is Ruby.
  - **The stale-base path itself has not been exercised on hosted CI.** This PR was freshly pushed, so its `base.sha` was current and old and new logic agree on it. The hosted run above proves the new code path executes correctly, not that it repairs a stale branch. #4820 specifies the throwaway stale docs-only PR needed to close that gap post-merge.
  - Whether `github.event.pull_request.head.sha` is ever empty on a real `pull_request` event is assumed, not observed; the code treats an empty value as "skip the staleness check" rather than failing.
  - **The `|| { ::error::; exit 1; }` guard on the changed-file assignment (item 8) has no executable test.** Lower stakes than when I first wrote this, since `set -e` aborts there regardless and the guard only improves the message. Exercising it needs a `git` that fails only on `diff --name-only`, and injecting one via `PATH` did not reliably reach the child shell in my environment, so any case I wrote would have passed or failed for reasons unrelated to the guard. I removed it rather than ship a test that is green for the wrong reason; the gap is recorded in the harness and tracked with #4824, where the logic moves into `script/` and the guard becomes directly callable. The equivalent guard in `script/ci-changes-detector` is likewise enforced by comment rather than by test.
  - How often a stale merge ref occurs in practice is unmeasured. If it turns out to be common rather than a rare race, the fail-closed choice in item 6 should be revisited in favor of fetching and classifying the reported head.
  - I did not observe a real conflicted PR producing a single-parent `HEAD` on this repo. That state is asserted from GitHub's documented merge-ref behavior.
- **Residual risk:** low and one-directional. If the two-parent guard ever fails to match, the step falls back to exactly today's behavior plus a warning, so the worst case is the status quo rather than a new failure mode.

## Detector classification for this PR

`script/ci-changes-detector origin/main` on this branch reports `CI infrastructure (full test suite, no benchmarks)` and sets `run_generators=true`, so `ci-required` will fail until hosted CI is requested. That is expected for any `.github/workflows/**` change and is not a symptom of this fix.


## Guard-spec failure: diagnosis (coordinator)

The full hosted matrix caught a real failure on the previous head — recorded here because the
authoring agent's session terminated on an API error before it could write this up. The diagnosis
below is the coordinator's own, verified against the committed YAML.

**Failure:** `react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb:116`,
`"uses the merge queue base SHA for merge_group change detection"`, on both
`rspec-package-tests (3.3, minimum, unit)` and `(4.0, latest, unit)`. Job:
https://github.com/shakacode/react_on_rails/actions/runs/30455997425/job/90589676685

**Cause: formatting, not behavior.** That spec asserts the raw file text of ten workflows contains
`github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main'`
as a contiguous string. The first revision of this PR moved that expression into an `EVENT_BASE_REF`
env var and wrapped it across lines in a YAML folded scalar, so the substring match failed even
though the expression was semantically identical.

The folded scalar was independently wrong: in YAML, continuation lines indented *more* than the
first content line are preserved literally rather than folded, so the wrapped form would have carried
embedded newlines into the value rather than collapsing to one line.

**Fix (`021e584a8`): the workflow, not the spec.** The expression is restored to a single line,
character-for-character what the guard expects, with an inline comment recording why it must stay
that way. The guard was deliberately **not** weakened or rewritten to match new behavior.

**Merge-queue behavior is preserved, and that was verified before accepting the fix:**

- `base_ref="${EVENT_BASE_REF}"` remains the default, so a `merge_group` event still resolves its
  base through `github.event.merge_group.base_sha` exactly as before.
- The new first-parent logic is gated behind `elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]`, so
  it cannot affect the merge queue path at all.
- The two-parent guard (`[ "${#parents[@]}" -eq 3 ]` against `git rev-list --parents -n 1 HEAD`)
  means a single-parent HEAD never takes `HEAD^1`.

This is why hosted CI was requested as `+ci-force-full` rather than `+ci-run-hosted`. This PR changes
the base ref that feeds suite selection, so optimized selection would have been grading its own
homework — and the guard spec that caught this is one an optimized run would most likely have
skipped.

**UNKNOWN carried forward:** the stale-base path itself is still not exercised on hosted CI. This
branch's `base.sha` is current, so old and new logic agree on it; the hosted run proves the new step
executes correctly, not that it repairs a stale branch. #4820 exists to close that gap post-merge.

Batch: `ror-a-17-1-wave-a-20260729`, lane `lane-4756-ci-mergebase`.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI changed-file detection by correctly resolving diff base for pull requests, workflow dispatches, and merge groups.
  * Added safety checks for stale or unexpected merge commit shapes and stricter failure behavior when mismatches are detected.
  * Enhanced CI output by printing the exact changed-file set used for classification (up to 50 files), with clearer handling when no changes are found.

* **Tests**
  * Added a CI diff-base validation harness covering multiple event scenarios, edge cases, and output/limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Merge qualifications (coordinator)

**Release gate: `beta`** (target `main`): confidence note + green required checks. Both satisfied at
head `e0c835ac3edaad83af78041b3b82be8470a739ad` — full rollup `SUCCESS`, zero failing, zero pending.
**Release mode: `development`** — the only open tracker (#4806) targets 17.0.1, already shipped.

**Merge ledger:** `--strict --changelog-classification not_user_visible` -> `complete_allowed: true`,
zero violations, zero unknown fields, CI `READY`, zero unresolved current-head review threads.
No changelog entry: internal CI plumbing, not user-visible, per the repo seam.

**Hosted CI: `+ci-force-full`, deliberately.** This PR changes the base ref that feeds suite
selection, so optimized selection would have been grading its own homework. That call was vindicated:
the full matrix caught a guard-spec failure (`ruby_version_support_spec.rb:116`) that optimized
selection would most likely have skipped.

**Review cohort:** CodeRabbit `APPROVED` at this head (superseding an earlier `CHANGES_REQUESTED`,
resolved by a comment-accuracy fix). Nine threads, zero unresolved. Two advisory threads were
resolved in-thread without a push, per review-loop convergence: the twelve-workflow blast radius
(tracked in #4818) and the eventual-consistency tradeoff on the fail-closed path (accepted and
documented).

**Coordinator verification, independent of the authoring lane:**

- Confirmed the root cause was **not** what #4756 described. Fetch depth was never involved:
  `script/lib/git-diff-base` already deepens 50 -> 100 -> ... -> `--unshallow` and hard-fails, so the
  "deepen or fail closed" half was already implemented upstream. The real cause is a stale
  `github.event.pull_request.base.sha`.
- Confirmed `bundle-size.yml:82-99` derives its baseline from the merge commit's first parent, so
  this follows existing repo precedent rather than inventing a pattern.
- Confirmed merge-queue behavior is preserved: `EVENT_BASE_REF` remains the default, so `merge_group`
  events still resolve through `github.event.merge_group.base_sha`, and the first-parent logic is
  gated behind `GITHUB_EVENT_NAME = pull_request`.
- Confirmed the final commit is comment-only by filtering the diff for non-comment lines (empty
  result), so the fully green matrix at `124b42a7b` carries to this head.
- Independently reproduced the `set -e` semantics behind the reworded comment: a plain assignment
  `x=$(false)` aborts under `set -e`; only declaration assignments (`local`/`export`/`declare`) mask
  it. The guard is retained for its actionable `::error::` diagnostic, not for the reason originally
  stated.
- Independently reproduced the hosted-gate behavior that justified fail-closed over conservative
  classification: `GITHUB_EVENT_NAME=pull_request RUN_GENERATORS=true SHOULD_RUN_HOSTED_CI=false`
  exits 1 with the "Comment `+ci-run-hosted`" message. Maximal classification would therefore have
  red-gated anyway, with the exact wrong remedy #4756 exists to eliminate.

**Two coordinator corrections are recorded in the decision log**, because both were wrong in ways a
future reader would repeat. First, an instruction to warn-and-continue on a stale merge ref; second,
an instruction to fall back to the event base, which addressed the wrong half of the diff — widening
changes what you diff *from*, while a stale `HEAD` is what you diff *to*, and its tree simply cannot
contain the newer head's changes. The lane's evidence overrode the coordinator on the final
mechanism, correctly.

**UNKNOWN carried forward:**
- The stale-base path is still not exercised on hosted CI. This branch's `base.sha` is current, so
  old and new logic agree; the hosted run proves the new step executes, not that it repairs a stale
  branch. #4820 closes that gap post-merge and is required by `.github/read-me.md`.
- The real-world frequency of a stale `refs/pull/<n>/merge` at checkout time is unmeasured. If it
  proves common rather than rare, fetching the reported head becomes a better trade than failing
  closed.
- The `changed_files` guard has no executable test: injecting a `git` that fails only on
  `diff --name-only` did not reliably reach the child shell. The lane removed a case that was
  passing for the wrong reason rather than ship it, and tracked it in #4824.
- The installed pack's `autonomous-merge-eligibility` gate is not adopted by this repository, so it
  cannot verify here by construction.

Batch: `ror-a-17-1-wave-a-20260729`, lane `lane-4756-ci-mergebase`. `merge_authority: auto_merge_when_gates_pass`.
