### PR TITLE
[Pro] Redact RSC render-error metadata on the fetched (client-navigation) payload path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **RSC render-error details are no longer sent to the browser on the fetched payload path**:
+  The RSC payload fetched during client-side navigation (via `rsc_payload_generation_url_path`) included
+  the server's rendering-error message and source-mapped stack — which contains server file paths — in its
+  metadata, in every environment. The inline (first-paint) payload path was already redacted, so error
+  detail that was hidden on first paint could still reach the browser on a client navigation. The fetched
+  path now applies the same fail-closed gate: full detail only in `development` and `test`, while
+  `production`, `staging`, and any unrecognized environment receive a generic `hasErrors: true` signal so
+  client error boundaries still fire. Server-side error handling is unaffected — `raise_prerender_error`
+  still receives the full message and stack, because redaction happens at the browser-facing boundary
+  after the server's own error transform runs. Fixes
+  [Issue 4736](https://github.com/shakacode/react_on_rails/issues/4736).
+  [PR 4821](https://github.com/shakacode/react_on_rails/pull/4821) by
+  [justin808](https://github.com/justin808).
+
 - **RailsContext now stays current across Turbo and Turbolinks navigation**: Parsed context is cached
   only while its source element and JSON text remain unchanged. Replacing the context element or
   morphing its payload in place now makes the next core render or immediate Pro hydration receive the

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1421,10 +1421,56 @@ module ReactOnRailsProHelper
       # persist an empty payload and every cache hit would serve zero bytes.
       # See https://github.com/shakacode/react_on_rails/issues/4550.
       html = chunk["html"] || ""
-      metadata = chunk.except("html").to_json
+      metadata = redact_rsc_payload_error_metadata(chunk.except("html")).to_json
       content_bytes = html.bytesize.to_s(16).rjust(8, "0")
       "#{metadata}\t#{content_bytes}\n#{html}".html_safe
     end
+  end
+
+  # The fetched (client-navigation) RSC payload crosses the trusted-server -> untrusted-client
+  # boundary, so server-internal error text must not ride along on it.
+  #
+  # This mirrors the fail-closed allowlist in `createRSCDiagnosticScript`
+  # (packages/react-on-rails-pro/src/injectRSCPayload.ts), which redacts the same fields on the
+  # inline payload path: full detail only in development/test, and every other environment --
+  # production, staging, or anything unrecognized -- is redacted.
+  #
+  # Redacting here rather than in the shared producer (`buildRenderMetadata` in
+  # packages/react-on-rails/src/serverRenderUtils.ts) is deliberate. `server_rendered_react_component`
+  # installs a raise-transform that runs BEFORE this one and feeds `renderingError` to
+  # `raise_prerender_error`/`rendering_error_from_result`. Redacting upstream would silently strip
+  # the message and stack out of `PrerenderError` for apps that enable
+  # `raise_non_shell_server_rendering_errors`. This transform is the last hop before the bytes
+  # reach the browser, so the server keeps full detail and only the wire is redacted.
+  #
+  # Returns a new Hash; never mutates the caller's chunk (StreamCache buffers it -- see
+  # https://github.com/shakacode/react_on_rails/issues/4550).
+  def redact_rsc_payload_error_metadata(metadata)
+    return metadata if Rails.env.development? || Rails.env.test?
+
+    error_signal = rsc_payload_rendering_error_signal?(metadata)
+    return metadata unless error_signal || metadata.key?("renderingError")
+
+    redacted = metadata.except("renderingError")
+    # Preserve a generic failure signal so client error boundaries still fire. `hasErrors` is
+    # forced true when only a non-blank message/stack indicated the failure, matching the
+    # inline path's redacted branch.
+    redacted["hasErrors"] = true if error_signal
+    redacted
+  end
+
+  def rsc_payload_rendering_error_signal?(metadata)
+    return true if metadata["hasErrors"] == true
+
+    rendering_error = metadata["renderingError"]
+    return false unless rendering_error.is_a?(Hash)
+
+    non_blank_rsc_metadata_string?(rendering_error["message"]) ||
+      non_blank_rsc_metadata_string?(rendering_error["stack"])
+  end
+
+  def non_blank_rsc_metadata_string?(value)
+    value.is_a?(String) && value.strip.present?
   end
 
   def build_react_component_result_for_server_streamed_content(

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -748,23 +748,155 @@ describe ReactOnRailsProHelper do
   end
 
   describe "#internal_rsc_payload_react_component" do
-    it "frames the payload without removing html from the input chunk" do
-      input_chunk = { "hasErrors" => false, "html" => "payload" }
+    # Obviously-synthetic stand-ins for server-internal error text. These deliberately mirror the
+    # fixtures in packages/react-on-rails-pro/tests/injectRSCPayload.test.ts so the inline and
+    # fetched redaction paths can be compared case-for-case.
+    let(:synthetic_message) { "User 48213 not authorized for org 77" }
+    let(:synthetic_stack) do
+      "Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)"
+    end
+    let(:rendering_error) { { "message" => synthetic_message, "stack" => synthetic_stack } }
+    let(:error_chunk) do
+      { "hasErrors" => true, "renderingError" => rendering_error, "html" => "payload" }
+    end
+
+    def stub_rails_env(name)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new(name))
+    end
+
+    # Runs `chunk` through the real helper transform chain and returns the wire bytes a browser
+    # would receive. An optional block mirrors the raise-transform that
+    # `server_rendered_react_component` installs (react_on_rails/lib/react_on_rails/helper.rb),
+    # which always runs BEFORE the framing transform added here.
+    def framed_wire_bytes(chunk, &inner_transform)
       upstream_stream = Struct.new(:input) do
         def each_chunk
           yield input
         end
-      end.new(input_chunk)
+      end.new(chunk)
       json_stream = ReactOnRailsPro::StreamDecorator.new(upstream_stream)
+      json_stream.transform(&inner_transform) if inner_transform
       render_options = instance_double(ReactOnRails::ReactComponent::RenderOptions)
 
       allow(self).to receive(:create_render_options).and_return(render_options)
       allow(self).to receive(:server_rendered_react_component).with(render_options).and_return(json_stream)
 
-      framed_stream = send(:internal_rsc_payload_react_component, "RscEchoProps")
+      send(:internal_rsc_payload_react_component, "RscEchoProps").each_chunk.to_a.join
+    end
 
-      expect(framed_stream.each_chunk.to_a).to eq(["{\"hasErrors\":false}\t00000007\npayload"])
+    it "frames the payload without removing html from the input chunk" do
+      input_chunk = { "hasErrors" => false, "html" => "payload" }
+
+      expect(framed_wire_bytes(input_chunk)).to eq("{\"hasErrors\":false}\t00000007\npayload")
       expect(input_chunk).to include("html" => "payload")
+    end
+
+    it "redacts renderingError from the fetched payload metadata in production" do
+      stub_rails_env("production")
+
+      wire = framed_wire_bytes(error_chunk)
+
+      expect(wire).to include("\"hasErrors\":true")
+      expect(wire).not_to include("renderingError")
+      expect(wire).not_to include("User 48213")
+      expect(wire).not_to include("not authorized")
+      expect(wire).not_to include("Auth.server.tsx")
+    end
+
+    it "redacts renderingError in non-development/test environments like staging" do
+      stub_rails_env("staging")
+
+      wire = framed_wire_bytes(error_chunk)
+
+      expect(wire).to include("\"hasErrors\":true")
+      expect(wire).not_to include("renderingError")
+      expect(wire).not_to include("User 48213")
+      expect(wire).not_to include("Auth.server.tsx")
+    end
+
+    it "redacts renderingError in an unrecognized environment (fail-closed)" do
+      stub_rails_env("qa-sandbox")
+
+      wire = framed_wire_bytes(error_chunk)
+
+      expect(wire).to include("\"hasErrors\":true")
+      expect(wire).not_to include("renderingError")
+      expect(wire).not_to include("User 48213")
+      expect(wire).not_to include("Auth.server.tsx")
+    end
+
+    it "forces hasErrors:true in production when the chunk reports hasErrors:false with an error signal" do
+      stub_rails_env("production")
+
+      wire = framed_wire_bytes(error_chunk.merge("hasErrors" => false))
+
+      expect(wire).to include("\"hasErrors\":true")
+      expect(wire).not_to include("renderingError")
+      expect(wire).not_to include("Auth.server.tsx")
+    end
+
+    it "leaves a clean production chunk untouched" do
+      stub_rails_env("production")
+
+      wire = framed_wire_bytes({ "hasErrors" => false, "html" => "payload" })
+
+      expect(wire).to eq("{\"hasErrors\":false}\t00000007\npayload")
+    end
+
+    it "includes the full renderingError in development" do
+      stub_rails_env("development")
+
+      wire = framed_wire_bytes(error_chunk)
+
+      expect(wire).to include("renderingError")
+      expect(wire).to include(synthetic_message)
+      expect(wire).to include("Auth.server.tsx")
+    end
+
+    it "includes the full renderingError in test" do
+      stub_rails_env("test")
+
+      wire = framed_wire_bytes(error_chunk)
+
+      expect(wire).to include("renderingError")
+      expect(wire).to include(synthetic_message)
+    end
+
+    it "does not mutate the upstream chunk when redacting, so StreamCache buffers the full payload" do
+      stub_rails_env("production")
+      input_chunk = error_chunk
+
+      wire = framed_wire_bytes(input_chunk)
+
+      expect(wire).not_to include("renderingError")
+      # StreamCache buffers a reference to this Hash and writes it to Rails.cache after the stream
+      # completes; mutating it here would persist a torn payload.
+      # See https://github.com/shakacode/react_on_rails/issues/4550.
+      expect(input_chunk).to eq(
+        "hasErrors" => true,
+        "renderingError" => { "message" => synthetic_message, "stack" => synthetic_stack },
+        "html" => "payload"
+      )
+    end
+
+    it "leaves renderingError intact for the server-side raise that runs before framing" do
+      stub_rails_env("production")
+      seen_by_server = nil
+
+      wire = framed_wire_bytes(error_chunk) do |chunk|
+        seen_by_server = chunk
+        chunk
+      end
+
+      # The browser-facing bytes are redacted...
+      expect(wire).not_to include("Auth.server.tsx")
+      # ...but raise_prerender_error/rendering_error_from_result still receive full detail.
+      expect(seen_by_server["renderingError"]).to eq(
+        "message" => synthetic_message, "stack" => synthetic_stack
+      )
+      server_side_error = send(:rendering_error_from_result, seen_by_server)
+      expect(server_side_error.message).to eq(synthetic_message)
+      expect(server_side_error.backtrace).to include("at Auth (/app/components/Auth.server.tsx:12:5)")
     end
   end
 


### PR DESCRIPTION
Fixes #4736

## What leaked, and where

The RSC payload fetched during **client-side navigation** (via `rsc_payload_generation_url_path` →
`internal_rsc_payload_react_component`) carried the server's `renderingError` — both the `message`
and the source-mapped `stack`, including absolute server file paths — to the browser in its
length-prefixed metadata, in **every** Rails environment.

The inline (first-paint) payload path was already redacted by `createRSCDiagnosticScript`
(PR #4631, issue #4629). The fetched path had no equivalent gate, so error metadata that is
redacted on first paint could still reach the browser on a client navigation.

`internal_rsc_payload_react_component` re-serializes `chunk.except("html")`, which re-emitted every
metadata field the Node renderer produced. That is the browser-facing boundary, and it is where the
gate now lives.

## Why the fix is in Ruby, not `serverRenderUtils.ts`

Issue #4736 proposed gating `buildRenderMetadata` in
`packages/react-on-rails/src/serverRenderUtils.ts`. **That would have been wrong**, and the issue's
own "risk to verify first" is exactly the reason.

The metadata has **two consumers on the fetched path with opposite requirements**:

1. **Inner transform (trusted, needs full detail).** `server_rendered_react_component`
   (`react_on_rails/lib/react_on_rails/helper.rb:1008-1020`) installs a raise-transform running
   `should_raise_streaming_prerender_error?` → `raise_prerender_error` →
   `rendering_error_from_result`, which reads `renderingError["message"]` and `["stack"]`.
   `render_options.streaming?` is true for `rsc_payload_streaming`, so **the fetched path runs this
   too**.
2. **Outer transform (browser-facing, must redact).** `internal_rsc_payload_react_component`.

`buildRenderMetadata` is the single shared producer upstream of both (its only external caller is
`streamingUtils.ts:136`, used by the inline *and* fetched paths). Redacting there would have
silently stripped the message and stack out of `PrerenderError` for any app setting
`raise_non_shell_server_rendering_errors = true`. Redacting in the outer transform — the last hop
before the bytes reach the browser — keeps server-side error handling fully intact.

**Correction for the record: issue #4736 named the wrong files.** `serverRenderUtils.ts` is the
wrong place to gate, and `injectRSCPayload.ts` is **inline-only** — it emits inline `<script>` tags
and is not involved in the fetched path at all, so it is a no-op for this issue. Neither TypeScript
file is touched by this PR.

## Security parity statement

Inline path, `createRSCDiagnosticScript` (`packages/react-on-rails-pro/src/injectRSCPayload.ts:99-124`):

```ts
const showFullDiagnostics = railsEnv === 'development' || railsEnv === 'test';
const clientPayload = showFullDiagnostics ? { hasErrors, renderingError } : { hasErrors: true };
```

This PR applies the same rule at the fetched-path boundary:

- **Fields redacted:** the entire `renderingError` object — both `message` and the source-mapped
  `stack` (which carries absolute server file paths). No other metadata field is altered.
- **Condition:** fail-closed allowlist. Full detail **only** in `development` and `test`.
  `production`, `staging`, and any unrecognized environment are redacted.
- **Preserved:** `hasErrors`, forced to `true` whenever a non-blank `message`/`stack` indicated
  failure, so client error boundaries still fire on a generic signal. This mirrors the inline
  redacted branch, which forces `hasErrors: true` for the same reason.
- **Unchanged:** clean chunks (no error signal, no `renderingError` key) pass through byte-identical.

**Correspondence to the inline path's existing redaction tests**
(`packages/react-on-rails-pro/tests/injectRSCPayload.test.ts:500-609`) — all five cases mirrored,
reusing the same synthetic fixtures so the two paths are comparable case-for-case:

| Inline test (`injectRSCPayload.test.ts`) | Fetched test (this PR) |
| --- | --- |
| `redacts renderingError from diagnostic metadata in production` | `redacts renderingError from the fetched payload metadata in production` |
| `redacts renderingError in non-development/test environments like staging` | `redacts renderingError in non-development/test environments like staging` |
| `redacts renderingError when railsEnv is not provided (undefined)` | `redacts renderingError in an unrecognized environment (fail-closed)` |
| `forces hasErrors:true in production even when metadata has hasErrors:false with renderingError signal` | `forces hasErrors:true in production when the chunk reports hasErrors:false with an error signal` |
| `includes full renderingError in diagnostic metadata in development` | `includes the full renderingError in development` (plus a `test`-env case) |

Assertions are made against the **actual framed wire bytes** the browser would receive, not an
intermediate hash.

Three additional tests cover requirements the inline path does not have:

- **StreamCache invariant (#4550):** redaction builds a copy; the upstream chunk is asserted
  byte-for-byte unchanged afterward, so the Hash StreamCache buffers still holds the full payload.
- **Server-side raise intact:** the chunk seen by the inner transform still carries full detail, and
  `rendering_error_from_result` on it still yields a `StandardError` with the original message and a
  backtrace frame — proving the behavior that redacting in the TS producer would have destroyed.
- **Clean chunk untouched:** a non-error production chunk frames byte-identically.

## RED → GREEN

**RED** (tests added, gate not yet implemented) — the failure output is itself the leak evidence:

```
10 examples, 6 failures

  1) ... redacts renderingError from the fetched payload metadata in production
     Failure/Error: expect(wire).not_to include("renderingError")
       expected "{\"hasErrors\":true,\"renderingError\":{\"message\":\"User 48213 not authorized for org 77\",\"stack...er 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)\"}}\t00000007\npayload" not to include "renderingError"
```

**GREEN** (after the gate):

```
ReactOnRailsProHelper
  #internal_rsc_payload_react_component
    frames the payload without removing html from the input chunk
    redacts renderingError from the fetched payload metadata in production
    redacts renderingError in non-development/test environments like staging
    redacts renderingError in an unrecognized environment (fail-closed)
    forces hasErrors:true in production when the chunk reports hasErrors:false with an error signal
    leaves a clean production chunk untouched
    includes the full renderingError in development
    includes the full renderingError in test
    does not mutate the upstream chunk when redacting, so StreamCache buffers the full payload
    leaves renderingError intact for the server-side raise that runs before framing

10 examples, 0 failures
```

**No regressions in the full helper spec** (the 23 failures are pre-existing on the clean base
`822b4c30b`, verified by stashing this change):

- baseline (change stashed): `142 examples, 23 failures`
- with this change: `151 examples, 23 failures`

**RuboCop:** `2 files inspected, no offenses detected`.

Labels: `runtime-fix`, `ready-for-hosted-ci` — a user-facing behavior fix on a security boundary in
the Pro helper that both the SSR and fetched RSC paths flow through, so it is worth the hosted
matrix rather than the optimized subset.

## Codex Decision Log

- **Redact at the Ruby browser-facing boundary rather than the shared TS producer.** Non-blocking,
  but it is the load-bearing design decision; rationale and the `raise_prerender_error` evidence are
  above. This made the change a Ruby lane rather than the TypeScript one the issue implied.
- **Always drop `renderingError` outside dev/test, even when it is blank or carries no error
  signal**, rather than only dropping it when a signal is present. Strictly safer and simpler; a
  blank or malformed `renderingError` never reaches the wire either. Matches the inline path in
  effect, which never emits `renderingError` outside dev/test.
- **Forced `hasErrors: true` only when an error signal was actually present**, leaving genuinely
  clean chunks untouched, so this does not manufacture error signals on healthy renders.
- **`consoleReplayScript` deliberately not audited in this PR.** It crosses the same
  `chunk.except("html")` boundary and is replayed client-side by `getReactServerComponent.client.ts`.
  Filed as #4822 rather than expanding this PR's scope.

Confidence note:
- Validated: `bundle exec rspec spec/helpers/react_on_rails_pro_helper_spec.rb -e "#internal_rsc_payload_react_component"` → 6 failures before the fix, `10 examples, 0 failures` after. Full file: `151 examples, 23 failures` vs. stashed baseline `142 examples, 23 failures` (no new failures). `bundle exec rubocop` on both changed files → `no offenses detected`. Pre-commit hooks (trailing-newlines, autofix, rubocop, pro-license-headers) all passed.
- Evidence: RED/GREEN output inline above; parity table maps each new test to its inline counterpart in `packages/react-on-rails-pro/tests/injectRSCPayload.test.ts:500-609`.
- UNKNOWN: no end-to-end browser verification of a real client navigation against a running dummy app — coverage is at the helper/transform level. The 23 pre-existing full-spec failures were not diagnosed (out of lane scope).
- Residual risk: low — the change is confined to one transform, is additive to a browser-facing serialization step, and leaves both the server-side raise path and clean-chunk framing byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RSC client-side navigation payloads no longer expose server error messages, stack traces, or internal file paths in production, staging, and unknown environments.
  * Browsers now receive a generic error signal while detailed error information remains available in development and test environments.
  * Server-side error handling continues to retain full rendering error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Merge qualifications (coordinator)

**Release gate applied: `beta`.** Target branch is `main` (phase `beta` per `AGENTS.md` -> Release-Train
Branching And Phase Gating): confidence note + green required checks. Both satisfied at head
`b7528c1034bb9bee407e699302790da60b6ffd16` — `required-pr-gate` SUCCESS, zero failing, zero pending.

**Release mode: `development`.** The only open tracker (#4806) targets 17.0.1, already shipped
(`v17.0.1` = `88c0de5b8994d7ed9bcd2cc2405d2e520e1bf20a`). Per `AGENTS.md` an unrelated final-release
target does not gate work whose own target is clear; this targets `main` on the 17.1 line.

**Merge ledger:** `script/pr-merge-ledger 4821 --strict --changelog-classification changelog_present`
-> `complete_allowed: true`, zero violations, zero unknown fields, CI `READY`, zero unresolved
current-head review threads, no `changes_requested`.

**Review cohort at this head:** CodeRabbit `APPROVED`; `claude` reviewed with one explicitly
non-blocking observation (the `consoleReplayScript` gap), replied to and resolved in-thread with the
scope rationale rather than by pushing a commit; Copilot returned a quota-limit failure, recorded as a
capacity waiver per the review-artifact barrier rather than treated as a pending gate.

**Coordinator verification, independent of the authoring worker.** The lane originally stopped rather
than implement, because issue #4736 named the wrong files. I verified that claim against live code
before authorizing the redirect, and it held on every point:

- `buildRenderMetadata` (`packages/react-on-rails/src/serverRenderUtils.ts:23-37`) is a shared
  producer whose only external caller is `packages/react-on-rails-pro/src/streamingUtils.ts:136`.
- `rendering_error_from_result` (`react_on_rails/lib/react_on_rails/helper.rb:922-935`) reads
  `renderingError["message"]` and `["stack"]`, so redacting in that shared producer — the fix the
  issue asked for — would have silently broken server-side `PrerenderError` for apps enabling
  `raise_non_shell_server_rendering_errors`.
- `injectRSCPayload.ts` builds an inline script tag and is not on the fetched path at all, so one of
  the two files the issue named was a no-op for this bug.
- `internal_rsc_payload_react_component` did `chunk.except("html").to_json` with no environment gate.
  That is the actual leak, and it is where this PR fixes it.

I also read the final implementation directly: the gate is a fail-closed allowlist
(`development`/`test` only), it returns a new Hash via `except` so the StreamCache chunk (#4550) is
never mutated, and `hasErrors` is preserved as a generic signal so client error boundaries still fire.

**Security evidence for the batch.** This wave ran no separate QA lane; per the batch plan this lane
carries the in-lane security evidence. Redacted: the whole `renderingError` object (message plus
source-mapped stack, which carries absolute server paths). Condition: fail-closed — `production`,
`staging`, and any unrecognized environment redact. Preserved: `hasErrors`. Parity: all five cases
from `injectRSCPayload.test.ts:500-609` mirrored one-for-one against actual framed wire bytes.

**UNKNOWN carried forward:**
- No end-to-end browser verification of a real client navigation; coverage is helper/transform level.
- 23 pre-existing failures in the full Pro helper spec on base `822b4c30b` were not diagnosed. The
  lane compared against a stashed baseline and added zero new failures, which is the right control,
  but those 23 remain unexplained and are out of this lane's scope.
- `consoleReplayScript` crosses the same boundary and was deliberately left unaudited — tracked as
  #4822.
- The installed Agent Workflows pack's `autonomous-merge-eligibility` gate is not adopted by this
  repository (none of its required runtime-trust paths exist in `origin/main`), so it cannot verify
  here by construction. This merge rests on the repo's own adopted contract.

Batch: `ror-a-17-1-wave-a-20260729`, lane `lane-4736-rsc-error-redact`. `merge_authority: auto_merge_when_gates_pass`.
