### PR TITLE
Build Node renderer VM contexts with DONT_CONTEXTIFY when available

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
@@ -314,7 +314,20 @@ async function buildVM(filePath: string): Promise<VMContext> {
       if (additionalContextIsObject) {
         extendContext(contextObject, additionalContext);
       }
-      const context = vm.createContext(contextObject);
+      // `vm.constants.DONT_CONTEXTIFY` (Node 20.18+ / 22.8+) creates a context whose global object
+      // is an ordinary one rather than being wrapped in V8 property interceptors, so global lookups
+      // inside the bundle (`React`, `process`, `Buffer`, ...) hit V8's normal fast paths. It is
+      // passed *instead of* the sandbox object and returns the new context's global, hence the
+      // assign afterwards; that object is reference-equal to `globalThis` inside the context, so
+      // the per-request injection/cleanup in `runInVM` is unaffected.
+      //
+      // `?.` because `vm.constants` itself only exists from Node 20.12/21.7; both it and the
+      // branch can go once 20.18/22.8 are the floor.
+      const dontContextify: typeof vm.constants.DONT_CONTEXTIFY | undefined = vm.constants?.DONT_CONTEXTIFY;
+      const context =
+        dontContextify === undefined
+          ? vm.createContext(contextObject)
+          : Object.assign(vm.createContext(dontContextify), contextObject);
 
       // Create explicit reference to global context, just in case (some libs can use it):
       vm.runInContext('global = this', context);

--- a/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
@@ -130,13 +130,29 @@ describe('buildVM and runInVM', () => {
   ])('VM context flavor: %s', (_label, preferVanilla) => {
     const runtimeHasDontContextify = vm.constants?.DONT_CONTEXTIFY !== undefined;
 
+    // `vm.constants` is a process-wide singleton, and this package's jest config sets
+    // `clearMocks`/`resetMocks` but not `restoreMocks` -- neither of which undoes a
+    // `replaceProperty`. Without the explicit restore below, the fallback case would leave
+    // `vm.constants` undefined for every later test in this file, silently forcing them all
+    // onto the older-Node path.
+    let constantsOverride: ReturnType<typeof jest.replaceProperty> | undefined;
+
     beforeEach(() => {
       // `vm.constants` is frozen, but `vm`'s own `constants` property is writable, so swapping
       // the whole object forces the module down the older-Node fallback path.
       if (!preferVanilla) {
-        jest.replaceProperty(vm, 'constants', undefined as unknown as typeof vm.constants);
+        constantsOverride = jest.replaceProperty(
+          vm,
+          'constants',
+          undefined as unknown as typeof vm.constants,
+        );
       }
       resetVM();
+    });
+
+    afterEach(() => {
+      constantsOverride?.restore();
+      constantsOverride = undefined;
     });
 
     test('creates the expected flavor without changing VM semantics', async () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
@@ -29,7 +29,7 @@ import {
   BUNDLE_TIMESTAMP,
   vmBundlePath,
 } from './helper';
-import { buildExecutionContext, hasVMContextForBundle, resetVM } from '../src/worker/vm';
+import { buildExecutionContext, getVMContext, hasVMContextForBundle, resetVM } from '../src/worker/vm';
 import { getConfig } from '../src/shared/configBuilder';
 import { isErrorRenderResult } from '../src/shared/utils';
 import * as errorReporter from '../src/shared/errorReporter';
@@ -119,6 +119,50 @@ describe('buildVM and runInVM', () => {
 
       const result = await runInVM('typeof testString !== "undefined"', uploadedBundlePathForTest());
       expect(result).toBe('true');
+    });
+  });
+
+  // The context is built with `vm.constants.DONT_CONTEXTIFY` when the Node version has it, and
+  // with a contextified sandbox otherwise. The two must be observationally identical here.
+  describe.each([
+    ['vanilla global (DONT_CONTEXTIFY)', true],
+    ['contextified sandbox (older-Node fallback)', false],
+  ])('VM context flavor: %s', (_label, preferVanilla) => {
+    const runtimeHasDontContextify = vm.constants?.DONT_CONTEXTIFY !== undefined;
+
+    beforeEach(() => {
+      // `vm.constants` is frozen, but `vm`'s own `constants` property is writable, so swapping
+      // the whole object forces the module down the older-Node fallback path.
+      if (!preferVanilla) {
+        jest.replaceProperty(vm, 'constants', undefined as unknown as typeof vm.constants);
+      }
+      resetVM();
+    });
+
+    test('creates the expected flavor without changing VM semantics', async () => {
+      getConfig().supportModules = true;
+      await createUploadedBundleForTest();
+      const bundlePath = uploadedBundlePathForTest();
+      const { runInVM } = await buildExecutionContext([bundlePath], /* buildVmsIfNeeded */ true);
+
+      const vmContext = getVMContext(bundlePath);
+      if (!vmContext) throw new Error(`no VM context built for ${bundlePath}`);
+      const { context } = vmContext;
+
+      // A vanilla context's handle IS its `globalThis`; a contextified sandbox is a separate object.
+      expect(vm.runInContext('globalThis', context) === context).toBe(
+        preferVanilla && runtimeHasDontContextify,
+      );
+
+      // Injected globals reach the bundle, and `global = this` still aliases.
+      expect(await runInVM('typeof Buffer !== "undefined"', bundlePath)).toBe('true');
+      expect(await runInVM('global === globalThis', bundlePath)).toBe('true');
+      // Per-request state is visible during execution, and cleared afterwards so it cannot leak
+      // into a later request sharing this pooled context.
+      expect(await runInVM('typeof renderingRequest', bundlePath)).toBe('string');
+      expect(vm.runInContext('typeof renderingRequest', context)).toBe('undefined');
+      // Nothing escaped into the worker's own realm.
+      expect(global.ReactOnRails).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Why

`buildVM` creates each bundle's sandbox with `vm.createContext(contextObject)`. Contextifying a sandbox installs V8 named/indexed property interceptors on the context's global object, so **every global lookup inside a server bundle** (`React`, `process`, `Buffer`, ...) traps through those interceptors instead of hitting V8's ordinary global fast paths. SSR bundles are very global-heavy, so this is on the hot path for every render.

`vm.constants.DONT_CONTEXTIFY` (Node 20.18+ / 22.8+) creates a context with an ordinary global object instead.

**Caveat, stated up front:** upstream documents this only qualitatively — *"speed up the global access if they don't need the interceptor behavior"* ([nodejs/node#54394](https://github.com/nodejs/node/pull/54394), repeated in the [20.18.0](https://nodejs.org/en/blog/release/v20.18.0) / [22.8.0](https://nodejs.org/en/blog/release/v22.8.0) release notes and the [`vm` docs](https://nodejs.org/api/vm.html)). That PR added **no benchmark**, and there is no `DONT_CONTEXTIFY` benchmark anywhere in `nodejs/node`. The mechanism is real and documented; the magnitude for our SSR workload is **unmeasured**. This PR lands the mechanism — the number still has to come from a local M1 A/B run.

## Implementation

`packages/react-on-rails-pro-node-renderer/src/worker/vm.ts` — one branch in `buildVM`:

```ts
const dontContextify: typeof vm.constants.DONT_CONTEXTIFY | undefined = vm.constants?.DONT_CONTEXTIFY;
const context =
  dontContextify === undefined
    ? vm.createContext(contextObject)
    : Object.assign(vm.createContext(dontContextify), contextObject);
```

Three things worth calling out for review:

- **The constant replaces the sandbox object; it is not a second argument.** The signature is `vm.createContext([contextObject[, options]])` where `contextObject` is `Object | vm.constants.DONT_CONTEXTIFY | undefined`, and the call returns the new context's *global* rather than the object passed in — hence the `Object.assign` afterwards. That returned object is reference-equal to `globalThis` inside the context, so the per-request `renderingRequest` / `sharedExecutionContext` / `runOnOtherBundle` injection and `finally` cleanup in `runInVM` are unaffected.
- **Feature-detected, not version-gated, and `?.` is load-bearing.** `vm.constants` itself only exists from Node 20.12/21.7, and this package declares `engines.node >= 18.19.0`, so the more obvious `'DONT_CONTEXTIFY' in vm.constants` throws `TypeError: Cannot use 'in' operator ... in undefined` on the floor version.
- **`DONT_CONTEXTIFY` is a `Symbol` at runtime, not a `number`.** `@types/node` (20.19.25 here) declares it as `number` and declares `vm.constants` as always-present — both wrong. Only presence is ever checked, and the annotation aliases the declared type (`typeof vm.constants.DONT_CONTEXTIFY | undefined`) rather than naming `number`, so it self-corrects if DefinitelyTyped is fixed. Without the annotation the value infers as plain `number`, the fallback branch narrows to `never` and reads as dead code.

## Test plan

`packages/react-on-rails-pro-node-renderer/tests/vm.test.ts` — a parameterized test over both flavors. CI's Node always takes the vanilla branch, so the fallback case stubs `vm.constants` to `undefined` to exercise the older-Node path that would otherwise never run.

Each flavor asserts which context type was actually built, then that behavior is unchanged: injected globals reach the bundle, `global = this` still aliases `globalThis`, per-request state is visible during execution and cleared afterwards (so it cannot leak into a later request sharing a pooled context), and nothing escapes into the worker's own realm.

Separately verified out-of-band that both flavors are observationally identical for every pattern this module relies on — including `Module.wrap` bundle evaluation with `require`/`__dirname`, stack-frame filenames (source-map keying), and host-side reads of globals defined by the bundle. The only difference is `globalThis === context`, which is the point of the change.

**Results** (`packages/react-on-rails-pro-node-renderer`):

- `tests/vm.test.ts` + `tests/vmSourceMapSupport.test.ts`: **91/91 pass**, including the existing `vm.createContext` synchronous-throw recovery test.
- Full package suite: **415 passed / 8 failed**. All 8 failures are pre-existing and unrelated — verified against a clean tree at the same commit, which fails identically (13 suites / 8 tests, missing `@fastify/formbody` and `@fastify/multipart`). The only delta is the 2 new passing tests.
- `type-check`: clean for `vm.ts` (the one error is the same pre-existing `@fastify/formbody` resolution failure in `src/worker.ts`).
- `eslint`: clean.

## Changelog

No entry. There is no user-visible behavior change, and the performance claim is unquantified — I'd rather add a changelog entry once the A/B run produces a number than claim an improvement we haven't measured. Happy to add one if a maintainer prefers.

## Labels

`Labels: benchmark` — classification only. Per `AGENTS.md`, `benchmark*` labels do **not** trigger hosted benchmark suites (hosted benchmark selection is disabled after the false-positive regressions in #4038–#4044).

`Benchmarks: local M1 A/B required` — this is a Node renderer hot-path change and the whole premise is a perf claim, so it needs `benchmarks/run-local-benchmark-comparison.rb` on a quiet machine before this is worth merging on performance grounds.

Not requesting hosted CI yet; say the word and I'll comment `+ci-run-hosted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering compatibility across supported Node.js versions.
  - Ensured consistent global behavior and injected settings in isolated rendering contexts.
  - Preserved request-state cleanup and isolation between worker executions.

- **Tests**
  - Added coverage for modern and legacy Node.js context creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->