### PR TITLE
Fix generated server config lint cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **Generated server webpack configs no longer include an unused `merge` import or stale comments**:
+  `commonWebpackConfig` already clones the shared client configuration, so the generated server configuration
+  stays lint-clean without changing its runtime behavior. Fixes
+  [Issue 4791](https://github.com/shakacode/react_on_rails/issues/4791).
+
 - **[Pro]** **RSC render-error details are no longer sent to the browser on the fetched payload path**:
   The RSC payload fetched during client-side navigation (via `rsc_payload_generation_url_path`) included
   the server's rendering-error message and source-mapped stack — which contains server file paths — in its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   `commonWebpackConfig` already clones the shared client configuration, so the generated server configuration
   stays lint-clean without changing its runtime behavior. Fixes
   [Issue 4791](https://github.com/shakacode/react_on_rails/issues/4791).
+  [PR 4840](https://github.com/shakacode/react_on_rails/pull/4840) by
+  [ihabadham](https://github.com/ihabadham).
 
 - **[Pro]** **RSC render-error details are no longer sent to the browser on the fetched payload path**:
   The RSC payload fetched during client-side navigation (via `rsc_payload_generation_url_path`) included

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
@@ -1,6 +1,6 @@
 <%= add_documentation_reference(config[:message], "// https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js") %>
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -38,10 +38,6 @@ const configureServer = (rscBundle = false) => {
 <% else -%>
 const configureServer = () => {
 <% end -%>
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/dummy/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails/spec/dummy/config/webpack/serverWebpackConfig.js
@@ -11,10 +11,6 @@ const isRspackClientOnlyPlugin = (plugin) =>
     (bundler.CssExtractRspackPlugin && plugin instanceof bundler.CssExtractRspackPlugin));
 
 const configureServer = () => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/react_on_rails/fixtures/generated/rspack_base/config/rspack/serverWebpackConfig.js
+++ b/react_on_rails/spec/react_on_rails/fixtures/generated/rspack_base/config/rspack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
 // The source code including full typescript support is available at: 
 // https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -17,10 +17,6 @@ function getLoaderPath(item) {
 }
 
 const configureServer = () => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/react_on_rails/fixtures/generated/rspack_pro/config/rspack/serverWebpackConfig.js
+++ b/react_on_rails/spec/react_on_rails/fixtures/generated/rspack_pro/config/rspack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
 // The source code including full typescript support is available at: 
 // https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -22,10 +22,6 @@ function extractLoader(rule, loaderName) {
 }
 
 const configureServer = () => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/react_on_rails/fixtures/generated/rspack_rsc/config/rspack/serverWebpackConfig.js
+++ b/react_on_rails/spec/react_on_rails/fixtures/generated/rspack_rsc/config/rspack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
 // The source code including full typescript support is available at: 
 // https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -31,10 +31,6 @@ function extractLoader(rule, loaderName) {
 
 // rscBundle parameter: when true, skips RSCRspackPlugin (RSC bundle doesn't need it)
 const configureServer = (rscBundle = false) => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_base/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_base/config/webpack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
 // The source code including full typescript support is available at: 
 // https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -17,10 +17,6 @@ function getLoaderPath(item) {
 }
 
 const configureServer = () => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_base_shakapacker8/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_base_shakapacker8/config/webpack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
 // The source code including full typescript support is available at: 
 // https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -17,10 +17,6 @@ function getLoaderPath(item) {
 }
 
 const configureServer = () => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_pro/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_pro/config/webpack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
 // The source code including full typescript support is available at: 
 // https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -22,10 +22,6 @@ function extractLoader(rule, loaderName) {
 }
 
 const configureServer = () => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry

--- a/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_rsc/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails/spec/react_on_rails/fixtures/generated/webpack_rsc/config/webpack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
 // The source code including full typescript support is available at: 
 // https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/serverWebpackConfig.js
 
-const { merge, config } = require('shakapacker');
+const { config } = require('shakapacker');
 const commonWebpackConfig = require('./commonWebpackConfig');
 
 const bundler = config.assets_bundler === 'rspack'
@@ -31,10 +31,6 @@ function extractLoader(rule, loaderName) {
 
 // rscBundle parameter: when true, skips RSCWebpackPlugin (RSC bundle doesn't need it)
 const configureServer = (rscBundle = false) => {
-  // We need to use "merge" because the clientConfigObject, EVEN after running
-  // toWebpackConfig() is a mutable GLOBAL. Thus any changes, like modifying the
-  // entry value will result in changing the client config!
-  // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
 
   // We just want the single server bundle entry


### PR DESCRIPTION
## Why

Generated server webpack configs imported `merge` from Shakapacker without using it, and nearby comments incorrectly said the server config performed a merge. The shared `commonWebpackConfig` already performs the defensive merge/clone, so keeping the extra import and comments creates lint noise and misleading generated code.

Fixes #4791.

## What changed

- Remove the unused `merge` import from the server webpack config template.
- Remove the stale merge comments from the template and dummy app.
- Regenerate all seven affected golden-output variants.
- Record the generator cleanup in the changelog.

## Decision

This removes the unused API rather than adding a redundant merge call. Runtime behavior remains unchanged because `commonWebpackConfig` continues to merge into a fresh object.

## Validation

- `REGENERATE_GENERATOR_GOLDEN=1 bundle exec rspec spec/react_on_rails/generators/generator_golden_output_spec.rb` — 34 examples, 0 failures
- Verification-mode golden-output spec — 34 examples, 0 failures (run by the independent code-review pass)
- OSS RuboCop — passed
- `pnpm run lint` — passed
- Prettier check — passed
- Pre-commit and pre-push hooks — passed
- `git diff --check` — passed
- Automated review against `origin/main` — no findings
- Fresh comment-publication pass — no changes required

## Churn notes

The first normal commit attempt was blocked by an outdated Corepack signature key. Corepack was updated to 0.34.6 and pnpm 10.33.4 was activated; hooks were then rerun normally and passed. No hook was bypassed.

## Codex decision log

- **Scope:** generator template, synchronized generated fixtures, dummy app, and changelog only.
- **Behavior:** no runtime semantic change.
- **Confidence:** high; source and all golden outputs are synchronized and the focused generator spec passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated server webpack configurations no longer include an unused import or outdated comments.
  * Server configuration behavior remains unchanged, ensuring existing builds continue to work as expected.

* **Documentation**
  * Added an unreleased changelog entry documenting the configuration cleanup and its unchanged runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- completed-batch-audit-summary:start -->
## Completed-batch audit

**Status:** Clean — no outstanding findings or follow-ups. [Durable receipt](https://github.com/shakacode/react_on_rails/pull/4840#issuecomment-5159947777).
<!-- completed-batch-audit-summary:end -->
