### PR TITLE
Fix malformed renderer URL credential redaction

### DIFF
--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -426,7 +426,7 @@ module ReactOnRails
         end
 
         def malformed_userinfo_continuation?(text, match)
-          continuation = text[match.end(0)..].match(/\A[[:blank:]]+(?<token>\S+)/)
+          continuation = text[match.end(0)..].match(/\A(?:[[:blank:]]+|["'])(?<token>\S+)/)
           return false unless continuation
 
           token = continuation[:token]

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -162,9 +162,11 @@ module ReactOnRails
           # caller — the credential would still leak here regardless. e.message is scrubbed too:
           # a URL malformed enough that URI.parse raises embeds the raw, unsanitized URL verbatim
           # in URI::InvalidURIError's own message.
-          msg = "You specified server rendering JS file: #{sanitized_renderer_url(server_js_file)}, but it cannot " \
+          sanitized_url = sanitized_renderer_url(server_js_file)
+          sanitized_error = sanitized_renderer_error_message(e.message, server_js_file, sanitized_url)
+          msg = "You specified server rendering JS file: #{sanitized_url}, but it cannot " \
                 "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
-                "avoid this warning.\nError is: #{strip_userinfo(e.message)}\n\n" \
+                "avoid this warning.\nError is: #{sanitized_error}\n\n" \
                 "#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
@@ -395,18 +397,33 @@ module ReactOnRails
         # Strips any embedded credentials from a configured renderer URL before it is
         # interpolated into an error message, so a password in the URL (a supported config
         # convenience, e.g. https://:password@host:3800) cannot leak into logs or error
-        # trackers. The span scanner also handles malformed text containing multiple schemes.
+        # trackers. One configured value is not free-form prose: multiple schemes or line breaks
+        # make it structurally ambiguous, so those values fail closed through their final @.
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
+          return url unless url.match?(%r{\Ahttps?://}i)
 
-          strip_userinfo(url)
+          return strip_malformed_url_userinfo(url) if url.match?(/[\r\n]/) || url.scan(%r{https?://}i).length > 1
+
+          sanitized_valid_http_url(url) || strip_malformed_url_userinfo(url)
+        end
+
+        def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))
+          message = message.to_s
+          return strip_userinfo(message) if raw_url.nil? || raw_url.empty?
+
+          # URI::InvalidURIError embeds String#inspect, while other errors may embed the raw value.
+          message = message.gsub(raw_url.inspect, sanitized_url.inspect)
+                           .gsub(raw_url, sanitized_url)
+          strip_userinfo(message)
         end
 
         # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
         # without collision-prone placeholder text. A candidate remains unprotected when any @
         # follows it before the next scheme or newline: punctuation and prose are not structural
-        # proof that the @ is unrelated to malformed userinfo. The same-line fallback may therefore
-        # over-redact ambiguous diagnostic text, preferring credential safety over fidelity.
+        # proof that the @ is unrelated to malformed userinfo. A credential-bearing candidate also
+        # remains unprotected when an unresolved scheme precedes it on the same line, allowing the
+        # fallback to redact the combined span. Ambiguous text may be over-redacted for safety.
         def strip_userinfo(text)
           text = text.to_s
           sanitized = text.dup.clear
@@ -417,6 +434,9 @@ module ReactOnRails
             protected_url = sanitized_valid_http_url(match[0])
             next unless protected_url
             next if userinfo_delimiter_before_structural_boundary?(text, match)
+            next if protected_url != match[0] && unresolved_scheme_on_current_line?(
+              text[unprotected_start...match.begin(0)]
+            )
 
             sanitized << strip_unprotected_userinfo(text[unprotected_start...match.begin(0)])
             sanitized << protected_url
@@ -431,6 +451,10 @@ module ReactOnRails
           boundary = continuation.match(%r{https?://|[\r\n]}i)
           continuation = continuation[...boundary.begin(0)] if boundary
           continuation.include?("@")
+        end
+
+        def unresolved_scheme_on_current_line?(text)
+          text.match?(%r{https?://[^\r\n]*\z}i)
         end
 
         # URI handles valid URLs structurally, so an @ in the path is never mistaken for userinfo.
@@ -501,8 +525,10 @@ module ReactOnRails
           # message, which Rails.logger and error trackers can persist. e.message is scrubbed as
           # well as url itself: a URL malformed enough that URI.parse raises embeds the raw,
           # unsanitized URL verbatim in URI::InvalidURIError's own message.
-          msg = "file_url_to_string #{sanitized_renderer_url(url)} failed\nError is: " \
-                "#{strip_userinfo(e.message)}\n\n#{Utils.default_troubleshooting_section}"
+          sanitized_url = sanitized_renderer_url(url)
+          sanitized_error = sanitized_renderer_error_message(e.message, url, sanitized_url)
+          msg = "file_url_to_string #{sanitized_url} failed\nError is: " \
+                "#{sanitized_error}\n\n#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
 

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -402,20 +402,23 @@ module ReactOnRails
           strip_url_userinfo(url)
         end
 
-        # Scrubs only HTTP(S) URL occurrences so unrelated message text remains intact. Handle
-        # quoted URLs first because URI::InvalidURIError may quote malformed userinfo containing
-        # whitespace; the bare-token pass then handles URLs embedded in ordinary error messages.
+        # Scrubs only HTTP(S)-anchored text so unrelated messages remain intact. Quoted URLs and
+        # bare tokens use the structured helper first. The final same-line fallback fails closed
+        # when malformed unquoted userinfo contains whitespace: it may over-redact diagnostic text
+        # or an ambiguous @ in a malformed URL path, preferring credential safety over fidelity.
         def strip_userinfo(text)
           sanitized = text.to_s.gsub(%r{(?<quote>["'])(?<url>https?://.*?)\k<quote>}i) do
             match = Regexp.last_match
             "#{match[:quote]}#{strip_url_userinfo(match[:url])}#{match[:quote]}"
           end
-          sanitized.gsub(%r{https?://[^\s"']+}i) { |url| strip_url_userinfo(url) }
+          sanitized = sanitized.gsub(%r{https?://[^\s"']+}i) { |url| strip_url_userinfo(url) }
+          sanitized.gsub(%r{(?<scheme>https?://)[^\r\n]*@}i) { Regexp.last_match[:scheme] }
         end
 
         # URI handles valid URLs without confusing an @ in the path for userinfo. When a raw
         # configured URL is malformed (including an unescaped slash in its password), fall back
-        # to the last @ so every credential fragment is removed while preserving the host/path.
+        # to the last @ and retain only the suffix that follows it. That suffix is best-effort
+        # diagnostic context, not a guarantee that every malformed URL keeps its original path.
         def strip_url_userinfo(url)
           scheme = url.match(%r{\Ahttps?://}i)
           return url unless scheme

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -428,8 +428,8 @@ module ReactOnRails
           return strip_userinfo(message) if raw_url.nil? || raw_url.empty?
 
           # URI::InvalidURIError embeds String#inspect, while other errors may embed the raw value.
-          message = message.gsub(raw_url.inspect, sanitized_url.inspect)
-                           .gsub(raw_url, sanitized_url)
+          message = message.gsub(raw_url.inspect) { sanitized_url.inspect }
+                           .gsub(raw_url) { sanitized_url }
           strip_userinfo(message)
         end
 
@@ -484,7 +484,7 @@ module ReactOnRails
           uri.password = nil
           uri.user = nil
           uri.to_s
-        rescue URI::InvalidURIError
+        rescue URI::Error
           nil
         end
 

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -402,29 +402,37 @@ module ReactOnRails
           strip_url_userinfo(url)
         end
 
-        # Scrubs only HTTP(S)-anchored text so unrelated messages remain intact. Quoted URLs and
-        # bare tokens use the structured helper first. The final same-line fallback activates only
-        # when horizontal whitespace precedes the final @. It may still over-redact ambiguous
-        # malformed diagnostic text, preferring credential safety over fidelity.
+        # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
+        # without collision-prone placeholder text. Invalid tokens remain in the intervening spans,
+        # where a same-line fallback fails closed through the last @. That fallback may over-redact
+        # truly malformed diagnostic text, preferring credential safety over fidelity.
         def strip_userinfo(text)
-          sanitized = text.to_s.gsub(%r{(?<quote>["'])(?<url>https?://.*?)\k<quote>}i) do
+          text = text.to_s
+          sanitized = text.dup.clear
+          unprotected_start = 0
+
+          text.to_enum(:scan, %r{https?://[^\s"']+}i).each do
             match = Regexp.last_match
-            "#{match[:quote]}#{strip_url_userinfo(match[:url])}#{match[:quote]}"
+            protected_url = sanitized_valid_http_url(match[0])
+            next unless protected_url
+
+            sanitized << strip_unprotected_userinfo(text[unprotected_start...match.begin(0)])
+            sanitized << protected_url
+            unprotected_start = match.end(0)
           end
-          sanitized = sanitized.gsub(%r{https?://[^\s"']+}i) { |url| strip_url_userinfo(url) }
-          sanitized.gsub(%r{(?<scheme>https?://)(?=[^\r\n]*[[:blank:]][^\r\n]*@)[^\r\n]*@}i) do
-            Regexp.last_match[:scheme]
-          end
+
+          sanitized << strip_unprotected_userinfo(text[unprotected_start..])
         end
 
-        # URI handles valid URLs without confusing an @ in the path for userinfo. When a raw
-        # configured URL is malformed (including an unescaped slash in its password), fall back
-        # to the last @ and retain only the suffix that follows it. That suffix is best-effort
-        # diagnostic context, not a guarantee that every malformed URL keeps its original path.
         def strip_url_userinfo(url)
-          scheme = url.match(%r{\Ahttps?://}i)
-          return url unless scheme
+          return url unless url.match?(%r{\Ahttps?://}i)
 
+          sanitized_valid_http_url(url) || strip_malformed_url_userinfo(url)
+        end
+
+        # URI handles valid URLs structurally, so an @ in the path is never mistaken for userinfo.
+        # Returning nil for invalid input keeps that token unprotected for the fail-closed pass.
+        def sanitized_valid_http_url(url)
           uri = URI.parse(url)
           return url if uri.userinfo.nil?
 
@@ -433,8 +441,19 @@ module ReactOnRails
           uri.user = nil
           uri.to_s
         rescue URI::InvalidURIError
+          nil
+        end
+
+        def strip_unprotected_userinfo(text)
+          text.gsub(%r{https?://[^\r\n]*@}i) { |span| strip_malformed_url_userinfo(span) }
+        end
+
+        # For malformed URLs or unprotected same-line spans, remove through the last @. The
+        # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
+        def strip_malformed_url_userinfo(url)
+          scheme = url.match(%r{\Ahttps?://}i)
           userinfo_delimiter = url.rindex("@")
-          return url unless userinfo_delimiter
+          return url unless scheme && userinfo_delimiter
 
           "#{url[...scheme.end(0)]}#{url[(userinfo_delimiter + 1)..]}"
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -415,6 +415,7 @@ module ReactOnRails
             match = Regexp.last_match
             protected_url = sanitized_valid_http_url(match[0])
             next unless protected_url
+            next if malformed_userinfo_continuation?(text, match)
 
             sanitized << strip_unprotected_userinfo(text[unprotected_start...match.begin(0)])
             sanitized << protected_url
@@ -422,6 +423,16 @@ module ReactOnRails
           end
 
           sanitized << strip_unprotected_userinfo(text[unprotected_start..])
+        end
+
+        def malformed_userinfo_continuation?(text, match)
+          continuation = text[match.end(0)..].match(/\A[[:blank:]]+(?<token>\S+)/)
+          return false unless continuation
+
+          token = continuation[:token]
+          return false if token.match?(%r{\Ahttps?://}i)
+
+          token.include?("@")
         end
 
         def strip_url_userinfo(url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -418,7 +418,7 @@ module ReactOnRails
         # URL fallback and by the rescue blocks below, so there is exactly one definition of
         # "strip userinfo" rather than two regexes that can drift apart.
         def strip_userinfo(text)
-          text.to_s.gsub(%r{//[^/@]*@}, "//")
+          text.to_s.gsub(%r{//[^/]*@}, "//")
         end
 
         def file_url_to_string(url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -395,9 +395,30 @@ module ReactOnRails
         # Strips any embedded credentials from a configured renderer URL before it is
         # interpolated into an error message, so a password in the URL (a supported config
         # convenience, e.g. https://:password@host:3800) cannot leak into logs or error
-        # trackers. Mirrors ReactOnRailsPro::Configuration#strip_renderer_url_userinfo.
+        # trackers. All valid and malformed URL paths converge on strip_url_userinfo below.
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
+
+          strip_url_userinfo(url)
+        end
+
+        # Scrubs only HTTP(S) URL occurrences so unrelated message text remains intact. Handle
+        # quoted URLs first because URI::InvalidURIError may quote malformed userinfo containing
+        # whitespace; the bare-token pass then handles URLs embedded in ordinary error messages.
+        def strip_userinfo(text)
+          sanitized = text.to_s.gsub(%r{(?<quote>["'])(?<url>https?://.*?)\k<quote>}i) do
+            match = Regexp.last_match
+            "#{match[:quote]}#{strip_url_userinfo(match[:url])}#{match[:quote]}"
+          end
+          sanitized.gsub(%r{https?://[^\s"']+}i) { |url| strip_url_userinfo(url) }
+        end
+
+        # URI handles valid URLs without confusing an @ in the path for userinfo. When a raw
+        # configured URL is malformed (including an unescaped slash in its password), fall back
+        # to the last @ so every credential fragment is removed while preserving the host/path.
+        def strip_url_userinfo(url)
+          scheme = url.match(%r{\Ahttps?://}i)
+          return url unless scheme
 
           uri = URI.parse(url)
           return url if uri.userinfo.nil?
@@ -407,18 +428,10 @@ module ReactOnRails
           uri.user = nil
           uri.to_s
         rescue URI::InvalidURIError
-          # A URL malformed enough that URI rejects it still shouldn't leak credentials.
-          strip_userinfo(url)
-        end
+          userinfo_delimiter = url.rindex("@")
+          return url unless userinfo_delimiter
 
-        # Best-effort strip of the common user:pass@ form from arbitrary text — not just a URL
-        # value, but also free-form text that may quote one, such as the message of a
-        # URI::InvalidURIError raised from an unparseable credential-bearing URL (that message
-        # embeds the raw original string verbatim). Shared by sanitized_renderer_url's malformed-
-        # URL fallback and by the rescue blocks below, so there is exactly one definition of
-        # "strip userinfo" rather than two regexes that can drift apart.
-        def strip_userinfo(text)
-          text.to_s.gsub(%r{//[^/]*@}, "//")
+          "#{url[...scheme.end(0)]}#{url[(userinfo_delimiter + 1)..]}"
         end
 
         def file_url_to_string(url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -403,16 +403,18 @@ module ReactOnRails
         end
 
         # Scrubs only HTTP(S)-anchored text so unrelated messages remain intact. Quoted URLs and
-        # bare tokens use the structured helper first. The final same-line fallback fails closed
-        # when malformed unquoted userinfo contains whitespace: it may over-redact diagnostic text
-        # or an ambiguous @ in a malformed URL path, preferring credential safety over fidelity.
+        # bare tokens use the structured helper first. The final same-line fallback activates only
+        # when horizontal whitespace precedes the final @. It may still over-redact ambiguous
+        # malformed diagnostic text, preferring credential safety over fidelity.
         def strip_userinfo(text)
           sanitized = text.to_s.gsub(%r{(?<quote>["'])(?<url>https?://.*?)\k<quote>}i) do
             match = Regexp.last_match
             "#{match[:quote]}#{strip_url_userinfo(match[:url])}#{match[:quote]}"
           end
           sanitized = sanitized.gsub(%r{https?://[^\s"']+}i) { |url| strip_url_userinfo(url) }
-          sanitized.gsub(%r{(?<scheme>https?://)[^\r\n]*@}i) { Regexp.last_match[:scheme] }
+          sanitized.gsub(%r{(?<scheme>https?://)(?=[^\r\n]*[[:blank:]][^\r\n]*@)[^\r\n]*@}i) do
+            Regexp.last_match[:scheme]
+          end
         end
 
         # URI handles valid URLs without confusing an @ in the path for userinfo. When a raw

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -398,14 +398,23 @@ module ReactOnRails
         # interpolated into an error message, so a password in the URL (a supported config
         # convenience, e.g. https://:password@host:3800) cannot leak into logs or error
         # trackers. One configured value is not free-form prose: multiple schemes or line breaks
-        # make it structurally ambiguous, so those values fail closed through their final @.
+        # after its first scheme make it structurally ambiguous, so that URL suffix fails closed
+        # through its final @. Any non-URL prefix is preserved for useful error context.
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
-          return url unless url.match?(%r{\Ahttps?://}i)
 
-          return strip_malformed_url_userinfo(url) if url.match?(/[\r\n]/) || url.scan(%r{https?://}i).length > 1
+          scheme = url.match(%r{https?://}i)
+          return url unless scheme
 
-          sanitized_valid_http_url(url) || strip_malformed_url_userinfo(url)
+          prefix = url[...scheme.begin(0)]
+          configured_url = url[scheme.begin(0)..]
+          sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(%r{https?://}i).length > 1
+                            strip_malformed_url_userinfo(configured_url)
+                          else
+                            sanitized_valid_http_url(configured_url) || strip_malformed_url_userinfo(configured_url)
+                          end
+
+          "#{prefix}#{sanitized_url}"
         end
 
         def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -149,7 +149,8 @@ module ReactOnRails
 
         def read_bundle_js_code
           server_js_file = ReactOnRails::Utils.server_bundle_js_file_path
-          if ReactOnRails::Utils.server_bundle_path_is_http?
+          server_bundle_path_is_http = ReactOnRails::Utils.server_bundle_path_is_http?
+          if server_bundle_path_is_http
             file_url_to_string(server_js_file)
           else
             File.read(server_js_file)
@@ -159,11 +160,16 @@ module ReactOnRails
           # (a supported config convenience, e.g. https://:password@host:3800). This is the
           # public entry point that file_url_to_string is called from, so without this the
           # sanitization inside file_url_to_string's own raise/rescue is moot for any real
-          # caller — the credential would still leak here regardless. e.message is scrubbed too:
-          # a URL malformed enough that URI.parse raises embeds the raw, unsanitized URL verbatim
-          # in URI::InvalidURIError's own message.
+          # caller — the credential would still leak here regardless. Errors already wrapped by
+          # file_url_to_string have passed through the same message sanitizer; scanning that
+          # wrapper again would treat its diagnostic text as fresh untrusted input. Other errors
+          # are scrubbed here because URI::InvalidURIError embeds the raw URL in its message.
           sanitized_url = sanitized_renderer_url(server_js_file)
-          sanitized_error = sanitized_renderer_error_message(e.message, server_js_file, sanitized_url)
+          sanitized_error = if server_bundle_path_is_http && e.is_a?(ReactOnRails::ServerBundleLoadError)
+                              e.message
+                            else
+                              sanitized_renderer_error_message(e.message, server_js_file, sanitized_url)
+                            end
           msg = "You specified server rendering JS file: #{sanitized_url}, but it cannot " \
                 "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
                 "avoid this warning.\nError is: #{sanitized_error}\n\n" \
@@ -429,10 +435,11 @@ module ReactOnRails
 
         # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
         # without collision-prone placeholder text. A candidate remains unprotected when any @
-        # follows it before the next scheme or newline: punctuation and prose are not structural
-        # proof that the @ is unrelated to malformed userinfo. A credential-bearing candidate also
-        # remains unprotected when an unresolved scheme precedes it on the same line, allowing the
-        # fallback to redact the combined span. Ambiguous text may be over-redacted for safety.
+        # follows it before the next scheme: punctuation, prose, and line breaks are not structural
+        # proof that the @ is unrelated to malformed userinfo. When an unresolved region precedes
+        # a credential-bearing candidate, that region is discarded and the candidate is sanitized
+        # independently rather than allowing one fallback match to consume through another scheme.
+        # Ambiguous text may be over-redacted for safety.
         def strip_userinfo(text)
           text = text.to_s
           sanitized = text.dup.clear
@@ -442,12 +449,10 @@ module ReactOnRails
             match = Regexp.last_match
             protected_url = sanitized_valid_http_url(match[0])
             next unless protected_url
-            next if userinfo_delimiter_before_structural_boundary?(text, match)
-            next if protected_url != match[0] && unresolved_scheme_on_current_line?(
-              text[unprotected_start...match.begin(0)]
-            )
+            next if userinfo_delimiter_before_next_scheme?(text, match)
 
-            sanitized << strip_unprotected_userinfo(text[unprotected_start...match.begin(0)])
+            unprotected = text[unprotected_start...match.begin(0)]
+            sanitized << sanitized_unprotected_prefix(unprotected, match[0], protected_url)
             sanitized << protected_url
             unprotected_start = match.end(0)
           end
@@ -455,15 +460,18 @@ module ReactOnRails
           sanitized << strip_unprotected_userinfo(text[unprotected_start..])
         end
 
-        def userinfo_delimiter_before_structural_boundary?(text, match)
+        def userinfo_delimiter_before_next_scheme?(text, match)
           continuation = text[match.end(0)..]
-          boundary = continuation.match(%r{https?://|[\r\n]}i)
+          boundary = continuation.match(%r{https?://}i)
           continuation = continuation[...boundary.begin(0)] if boundary
           continuation.include?("@")
         end
 
-        def unresolved_scheme_on_current_line?(text)
-          text.match?(%r{https?://[^\r\n]*\z}i)
+        def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
+          unresolved_scheme = text.match(%r{https?://}i)
+          return strip_unprotected_userinfo(text) if raw_url == sanitized_url || unresolved_scheme.nil?
+
+          text[...unresolved_scheme.begin(0)]
         end
 
         # URI handles valid URLs structurally, so an @ in the path is never mistaken for userinfo.
@@ -481,10 +489,10 @@ module ReactOnRails
         end
 
         def strip_unprotected_userinfo(text)
-          text.gsub(%r{https?://[^\r\n]*@}i) { |span| strip_malformed_url_userinfo(span) }
+          text.gsub(%r{https?://(?:(?!https?://).)*@}im) { |span| strip_malformed_url_userinfo(span) }
         end
 
-        # For malformed URLs or unprotected same-line spans, remove through the last @. The
+        # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The
         # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
         def strip_malformed_url_userinfo(url)
           scheme = url.match(%r{\Ahttps?://}i)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -403,9 +403,10 @@ module ReactOnRails
         end
 
         # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
-        # without collision-prone placeholder text. Invalid tokens remain in the intervening spans,
-        # where a same-line fallback fails closed through the last @. That fallback may over-redact
-        # truly malformed diagnostic text, preferring credential safety over fidelity.
+        # without collision-prone placeholder text. A candidate remains unprotected when any @
+        # follows it before the next scheme or newline: punctuation and prose are not structural
+        # proof that the @ is unrelated to malformed userinfo. The same-line fallback may therefore
+        # over-redact ambiguous diagnostic text, preferring credential safety over fidelity.
         def strip_userinfo(text)
           text = text.to_s
           sanitized = text.dup.clear
@@ -415,7 +416,7 @@ module ReactOnRails
             match = Regexp.last_match
             protected_url = sanitized_valid_http_url(match[0])
             next unless protected_url
-            next if malformed_userinfo_continuation?(text, match)
+            next if userinfo_delimiter_before_structural_boundary?(text, match)
 
             sanitized << strip_unprotected_userinfo(text[unprotected_start...match.begin(0)])
             sanitized << protected_url
@@ -425,14 +426,11 @@ module ReactOnRails
           sanitized << strip_unprotected_userinfo(text[unprotected_start..])
         end
 
-        def malformed_userinfo_continuation?(text, match)
-          continuation = text[match.end(0)..].match(/\A(?:[[:blank:]]+|["'])(?<token>\S+)/)
-          return false unless continuation
-
-          token = continuation[:token]
-          return false if token.match?(%r{\Ahttps?://}i)
-
-          token.include?("@")
+        def userinfo_delimiter_before_structural_boundary?(text, match)
+          continuation = text[match.end(0)..]
+          boundary = continuation.match(%r{https?://|[\r\n]}i)
+          continuation = continuation[...boundary.begin(0)] if boundary
+          continuation.include?("@")
         end
 
         def strip_url_userinfo(url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -395,11 +395,11 @@ module ReactOnRails
         # Strips any embedded credentials from a configured renderer URL before it is
         # interpolated into an error message, so a password in the URL (a supported config
         # convenience, e.g. https://:password@host:3800) cannot leak into logs or error
-        # trackers. All valid and malformed URL paths converge on strip_url_userinfo below.
+        # trackers. The span scanner also handles malformed text containing multiple schemes.
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
 
-          strip_url_userinfo(url)
+          strip_userinfo(url)
         end
 
         # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
@@ -412,7 +412,7 @@ module ReactOnRails
           sanitized = text.dup.clear
           unprotected_start = 0
 
-          text.to_enum(:scan, %r{https?://[^\s"']+}i).each do
+          text.to_enum(:scan, %r{https?://(?:(?!https?://)[^\s"'])+}i).each do
             match = Regexp.last_match
             protected_url = sanitized_valid_http_url(match[0])
             next unless protected_url
@@ -431,12 +431,6 @@ module ReactOnRails
           boundary = continuation.match(%r{https?://|[\r\n]}i)
           continuation = continuation[...boundary.begin(0)] if boundary
           continuation.include?("@")
-        end
-
-        def strip_url_userinfo(url)
-          return url unless url.match?(%r{\Ahttps?://}i)
-
-          sanitized_valid_http_url(url) || strip_malformed_url_userinfo(url)
         end
 
         # URI handles valid URLs structurally, so an @ in the path is never mistaken for userinfo.

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -550,6 +550,38 @@ module ReactOnRails
           end
         end
 
+        nested_scheme_cases = [
+          ["a comma", "http://outer.test/first,http://synthetic-user:synthetic-secret@host/path"],
+          ["a semicolon", "http://outer.test/first;http://synthetic-user:synthetic-secret@host/path"],
+          ["a parenthesis", "http://outer.test/first(http://synthetic-user:synthetic-secret@host/path)"],
+          ["no delimiter", "http://outer.test/firsthttp://synthetic-user:synthetic-secret@host/path"],
+          ["mixed-case HTTP then HTTPS",
+           "hTtP://outer.test/first;HtTpS://synthetic-user:synthetic-secret@host/path"],
+          ["mixed-case HTTPS then HTTP",
+           "HtTpS://outer.test/first;hTtP://synthetic-user:synthetic-secret@host/path"]
+        ]
+
+        context "when the configured URL contains another scheme without whitespace" do
+          nested_scheme_cases.each do |description, server_bundle_url|
+            it "sanitizes credentials after #{description}" do
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+              allow(Net::HTTP).to receive(:get_response).and_raise("connection failed")
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                expect(error.message).not_to include("synthetic-user")
+                expect(error.message).not_to include("synthetic-secret")
+                expect(error.message).to include("outer.test/first")
+                expect(error.message).to include("host/path")
+              }
+            end
+          end
+        end
+
         context "when malformed URL userinfo contains a literal double quote" do
           it "redacts the escaped URL from the URI error" do
             server_bundle_url = "http://synthetic-user:sec\"ret@host/path"
@@ -640,6 +672,30 @@ module ReactOnRails
               end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
                 credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
                 expect(error.message).to include("Failure loading http://host/path")
+              }
+            end
+          end
+        end
+
+        context "when an ordinary error contains another scheme without whitespace" do
+          nested_scheme_cases.each do |description, nested_urls|
+            it "sanitizes credentials after #{description}" do
+              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+              failure_message = "Failure loading #{nested_urls}"
+
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                expect(error.message).not_to include("synthetic-user")
+                expect(error.message).not_to include("synthetic-secret")
+                expect(error.message).to include("outer.test/first")
+                expect(error.message).to include("host/path")
               }
             end
           end

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -503,6 +503,27 @@ module ReactOnRails
           end
         end
 
+        context "when malformed URL userinfo contains a literal double quote" do
+          it "redacts the escaped URL from the URI error" do
+            server_bundle_url = "http://synthetic-user:sec\"ret@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("sec")
+              expect(error.message).not_to include("ret")
+              expect(error.message).to include("bad URI")
+              expect(error.message).to include("host/path")
+            }
+          end
+        end
+
         context "when a bundle-load failure embeds an unquoted malformed credential URL" do
           it "fails closed across whitespace in the credential" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
@@ -529,6 +550,25 @@ module ReactOnRails
           it "preserves the URL because it has no userinfo" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://host/path@example"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(failure_message)
+            }
+          end
+        end
+
+        context "when a valid URL is followed by prose containing an email address" do
+          it "preserves both the URL and the later prose" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://host/path; contact dev@example.com"
 
             allow(ReactOnRails::Utils).to receive_messages(
               server_bundle_js_file_path: server_bundle_url,

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -302,6 +302,29 @@ module ReactOnRails
       end
 
       describe ".read_bundle_js_code" do
+        def stub_http_bundle_failure(error, bundle_url: "http://localhost:3035/webpack/development/server-bundle.js")
+          allow(ReactOnRails::Utils).to receive_messages(
+            server_bundle_js_file_path: bundle_url,
+            server_bundle_path_is_http?: true
+          )
+          allow(Net::HTTP).to receive(:get_response).and_raise(error)
+        end
+
+        def stub_local_bundle_failure(error, bundle_path: "/tmp/server-bundle.js")
+          allow(ReactOnRails::Utils).to receive_messages(
+            server_bundle_js_file_path: bundle_path,
+            server_bundle_path_is_http?: false
+          )
+          allow(File).to receive(:read).with(bundle_path).and_raise(error)
+        end
+
+        def bundle_load_error_message
+          described_class.read_bundle_js_code
+          raise "expected read_bundle_js_code to raise"
+        rescue ReactOnRails::ServerBundleLoadError => e
+          e.message
+        end
+
         it "raises a bundle-load error when an HTTP server bundle cannot be read" do
           server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
 
@@ -393,23 +416,16 @@ module ReactOnRails
         context "when the HTTP-served bundle URL embeds credentials and the connection fails" do
           it "does not leak the credential into the raised error message" do
             server_bundle_url = "http://bundle-user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
-
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(
-              Errno::ECONNREFUSED.new("connect(2) for localhost:3035")
+            stub_http_bundle_failure(
+              Errno::ECONNREFUSED.new("connect(2) for localhost:3035"),
+              bundle_url: server_bundle_url
             )
 
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("s3cr3t")
-              expect(error.message).not_to include("bundle-user")
-              expect(error.message).to include("localhost:3035")
-              expect(error.message).to include("cannot be read")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("s3cr3t")
+            expect(message).not_to include("bundle-user")
+            expect(message).to include("localhost:3035")
+            expect(message).to include("cannot be read")
           end
         end
 
@@ -420,22 +436,15 @@ module ReactOnRails
         context "when the HTTP-served bundle URL embeds credentials and is malformed enough to fail URI parsing" do
           it "does not leak the credential into the raised error message" do
             server_bundle_url = "http://bundle-user:s3cr3t@bad host/webpack/development/server-bundle.js"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("s3cr3t")
-              expect(error.message).not_to include("bundle-user")
-              # The error must still say the URL was malformed and show enough of it (host/path
-              # minus credentials) for an operator to identify which configured URL failed.
-              expect(error.message).to include("bad URI")
-              expect(error.message).to include("bad host")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("s3cr3t")
+            expect(message).not_to include("bundle-user")
+            # The error must still say the URL was malformed and show enough of it (host/path
+            # minus credentials) for an operator to identify which configured URL failed.
+            expect(message).to include("bad URI")
+            expect(message).to include("bad host")
           end
         end
 
@@ -443,83 +452,55 @@ module ReactOnRails
           it "redacts the entire userinfo while retaining the host and path" do
             server_bundle_url =
               "http://bundle-user:password-prefix@password-suffix@bad host/webpack/development/server-bundle.js"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("bundle-user")
-              expect(error.message).not_to include("password-prefix")
-              expect(error.message).not_to include("password-suffix")
-              expect(error.message).to include("bad URI")
-              expect(error.message).to include("bad host/webpack/development/server-bundle.js")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("bundle-user")
+            expect(message).not_to include("password-prefix")
+            expect(message).not_to include("password-suffix")
+            expect(message).to include("bad URI")
+            expect(message).to include("bad host/webpack/development/server-bundle.js")
           end
         end
 
         context "when malformed URL userinfo contains an unescaped slash" do
           it "redacts every credential fragment while retaining the host and path" do
             server_bundle_url = "http://user:prefix/secret@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("user")
-              expect(error.message).not_to include("prefix")
-              expect(error.message).not_to include("secret")
-              expect(error.message).to include("bad URI")
-              expect(error.message).to include("host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("user")
+            expect(message).not_to include("prefix")
+            expect(message).not_to include("secret")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
           end
         end
 
         context "when malformed URL userinfo contains whitespace" do
           it "redacts the quoted URL from the URI error while retaining the host and path" do
             server_bundle_url = "http://user:prefix secret@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("user")
-              expect(error.message).not_to include("prefix")
-              expect(error.message).not_to include("secret")
-              expect(error.message).to include("bad URI")
-              expect(error.message).to include("host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("user")
+            expect(message).not_to include("prefix")
+            expect(message).not_to include("secret")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
           end
         end
 
         context "when whitespace makes malformed userinfo look like a valid host prefix" do
           it "does not protect the prefix quoted by the configured URL's URI error" do
             server_bundle_url = "http://synthetic-user secret-final@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("secret-final")
-              expect(error.message).to include("bad URI")
-              expect(error.message).to include("host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
           end
         end
 
@@ -534,18 +515,12 @@ module ReactOnRails
              %w[synthetic-user secret-middle secret-final]]
           ].each do |description, server_bundle_url, credential_fragments|
             it "redacts credentials after #{description}" do
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
-                expect(error.message).to include("bad URI")
-                expect(error.message).to include("host/path")
-              }
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("bad URI")
+              expect(message).to include("host/path")
             end
           end
         end
@@ -565,20 +540,13 @@ module ReactOnRails
         context "when the configured URL contains another scheme without whitespace" do
           nested_scheme_cases.each do |description, server_bundle_url|
             it "sanitizes credentials after #{description}" do
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
-              allow(Net::HTTP).to receive(:get_response).and_raise("connection failed")
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                expect(error.message).not_to include("synthetic-user")
-                expect(error.message).not_to include("synthetic-secret")
-                expect(error.message).not_to include("outer.test/first")
-                expect(error.message).to include("host/path")
-              }
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).not_to include("outer.test/first")
+              expect(message).to include("host/path")
             end
           end
         end
@@ -601,18 +569,11 @@ module ReactOnRails
         context "when the configured URL has an unresolved scheme before a credential URL" do
           unresolved_prefix_cases.each do |description, server_bundle_url, credential_fragments|
             it "fails closed across #{description}" do
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
-              allow(Net::HTTP).to receive(:get_response).and_raise("connection failed")
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
-                expect(error.message).to include("host/path")
-              }
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("host/path")
             end
           end
         end
@@ -625,18 +586,12 @@ module ReactOnRails
             ["a quote and newline", "http://synthetic-user\"\nsynthetic-secret@host/path"]
           ].each do |description, server_bundle_url|
             it "fails closed across #{description} within the configured value" do
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                expect(error.message).not_to include("synthetic-user")
-                expect(error.message).not_to include("synthetic-secret")
-                expect(error.message).to include("host/path")
-              }
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("host/path")
             end
           end
         end
@@ -644,18 +599,9 @@ module ReactOnRails
         context "when a configured URL has an at sign only in its path" do
           it "preserves the URL because the configured value parses without userinfo" do
             server_bundle_url = "http://host/path@example"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise("connection failed")
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).to include(server_bundle_url)
-            }
+            expect(bundle_load_error_message).to include(server_bundle_url)
           end
         end
 
@@ -676,23 +622,16 @@ module ReactOnRails
                 failure_message = "raw=#{server_bundle_url} inspected=#{server_bundle_url.inspect} " \
                                   "repeated=#{server_bundle_url}"
 
-                allow(ReactOnRails::Utils).to receive_messages(
-                  server_bundle_js_file_path: server_bundle_url,
-                  server_bundle_path_is_http?: http_path
-                )
                 if http_path
-                  allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+                  stub_http_bundle_failure(failure_message, bundle_url: server_bundle_url)
                 else
-                  allow(File).to receive(:read).with(server_bundle_url).and_raise(failure_message)
+                  stub_local_bundle_failure(failure_message, bundle_path: server_bundle_url)
                 end
 
-                expect do
-                  described_class.read_bundle_js_code
-                end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                  expect(error.message).not_to include("synthetic-user")
-                  expect(error.message).not_to include("synthetic-secret")
-                  expect(error.message).to include(sanitized_url)
-                }
+                message = bundle_load_error_message
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include(sanitized_url)
               end
             end
           end
@@ -701,65 +640,40 @@ module ReactOnRails
         context "when malformed URL userinfo contains a literal double quote" do
           it "redacts the escaped URL from the URI error" do
             server_bundle_url = "http://synthetic-user:sec\"ret@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("sec")
-              expect(error.message).not_to include("ret")
-              expect(error.message).to include("bad URI")
-              expect(error.message).to include("host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("sec")
+            expect(message).not_to include("ret")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
           end
         end
 
         context "when a bundle-load failure embeds an unquoted malformed credential URL" do
           it "fails closed across whitespace in the credential" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://synthetic-user:prefix secret-final@host/path"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("prefix")
-              expect(error.message).not_to include("secret-final")
-              expect(error.message).to include("Failure loading http://host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("prefix")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
           end
         end
 
         context "when malformed userinfo looks like a valid host prefix in an ordinary error" do
           it "does not protect the prefix before the whitespace-delimited credential suffix" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://synthetic-user:123 secret-final@host/path"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("123")
-              expect(error.message).not_to include("secret-final")
-              expect(error.message).to include("Failure loading http://host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("123")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
           end
         end
 
@@ -774,21 +688,12 @@ module ReactOnRails
              %w[synthetic-user secret-middle secret-final]]
           ].each do |description, malformed_url, credential_fragments|
             it "redacts credentials after #{description}" do
-              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
               failure_message = "Failure loading #{malformed_url}"
+              stub_http_bundle_failure(failure_message)
 
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
-              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
-                expect(error.message).to include("Failure loading http://host/path")
-              }
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("Failure loading http://host/path")
             end
           end
         end
@@ -801,22 +706,13 @@ module ReactOnRails
             ["a quote and LF", "http://synthetic-user\"\nsynthetic-secret@host/path"]
           ].each do |description, malformed_url|
             it "fails closed across #{description}" do
-              server_bundle_path = "/tmp/server-bundle.js"
               failure_message = "Failure loading #{malformed_url}"
+              stub_local_bundle_failure(failure_message)
 
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_path,
-                server_bundle_path_is_http?: false
-              )
-              allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
-
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                expect(error.message).not_to include("synthetic-user")
-                expect(error.message).not_to include("synthetic-secret")
-                expect(error.message).to include("Failure loading http://host/path")
-              }
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("Failure loading http://host/path")
             end
           end
         end
@@ -824,23 +720,14 @@ module ReactOnRails
         context "when an ordinary error contains another scheme without whitespace" do
           nested_scheme_cases.each do |description, nested_urls|
             it "sanitizes credentials after #{description}" do
-              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
               failure_message = "Failure loading #{nested_urls}"
+              stub_http_bundle_failure(failure_message)
 
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
-              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                expect(error.message).not_to include("synthetic-user")
-                expect(error.message).not_to include("synthetic-secret")
-                expect(error.message).to include("outer.test/first")
-                expect(error.message).to include("host/path")
-              }
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("outer.test/first")
+              expect(message).to include("host/path")
             end
           end
         end
@@ -848,270 +735,150 @@ module ReactOnRails
         context "when an ordinary error has an unresolved scheme before a credential URL" do
           unresolved_prefix_cases.each do |description, nested_urls, credential_fragments|
             it "fails closed across #{description}" do
-              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
               failure_message = "Failure loading #{nested_urls}"
+              stub_http_bundle_failure(failure_message)
 
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
-              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
-                expect(error.message).to include("Failure loading http://host/path")
-              }
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("Failure loading http://host/path")
             end
           end
         end
 
         context "when an invalid credential URL is followed by a valid URL" do
           it "redacts the credential and preserves the later URL" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://synthetic-user secret-final@host/path " \
                               "http://healthy-host/path"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("secret-final")
-              expect(error.message).to include("Failure loading http://host/path http://healthy-host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path http://healthy-host/path")
           end
         end
 
         context "when an ordinary error quotes malformed userinfo across whitespace" do
           it "redacts the quoted credential while retaining the host and path" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = 'Failure loading "http://synthetic-user secret-final@host/path"'
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("secret-final")
-              expect(error.message).to include('Failure loading "http://host/path"')
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include('Failure loading "http://host/path"')
           end
         end
 
         context "when a quote truncates a malformed credential URL token" do
           it "does not protect the valid-looking prefix before the double quote" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = 'Failure loading http://synthetic-user"secret-final@host/path'
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("secret-final")
-              expect(error.message).to include("Failure loading http://host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
           end
 
           it "does not protect the valid-looking prefix before the single quote" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://synthetic-user'secret-final@host/path"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("secret-final")
-              expect(error.message).to include("Failure loading http://host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
           end
         end
 
         context "when a bundle-load failure embeds a valid URL with an at sign in its path" do
           it "preserves the URL because it has no userinfo" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://host/path@example"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).to include(failure_message)
-            }
+            expect(bundle_load_error_message).to include(failure_message)
           end
         end
 
         context "when a bundle-load failure contains two valid URLs" do
           it "preserves both URLs, including an at sign in the second URL's path" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://first-host/path http://second-host/path@example"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).to include(failure_message)
-            }
+            expect(bundle_load_error_message).to include(failure_message)
           end
         end
 
         context "when a line boundary precedes an ambiguous email at sign" do
           [["LF", "\n"], ["CR", "\r"], ["CRLF", "\r\n"]].each do |description, boundary|
             it "fails closed across #{description}" do
-              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
               failure_message = "Failure loading http://host/path#{boundary}contact dev@example.com"
+              stub_http_bundle_failure(failure_message)
 
-              allow(ReactOnRails::Utils).to receive_messages(
-                server_bundle_js_file_path: server_bundle_url,
-                server_bundle_path_is_http?: true
-              )
-              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-              expect do
-                described_class.read_bundle_js_code
-              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                expect(error.message).not_to include("host/path")
-                expect(error.message).not_to include("contact dev")
-                expect(error.message).to include("Failure loading http://example.com")
-              }
+              message = bundle_load_error_message
+              expect(message).not_to include("host/path")
+              expect(message).not_to include("contact dev")
+              expect(message).to include("Failure loading http://example.com")
             end
           end
         end
 
         context "when multiline error text contains a later URL scheme" do
           it "redacts malformed multiline userinfo without consuming the later URL" do
-            server_bundle_path = "/tmp/server-bundle.js"
             failure_message = "Failure loading http://synthetic-user\nsynthetic-secret@host/path\n" \
                               "hTtPs://healthy-host/path@example"
+            stub_local_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_path,
-              server_bundle_path_is_http?: false
-            )
-            allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("synthetic-secret")
-              expect(error.message).to include("Failure loading http://host/path\nhTtPs://healthy-host/path@example")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("Failure loading http://host/path\nhTtPs://healthy-host/path@example")
           end
 
           it "fails closed before the later scheme while preserving that separate URL" do
-            server_bundle_path = "/tmp/server-bundle.js"
             failure_message = "Failure loading http://first-host/path\ncontact dev@example.com\n" \
                               "HTTP://second-host/path"
+            stub_local_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_path,
-              server_bundle_path_is_http?: false
-            )
-            allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("first-host/path")
-              expect(error.message).not_to include("contact dev")
-              expect(error.message).to include("Failure loading http://example.com\nHTTP://second-host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("first-host/path")
+            expect(message).not_to include("contact dev")
+            expect(message).to include("Failure loading http://example.com\nHTTP://second-host/path")
           end
 
           it "discards an unresolved multiline region before sanitizing the next credential URL" do
-            server_bundle_path = "/tmp/server-bundle.js"
             failure_message = "Failure loading http://synthetic-user:nonnumeric-prefix\nsynthetic-tail " \
                               "HtTpS://synthetic-secret@host/path"
+            stub_local_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_path,
-              server_bundle_path_is_http?: false
-            )
-            allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("synthetic-user")
-              expect(error.message).not_to include("nonnumeric-prefix")
-              expect(error.message).not_to include("synthetic-tail")
-              expect(error.message).not_to include("synthetic-secret")
-              expect(error.message).to include("Failure loading https://host/path")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("nonnumeric-prefix")
+            expect(message).not_to include("synthetic-tail")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("Failure loading https://host/path")
           end
         end
 
         context "when a valid-looking URL is followed by prose containing an email address" do
           it "fails closed because no structural boundary separates the later at sign" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://host/path; contact dev@example.com"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("host/path")
-              expect(error.message).not_to include("contact dev")
-              expect(error.message).to include("Failure loading http://example.com")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("host/path")
+            expect(message).not_to include("contact dev")
+            expect(message).to include("Failure loading http://example.com")
           end
         end
 
         context "when a bundle-load failure contains non-URL double-slash text" do
           it "preserves the arbitrary message text" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "// contact dev@example"
+            stub_http_bundle_failure(failure_message)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
-
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).to include(failure_message)
-            }
+            expect(bundle_load_error_message).to include(failure_message)
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -439,6 +439,28 @@ module ReactOnRails
           end
         end
 
+        context "when malformed URL userinfo contains multiple at signs" do
+          it "redacts the entire userinfo while retaining the host and path" do
+            server_bundle_url =
+              "http://bundle-user:password-prefix@password-suffix@bad host/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("bundle-user")
+              expect(error.message).not_to include("password-prefix")
+              expect(error.message).not_to include("password-suffix")
+              expect(error.message).to include("bad URI")
+              expect(error.message).to include("bad host/webpack/development/server-bundle.js")
+            }
+          end
+        end
+
         # read_bundle_js_code also serves the local (non-HTTP) bundle path, where
         # server_bundle_js_file is a plain filesystem path rather than a URL.
         # sanitized_renderer_url must pass such paths through unchanged (no embedded userinfo to

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -503,6 +503,28 @@ module ReactOnRails
           end
         end
 
+        context "when a bundle-load failure embeds an unquoted malformed credential URL" do
+          it "fails closed across whitespace in the credential" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://synthetic-user:prefix secret-final@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("prefix")
+              expect(error.message).not_to include("secret-final")
+              expect(error.message).to include("Failure loading http://host/path")
+            }
+          end
+        end
+
         context "when a bundle-load failure contains non-URL double-slash text" do
           it "preserves the arbitrary message text" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -523,6 +523,33 @@ module ReactOnRails
           end
         end
 
+        context "when configured malformed userinfo has a delayed at sign" do
+          [
+            ["multiple intervening words", "http://synthetic-user secret-middle secret-final@host/path",
+             %w[synthetic-user secret-middle secret-final]],
+            ["a quote and whitespace", 'http://synthetic-user" secret-final@host/path',
+             %w[synthetic-user secret-final]],
+            ["a quote and multiple intervening words",
+             'http://synthetic-user" secret-middle secret-final@host/path',
+             %w[synthetic-user secret-middle secret-final]]
+          ].each do |description, server_bundle_url, credential_fragments|
+            it "redacts credentials after #{description}" do
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
+                expect(error.message).to include("bad URI")
+                expect(error.message).to include("host/path")
+              }
+            end
+          end
+        end
+
         context "when malformed URL userinfo contains a literal double quote" do
           it "redacts the escaped URL from the URI error" do
             server_bundle_url = "http://synthetic-user:sec\"ret@host/path"
@@ -585,6 +612,36 @@ module ReactOnRails
               expect(error.message).not_to include("secret-final")
               expect(error.message).to include("Failure loading http://host/path")
             }
+          end
+        end
+
+        context "when an ordinary error has a delayed credential at sign" do
+          [
+            ["multiple intervening words", "http://synthetic-user secret-middle secret-final@host/path",
+             %w[synthetic-user secret-middle secret-final]],
+            ["a quote and whitespace", 'http://synthetic-user" secret-final@host/path',
+             %w[synthetic-user secret-final]],
+            ["a quote and multiple intervening words",
+             'http://synthetic-user" secret-middle secret-final@host/path',
+             %w[synthetic-user secret-middle secret-final]]
+          ].each do |description, malformed_url, credential_fragments|
+            it "redacts credentials after #{description}" do
+              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+              failure_message = "Failure loading #{malformed_url}"
+
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
+                expect(error.message).to include("Failure loading http://host/path")
+              }
+            end
           end
         end
 
@@ -709,8 +766,27 @@ module ReactOnRails
           end
         end
 
-        context "when a valid URL is followed by prose containing an email address" do
-          it "preserves both the URL and the later prose" do
+        context "when an email address follows a valid URL on the next line" do
+          it "preserves both because the newline is a structural boundary" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://host/path\ncontact dev@example.com"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(failure_message)
+            }
+          end
+        end
+
+        context "when a valid-looking URL is followed by prose containing an email address" do
+          it "fails closed because no structural boundary separates the later at sign" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://host/path; contact dev@example.com"
 
@@ -723,7 +799,9 @@ module ReactOnRails
             expect do
               described_class.read_bundle_js_code
             end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).to include(failure_message)
+              expect(error.message).not_to include("host/path")
+              expect(error.message).not_to include("contact dev")
+              expect(error.message).to include("Failure loading http://example.com")
             }
           end
         end

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -554,7 +554,8 @@ module ReactOnRails
           ["a comma", "http://outer.test/first,http://synthetic-user:synthetic-secret@host/path"],
           ["a semicolon", "http://outer.test/first;http://synthetic-user:synthetic-secret@host/path"],
           ["a parenthesis", "http://outer.test/first(http://synthetic-user:synthetic-secret@host/path)"],
-          ["no delimiter", "http://outer.test/firsthttp://synthetic-user:synthetic-secret@host/path"],
+          ["a valid URL directly before a valid credential URL",
+           "http://outer.test/firsthttp://synthetic-user:synthetic-secret@host/path"],
           ["mixed-case HTTP then HTTPS",
            "hTtP://outer.test/first;HtTpS://synthetic-user:synthetic-secret@host/path"],
           ["mixed-case HTTPS then HTTP",
@@ -575,10 +576,86 @@ module ReactOnRails
               end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
                 expect(error.message).not_to include("synthetic-user")
                 expect(error.message).not_to include("synthetic-secret")
-                expect(error.message).to include("outer.test/first")
+                expect(error.message).not_to include("outer.test/first")
                 expect(error.message).to include("host/path")
               }
             end
+          end
+        end
+
+        unresolved_prefix_cases = [
+          ["an invalid prefix before a valid credential URL",
+           "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
+           %w[synthetic-user nonnumeric-prefix synthetic-secret]],
+          ["a numeric-port prefix",
+           "http://synthetic-user:123synthetic-prefixhttp://synthetic-secret@host/path",
+           %w[synthetic-user 123synthetic-prefix synthetic-secret]],
+          ["a slash in the invalid prefix",
+           "http://synthetic-user:nonnumeric-prefix/synthetic-tailhttp://synthetic-secret@host/path",
+           %w[synthetic-user nonnumeric-prefix synthetic-tail synthetic-secret]],
+          ["a semicolon in the invalid prefix",
+           "http://synthetic-user:nonnumeric-prefix;synthetic-tailhttp://synthetic-secret@host/path",
+           %w[synthetic-user nonnumeric-prefix synthetic-tail synthetic-secret]]
+        ]
+
+        context "when the configured URL has an unresolved scheme before a credential URL" do
+          unresolved_prefix_cases.each do |description, server_bundle_url, credential_fragments|
+            it "fails closed across #{description}" do
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+              allow(Net::HTTP).to receive(:get_response).and_raise("connection failed")
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
+                expect(error.message).to include("host/path")
+              }
+            end
+          end
+        end
+
+        context "when configured malformed userinfo spans line breaks" do
+          [
+            ["LF", "http://synthetic-user\nsynthetic-secret@host/path"],
+            ["CR", "http://synthetic-user\rsynthetic-secret@host/path"],
+            ["CRLF", "http://synthetic-user\r\nsynthetic-secret@host/path"],
+            ["a quote and newline", "http://synthetic-user\"\nsynthetic-secret@host/path"]
+          ].each do |description, server_bundle_url|
+            it "fails closed across #{description} within the configured value" do
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                expect(error.message).not_to include("synthetic-user")
+                expect(error.message).not_to include("synthetic-secret")
+                expect(error.message).to include("host/path")
+              }
+            end
+          end
+        end
+
+        context "when a configured URL has an at sign only in its path" do
+          it "preserves the URL because the configured value parses without userinfo" do
+            server_bundle_url = "http://host/path@example"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise("connection failed")
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(server_bundle_url)
+            }
           end
         end
 
@@ -696,6 +773,28 @@ module ReactOnRails
                 expect(error.message).not_to include("synthetic-secret")
                 expect(error.message).to include("outer.test/first")
                 expect(error.message).to include("host/path")
+              }
+            end
+          end
+        end
+
+        context "when an ordinary error has an unresolved scheme before a credential URL" do
+          unresolved_prefix_cases.each do |description, nested_urls, credential_fragments|
+            it "fails closed across #{description}" do
+              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+              failure_message = "Failure loading #{nested_urls}"
+
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                credential_fragments.each { |fragment| expect(error.message).not_to include(fragment) }
+                expect(error.message).to include("Failure loading http://host/path")
               }
             end
           end
@@ -822,22 +921,24 @@ module ReactOnRails
           end
         end
 
-        context "when an email address follows a valid URL on the next line" do
-          it "preserves both because the newline is a structural boundary" do
-            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
-            failure_message = "Failure loading http://host/path\ncontact dev@example.com"
+        context "when a line boundary separates a valid URL from an email address" do
+          [["LF", "\n"], ["CR", "\r"], ["CRLF", "\r\n"]].each do |description, boundary|
+            it "preserves both across #{description}" do
+              server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+              failure_message = "Failure loading http://host/path#{boundary}contact dev@example.com"
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+              allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
 
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).to include(failure_message)
-            }
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                expect(error.message).to include(failure_message)
+              }
+            end
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -651,6 +651,37 @@ module ReactOnRails
           end
         end
 
+        context "when URI parsing raises another URI::Error subtype" do
+          it "redacts configured credentials through the public entrypoint" do
+            server_bundle_url = "http://synthetic-user:synthetic-secret@host/path"
+            allow(URI).to receive(:parse).and_call_original
+            allow(URI).to receive(:parse).with(server_bundle_url)
+                                         .and_raise(URI::BadURIError, "bad URI for #{server_bundle_url}")
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("bad URI for http://host/path")
+          end
+        end
+
+        context "when a local bundle path contains replacement metacharacters" do
+          it "preserves them literally while redacting credentials from the load error" do
+            server_bundle_path = %q(/tmp/\k<foo>-\1-\&-\0-literal\backslash/server-bundle.js)
+            failure_message = "raw=#{server_bundle_path} inspected=#{server_bundle_path.inspect} " \
+                              "credential=http://synthetic-user:synthetic-secret@host/path"
+            stub_local_bundle_failure(failure_message, bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).to include(server_bundle_path)
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("http://host/path")
+            expect(message).to include("react_on_rails@shakacode.com")
+          end
+        end
+
         context "when a bundle-load failure embeds an unquoted malformed credential URL" do
           it "fails closed across whitespace in the credential" do
             failure_message = "Failure loading http://synthetic-user:prefix secret-final@host/path"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -461,6 +461,67 @@ module ReactOnRails
           end
         end
 
+        context "when malformed URL userinfo contains an unescaped slash" do
+          it "redacts every credential fragment while retaining the host and path" do
+            server_bundle_url = "http://user:prefix/secret@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("user")
+              expect(error.message).not_to include("prefix")
+              expect(error.message).not_to include("secret")
+              expect(error.message).to include("bad URI")
+              expect(error.message).to include("host/path")
+            }
+          end
+        end
+
+        context "when malformed URL userinfo contains whitespace" do
+          it "redacts the quoted URL from the URI error while retaining the host and path" do
+            server_bundle_url = "http://user:prefix secret@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("user")
+              expect(error.message).not_to include("prefix")
+              expect(error.message).not_to include("secret")
+              expect(error.message).to include("bad URI")
+              expect(error.message).to include("host/path")
+            }
+          end
+        end
+
+        context "when a bundle-load failure contains non-URL double-slash text" do
+          it "preserves the arbitrary message text" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "// contact dev@example"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(failure_message)
+            }
+          end
+        end
+
         # read_bundle_js_code also serves the local (non-HTTP) bundle path, where
         # server_bundle_js_file is a plain filesystem path rather than a URL.
         # sanitized_renderer_url must pass such paths through unchanged (no embedded userinfo to

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -525,6 +525,25 @@ module ReactOnRails
           end
         end
 
+        context "when a bundle-load failure embeds a valid URL with an at sign in its path" do
+          it "preserves the URL because it has no userinfo" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://host/path@example"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(failure_message)
+            }
+          end
+        end
+
         context "when a bundle-load failure contains non-URL double-slash text" do
           it "preserves the arbitrary message text" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -793,6 +793,34 @@ module ReactOnRails
           end
         end
 
+        context "when malformed userinfo in an ordinary error spans line breaks" do
+          [
+            ["LF", "http://synthetic-user\nsynthetic-secret@host/path"],
+            ["CR", "http://synthetic-user\rsynthetic-secret@host/path"],
+            ["CRLF", "http://synthetic-user\r\nsynthetic-secret@host/path"],
+            ["a quote and LF", "http://synthetic-user\"\nsynthetic-secret@host/path"]
+          ].each do |description, malformed_url|
+            it "fails closed across #{description}" do
+              server_bundle_path = "/tmp/server-bundle.js"
+              failure_message = "Failure loading #{malformed_url}"
+
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_path,
+                server_bundle_path_is_http?: false
+              )
+              allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                expect(error.message).not_to include("synthetic-user")
+                expect(error.message).not_to include("synthetic-secret")
+                expect(error.message).to include("Failure loading http://host/path")
+              }
+            end
+          end
+        end
+
         context "when an ordinary error contains another scheme without whitespace" do
           nested_scheme_cases.each do |description, nested_urls|
             it "sanitizes credentials after #{description}" do
@@ -960,9 +988,9 @@ module ReactOnRails
           end
         end
 
-        context "when a line boundary separates a valid URL from an email address" do
+        context "when a line boundary precedes an ambiguous email at sign" do
           [["LF", "\n"], ["CR", "\r"], ["CRLF", "\r\n"]].each do |description, boundary|
-            it "preserves both across #{description}" do
+            it "fails closed across #{description}" do
               server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
               failure_message = "Failure loading http://host/path#{boundary}contact dev@example.com"
 
@@ -975,9 +1003,75 @@ module ReactOnRails
               expect do
                 described_class.read_bundle_js_code
               end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-                expect(error.message).to include(failure_message)
+                expect(error.message).not_to include("host/path")
+                expect(error.message).not_to include("contact dev")
+                expect(error.message).to include("Failure loading http://example.com")
               }
             end
+          end
+        end
+
+        context "when multiline error text contains a later URL scheme" do
+          it "redacts malformed multiline userinfo without consuming the later URL" do
+            server_bundle_path = "/tmp/server-bundle.js"
+            failure_message = "Failure loading http://synthetic-user\nsynthetic-secret@host/path\n" \
+                              "hTtPs://healthy-host/path@example"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_path,
+              server_bundle_path_is_http?: false
+            )
+            allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("synthetic-secret")
+              expect(error.message).to include("Failure loading http://host/path\nhTtPs://healthy-host/path@example")
+            }
+          end
+
+          it "fails closed before the later scheme while preserving that separate URL" do
+            server_bundle_path = "/tmp/server-bundle.js"
+            failure_message = "Failure loading http://first-host/path\ncontact dev@example.com\n" \
+                              "HTTP://second-host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_path,
+              server_bundle_path_is_http?: false
+            )
+            allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("first-host/path")
+              expect(error.message).not_to include("contact dev")
+              expect(error.message).to include("Failure loading http://example.com\nHTTP://second-host/path")
+            }
+          end
+
+          it "discards an unresolved multiline region before sanitizing the next credential URL" do
+            server_bundle_path = "/tmp/server-bundle.js"
+            failure_message = "Failure loading http://synthetic-user:nonnumeric-prefix\nsynthetic-tail " \
+                              "HtTpS://synthetic-secret@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_path,
+              server_bundle_path_is_http?: false
+            )
+            allow(File).to receive(:read).with(server_bundle_path).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("nonnumeric-prefix")
+              expect(error.message).not_to include("synthetic-tail")
+              expect(error.message).not_to include("synthetic-secret")
+              expect(error.message).to include("Failure loading https://host/path")
+            }
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -503,6 +503,26 @@ module ReactOnRails
           end
         end
 
+        context "when whitespace makes malformed userinfo look like a valid host prefix" do
+          it "does not protect the prefix quoted by the configured URL's URI error" do
+            server_bundle_url = "http://synthetic-user secret-final@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("secret-final")
+              expect(error.message).to include("bad URI")
+              expect(error.message).to include("host/path")
+            }
+          end
+        end
+
         context "when malformed URL userinfo contains a literal double quote" do
           it "redacts the escaped URL from the URI error" do
             server_bundle_url = "http://synthetic-user:sec\"ret@host/path"
@@ -546,10 +566,94 @@ module ReactOnRails
           end
         end
 
+        context "when malformed userinfo looks like a valid host prefix in an ordinary error" do
+          it "does not protect the prefix before the whitespace-delimited credential suffix" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://synthetic-user:123 secret-final@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("123")
+              expect(error.message).not_to include("secret-final")
+              expect(error.message).to include("Failure loading http://host/path")
+            }
+          end
+        end
+
+        context "when an invalid credential URL is followed by a valid URL" do
+          it "redacts the credential and preserves the later URL" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://synthetic-user secret-final@host/path " \
+                              "http://healthy-host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("secret-final")
+              expect(error.message).to include("Failure loading http://host/path http://healthy-host/path")
+            }
+          end
+        end
+
+        context "when an ordinary error quotes malformed userinfo across whitespace" do
+          it "redacts the quoted credential while retaining the host and path" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = 'Failure loading "http://synthetic-user secret-final@host/path"'
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("secret-final")
+              expect(error.message).to include('Failure loading "http://host/path"')
+            }
+          end
+        end
+
         context "when a bundle-load failure embeds a valid URL with an at sign in its path" do
           it "preserves the URL because it has no userinfo" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
             failure_message = "Failure loading http://host/path@example"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(failure_message)
+            }
+          end
+        end
+
+        context "when a bundle-load failure contains two valid URLs" do
+          it "preserves both URLs, including an at sign in the second URL's path" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://first-host/path http://second-host/path@example"
 
             allow(ReactOnRails::Utils).to receive_messages(
               server_bundle_js_file_path: server_bundle_url,

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -659,6 +659,45 @@ module ReactOnRails
           end
         end
 
+        context "when non-URL text precedes a configured credential URL" do
+          classifications = [["HTTP", true], ["local-path", false]]
+
+          [
+            ["a space", " ", "http"],
+            ["a tab", "\t", "http"],
+            ["a newline", "\n", "http"],
+            ["a quote", '"', "http"],
+            ["a label and mixed-case scheme", "URL=", "hTtPs"]
+          ].each do |description, prefix, scheme|
+            classifications.each do |classification, http_path|
+              it "sanitizes #{description} through the #{classification} branch" do
+                server_bundle_url = "#{prefix}#{scheme}://synthetic-user:synthetic-secret@host/path"
+                sanitized_url = "#{prefix}#{scheme.downcase}://host/path"
+                failure_message = "raw=#{server_bundle_url} inspected=#{server_bundle_url.inspect} " \
+                                  "repeated=#{server_bundle_url}"
+
+                allow(ReactOnRails::Utils).to receive_messages(
+                  server_bundle_js_file_path: server_bundle_url,
+                  server_bundle_path_is_http?: http_path
+                )
+                if http_path
+                  allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+                else
+                  allow(File).to receive(:read).with(server_bundle_url).and_raise(failure_message)
+                end
+
+                expect do
+                  described_class.read_bundle_js_code
+                end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                  expect(error.message).not_to include("synthetic-user")
+                  expect(error.message).not_to include("synthetic-secret")
+                  expect(error.message).to include(sanitized_url)
+                }
+              end
+            end
+          end
+        end
+
         context "when malformed URL userinfo contains a literal double quote" do
           it "redacts the escaped URL from the URI error" do
             server_bundle_url = "http://synthetic-user:sec\"ret@host/path"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -631,6 +631,46 @@ module ReactOnRails
           end
         end
 
+        context "when a quote truncates a malformed credential URL token" do
+          it "does not protect the valid-looking prefix before the double quote" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = 'Failure loading http://synthetic-user"secret-final@host/path'
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("secret-final")
+              expect(error.message).to include("Failure loading http://host/path")
+            }
+          end
+
+          it "does not protect the valid-looking prefix before the single quote" do
+            server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+            failure_message = "Failure loading http://synthetic-user'secret-final@host/path"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(failure_message)
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("synthetic-user")
+              expect(error.message).not_to include("secret-final")
+              expect(error.message).to include("Failure loading http://host/path")
+            }
+          end
+        end
+
         context "when a bundle-load failure embeds a valid URL with an at sign in its path" do
           it "preserves the URL because it has no userinfo" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"


### PR DESCRIPTION
## Why

Malformed HTTP(S) renderer URLs can contain more than one `@` in userinfo. The fallback sanitizer stopped at the first one, allowing a credential suffix to survive in a bundle-load diagnostic.

This is a release-first stabilizer for 17.1.0 and addresses #4825.

## What changed

- scan renderer diagnostics as protected, structurally valid HTTP(S) URL spans plus unprotected text spans
- remove userinfo structurally from valid credential URLs while preserving valid no-userinfo URLs exactly
- fail closed through the final `@` inside ambiguous malformed spans, with only a new HTTP(S) scheme as the structural boundary
- split at every nested HTTP(S) scheme so punctuation-adjacent URLs cannot shield credentials
- sanitize configured renderer values as one fail-closed value across nested schemes and line breaks while retaining newline boundaries for free-form diagnostic prose
- add public-entrypoint regressions proving credential fragments are absent while preserving valid path-`@` URLs, HTTP status context, local-file diagnostics, and structurally separated URLs

No public API or configuration is added.

## Verification

- RED: focused regression failed because the error contained the credential suffix
- GREEN: focused regression passed
- full `ruby_embedded_java_script_spec.rb`: 103 examples, 0 failures
- focused RuboCop: 2 files, 0 offenses
- diff check: passed
- branch pre-push hook: passed focused Ruby lint and Markdown-link selection
- `.agents/bin/validate --changed`: broad validation remains non-evidence because the same RBS `Configuration#node_modules_location` type mismatch reproduces on the untouched release base; exact-head hosted CI remains required
- independent adversarial QA at exact head `c4e693bb6486d4e580f072c26c6b697f80fa50e1`: PASS, with 0 BLOCKING / 0 DISCUSS / 0 OPTIONAL findings; both new regressions fail on the previous head and pass here; public leak matrix 45/45 and credential-authority fuzz matrix 108/108

## Release handling

- Base: `release/17.1.0`
- Merge authority: ask
- Tag/publication authority: none
- Changelog: the existing 17.1.0 credential-redaction entry covers this stabilizer; no duplicate entry is needed
- A forward-port to `main` will be handled separately after this release PR lands.

## Merge qualifications

- **Release-mode gate:** `strict-rc` from release tracker #4842; the standard merge qualification is satisfied.
- **Finding disposition:** The P2 nested-scheme/prefix finding is fixed at the current head; the resolved thread records the implementation and exact-head QA evidence: https://github.com/shakacode/react_on_rails/pull/4845#discussion_r3708089070

Confidence note:
- **Validated:** focused RubyEmbeddedJavaScript specs (103 examples, 0 failures); red/green regression checks; 45-case credential-leak matrix; 108-case fuzz matrix; 14 literal-replacement cases; RuboCop on both changed files; complete hosted CI including RSC Playwright E2E.
- **Evidence:** QA receipt https://github.com/shakacode/react_on_rails/pull/4845#issuecomment-5172402639; review-triage receipt https://github.com/shakacode/react_on_rails/pull/4845#issuecomment-5172402537; current-head checks https://github.com/shakacode/react_on_rails/pull/4845/checks.
- **UNKNOWN:** none.
- **Residual risk:** malformed renderer URLs require conservative parsing, but the known edge classes are covered by regression, adversarial, fuzz, and hosted integration evidence.

- **Merge authority:** `ask`; explicit maintainer approval received for this exact diff.
- **Publication authority:** none; this PR merge does not tag or publish a release.