### PR TITLE
Silence routine startup diagnostics for Rails commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **Routine startup diagnostics no longer clutter Rails command output**: Successful package validation, valid
   Pro license checks, non-production license notices, and Node renderer connection setup now log at `DEBUG`
   instead of `INFO`. Package validation still runs, while production license warnings and renderer failures remain
-  visible and actionable. Fixes [Issue 4848](https://github.com/shakacode/react_on_rails/issues/4848), reported by
+  visible and actionable. Fixes [Issue 4848](https://github.com/shakacode/react_on_rails/issues/4848).
+  [PR 4849](https://github.com/shakacode/react_on_rails/pull/4849) by
   [Justin Gordon](https://github.com/justin808).
 
 - **Generated server webpack configs no longer include an unused `merge` import or stale comments**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **Routine startup diagnostics no longer clutter Rails command output**: Successful package validation, valid
+  Pro license checks, non-production license notices, and Node renderer connection setup now log at `DEBUG`
+  instead of `INFO`. Package validation still runs, while production license warnings and renderer failures remain
+  visible and actionable. Fixes [Issue 4848](https://github.com/shakacode/react_on_rails/issues/4848), reported by
+  [Justin Gordon](https://github.com/justin808).
+
 - **Generated server webpack configs no longer include an unused `merge` import or stale comments**:
   `commonWebpackConfig` already clones the shared client configuration, so the generated server configuration
   stays lint-clean without changing its runtime behavior. Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
-- **Routine startup diagnostics no longer clutter Rails command output**: Successful package validation, valid
-  Pro license checks, non-production license notices, and Node renderer connection setup now log at `DEBUG`
-  instead of `INFO`. Package validation still runs, while production license warnings and renderer failures remain
-  visible and actionable. Fixes [Issue 4848](https://github.com/shakacode/react_on_rails/issues/4848).
+- **Routine startup diagnostics no longer appear in default `INFO` logs**: Successful package validation, valid
+  Pro license checks, non-production missing-license notices, and Node renderer connection setup now log at `DEBUG`
+  instead of `INFO`. Package validation still runs, while expired or invalid configured licenses remain visible outside
+  production, and production license warnings and renderer failures remain actionable. Fixes
+  [Issue 4848](https://github.com/shakacode/react_on_rails/issues/4848).
   [PR 4849](https://github.com/shakacode/react_on_rails/pull/4849) by
   [Justin Gordon](https://github.com/justin808).
 

--- a/react_on_rails/lib/react_on_rails/engine.rb
+++ b/react_on_rails/lib/react_on_rails/engine.rb
@@ -30,9 +30,9 @@ module ReactOnRails
       config.after_initialize do
         next if Engine.skip_version_validation?
 
-        Rails.logger.info "[React on Rails] Validating package version and compatibility..."
+        Rails.logger.debug "[React on Rails] Validating package version and compatibility..."
         VersionChecker.build.validate_version_and_package_compatibility!
-        Rails.logger.info "[React on Rails] Package validation successful"
+        Rails.logger.debug "[React on Rails] Package validation successful"
       end
     end
 

--- a/react_on_rails/spec/react_on_rails/engine_spec.rb
+++ b/react_on_rails/spec/react_on_rails/engine_spec.rb
@@ -9,6 +9,55 @@ require "tmpdir"
 
 module ReactOnRails
   RSpec.describe Engine do
+    describe "package validation initializer" do
+      subject(:run_after_initialize) do
+        after_initialize_callback = nil
+        allow(described_class.config).to receive(:after_initialize) do |&block|
+          after_initialize_callback = block
+        end
+
+        initializer.bind(described_class.instance).run
+        after_initialize_callback.call
+      end
+
+      let(:initializer) do
+        described_class.initializers.find do |candidate|
+          candidate.name == "react_on_rails.validate_version_and_package_compatibility"
+        end
+      end
+      let(:logger) { instance_spy(ActiveSupport::Logger) }
+      let(:version_checker) { instance_spy(VersionChecker) }
+
+      before do
+        allow(described_class).to receive(:skip_version_validation?).and_return(false)
+        allow(VersionChecker).to receive(:build).and_return(version_checker)
+        allow(Rails).to receive(:logger).and_return(logger)
+      end
+
+      it "runs package validation while keeping healthy diagnostics at debug level" do
+        run_after_initialize
+
+        expect(version_checker).to have_received(:validate_version_and_package_compatibility!)
+        expect(logger).to have_received(:debug)
+          .with("[React on Rails] Validating package version and compatibility...")
+        expect(logger).to have_received(:debug)
+          .with("[React on Rails] Package validation successful")
+        expect(logger).not_to have_received(:info)
+      end
+
+      it "still fails startup when package validation finds an incompatibility" do
+        allow(version_checker).to receive(:validate_version_and_package_compatibility!)
+          .and_raise(ReactOnRails::Error, "react-on-rails package version mismatch")
+
+        expect { run_after_initialize }
+          .to raise_error(ReactOnRails::Error, "react-on-rails package version mismatch")
+        expect(logger).to have_received(:debug)
+          .with("[React on Rails] Validating package version and compatibility...")
+        expect(logger).not_to have_received(:debug)
+          .with("[React on Rails] Package validation successful")
+      end
+    end
+
     describe ".skip_version_validation?" do
       let(:package_json_path) { "/fake/path/package.json" }
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
@@ -109,7 +109,7 @@ module ReactOnRailsPro
 
         message += " Attribution required for this license type." if attribution_required
 
-        Rails.logger.info message
+        Rails.logger.debug message
       end
 
       def plan_display_name(plan)
@@ -134,7 +134,7 @@ module ReactOnRailsPro
                     "If this deployment is Production Use, #{action}"
           Rails.logger.warn "#{prefix} #{warning}"
         else
-          Rails.logger.info "#{prefix} No license required for development/test environments."
+          Rails.logger.debug "#{prefix} No license required for development/test environments."
         end
       end
     end

--- a/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
@@ -79,9 +79,13 @@ module ReactOnRailsPro
         when :expired
           expiration = ReactOnRailsPro::LicenseValidator.license_expiration
           expired_on = expiration ? " (expired on #{expiration.strftime('%Y-%m-%d')})" : ""
-          log_license_issue("License has expired#{expired_on}", "Renew your license at #{LICENSE_URL}")
+          log_license_issue(
+            "License has expired#{expired_on}",
+            "Renew your license at #{LICENSE_URL}",
+            warn_outside_production: true
+          )
         when :invalid
-          log_license_issue("Invalid license", "Get a license at #{LICENSE_URL}")
+          log_license_issue("Invalid license", "Get a license at #{LICENSE_URL}", warn_outside_production: true)
         end
       end
 
@@ -126,13 +130,15 @@ module ReactOnRailsPro
         end
       end
 
-      def log_license_issue(issue, action)
+      def log_license_issue(issue, action, warn_outside_production: false)
         prefix = "[React on Rails Pro] #{issue}."
 
         if Rails.env.production?
           warning = "Production Use of React on Rails Pro requires a valid license. " \
                     "If this deployment is Production Use, #{action}"
           Rails.logger.warn "#{prefix} #{warning}"
+        elsif warn_outside_production
+          Rails.logger.warn "#{prefix} #{action}"
         else
           Rails.logger.debug "#{prefix} No license required for development/test environments."
         end

--- a/react_on_rails_pro/lib/react_on_rails_pro/request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/request.rb
@@ -666,7 +666,7 @@ module ReactOnRailsPro
 
       def create_connection
         url = ReactOnRailsPro.configuration.renderer_url
-        Rails.logger.info do
+        Rails.logger.debug do
           "[ReactOnRailsPro] Setting up Node Renderer connection to #{url}"
         end
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb
@@ -20,7 +20,7 @@ require_relative "spec_helper"
 RSpec.describe ReactOnRailsPro::Engine do
   let(:test_private_key) { OpenSSL::PKey::RSA.new(2048) }
   let(:test_public_key) { test_private_key.public_key }
-  let(:mock_logger) { instance_double(Logger, warn: nil, info: nil) }
+  let(:mock_logger) { instance_double(Logger, warn: nil, info: nil, debug: nil) }
 
   let(:valid_payload) do
     {
@@ -119,13 +119,14 @@ RSpec.describe ReactOnRailsPro::Engine do
           ENV["REACT_ON_RAILS_PRO_LICENSE"] = token
         end
 
-        it "logs success info" do
-          expect(mock_logger).to receive(:info).with(/License validated successfully/)
+        it "keeps successful validation at debug level" do
+          expect(mock_logger).to receive(:debug).with(/License validated successfully/)
+          expect(mock_logger).not_to receive(:info)
           described_class.log_license_status
         end
 
         it "keeps the organization in private diagnostics and does not include the paid plan name" do
-          expect(mock_logger).to receive(:info)
+          expect(mock_logger).to receive(:debug)
             .with("[React on Rails Pro] License validated successfully (Acme Corp). " \
                   "Attribution required for this license type.")
           described_class.log_license_status
@@ -142,8 +143,8 @@ RSpec.describe ReactOnRailsPro::Engine do
           ReactOnRailsPro.configuration.license_token = JWT.encode(valid_payload, test_private_key, "RS256")
         end
 
-        it "logs success info" do
-          expect(mock_logger).to receive(:info).with(/License validated successfully/)
+        it "logs successful validation at debug level" do
+          expect(mock_logger).to receive(:debug).with(/License validated successfully/)
           described_class.log_license_status
         end
       end
@@ -175,7 +176,7 @@ RSpec.describe ReactOnRailsPro::Engine do
 
           it "logs success with plan type" do
             pattern = /License validated successfully \(#{Regexp.escape(config[:org])} - #{config[:display]}\)/
-            expect(mock_logger).to receive(:info).with(pattern)
+            expect(mock_logger).to receive(:debug).with(pattern)
             described_class.log_license_status
           end
         end
@@ -188,14 +189,15 @@ RSpec.describe ReactOnRailsPro::Engine do
       end
 
       context "with missing license" do
-        it "logs info instead of warning" do
-          expect(mock_logger).to receive(:info).with(/No license found/)
+        it "keeps the non-actionable status at debug level" do
+          expect(mock_logger).to receive(:debug).with(/No license found/)
+          expect(mock_logger).not_to receive(:info)
           expect(mock_logger).not_to receive(:warn)
           described_class.log_license_status
         end
 
         it "includes the development/test message" do
-          expect(mock_logger).to receive(:info).with(%r{No license required for development/test environments})
+          expect(mock_logger).to receive(:debug).with(%r{No license required for development/test environments})
           described_class.log_license_status
         end
       end
@@ -209,20 +211,20 @@ RSpec.describe ReactOnRailsPro::Engine do
           ENV["REACT_ON_RAILS_PRO_LICENSE"] = token
         end
 
-        it "logs info instead of warning" do
-          expect(mock_logger).to receive(:info).with(/License has expired/)
+        it "logs debug instead of warning" do
+          expect(mock_logger).to receive(:debug).with(/License has expired/)
           expect(mock_logger).not_to receive(:warn)
           described_class.log_license_status
         end
 
         it "includes the expiration date" do
           expected_date = Time.at(expired_time).strftime("%Y-%m-%d")
-          expect(mock_logger).to receive(:info).with(/expired on #{expected_date}/)
+          expect(mock_logger).to receive(:debug).with(/expired on #{expected_date}/)
           described_class.log_license_status
         end
 
         it "includes the development/test message" do
-          expect(mock_logger).to receive(:info).with(%r{No license required for development/test environments})
+          expect(mock_logger).to receive(:debug).with(%r{No license required for development/test environments})
           described_class.log_license_status
         end
       end
@@ -233,8 +235,8 @@ RSpec.describe ReactOnRailsPro::Engine do
           ENV["REACT_ON_RAILS_PRO_LICENSE"] = token
         end
 
-        it "logs success info" do
-          expect(mock_logger).to receive(:info).with(/License validated successfully/)
+        it "logs successful validation at debug level" do
+          expect(mock_logger).to receive(:debug).with(/License validated successfully/)
           described_class.log_license_status
         end
       end
@@ -257,7 +259,7 @@ RSpec.describe ReactOnRailsPro::Engine do
         end
 
         it "logs success with plan type" do
-          expect(mock_logger).to receive(:info)
+          expect(mock_logger).to receive(:debug)
             .with(/License validated successfully \(Startup Inc - startup license\)/)
           described_class.log_license_status
         end

--- a/react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb
@@ -211,20 +211,29 @@ RSpec.describe ReactOnRailsPro::Engine do
           ENV["REACT_ON_RAILS_PRO_LICENSE"] = token
         end
 
-        it "logs debug instead of warning" do
-          expect(mock_logger).to receive(:debug).with(/License has expired/)
-          expect(mock_logger).not_to receive(:warn)
+        it "warns because the configured license needs attention" do
+          expect(mock_logger).to receive(:warn).with(/License has expired/)
+          expect(mock_logger).not_to receive(:debug)
           described_class.log_license_status
         end
 
-        it "includes the expiration date" do
+        it "includes the expiration date and renewal URL" do
           expected_date = Time.at(expired_time).strftime("%Y-%m-%d")
-          expect(mock_logger).to receive(:debug).with(/expired on #{expected_date}/)
+          expect(mock_logger).to receive(:warn).with(/expired on #{expected_date}.*pro\.reactonrails\.com/)
           described_class.log_license_status
         end
+      end
 
-        it "includes the development/test message" do
-          expect(mock_logger).to receive(:debug).with(%r{No license required for development/test environments})
+      context "with invalid license" do
+        before do
+          wrong_key = OpenSSL::PKey::RSA.new(2048)
+          token = JWT.encode(valid_payload, wrong_key, "RS256")
+          ENV["REACT_ON_RAILS_PRO_LICENSE"] = token
+        end
+
+        it "warns with the license URL because the configured token needs attention" do
+          expect(mock_logger).to receive(:warn).with(/Invalid license.*pro\.reactonrails\.com/)
+          expect(mock_logger).not_to receive(:debug)
           described_class.log_license_status
         end
       end

--- a/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
@@ -811,6 +811,43 @@ describe ReactOnRailsPro::Request do
       described_class.instance_variable_set(:@connection, nil)
     end
 
+    it "keeps routine connection setup at debug level" do
+      connection = instance_double(ReactOnRailsPro::RendererHttpClient)
+      setup_messages = []
+      allow(ReactOnRailsPro.configuration).to receive_messages(
+        renderer_http_pool_timeout: 5,
+        ssr_timeout: 10
+      )
+      allow(ReactOnRailsPro::RendererHttpClient).to receive(:new).and_return(connection)
+      allow(logger_mock).to receive(:debug) { |&block| setup_messages << block.call }
+      expect(logger_mock).not_to receive(:info)
+
+      expect(described_class.send(:create_connection)).to be(connection)
+      expect(setup_messages).to eq(["[ReactOnRailsPro] Setting up Node Renderer connection to #{renderer_url}"])
+    end
+
+    it "keeps renderer connection failures actionable" do
+      allow(ReactOnRailsPro.configuration).to receive_messages(
+        renderer_http_pool_timeout: 5,
+        renderer_http_pool_warn_timeout: 10,
+        renderer_http_keep_alive_timeout: 15,
+        ssr_timeout: 20
+      )
+      allow(ReactOnRailsPro::RendererHttpClient).to receive(:new)
+        .and_raise(StandardError, "invalid renderer URL")
+
+      expect { described_class.send(:create_connection) }
+        .to raise_error(
+          ReactOnRailsPro::Error,
+          a_string_including(
+            "Error creating async-http connection",
+            "renderer_url = #{renderer_url}",
+            "Be sure to use a url that contains the protocol of http or https",
+            "invalid renderer URL"
+          )
+        )
+    end
+
     it "creates only one connection when accessed concurrently" do
       connections_created = 0
       counter_mutex = Mutex.new


### PR DESCRIPTION
## Why

Routine Rails commands currently print successful React on Rails setup and validation messages at the default `INFO` level. These healthy-path diagnostics obscure the output users actually requested, including for unrelated database commands.

## What changed

- Move Core package-validation start/success messages from `INFO` to `DEBUG`.
- Move successful Pro license validation and the non-production missing-license notice from `INFO` to `DEBUG`, while keeping expired or invalid configured licenses visible at `WARN` in every environment.
- Move initial Node renderer connection setup from `INFO` to `DEBUG`.
- Preserve package validation execution and exceptions, production and configured-license warnings, and renderer connection failures.
- Add focused regression coverage for the changed log levels and preserved failure behavior.

Fixes #4848.

## Validation

- Core engine spec: 47 examples, 0 failures.
- Pro engine/request specs: 83 examples, 0 failures, 1 pre-existing pending example (#3300).
- Core CI-equivalent RuboCop: 247 files, 0 offenses.
- Pro CI-equivalent RuboCop: 247 files, 0 offenses.
- Pro license headers: 873/873 current.
- Production dummy Rails runner smoke: the routine startup messages are absent at default `INFO`; the production missing-license warning remains visible.
- `.agents/bin/validate --fast`: all configured fast checks passed.
- Independent `codex review --base origin/main`: clean, no actionable findings.

The broader `.agents/bin/validate --changed` run passed dependency setup, documentation checks, lint/format/typechecking, builds, JavaScript suites, React compatibility packs, and the Pro Node renderer suite. Its later full Core RSpec phase ended non-green with roughly 235 unrelated failures spanning GitUtils, Locales, PackerUtils, render options, and other untouched areas after generator scenarios. The changed specs and a representative unrelated GitUtils spec both pass independently; this is recorded as an order/environment/toolchain caveat rather than claimed green full-suite evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reduced routine startup, package validation, license status, and renderer connection messages to debug-level logging.
  * Production license warnings and non-production expired or invalid license notices remain visible.
  * Renderer connection failures continue to be visible with clearer error reporting.
  * Preserved existing validation and license-check behavior while reducing normal startup noise.
* **Documentation**
  * Added unreleased changelog notes describing the logging improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- completed-batch-audit-summary:start -->
## Completed-batch audit

**Status:** Follow-ups remain — see the durable receipt. [Durable receipt](https://github.com/shakacode/react_on_rails/pull/4849#issuecomment-5211378162).
<!-- completed-batch-audit-summary:end -->