### PR TITLE
PPR: define settle criterion for all three prerender abort points

### DIFF
--- a/internal/analysis/ppr-rsc-payload-by-example.md
+++ b/internal/analysis/ppr-rsc-payload-by-example.md
@@ -386,11 +386,13 @@ Flight renderer produces an RSC stream. That stream is fed into React DOM's
 prelude HTML  ──→  Saved as static file (e.g., /page.html)
 postponed     ──→  Serialized to metadata
 RSC chunks    ──→  Inlined as <script> tags in the HTML
-                   (self.__next_f.push([1, "..."]))
+                   (framework-specific embedding mechanism)
 ```
 
 The RSC payload is embedded in the HTML as `<script>` tags, so the client
-can hydrate without a separate data fetch.
+can hydrate without a separate data fetch. The exact embedding format is a
+framework concern — Next.js uses `self.__next_f.push(...)`, React on Rails
+will need its own equivalent.
 
 ### Step 4: Request time — Serve the shell
 
@@ -500,6 +502,16 @@ renderer produces a prelude with fallbacks for the hanging parts.
 ---
 
 ## Chapter 8: What the Browser Sees
+
+> **Note:** Chapters 1–7 use vanilla React APIs (`react-dom/static`,
+> `react-dom/server`) — no framework code. This chapter shows the
+> **framework-level** integration that Next.js adds on top: specifically, how
+> the Flight data is inlined into the HTML as `<script>` tags. The
+> `self.__next_f` naming convention, the `$RC` replacement script, and the
+> `[0]`/`[1]`/`[3]` type codes are all **Next.js-specific implementation
+> details**, not React built-ins. React on Rails will need its own equivalent
+> inlining mechanism — the wire protocol (Flight rows) is the same, but the
+> HTML embedding is a framework concern.
 
 Let's trace what a user's browser receives for a PPR page:
 

--- a/internal/analysis/ppr-rsc-payload-by-example.md
+++ b/internal/analysis/ppr-rsc-payload-by-example.md
@@ -51,16 +51,20 @@ streams in and replaces the fallback.
 **Build time** — `prerender()` produces the static shell:
 
 ```html
-<!DOCTYPE html><html><head></head><body>
-<div>
-  <h1>My App</h1>
-  <nav>Home | About | Contact</nav>
-  <!--$?--><template id="B:0"></template>
-  <p>👤 Loading user...</p>
-  <!--/$-->
-  <footer>© 2024 MyApp</footer>
-</div>
-</body></html>
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <div>
+      <h1>My App</h1>
+      <nav>Home | About | Contact</nav>
+      <!--$?--><template id="B:0"></template>
+      <p>👤 Loading user...</p>
+      <!--/$-->
+      <footer>© 2024 MyApp</footer>
+    </div>
+  </body>
+</html>
 ```
 
 **Request time** — `resumeToPipeableStream()` fills the hole:
@@ -87,7 +91,7 @@ Here's what each one means:
 
 ```html
 <!--$-->
-  <div>This content resolved successfully</div>
+<div>This content resolved successfully</div>
 <!--/$-->
 ```
 
@@ -98,8 +102,8 @@ below is the actual component output." The `<!--/$-->` marks the end.
 
 ```html
 <!--$?-->
-  <template id="B:0"></template>
-  <p>Loading...</p>
+<template id="B:0"></template>
+<p>Loading...</p>
 <!--/$-->
 ```
 
@@ -117,7 +121,7 @@ function App() {
     <div>
       <h1>Static Header</h1>
       <Suspense fallback={<p>Loading...</p>}>
-        <DynamicComponent />       {/* hangs during prerender */}
+        <DynamicComponent /> {/* hangs during prerender */}
       </Suspense>
       <footer>Static Footer</footer>
     </div>
@@ -130,7 +134,9 @@ function App() {
 ```html
 <div>
   <h1>Static Header</h1>
-  <!--$?--><template id="B:0"></template><p>Loading...</p><!--/$-->
+  <!--$?--><template id="B:0"></template>
+  <p>Loading...</p>
+  <!--/$-->
   <footer>Static Footer</footer>
 </div>
 ```
@@ -153,7 +159,9 @@ Same component, two scenarios:
 **Scenario A**: `AsyncContent` resolves before abort (e.g., cache hit):
 
 ```html
-<!--$--><div>Async Content</div><!--/$-->
+<!--$-->
+<div>Async Content</div>
+<!--/$-->
 ```
 
 No `<template>`, no fallback. The content is directly in the shell. The
@@ -163,7 +171,9 @@ and it resolved." This is purely for hydration — the user just sees the conten
 **Scenario B**: `AsyncContent` is still pending at abort time:
 
 ```html
-<!--$?--><template id="B:0"></template><p>Loading...</p><!--/$-->
+<!--$?--><template id="B:0"></template>
+<p>Loading...</p>
+<!--/$-->
 ```
 
 The fallback renders. The `<template>` marker waits for the resume stream.
@@ -182,11 +192,11 @@ function Dashboard() {
   return (
     <div>
       <Suspense fallback={<p>Loading notifications...</p>}>
-        <Notifications />     {/* dynamic — reads user session */}
+        <Notifications /> {/* dynamic — reads user session */}
       </Suspense>
       <p>Dashboard overview (static)</p>
       <Suspense fallback={<p>Loading activity...</p>}>
-        <RecentActivity />    {/* dynamic — reads user session */}
+        <RecentActivity /> {/* dynamic — reads user session */}
       </Suspense>
     </div>
   );
@@ -211,10 +221,22 @@ Each hole gets its own boundary ID (`B:0`, `B:1`). At request time, the resume
 stream fills each one independently:
 
 ```html
-<div hidden id="S:0"><ul><li>3 new messages</li></ul></div>
-<script>$RC("B:0","S:0")</script>
-<div hidden id="S:1"><ul><li>Deployed v2.1</li></ul></div>
-<script>$RC("B:1","S:1")</script>
+<div hidden id="S:0">
+  <ul>
+    <li>3 new messages</li>
+  </ul>
+</div>
+<script>
+  $RC('B:0', 'S:0');
+</script>
+<div hidden id="S:1">
+  <ul>
+    <li>Deployed v2.1</li>
+  </ul>
+</div>
+<script>
+  $RC('B:1', 'S:1');
+</script>
 ```
 
 Static content between holes renders normally in the shell.
@@ -233,11 +255,12 @@ const { prelude, postponed } = await prerender(<App />, { signal });
 ```
 
 Returns:
+
 - **`prelude`** — a `ReadableStream` of the static HTML shell
 - **`postponed`** — an opaque object describing the holes (or `null` if
   everything resolved)
 
-The prelude contains the *final* HTML for everything that resolved. Pending
+The prelude contains the _final_ HTML for everything that resolved. Pending
 boundaries show their fallbacks. Nothing more will come from this API —
 the prelude is complete and cacheable.
 
@@ -247,11 +270,14 @@ the prelude is complete and cacheable.
 
 ```js
 const { pipe } = renderToPipeableStream(<App />, {
-  onShellReady() { pipe(response); },
+  onShellReady() {
+    pipe(response);
+  },
 });
 ```
 
 Streams HTML in real-time:
+
 1. First: the shell (with fallbacks for pending boundaries)
 2. Then: resolved content in hidden `<div>`s + `$RC` replacement scripts
 
@@ -267,9 +293,12 @@ a hanging component):
 ```html
 <div>
   <h1>Shell</h1>
-  <!--$--><p>[Slow content resolved after 50ms]</p><!--/$-->
+  <!--$-->
+  <p>[Slow content resolved after 50ms]</p>
+  <!--/$-->
   <!--$?--><template id="B:0"></template>
-  <p>Loading dynamic...</p><!--/$-->
+  <p>Loading dynamic...</p>
+  <!--/$-->
 </div>
 ```
 
@@ -284,16 +313,20 @@ pending boundary.
 <div>
   <h1>Shell</h1>
   <!--$?--><template id="B:0"></template>
-  <p>Loading slow...</p><!--/$-->
+  <p>Loading slow...</p>
+  <!--/$-->
   <!--$?--><template id="B:1"></template>
-  <p>Loading dynamic...</p><!--/$-->
+  <p>Loading dynamic...</p>
+  <!--/$-->
 </div>
 
 <!-- STREAMED LATER (after 50ms): -->
 <div hidden id="S:0">
   <p>[Slow content resolved after 50ms]</p>
 </div>
-<script>$RC("B:0","S:0")</script>
+<script>
+  $RC('B:0', 'S:0');
+</script>
 ```
 
 With streaming, the shell ships immediately with **both** fallbacks visible.
@@ -441,8 +474,8 @@ HTML generation, they're replayed as an **unclosing stream**:
 new ReadableStream({
   pull(controller) {
     if (i < chunks.length) controller.enqueue(chunks[i++]);
-    else controller.close();  // ← stream ends
-  }
+    else controller.close(); // ← stream ends
+  },
 });
 
 // Unclosing stream: delivers all chunks, then HANGS
@@ -450,7 +483,7 @@ new ReadableStream({
   pull(controller) {
     if (i < chunks.length) controller.enqueue(chunks[i++]);
     // ← no close() call — stream stays "open" forever
-  }
+  },
 });
 ```
 
@@ -475,26 +508,35 @@ Let's trace what a user's browser receives for a PPR page:
 ```html
 <!DOCTYPE html>
 <html>
-<head>...</head>
-<body>
-  <div>
-    <h1>My App</h1>
-    <nav>Home | About | Contact</nav>
-    <!--$?--><template id="B:0"></template>
-    <p>👤 Loading user...</p>
-    <!--/$-->
-    <footer>© 2024 MyApp</footer>
-  </div>
+  <head>
+    ...
+  </head>
+  <body>
+    <div>
+      <h1>My App</h1>
+      <nav>Home | About | Contact</nav>
+      <!--$?--><template id="B:0"></template>
+      <p>👤 Loading user...</p>
+      <!--/$-->
+      <footer>© 2024 MyApp</footer>
+    </div>
 
-  <!-- RSC data for hydration: -->
-  <script>(self.__next_f=self.__next_f||[]).push([0])</script>
-  <script>self.__next_f.push([1,"0:..."])</script>
-  <script>self.__next_f.push([1,"1:..."])</script>
-</body>
+    <!-- RSC data for hydration: -->
+    <script>
+      (self.__next_f = self.__next_f || []).push([0]);
+    </script>
+    <script>
+      self.__next_f.push([1, '0:...']);
+    </script>
+    <script>
+      self.__next_f.push([1, '1:...']);
+    </script>
+  </body>
 </html>
 ```
 
 The browser renders immediately:
+
 - Header ✓
 - Navigation ✓
 - "👤 Loading user..." (fallback) ✓
@@ -506,10 +548,13 @@ The browser renders immediately:
 <div hidden id="S:0">
   <p>Hello, Abanoub!</p>
 </div>
-<script>$RC("B:0","S:0")</script>
+<script>
+  $RC('B:0', 'S:0');
+</script>
 ```
 
 The `$RC` script:
+
 1. Finds `<template id="B:0">` in the DOM
 2. Finds `<div hidden id="S:0">`
 3. Removes the fallback ("👤 Loading user...")
@@ -525,11 +570,17 @@ of the Flight protocol:
 
 ```html
 <!-- Initialize the buffer -->
-<script>(self.__next_f=self.__next_f||[]).push([0])</script>
+<script>
+  (self.__next_f = self.__next_f || []).push([0]);
+</script>
 
 <!-- Flight data chunks (the serialized component tree) -->
-<script>self.__next_f.push([1,"0:{\"key\":\"value\"}\n"])</script>
-<script>self.__next_f.push([1,"1:[\"$\",\"div\",null,{...}]\n"])</script>
+<script>
+  self.__next_f.push([1, '0:{"key":"value"}\n']);
+</script>
+<script>
+  self.__next_f.push([1, '1:["$","div",null,{...}]\n']);
+</script>
 ```
 
 The client-side React code reads these chunks, reconstructs the component
@@ -542,11 +593,11 @@ interactive.
 
 A PPR prerender produces three things:
 
-| Output | What it is | When it's used |
-|--------|-----------|----------------|
-| **Prelude HTML** | Complete HTML document with fallbacks for dynamic holes | Served instantly from cache |
-| **Postponed state** | Opaque object describing which boundaries need to be filled | Passed to `resumeToPipeableStream()` at request time |
-| **RSC data** | Serialized component tree (Flight protocol) embedded as `<script>` tags | Used by the client for hydration |
+| Output              | What it is                                                              | When it's used                                       |
+| ------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| **Prelude HTML**    | Complete HTML document with fallbacks for dynamic holes                 | Served instantly from cache                          |
+| **Postponed state** | Opaque object describing which boundaries need to be filled             | Passed to `resumeToPipeableStream()` at request time |
+| **RSC data**        | Serialized component tree (Flight protocol) embedded as `<script>` tags | Used by the client for hydration                     |
 
 The **prelude** is what the user sees immediately.
 The **postponed state** is what the server needs to fill in the gaps.
@@ -554,5 +605,5 @@ The **RSC data** is what React needs to make the page interactive.
 
 ---
 
-*All examples verified on React 19.2.8, Node.js, macOS.*
-*Source experiments: 13, 14, 15 in the settle-criterion directory.*
+_All examples verified on React 19.2.8, Node.js, macOS._
+_Source experiments: 13, 14, 15 in the settle-criterion directory._

--- a/internal/analysis/ppr-rsc-payload-by-example.md
+++ b/internal/analysis/ppr-rsc-payload-by-example.md
@@ -1,0 +1,558 @@
+# The RSC Payload in PPR — By Example
+
+**How the data flows from your React components to the HTML the user sees.**
+
+Every example was tested on React 19.2.8. No Next.js framework code — just
+vanilla React APIs (`react-dom/static`, `react-dom/server`) to show the
+mechanics that PPR builds on.
+
+---
+
+## Chapter 1: What PPR Actually Produces
+
+PPR splits your page into two pieces at build time:
+
+```
+┌─────────────────────────────────────────────────┐
+│              YOUR REACT TREE                     │
+│                                                  │
+│  <App>                                           │
+│    <Header />           ← static                 │
+│    <Nav />              ← static                 │
+│    <Suspense fallback={<Skeleton />}>             │
+│      <UserGreeting />   ← dynamic (needs cookies)│
+│    </Suspense>                                    │
+│    <Footer />           ← static                 │
+│  </App>                                          │
+│                                                  │
+└─────────────────────────────────────────────────┘
+                    │
+          PPR splits it into:
+                    │
+         ┌──────────┴──────────┐
+         ▼                     ▼
+┌─────────────────┐   ┌─────────────────┐
+│  STATIC SHELL   │   │  RESUME STREAM  │
+│  (cached)       │   │  (per-request)  │
+│                 │   │                 │
+│  <h1>My App</h1>│   │  Hello, Abanoub!│
+│  <nav>...</nav> │   │  + swap script  │
+│  👤 Loading...  │   │                 │
+│  <footer>...</  │   │                 │
+└─────────────────┘   └─────────────────┘
+   Served instantly       Streamed in
+```
+
+The user sees the shell immediately (instant TTFB), then the dynamic content
+streams in and replaces the fallback.
+
+### Real output from experiment 15
+
+**Build time** — `prerender()` produces the static shell:
+
+```html
+<!DOCTYPE html><html><head></head><body>
+<div>
+  <h1>My App</h1>
+  <nav>Home | About | Contact</nav>
+  <!--$?--><template id="B:0"></template>
+  <p>👤 Loading user...</p>
+  <!--/$-->
+  <footer>© 2024 MyApp</footer>
+</div>
+</body></html>
+```
+
+**Request time** — `resumeToPipeableStream()` fills the hole:
+
+```html
+<div hidden id="S:0">
+  <p>Hello, Abanoub!</p>
+</div>
+<script>$RC("B:0","S:0")</script>
+</body></html>
+```
+
+The `$RC` script finds the `<template id="B:0">` marker in the shell, finds
+the hidden `<div id="S:0">`, and swaps the fallback for the real content.
+
+---
+
+## Chapter 2: The HTML Markers — A Field Guide
+
+React uses HTML comments and template elements to mark up Suspense boundaries.
+Here's what each one means:
+
+### Resolved boundary (content is ready)
+
+```html
+<!--$-->
+  <div>This content resolved successfully</div>
+<!--/$-->
+```
+
+The `<!--$-->` comment means "this Suspense boundary resolved — the content
+below is the actual component output." The `<!--/$-->` marks the end.
+
+### Pending boundary (content not ready — showing fallback)
+
+```html
+<!--$?-->
+  <template id="B:0"></template>
+  <p>Loading...</p>
+<!--/$-->
+```
+
+The `<!--$?-->` means "this Suspense boundary is still pending." The
+`<template id="B:0">` is an invisible marker that the resume script uses to
+find this spot later. The `<p>Loading...</p>` is the fallback the user sees.
+
+### What it looks like with real components
+
+If you write this:
+
+```jsx
+function App() {
+  return (
+    <div>
+      <h1>Static Header</h1>
+      <Suspense fallback={<p>Loading...</p>}>
+        <DynamicComponent />       {/* hangs during prerender */}
+      </Suspense>
+      <footer>Static Footer</footer>
+    </div>
+  );
+}
+```
+
+`prerender()` produces:
+
+```html
+<div>
+  <h1>Static Header</h1>
+  <!--$?--><template id="B:0"></template><p>Loading...</p><!--/$-->
+  <footer>Static Footer</footer>
+</div>
+```
+
+Static content renders normally. The dynamic component becomes a pending
+boundary with its fallback.
+
+---
+
+## Chapter 3: Resolved vs Pending — Side by Side
+
+Same component, two scenarios:
+
+```jsx
+<Suspense fallback={<p>Loading...</p>}>
+  <AsyncContent />
+</Suspense>
+```
+
+**Scenario A**: `AsyncContent` resolves before abort (e.g., cache hit):
+
+```html
+<!--$--><div>Async Content</div><!--/$-->
+```
+
+No `<template>`, no fallback. The content is directly in the shell. The
+`<!--$-->` marker (without `?`) tells React "this was a Suspense boundary
+and it resolved." This is purely for hydration — the user just sees the content.
+
+**Scenario B**: `AsyncContent` is still pending at abort time:
+
+```html
+<!--$?--><template id="B:0"></template><p>Loading...</p><!--/$-->
+```
+
+The fallback renders. The `<template>` marker waits for the resume stream.
+
+**The difference is entirely determined by timing** — did the component resolve
+before the abort signal fired?
+
+---
+
+## Chapter 4: Multiple Dynamic Holes
+
+A page can have multiple independent dynamic holes:
+
+```jsx
+function Dashboard() {
+  return (
+    <div>
+      <Suspense fallback={<p>Loading notifications...</p>}>
+        <Notifications />     {/* dynamic — reads user session */}
+      </Suspense>
+      <p>Dashboard overview (static)</p>
+      <Suspense fallback={<p>Loading activity...</p>}>
+        <RecentActivity />    {/* dynamic — reads user session */}
+      </Suspense>
+    </div>
+  );
+}
+```
+
+`prerender()` output:
+
+```html
+<div>
+  <!--$?--><template id="B:0"></template>
+  <p>Loading notifications...</p>
+  <!--/$-->
+  <p>Dashboard overview (static)</p>
+  <!--$?--><template id="B:1"></template>
+  <p>Loading activity...</p>
+  <!--/$-->
+</div>
+```
+
+Each hole gets its own boundary ID (`B:0`, `B:1`). At request time, the resume
+stream fills each one independently:
+
+```html
+<div hidden id="S:0"><ul><li>3 new messages</li></ul></div>
+<script>$RC("B:0","S:0")</script>
+<div hidden id="S:1"><ul><li>Deployed v2.1</li></ul></div>
+<script>$RC("B:1","S:1")</script>
+```
+
+Static content between holes renders normally in the shell.
+
+---
+
+## Chapter 5: prerender() vs renderToPipeableStream()
+
+React offers two server rendering APIs. Understanding the difference is
+crucial for PPR:
+
+### `prerender()` (from `react-dom/static`)
+
+```js
+const { prelude, postponed } = await prerender(<App />, { signal });
+```
+
+Returns:
+- **`prelude`** — a `ReadableStream` of the static HTML shell
+- **`postponed`** — an opaque object describing the holes (or `null` if
+  everything resolved)
+
+The prelude contains the *final* HTML for everything that resolved. Pending
+boundaries show their fallbacks. Nothing more will come from this API —
+the prelude is complete and cacheable.
+
+**What you get**: a snapshot at the moment of abort.
+
+### `renderToPipeableStream()` (from `react-dom/server`)
+
+```js
+const { pipe } = renderToPipeableStream(<App />, {
+  onShellReady() { pipe(response); },
+});
+```
+
+Streams HTML in real-time:
+1. First: the shell (with fallbacks for pending boundaries)
+2. Then: resolved content in hidden `<div>`s + `$RC` replacement scripts
+
+**What you get**: a continuous stream that progressively fills in content.
+
+### The key difference
+
+With the same component tree (an async component that resolves after 50ms +
+a hanging component):
+
+**`prerender()` output** (aborted at 100ms):
+
+```html
+<div>
+  <h1>Shell</h1>
+  <!--$--><p>[Slow content resolved after 50ms]</p><!--/$-->
+  <!--$?--><template id="B:0"></template>
+  <p>Loading dynamic...</p><!--/$-->
+</div>
+```
+
+The slow content (50ms) had time to resolve, so it's **inlined directly** in
+the prelude — no fallback, no replacement script. The hanging component is a
+pending boundary.
+
+**`renderToPipeableStream()` output** (shell + stream):
+
+```html
+<!-- SHELL (sent immediately): -->
+<div>
+  <h1>Shell</h1>
+  <!--$?--><template id="B:0"></template>
+  <p>Loading slow...</p><!--/$-->
+  <!--$?--><template id="B:1"></template>
+  <p>Loading dynamic...</p><!--/$-->
+</div>
+
+<!-- STREAMED LATER (after 50ms): -->
+<div hidden id="S:0">
+  <p>[Slow content resolved after 50ms]</p>
+</div>
+<script>$RC("B:0","S:0")</script>
+```
+
+With streaming, the shell ships immediately with **both** fallbacks visible.
+Then the slow content arrives later as a hidden div + replacement script.
+
+**Why PPR uses `prerender()`**: Because the prelude is a complete, static HTML
+document that can be cached and served from a CDN. The only dynamic parts are
+the postponed boundaries, which are filled by a separate resume stream at
+request time.
+
+---
+
+## Chapter 6: The Complete PPR Pipeline
+
+Here's the full lifecycle, step by step:
+
+### Step 1: Build time — Prospective prerender (fill caches)
+
+```
+React tree → Flight renderer → RSC payload stream
+                                      ↓
+                              CacheSignal tracks all
+                              cache reads (beginRead/endRead)
+                                      ↓
+                              All caches filled → abort
+                                      ↓
+                              RSC stream is DISCARDED
+                              (only side-effect: warm caches)
+```
+
+The entire purpose of this step is to populate caches. The output is thrown away.
+
+### Step 2: Build time — Final prerender (produce the shell)
+
+```
+React tree → Flight renderer → RSC payload stream
+             (warm caches →       ↓
+              resolves fast)  Collected as chunks
+                                  ↓
+                              RSC stream → fed into Fizz
+                                  ↓
+                              prerender(<App />, { signal })
+                                  ↓
+                              { prelude, postponed }
+                                  ↓
+                        prelude = static HTML shell
+                        postponed = hole descriptions
+```
+
+Caches are warm, so cacheable components resolve within a microtask. The
+Flight renderer produces an RSC stream. That stream is fed into React DOM's
+`prerender()`, which converts it to HTML + postponed state.
+
+### Step 3: Build time — Package the output
+
+```
+prelude HTML  ──→  Saved as static file (e.g., /page.html)
+postponed     ──→  Serialized to metadata
+RSC chunks    ──→  Inlined as <script> tags in the HTML
+                   (self.__next_f.push([1, "..."]))
+```
+
+The RSC payload is embedded in the HTML as `<script>` tags, so the client
+can hydrate without a separate data fetch.
+
+### Step 4: Request time — Serve the shell
+
+```
+Browser requests /page
+    ↓
+CDN/server serves the cached static HTML instantly
+    ↓
+Browser renders: Header, Nav, Fallbacks, Footer
+    ↓
+User sees the page structure immediately (fast LCP)
+```
+
+### Step 5: Request time — Resume the dynamic holes
+
+```
+Server renders the app again with real user data
+    ↓
+resumeToPipeableStream(<App />, postponed)
+    ↓
+Produces: hidden <div>s with resolved content
+        + $RC scripts to swap fallbacks
+    ↓
+Streamed to the browser alongside the static shell
+    ↓
+Browser swaps fallbacks → real content
+```
+
+### The complete picture
+
+```
+BUILD TIME:
+                                    ┌──────────────┐
+  App tree ──→ Flight render ──→   │ RSC stream   │
+                                    └──────┬───────┘
+                                           │
+                                    ┌──────▼───────┐
+                                    │ Fizz prerender│
+                                    └──────┬───────┘
+                                           │
+                              ┌────────────┼────────────┐
+                              ▼            ▼            ▼
+                        ┌──────────┐ ┌──────────┐ ┌──────────┐
+                        │ Static   │ │Postponed │ │ RSC data │
+                        │ HTML     │ │ state    │ │ (scripts)│
+                        └──────────┘ └──────────┘ └──────────┘
+                              │            │            │
+                              └────────────┼────────────┘
+                                           ▼
+                                    ┌──────────────┐
+                                    │  page.html   │
+                                    │  (cached)    │
+                                    └──────────────┘
+
+REQUEST TIME:
+
+  Browser ──→ CDN serves page.html (instant)
+                    │
+                    │   Meanwhile:
+                    │
+  Server ──→ resumeToPipeableStream() ──→ dynamic content stream
+                                                │
+                                                ▼
+                                          Browser swaps
+                                          fallbacks → content
+```
+
+---
+
+## Chapter 7: The Unclosing Stream Trick
+
+There's a subtle but critical detail in how the RSC stream feeds into the
+HTML renderer.
+
+During the final prerender, the RSC stream is collected into memory (an array
+of byte chunks). When it's time to feed those bytes into `prerender()` for
+HTML generation, they're replayed as an **unclosing stream**:
+
+```js
+// Normal stream: delivers all chunks, then CLOSES
+new ReadableStream({
+  pull(controller) {
+    if (i < chunks.length) controller.enqueue(chunks[i++]);
+    else controller.close();  // ← stream ends
+  }
+});
+
+// Unclosing stream: delivers all chunks, then HANGS
+new ReadableStream({
+  pull(controller) {
+    if (i < chunks.length) controller.enqueue(chunks[i++]);
+    // ← no close() call — stream stays "open" forever
+  }
+});
+```
+
+**Why?** Because the RSC stream may contain references to components that are
+still pending (dynamic holes). If the stream closed, React would error on those
+unresolved references — "stream ended but chunk X was never received." By
+keeping the stream open, React treats those references as "still loading" and
+shows their Suspense fallbacks in the HTML output.
+
+This is the mechanism that makes PPR possible at the React API level: the RSC
+stream delivers the static data, keeps hanging references alive, and the HTML
+renderer produces a prelude with fallbacks for the hanging parts.
+
+---
+
+## Chapter 8: What the Browser Sees
+
+Let's trace what a user's browser receives for a PPR page:
+
+### Initial HTML (from cache, instant):
+
+```html
+<!DOCTYPE html>
+<html>
+<head>...</head>
+<body>
+  <div>
+    <h1>My App</h1>
+    <nav>Home | About | Contact</nav>
+    <!--$?--><template id="B:0"></template>
+    <p>👤 Loading user...</p>
+    <!--/$-->
+    <footer>© 2024 MyApp</footer>
+  </div>
+
+  <!-- RSC data for hydration: -->
+  <script>(self.__next_f=self.__next_f||[]).push([0])</script>
+  <script>self.__next_f.push([1,"0:..."])</script>
+  <script>self.__next_f.push([1,"1:..."])</script>
+</body>
+</html>
+```
+
+The browser renders immediately:
+- Header ✓
+- Navigation ✓
+- "👤 Loading user..." (fallback) ✓
+- Footer ✓
+
+### Resume stream (arrives slightly later):
+
+```html
+<div hidden id="S:0">
+  <p>Hello, Abanoub!</p>
+</div>
+<script>$RC("B:0","S:0")</script>
+```
+
+The `$RC` script:
+1. Finds `<template id="B:0">` in the DOM
+2. Finds `<div hidden id="S:0">`
+3. Removes the fallback ("👤 Loading user...")
+4. Inserts the real content ("Hello, Abanoub!")
+5. Changes `<!--$?-->` to `<!--$-->` (marks boundary as resolved)
+
+The user sees the transition: Loading → Hello, Abanoub!
+
+### The `self.__next_f` scripts
+
+These embed the RSC (Flight) data inline in the HTML. Each push is a chunk
+of the Flight protocol:
+
+```html
+<!-- Initialize the buffer -->
+<script>(self.__next_f=self.__next_f||[]).push([0])</script>
+
+<!-- Flight data chunks (the serialized component tree) -->
+<script>self.__next_f.push([1,"0:{\"key\":\"value\"}\n"])</script>
+<script>self.__next_f.push([1,"1:[\"$\",\"div\",null,{...}]\n"])</script>
+```
+
+The client-side React code reads these chunks, reconstructs the component
+tree, and hydrates the HTML — attaching event handlers and making it
+interactive.
+
+---
+
+## Chapter 9: Summary — The Three Outputs
+
+A PPR prerender produces three things:
+
+| Output | What it is | When it's used |
+|--------|-----------|----------------|
+| **Prelude HTML** | Complete HTML document with fallbacks for dynamic holes | Served instantly from cache |
+| **Postponed state** | Opaque object describing which boundaries need to be filled | Passed to `resumeToPipeableStream()` at request time |
+| **RSC data** | Serialized component tree (Flight protocol) embedded as `<script>` tags | Used by the client for hydration |
+
+The **prelude** is what the user sees immediately.
+The **postponed state** is what the server needs to fill in the gaps.
+The **RSC data** is what React needs to make the page interactive.
+
+---
+
+*All examples verified on React 19.2.8, Node.js, macOS.*
+*Source experiments: 13, 14, 15 in the settle-criterion directory.*

--- a/internal/analysis/ppr-settle-by-example.md
+++ b/internal/analysis/ppr-settle-by-example.md
@@ -1,0 +1,344 @@
+# PPR Settle Criterion — By Example
+
+**What you'll get from each component pattern when React aborts the prerender.**
+
+Every example was tested on React 19.2.8 with `react-dom/static`'s `prerender()` API.
+The `signal` on the `AbortController` is what stops the render — everything still
+pending at that moment becomes a "hole" showing its Suspense fallback.
+
+---
+
+## Rule #1: The abort timing decides which fallback the user sees
+
+```jsx
+<Suspense fallback={<Spinner />}>      ← "coarse" fallback
+  <ProductLayout>                       ← async, loads in 20ms
+    <Sidebar />                         ← sync
+    <Suspense fallback={<Skeleton />}>  ← "fine" fallback
+      <UserReviews />                   ← dynamic (never resolves)
+    </Suspense>
+  </ProductLayout>
+</Suspense>
+```
+
+**If you abort before `ProductLayout` finishes (before 20ms):**
+
+```html
+<Spinner />       ← the coarse fallback — the user sees a blank spinner
+```
+
+The whole middle of the page is gone. `Sidebar` is gone. The fine `<Skeleton />`
+is gone. React never got past `ProductLayout`, so it never discovered the inner
+Suspense boundary at all.
+
+**If you abort after `ProductLayout` finishes (after 20ms):**
+
+```html
+<ProductLayout>
+  <Sidebar />     ← ✓ fully rendered
+  <Skeleton />    ← the FINE fallback — much better!
+</ProductLayout>
+```
+
+Now the user sees the layout, the sidebar, and a small skeleton where reviews
+will stream in. This is what PPR is supposed to deliver.
+
+**The lesson**: aborting too early doesn't produce an error — it produces a
+*valid but worse* page. The output is correct HTML, just shallower than it could be.
+This is the most dangerous failure mode because it's silent.
+
+---
+
+## Rule #2: Only async work the framework TRACKS keeps it waiting
+
+There are two kinds of abort strategies:
+
+1. **Tracked abort (CacheSignal)**: the framework knows about each async
+   operation and waits for all of them before aborting
+2. **Task-schedule abort**: abort after a fixed number of event-loop turns,
+   regardless of what's still pending
+
+### What gets tracked? What doesn't?
+
+| Code pattern | Tracked? | Will it make it into the shell? |
+|---|---|---|
+| `await Promise.resolve()` | doesn't matter | ✓ Yes — resolves within a microtask, fast enough for any abort |
+| `await setTimeout(0)` | doesn't matter | ✓ Yes — resolves within one macrotask |
+| `await fetch(url)` through framework | ✓ tracked | ✓ Yes |
+| `await fetch(url)` raw (your own) | ✗ untracked | ❌ **No** — invisible to the framework |
+| `await db.query(...)` | ✗ untracked | ❌ **No** |
+| `await readFile(...)` | ✗ untracked | ❌ **No** |
+| `await crossProcessCacheRead()` | ✗ untracked | ❌ **No** — even if it's "fast" (5ms+) |
+
+### Proof: the speed cutoff
+
+We tested a single async component at different speeds, with a task-schedule
+abort (the strategy used for the final render pass):
+
+| Async work | Time | Result |
+|---|---|---|
+| `await Promise.resolve()` | ~0ms (microtask) | ✓ Rendered |
+| `await setTimeout(0)` | ~1ms (one macrotask) | ✓ Rendered |
+| `await setTimeout(5)` | ~5ms | ❌ **Premature abort** |
+| `await setTimeout(20)` | ~20ms | ❌ **Premature abort** |
+| `await setTimeout(100)` | ~100ms | ❌ **Premature abort** |
+
+**The cutoff is around 1-2ms.** Anything slower than a single macrotask turn
+gets missed by a task-schedule abort. Any real I/O (database queries, network
+calls, file reads, cross-process communication) takes longer than that.
+
+---
+
+## Rule #3: An untracked component loses EVERYTHING below it
+
+This is the most important rule. When an untracked async component is still
+pending at abort time, React hasn't descended into it. So any Suspense boundaries,
+children, or static content *below* it in the tree are completely lost.
+
+```jsx
+<Suspense fallback={<p>Loading all...</p>}>      ← boundary A
+  <TrackedLayout>                                  ← tracked, 20ms → renders ✓
+    <TrackedSidebar>                               ← tracked, 20ms → renders ✓
+      <UntrackedContent>                           ← UNTRACKED, 20ms
+        <Suspense fallback={<p>Dynamic hole</p>}>  ← boundary B (never reached!)
+          <HangingComponent />
+        </Suspense>
+      </UntrackedContent>
+    </TrackedSidebar>
+  </TrackedLayout>
+</Suspense>
+```
+
+**What you'd expect**: Layout and Sidebar render. Content is pending. Boundary B
+shows "Dynamic hole".
+
+**What actually happens**: Layout and Sidebar render inside a hidden div.
+`UntrackedContent` is still pending when the CacheSignal settles (because the
+CacheSignal doesn't know about it). Since `UntrackedContent` is between
+boundary A and boundary B, it suspends at boundary A. The user sees:
+
+```html
+<p>Loading all...</p>     ← the OUTERMOST fallback!
+```
+
+Layout and Sidebar are in a hidden `<div>` (React's streaming buffer), but
+they're invisible. Boundary B's "Dynamic hole" fallback never appears because
+React never reached it.
+
+**The fix**: either track `UntrackedContent` with beginRead/endRead, or put a
+Suspense boundary *directly above* it:
+
+```jsx
+<Suspense fallback={<p>Loading layout...</p>}>
+  <TrackedLayout>
+    <TrackedSidebar>
+      <Suspense fallback={<p>Loading content...</p>}>   ← NEW boundary
+        <UntrackedContent>
+          <Suspense fallback={<p>Dynamic hole</p>}>
+            <HangingComponent />
+          </Suspense>
+        </UntrackedContent>
+      </Suspense>
+    </TrackedSidebar>
+  </TrackedLayout>
+</Suspense>
+```
+
+Now if `UntrackedContent` is still pending, it suspends at the NEW boundary.
+The user sees Layout + Sidebar + "Loading content..." instead of just
+"Loading all...".
+
+---
+
+## Rule #4: The mixed-tracking trap
+
+When tracked and untracked components are mixed in the same tree, the CacheSignal
+correctly waits for tracked components but then settles immediately — even if
+an untracked child was *just* discovered by the tracked component's resolution.
+
+```jsx
+<Suspense fallback={<p>Loading...</p>}>
+  <TrackedLayout>              ← tracked, 20ms
+    <Suspense fallback={<p>Content loading...</p>}>
+      <UntrackedContent>       ← untracked, 20ms
+        <Suspense fallback={<p>Details loading...</p>}>
+          <HangingComponent />
+        </Suspense>
+      </UntrackedContent>
+    </Suspense>
+  </TrackedLayout>
+</Suspense>
+```
+
+Timeline:
+```
+  0ms: TrackedLayout starts (beginRead, count=1)
+ 20ms: TrackedLayout finishes (endRead, count=0)
+       → CacheSignal schedules settle check
+       → React renders TrackedLayout's children
+       → Discovers UntrackedContent, starts its 20ms work
+ 21ms: CacheSignal's setImmediate fires
+ 22ms: CacheSignal's setTimeout fires → count still 0 → SETTLED
+       → Abort fires!
+       → UntrackedContent is still at 2ms out of 20ms → MISSED
+```
+
+**Result**: TrackedLayout renders. "Content loading..." shows for the untracked
+component. You get the middle fallback, not the deepest one.
+
+```html
+<div>
+  [Layout-tracked]
+  <p>Content loading...</p>    ← middle fallback, not "Details loading..."
+</div>
+```
+
+This is better than the outermost fallback (because we have a Suspense boundary
+between the tracked parent and the untracked child), but it's still not ideal.
+The "Details loading..." fallback would have been more specific.
+
+---
+
+## Rule #5: Fallbacks can themselves suspend — and that can empty your shell
+
+```jsx
+// ⚠️ DANGEROUS: async fallback
+<Suspense fallback={<AsyncFallback />}>     ← fallback is async (50ms)!
+  <HangingComponent />
+</Suspense>
+```
+
+**If you abort before `AsyncFallback` resolves (before 50ms):**
+
+```html
+(empty)     ← the shell is COMPLETELY EMPTY
+```
+
+React needs to show the fallback, but the fallback itself is pending. There's no
+Suspense boundary above it to catch the suspension. The prelude is empty.
+
+**If you abort after 50ms**: the async fallback renders normally.
+
+**Safe version** — wrap the async fallback in its own Suspense:
+
+```jsx
+<Suspense fallback={
+  <Suspense fallback={<p>Loading...</p>}>   ← sync fallback catches it
+    <AsyncFallback />
+  </Suspense>
+}>
+  <HangingComponent />
+</Suspense>
+```
+
+Now if `AsyncFallback` is still pending at abort time, the inner Suspense catches
+it and shows the sync "Loading..." text. The shell is never empty.
+
+**Practical rule**: keep your Suspense fallbacks synchronous. If you must use an
+async fallback, wrap it in another Suspense with a sync fallback.
+
+---
+
+## Rule #6: `Promise.resolve()` is magic — it always works
+
+If your async component's work resolves via `Promise.resolve()` (or any
+already-fulfilled promise), it will ALWAYS make it into the shell, regardless of
+abort strategy:
+
+```jsx
+async function FastComponent({ children }) {
+  const data = await Promise.resolve(cachedData);  // ← instant
+  return <div>{data}</div>;
+}
+```
+
+**Why**: React processes resolved promises via microtasks. Microtasks run before
+ANY macrotask (before `setImmediate`, before `setTimeout`). So even if you abort
+on the very next `setImmediate`, the component has already resolved.
+
+This is why the final render pass works in Next.js — warm cache reads return
+already-fulfilled promises, so they all resolve within a single rendering task.
+
+**This breaks if**: the "warm" read still crosses a process boundary. Even a
+"cached" value that requires an HTTP round-trip (Node → Rails → response) takes
+5-20ms of real wall-clock time. That's too slow.
+
+---
+
+## Rule #7: Nesting depth doesn't matter — speed does
+
+We tested 5 levels of async components, each resolving via `Promise.resolve()`:
+
+```jsx
+<L1>           ← async, Promise.resolve()
+  <L2>         ← async, Promise.resolve()
+    <L3>       ← async, Promise.resolve()
+      <L4>     ← async, Promise.resolve()
+        <L5>   ← async, Promise.resolve()
+          ...
+```
+
+**Result with setImmediate abort**: all 5 levels rendered ✓
+
+Each level resolves in a microtask. React chains them: L1 resolves → render
+children → L2 resolves → render children → ... → all done, all within the same
+macrotask.
+
+But change `Promise.resolve()` to `setTimeout(20)` and only the first level
+renders. The rest are pending at abort time.
+
+**The rule**: nesting depth doesn't matter. What matters is whether each level
+resolves within the same event-loop turn (microtask-fast) or requires real
+wall-clock time.
+
+---
+
+## Summary: When does each component pattern make it into the static shell?
+
+| Your component does... | Prospective pass (CacheSignal) | Final pass (task-schedule) |
+|---|---|---|
+| `await Promise.resolve(data)` | ✓ always works | ✓ always works |
+| `await trackedCacheRead()` (20ms) | ✓ CacheSignal waits | ✓ if cache is warm (instant) |
+| `await rawFetch(url)` (20ms) | ❌ missed (untracked) | ❌ missed (too slow) |
+| `await db.query()` (20ms) | ❌ missed (untracked) | ❌ missed (too slow) |
+| `await crossProcessRead()` (5ms) | ❌ missed (untracked) | ❌ missed (too slow) |
+| `cookies()` / `headers()` | hanging (correct) | hanging (correct) |
+
+**The takeaway**: the only async work that reliably makes it into the shell is
+work that either:
+1. Resolves instantly (already-fulfilled promise), or
+2. Is explicitly tracked by the framework (beginRead/endRead)
+
+Everything else is a gamble on timing.
+
+---
+
+## Visual Summary
+
+```
+Abort too early                  Abort at right time
+─────────────────                ─────────────────
+
+┌──────────────┐                 ┌──────────────┐
+│   Header ✓   │                 │   Header ✓   │
+├──────────────┤                 ├──────────────┤
+│              │                 │  Layout ✓    │
+│  Loading...  │  ← coarse       │ ┌──────────┐ │
+│  (spinner)   │    fallback     │ │Sidebar ✓ │ │
+│              │                 │ ├──────────┤ │
+├──────────────┤                 │ │Loading...│ │ ← fine
+│   Footer ✓   │                 │ │(skeleton)│ │   fallback
+└──────────────┘                 │ └──────────┘ │
+                                 ├──────────────┤
+                                 │   Footer ✓   │
+                                 └──────────────┘
+
+User sees less.                  User sees more.
+LCP is worse.                    LCP is better.
+More work at request time.       Less work at request time.
+```
+
+---
+
+*All findings verified empirically on React 19.2.8, Node.js, macOS.*
+*Source experiments: experiments 9-12 in the settle-criterion directory.*

--- a/internal/analysis/ppr-settle-by-example.md
+++ b/internal/analysis/ppr-settle-by-example.md
@@ -13,15 +13,15 @@ pending at that moment becomes a "hole" showing its Suspense fallback.
 ```jsx
 <Suspense fallback={<Spinner />}>
   {' '}
-  ← "coarse" fallback
+  {/* "coarse" fallback */}
   <ProductLayout>
     {' '}
-    ← async, loads in 20ms
-    <Sidebar /> ← sync
+    {/* async, loads in 20ms */}
+    <Sidebar /> {/* sync */}
     <Suspense fallback={<Skeleton />}>
       {' '}
-      ← "fine" fallback
-      <UserReviews /> ← dynamic (never resolves)
+      {/* "fine" fallback */}
+      <UserReviews /> {/* dynamic (never resolves) */}
     </Suspense>
   </ProductLayout>
 </Suspense>
@@ -30,7 +30,8 @@ pending at that moment becomes a "hole" showing its Suspense fallback.
 **If you abort before `ProductLayout` finishes (before 20ms):**
 
 ```html
-<Spinner /> ← the coarse fallback — the user sees a blank spinner
+<!-- the coarse fallback — the user sees a blank spinner -->
+<Spinner />
 ```
 
 The whole middle of the page is gone. `Sidebar` is gone. The fine `<Skeleton />`
@@ -41,7 +42,10 @@ Suspense boundary at all.
 
 ```html
 <ProductLayout>
-  <Sidebar /> ← ✓ fully rendered <Skeleton /> ← the FINE fallback — much better!
+  <Sidebar />
+  <!-- ✓ fully rendered -->
+  <Skeleton />
+  <!-- the FINE fallback — much better! -->
 </ProductLayout>
 ```
 
@@ -103,19 +107,19 @@ children, or static content _below_ it in the tree are completely lost.
 ```jsx
 <Suspense fallback={<p>Loading all...</p>}>
   {' '}
-  ← boundary A
+  {/* boundary A */}
   <TrackedLayout>
     {' '}
-    ← tracked, 20ms → renders ✓
+    {/* tracked, 20ms → renders ✓ */}
     <TrackedSidebar>
       {' '}
-      ← tracked, 20ms → renders ✓
+      {/* tracked, 20ms → renders ✓ */}
       <UntrackedContent>
         {' '}
-        ← UNTRACKED, 20ms
+        {/* UNTRACKED, 20ms */}
         <Suspense fallback={<p>Dynamic hole</p>}>
           {' '}
-          ← boundary B (never reached!)
+          {/* boundary B (never reached!) */}
           <HangingComponent />
         </Suspense>
       </UntrackedContent>
@@ -133,8 +137,8 @@ CacheSignal doesn't know about it). Since `UntrackedContent` is between
 boundary A and boundary B, it suspends at boundary A. The user sees:
 
 ```html
+<!-- the OUTERMOST fallback! -->
 <p>Loading all...</p>
-← the OUTERMOST fallback!
 ```
 
 Layout and Sidebar are in a hidden `<div>` (React's streaming buffer), but
@@ -150,7 +154,7 @@ Suspense boundary _directly above_ it:
     <TrackedSidebar>
       <Suspense fallback={<p>Loading content...</p>}>
         {' '}
-        ← NEW boundary
+        {/* NEW boundary */}
         <UntrackedContent>
           <Suspense fallback={<p>Dynamic hole</p>}>
             <HangingComponent />
@@ -178,11 +182,11 @@ an untracked child was _just_ discovered by the tracked component's resolution.
 <Suspense fallback={<p>Loading...</p>}>
   <TrackedLayout>
     {' '}
-    ← tracked, 20ms
+    {/* tracked, 20ms */}
     <Suspense fallback={<p>Content loading...</p>}>
       <UntrackedContent>
         {' '}
-        ← untracked, 20ms
+        {/* untracked, 20ms */}
         <Suspense fallback={<p>Details loading...</p>}>
           <HangingComponent />
         </Suspense>
@@ -212,8 +216,8 @@ component. You get the middle fallback, not the deepest one.
 ```html
 <div>
   [Layout-tracked]
+  <!-- middle fallback, not "Details loading..." -->
   <p>Content loading...</p>
-  ← middle fallback, not "Details loading..."
 </div>
 ```
 
@@ -227,17 +231,18 @@ The "Details loading..." fallback would have been more specific.
 
 ```jsx
 // ⚠️ DANGEROUS: async fallback
+{
+  /* ⚠️ fallback is async (50ms)! */
+}
 <Suspense fallback={<AsyncFallback />}>
-  {' '}
-  ← fallback is async (50ms)!
   <HangingComponent />
-</Suspense>
+</Suspense>;
 ```
 
 **If you abort before `AsyncFallback` resolves (before 50ms):**
 
 ```html
-(empty) ← the shell is COMPLETELY EMPTY
+<!-- the shell is COMPLETELY EMPTY -->
 ```
 
 React needs to show the fallback, but the fallback itself is pending. There's no
@@ -252,7 +257,7 @@ Suspense boundary above it to catch the suspension. The prelude is empty.
   fallback={
     <Suspense fallback={<p>Loading...</p>}>
       {' '}
-      ← sync fallback catches it
+      {/* sync fallback catches it */}
       <AsyncFallback />
     </Suspense>
   }

--- a/internal/analysis/ppr-settle-by-example.md
+++ b/internal/analysis/ppr-settle-by-example.md
@@ -11,11 +11,17 @@ pending at that moment becomes a "hole" showing its Suspense fallback.
 ## Rule #1: The abort timing decides which fallback the user sees
 
 ```jsx
-<Suspense fallback={<Spinner />}>      ← "coarse" fallback
-  <ProductLayout>                       ← async, loads in 20ms
-    <Sidebar />                         ← sync
-    <Suspense fallback={<Skeleton />}>  ← "fine" fallback
-      <UserReviews />                   ← dynamic (never resolves)
+<Suspense fallback={<Spinner />}>
+  {' '}
+  ← "coarse" fallback
+  <ProductLayout>
+    {' '}
+    ← async, loads in 20ms
+    <Sidebar /> ← sync
+    <Suspense fallback={<Skeleton />}>
+      {' '}
+      ← "fine" fallback
+      <UserReviews /> ← dynamic (never resolves)
     </Suspense>
   </ProductLayout>
 </Suspense>
@@ -24,7 +30,7 @@ pending at that moment becomes a "hole" showing its Suspense fallback.
 **If you abort before `ProductLayout` finishes (before 20ms):**
 
 ```html
-<Spinner />       ← the coarse fallback — the user sees a blank spinner
+<Spinner /> ← the coarse fallback — the user sees a blank spinner
 ```
 
 The whole middle of the page is gone. `Sidebar` is gone. The fine `<Skeleton />`
@@ -35,8 +41,7 @@ Suspense boundary at all.
 
 ```html
 <ProductLayout>
-  <Sidebar />     ← ✓ fully rendered
-  <Skeleton />    ← the FINE fallback — much better!
+  <Sidebar /> ← ✓ fully rendered <Skeleton /> ← the FINE fallback — much better!
 </ProductLayout>
 ```
 
@@ -44,7 +49,7 @@ Now the user sees the layout, the sidebar, and a small skeleton where reviews
 will stream in. This is what PPR is supposed to deliver.
 
 **The lesson**: aborting too early doesn't produce an error — it produces a
-*valid but worse* page. The output is correct HTML, just shallower than it could be.
+_valid but worse_ page. The output is correct HTML, just shallower than it could be.
 This is the most dangerous failure mode because it's silent.
 
 ---
@@ -60,28 +65,28 @@ There are two kinds of abort strategies:
 
 ### What gets tracked? What doesn't?
 
-| Code pattern | Tracked? | Will it make it into the shell? |
-|---|---|---|
-| `await Promise.resolve()` | doesn't matter | ✓ Yes — resolves within a microtask, fast enough for any abort |
-| `await setTimeout(0)` | doesn't matter | ✓ Yes — resolves within one macrotask |
-| `await fetch(url)` through framework | ✓ tracked | ✓ Yes |
-| `await fetch(url)` raw (your own) | ✗ untracked | ❌ **No** — invisible to the framework |
-| `await db.query(...)` | ✗ untracked | ❌ **No** |
-| `await readFile(...)` | ✗ untracked | ❌ **No** |
-| `await crossProcessCacheRead()` | ✗ untracked | ❌ **No** — even if it's "fast" (5ms+) |
+| Code pattern                         | Tracked?       | Will it make it into the shell?                                |
+| ------------------------------------ | -------------- | -------------------------------------------------------------- |
+| `await Promise.resolve()`            | doesn't matter | ✓ Yes — resolves within a microtask, fast enough for any abort |
+| `await setTimeout(0)`                | doesn't matter | ✓ Yes — resolves within one macrotask                          |
+| `await fetch(url)` through framework | ✓ tracked      | ✓ Yes                                                          |
+| `await fetch(url)` raw (your own)    | ✗ untracked    | ❌ **No** — invisible to the framework                         |
+| `await db.query(...)`                | ✗ untracked    | ❌ **No**                                                      |
+| `await readFile(...)`                | ✗ untracked    | ❌ **No**                                                      |
+| `await crossProcessCacheRead()`      | ✗ untracked    | ❌ **No** — even if it's "fast" (5ms+)                         |
 
 ### Proof: the speed cutoff
 
 We tested a single async component at different speeds, with a task-schedule
 abort (the strategy used for the final render pass):
 
-| Async work | Time | Result |
-|---|---|---|
-| `await Promise.resolve()` | ~0ms (microtask) | ✓ Rendered |
-| `await setTimeout(0)` | ~1ms (one macrotask) | ✓ Rendered |
-| `await setTimeout(5)` | ~5ms | ❌ **Premature abort** |
-| `await setTimeout(20)` | ~20ms | ❌ **Premature abort** |
-| `await setTimeout(100)` | ~100ms | ❌ **Premature abort** |
+| Async work                | Time                 | Result                 |
+| ------------------------- | -------------------- | ---------------------- |
+| `await Promise.resolve()` | ~0ms (microtask)     | ✓ Rendered             |
+| `await setTimeout(0)`     | ~1ms (one macrotask) | ✓ Rendered             |
+| `await setTimeout(5)`     | ~5ms                 | ❌ **Premature abort** |
+| `await setTimeout(20)`    | ~20ms                | ❌ **Premature abort** |
+| `await setTimeout(100)`   | ~100ms               | ❌ **Premature abort** |
 
 **The cutoff is around 1-2ms.** Anything slower than a single macrotask turn
 gets missed by a task-schedule abort. Any real I/O (database queries, network
@@ -93,14 +98,24 @@ calls, file reads, cross-process communication) takes longer than that.
 
 This is the most important rule. When an untracked async component is still
 pending at abort time, React hasn't descended into it. So any Suspense boundaries,
-children, or static content *below* it in the tree are completely lost.
+children, or static content _below_ it in the tree are completely lost.
 
 ```jsx
-<Suspense fallback={<p>Loading all...</p>}>      ← boundary A
-  <TrackedLayout>                                  ← tracked, 20ms → renders ✓
-    <TrackedSidebar>                               ← tracked, 20ms → renders ✓
-      <UntrackedContent>                           ← UNTRACKED, 20ms
-        <Suspense fallback={<p>Dynamic hole</p>}>  ← boundary B (never reached!)
+<Suspense fallback={<p>Loading all...</p>}>
+  {' '}
+  ← boundary A
+  <TrackedLayout>
+    {' '}
+    ← tracked, 20ms → renders ✓
+    <TrackedSidebar>
+      {' '}
+      ← tracked, 20ms → renders ✓
+      <UntrackedContent>
+        {' '}
+        ← UNTRACKED, 20ms
+        <Suspense fallback={<p>Dynamic hole</p>}>
+          {' '}
+          ← boundary B (never reached!)
           <HangingComponent />
         </Suspense>
       </UntrackedContent>
@@ -118,7 +133,8 @@ CacheSignal doesn't know about it). Since `UntrackedContent` is between
 boundary A and boundary B, it suspends at boundary A. The user sees:
 
 ```html
-<p>Loading all...</p>     ← the OUTERMOST fallback!
+<p>Loading all...</p>
+← the OUTERMOST fallback!
 ```
 
 Layout and Sidebar are in a hidden `<div>` (React's streaming buffer), but
@@ -126,13 +142,15 @@ they're invisible. Boundary B's "Dynamic hole" fallback never appears because
 React never reached it.
 
 **The fix**: either track `UntrackedContent` with beginRead/endRead, or put a
-Suspense boundary *directly above* it:
+Suspense boundary _directly above_ it:
 
 ```jsx
 <Suspense fallback={<p>Loading layout...</p>}>
   <TrackedLayout>
     <TrackedSidebar>
-      <Suspense fallback={<p>Loading content...</p>}>   ← NEW boundary
+      <Suspense fallback={<p>Loading content...</p>}>
+        {' '}
+        ← NEW boundary
         <UntrackedContent>
           <Suspense fallback={<p>Dynamic hole</p>}>
             <HangingComponent />
@@ -154,13 +172,17 @@ The user sees Layout + Sidebar + "Loading content..." instead of just
 
 When tracked and untracked components are mixed in the same tree, the CacheSignal
 correctly waits for tracked components but then settles immediately — even if
-an untracked child was *just* discovered by the tracked component's resolution.
+an untracked child was _just_ discovered by the tracked component's resolution.
 
 ```jsx
 <Suspense fallback={<p>Loading...</p>}>
-  <TrackedLayout>              ← tracked, 20ms
+  <TrackedLayout>
+    {' '}
+    ← tracked, 20ms
     <Suspense fallback={<p>Content loading...</p>}>
-      <UntrackedContent>       ← untracked, 20ms
+      <UntrackedContent>
+        {' '}
+        ← untracked, 20ms
         <Suspense fallback={<p>Details loading...</p>}>
           <HangingComponent />
         </Suspense>
@@ -171,6 +193,7 @@ an untracked child was *just* discovered by the tracked component's resolution.
 ```
 
 Timeline:
+
 ```
   0ms: TrackedLayout starts (beginRead, count=1)
  20ms: TrackedLayout finishes (endRead, count=0)
@@ -189,7 +212,8 @@ component. You get the middle fallback, not the deepest one.
 ```html
 <div>
   [Layout-tracked]
-  <p>Content loading...</p>    ← middle fallback, not "Details loading..."
+  <p>Content loading...</p>
+  ← middle fallback, not "Details loading..."
 </div>
 ```
 
@@ -203,7 +227,9 @@ The "Details loading..." fallback would have been more specific.
 
 ```jsx
 // ⚠️ DANGEROUS: async fallback
-<Suspense fallback={<AsyncFallback />}>     ← fallback is async (50ms)!
+<Suspense fallback={<AsyncFallback />}>
+  {' '}
+  ← fallback is async (50ms)!
   <HangingComponent />
 </Suspense>
 ```
@@ -211,7 +237,7 @@ The "Details loading..." fallback would have been more specific.
 **If you abort before `AsyncFallback` resolves (before 50ms):**
 
 ```html
-(empty)     ← the shell is COMPLETELY EMPTY
+(empty) ← the shell is COMPLETELY EMPTY
 ```
 
 React needs to show the fallback, but the fallback itself is pending. There's no
@@ -222,11 +248,15 @@ Suspense boundary above it to catch the suspension. The prelude is empty.
 **Safe version** — wrap the async fallback in its own Suspense:
 
 ```jsx
-<Suspense fallback={
-  <Suspense fallback={<p>Loading...</p>}>   ← sync fallback catches it
-    <AsyncFallback />
-  </Suspense>
-}>
+<Suspense
+  fallback={
+    <Suspense fallback={<p>Loading...</p>}>
+      {' '}
+      ← sync fallback catches it
+      <AsyncFallback />
+    </Suspense>
+  }
+>
   <HangingComponent />
 </Suspense>
 ```
@@ -247,7 +277,7 @@ abort strategy:
 
 ```jsx
 async function FastComponent({ children }) {
-  const data = await Promise.resolve(cachedData);  // ← instant
+  const data = await Promise.resolve(cachedData); // ← instant
   return <div>{data}</div>;
 }
 ```
@@ -295,17 +325,18 @@ wall-clock time.
 
 ## Summary: When does each component pattern make it into the static shell?
 
-| Your component does... | Prospective pass (CacheSignal) | Final pass (task-schedule) |
-|---|---|---|
-| `await Promise.resolve(data)` | ✓ always works | ✓ always works |
-| `await trackedCacheRead()` (20ms) | ✓ CacheSignal waits | ✓ if cache is warm (instant) |
-| `await rawFetch(url)` (20ms) | ❌ missed (untracked) | ❌ missed (too slow) |
-| `await db.query()` (20ms) | ❌ missed (untracked) | ❌ missed (too slow) |
-| `await crossProcessRead()` (5ms) | ❌ missed (untracked) | ❌ missed (too slow) |
-| `cookies()` / `headers()` | hanging (correct) | hanging (correct) |
+| Your component does...            | Prospective pass (CacheSignal) | Final pass (task-schedule)   |
+| --------------------------------- | ------------------------------ | ---------------------------- |
+| `await Promise.resolve(data)`     | ✓ always works                 | ✓ always works               |
+| `await trackedCacheRead()` (20ms) | ✓ CacheSignal waits            | ✓ if cache is warm (instant) |
+| `await rawFetch(url)` (20ms)      | ❌ missed (untracked)          | ❌ missed (too slow)         |
+| `await db.query()` (20ms)         | ❌ missed (untracked)          | ❌ missed (too slow)         |
+| `await crossProcessRead()` (5ms)  | ❌ missed (untracked)          | ❌ missed (too slow)         |
+| `cookies()` / `headers()`         | hanging (correct)              | hanging (correct)            |
 
 **The takeaway**: the only async work that reliably makes it into the shell is
 work that either:
+
 1. Resolves instantly (already-fulfilled promise), or
 2. Is explicitly tracked by the framework (beginRead/endRead)
 
@@ -340,5 +371,5 @@ More work at request time.       Less work at request time.
 
 ---
 
-*All findings verified empirically on React 19.2.8, Node.js, macOS.*
-*Source experiments: experiments 9-12 in the settle-criterion directory.*
+_All findings verified empirically on React 19.2.8, Node.js, macOS._
+_Source experiments: experiments 9-12 in the settle-criterion directory._

--- a/internal/analysis/ppr-settle-criterion-findings.md
+++ b/internal/analysis/ppr-settle-criterion-findings.md
@@ -9,7 +9,7 @@
 ### The Problem in One Sentence
 
 When you prerender a page with Partial Prerendering (PPR), React needs to render
-as much of the static shell as possible, then *stop* and leave "holes" for
+as much of the static shell as possible, then _stop_ and leave "holes" for
 dynamic content. The question is: **when exactly should it stop?**
 
 ### Why Getting It Wrong Is Bad
@@ -41,19 +41,19 @@ page layout like this:
 └────────────────────────────────┘
 ```
 
-If you abort *before* the Layout component finishes loading, the entire middle
+If you abort _before_ the Layout component finishes loading, the entire middle
 section shows a spinner ("Loading..."). The user sees Header + spinner + Footer.
 
-If you abort *after* Layout finishes but before Content and Comments resolve,
+If you abort _after_ Layout finishes but before Content and Comments resolve,
 the user sees Header + Layout + Sidebar + "Content loading..." + Footer.
 
-If you wait for *everything* to resolve (Layout → Content → Comments) and then
+If you wait for _everything_ to resolve (Layout → Content → Comments) and then
 abort, the user sees the complete page with only the tiny Replies section as a
 dynamic hole. This is vastly better for LCP/TTFB — the user sees the whole page
 structure instantly.
 
 **Abort too late** → You never abort at all. Dynamic content (like user-specific
-replies) is backed by promises that *never resolve* during prerender. If the
+replies) is backed by promises that _never resolve_ during prerender. If the
 abort criterion waits for "no pending work" without understanding that some
 promises are deliberately hanging, you get a deadlock. The prerender hangs
 forever.
@@ -62,21 +62,22 @@ forever.
 
 Next.js solves this with a two-pass prerender:
 
-**Pass 1: "Fill the caches"** (called the *prospective* prerender)
+**Pass 1: "Fill the caches"** (called the _prospective_ prerender)
 
 Think of it like a dry run. Next.js renders your entire component tree, letting
 every `"use cache"` function, `fetch()` call, and async component run to
 completion. The goal is purely to fill caches — the HTML output is thrown away.
 
 The key mechanism is a **counter** called `CacheSignal`:
+
 - Every time a cache read starts → counter goes up
 - Every time a cache read finishes → counter goes down
-- When the counter hits zero and *stays at zero* for a brief window → all caches
+- When the counter hits zero and _stays at zero_ for a brief window → all caches
   are filled
 
-Only *after* all caches are filled does Next.js abort this pass.
+Only _after_ all caches are filled does Next.js abort this pass.
 
-**Pass 2: "Render with warm caches"** (called the *final* prerender)
+**Pass 2: "Render with warm caches"** (called the _final_ prerender)
 
 Now Next.js renders again, but this time all the cache data is already available.
 Async components that read from cache resolve instantly (within a microtask).
@@ -100,20 +101,24 @@ Here's a page with three levels of async components:
 export default async function Page() {
   return (
     <div>
-      <Header />                  {/* sync — always in shell */}
+      <Header /> {/* sync — always in shell */}
       <Suspense fallback={<Spinner />}>
-        <ProductLayout>           {/* async — loads categories from cache */}
-          <Sidebar />             {/* sync child */}
+        <ProductLayout>
+          {' '}
+          {/* async — loads categories from cache */}
+          <Sidebar /> {/* sync child */}
           <Suspense fallback={<ContentSkeleton />}>
-            <ProductList>         {/* async — loads products from cache */}
+            <ProductList>
+              {' '}
+              {/* async — loads products from cache */}
               <Suspense fallback={<ReviewsSkeleton />}>
-                <UserReviews />   {/* dynamic — needs user session */}
+                <UserReviews /> {/* dynamic — needs user session */}
               </Suspense>
             </ProductList>
           </Suspense>
         </ProductLayout>
       </Suspense>
-      <Footer />                  {/* sync — always in shell */}
+      <Footer /> {/* sync — always in shell */}
     </div>
   );
 }
@@ -139,12 +144,12 @@ and a skeleton where reviews will stream in.
 The critical difference between the two passes is **whether async work is
 tracked**:
 
-| | Pass 1 (Prospective) | Pass 2 (Final) |
-|---|---|---|
-| **Cache tracking** | Yes — CacheSignal | None — caches are warm |
-| **Abort trigger** | CacheSignal settles | Fixed task schedule |
-| **Dynamic APIs** | Keep rendering past them | Abort on encounter |
-| **Purpose** | Fill caches | Produce output |
+|                    | Pass 1 (Prospective)     | Pass 2 (Final)         |
+| ------------------ | ------------------------ | ---------------------- |
+| **Cache tracking** | Yes — CacheSignal        | None — caches are warm |
+| **Abort trigger**  | CacheSignal settles      | Fixed task schedule    |
+| **Dynamic APIs**   | Keep rendering past them | Abort on encounter     |
+| **Purpose**        | Fill caches              | Produce output         |
 
 This means: **if your async component does I/O that doesn't go through a tracked
 channel (cache, fetch, module load), the framework cannot see it, and a bare
@@ -163,6 +168,7 @@ When count drops to 0:
 ```
 
 **Why two levels?** React schedules new rendering work in different ways:
+
 - During prerender, React uses **microtasks** to schedule follow-up work
 - During normal rendering, React uses **setImmediate**
 
@@ -181,6 +187,7 @@ We ran 8 experiments on React 19.2.8 to verify this:
 
 **Experiment 1 — Fallback Reachability**: An outer async component (50ms) wraps
 an inner Suspense boundary backed by a hanging promise.
+
 - Abort at 0ms → shows "Loading outer..." (outer's coarser fallback — **bad**)
 - Abort at 100ms → shows "Loading inner..." (inner's own fallback — **good**)
 - The difference is whether the framework waited for the outer component to
@@ -188,6 +195,7 @@ an inner Suspense boundary backed by a hanging promise.
 
 **Experiment 3 — Complex Nested Tree**: Header/Layout/Sidebar/Content/Comments/
 Replies with 4 Suspense boundaries at different depths.
+
 - Abort at 5ms → only "Main loading..." (everything behind outer spinner)
 - Abort at 30ms → Layout+Sidebar visible, "Content loading..." shown
 - Abort at 80ms → Content visible, "Comments loading..." shown
@@ -207,6 +215,7 @@ L3.beginRead → L3.endRead → [setImmediate+setTimeout → SETTLED]
 Result: all three levels rendered, deep fallback shown. ✓
 
 **Experiment 8 — Untracked I/O** (the critical finding):
+
 - **Without tracking**: bare `setImmediate` abort → premature abort, shows outer
   fallback. The cross-process reads (20ms each) were invisible to the framework.
 - **With CacheSignal tracking**: waits for both reads, shows deep fallback. ✓
@@ -230,6 +239,7 @@ Server Components tree.
 
 **Settle criterion**: `CacheSignal.cacheReady()` — a reference-counting signal
 that tracks every `beginRead()`/`endRead()` pair across:
+
 - `"use cache"` function calls
 - `fetch()` calls (the patched version)
 - `unstable_cache` calls
@@ -349,6 +359,7 @@ queue drains).
 **Standard tier: `cacheReady()`** — `setImmediate(() => setTimeout(0))`
 
 Used for the main prerender abort decision. Fires after two event-loop turns:
+
 1. `setImmediate` runs after I/O callbacks but before timers
 2. `setTimeout(0)` runs in the next timer phase
 
@@ -412,6 +423,7 @@ if (prerenderStore.type === 'prerender') {
 ```
 
 `makeRuntimeHangingPromise` returns:
+
 ```javascript
 new Promise((_, reject) => {
   signal.addEventListener('abort', () => reject(error), { once: true });
@@ -429,18 +441,18 @@ rejects, and React knows to finalize that boundary as a "postponed" placeholder.
 The system distinguishes between "work that will finish" and "work that should
 never finish during prerender" through what gets tracked:
 
-| Type | Tracked by CacheSignal? | Resolves during prerender? |
-|---|---|---|
-| `fetch('/api/data')` with cache | ✓ Yes (beginRead/endRead) | Yes |
-| `"use cache"` function | ✓ Yes | Yes |
-| `import('./Component')` | ✓ Yes (module loading) | Yes |
-| `cookies()` | ✗ No | No (hanging promise) |
-| `headers()` | ✗ No | No (hanging promise) |
-| `searchParams` | ✗ No | No (hanging promise) |
-| `connection()` | ✗ No | No (hanging promise) |
+| Type                            | Tracked by CacheSignal?   | Resolves during prerender? |
+| ------------------------------- | ------------------------- | -------------------------- |
+| `fetch('/api/data')` with cache | ✓ Yes (beginRead/endRead) | Yes                        |
+| `"use cache"` function          | ✓ Yes                     | Yes                        |
+| `import('./Component')`         | ✓ Yes (module loading)    | Yes                        |
+| `cookies()`                     | ✗ No                      | No (hanging promise)       |
+| `headers()`                     | ✗ No                      | No (hanging promise)       |
+| `searchParams`                  | ✗ No                      | No (hanging promise)       |
+| `connection()`                  | ✗ No                      | No (hanging promise)       |
 
 The CacheSignal only counts tracked work. Hanging promises are invisible to it.
-So when CacheSignal says "settled," it means "all the work that *can* resolve has
+So when CacheSignal says "settled," it means "all the work that _can_ resolve has
 resolved." The hanging promises are still hanging, but that's correct — they're
 the dynamic holes.
 
@@ -458,11 +470,13 @@ framework-controlled channels (`fetch`, `"use cache"`, `import()`). The framewor
 intercepts each one and brackets it with `beginRead()`/`endRead()`.
 
 For react_on_rails, the tracked operations should be:
+
 1. **Resume Data Cache reads** — equivalent to Next.js's `"use cache"` reads
 2. **Module/chunk loads** — same as Next.js
 3. **Any other framework-controlled async** — e.g., our own data-fetching helpers
 
 The deliberately-hanging operations should be:
+
 1. **Dynamic boundary markers** — our equivalent of cookies/headers access
 2. **Any per-request data access** that signals "this is not cacheable"
 
@@ -476,6 +490,7 @@ HTTP), even "warm" reads take real wall-clock time. A single-task abort would fi
 before those reads complete.
 
 **Solution options**:
+
 1. **Keep the RDC in-process** (JavaScript-side cache): The final pass's
    single-task abort works correctly, matching Next.js's behavior.
 2. **Track RDC reads in the final pass too**: Use a CacheSignal even in the
@@ -523,11 +538,13 @@ produce slightly different shells on different builds if component resolution
 times vary.
 
 Next.js handles this implicitly because:
+
 - Cached values resolve synchronously (microtask-fast) on the final pass
 - The task schedule is deterministic (same number of macrotasks)
 - The only variance is in the prospective pass, whose output is discarded
 
 For react_on_rails, determinism requires:
+
 1. The RDC must be in-process (so final-pass reads are synchronous)
 2. The settle criterion must be event-driven (CacheSignal), not time-based
 3. Builds should be validated with a diff check: prerender twice, compare shells
@@ -536,11 +553,11 @@ For react_on_rails, determinism requires:
 
 ## Part 6: Summary Table
 
-| Abort Point | Next.js Criterion | Mechanism | Window |
-|---|---|---|---|
+| Abort Point     | Next.js Criterion          | Mechanism                          | Window                         |
+| --------------- | -------------------------- | ---------------------------------- | ------------------------------ |
 | RSC Prospective | `CacheSignal.cacheReady()` | Reference counter + deferred check | Until all tracked work settles |
-| RSC Final | `runInSequentialTasks` | Task-schedule (4 macrotasks) | ~4 event-loop turns |
-| HTML/Fizz | `runInSequentialTasks` | Task-schedule (2 macrotasks) | ~2 event-loop turns |
+| RSC Final       | `runInSequentialTasks`     | Task-schedule (4 macrotasks)       | ~4 event-loop turns            |
+| HTML/Fizz       | `runInSequentialTasks`     | Task-schedule (2 macrotasks)       | ~2 event-loop turns            |
 
 The prospective pass is the only one with an open-ended wait. The final pass and
 HTML pass use fixed schedules because their inputs are already resolved.
@@ -549,16 +566,16 @@ HTML pass use fixed schedules because their inputs are already resolved.
 
 ## Appendix A: Experiment Results Summary
 
-| # | Experiment | Key Finding |
-|---|---|---|
-| 1 | Fallback reachability | Abort timing determines WHICH Suspense fallback appears — inner (narrow) or outer (coarse) |
-| 2 | Deep nested async | 3 levels of async (30ms each): setImmediate abort misses all; 150ms gets all |
-| 3 | Complex tree | Progressive reveal: each resolved level exposes one more Suspense boundary |
-| 4 | CacheSignal simulation | CacheSignal correctly chains through L1→L2→L3, settling only after L3 |
-| 5 | setImmediate vs deferred | With *already-tracked* components (manual beginRead/endRead), all strategies work because React's own scheduling is microtask-fast |
-| 6 | Microtask gap | Warm-cache scenario (Promise.resolve): CacheSignal survives the gap between endRead and React's follow-up render |
-| 7 | Bare abort without tracking | When all components are microtask-fast, even bare setImmediate works (React resolves everything in one task) |
-| 8 | **Untracked I/O** | **The critical finding**: Without CacheSignal tracking, a 20ms cross-process read is invisible → premature abort → shallow shell. With tracking: correct. |
+| #   | Experiment                  | Key Finding                                                                                                                                               |
+| --- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Fallback reachability       | Abort timing determines WHICH Suspense fallback appears — inner (narrow) or outer (coarse)                                                                |
+| 2   | Deep nested async           | 3 levels of async (30ms each): setImmediate abort misses all; 150ms gets all                                                                              |
+| 3   | Complex tree                | Progressive reveal: each resolved level exposes one more Suspense boundary                                                                                |
+| 4   | CacheSignal simulation      | CacheSignal correctly chains through L1→L2→L3, settling only after L3                                                                                     |
+| 5   | setImmediate vs deferred    | With _already-tracked_ components (manual beginRead/endRead), all strategies work because React's own scheduling is microtask-fast                        |
+| 6   | Microtask gap               | Warm-cache scenario (Promise.resolve): CacheSignal survives the gap between endRead and React's follow-up render                                          |
+| 7   | Bare abort without tracking | When all components are microtask-fast, even bare setImmediate works (React resolves everything in one task)                                              |
+| 8   | **Untracked I/O**           | **The critical finding**: Without CacheSignal tracking, a 20ms cross-process read is invisible → premature abort → shallow shell. With tracking: correct. |
 
 **Experiment 8 is the proof that tracking is necessary.** A bare timing abort
 only works when all async work resolves within the first macrotask (microtask-
@@ -597,5 +614,5 @@ takes longer and is invisible without explicit tracking.
 
 ---
 
-*Experiments run on: Node.js, React 19.2.8, macOS Darwin 25.5.0*
-*Source: Next.js canary (latest as of 2026-08-08)*
+_Experiments run on: Node.js, React 19.2.8, macOS Darwin 25.5.0_
+_Source: Next.js canary (latest as of 2026-08-08)_

--- a/internal/analysis/ppr-settle-criterion-findings.md
+++ b/internal/analysis/ppr-settle-criterion-findings.md
@@ -1,0 +1,601 @@
+# How Next.js Decides When to Stop Prerendering (PPR Settle Criterion)
+
+**Research for [#4852](https://github.com/shakacode/react_on_rails/issues/4852)** — findings from Next.js source code analysis + empirical validation on React 19.2.8.
+
+---
+
+## Part 1: The Practical Picture
+
+### The Problem in One Sentence
+
+When you prerender a page with Partial Prerendering (PPR), React needs to render
+as much of the static shell as possible, then *stop* and leave "holes" for
+dynamic content. The question is: **when exactly should it stop?**
+
+### Why Getting It Wrong Is Bad
+
+There are two failure modes, and they're both silent:
+
+**Abort too early** → You get a shallower shell than you could have. Imagine a
+page layout like this:
+
+```
+┌────────────────────────────────┐
+│ Header (sync — always static)  │
+├────────────────────────────────┤
+│ Layout (async — loads in 20ms) │
+│ ┌────────────┬───────────────┐ │
+│ │ Sidebar    │ Content       │ │
+│ │ (sync)     │ (async 40ms)  │ │
+│ │            │ ┌───────────┐ │ │
+│ │            │ │ Comments  │ │ │
+│ │            │ │ (async)   │ │ │
+│ │            │ │ ┌───────┐ │ │ │
+│ │            │ │ │Replies│ │ │ │
+│ │            │ │ │(dyn.) │ │ │ │
+│ │            │ │ └───────┘ │ │ │
+│ │            │ └───────────┘ │ │
+│ └────────────┴───────────────┘ │
+├────────────────────────────────┤
+│ Footer (sync — always static)  │
+└────────────────────────────────┘
+```
+
+If you abort *before* the Layout component finishes loading, the entire middle
+section shows a spinner ("Loading..."). The user sees Header + spinner + Footer.
+
+If you abort *after* Layout finishes but before Content and Comments resolve,
+the user sees Header + Layout + Sidebar + "Content loading..." + Footer.
+
+If you wait for *everything* to resolve (Layout → Content → Comments) and then
+abort, the user sees the complete page with only the tiny Replies section as a
+dynamic hole. This is vastly better for LCP/TTFB — the user sees the whole page
+structure instantly.
+
+**Abort too late** → You never abort at all. Dynamic content (like user-specific
+replies) is backed by promises that *never resolve* during prerender. If the
+abort criterion waits for "no pending work" without understanding that some
+promises are deliberately hanging, you get a deadlock. The prerender hangs
+forever.
+
+### What Next.js Actually Does: A Two-Pass System
+
+Next.js solves this with a two-pass prerender:
+
+**Pass 1: "Fill the caches"** (called the *prospective* prerender)
+
+Think of it like a dry run. Next.js renders your entire component tree, letting
+every `"use cache"` function, `fetch()` call, and async component run to
+completion. The goal is purely to fill caches — the HTML output is thrown away.
+
+The key mechanism is a **counter** called `CacheSignal`:
+- Every time a cache read starts → counter goes up
+- Every time a cache read finishes → counter goes down
+- When the counter hits zero and *stays at zero* for a brief window → all caches
+  are filled
+
+Only *after* all caches are filled does Next.js abort this pass.
+
+**Pass 2: "Render with warm caches"** (called the *final* prerender)
+
+Now Next.js renders again, but this time all the cache data is already available.
+Async components that read from cache resolve instantly (within a microtask).
+This pass uses a strict task-based schedule:
+
+1. **Task 1**: Start the render. React runs one rendering "work unit."
+2. **Task 2**: Advance to the "Static" stage (static params become available).
+3. **Task 3**: Collect metadata.
+4. **Task 4**: **Abort.** Whatever is still pending becomes a dynamic hole.
+
+Because the caches are warm, every cacheable component resolves within the first
+task. The only things still pending at abort time are genuinely dynamic
+(hanging promises for `cookies()`, `headers()`, user-specific data).
+
+### Concrete Example
+
+Here's a page with three levels of async components:
+
+```jsx
+// app/page.tsx
+export default async function Page() {
+  return (
+    <div>
+      <Header />                  {/* sync — always in shell */}
+      <Suspense fallback={<Spinner />}>
+        <ProductLayout>           {/* async — loads categories from cache */}
+          <Sidebar />             {/* sync child */}
+          <Suspense fallback={<ContentSkeleton />}>
+            <ProductList>         {/* async — loads products from cache */}
+              <Suspense fallback={<ReviewsSkeleton />}>
+                <UserReviews />   {/* dynamic — needs user session */}
+              </Suspense>
+            </ProductList>
+          </Suspense>
+        </ProductLayout>
+      </Suspense>
+      <Footer />                  {/* sync — always in shell */}
+    </div>
+  );
+}
+```
+
+**Pass 1** renders the whole tree. `ProductLayout` fetches categories (20ms),
+`ProductList` fetches products (40ms). Both results get cached. CacheSignal
+counts: 1→2→1→0. After `setImmediate + setTimeout(0)`, count is still 0 →
+settled. Pass 1 aborts. HTML is discarded.
+
+**Pass 2** renders again. `ProductLayout` reads from cache → resolves instantly.
+React renders its children in the same microtask. `ProductList` reads from cache
+→ resolves instantly. React descends to `UserReviews` which reads `cookies()` →
+gets a hanging promise (deliberate). React shows the `<ReviewsSkeleton />`
+fallback. After 4 tasks, abort fires. Output: the full page with only
+`<ReviewsSkeleton />` as a placeholder.
+
+Result: the user instantly sees the complete page layout, sidebar, product list,
+and a skeleton where reviews will stream in.
+
+### The Key Insight: Tracking vs Not Tracking
+
+The critical difference between the two passes is **whether async work is
+tracked**:
+
+| | Pass 1 (Prospective) | Pass 2 (Final) |
+|---|---|---|
+| **Cache tracking** | Yes — CacheSignal | None — caches are warm |
+| **Abort trigger** | CacheSignal settles | Fixed task schedule |
+| **Dynamic APIs** | Keep rendering past them | Abort on encounter |
+| **Purpose** | Fill caches | Produce output |
+
+This means: **if your async component does I/O that doesn't go through a tracked
+channel (cache, fetch, module load), the framework cannot see it, and a bare
+task-schedule abort will miss it.**
+
+### What Does "Settled" Actually Mean?
+
+The settle detection uses a two-level deferred check:
+
+```
+When count drops to 0:
+  → Schedule a setImmediate callback
+    → Inside that, schedule a setTimeout(0) callback
+      → If count is STILL 0: settled! Fire the signal.
+      → If count went back up: cancel, wait for next 0.
+```
+
+**Why two levels?** React schedules new rendering work in different ways:
+- During prerender, React uses **microtasks** to schedule follow-up work
+- During normal rendering, React uses **setImmediate**
+
+By waiting through both a `setImmediate` and a `setTimeout(0)`, the settle check
+ensures React has had a chance to process the resolved data and discover new
+components that might need their own cache reads.
+
+**In practice**: when `ProductLayout` finishes loading and React renders its
+children, React might discover that `ProductList` needs to start its own cache
+read. If the settle check fired too early (right when `ProductLayout`'s read
+finished), it would miss `ProductList` entirely.
+
+### Empirical Proof
+
+We ran 8 experiments on React 19.2.8 to verify this:
+
+**Experiment 1 — Fallback Reachability**: An outer async component (50ms) wraps
+an inner Suspense boundary backed by a hanging promise.
+- Abort at 0ms → shows "Loading outer..." (outer's coarser fallback — **bad**)
+- Abort at 100ms → shows "Loading inner..." (inner's own fallback — **good**)
+- The difference is whether the framework waited for the outer component to
+  resolve, revealing the inner boundary.
+
+**Experiment 3 — Complex Nested Tree**: Header/Layout/Sidebar/Content/Comments/
+Replies with 4 Suspense boundaries at different depths.
+- Abort at 5ms → only "Main loading..." (everything behind outer spinner)
+- Abort at 30ms → Layout+Sidebar visible, "Content loading..." shown
+- Abort at 80ms → Content visible, "Comments loading..." shown
+- Abort at 150ms → Everything visible, only "Replies loading..." as the hole
+
+Each level of async resolution reveals one more Suspense boundary's own fallback.
+
+**Experiment 4 — CacheSignal Simulation**: Three levels of tracked async
+components (30ms each). CacheSignal correctly waits through all three:
+
+```
+L1.beginRead → L1.endRead → [settle check cancels because:]
+L2.beginRead → L2.endRead → [settle check cancels because:]
+L3.beginRead → L3.endRead → [setImmediate+setTimeout → SETTLED]
+```
+
+Result: all three levels rendered, deep fallback shown. ✓
+
+**Experiment 8 — Untracked I/O** (the critical finding):
+- **Without tracking**: bare `setImmediate` abort → premature abort, shows outer
+  fallback. The cross-process reads (20ms each) were invisible to the framework.
+- **With CacheSignal tracking**: waits for both reads, shows deep fallback. ✓
+
+This experiment proves that **a bare timing-based abort is not sufficient when
+components do real I/O.** You need explicit tracking of in-flight work.
+
+---
+
+## Part 2: The Three Abort Points
+
+Now let's look at the three distinct abort points in a PPR prerender and what
+signal each one should use.
+
+### Abort Point 1: RSC Prospective Pass
+
+**When**: During `next build` or ISR revalidation, the first render of the React
+Server Components tree.
+
+**Purpose**: Fill all caches so the final pass can read them synchronously.
+
+**Settle criterion**: `CacheSignal.cacheReady()` — a reference-counting signal
+that tracks every `beginRead()`/`endRead()` pair across:
+- `"use cache"` function calls
+- `fetch()` calls (the patched version)
+- `unstable_cache` calls
+- Dynamic `import()` / chunk loads (via module loading subscription)
+- Server Action argument decryption
+
+**How it works in practice**:
+
+```
+Component render starts
+  → fetch('/api/products') → beginRead() [count=1]
+  → "use cache" getData() → beginRead() [count=2]
+  → fetch completes → endRead() [count=1]
+  → getData() completes → endRead() [count=0]
+  → schedule setImmediate → schedule setTimeout(0) → count still 0?
+    → YES → cacheReady() resolves
+    → Abort React render
+```
+
+If a just-completed cache read causes React to render a new component that
+starts another cache read, the cycle restarts:
+
+```
+  → endRead() [count=0]
+  → schedule setImmediate
+  → React processes result, renders child, child calls fetch()
+  → beginRead() [count=1] → cancels pending setImmediate
+  → ... eventually count=0 again → new settle check
+```
+
+**The deferred check prevents a specific race**: when `endRead()` fires, React
+hasn't yet processed the resolved promise. It will do so in a microtask (during
+prerender) or `setImmediate` (during rendering). The `setImmediate + setTimeout`
+window guarantees React's follow-up rendering has happened before the settle
+check runs.
+
+### Abort Point 2: RSC Final Pass
+
+**When**: After all caches are warm, the second render that produces the actual
+RSC Flight stream.
+
+**Purpose**: Produce the static Flight data, with dynamic holes for anything
+that can't be prerendered.
+
+**Settle criterion**: Task-schedule-based via `runInSequentialTasks`. Each
+function in the sequence runs in its own macrotask (`setTimeout(0)`). The abort
+fires in the last task, unconditionally.
+
+**Why this works**: All caches are warm from Pass 1. Cache reads resolve via
+already-fulfilled promises (microtask-fast). React processes them within a single
+rendering task. By the time the abort fires (task 4), every cacheable component
+has resolved.
+
+**What it assumes**: Warm cache reads resolve within a microtask. This is true
+when the cache is in-process (a JavaScript Map or similar). It is **NOT
+guaranteed** when cache reads cross a process boundary (e.g., an HTTP call to
+a Ruby process to read from ActiveSupport::Cache).
+
+**Relevant for react_on_rails**: If our Resume Data Cache adapter crosses a
+process boundary (Node → Ruby via HTTP/Unix socket), the final pass's
+single-task window may not be enough. The prospective pass fills the cache, but
+the final pass reads from it, and those reads might take real wall-clock time
+if they're not in-process. This is safe only if the RDC is an in-process
+JavaScript cache (which is the plan).
+
+### Abort Point 3: HTML/Fizz Prerender
+
+**When**: After the RSC Flight stream is produced, it's consumed by React DOM's
+`prerender()` to produce the HTML shell.
+
+**Purpose**: Convert the Flight data to HTML, with `postponed` state for dynamic
+holes.
+
+**Settle criterion**: Same task-schedule pattern:
+
+```
+Task 1: Start React DOM prerender (pass the Flight stream + signal)
+Task 2: Abort the React DOM render
+```
+
+Two tasks, one macrotask window. The Flight stream is already fully produced, so
+there are no pending data reads. Any postponed boundaries become `postponed`
+state that React DOM returns alongside the HTML prelude.
+
+**Why this is safe**: The Flight stream is complete. React DOM is just converting
+it to HTML. All the async resolution happened in the RSC passes. React DOM's
+prerender processes the Flight data, emits HTML for resolved subtrees, and emits
+`<template>` placeholders for postponed boundaries.
+
+---
+
+## Part 3: CacheSignal Deep Dive
+
+### The Reference Counter
+
+At its core, CacheSignal is a counter:
+
+```
+beginRead() → count++, cancel any pending settle timer
+endRead()   → count--, if count==0 schedule settle check
+```
+
+It's conceptually identical to a "pending work" semaphore. The subtle part is the
+settle check timing.
+
+### The Two-Tier Settle Check
+
+CacheSignal has two resolve speeds:
+
+**Fast tier: `inputReady()`** — `queueMicrotask(() => process.nextTick(...))`
+
+Used to abort hanging promise inputs to cached functions. When all cache reads
+have their inputs ready, there's no point keeping hanging promises alive. This
+fires quickly (microtask + nextTick ≈ same tick, just after current microtask
+queue drains).
+
+**Standard tier: `cacheReady()`** — `setImmediate(() => setTimeout(0))`
+
+Used for the main prerender abort decision. Fires after two event-loop turns:
+1. `setImmediate` runs after I/O callbacks but before timers
+2. `setTimeout(0)` runs in the next timer phase
+
+The two-level design covers both scheduling strategies React uses internally:
+React schedules prerender follow-up work via microtasks, and rendering follow-up
+work via `setImmediate`. By waiting past both, CacheSignal ensures React has
+fully processed any resolved data before declaring settlement.
+
+### Module Loading Integration
+
+Dynamic `import()` calls are also tracked. A global `moduleLoadingSignal` (itself
+a CacheSignal) tracks all chunk loads. Per-render CacheSignals subscribe to it
+via `subscribeToReads()`:
+
+```
+Global moduleLoadingSignal
+  ├── beginRead() for import('./ProductList.js')
+  ├── propagates to → Per-render cacheSignal.beginRead()
+  │
+  ├── Chunk loads, module evaluates
+  ├── endRead()
+  └── propagates to → Per-render cacheSignal.endRead()
+```
+
+This prevents aborting while modules are still loading — a loading module might
+contain a component that reads from cache.
+
+### The Cancellation Dance
+
+When a new `beginRead()` arrives while a settle timer is pending:
+
+```
+endRead()      → count=0 → schedule setImmediate (timer A)
+beginRead()    → count=1 → CANCEL timer A
+endRead()      → count=0 → schedule setImmediate (timer B)
+[no more reads]
+setImmediate B → schedule setTimeout C
+setTimeout C   → count still 0 → SETTLED
+```
+
+This is crucial: without cancellation, the first `setImmediate` would fire while
+count was 1 (because the second read started before the timer ran), and either
+incorrectly settle or require complex count-checking.
+
+---
+
+## Part 4: Hanging Promises — How Dynamic Holes Work
+
+### The Mechanism
+
+Dynamic content in Next.js doesn't use `React.postpone()` (that's the legacy
+PPR path). The modern path uses **hanging promises**: promises that never resolve.
+
+When a server component calls a dynamic API:
+
+```
+// Inside cookies() implementation
+if (prerenderStore.type === 'prerender') {
+  return makeRuntimeHangingPromise(renderSignal, error);
+}
+```
+
+`makeRuntimeHangingPromise` returns:
+```javascript
+new Promise((_, reject) => {
+  signal.addEventListener('abort', () => reject(error), { once: true });
+});
+```
+
+This promise never resolves. React sees it, suspends at the nearest Suspense
+boundary, and renders the fallback. The Suspense boundary becomes a dynamic hole.
+
+When the prerender eventually aborts (via the abort signal), the hanging promise
+rejects, and React knows to finalize that boundary as a "postponed" placeholder.
+
+### Hanging Promises vs Real Async Work
+
+The system distinguishes between "work that will finish" and "work that should
+never finish during prerender" through what gets tracked:
+
+| Type | Tracked by CacheSignal? | Resolves during prerender? |
+|---|---|---|
+| `fetch('/api/data')` with cache | ✓ Yes (beginRead/endRead) | Yes |
+| `"use cache"` function | ✓ Yes | Yes |
+| `import('./Component')` | ✓ Yes (module loading) | Yes |
+| `cookies()` | ✗ No | No (hanging promise) |
+| `headers()` | ✗ No | No (hanging promise) |
+| `searchParams` | ✗ No | No (hanging promise) |
+| `connection()` | ✗ No | No (hanging promise) |
+
+The CacheSignal only counts tracked work. Hanging promises are invisible to it.
+So when CacheSignal says "settled," it means "all the work that *can* resolve has
+resolved." The hanging promises are still hanging, but that's correct — they're
+the dynamic holes.
+
+---
+
+## Part 5: What This Means for React on Rails
+
+### The Core Design Decision
+
+React on Rails needs to answer: **which of our async operations need tracking,
+and which are deliberate hanging promises?**
+
+In Next.js, the answer is clean because all cacheable work flows through
+framework-controlled channels (`fetch`, `"use cache"`, `import()`). The framework
+intercepts each one and brackets it with `beginRead()`/`endRead()`.
+
+For react_on_rails, the tracked operations should be:
+1. **Resume Data Cache reads** — equivalent to Next.js's `"use cache"` reads
+2. **Module/chunk loads** — same as Next.js
+3. **Any other framework-controlled async** — e.g., our own data-fetching helpers
+
+The deliberately-hanging operations should be:
+1. **Dynamic boundary markers** — our equivalent of cookies/headers access
+2. **Any per-request data access** that signals "this is not cacheable"
+
+### The Cross-Process Question
+
+Next.js's final pass works with a single-task abort because warm cache reads are
+in-process (a JavaScript `Map`). The concern for react_on_rails is:
+
+If the Resume Data Cache adapter crosses a process boundary (Node → Rails via
+HTTP), even "warm" reads take real wall-clock time. A single-task abort would fire
+before those reads complete.
+
+**Solution options**:
+1. **Keep the RDC in-process** (JavaScript-side cache): The final pass's
+   single-task abort works correctly, matching Next.js's behavior.
+2. **Track RDC reads in the final pass too**: Use a CacheSignal even in the
+   final pass, turning the cross-process reads into tracked operations. The abort
+   waits for them.
+3. **Use a timeout budget**: Set a maximum wait time (e.g., 5 seconds) beyond
+   which the prerender aborts regardless, degrading gracefully to more dynamic
+   holes.
+
+Option 1 is what the plan already specifies (the RDC is a Node-side cache). The
+prospective pass fills it via cross-process reads, and the final pass reads from
+the local JavaScript cache. This is architecturally correct.
+
+### The Budget/Escape Hatch
+
+Next.js doesn't have an explicit timeout budget — it relies on the CacheSignal
+settling naturally. But pathological cases exist:
+
+- A `"use cache"` function that does an extremely slow external API call
+- Circular cache dependencies that never settle
+- A module that takes forever to load
+
+For react_on_rails, a hard timeout cap is advisable:
+
+```
+const settled = await Promise.race([
+  cacheSignal.cacheReady(),
+  timeout(5000).then(() => 'TIMEOUT')
+]);
+
+if (settled === 'TIMEOUT') {
+  log.warn('Prerender settle timeout — aborting with partial shell');
+}
+controller.abort();
+```
+
+When the timeout trips, the result is a shallower shell (more dynamic holes), not
+a build failure. This is a **degradation**, not an error — the page still works,
+it just has more content streaming in dynamically.
+
+### Determinism
+
+A timing-based settle criterion introduces non-determinism: the same page might
+produce slightly different shells on different builds if component resolution
+times vary.
+
+Next.js handles this implicitly because:
+- Cached values resolve synchronously (microtask-fast) on the final pass
+- The task schedule is deterministic (same number of macrotasks)
+- The only variance is in the prospective pass, whose output is discarded
+
+For react_on_rails, determinism requires:
+1. The RDC must be in-process (so final-pass reads are synchronous)
+2. The settle criterion must be event-driven (CacheSignal), not time-based
+3. Builds should be validated with a diff check: prerender twice, compare shells
+
+---
+
+## Part 6: Summary Table
+
+| Abort Point | Next.js Criterion | Mechanism | Window |
+|---|---|---|---|
+| RSC Prospective | `CacheSignal.cacheReady()` | Reference counter + deferred check | Until all tracked work settles |
+| RSC Final | `runInSequentialTasks` | Task-schedule (4 macrotasks) | ~4 event-loop turns |
+| HTML/Fizz | `runInSequentialTasks` | Task-schedule (2 macrotasks) | ~2 event-loop turns |
+
+The prospective pass is the only one with an open-ended wait. The final pass and
+HTML pass use fixed schedules because their inputs are already resolved.
+
+---
+
+## Appendix A: Experiment Results Summary
+
+| # | Experiment | Key Finding |
+|---|---|---|
+| 1 | Fallback reachability | Abort timing determines WHICH Suspense fallback appears — inner (narrow) or outer (coarse) |
+| 2 | Deep nested async | 3 levels of async (30ms each): setImmediate abort misses all; 150ms gets all |
+| 3 | Complex tree | Progressive reveal: each resolved level exposes one more Suspense boundary |
+| 4 | CacheSignal simulation | CacheSignal correctly chains through L1→L2→L3, settling only after L3 |
+| 5 | setImmediate vs deferred | With *already-tracked* components (manual beginRead/endRead), all strategies work because React's own scheduling is microtask-fast |
+| 6 | Microtask gap | Warm-cache scenario (Promise.resolve): CacheSignal survives the gap between endRead and React's follow-up render |
+| 7 | Bare abort without tracking | When all components are microtask-fast, even bare setImmediate works (React resolves everything in one task) |
+| 8 | **Untracked I/O** | **The critical finding**: Without CacheSignal tracking, a 20ms cross-process read is invisible → premature abort → shallow shell. With tracking: correct. |
+
+**Experiment 8 is the proof that tracking is necessary.** A bare timing abort
+only works when all async work resolves within the first macrotask (microtask-
+fast). Any real I/O — network calls, file reads, cross-process communication —
+takes longer and is invisible without explicit tracking.
+
+---
+
+## Appendix B: The Exact Settle Sequence (From Next.js Source)
+
+```
+1. Create CacheSignal (count=0)
+2. Create AbortController for React render
+3. Start React prerender(element, { signal })
+4. trackPendingModules(cacheSignal)  ← subscribe to module loads
+5. await cacheSignal.cacheReady()    ← blocks until settled
+   │
+   │  During render, React calls components:
+   │    Component A: fetch() → cacheSignal.beginRead() [count=1]
+   │    Component A: fetch resolves → cacheSignal.endRead() [count=0]
+   │      → schedule setImmediate (timer 1)
+   │    React processes result, renders child B
+   │    Component B: "use cache" → cacheSignal.beginRead() [count=1]
+   │      → CANCEL timer 1
+   │    Component B: cache resolves → cacheSignal.endRead() [count=0]
+   │      → schedule setImmediate (timer 2)
+   │    React processes result, renders child C
+   │    Component C: dynamic API (cookies) → hanging promise (NOT tracked)
+   │    [no more beginReads]
+   │    setImmediate timer 2 fires → schedule setTimeout(0) (timer 3)
+   │    setTimeout timer 3 fires → count still 0 → SETTLED
+   │
+6. abortController.abort()           ← kill the React render
+7. Collect the produced stream (used to fill caches, HTML discarded)
+```
+
+---
+
+*Experiments run on: Node.js, React 19.2.8, macOS Darwin 25.5.0*
+*Source: Next.js canary (latest as of 2026-08-08)*

--- a/internal/analysis/ppr-settle-criterion-findings.md
+++ b/internal/analysis/ppr-settle-criterion-findings.md
@@ -324,8 +324,16 @@ Two tasks, one macrotask window. The Flight stream is already fully produced, so
 there are no pending data reads. Any postponed boundaries become `postponed`
 state that React DOM returns alongside the HTML prelude.
 
+**Module loading is also tracked.** While no _data_ reads are pending, the HTML
+pass does need to load client component modules (chunks referenced in the Flight
+stream). A separate per-pass CacheSignal tracks module/chunk loads via
+`trackPendingModules(cacheSignal)`. The HTML pass waits for module loading to
+settle before aborting. If a module hasn't loaded by abort time, its component
+becomes a postponed placeholder. In practice, modules are warm from the
+prospective pass, so they resolve instantly.
+
 **Why this is safe**: The Flight stream is complete. React DOM is just converting
-it to HTML. All the async resolution happened in the RSC passes. React DOM's
+it to HTML. All the async data resolution happened in the RSC passes. React DOM's
 prerender processes the Flight data, emits HTML for resolved subtrees, and emits
 `<template>` placeholders for postponed boundaries.
 
@@ -422,12 +430,20 @@ if (prerenderStore.type === 'prerender') {
 }
 ```
 
-`makeRuntimeHangingPromise` returns:
+`makeRuntimeHangingPromise` returns (simplified from Next.js's
+`makeHangingPromiseWithError`):
 
 ```javascript
-new Promise((_, reject) => {
-  signal.addEventListener('abort', () => reject(error), { once: true });
-});
+function makeHangingPromise(signal, error) {
+  if (signal.aborted) {
+    return Promise.reject(error); // already aborted — reject immediately
+  }
+  const promise = new Promise((_, reject) => {
+    signal.addEventListener('abort', () => reject(error), { once: true });
+  });
+  promise.catch(() => {}); // suppress unhandled rejection warnings
+  return promise;
+}
 ```
 
 This promise never resolves. React sees it, suspends at the nearest Suspense

--- a/internal/planning/ppr-implementation-plan.md
+++ b/internal/planning/ppr-implementation-plan.md
@@ -607,17 +607,32 @@ equivalent mechanism without requiring SWC/Babel integration. If we later add
 a `"use cache"` directive with compiler support, the wrapper becomes its
 compiled output — the runtime mechanism is the same.
 
-**What `cacheRead` tracks.** Only the top-level promise returned by `fn` is
-tracked. If `fn` does multiple internal awaits, they are all covered by the
-single `beginRead()`/`endRead()` pair. Nested `cacheRead()` calls are also
+**What `cacheRead` does.** `cacheRead` is both a **tracker** and a **caching
+wrapper**. It calls `beginRead()` before the work starts, executes `fn`,
+stores the result in the Resume Data Cache (RDC) keyed by a stable identifier,
+and calls `endRead()` when the work settles. On subsequent calls with the same
+key, it returns the cached result from the RDC instead of re-executing `fn`.
+
+If `fn` does multiple internal awaits, they are all covered by the single
+`beginRead()`/`endRead()` pair. Nested `cacheRead()` calls are also
 supported — each gets its own pair, and the settle criterion waits for all of
 them.
 
 **Interaction with the two-pass system.** During the prospective pass,
-`cacheRead` registers the work with CacheSignal. During the final pass,
-`cacheSignal` is null — `cacheRead` still runs the function but does not
-register it (the cache should already be warm, so the function resolves via
-an already-fulfilled promise from the Resume Data Cache).
+`cacheRead` registers the work with CacheSignal and populates the RDC with the
+result. During the final pass, `cacheSignal` is null — `cacheRead` reads from
+the already-populated RDC, returning an already-fulfilled promise
+(microtask-fast). This is what makes the final pass's fixed task-schedule
+abort safe: every `cacheRead` call resolves within a microtask because the
+data is already in the in-process RDC.
+
+**Relationship to `"use cache"`.** `cacheRead` is the runtime primitive that
+`"use cache"` compiles down to. The `"use cache"` directive adds build-time
+key derivation (stable ID from filename + export name), argument serialization
+via `encodeReply`, and storage via the full `CacheHandler` interface.
+`cacheRead` is a simpler entry point for users who need tracking without the
+full `"use cache"` infrastructure — it uses the RDC directly with a
+user-provided or auto-derived key.
 
 #### `connection()` — "this component needs a real request"
 

--- a/internal/planning/ppr-implementation-plan.md
+++ b/internal/planning/ppr-implementation-plan.md
@@ -127,6 +127,7 @@ timer is scheduled. This loop continues until no more reads start during the
 settle window — only then does `cacheReady()` resolve.
 
 **Two-tier resolution.** CacheSignal offers two resolution speeds:
+
 - **`inputReady()`** — fast tier (`queueMicrotask(() => process.nextTick(…))`).
   Used to abort hanging promise inputs to cached functions when all cache
   inputs are ready. Fires quickly, essentially same-tick.
@@ -179,7 +180,7 @@ For React on Rails this means two APIs:
 
    ```jsx
    async function UserGreeting() {
-     await connection();  // ← hangs during prerender, no-op at request time
+     await connection(); // ← hangs during prerender, no-op at request time
      const user = getCurrentUser();
      return <p>Hello, {user.name}!</p>;
    }
@@ -539,6 +540,7 @@ refs), and identical per-request behavior under counters and timing.
 > **Evidence base.** This section is backed by source-code analysis of the
 > Next.js canary (August 2026) and 15 empirical experiments run on React
 > 19.2.8. The findings are documented in full at:
+>
 > - [`internal/analysis/ppr-settle-criterion-findings.md`](../analysis/ppr-settle-criterion-findings.md)
 > - [`internal/analysis/ppr-settle-by-example.md`](../analysis/ppr-settle-by-example.md)
 > - [`internal/analysis/ppr-rsc-payload-by-example.md`](../analysis/ppr-rsc-payload-by-example.md)
@@ -557,11 +559,11 @@ promises. Both failures are silent — the output is valid HTML, just worse.
 
 ### The three abort points
 
-| # | Abort point | Settle criterion | Mechanism | Window |
-|---|---|---|---|---|
-| 1 | **RSC prospective pass** | `CacheSignal.cacheReady()` | Reference counter + deferred check | Until all tracked work settles |
-| 2 | **RSC final pass** | `runInSequentialTasks` | Fixed task schedule | ~4 macrotask turns |
-| 3 | **HTML/Fizz prerender** | `runInSequentialTasks` | Fixed task schedule | ~2 macrotask turns |
+| #   | Abort point              | Settle criterion           | Mechanism                          | Window                         |
+| --- | ------------------------ | -------------------------- | ---------------------------------- | ------------------------------ |
+| 1   | **RSC prospective pass** | `CacheSignal.cacheReady()` | Reference counter + deferred check | Until all tracked work settles |
+| 2   | **RSC final pass**       | `runInSequentialTasks`     | Fixed task schedule                | ~4 macrotask turns             |
+| 3   | **HTML/Fizz prerender**  | `runInSequentialTasks`     | Fixed task schedule                | ~2 macrotask turns             |
 
 The prospective pass is the only one with an open-ended wait. The final pass
 and HTML pass use fixed schedules because their inputs are already resolved
@@ -583,7 +585,13 @@ import { cacheRead } from 'react-on-rails-pro';
 
 async function ProductList() {
   const products = await cacheRead(() => db.query('SELECT * FROM products'));
-  return <ul>{products.map(p => <li key={p.id}>{p.name}</li>)}</ul>;
+  return (
+    <ul>
+      {products.map((p) => (
+        <li key={p.id}>{p.name}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 
@@ -621,13 +629,14 @@ immediately:
 import { connection } from 'react-on-rails-pro';
 
 async function UserProfile() {
-  await connection();  // hangs during prerender → dynamic hole
+  await connection(); // hangs during prerender → dynamic hole
   const user = await getCurrentUser();
   return <div>{user.name}</div>;
 }
 ```
 
 **Design properties:**
+
 - The hanging promise is **NOT** tracked by CacheSignal. It is invisible to
   the settle criterion. This is what prevents deadlock.
 - At request time, `connection()` resolves immediately (a no-op).
@@ -637,16 +646,16 @@ async function UserProfile() {
 
 ### Tracked vs untracked work
 
-| Async operation | Tracked by CacheSignal? | Makes it into the shell? |
-|---|---|---|
-| `await cacheRead(() => ...)` | ✅ Yes | ✅ Yes — CacheSignal waits |
-| `await cachedFunction()` (with `"use cache"`) | ✅ Yes | ✅ Yes |
-| Module/chunk loads (`import()`, `React.lazy`) | ✅ Yes (module loading subscription) | ✅ Yes |
-| `await connection()` | ❌ No (by design) | ❌ No — becomes a hole |
-| `await rawFetch(url)` (untracked) | ❌ No | ⚠️ Only if microtask-fast |
-| `await db.query()` (untracked) | ❌ No | ⚠️ Only if microtask-fast |
-| Client component async during SSR | ❌ No | ⚠️ Only if microtask-fast |
-| Third-party `throw promise` / `React.use(p)` | ❌ No | ⚠️ Only if microtask-fast |
+| Async operation                               | Tracked by CacheSignal?              | Makes it into the shell?   |
+| --------------------------------------------- | ------------------------------------ | -------------------------- |
+| `await cacheRead(() => ...)`                  | ✅ Yes                               | ✅ Yes — CacheSignal waits |
+| `await cachedFunction()` (with `"use cache"`) | ✅ Yes                               | ✅ Yes                     |
+| Module/chunk loads (`import()`, `React.lazy`) | ✅ Yes (module loading subscription) | ✅ Yes                     |
+| `await connection()`                          | ❌ No (by design)                    | ❌ No — becomes a hole     |
+| `await rawFetch(url)` (untracked)             | ❌ No                                | ⚠️ Only if microtask-fast  |
+| `await db.query()` (untracked)                | ❌ No                                | ⚠️ Only if microtask-fast  |
+| Client component async during SSR             | ❌ No                                | ⚠️ Only if microtask-fast  |
+| Third-party `throw promise` / `React.use(p)`  | ❌ No                                | ⚠️ Only if microtask-fast  |
 
 **The "microtask-fast" cutoff.** Untracked async work that resolves via
 `Promise.resolve()` (already-fulfilled promise) always makes it into the shell
@@ -667,7 +676,7 @@ A hard timeout cap prevents pathological applications from stalling builds:
 ```js
 const settled = await Promise.race([
   cacheSignal.cacheReady(),
-  timeout(SETTLE_TIMEOUT_MS).then(() => 'TIMEOUT')
+  timeout(SETTLE_TIMEOUT_MS).then(() => 'TIMEOUT'),
 ]);
 
 if (settled === 'TIMEOUT') {

--- a/internal/planning/ppr-implementation-plan.md
+++ b/internal/planning/ppr-implementation-plan.md
@@ -65,19 +65,36 @@ Static generation needs two passes with intentionally opposite timing
 requirements:
 
 1. **Prospective pass (unbounded).** Renders the tree purely to warm caches.
-   Gated by a coordination signal that resolves only once every in-flight
-   `"use cache"` read settles and no new reads arrive within a full
+   Gated by a coordination signal (CacheSignal) that resolves only once every
+   in-flight cache read settles and no new reads arrive within a full
    event-loop turn. Once the signal resolves, the pass is aborted and **its
    output is discarded**. Slow by design — it has to wait for real cache fills.
 2. **Final pass (bounded).** Renders again with caches now warm. Aborted after
-   a single task (`setImmediate`). Whatever resolved within that window
+   a fixed task schedule (a small number of sequential `setTimeout(0)` calls,
+   typically 4 macrotask windows). Whatever resolved within that window
    becomes the static shell / prelude; whatever was still suspended on
-   dynamic-data hanging promises becomes a streaming hole.
+   dynamic-data hanging promises becomes a streaming hole. Warm cache reads
+   resolve via already-fulfilled promises (microtask-fast), so every cacheable
+   component resolves within the first rendering task. The fixed schedule is
+   only safe **because** the Resume Data Cache is an in-process JavaScript
+   `Map` — cross-process reads would take real wall-clock time and be missed
+   by the task-schedule abort. (See §"Settle Criterion Design" for the
+   empirical proof.)
 
 A single bounded cold pass would lose cached content (the fill cannot finish
 within the deadline). A single unbounded pass would deadlock on the hanging
 dynamic boundaries. The two passes resolve the contradiction by splitting the
 two jobs.
+
+**The unclosing stream bridge.** Between the RSC pass and the HTML pass, the
+collected RSC (Flight) stream is replayed as an "unclosing stream" — a
+`ReadableStream` that delivers all buffered chunks but intentionally never
+calls `controller.close()`. This prevents React from erroring on unresolved
+Flight references (dynamic holes): missing chunks stay as pending thenables
+that cause clean Suspense-style suspension rather than "connection closed"
+errors. The HTML renderer then converts those suspensions into postponed
+boundaries in the prelude. This is the mechanism that propagates dynamic holes
+from the RSC layer to the HTML layer without loss of information.
 
 ### The coordination signal (a faithful port required)
 
@@ -92,12 +109,44 @@ needs exactly two rules:
    resets the readiness clock; the signal does not declare ready until a full
    turn passes with no new reads.
 
+**Why two event-loop turns.** The deferred check uses `setImmediate` followed
+by `setTimeout(0)` because React schedules follow-up rendering work in two
+different ways: microtasks during prerender, and `setImmediate` during
+rendering. When a cache read completes and React processes the result, it may
+discover new components that start their own cache reads. The two-level timing
+ensures those follow-on reads have time to call `beginRead()` before the
+settle check fires. Empirically validated on React 19.2.8: a single
+`setImmediate` also works for microtask-fast cache reads, but the extra
+`setTimeout(0)` provides a safety margin for React's `setImmediate`-based
+rendering scheduler.
+
+**The cancellation dance.** When the count drops to zero and a settle timer is
+scheduled, a subsequent `beginRead()` cancels the pending timer immediately.
+When that new read's `endRead()` fires and count returns to zero, a fresh
+timer is scheduled. This loop continues until no more reads start during the
+settle window — only then does `cacheReady()` resolve.
+
+**Two-tier resolution.** CacheSignal offers two resolution speeds:
+- **`inputReady()`** — fast tier (`queueMicrotask(() => process.nextTick(…))`).
+  Used to abort hanging promise inputs to cached functions when all cache
+  inputs are ready. Fires quickly, essentially same-tick.
+- **`cacheReady()`** — standard tier (`setImmediate(() => setTimeout(0))`).
+  Used for the main prerender abort decision. The extra delay ensures React
+  has fully processed resolved data before the settle check runs.
+
 A separate process-global signal tracks **in-flight dynamic module loads**
 (code-split chunks that may, when loaded, expose more caches). The prospective
-prerender subscribes its cache signal to this module-loading signal so that
-slow lazy imports also hold readiness open. This is the only kind of "slow
-async" the prospective pass waits for; bare uncached I/O is intentionally
-treated as a dynamic boundary (it becomes a streamed hole).
+prerender subscribes its cache signal to this module-loading signal via
+`subscribeToReads()` so that slow lazy imports also hold readiness open.
+
+**Module load subscription.** `subscribeToReads(subscriber)` adds the
+per-render CacheSignal as a subscriber to the global module-loading signal.
+Every `beginRead()`/`endRead()` on the global signal is forwarded to all
+subscribers. On subscription, existing in-flight counts are transferred
+(each already-pending read triggers a `beginRead()` on the subscriber). The
+subscription auto-unsubscribes when `cacheReady()` resolves. This is the only
+kind of "slow async" the prospective pass waits for; bare uncached I/O is
+intentionally treated as a dynamic boundary (it becomes a streamed hole).
 
 The full port of these two pieces is ~150 lines of plain JavaScript; see the
 reference repo.
@@ -111,10 +160,36 @@ component suspends. When the bounded final pass aborts after one task, those
 suspended boundaries become Suspense placeholders in the prelude — no errors
 thrown, abort gracefully turns them into holes.
 
-For React on Rails this means we need a small `makeHangingPromise(signal)`
-helper and routing every Rails-side "request data" API (current_user, locale,
-session, params we want treated as dynamic) through it during the prerender
-phase. At request time the same APIs return real values.
+The critical design property: **hanging promises are NOT tracked by
+CacheSignal.** CacheSignal only counts work that will eventually resolve
+(cache reads, module loads). Hanging promises are invisible to it. This is
+what prevents deadlock: CacheSignal settles when all _resolvable_ work is
+done, regardless of how many hanging promises are still pending.
+
+For React on Rails this means two APIs:
+
+1. **`makeHangingPromise(signal)`** — a helper that creates a promise which
+   never resolves, only rejects when the abort signal fires. Used internally
+   to implement dynamic-boundary markers.
+
+2. **`connection()`** — a user-facing API that components call to declare
+   "this component needs a real request." During prerender it returns a hanging
+   promise (the component suspends, becoming a dynamic hole). At request time
+   it returns immediately. This is the explicit opt-in to dynamic rendering.
+
+   ```jsx
+   async function UserGreeting() {
+     await connection();  // ← hangs during prerender, no-op at request time
+     const user = getCurrentUser();
+     return <p>Hello, {user.name}!</p>;
+   }
+   ```
+
+   Every Rails-side "request data" API (current_user, locale, session, params
+   we want treated as dynamic) should be routed through `connection()` during
+   the prerender phase. Components that call any of these APIs automatically
+   become dynamic holes without the user needing to understand hanging
+   promises.
 
 ---
 
@@ -363,6 +438,31 @@ signal })` returns `{ prelude, postponed }`. We persist the prelude (the
   shell is served from cache; the resumed tail is appended in the same HTTP
   response.
 
+### HTML pass settle criterion
+
+The HTML/Fizz prerender uses the same task-schedule abort as the RSC final
+pass — a fixed sequence of macrotasks (typically 2: start the prerender, then
+abort). This is safe because the HTML pass's input — the RSC Flight stream —
+is already fully produced and buffered. There are no pending data reads. React
+DOM's `prerender()` is just converting the Flight data to HTML: resolved
+subtrees become markup, unresolved Flight chunks (propagated via the unclosing
+stream) become postponed Suspense boundaries in the prelude.
+
+**What CacheSignal tracks in the HTML pass.** The HTML pass sets
+`cacheSignal: null` — cache tracking is not needed because all caches are
+warm. The only tracked activity is **module/chunk loading**: client component
+references in the Flight stream trigger chunk loads during SSR, and those are
+tracked by a separate per-pass CacheSignal dedicated to module loading. This
+prevents aborting the HTML pass while client component modules are still being
+loaded and evaluated.
+
+**Client component async work is untracked.** If a React 19 async client
+component does async work during SSR (e.g., `await` expressions in the
+component body), that work is invisible to any CacheSignal. If it doesn't
+resolve within the task-schedule window, it becomes a dynamic hole. This is
+correct behavior — client component async work is expected to complete during
+hydration on the client.
+
 Treat `postponedState` as **opaque** — never parse, never modify. It is a
 React-internal serialization of the postponed Fizz state.
 
@@ -434,6 +534,183 @@ refs), and identical per-request behavior under counters and timing.
 
 ---
 
+## Settle Criterion Design
+
+> **Evidence base.** This section is backed by source-code analysis of the
+> Next.js canary (August 2026) and 15 empirical experiments run on React
+> 19.2.8. The findings are documented in full at:
+> - [`internal/analysis/ppr-settle-criterion-findings.md`](../analysis/ppr-settle-criterion-findings.md)
+> - [`internal/analysis/ppr-settle-by-example.md`](../analysis/ppr-settle-by-example.md)
+> - [`internal/analysis/ppr-rsc-payload-by-example.md`](../analysis/ppr-rsc-payload-by-example.md)
+
+### The core problem
+
+When React prerenders a page, it needs to render as much of the static shell
+as possible, then stop and leave holes for dynamic content. React provides one
+control: the abort signal. **React never tells the framework "I'm done with
+all static work."** There is no `onAllStaticWorkComplete()` callback. The
+framework must decide when to fire the signal.
+
+Aborting too early produces a shallower shell (the user sees coarse spinners
+instead of fine-grained skeletons). Aborting too late deadlocks on hanging
+promises. Both failures are silent — the output is valid HTML, just worse.
+
+### The three abort points
+
+| # | Abort point | Settle criterion | Mechanism | Window |
+|---|---|---|---|---|
+| 1 | **RSC prospective pass** | `CacheSignal.cacheReady()` | Reference counter + deferred check | Until all tracked work settles |
+| 2 | **RSC final pass** | `runInSequentialTasks` | Fixed task schedule | ~4 macrotask turns |
+| 3 | **HTML/Fizz prerender** | `runInSequentialTasks` | Fixed task schedule | ~2 macrotask turns |
+
+The prospective pass is the only one with an open-ended wait. The final pass
+and HTML pass use fixed schedules because their inputs are already resolved
+(warm caches / complete Flight stream respectively).
+
+### User-facing APIs
+
+Two user-facing APIs form the contract between application code and the settle
+criterion:
+
+#### `cacheRead(fn)` — "wait for this before aborting"
+
+A wrapper function that users place around any async work they want the
+framework to wait for. Internally calls `beginRead()` before the work starts
+and `endRead()` when it settles:
+
+```jsx
+import { cacheRead } from 'react-on-rails-pro';
+
+async function ProductList() {
+  const products = await cacheRead(() => db.query('SELECT * FROM products'));
+  return <ul>{products.map(p => <li key={p.id}>{p.name}</li>)}</ul>;
+}
+```
+
+Without this wrapper, async work is invisible to the settle criterion and may
+be aborted prematurely, causing the component's entire subtree to fall behind
+the nearest ancestor Suspense boundary's fallback.
+
+**Why explicit wrapping is needed.** Unlike Next.js, which uses a compiler
+transform (`"use cache"` directive) to inject `beginRead()`/`endRead()`
+automatically, and monkey-patches `fetch()` to track it, React on Rails does
+not have a compiler transform for this purpose. The explicit wrapper is the
+equivalent mechanism without requiring SWC/Babel integration. If we later add
+a `"use cache"` directive with compiler support, the wrapper becomes its
+compiled output — the runtime mechanism is the same.
+
+**What `cacheRead` tracks.** Only the top-level promise returned by `fn` is
+tracked. If `fn` does multiple internal awaits, they are all covered by the
+single `beginRead()`/`endRead()` pair. Nested `cacheRead()` calls are also
+supported — each gets its own pair, and the settle criterion waits for all of
+them.
+
+**Interaction with the two-pass system.** During the prospective pass,
+`cacheRead` registers the work with CacheSignal. During the final pass,
+`cacheSignal` is null — `cacheRead` still runs the function but does not
+register it (the cache should already be warm, so the function resolves via
+an already-fulfilled promise from the Resume Data Cache).
+
+#### `connection()` — "this component needs a real request"
+
+A function that components call to declare themselves dynamic. During
+prerender it returns a hanging promise; at request time it returns
+immediately:
+
+```jsx
+import { connection } from 'react-on-rails-pro';
+
+async function UserProfile() {
+  await connection();  // hangs during prerender → dynamic hole
+  const user = await getCurrentUser();
+  return <div>{user.name}</div>;
+}
+```
+
+**Design properties:**
+- The hanging promise is **NOT** tracked by CacheSignal. It is invisible to
+  the settle criterion. This is what prevents deadlock.
+- At request time, `connection()` resolves immediately (a no-op).
+- Every Rails-side request-data API (`current_user`, `session`, `locale`,
+  `request`, etc.) should internally call `connection()` so that components
+  using them automatically become dynamic holes.
+
+### Tracked vs untracked work
+
+| Async operation | Tracked by CacheSignal? | Makes it into the shell? |
+|---|---|---|
+| `await cacheRead(() => ...)` | ✅ Yes | ✅ Yes — CacheSignal waits |
+| `await cachedFunction()` (with `"use cache"`) | ✅ Yes | ✅ Yes |
+| Module/chunk loads (`import()`, `React.lazy`) | ✅ Yes (module loading subscription) | ✅ Yes |
+| `await connection()` | ❌ No (by design) | ❌ No — becomes a hole |
+| `await rawFetch(url)` (untracked) | ❌ No | ⚠️ Only if microtask-fast |
+| `await db.query()` (untracked) | ❌ No | ⚠️ Only if microtask-fast |
+| Client component async during SSR | ❌ No | ⚠️ Only if microtask-fast |
+| Third-party `throw promise` / `React.use(p)` | ❌ No | ⚠️ Only if microtask-fast |
+
+**The "microtask-fast" cutoff.** Untracked async work that resolves via
+`Promise.resolve()` (already-fulfilled promise) always makes it into the shell
+because React processes resolved promises via microtasks, which run before any
+macrotask. Untracked work that takes real wall-clock time (≥5ms) is missed by
+the task-schedule abort. This was proven in experiments 7–9.
+
+**The gap users need to understand.** Any raw `await` without `cacheRead()`
+wrapping is a gamble on timing. If it resolves within a microtask, it works.
+If it takes real time (database query, network call, cross-process
+communication), it's missed and the component becomes a dynamic hole. The
+documentation must make this clear.
+
+### Budget and escape hatch
+
+A hard timeout cap prevents pathological applications from stalling builds:
+
+```js
+const settled = await Promise.race([
+  cacheSignal.cacheReady(),
+  timeout(SETTLE_TIMEOUT_MS).then(() => 'TIMEOUT')
+]);
+
+if (settled === 'TIMEOUT') {
+  log.warn('Prerender settle timeout — aborting with partial shell');
+}
+controller.abort();
+```
+
+When the timeout trips, the result is a shallower shell (more dynamic holes),
+not a build failure. The page still works — it just has more content streaming
+in dynamically. The timeout should be configurable, with a sensible default
+(e.g., 30 seconds for the prospective pass).
+
+### Determinism
+
+A timing-based settle criterion introduces non-determinism: the same page
+might produce different shells on different builds if component resolution
+times vary. Three constraints ensure determinism:
+
+1. **The Resume Data Cache must be in-process** (a JavaScript `Map`). This
+   guarantees that final-pass cache reads resolve via already-fulfilled
+   promises (microtask-fast), making the task-schedule abort deterministic.
+   Cross-process reads (Node → Ruby via HTTP) would introduce timing
+   variation.
+
+2. **The settle criterion must be event-driven** (CacheSignal), not
+   time-based. CacheSignal fires when all tracked work finishes, regardless
+   of how long it took. Two runs with different wall-clock timings produce
+   the same settle point as long as the same work is tracked.
+
+3. **Build validation.** Prerender the same page twice and diff the shells.
+   If the shell differs between runs, it indicates non-deterministic async
+   work leaking into the prerender. This can be automated as a CI check.
+
+### Ordering constraint
+
+The `postponed` state must be serialized only **after** the prelude has fully
+flushed (see react#36779 and P6 spike finding #3). Any settle design must
+preserve this: abort the React render first, collect the prelude, then
+serialize `postponed`.
+
+---
+
 ## Implementation Phasing
 
 Each phase ends with tests + a working demo and can be merged independently.
@@ -497,4 +774,11 @@ runtime/cache/coordination).
   (PR #3314) — the upstream investigation this plan builds on.
 - Reference implementation:
   <https://github.com/AbanoubGhadban/ppr-from-scratch>
+- Settle criterion research (PR #4852):
+  - [`internal/analysis/ppr-settle-criterion-findings.md`](../analysis/ppr-settle-criterion-findings.md)
+    — Next.js CacheSignal mechanism analysis + experiment results
+  - [`internal/analysis/ppr-settle-by-example.md`](../analysis/ppr-settle-by-example.md)
+    — component-level "if you write this, you get that" patterns
+  - [`internal/analysis/ppr-rsc-payload-by-example.md`](../analysis/ppr-rsc-payload-by-example.md)
+    — RSC payload lifecycle in the PPR pipeline
 - Closes #3315.

--- a/internal/planning/ppr-implementation-plan.md
+++ b/internal/planning/ppr-implementation-plan.md
@@ -703,7 +703,10 @@ controller.abort();
 When the timeout trips, the result is a shallower shell (more dynamic holes),
 not a build failure. The page still works — it just has more content streaming
 in dynamically. The timeout should be configurable, with a sensible default
-(e.g., 30 seconds for the prospective pass).
+(e.g., 10 seconds for the prospective pass). Note: the findings doc uses 5s
+in its illustrative code snippet; the actual default is an implementation
+decision for #3571 — the key property is that the timeout exists, is
+configurable, and degrades gracefully rather than failing the build.
 
 ### Determinism
 


### PR DESCRIPTION
## What

Updates the PPR implementation plan (`internal/planning/ppr-implementation-plan.md`) with a validated settle criterion design for each of the three prerender abort points, based on Next.js source-code analysis and 15 empirical experiments on React 19.2.8.

## Why

The plan previously defined a settle criterion for only one of the three abort points (RSC prospective, via CacheSignal) and hand-waved the other two. The P6 spike (#4771) hit this directly (finding #4) and documented that `await Promise.all(shellData)` is not an implementable criterion. This PR fills the gap.

## Changes

### Plan amendments (existing sections)

- **§Two-pass prerender**: document the unclosing stream bridge between RSC and HTML passes; clarify why the final pass task-schedule abort is safe (requires in-process RDC)
- **§Coordination signal**: add deferred settle timing details (`setImmediate + setTimeout`), cancellation dance, two-tier resolution (`inputReady` vs `cacheReady`), module load subscription mechanism
- **§Hanging promise**: add `connection()` API design; clarify that hanging promises are NOT tracked by CacheSignal (prevents deadlock)
- **§HTML Generation**: add HTML pass settle criterion (task-schedule, safe because Flight stream is complete); module loading tracking in the HTML pass

### New consolidated section

**§Settle Criterion Design** — the three abort points table, two user-facing APIs (`cacheRead()` + `connection()`), tracked vs untracked work matrix, budget/escape hatch, determinism constraints, ordering constraint.

### Supporting findings docs (`internal/analysis/`)

- `ppr-settle-criterion-findings.md` — Next.js CacheSignal mechanism analysis + experiment results
- `ppr-settle-by-example.md` — component-level patterns: "if you write this, you get that"
- `ppr-rsc-payload-by-example.md` — RSC payload lifecycle in the PPR pipeline

## Key design decisions

1. **`cacheRead(fn)`** — explicit wrapper for async work the framework should wait for (equivalent to Next.js's `"use cache"` without requiring compiler support)
2. **`connection()`** — dynamic-boundary marker that returns a hanging promise during prerender (equivalent to Next.js's `connection()`/`cookies()`/`headers()`)
3. **In-process RDC** — required for the final pass task-schedule abort to be deterministic (cross-process reads would be missed)
4. **Budget cap** — hard timeout for pathological settle (degrades to more dynamic holes, not build failure)

## Out of scope

Implementation of the settle criterion in code — that lands in #3571 phases 4 and 6. This PR is plan-only.

Closes #4852

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides explaining Partial Prerendering (PPR) payloads, static shells, dynamic content, Suspense boundaries, and rendering outputs.
  * Documented PPR settlement criteria, including asynchronous work, abort timing, fallbacks, and boundary placement.
  * Expanded the implementation plan with two-pass rendering, readiness checks, timeout behavior, and deterministic output guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->