### PR TITLE
[Pro] Redact RSC error diagnostics at browser boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,18 +33,19 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4840](https://github.com/shakacode/react_on_rails/pull/4840) by
   [ihabadham](https://github.com/ihabadham).
 
-- **[Pro]** **RSC render-error details are no longer sent to the browser on the fetched payload path**:
-  The RSC payload fetched during client-side navigation (via `rsc_payload_generation_url_path`) included
-  the server's rendering-error message and source-mapped stack — which contains server file paths — in its
-  metadata, in every environment. The inline (first-paint) payload path was already redacted, so error
-  detail that was hidden on first paint could still reach the browser on a client navigation. The fetched
-  path now applies the same fail-closed gate: full detail only in `development` and `test`, while
-  `production`, `staging`, and any unrecognized environment receive a generic `hasErrors: true` signal so
-  client error boundaries still fire. Server-side error handling is unaffected — `raise_prerender_error`
-  still receives the full message and stack, because redaction happens at the browser-facing boundary
-  after the server's own error transform runs. Fixes
-  [Issue 4736](https://github.com/shakacode/react_on_rails/issues/4736).
-  [PR 4821](https://github.com/shakacode/react_on_rails/pull/4821) by
+- **[Pro]** **RSC render-error details no longer reach browser-facing payloads in production-like
+  environments**: Fetched RSC payload metadata now uses a fail-closed allowlist that exposes only the
+  generic `hasErrors` signal needed by client error boundaries. Inline error-bearing payload chunks now
+  also suppress console replay in `production`, `staging`, and unrecognized environments, closing a path
+  that could repeat the server error message or source-mapped file paths after diagnostic metadata was
+  redacted. Full diagnostics and console replay remain available in `development` and `test`, clean
+  production chunks retain console replay, and server-side reporting still receives the original error
+  details before the browser-boundary redaction runs. Fixes
+  [Issue 4736](https://github.com/shakacode/react_on_rails/issues/4736),
+  [Issue 4822](https://github.com/shakacode/react_on_rails/issues/4822), and
+  [Issue 4827](https://github.com/shakacode/react_on_rails/issues/4827).
+  [PR 4821](https://github.com/shakacode/react_on_rails/pull/4821) and
+  [PR 4856](https://github.com/shakacode/react_on_rails/pull/4856) by
   [justin808](https://github.com/justin808).
 
 - **HTTP-served SSR bundle loading now honors the response charset, rejects non-2xx responses,

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -96,6 +96,15 @@ function hasRenderingErrorSignal(renderingError: unknown) {
   return nonEmptyMetadataString(message) || nonEmptyMetadataString(stack);
 }
 
+function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: string) {
+  // Console replay remains useful in development/test and for clean production chunks. On an
+  // error-bearing chunk, however, it can repeat the same server-only message or stack path that
+  // diagnostic metadata redacts, so unknown and production-like environments fail closed.
+  if (railsEnv === 'development' || railsEnv === 'test') return true;
+
+  return metadata.hasErrors !== true && !hasRenderingErrorSignal(metadata.renderingError);
+}
+
 function createRSCDiagnosticScript(
   metadata: Record<string, unknown>,
   cacheKey: string,
@@ -2068,7 +2077,7 @@ export default function injectRSCPayload(
 
               // Emit console replay as a separate <script> tag (not inside the payload)
               const consoleScript = metadata.consoleReplayScript as string;
-              if (consoleScript) {
+              if (consoleScript && shouldEmitConsoleReplay(metadata, railsEnv)) {
                 rscPayloadBuffers.push(Buffer.from(createScriptTag(consoleScript, sanitizedNonce)));
               }
               // Primary flush is handled by React's flush() callback (see above).

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -417,7 +417,7 @@ describe('injectRSCPayload', () => {
         message: 'useState is not a function',
         stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
       },
-      consoleReplayScript: '<script>console.log("replay")</script>',
+      consoleReplayScript: 'console.log("test diagnostic replay")',
       serializedProps: { token: 'do-not-serialize' },
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
@@ -439,6 +439,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('serializedProps');
     expect(resultStr).not.toContain('do-not-serialize');
     expect(resultStr).not.toContain('consoleReplayScript');
+    expect(resultStr).toContain('<script>console.log("test diagnostic replay")</script>');
   });
 
   it('keeps the first RSC diagnostic metadata for a payload key', async () => {
@@ -504,6 +505,8 @@ describe('injectRSCPayload', () => {
         message: 'User 48213 not authorized for org 77',
         stack: 'Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)',
       },
+      consoleReplayScript:
+        'console.error("RSC inline failed for User 48213 at /srv/private/Auth.server.tsx:12:5")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -519,6 +522,8 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('not authorized');
     expect(resultStr).not.toContain('Auth.server.tsx');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('RSC inline failed');
+    expect(resultStr).not.toContain('/srv/private/Auth.server.tsx');
   });
 
   it('redacts renderingError in non-development/test environments like staging', async () => {
@@ -528,6 +533,7 @@ describe('injectRSCPayload', () => {
         message: 'Internal server failure',
         stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
       },
+      consoleReplayScript: 'console.error("staging secret at /srv/private/server.ts:42:7")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -542,6 +548,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('Internal server failure');
     expect(resultStr).not.toContain('server.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('staging secret');
   });
 
   it('redacts renderingError when railsEnv is not provided (undefined)', async () => {
@@ -551,6 +558,7 @@ describe('injectRSCPayload', () => {
         message: 'Database connection refused at 10.0.3.42:5432',
         stack: 'Error: Database connection refused\n    at Pool (/app/lib/db.ts:18:11)',
       },
+      consoleReplayScript: 'console.error("unknown-env secret at /srv/private/db.ts:18:11")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -563,6 +571,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('10.0.3.42');
     expect(resultStr).not.toContain('db.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('unknown-env secret');
   });
 
   it('forces hasErrors:true in production even when metadata has hasErrors:false with renderingError signal', async () => {
@@ -572,6 +581,7 @@ describe('injectRSCPayload', () => {
         message: 'Internal server failure',
         stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
       },
+      consoleReplayScript: 'console.error("secondary inline secret at /srv/private/server.ts:42:7")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -585,6 +595,24 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('Internal server failure');
     expect(resultStr).not.toContain('server.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('secondary inline secret');
+    expect(resultStr).not.toContain('/srv/private/server.ts');
+  });
+
+  it('preserves console replay for clean production chunks', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: false,
+      consoleReplayScript: 'console.log("clean production replay")',
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'production',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('<script>console.log("clean production replay")</script>');
   });
 
   it('includes full renderingError in diagnostic metadata in development', async () => {
@@ -594,6 +622,7 @@ describe('injectRSCPayload', () => {
         message: 'useState is not a function',
         stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
       },
+      consoleReplayScript: 'console.error("development diagnostic replay")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -607,6 +636,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain('useState is not a function');
     expect(resultStr).toContain('Broken.server.tsx');
     expect(resultStr).toContain('renderingError');
+    expect(resultStr).toContain('<script>console.error("development diagnostic replay")</script>');
   });
 
   it('promotes streamed RSC client chunk stylesheet preloads to gate reveal', async () => {

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1451,12 +1451,10 @@ module ReactOnRailsProHelper
     error_signal = rsc_payload_rendering_error_signal?(metadata)
     return metadata unless error_signal || metadata.key?("renderingError")
 
-    redacted = metadata.except("renderingError")
-    # Preserve a generic failure signal so client error boundaries still fire. `hasErrors` is
-    # forced true when only a non-blank message/stack indicated the failure, matching the
-    # inline path's redacted branch.
-    redacted["hasErrors"] = true if error_signal
-    redacted
+    # Match the inline path's production allowlist exactly. Error chunks may carry sensitive
+    # details in console replay or future metadata fields, so forwarding every field except the
+    # known renderingError key would fail open as the producer evolves.
+    { "hasErrors" => error_signal }
   end
 
   def rsc_payload_rendering_error_signal?(metadata)

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -755,6 +755,9 @@ describe ReactOnRailsProHelper do
     let(:synthetic_stack) do
       "Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)"
     end
+    let(:synthetic_console_replay_script) do
+      'console.error("RSC fetch failed for User 48213 at /app/components/Auth.server.tsx:12:5")'
+    end
     let(:rendering_error) { { "message" => synthetic_message, "stack" => synthetic_stack } }
     let(:error_chunk) do
       { "hasErrors" => true, "renderingError" => rendering_error, "html" => "payload" }
@@ -803,6 +806,30 @@ describe ReactOnRailsProHelper do
       expect(wire).not_to include("Auth.server.tsx")
     end
 
+    it "allowlists only a generic error signal in production browser metadata" do
+      stub_rails_env("production")
+      server_metadata = error_chunk.merge(
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" }
+      )
+      seen_by_server = nil
+
+      wire = framed_wire_bytes(server_metadata) do |chunk|
+        seen_by_server = chunk
+        chunk
+      end
+
+      expect(wire).to eq("{\"hasErrors\":true}\t00000007\npayload")
+      expect(wire).not_to include(synthetic_message)
+      expect(wire).not_to include("/srv/private/Auth.server.tsx")
+      expect(wire).not_to include(synthetic_console_replay_script)
+      expect(seen_by_server).to include(
+        "renderingError" => rendering_error,
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" }
+      )
+    end
+
     it "redacts renderingError in non-development/test environments like staging" do
       stub_rails_env("staging")
 
@@ -843,14 +870,16 @@ describe ReactOnRailsProHelper do
       expect(wire).to eq("{\"hasErrors\":false}\t00000007\npayload")
     end
 
-    it "includes the full renderingError in development" do
+    it "includes full error and console diagnostics in development" do
       stub_rails_env("development")
 
-      wire = framed_wire_bytes(error_chunk)
+      wire = framed_wire_bytes(error_chunk.merge("consoleReplayScript" => synthetic_console_replay_script))
+      metadata = JSON.parse(wire.split("\t", 2).first)
 
       expect(wire).to include("renderingError")
       expect(wire).to include(synthetic_message)
       expect(wire).to include("Auth.server.tsx")
+      expect(metadata["consoleReplayScript"]).to eq(synthetic_console_replay_script)
     end
 
     it "includes the full renderingError in test" do


### PR DESCRIPTION
## Why

Production RSC responses had two browser-facing paths that could disclose server-only diagnostics:

- fetched payload framing removed `renderingError` but forwarded other metadata such as console replay and future diagnostic fields;
- inline payload HTML redacted the diagnostic object but separately emitted an error chunk's console replay script.

This closes Issues #4822 and #4827 without weakening the upstream metadata used by Rails error transformation or the Node renderer reporter.

## What changed

- Make fetched production error metadata fail closed with the same generic `hasErrors` allowlist used by the inline path.
- Suppress console replay only for error-bearing inline chunks outside development/test.
- Preserve development/test diagnostics and clean production-chunk replay.
- Add focused Ruby and Jest regressions through the final browser-visible boundaries.

## Review path

1. Review the fetched payload allowlist in `react_on_rails_pro_helper.rb` and its framing spec.
2. Review error-chunk replay gating in `injectRSCPayload.ts` and its final-output Jest cases.
3. Confirm shared producers, server reporters, public API, and configuration are unchanged.

## Validation

- Focused fetched-path RSpec: 11 examples, 0 failures.
- Final inline-path Jest: 83 tests, 0 failures.
- Pro typecheck, source ESLint, full Pro RuboCop (247 files), Pro license headers (873 files), Prettier, Lychee 0.23.0, and diff checks passed.
- Final combined Sol/xhigh review against `origin/release/17.1.0` found no introduced defects.
- Independent production sink validation confirmed the pre-fix inline disclosure and the server-reporter separation.
- The whole helper file remains baseline-degraded because generated renderer bundles are absent locally; all 11 changed helper examples pass.
- Exact-head hosted CI and independent batch QA are pending.

Fixes #4822.
Fixes #4827.

<details>
<summary>Agent details</summary>

- Batch: `ror-17-1-security-stabilizers-20260803`
- Release mode: `strict-rc`; phase: `rc`
- Merge authority: `ask`
- Publication authority: none
- Preferred maker/checker route: `gpt-5.6-sol/xhigh`; observed maker host/model/effort: `codex/UNKNOWN/UNKNOWN`
- Decision: #4822 and #4827 share one browser-boundary fix lane; no separate #4827 PR.
- Labels: exact-head hosted CI requested after the final push.
- Changelog classification: `Pro runtime`; the existing Unreleased entry now covers fetched and inline browser boundaries and links this PR.

### Audit receipts

Pending final exact-head QA and merge-ledger receipts.

</details>
