### PR TITLE
Prevent typo-scheme renderer credential leaks

### DIFF
--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -166,7 +166,10 @@ module ReactOnRails
           # file_url_to_string have passed through the same message sanitizer; scanning that
           # wrapper again would treat its diagnostic text as fresh untrusted input. Other errors
           # are scrubbed here because URI::InvalidURIError embeds the raw URL in its message.
-          sanitized_url = sanitized_renderer_url(server_js_file)
+          sanitized_url = sanitized_renderer_url(
+            server_js_file,
+            preserve_filesystem_path: !server_bundle_path_is_http
+          )
           sanitized_error = if server_bundle_path_is_http && e.is_a?(ReactOnRails::ServerBundleLoadError)
                               e.message
                             else
@@ -388,14 +391,7 @@ module ReactOnRails
             value = ENV.fetch(var, nil)
             next if value.nil? || value.empty?
 
-            leading_scheme = value.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)&.begin(0)&.zero?
-            userinfo_delimiter = value.rindex("@")
-            sanitized_url = if !leading_scheme && userinfo_delimiter
-                              value[(userinfo_delimiter + 1)..]
-                            else
-                              sanitized_renderer_url(value)
-                            end
-            return [var, sanitized_url]
+            return [var, sanitized_renderer_url(value, strict_schemeless: true)]
           end
           [nil, nil]
         end
@@ -422,11 +418,14 @@ module ReactOnRails
         # schemes or line breaks after its first scheme make it structurally ambiguous, so that URL
         # suffix fails closed through its final @. A safe non-URL prefix is preserved for context,
         # while a pre-scheme @ makes that prefix ambiguous credential material and fails closed.
-        def sanitized_renderer_url(url)
-          return url if url.nil? || url.empty?
+        def sanitized_renderer_url(url, preserve_filesystem_path: false, strict_schemeless: false)
+          return url if passthrough_renderer_url?(url, preserve_filesystem_path)
+
+          ambiguous_url = sanitized_ambiguous_renderer_url(url, strict_schemeless)
+          return ambiguous_url if ambiguous_url
 
           scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
-          return sanitized_schemeless_authority(url) unless scheme
+          return sanitized_schemeless_authority(url, strict_schemeless:) unless scheme
 
           prefix = url[...scheme.begin(0)]
           configured_url = url[scheme.begin(0)..]
@@ -442,15 +441,51 @@ module ReactOnRails
           "#{prefix}#{sanitized_url}"
         end
 
-        def sanitized_schemeless_authority(url)
+        def passthrough_renderer_url?(url, preserve_filesystem_path)
+          url.nil? || url.empty? || (preserve_filesystem_path && explicit_filesystem_path?(url))
+        end
+
+        def sanitized_ambiguous_renderer_url(url, strict_schemeless)
+          scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
+          return unless scheme
+
+          candidate = ambiguous_renderer_url_candidate(url, scheme, strict_schemeless)
+          sanitized_renderer_url(candidate, strict_schemeless:) if candidate
+        end
+
+        def ambiguous_renderer_url_candidate(url, scheme, strict_schemeless)
+          prefix = url[...scheme.begin(0)]
+          configured_url = url[scheme.begin(0)..]
+          userinfo_delimiter = url.rindex("@")
+          return url[(userinfo_delimiter + 1)..] if
+            embedded_http_scheme_in_schemeless_userinfo?(scheme, prefix, userinfo_delimiter)
+          return unless scheme.begin(0).positive? && userinfo_delimiter &&
+                        (strict_schemeless || (prefix.include?(":") && !prefix.end_with?(":")))
+
+          userinfo_delimiter < scheme.begin(0) ? configured_url : url[(userinfo_delimiter + 1)..]
+        end
+
+        def sanitized_schemeless_authority(url, strict_schemeless: false)
           userinfo_delimiter = url.rindex("@")
           return url unless userinfo_delimiter
 
           userinfo = url[...userinfo_delimiter]
-          return url unless userinfo.include?(":")
-          return url if userinfo.match?(%r{[/\\]})
+          return url unless strict_schemeless || userinfo.include?(":")
 
           url[(userinfo_delimiter + 1)..]
+        end
+
+        def embedded_http_scheme_in_schemeless_userinfo?(scheme, prefix, userinfo_delimiter)
+          return false unless userinfo_delimiter && userinfo_delimiter > scheme.end(0)
+          return false unless prefix.end_with?(":")
+
+          scheme[0].delete_suffix("://").match?(/.+https?\z/i)
+        end
+
+        def explicit_filesystem_path?(url)
+          (url.start_with?("/") && !url.start_with?("//")) ||
+            url.start_with?("./", "../", ".\\", "..\\", "\\\\") ||
+            url.match?(%r{\A[A-Za-z]:[/\\]})
         end
 
         def ambiguous_credential_prefix?(prefix, configured_url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -317,6 +317,9 @@ module ReactOnRails
 
         def renderer_connection_error_message(err)
           target = renderer_target_from_error(err)
+          caught_error = err.message.to_s
+          raw_target = target_from_message(caught_error)
+          caught_error = sanitized_renderer_error_message(caught_error, raw_target) if raw_target
           configured_var, configured_url = configured_renderer_url
           configured_line = if configured_url
                               "#{configured_var} is currently \"#{configured_url}\" — confirm it matches the " \
@@ -330,7 +333,7 @@ module ReactOnRails
             React on Rails could not connect to the Node renderer#{" at #{target}" if target}.
             ===============================================================
             Caught error:
-            #{err.message}
+            #{caught_error}
             ===============================================================
             This is a renderer connection failure, not a webpack/server-bundle evaluation error.
             The bundle was not evaluated because the renderer could not be reached.

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -403,7 +403,7 @@ module ReactOnRails
         def target_from_message(message)
           message = message.to_s
           [
-            /\AConnection error on renderer request:\s*(?<target>[^\s,)]+)\s*\z/i,
+            /\A(?:Connection|Time out) error on renderer request:\s*(?<target>[^\s,)]+)\s*\z/i,
             /connect\(2\) for (?<target>[^\s,)]+)/,
             /TCP connection to (?<target>[^\s,)]+)/,
             %r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i,

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -45,6 +45,8 @@ module ReactOnRails
         | error\son\srenderer\srequest
       /xi
 
+      CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[a-z][a-z0-9+.-]*://}i
+
       class << self
         def reset_pool
           @js_context_pool = ConnectionPool.new(
@@ -400,24 +402,26 @@ module ReactOnRails
           nil
         end
 
-        # Strips any embedded credentials from a configured renderer URL before it is
-        # interpolated into an error message, so a password in the URL (a supported config
-        # convenience, e.g. https://:password@host:3800) cannot leak into logs or error
-        # trackers. One configured value is not free-form prose: multiple schemes or line breaks
-        # after its first scheme make it structurally ambiguous, so that URL suffix fails closed
-        # through its final @. Any non-URL prefix is preserved for useful error context.
+        # Strips embedded credentials from a configured renderer value before it is interpolated
+        # into an error message. HTTP(S) credentials are supported configuration, while a
+        # syntactically scheme-like typo or unsupported authority is still sanitized so malformed
+        # configuration cannot leak secrets. One configured value is not free-form prose: multiple
+        # schemes or line breaks after its first scheme make it structurally ambiguous, so that URL
+        # suffix fails closed through its final @. Any non-URL prefix is preserved for context.
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
 
-          scheme = url.match(%r{https?://}i)
+          scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
           return url unless scheme
 
           prefix = url[...scheme.begin(0)]
           configured_url = url[scheme.begin(0)..]
-          sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(%r{https?://}i).length > 1
+          sanitized_url = if configured_url.match?(/[\r\n]/) ||
+                             configured_url.scan(CONFIGURED_AUTHORITY_SCHEME_REGEX).length > 1
                             strip_malformed_url_userinfo(configured_url)
                           else
-                            sanitized_valid_http_url(configured_url) || strip_malformed_url_userinfo(configured_url)
+                            sanitized_valid_authority_url(configured_url) ||
+                              strip_malformed_url_userinfo(configured_url)
                           end
 
           "#{prefix}#{sanitized_url}"
@@ -447,7 +451,7 @@ module ReactOnRails
 
           text.to_enum(:scan, %r{https?://(?:(?!https?://)[^\s"'])+}i).each do
             match = Regexp.last_match
-            protected_url = sanitized_valid_http_url(match[0])
+            protected_url = sanitized_valid_authority_url(match[0])
             next unless protected_url
             next if userinfo_delimiter_before_next_scheme?(text, match)
 
@@ -474,11 +478,18 @@ module ReactOnRails
           text[...unresolved_scheme.begin(0)]
         end
 
-        # URI handles valid URLs structurally, so an @ in the path is never mistaken for userinfo.
-        # Returning nil for invalid input keeps that token unprotected for the fail-closed pass.
-        def sanitized_valid_http_url(url)
+        # URI handles valid authority URLs structurally, so an @ in the path is never mistaken for
+        # userinfo. Some scheme-specific parsers, such as URI::File, discard authority credentials
+        # while exposing no userinfo; use their serialized value only when the raw authority contained
+        # an @ so ordinary scheme spelling and valid path @ characters remain unchanged. Returning nil
+        # for invalid input keeps that token unprotected for fail-closed handling.
+        def sanitized_valid_authority_url(url)
           uri = URI.parse(url)
-          return url if uri.userinfo.nil?
+          if uri.userinfo.nil?
+            scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
+            authority = url[scheme.end(0)..].split(%r{[/?#]}, 2).first
+            return authority&.include?("@") ? uri.to_s : url
+          end
 
           # URI rejects a password without a user, so clear password first.
           uri.password = nil
@@ -495,9 +506,9 @@ module ReactOnRails
         # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The
         # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
         def strip_malformed_url_userinfo(url)
-          scheme = url.match(%r{\Ahttps?://}i)
+          scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
           userinfo_delimiter = url.rindex("@")
-          return url unless scheme && userinfo_delimiter
+          return url unless scheme&.begin(0)&.zero? && userinfo_delimiter
 
           "#{url[...scheme.end(0)]}#{url[(userinfo_delimiter + 1)..]}"
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -518,6 +518,7 @@ module ReactOnRails
               next
             end
 
+            same_line = same_family_target_segment(same_line, prefix_regex, allow_request_path:)
             target = renderer_target_candidate(same_line, allow_request_path:)
             unless target
               start_at = prefix.end(0)
@@ -527,6 +528,19 @@ module ReactOnRails
             yield [target, prefix.end(0)...(prefix.end(0) + target.length)]
             start_at = prefix.end(0)
           end
+        end
+
+        def same_family_target_segment(same_line, prefix_regex, allow_request_path:)
+          next_prefix = prefix_regex.match(same_line)
+          return same_line unless next_prefix
+
+          prefix_lead = same_line[...next_prefix.begin(0)]
+          separator = prefix_lead.rindex(/[.;,](?=\s)/)
+          return same_line unless separator
+
+          segment = same_line[...separator].rstrip
+          first_target = segment[RENDERER_TARGET_AT_LINE_START_REGEX, :target]
+          recognized_renderer_target?(first_target, allow_request_path:) ? segment : same_line
         end
 
         def renderer_target_candidate(same_line, allow_request_path:)
@@ -733,7 +747,9 @@ module ReactOnRails
           while current_target
             current_range, current_sanitized_target = current_target
             sanitized << strip_userinfo(message[cursor...current_range.begin])
-            if delayed_userinfo_after_target?(message, current_range)
+            next_target = immediately_following_http_target(message, current_range.end) ||
+                          target_with_range_from_message(message, current_range.end)
+            if delayed_userinfo_after_target?(message, current_range, next_target)
               sanitized << strip_userinfo(message[current_range.begin..])
               return sanitized
             end
@@ -741,8 +757,6 @@ module ReactOnRails
             sanitized << current_sanitized_target
             cursor = current_range.end
 
-            next_target = immediately_following_http_target(message, cursor) ||
-                          target_with_range_from_message(message, cursor)
             current_target = if next_target
                                next_raw_target, next_range = next_target
                                [next_range, sanitized_renderer_target(next_raw_target)]
@@ -752,12 +766,14 @@ module ReactOnRails
           sanitized << strip_userinfo(message[cursor..])
         end
 
-        def delayed_userinfo_after_target?(message, target_range)
+        def delayed_userinfo_after_target?(message, target_range, next_target)
           continuation = message[target_range.end..]
           return false if safe_notification_email_prose?(continuation)
 
-          boundary = continuation.match(%r{https?://}i)
-          continuation = continuation[...boundary.begin(0)] if boundary
+          scheme_boundary = continuation.match(%r{https?://}i)&.begin(0)
+          target_boundary = next_target.last.begin - target_range.end if next_target
+          boundary = [scheme_boundary, target_boundary].compact.min
+          continuation = continuation[...boundary] if boundary
           continuation.include?("@")
         end
 

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -168,7 +168,8 @@ module ReactOnRails
           # are scrubbed here because URI::InvalidURIError embeds the raw URL in its message.
           sanitized_url = sanitized_renderer_url(
             server_js_file,
-            preserve_filesystem_path: !server_bundle_path_is_http
+            preserve_filesystem_path: !server_bundle_path_is_http,
+            strict_schemeless: true
           )
           sanitized_error = if server_bundle_path_is_http && e.is_a?(ReactOnRails::ServerBundleLoadError)
                               e.message
@@ -402,6 +403,7 @@ module ReactOnRails
         def target_from_message(message)
           message = message.to_s
           [
+            /\AConnection error on renderer request:\s*(?<target>[^\s,)]+)\s*\z/i,
             /connect\(2\) for (?<target>[^\s,)]+)/,
             /TCP connection to (?<target>[^\s,)]+)/,
             %r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i,
@@ -425,7 +427,7 @@ module ReactOnRails
         def sanitized_renderer_url(url, preserve_filesystem_path: false, strict_schemeless: false)
           return url if passthrough_renderer_url?(url, preserve_filesystem_path)
 
-          ambiguous_url = sanitized_ambiguous_renderer_url(url, strict_schemeless)
+          ambiguous_url = sanitized_ambiguous_renderer_url(url, strict_schemeless, preserve_filesystem_path)
           return ambiguous_url if ambiguous_url
 
           scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
@@ -449,13 +451,25 @@ module ReactOnRails
           url.nil? || url.empty? || (preserve_filesystem_path && explicit_filesystem_path?(url))
         end
 
-        def sanitized_ambiguous_renderer_url(url, strict_schemeless)
+        def sanitized_ambiguous_renderer_url(url, strict_schemeless, preserve_filesystem_path)
           scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
           return unless scheme
 
           candidate = embedded_http_url_candidate(url, scheme)
-          candidate ||= ambiguous_renderer_url_candidate(url, scheme, strict_schemeless)
+          candidate ||= unknown_apparent_scheme_candidate(url, scheme)
+          strict_prefix = strict_schemeless && !preserve_filesystem_path
+          candidate ||= ambiguous_renderer_url_candidate(url, scheme, strict_prefix)
           sanitized_renderer_url(candidate, strict_schemeless:) if candidate
+        end
+
+        def unknown_apparent_scheme_candidate(url, scheme)
+          userinfo_delimiter = url.rindex("@")
+          return unless scheme.begin(0).zero? && userinfo_delimiter && userinfo_delimiter >= scheme.end(0)
+
+          scheme_name = scheme[0].delete_suffix("://").upcase
+          return if URI.scheme_list.key?(scheme_name)
+
+          url[(userinfo_delimiter + 1)..]
         end
 
         def ambiguous_renderer_url_candidate(url, scheme, strict_schemeless)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -443,28 +443,74 @@ module ReactOnRails
 
         def target_with_range_from_message(message, start_at = 0)
           message = message.to_s
-          target = target_with_range_after_prefix(message, CONNECT_TARGET_PREFIX_REGEX, start_at:)
-          return target if target
+          candidates = target_candidates_from_message(message, start_at)
 
-          target = target_with_range_after_prefix(message, TCP_CONNECTION_TARGET_PREFIX_REGEX, start_at:)
-          return target if target
+          # Array order is the specificity tie-breaker: an anchored renderer/socket prefix
+          # wins over a generic URL candidate when both identify a target at the same offset.
+          candidates.each_with_index
+                    .reject { |candidate, _priority| candidate.nil? }
+                    .min_by { |candidate, priority| [candidate.last.begin, priority] }
+                    &.first
+        end
 
-          match = message.match(%r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i, start_at)
-          return [match[:target], match.begin(:target)...match.end(:target)] if match
+        def target_candidates_from_message(message, start_at)
+          connect_target = each_target_with_range_after_prefix(message, CONNECT_TARGET_PREFIX_REGEX, start_at:).first
+          tcp_target = each_target_with_range_after_prefix(message, TCP_CONNECTION_TARGET_PREFIX_REGEX, start_at:).first
+          wrapper_target = preferred_wrapper_target_with_range(message, start_at)
+          embedded_http_target = target_with_range_for_match(
+            message.match(%r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i, start_at)
+          )
+          socket_targets = [connect_target, tcp_target].compact
+          authority_targets = socket_targets + Array(embedded_http_target)
+          authority_targets << wrapper_target if wrapper_authority_target?(wrapper_target)
+          wrapper_target = nil if wrapper_target_deferred?(wrapper_target, authority_targets, socket_targets)
 
-          target = target_with_range_after_prefix(
+          structured_targets = [connect_target, tcp_target, wrapper_target, embedded_http_target].compact
+          return structured_targets unless structured_targets.empty?
+
+          [target_with_range_for_match(message.match(%r{(?<target>https?://[^\s,"')]+)}, start_at))]
+        end
+
+        def preferred_wrapper_target_with_range(message, start_at)
+          fallback = nil
+          each_target_with_range_after_prefix(
             message,
             RENDERER_REQUEST_WRAPPER_PREFIX_REGEX,
             allow_request_path: true,
             start_at:
-          )
-          return target if target
+          ).each do |candidate|
+            fallback ||= candidate
+            return candidate if wrapper_authority_target?(candidate) && !explicit_filesystem_path?(candidate.first)
+          end
+          fallback
+        end
 
-          match = message.match(%r{(?<target>https?://[^\s,"')]+)}, start_at)
+        def wrapper_authority_target?(candidate)
+          return false unless candidate
+
+          target = candidate.first
+          target.include?("@") || recognized_renderer_target?(target, allow_request_path: false)
+        end
+
+        def wrapper_target_deferred?(wrapper_target, authority_targets, socket_targets)
+          return false unless wrapper_target && authority_targets.any?
+
+          target, range = wrapper_target
+          nested_socket_target = socket_targets.any? do |candidate|
+            range.cover?(candidate.last.begin)
+          end
+          return true if nested_socket_target || explicit_filesystem_path?(target)
+
+          !target.include?("@") && !recognized_renderer_target?(target, allow_request_path: false)
+        end
+
+        def target_with_range_for_match(match)
           [match[:target], match.begin(:target)...match.end(:target)] if match
         end
 
-        def target_with_range_after_prefix(message, prefix_regex, allow_request_path: false, start_at: 0)
+        def each_target_with_range_after_prefix(message, prefix_regex, allow_request_path: false, start_at: 0)
+          return enum_for(__method__, message, prefix_regex, allow_request_path:, start_at:) unless block_given?
+
           while (prefix = prefix_regex.match(message, start_at))
             same_line = message[prefix.end(0)..].to_s.split(/[\r\n]/, 2).first
             if same_line.nil? || same_line.empty?
@@ -478,9 +524,9 @@ module ReactOnRails
               next
             end
 
-            return [target, prefix.end(0)...(prefix.end(0) + target.length)]
+            yield [target, prefix.end(0)...(prefix.end(0) + target.length)]
+            start_at = prefix.end(0)
           end
-          nil
         end
 
         def renderer_target_candidate(same_line, allow_request_path:)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -46,7 +46,10 @@ module ReactOnRails
 
       RENDERER_REQUEST_WRAPPER_REGEX = /
         (?:(?:Connection|Time\sout)\s)?error\son\srenderer\srequest:
-        \s*(?<target>[^\s,)]+)
+        \s*(?<target>
+          (?=[^\s)]*@)[^\s)]*@[^\s,)]+
+          | [^\s,)]+
+        )
       /xi
 
       CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[^:/\s"'?=#@]*://}

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -45,7 +45,7 @@ module ReactOnRails
         | error\son\srenderer\srequest
       /xi
 
-      CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[a-z][a-z0-9+._-]*://}i
+      CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[^/\s"'?=#@]*://}
 
       class << self
         def reset_pool
@@ -484,13 +484,17 @@ module ReactOnRails
         # structurally ambiguous because a delimiter may have hidden malformed userinfo from the
         # parser. Returning nil keeps that token unprotected for the caller's fail-closed pass.
         def sanitized_valid_authority_url(url, fail_closed_after_authority: false)
+          scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
+          scheme_suffix = url[scheme.end(0)..]
+          authority_boundary = scheme_suffix.index(%r{[/?#]})
+          if fail_closed_after_authority && authority_boundary && scheme_suffix[authority_boundary..].include?("@")
+            return nil
+          end
+
           uri = URI.parse(url)
           if uri.userinfo.nil?
-            scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
-            scheme_suffix = url[scheme.end(0)..]
             authority = scheme_suffix.split(%r{[/?#]}, 2).first
             return uri.to_s if authority&.include?("@")
-            return nil if fail_closed_after_authority && scheme_suffix.include?("@")
 
             return url
           end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -401,6 +401,7 @@ module ReactOnRails
           [
             /connect\(2\) for (?<target>[^\s,)]+)/,
             /TCP connection to (?<target>[^\s,)]+)/,
+            %r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i,
             %r{(?<target>https?://[^\s,"')]+)}
           ].each do |regex|
             match = message.match(regex)
@@ -449,7 +450,8 @@ module ReactOnRails
           scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
           return unless scheme
 
-          candidate = ambiguous_renderer_url_candidate(url, scheme, strict_schemeless)
+          candidate = embedded_http_url_candidate(url, scheme)
+          candidate ||= ambiguous_renderer_url_candidate(url, scheme, strict_schemeless)
           sanitized_renderer_url(candidate, strict_schemeless:) if candidate
         end
 
@@ -463,6 +465,22 @@ module ReactOnRails
                         (strict_schemeless || (prefix.include?(":") && !prefix.end_with?(":")))
 
           userinfo_delimiter < scheme.begin(0) ? configured_url : url[(userinfo_delimiter + 1)..]
+        end
+
+        def embedded_http_url_candidate(url, scheme)
+          userinfo_delimiter = url.rindex("@")
+          return unless userinfo_delimiter && userinfo_delimiter >= scheme.end(0)
+
+          scheme_name = scheme[0].delete_suffix("://")
+          embedded_http_scheme = scheme_name.match(/https?\z/i)
+          return unless embedded_http_scheme&.begin(0)&.positive?
+
+          prefix = url[...scheme.begin(0)]
+          configured_url = url[scheme.begin(0)..]
+          return if ambiguous_credential_prefix?(prefix, configured_url)
+
+          embedded_scheme_start = scheme.begin(0) + embedded_http_scheme.begin(0)
+          "#{prefix}#{url[embedded_scheme_start..]}"
         end
 
         def sanitized_schemeless_authority(url, strict_schemeless: false)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -426,8 +426,8 @@ module ReactOnRails
           return url unless scheme
 
           prefix = url[...scheme.begin(0)]
-          prefix = "" if prefix.include?("@")
           configured_url = url[scheme.begin(0)..]
+          prefix = "" if ambiguous_credential_prefix?(prefix, configured_url)
           sanitized_url = if configured_url.match?(/[\r\n]/) ||
                              configured_url.scan(CONFIGURED_AUTHORITY_SCHEME_REGEX).length > 1
                             strip_malformed_url_userinfo(configured_url)
@@ -437,6 +437,13 @@ module ReactOnRails
                           end
 
           "#{prefix}#{sanitized_url}"
+        end
+
+        def ambiguous_credential_prefix?(prefix, configured_url)
+          return true if prefix.include?("@")
+          return false unless configured_url.include?("@")
+
+          prefix.include?(":")
         end
 
         def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -423,7 +423,7 @@ module ReactOnRails
           return url if url.nil? || url.empty?
 
           scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
-          return url unless scheme
+          return sanitized_schemeless_authority(url) unless scheme
 
           prefix = url[...scheme.begin(0)]
           configured_url = url[scheme.begin(0)..]
@@ -437,6 +437,17 @@ module ReactOnRails
                           end
 
           "#{prefix}#{sanitized_url}"
+        end
+
+        def sanitized_schemeless_authority(url)
+          userinfo_delimiter = url.rindex("@")
+          return url unless userinfo_delimiter
+
+          userinfo = url[...userinfo_delimiter]
+          return url unless userinfo.include?(":")
+          return url if userinfo.match?(%r{[/\\]})
+
+          url[(userinfo_delimiter + 1)..]
         end
 
         def ambiguous_credential_prefix?(prefix, configured_url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -377,12 +377,22 @@ module ReactOnRails
 
         # Resolves the configured renderer URL and the env var it came from, so the headline
         # target and the checklist line stay consistent. A blank (present-but-empty) value is
-        # treated as unset, and the legacy RENDERER_URL alias is the fallback. Credentials are
-        # stripped for safe display. Returns [var_name, sanitized_url] or [nil, nil].
+        # treated as unset, and the legacy RENDERER_URL alias is the fallback. Credentials,
+        # including userinfo on a scheme-less authority, are stripped for safe display. Returns
+        # [var_name, sanitized_url] or [nil, nil].
         def configured_renderer_url
           %w[REACT_RENDERER_URL RENDERER_URL].each do |var|
             value = ENV.fetch(var, nil)
-            return [var, sanitized_renderer_url(value)] unless value.nil? || value.empty?
+            next if value.nil? || value.empty?
+
+            leading_scheme = value.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)&.begin(0)&.zero?
+            userinfo_delimiter = value.rindex("@")
+            sanitized_url = if !leading_scheme && userinfo_delimiter
+                              value[(userinfo_delimiter + 1)..]
+                            else
+                              sanitized_renderer_url(value)
+                            end
+            return [var, sanitized_url]
           end
           [nil, nil]
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -47,9 +47,13 @@ module ReactOnRails
       RENDERER_REQUEST_WRAPPER_REGEX = /
         (?:(?:Connection|Time\sout)\s)?error\son\srenderer\srequest:
         \s*(?<target>
-          (?=[^\s)]*@)[^\s)]*@[^\s,)]+
+          (?=[^\s]*@)[^\s]*@[^\s,)]+
           | [^\s,)]+
         )
+      /xi
+
+      TARGETLESS_RENDERER_REQUEST_WRAPPER_REGEX = /
+        \A(?:(?:Connection|Time\sout)\s)?error\son\srenderer\srequest:?\s*\z
       /xi
 
       CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[^:/\s"'?=#@]*://}
@@ -312,7 +316,8 @@ module ReactOnRails
           each_in_cause_chain(err) do |current|
             message = current.message.to_s
             return true if message.match?(RENDERER_CONNECTION_ERROR_REGEX) ||
-                           message.match?(RENDERER_REQUEST_WRAPPER_REGEX)
+                           message.match?(RENDERER_REQUEST_WRAPPER_REGEX) ||
+                           message.match?(TARGETLESS_RENDERER_REQUEST_WRAPPER_REGEX)
           end
           false
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -44,12 +44,17 @@ module ReactOnRails
         | Failed\sto\sopen\sTCP\sconnection
       /xi
 
+      RENDERER_TARGET_TOKEN_REGEX = /
+        (?=[^\s]*@)[^\s]*@[^\s,)]+
+        | [^\s,)]+
+      /x
+
+      CONNECT_TARGET_REGEX = /connect\(2\) for (?<target>#{RENDERER_TARGET_TOKEN_REGEX})/
+      TCP_CONNECTION_TARGET_REGEX = /TCP connection to (?<target>#{RENDERER_TARGET_TOKEN_REGEX})/
+
       RENDERER_REQUEST_WRAPPER_REGEX = /
         (?:(?:Connection|Time\sout)\s)?error\son\srenderer\srequest:
-        \s*(?<target>
-          (?=[^\s]*@)[^\s]*@[^\s,)]+
-          | [^\s,)]+
-        )
+        \s*(?<target>#{RENDERER_TARGET_TOKEN_REGEX})
       /xi
 
       TARGETLESS_RENDERER_REQUEST_WRAPPER_REGEX = /
@@ -421,8 +426,8 @@ module ReactOnRails
         def target_from_message(message)
           message = message.to_s
           [
-            /connect\(2\) for (?<target>[^\s,)]+)/,
-            /TCP connection to (?<target>[^\s,)]+)/,
+            CONNECT_TARGET_REGEX,
+            TCP_CONNECTION_TARGET_REGEX,
             %r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i,
             RENDERER_REQUEST_WRAPPER_REGEX,
             %r{(?<target>https?://[^\s,"')]+)}
@@ -471,7 +476,10 @@ module ReactOnRails
         end
 
         def passthrough_renderer_url?(url, preserve_filesystem_path)
-          url.nil? || url.empty? || (preserve_filesystem_path && explicit_filesystem_path?(url))
+          return true if url.nil? || url.empty?
+
+          preserve_filesystem_path &&
+            (explicit_filesystem_path?(url) || explicit_scoped_package_path?(url))
         end
 
         def sanitized_ambiguous_renderer_url(url, strict_schemeless, preserve_filesystem_path)
@@ -544,6 +552,10 @@ module ReactOnRails
           (url.start_with?("/") && !url.start_with?("//")) ||
             url.start_with?("./", "../", ".\\", "..\\", "\\\\") ||
             url.match?(%r{\A[A-Za-z]:[/\\]})
+        end
+
+        def explicit_scoped_package_path?(url)
+          url.match?(%r{\A(?:node_modules/)?@[A-Za-z0-9._-]+/[A-Za-z0-9._-]+(?:/[^/\s@]+)*\z})
         end
 
         def ambiguous_credential_prefix?(prefix, configured_url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -322,7 +322,10 @@ module ReactOnRails
           target = renderer_target_from_error(err)
           caught_error = err.message.to_s
           raw_target = target_from_message(caught_error)
-          caught_error = sanitized_renderer_error_message(caught_error, raw_target) if raw_target
+          if raw_target
+            sanitized_target = sanitized_renderer_url(raw_target, strict_schemeless: true)
+            caught_error = sanitized_renderer_error_message(caught_error, raw_target, sanitized_target)
+          end
           configured_var, configured_url = configured_renderer_url
           configured_line = if configured_url
                               "#{configured_var} is currently \"#{configured_url}\" — confirm it matches the " \
@@ -376,7 +379,7 @@ module ReactOnRails
             target = target_from_message(current.message)
             # Sanitize here too: a target scraped from the message can itself be a full URL
             # with embedded credentials (e.g. "TCP connection to https://user:pw@host:3800").
-            return sanitized_renderer_url(target) if target
+            return sanitized_renderer_url(target, strict_schemeless: true) if target
           end
           configured_renderer_url.last
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -473,7 +473,10 @@ module ReactOnRails
 
         def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
           unresolved_scheme = text.match(%r{https?://}i)
-          return strip_unprotected_userinfo(text) if raw_url == sanitized_url || unresolved_scheme.nil?
+          return strip_unprotected_userinfo(text) if unresolved_scheme.nil?
+
+          empty_userinfo_url = raw_url.match?(%r{\Ahttps?://@[^@/?#]*(?:[/?#]|\z)}i)
+          return strip_unprotected_userinfo(text) if raw_url == sanitized_url && !empty_userinfo_url
 
           text[...unresolved_scheme.begin(0)]
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -345,10 +345,20 @@ module ReactOnRails
         def renderer_connection_error_message(err)
           target = renderer_target_from_error(err)
           caught_error = err.message.to_s
-          raw_target = target_from_message(caught_error)
-          if raw_target
+          target_with_range = target_with_range_from_message(caught_error)
+          if target_with_range
+            raw_target, target_range = target_with_range
             sanitized_target = sanitized_renderer_target(raw_target)
-            caught_error = sanitized_renderer_error_message(caught_error, raw_target, sanitized_target)
+            caught_error = sanitized_renderer_target_error_message(
+              caught_error,
+              raw_target,
+              sanitized_target,
+              target_range
+            )
+          end
+          sanitized_caught_target = target_from_message(caught_error)
+          if sanitized_caught_target && !explicit_filesystem_path?(sanitized_caught_target)
+            target = sanitized_renderer_target(sanitized_caught_target)
           end
           configured_var, configured_url = configured_renderer_url
           configured_line = if configured_url
@@ -428,36 +438,80 @@ module ReactOnRails
         end
 
         def target_from_message(message)
-          message = message.to_s
-          target = target_after_prefix(message, CONNECT_TARGET_PREFIX_REGEX)
-          return target if target
-
-          target = target_after_prefix(message, TCP_CONNECTION_TARGET_PREFIX_REGEX)
-          return target if target
-
-          match = message.match(%r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i)
-          return match[:target] if match
-
-          target = target_after_prefix(message, RENDERER_REQUEST_WRAPPER_PREFIX_REGEX, allow_request_path: true)
-          return target if target
-
-          message[%r{(?<target>https?://[^\s,"')]+)}, :target]
+          target_with_range_from_message(message)&.first
         end
 
-        def target_after_prefix(message, prefix_regex, allow_request_path: false)
-          message.to_enum(:scan, prefix_regex).each do
-            prefix = Regexp.last_match
+        def target_with_range_from_message(message, start_at = 0)
+          message = message.to_s
+          target = target_with_range_after_prefix(message, CONNECT_TARGET_PREFIX_REGEX, start_at:)
+          return target if target
+
+          target = target_with_range_after_prefix(message, TCP_CONNECTION_TARGET_PREFIX_REGEX, start_at:)
+          return target if target
+
+          match = message.match(%r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i, start_at)
+          return [match[:target], match.begin(:target)...match.end(:target)] if match
+
+          target = target_with_range_after_prefix(
+            message,
+            RENDERER_REQUEST_WRAPPER_PREFIX_REGEX,
+            allow_request_path: true,
+            start_at:
+          )
+          return target if target
+
+          match = message.match(%r{(?<target>https?://[^\s,"')]+)}, start_at)
+          [match[:target], match.begin(:target)...match.end(:target)] if match
+        end
+
+        def target_with_range_after_prefix(message, prefix_regex, allow_request_path: false, start_at: 0)
+          while (prefix = prefix_regex.match(message, start_at))
             same_line = message[prefix.end(0)..].to_s.split(/[\r\n]/, 2).first
-            next if same_line.nil? || same_line.empty?
+            if same_line.nil? || same_line.empty?
+              start_at = prefix.end(0)
+              next
+            end
 
-            # A structurally complete first token owns the target boundary. Only an unresolved
-            # first token may absorb later same-line text through a credential-bearing authority.
-            first_target = same_line[RENDERER_TARGET_AT_LINE_START_REGEX, :target]
-            return first_target if recognized_renderer_target?(first_target, allow_request_path:)
+            target = renderer_target_candidate(same_line, allow_request_path:)
+            unless target
+              start_at = prefix.end(0)
+              next
+            end
 
-            return ambiguous_renderer_target_span(same_line) || first_target
+            return [target, prefix.end(0)...(prefix.end(0) + target.length)]
           end
           nil
+        end
+
+        def renderer_target_candidate(same_line, allow_request_path:)
+          # A structurally complete first token owns the target boundary unless a later @ names
+          # another renderer authority. That later authority makes the whole span ambiguous
+          # userinfo, while ordinary prose such as an email address remains outside the target.
+          first_target = same_line[RENDERER_TARGET_AT_LINE_START_REGEX, :target]
+          ambiguous_target = ambiguous_renderer_target_span(same_line)
+          ambiguous_target ||= ambiguous_http_userinfo_span(same_line, first_target)
+          return first_target if recognized_renderer_target?(first_target, allow_request_path:) && ambiguous_target.nil?
+
+          ambiguous_target || first_target
+        end
+
+        def ambiguous_http_userinfo_span(same_line, first_target)
+          return unless first_target&.match?(%r{\Ahttps?://}i)
+
+          trailing_text = same_line[first_target.length..]
+          return if safe_notification_email_prose?(trailing_text)
+
+          userinfo_delimiter = trailing_text.rindex("@")
+          return unless userinfo_delimiter
+
+          authority_end = trailing_text.index(/[\s,"')]/, userinfo_delimiter + 1) || trailing_text.length
+          return if authority_end == userinfo_delimiter + 1
+
+          same_line[...(first_target.length + authority_end)]
+        end
+
+        def safe_notification_email_prose?(text)
+          text.match?(%r{\A while notifying [A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}\z})
         end
 
         def recognized_renderer_target?(target, allow_request_path:)
@@ -619,6 +673,53 @@ module ReactOnRails
           message = message.gsub(raw_url.inspect) { sanitized_url.inspect }
                            .gsub(raw_url) { sanitized_url }
           strip_userinfo(message)
+        end
+
+        def sanitized_renderer_target_error_message(message, raw_target, sanitized_target, target_range)
+          return sanitized_renderer_error_message(message, raw_target, sanitized_target) unless
+            recognized_renderer_target?(sanitized_target, allow_request_path: false)
+
+          message = message.to_s
+          sanitized = message.dup.clear
+          cursor = 0
+          current_target = [target_range, sanitized_target]
+
+          while current_target
+            current_range, current_sanitized_target = current_target
+            sanitized << strip_userinfo(message[cursor...current_range.begin])
+            if delayed_userinfo_after_target?(message, current_range)
+              sanitized << strip_userinfo(message[current_range.begin..])
+              return sanitized
+            end
+
+            sanitized << current_sanitized_target
+            cursor = current_range.end
+
+            next_target = immediately_following_http_target(message, cursor) ||
+                          target_with_range_from_message(message, cursor)
+            current_target = if next_target
+                               next_raw_target, next_range = next_target
+                               [next_range, sanitized_renderer_target(next_raw_target)]
+                             end
+          end
+
+          sanitized << strip_userinfo(message[cursor..])
+        end
+
+        def delayed_userinfo_after_target?(message, target_range)
+          continuation = message[target_range.end..]
+          return false if safe_notification_email_prose?(continuation)
+
+          boundary = continuation.match(%r{https?://}i)
+          continuation = continuation[...boundary.begin(0)] if boundary
+          continuation.include?("@")
+        end
+
+        def immediately_following_http_target(message, start_at)
+          match = message.match(%r{(?<target>https?://[^\s,"')]+)}, start_at)
+          return unless match && message[start_at...match.begin(:target)].match?(/\A\s*\z/)
+
+          [match[:target], match.begin(:target)...match.end(:target)]
         end
 
         # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -45,7 +45,7 @@ module ReactOnRails
         | error\son\srenderer\srequest
       /xi
 
-      CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[^/\s"'?=#@]*://}
+      CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[^:/\s"'?=#@]*://}
 
       class << self
         def reset_pool

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -45,7 +45,7 @@ module ReactOnRails
         | error\son\srenderer\srequest
       /xi
 
-      CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[a-z][a-z0-9+.-]*://}i
+      CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[a-z][a-z0-9+._-]*://}i
 
       class << self
         def reset_pool
@@ -420,7 +420,7 @@ module ReactOnRails
                              configured_url.scan(CONFIGURED_AUTHORITY_SCHEME_REGEX).length > 1
                             strip_malformed_url_userinfo(configured_url)
                           else
-                            sanitized_valid_authority_url(configured_url) ||
+                            sanitized_valid_authority_url(configured_url, fail_closed_after_authority: true) ||
                               strip_malformed_url_userinfo(configured_url)
                           end
 
@@ -478,17 +478,21 @@ module ReactOnRails
           text[...unresolved_scheme.begin(0)]
         end
 
-        # URI handles valid authority URLs structurally, so an @ in the path is never mistaken for
-        # userinfo. Some scheme-specific parsers, such as URI::File, discard authority credentials
-        # while exposing no userinfo; use their serialized value only when the raw authority contained
-        # an @ so ordinary scheme spelling and valid path @ characters remain unchanged. Returning nil
-        # for invalid input keeps that token unprotected for fail-closed handling.
-        def sanitized_valid_authority_url(url)
+        # Some scheme-specific parsers, such as URI::File, discard authority credentials while
+        # exposing no userinfo; use their serialized value when the raw authority contained an @.
+        # When configured-value sanitization requests fail-closed handling, any later @ is
+        # structurally ambiguous because a delimiter may have hidden malformed userinfo from the
+        # parser. Returning nil keeps that token unprotected for the caller's fail-closed pass.
+        def sanitized_valid_authority_url(url, fail_closed_after_authority: false)
           uri = URI.parse(url)
           if uri.userinfo.nil?
             scheme = url.match(CONFIGURED_AUTHORITY_SCHEME_REGEX)
-            authority = url[scheme.end(0)..].split(%r{[/?#]}, 2).first
-            return authority&.include?("@") ? uri.to_s : url
+            scheme_suffix = url[scheme.end(0)..]
+            authority = scheme_suffix.split(%r{[/?#]}, 2).first
+            return uri.to_s if authority&.include?("@")
+            return nil if fail_closed_after_authority && scheme_suffix.include?("@")
+
+            return url
           end
 
           # URI rejects a password without a user, so clear password first.

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -494,7 +494,7 @@ module ReactOnRails
           uri = URI.parse(url)
           if uri.userinfo.nil?
             authority = scheme_suffix.split(%r{[/?#]}, 2).first
-            return uri.to_s if authority&.include?("@")
+            return sanitized_dropped_userinfo_url(url, uri, authority) if authority&.include?("@")
 
             return url
           end
@@ -505,6 +505,12 @@ module ReactOnRails
           uri.to_s
         rescue URI::Error
           nil
+        end
+
+        def sanitized_dropped_userinfo_url(url, uri, authority)
+          return url if authority.match?(/\A@[^@]*\z/)
+
+          uri.to_s
         end
 
         def strip_unprotected_userinfo(text)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -42,7 +42,11 @@ module ReactOnRails
       RENDERER_CONNECTION_ERROR_REGEX = /
         connect\(2\)\sfor
         | Failed\sto\sopen\sTCP\sconnection
-        | error\son\srenderer\srequest
+      /xi
+
+      RENDERER_REQUEST_WRAPPER_REGEX = /
+        (?:(?:Connection|Time\sout)\s)?error\son\srenderer\srequest:
+        \s*(?<target>[^\s,)]+)
       /xi
 
       CONFIGURED_AUTHORITY_SCHEME_REGEX = %r{[^:/\s"'?=#@]*://}
@@ -303,7 +307,9 @@ module ReactOnRails
 
         def connection_error_message_in_chain?(err)
           each_in_cause_chain(err) do |current|
-            return true if current.message.to_s.match?(RENDERER_CONNECTION_ERROR_REGEX)
+            message = current.message.to_s
+            return true if message.match?(RENDERER_CONNECTION_ERROR_REGEX) ||
+                           message.match?(RENDERER_REQUEST_WRAPPER_REGEX)
           end
           false
         end
@@ -324,7 +330,7 @@ module ReactOnRails
           caught_error = err.message.to_s
           raw_target = target_from_message(caught_error)
           if raw_target
-            sanitized_target = sanitized_renderer_url(raw_target, strict_schemeless: true)
+            sanitized_target = sanitized_renderer_target(raw_target)
             caught_error = sanitized_renderer_error_message(caught_error, raw_target, sanitized_target)
           end
           configured_var, configured_url = configured_renderer_url
@@ -378,9 +384,13 @@ module ReactOnRails
         def renderer_target_from_error(err)
           each_in_cause_chain(err) do |current|
             target = target_from_message(current.message)
+            # The Pro wrapper places its HTTP request path after this marker. It proves a
+            # connection failure, but a path is not the renderer's network address.
+            next if target && explicit_filesystem_path?(target)
+
             # Sanitize here too: a target scraped from the message can itself be a full URL
             # with embedded credentials (e.g. "TCP connection to https://user:pw@host:3800").
-            return sanitized_renderer_url(target, strict_schemeless: true) if target
+            return sanitized_renderer_target(target) if target
           end
           configured_renderer_url.last
         end
@@ -403,18 +413,23 @@ module ReactOnRails
         def target_from_message(message)
           message = message.to_s
           [
-            /\A(?:Connection|Time out) error on renderer request:\s*(?<target>[^\s,)]+)\s*\z/i,
             /connect\(2\) for (?<target>[^\s,)]+)/,
             /TCP connection to (?<target>[^\s,)]+)/,
             %r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i,
+            RENDERER_REQUEST_WRAPPER_REGEX,
             %r{(?<target>https?://[^\s,"')]+)}
           ].each do |regex|
             match = message.match(regex)
-            # Trim trailing prose punctuation (e.g. a sentence-final "." or ":") that the
-            # broad capture classes can otherwise absorb.
-            return match[:target].delete('"').sub(/[.;:]+\z/, "") if match
+            return match[:target] if match
           end
           nil
+        end
+
+        def sanitized_renderer_target(raw_target)
+          # Keep raw_target untouched so caught-error substitution can match quote-bearing input;
+          # normalize only the separate value used in the public display.
+          display_target = raw_target.delete('"').sub(/[.;:]+\z/, "")
+          sanitized_renderer_url(display_target, strict_schemeless: true)
         end
 
         # Strips embedded credentials from a configured renderer value before it is interpolated

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -407,7 +407,8 @@ module ReactOnRails
         # syntactically scheme-like typo or unsupported authority is still sanitized so malformed
         # configuration cannot leak secrets. One configured value is not free-form prose: multiple
         # schemes or line breaks after its first scheme make it structurally ambiguous, so that URL
-        # suffix fails closed through its final @. Any non-URL prefix is preserved for context.
+        # suffix fails closed through its final @. A safe non-URL prefix is preserved for context,
+        # while a pre-scheme @ makes that prefix ambiguous credential material and fails closed.
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
 
@@ -415,6 +416,7 @@ module ReactOnRails
           return url unless scheme
 
           prefix = url[...scheme.begin(0)]
+          prefix = "" if prefix.include?("@")
           configured_url = url[scheme.begin(0)..]
           sanitized_url = if configured_url.match?(/[\r\n]/) ||
                              configured_url.scan(CONFIGURED_AUTHORITY_SCHEME_REGEX).length > 1

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -48,13 +48,17 @@ module ReactOnRails
         (?=[^\s]*@)[^\s]*@[^\s,)]+
         | [^\s,)]+
       /x
+      RENDERER_TARGET_AT_LINE_START_REGEX = /\A(?<target>#{RENDERER_TARGET_TOKEN_REGEX})/
 
-      CONNECT_TARGET_REGEX = /connect\(2\) for (?<target>#{RENDERER_TARGET_TOKEN_REGEX})/
-      TCP_CONNECTION_TARGET_REGEX = /TCP connection to (?<target>#{RENDERER_TARGET_TOKEN_REGEX})/
+      CONNECT_TARGET_PREFIX_REGEX = /connect\(2\) for[ \t]+/i
+      TCP_CONNECTION_TARGET_PREFIX_REGEX = /TCP connection to[ \t]+/i
+      RENDERER_REQUEST_WRAPPER_PREFIX_REGEX = /
+        (?:(?:Connection|Time\sout)\s)?error\son\srenderer\srequest:\s*
+      /xi
 
       RENDERER_REQUEST_WRAPPER_REGEX = /
-        (?:(?:Connection|Time\sout)\s)?error\son\srenderer\srequest:
-        \s*(?<target>#{RENDERER_TARGET_TOKEN_REGEX})
+        #{RENDERER_REQUEST_WRAPPER_PREFIX_REGEX}
+        (?<target>#{RENDERER_TARGET_TOKEN_REGEX})
       /xi
 
       TARGETLESS_RENDERER_REQUEST_WRAPPER_REGEX = /
@@ -425,15 +429,57 @@ module ReactOnRails
 
         def target_from_message(message)
           message = message.to_s
-          [
-            CONNECT_TARGET_REGEX,
-            TCP_CONNECTION_TARGET_REGEX,
-            %r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i,
-            RENDERER_REQUEST_WRAPPER_REGEX,
-            %r{(?<target>https?://[^\s,"')]+)}
-          ].each do |regex|
-            match = message.match(regex)
-            return match[:target] if match
+          target = target_after_prefix(message, CONNECT_TARGET_PREFIX_REGEX)
+          return target if target
+
+          target = target_after_prefix(message, TCP_CONNECTION_TARGET_PREFIX_REGEX)
+          return target if target
+
+          match = message.match(%r{(?<target>[^:/\s"'?=#@]+https?://[^\s,"')]*@[^\s,"')]+)}i)
+          return match[:target] if match
+
+          target = target_after_prefix(message, RENDERER_REQUEST_WRAPPER_PREFIX_REGEX, allow_request_path: true)
+          return target if target
+
+          message[%r{(?<target>https?://[^\s,"')]+)}, :target]
+        end
+
+        def target_after_prefix(message, prefix_regex, allow_request_path: false)
+          message.to_enum(:scan, prefix_regex).each do
+            prefix = Regexp.last_match
+            same_line = message[prefix.end(0)..].to_s.split(/[\r\n]/, 2).first
+            next if same_line.nil? || same_line.empty?
+
+            # A structurally complete first token owns the target boundary. Only an unresolved
+            # first token may absorb later same-line text through a credential-bearing authority.
+            first_target = same_line[RENDERER_TARGET_AT_LINE_START_REGEX, :target]
+            return first_target if recognized_renderer_target?(first_target, allow_request_path:)
+
+            return ambiguous_renderer_target_span(same_line) || first_target
+          end
+          nil
+        end
+
+        def recognized_renderer_target?(target, allow_request_path:)
+          return false unless target
+
+          display_target = target.delete('"').sub(/[.;:]+\z/, "")
+          return true if display_target.match?(%r{\A(?:\[[^\]\s]+\]|[^:@/\s]+):\d+(?:[/?#][^\s]*)?\z})
+          return true if allow_request_path && explicit_filesystem_path?(display_target)
+
+          parsed = URI.parse(display_target)
+          parsed.is_a?(URI::HTTP) && parsed.host
+        rescue URI::Error
+          false
+        end
+
+        def ambiguous_renderer_target_span(same_line)
+          same_line.to_enum(:scan, /@(?<authority>[^\s,@)]+)/).each do
+            match = Regexp.last_match
+            authority = match[:authority].sub(/[.;:]+\z/, "")
+            next unless recognized_renderer_target?(authority, allow_request_path: false)
+
+            return same_line[0...(match.begin(:authority) + authority.length)]
           end
           nil
         end

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -957,6 +957,19 @@ module ReactOnRails
             end
           end
 
+          it "fails closed when parsed userinfo precedes another delayed userinfo delimiter" do
+            server_bundle_path =
+              "htps://synthetic-user:synthetic-prefix@synthetic-middle/synthetic-secret@renderer.example/path"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-prefix")
+            expect(message).not_to include("synthetic-middle")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("htps://renderer.example/path")
+          end
+
           it "fails closed when a path at sign could be delayed userinfo" do
             server_bundle_path = "htps://renderer.example/bundle@example.js"
             stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
@@ -985,6 +998,19 @@ module ReactOnRails
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
             expect(message).to include("http_://renderer.example/bundle.js")
+          end
+
+          [["a percent sign", "http%"], ["only digits", "123"]].each do |description, scheme|
+            it "redacts credentials when the scheme contains #{description}" do
+              server_bundle_path =
+                "#{scheme}://synthetic-user:synthetic-secret@renderer.example/bundle.js"
+              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("#{scheme}://renderer.example/bundle.js")
+            end
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -371,6 +371,74 @@ module ReactOnRails
           end
         end
 
+        context "when repeated same-family prefixes contain later credentials" do
+          it "keeps an earlier safe connect(2) target while sanitizing the later target" do
+            error_message =
+              "connect(2) for renderer-a.internal:3800; " \
+              "connect(2) for synthetic-user:synthetic-secret@renderer-b.internal:3800"
+
+            message = render_error_for(StandardError.new(error_message)).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("could not connect to the Node renderer at renderer-a.internal:3800")
+            expect(message).to include(
+              "Caught error:\nconnect(2) for renderer-a.internal:3800; connect(2) for renderer-b.internal:3800"
+            )
+          end
+
+          it "keeps an earlier safe TCP target while sanitizing the later target" do
+            error_message =
+              "Failed to open TCP connection to renderer-a.internal:3800; " \
+              "Failed to open TCP connection to synthetic-user:synthetic-secret@renderer-b.internal:3800"
+
+            message = render_error_for(StandardError.new(error_message)).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("could not connect to the Node renderer at renderer-a.internal:3800")
+            expect(message).to include(
+              "Caught error:\nFailed to open TCP connection to renderer-a.internal:3800; " \
+              "Failed to open TCP connection to renderer-b.internal:3800"
+            )
+          end
+
+          it "keeps an earlier safe wrapper target while sanitizing the later target" do
+            error_message =
+              "Connection error on renderer request: renderer-a.internal:3800; " \
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer-b.internal:3800"
+
+            message = render_error_for(StandardError.new(error_message)).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("could not connect to the Node renderer at renderer-a.internal:3800")
+            expect(message).to include(
+              "Caught error:\nConnection error on renderer request: renderer-a.internal:3800; " \
+              "Connection error on renderer request: renderer-b.internal:3800"
+            )
+          end
+
+          it "does not treat delimiter-free repeated family prefixes as safe boundaries" do
+            prefixes = [
+              "connect(2) for ",
+              "Failed to open TCP connection to ",
+              "Connection error on renderer request: "
+            ]
+
+            prefixes.each do |prefix|
+              error_message =
+                "#{prefix}http://synthetic-user " \
+                "#{prefix}synthetic-secret@renderer.internal:3800"
+              message = render_error_for(StandardError.new(error_message)).message
+
+              aggregate_failures(prefix.strip) do
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include("renderer.internal:3800")
+              end
+            end
+          end
+        end
+
         context "when malformed renderer-request wrapper userinfo contains punctuation" do
           credential_canaries = %w[synthetic-user sec ret]
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -228,6 +228,17 @@ module ReactOnRails
           end
         end
 
+        context "when the renderer-request wrapper has no target" do
+          ["error on renderer request", "error on renderer request:", "error on renderer request:   "].each do |marker|
+            it "classifies #{marker.inspect} as a connection failure" do
+              message = render_error_for(StandardError.new(marker)).message
+              expect(message).to include("could not connect to the Node renderer")
+              expect(message).to include("Caught error:\n#{marker}")
+              expect(message).not_to include("Check your webpack configuration")
+            end
+          end
+        end
+
         context "when a renderer-request wrapper embeds an untrusted scheme-less authority" do
           [
             [
@@ -274,7 +285,19 @@ module ReactOnRails
 
         context "when malformed renderer-request wrapper userinfo contains punctuation" do
           credential_canaries = %w[synthetic-user sec ret]
+
           ["Connection", "Time out"].each do |wrapper_type|
+            it "redacts right-parenthesis-separated credentials from the #{wrapper_type} wrapper" do
+              error = StandardError.new(
+                "#{wrapper_type} error on renderer request: " \
+                "synthetic-user:sec)ret@renderer.internal:3800"
+              )
+
+              message = render_error_for(error).message
+              credential_canaries.each { |canary| expect(message).not_to include(canary) }
+              expect(message).to include("renderer.internal:3800")
+            end
+
             it "redacts comma-separated credentials from the #{wrapper_type} wrapper" do
               error = StandardError.new(
                 "#{wrapper_type} error on renderer request: " \
@@ -299,6 +322,18 @@ module ReactOnRails
               expect(message).not_to include("synthetic-secret")
               expect(message).to include("renderer.internal:3800#{trailing_context}")
             end
+          end
+
+          it "keeps a right parenthesis outside the credential-bearing authority" do
+            error = StandardError.new(
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer.internal:3800)"
+            )
+
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer.internal:3800)")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -283,6 +283,94 @@ module ReactOnRails
           end
         end
 
+        context "when a renderer error message contains mixed target prefixes" do
+          it "sanitizes an earlier wrapper target before a later connect(2) target" do
+            error = StandardError.new(
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer-a.internal:3800; " \
+              "connect(2) for renderer-b.internal:3800"
+            )
+
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer-a.internal:3800")
+            expect(message).to include("renderer-b.internal:3800")
+          end
+
+          [
+            [
+              "connect(2) before a wrapper",
+              "connect(2) for synthetic-user:synthetic-secret@renderer-a.internal:3800; " \
+              "Connection error on renderer request: renderer-b.internal:3800"
+            ],
+            [
+              "a wrapper before TCP",
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer-a.internal:3800; " \
+              "Failed to open TCP connection to renderer-b.internal:3800"
+            ],
+            [
+              "TCP before a wrapper",
+              "Failed to open TCP connection to synthetic-user:synthetic-secret@renderer-a.internal:3800; " \
+              "Connection error on renderer request: renderer-b.internal:3800"
+            ]
+          ].each do |description, error_message|
+            it "sanitizes #{description} in textual order" do
+              message = render_error_for(StandardError.new(error_message)).message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("renderer-a.internal:3800")
+              expect(message).to include("renderer-b.internal:3800")
+            end
+          end
+
+          it "does not let an unrelated earlier URL mask a later credentialed wrapper" do
+            error = StandardError.new(
+              "See https://docs.example/help; Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer.internal:3800"
+            )
+
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("https://docs.example/help")
+            expect(message).to include("renderer.internal:3800")
+          end
+
+          it "continues past a request-path wrapper to sanitize a later credentialed wrapper" do
+            error = StandardError.new(
+              "Connection error on renderer request: /bundles/x; " \
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer-a.internal:3800; " \
+              "connect(2) for renderer-b.internal:3800"
+            )
+
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer-a.internal:3800")
+            expect(message).to include("renderer-b.internal:3800")
+          end
+        end
+
+        context "when a prefix-aware target and a generic URL start together" do
+          [
+            "connect(2) for ",
+            "Failed to open TCP connection to ",
+            "Connection error on renderer request: "
+          ].each do |target_prefix|
+            it "keeps the prefix-aware span for #{target_prefix.strip}" do
+              target = "http://synthetic-user synthetic-secret@renderer.internal:3800"
+              message = "#{target_prefix}#{target}"
+
+              extracted_target, target_range = described_class.send(:target_with_range_from_message, message)
+              expect(extracted_target).to eq(target)
+              expect(message[target_range]).to eq(target)
+            end
+          end
+        end
+
         context "when malformed renderer-request wrapper userinfo contains punctuation" do
           credential_canaries = %w[synthetic-user sec ret]
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -332,6 +332,18 @@ module ReactOnRails
           end
         end
 
+        context "when the error message names a token-style scheme-less renderer authority" do
+          let(:error) do
+            Errno::ECONNREFUSED.new("connect(2) for synthetic-token@renderer.internal:3800")
+          end
+
+          it "redacts the token from the entire public connection diagnostic" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-token")
+            expect(message).to include("renderer.internal:3800")
+          end
+        end
+
         context "when an error target absorbs credential text into an apparent scheme" do
           let(:error) do
             Errno::ECONNREFUSED.new(

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -203,6 +203,15 @@ module ReactOnRails
             expect(message).to include("could not connect to the Node renderer")
             expect(message).not_to include("Check your webpack configuration")
           end
+
+          it "uses the configured renderer authority instead of the wrapped request path" do
+            ENV["REACT_RENDERER_URL"] = "http://renderer.internal:3800"
+
+            message = render_error_for(error).message
+            expect(message).to include("could not connect to the Node renderer at http://renderer.internal:3800")
+            expect(message).to include("renderer process is running and listening on http://renderer.internal:3800")
+            expect(message).not_to include("Node renderer at /bundles/abc123/render")
+          end
         end
 
         context "when a timeout wrapper names only a token-style scheme-less renderer authority" do
@@ -216,6 +225,50 @@ module ReactOnRails
             message = render_error_for(error).message
             expect(message).not_to include("synthetic-token")
             expect(message).to include("renderer.internal:3800")
+          end
+        end
+
+        context "when a renderer-request wrapper embeds an untrusted scheme-less authority" do
+          [
+            [
+              "a quote-bearing target",
+              "Connection error on renderer request: synthetic-user:sec\"ret@renderer.internal:3800",
+              ["synthetic-user", "sec\"ret"]
+            ],
+            [
+              "a quote-bearing HTTP target",
+              "Connection error on renderer request: https://synthetic-user:sec\"ret@renderer.internal:3800",
+              ["synthetic-user", "sec\"ret"]
+            ],
+            [
+              "the generic lowercase wrapper",
+              "error on renderer request: synthetic-user:synthetic-secret@renderer.internal:3800",
+              %w[synthetic-user synthetic-secret]
+            ],
+            [
+              "a prefixed connection wrapper",
+              "transport failure: Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer.internal:3800",
+              %w[synthetic-user synthetic-secret]
+            ],
+            [
+              "a connection wrapper with trailing context",
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer.internal:3800 while retrying",
+              %w[synthetic-user synthetic-secret]
+            ],
+            [
+              "wrapper context before a later credential URL",
+              "Connection error on renderer request: " \
+              "synthetic-secret,https://synthetic-user:synthetic-password@renderer.internal:3800",
+              %w[synthetic-secret synthetic-user synthetic-password]
+            ]
+          ].each do |description, wrapper_message, canaries|
+            it "redacts #{description} from the entire public connection diagnostic" do
+              message = render_error_for(StandardError.new(wrapper_message)).message
+              canaries.each { |canary| expect(message).not_to include(canary) }
+              expect(message).to include("renderer.internal:3800")
+            end
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -250,6 +250,42 @@ module ReactOnRails
           end
         end
 
+        context "when scheme-less renderer credentials precede a separate URL" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          before do
+            ENV["REACT_RENDERER_URL"] =
+              "u:leaked_secret@stray_context http://renderer-host:3800"
+          end
+
+          it "fails closed across the entire ambiguous prefix" do
+            message = render_error_for(error).message
+            expect(message).not_to include("leaked_secret")
+            expect(message).not_to include("stray_context")
+            expect(message).to include("could not connect to the Node renderer at http://renderer-host:3800")
+            expect(message).to include('REACT_RENDERER_URL is currently "http://renderer-host:3800"')
+          end
+        end
+
+        context "when malformed renderer credentials resemble filesystem or custom-scheme values" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          [
+            "/http://synthetic-user:synthetic-secret@renderer.internal:3800",
+            "synthetic-user:synthetic-secretx://suffix@renderer.internal:3800"
+          ].each do |renderer_url|
+            it "fails closed for #{renderer_url.inspect}" do
+              ENV["REACT_RENDERER_URL"] = renderer_url
+
+              message = render_error_for(error).message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
+              expect(message).to include('REACT_RENDERER_URL is currently "renderer.internal:3800"')
+            end
+          end
+        end
+
         context "when a configured typo-scheme renderer authority has multiple at signs" do
           let(:error) { Errno::ECONNREFUSED.new }
 
@@ -344,6 +380,21 @@ module ReactOnRails
             expect(message).not_to include("synthetic-secret")
             expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
             expect(message).to include('RENDERER_URL is currently "renderer.internal:3800"')
+          end
+        end
+
+        context "when a renderer env value has token-style scheme-less userinfo" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          %w[REACT_RENDERER_URL RENDERER_URL].each do |renderer_env|
+            it "fails closed through the userinfo delimiter for #{renderer_env}" do
+              ENV[renderer_env] = "synthetic-token@renderer.internal:3800"
+
+              message = render_error_for(error).message
+              expect(message).not_to include("synthetic-token")
+              expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
+              expect(message).to include(%(#{renderer_env} is currently "renderer.internal:3800"))
+            end
           end
         end
 
@@ -828,14 +879,35 @@ module ReactOnRails
             expect(message).not_to include("synthetic-secret")
             expect(message).to include("cdn.example.com/bundle.js")
           end
+
+          it "fails closed when a slash appears before the userinfo delimiter" do
+            server_bundle_path =
+              "synthetic-user:synthetic-secret/part@cdn.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("part@")
+            expect(message).to include("cdn.example/bundle.js")
+          end
         end
 
         context "when an ordinary local bundle path contains an at sign" do
-          it "preserves the configured path byte for byte" do
-            server_bundle_path = "/tmp/releases/build@2026/server-bundle.js"
-            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+          [
+            ["an absolute POSIX path", "/tmp/releases/build@2026/server-bundle.js"],
+            ["a dot-relative POSIX path", "./releases/build@2026/server-bundle.js"],
+            ["a parent-relative POSIX path", "../releases/build@2026/server-bundle.js"],
+            ["a Windows drive path", "C:\\releases\\build@2026\\server-bundle.js"],
+            ["a dot-relative Windows path", ".\\releases\\build@2026\\server-bundle.js"],
+            ["a parent-relative Windows path", "..\\releases\\build@2026\\server-bundle.js"],
+            ["a Windows UNC path", "\\\\server\\share\\build@2026\\server-bundle.js"]
+          ].each do |description, server_bundle_path|
+            it "preserves #{description} byte for byte" do
+              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
 
-            expect(bundle_load_error_message).to include(server_bundle_path)
+              expect(bundle_load_error_message).to include(server_bundle_path)
+            end
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -564,6 +564,138 @@ module ReactOnRails
           end
         end
 
+        context "when a safe renderer URL target precedes unrelated email prose" do
+          it "preserves the exact HTTP(S) wrapper text in the caught error" do
+            aggregate_failures do
+              %w[http https].each do |scheme|
+                caught_error =
+                  "Connection error on renderer request: " \
+                  "#{scheme}://renderer.internal:3800/render?x=1#frag while notifying ops@example.com"
+
+                message = render_error_for(StandardError.new(caught_error)).message
+                expect(message).to include("Caught error:\n#{caught_error}\n====")
+              end
+            end
+          end
+
+          it "still redacts HTTP(S) target credentials before preserving the later prose" do
+            aggregate_failures do
+              %w[http https].each do |scheme|
+                caught_error =
+                  "Connection error on renderer request: " \
+                  "#{scheme}://synthetic-user:synthetic-secret@renderer.internal:3800/render?x=1#frag " \
+                  "while notifying ops@example.com"
+                sanitized_caught_error =
+                  "Connection error on renderer request: " \
+                  "#{scheme}://renderer.internal:3800/render?x=1#frag while notifying ops@example.com"
+
+                message = render_error_for(StandardError.new(caught_error)).message
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include("Caught error:\n#{sanitized_caught_error}\n====")
+              end
+            end
+          end
+
+          it "protects the wrapper target rather than an earlier duplicate URL" do
+            aggregate_failures do
+              %w[http https].each do |scheme|
+                target = "#{scheme}://renderer.internal:3800/render?x=1#frag"
+                caught_error =
+                  "Previous attempt to #{target} failed; " \
+                  "Connection error on renderer request: #{target} while notifying ops@example.com"
+
+                message = render_error_for(StandardError.new(caught_error)).message
+                expect(message).to include("Caught error:\n#{caught_error}\n====")
+              end
+            end
+          end
+
+          it "still fails closed when renderer credentials cross the target boundary" do
+            aggregate_failures do
+              %w[http https].each do |scheme|
+                caught_error =
+                  "Connection error on renderer request: " \
+                  "#{scheme}://synthetic-user synthetic-secret@renderer.internal:3800"
+
+                message = render_error_for(StandardError.new(caught_error)).message
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include("renderer.internal:3800")
+              end
+            end
+          end
+
+          it "fails closed when the later credential authority has no explicit port" do
+            aggregate_failures do
+              %w[http https].product(["renderer.internal", "renderer.internal/render"]).each do |scheme, authority|
+                caught_error =
+                  "Connection error on renderer request: " \
+                  "#{scheme}://synthetic-user synthetic-secret@#{authority}"
+
+                message = render_error_for(StandardError.new(caught_error)).message
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include(authority)
+              end
+            end
+          end
+
+          it "sanitizes a later credential-bearing renderer wrapper" do
+            caught_error =
+              "Connection error on renderer request: http://renderer-a.internal:3800\n" \
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret@renderer-b.internal:3800"
+
+            message = render_error_for(StandardError.new(caught_error)).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer-b.internal:3800")
+          end
+
+          it "does not mistake renderer credentials for notification email prose" do
+            caught_error =
+              "Connection error on renderer request: http://renderer-a.internal:3800/render " \
+              "while notifying synthetic-user:synthetic-secret@renderer-b.internal"
+
+            message = render_error_for(StandardError.new(caught_error)).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer-b.internal")
+          end
+
+          it "does not protect a malformed HTTP target from credentials on the next line" do
+            caught_error =
+              "Connection error on renderer request: http://synthetic-user:synthetic-secret\n" \
+              "part@renderer.internal:3800"
+
+            message = render_error_for(StandardError.new(caught_error)).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("part@")
+            expect(message).to include("renderer.internal:3800")
+          end
+
+          it "does not protect a later malformed HTTP target from its delayed userinfo" do
+            caught_error =
+              "Connection error on renderer request: http://renderer-a.internal:3800\n" \
+              "http://synthetic-user synthetic-secret@renderer-b.internal:3800"
+
+            message = render_error_for(StandardError.new(caught_error)).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer-b.internal:3800")
+          end
+
+          it "sanitizes a long diagnostic without recursive stack growth" do
+            caught_error =
+              "Connection error on renderer request: http://renderer.internal:3800 " \
+              "#{'http://other-renderer.internal:3800 ' * 5000}"
+
+            expect { render_error_for(StandardError.new(caught_error)) }.not_to raise_error
+          end
+        end
+
         context "when whitespace-spanning userinfo starts with an apparent URL" do
           it "does not accept a typo scheme as the renderer-target boundary" do
             error = Errno::ECONNREFUSED.new(

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -275,13 +275,11 @@ module ReactOnRails
             )
           end
 
-          it "redacts credentials from the target named in the headline" do
+          it "redacts credentials from the full connection diagnostic" do
             message = render_error_for(error).message
             expect(message).to include("could not connect to the Node renderer at https://renderer.example.com:3800")
-            # The credentialed form must not appear in the target position. (The raw exception
-            # text is still echoed verbatim under "Caught error:" — pre-existing behavior for
-            # every error type in this file — so the password can survive there.)
-            expect(message).not_to include("at https://user:sekret@")
+            expect(message).not_to include("user")
+            expect(message).not_to include("sekret")
           end
         end
 
@@ -290,10 +288,11 @@ module ReactOnRails
             Errno::ECONNREFUSED.new("connect(2) for synthetic-user:synthetic-secret@renderer.example.com:3800")
           end
 
-          it "redacts credentials from the target named in the headline" do
+          it "redacts credentials from the full connection diagnostic" do
             message = render_error_for(error).message
             expect(message).to include("could not connect to the Node renderer at renderer.example.com:3800")
-            expect(message).not_to include("at synthetic-user:synthetic-secret@")
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -285,6 +285,18 @@ module ReactOnRails
           end
         end
 
+        context "when the error message names a scheme-less renderer authority with credentials" do
+          let(:error) do
+            Errno::ECONNREFUSED.new("connect(2) for synthetic-user:synthetic-secret@renderer.example.com:3800")
+          end
+
+          it "redacts credentials from the target named in the headline" do
+            message = render_error_for(error).message
+            expect(message).to include("could not connect to the Node renderer at renderer.example.com:3800")
+            expect(message).not_to include("at synthetic-user:synthetic-secret@")
+          end
+        end
+
         context "when only the legacy RENDERER_URL is set and the error carries no host/port" do
           let(:error) { Errno::ECONNREFUSED.new }
 
@@ -803,6 +815,19 @@ module ReactOnRails
             stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
 
             expect(bundle_load_error_message).to include(failure_message)
+          end
+        end
+
+        context "when a configured local bundle value is a scheme-less credential authority" do
+          it "redacts credentials while retaining the host and path" do
+            server_bundle_path =
+              "synthetic-user:synthetic-secret@cdn.example.com/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("cdn.example.com/bundle.js")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -858,6 +858,17 @@ module ReactOnRails
 
             expect(bundle_load_error_message).to include(failure_message)
           end
+
+          it "does not let the token protect unresolved credentials before it" do
+            failure_message =
+              "Failure loading http://synthetic-user:synthetic-secret-prefixhttp://@host/path"
+            stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret-prefix")
+            expect(message).to include("Failure loading http://@host/path")
+          end
         end
 
         context "when a bundle-load failure contains two valid URLs" do

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -535,6 +535,98 @@ module ReactOnRails
           end
         end
 
+        context "when connection-target userinfo spans whitespace" do
+          credential_canaries = %w[synthetic-user synthetic-secret part@]
+
+          [
+            ["connect(2)", Errno::ECONNREFUSED, "connect(2) for"],
+            ["TCP", StandardError, "Failed to open TCP connection to"],
+            ["Connection wrapper", StandardError, "Connection error on renderer request:"],
+            ["Time out wrapper", StandardError, "Time out error on renderer request:"]
+          ].each do |target_type, error_class, target_prefix|
+            it "redacts credentials through a later authority in a #{target_type} target" do
+              error = error_class.new(
+                "#{target_prefix} synthetic-user:synthetic-secret part@renderer.internal:3800"
+              )
+
+              message = render_error_for(error).message
+              credential_canaries.each { |canary| expect(message).not_to include(canary) }
+              expect(message).to include("renderer.internal:3800")
+            end
+
+            it "keeps a valid #{target_type} target ahead of unrelated later at-sign prose" do
+              caught_error = "#{target_prefix} renderer.internal:3800 while notifying ops@example.com"
+
+              message = render_error_for(error_class.new(caught_error)).message
+              expect(message).to include("could not connect to the Node renderer at renderer.internal:3800.")
+              expect(message).to include(caught_error)
+            end
+          end
+        end
+
+        context "when whitespace-spanning userinfo starts with an apparent URL" do
+          it "does not accept a typo scheme as the renderer-target boundary" do
+            error = Errno::ECONNREFUSED.new(
+              "connect(2) for synthetic-secrethtps://decoy part@renderer.internal:3800"
+            )
+
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("part@")
+            expect(message).to include("renderer.internal:3800")
+          end
+
+          it "redacts through a later authority with a request path" do
+            error = StandardError.new(
+              "Connection error on renderer request: " \
+              "synthetic-user:synthetic-secret part@renderer.internal:3800/render"
+            )
+
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("part@")
+            expect(message).to include("renderer.internal:3800/render")
+          end
+        end
+
+        context "when a renderer-request wrapper target starts after a line break" do
+          wrapper_types = ["Connection", "Time out"]
+          line_breaks = ["\n", "\r", "\r\n"]
+
+          wrapper_types.each do |wrapper_type|
+            line_breaks.each do |line_break|
+              it "redacts #{wrapper_type} credentials after #{line_break.inspect}" do
+                error = StandardError.new(
+                  "#{wrapper_type} error on renderer request:#{line_break}" \
+                  "synthetic-user:synthetic-secret@renderer.internal:3800"
+                )
+
+                message = render_error_for(error).message
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include("renderer.internal:3800")
+              end
+            end
+          end
+        end
+
+        context "when a targetless socket prefix precedes a credential-bearing prefix" do
+          ["connect(2) for", "Failed to open TCP connection to"].each do |target_prefix|
+            it "continues to the later #{target_prefix} target" do
+              error = StandardError.new(
+                "#{target_prefix} \n#{target_prefix} " \
+                "synthetic-user:synthetic-secret@renderer.internal:3800"
+              )
+
+              message = render_error_for(error).message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("renderer.internal:3800")
+            end
+          end
+        end
+
         context "when an error target absorbs credential text into an apparent scheme" do
           let(:error) do
             Errno::ECONNREFUSED.new(

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -722,6 +722,16 @@ module ReactOnRails
               end
             end
           end
+
+          it "preserves a safe label before a credential-bearing URL" do
+            server_bundle_path = "URL=https://synthetic-user:synthetic-secret@host/path"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("URL=https://host/path")
+          end
         end
 
         context "when configured credential material precedes the URL scheme" do
@@ -734,6 +744,39 @@ module ReactOnRails
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
             expect(message).to include("https://renderer-host:3800")
+          end
+
+          it "fails closed when a nested scheme hides the userinfo delimiter from the prefix" do
+            server_bundle_path =
+              "synthetic-user:synthetic-secretx:y://token@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer.example/bundle.js")
+          end
+
+          it "fails closed when malformed characters split a nested credential prefix" do
+            server_bundle_path =
+              "synthetic-user:prefix/secret:y://token@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("prefix/secret")
+            expect(message).to include("renderer.example/bundle.js")
+          end
+
+          it "fails closed when a separator leaves one colon before a nested scheme" do
+            server_bundle_path =
+              "synthetic-user:synthetic-secret/y://token@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer.example/bundle.js")
           end
         end
 
@@ -749,6 +792,14 @@ module ReactOnRails
           it "preserves a scheme-less credential-shaped token byte for byte" do
             failure_message =
               "Failure loading synthetic-user:synthetic-secret@renderer.internal:3800"
+            stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
+
+            expect(bundle_load_error_message).to include(failure_message)
+          end
+
+          it "preserves an unsupported nested-scheme token byte for byte" do
+            failure_message =
+              "Failure loading synthetic-user:synthetic-secretx:y://token@renderer.example/bundle.js"
             stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
 
             expect(bundle_load_error_message).to include(failure_message)
@@ -1149,7 +1200,7 @@ module ReactOnRails
             message = bundle_load_error_message
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
-            expect(message).to include("x:y://renderer.example/bundle.js")
+            expect(message).to include("y://renderer.example/bundle.js")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -205,6 +205,20 @@ module ReactOnRails
           end
         end
 
+        context "when a timeout wrapper names only a token-style scheme-less renderer authority" do
+          let(:error) do
+            StandardError.new(
+              "Time out error on renderer request: synthetic-token@renderer.internal:3800"
+            )
+          end
+
+          it "redacts the token from the entire public connection diagnostic" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-token")
+            expect(message).to include("renderer.internal:3800")
+          end
+        end
+
         context "when the error uses the Net::HTTP 'Failed to open TCP connection' format" do
           let(:error) do
             StandardError.new("Failed to open TCP connection to 127.0.0.1:3800 (Connection refused)")

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -501,6 +501,40 @@ module ReactOnRails
           end
         end
 
+        context "when connection-target userinfo contains malformed punctuation" do
+          credential_canaries = %w[synthetic-user sec ret]
+          punctuation_marks = [")", ","]
+
+          [
+            ["connect(2)", Errno::ECONNREFUSED, "connect(2) for"],
+            ["TCP", StandardError, "Failed to open TCP connection to"]
+          ].each do |target_type, error_class, target_prefix|
+            punctuation_marks.each do |punctuation|
+              it "redacts #{punctuation.inspect} inside #{target_type} target userinfo" do
+                error = error_class.new(
+                  "#{target_prefix} synthetic-user:sec#{punctuation}ret@renderer.internal:3800"
+                )
+
+                message = render_error_for(error).message
+                credential_canaries.each { |canary| expect(message).not_to include(canary) }
+                expect(message).to include("renderer.internal:3800")
+              end
+
+              it "keeps #{punctuation.inspect} after the #{target_type} authority" do
+                error = error_class.new(
+                  "#{target_prefix} synthetic-user:synthetic-secret@renderer.internal:3800#{punctuation}"
+                )
+
+                message = render_error_for(error).message
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include("could not connect to the Node renderer at renderer.internal:3800.")
+                expect(message).to include("#{target_prefix} renderer.internal:3800#{punctuation}")
+              end
+            end
+          end
+        end
+
         context "when an error target absorbs credential text into an apparent scheme" do
           let(:error) do
             Errno::ECONNREFUSED.new(
@@ -1199,6 +1233,19 @@ module ReactOnRails
             ["a dot-relative Windows path", ".\\releases\\build@2026\\server-bundle.js"],
             ["a parent-relative Windows path", "..\\releases\\build@2026\\server-bundle.js"],
             ["a Windows UNC path", "\\\\server\\share\\build@2026\\server-bundle.js"]
+          ].each do |description, server_bundle_path|
+            it "preserves #{description} byte for byte" do
+              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+              expect(bundle_load_error_message).to include(server_bundle_path)
+            end
+          end
+        end
+
+        context "when a configured local bundle uses a scoped-package path" do
+          [
+            ["a node_modules scoped-package path", "node_modules/@org/pkg/dist/server-bundle.js"],
+            ["a direct scoped-package path", "@org/pkg/server-bundle.js"]
           ].each do |description, server_bundle_path|
             it "preserves #{description} byte for byte" do
               stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -851,6 +851,15 @@ module ReactOnRails
           end
         end
 
+        context "when unrelated reporter text contains an empty-userinfo URL" do
+          it "preserves the empty-userinfo token" do
+            failure_message = "Failure loading http://@host/path"
+            stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
+
+            expect(bundle_load_error_message).to include(failure_message)
+          end
+        end
+
         context "when a bundle-load failure contains two valid URLs" do
           it "preserves both URLs, including an at sign in the second URL's path" do
             failure_message = "Failure loading http://first-host/path http://second-host/path@example"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -272,6 +272,36 @@ module ReactOnRails
           end
         end
 
+        context "when malformed renderer-request wrapper userinfo contains punctuation" do
+          credential_canaries = %w[synthetic-user sec ret]
+          ["Connection", "Time out"].each do |wrapper_type|
+            it "redacts comma-separated credentials from the #{wrapper_type} wrapper" do
+              error = StandardError.new(
+                "#{wrapper_type} error on renderer request: " \
+                "synthetic-user:sec,ret@renderer.internal:3800"
+              )
+
+              message = render_error_for(error).message
+              credential_canaries.each { |canary| expect(message).not_to include(canary) }
+              expect(message).to include("renderer.internal:3800")
+            end
+          end
+
+          [",", ", while retrying"].each do |trailing_context|
+            it "keeps #{trailing_context.inspect} outside the credential-bearing authority" do
+              error = StandardError.new(
+                "Connection error on renderer request: " \
+                "synthetic-user:synthetic-secret@renderer.internal:3800#{trailing_context}"
+              )
+
+              message = render_error_for(error).message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("renderer.internal:3800#{trailing_context}")
+            end
+          end
+        end
+
         context "when the error uses the Net::HTTP 'Failed to open TCP connection' format" do
           let(:error) do
             StandardError.new("Failed to open TCP connection to 127.0.0.1:3800 (Connection refused)")

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -332,6 +332,52 @@ module ReactOnRails
           end
         end
 
+        context "when an error target absorbs credential text into an apparent scheme" do
+          let(:error) do
+            Errno::ECONNREFUSED.new(
+              "connect(2) for synthetic-secrethttps://apikey@renderer.internal:3800"
+            )
+          end
+
+          it "redacts the credential from the entire public connection diagnostic" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("apikey")
+            expect(message).to include("https://renderer.internal:3800")
+          end
+        end
+
+        context "when a wrapped connection error absorbs credential text into an apparent scheme" do
+          let(:error) do
+            StandardError.new(
+              "Connection error on renderer request: synthetic-secrethttps://apikey@renderer.internal:3800"
+            )
+          end
+
+          it "redacts the credential from the entire public connection diagnostic" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("apikey")
+            expect(message).to include("https://renderer.internal:3800")
+          end
+        end
+
+        context "when a cause has unrelated token text before a URL without userinfo" do
+          let(:error) do
+            wrapped_error(
+              Errno::ECONNREFUSED,
+              "transport metadata=synthetic-tokenhttps://renderer.internal:3800",
+              "renderer request failed"
+            )
+          end
+
+          it "does not promote the unrelated token into the public connection target" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-token")
+            expect(message).to include("https://renderer.internal:3800")
+          end
+        end
+
         context "when only the legacy RENDERER_URL is set and the error carries no host/port" do
           let(:error) { Errno::ECONNREFUSED.new }
 
@@ -394,6 +440,29 @@ module ReactOnRails
               expect(message).not_to include("synthetic-token")
               expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
               expect(message).to include(%(#{renderer_env} is currently "renderer.internal:3800"))
+            end
+          end
+        end
+
+        context "when renderer env credentials are absorbed into an apparent scheme" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          %w[REACT_RENDERER_URL RENDERER_URL].each do |renderer_env|
+            it "redacts the apparent-scheme credential for #{renderer_env}" do
+              ENV[renderer_env] = "synthetic-secrethttps://apikey@renderer.internal:3800"
+
+              message = render_error_for(error).message
+              expect(message).not_to include("synthetic-secret")
+              expect(message).not_to include("apikey")
+              expect(message).to include("renderer.internal:3800")
+            end
+
+            it "redacts the apparent-scheme credential before empty userinfo for #{renderer_env}" do
+              ENV[renderer_env] = "synthetic-secrethttps://@renderer.internal:3800"
+
+              message = render_error_for(error).message
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("renderer.internal:3800")
             end
           end
         end
@@ -865,6 +934,40 @@ module ReactOnRails
             stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
 
             expect(bundle_load_error_message).to include(failure_message)
+          end
+
+          it "keeps apparent-scheme text on the existing free-form scanning path" do
+            failure_message =
+              "Failure loading synthetic-secrethttps://apikey@renderer.internal:3800"
+            stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
+
+            message = bundle_load_error_message
+            expect(message).to include("Failure loading synthetic-secrethttps://renderer.internal:3800")
+            expect(message).not_to include("apikey")
+          end
+        end
+
+        context "when a configured bundle URL absorbs credential text into an apparent scheme" do
+          it "redacts the credential while retaining the safe URL context" do
+            server_bundle_url =
+              "synthetic-secrethttps://apikey@renderer.internal:3800/bundle.js"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("apikey")
+            expect(message).to include("https://renderer.internal:3800/bundle.js")
+          end
+
+          it "preserves a safe label while redacting the absorbed credential" do
+            server_bundle_url =
+              "URL=synthetic-secrethttps://apikey@renderer.internal:3800/bundle.js"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to include("apikey")
+            expect(message).to include("URL=https://renderer.internal:3800/bundle.js")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -656,6 +656,29 @@ module ReactOnRails
           end
         end
 
+        context "when configured credential material precedes the URL scheme" do
+          it "fails closed across the pre-scheme userinfo delimiter" do
+            server_bundle_path =
+              "synthetic-user:synthetic-secret@https://renderer-host:3800"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("https://renderer-host:3800")
+          end
+        end
+
+        context "when the same token appears only in unrelated reporter text" do
+          it "preserves the free-form token byte for byte" do
+            failure_message =
+              "Failure loading synthetic-user:synthetic-secret@https://renderer-host:3800"
+            stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
+
+            expect(bundle_load_error_message).to include(failure_message)
+          end
+        end
+
         context "when malformed URL userinfo contains a literal double quote" do
           it "redacts the escaped URL from the URI error" do
             server_bundle_url = "http://synthetic-user:sec\"ret@host/path"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -216,6 +216,23 @@ module ReactOnRails
           end
         end
 
+        context "when a configured typo-scheme renderer authority has multiple at signs" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          before do
+            ENV["REACT_RENDERER_URL"] =
+              "htps://synthetic-user:synthetic-prefix@synthetic-secret@renderer.example.com:3800/path"
+          end
+
+          it "fails closed through the final at sign while retaining the scheme, host, and path" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-prefix")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("htps://renderer.example.com:3800/path")
+          end
+        end
+
         context "when the error message itself names a renderer URL with embedded credentials" do
           let(:error) do
             StandardError.new(
@@ -910,6 +927,59 @@ module ReactOnRails
             stub_http_bundle_failure(failure_message)
 
             expect(bundle_load_error_message).to include(failure_message)
+          end
+        end
+
+        context "when a configured typo-scheme bundle authority embeds credentials" do
+          it "redacts the credentials while retaining the scheme, host, and path" do
+            server_bundle_path =
+              "htps://synthetic-user:synthetic-secret@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("htps://renderer.example/bundle.js")
+          end
+
+          it "preserves an at sign that belongs only to the path" do
+            server_bundle_path = "htps://renderer.example/bundle@example.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            expect(bundle_load_error_message).to include(server_bundle_path)
+          end
+
+          it "preserves a scheme-only value without masking the bundle-load diagnostic" do
+            server_bundle_path = "htps://"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            expect(bundle_load_error_message).to include(server_bundle_path)
+          end
+        end
+
+        context "when the configured scheme parser discards userinfo" do
+          it "uses the parser's sanitized value rather than returning the raw credentials" do
+            server_bundle_path = "file://synthetic-user:synthetic-secret@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("file://renderer.example/bundle.js")
+          end
+        end
+
+        context "when a configured typo-scheme value contains another authority scheme" do
+          it "fails closed across the ambiguous prefix while retaining the credential authority's host and path" do
+            server_bundle_path =
+              "htps://outer.example/pathcustom://synthetic-user:synthetic-secret@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("outer.example")
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("htps://renderer.example/bundle.js")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -121,6 +121,31 @@ module ReactOnRails
           end
         end
 
+        context "when a wrapper names only a scheme-less renderer authority" do
+          let(:error) do
+            StandardError.new(
+              "Connection error on renderer request: synthetic-user:synthetic-secret@renderer.internal:3800"
+            )
+          end
+
+          it "redacts credentials from the entire public connection diagnostic" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("renderer.internal:3800")
+          end
+
+          it "redacts token-style userinfo from the entire public connection diagnostic" do
+            token_error = StandardError.new(
+              "Connection error on renderer request: synthetic-token@renderer.internal:3800"
+            )
+
+            message = render_error_for(token_error).message
+            expect(message).not_to include("synthetic-token")
+            expect(message).to include("renderer.internal:3800")
+          end
+        end
+
         context "when the connection Errno survives only as the error's #cause" do
           # The Pro renderer client wraps the original Errno (ReactOnRailsPro::Error ->
           # ConnectionError -> Errno::ECONNREFUSED). The wrapper message here carries no
@@ -294,12 +319,12 @@ module ReactOnRails
               "htps://synthetic-user:synthetic-prefix@synthetic-secret@renderer.example.com:3800/path"
           end
 
-          it "fails closed through the final at sign while retaining the scheme, host, and path" do
+          it "fails closed through the final at sign while retaining the host and path" do
             message = render_error_for(error).message
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-prefix")
             expect(message).not_to include("synthetic-secret")
-            expect(message).to include("htps://renderer.example.com:3800/path")
+            expect(message).to include("renderer.example.com:3800/path")
           end
         end
 
@@ -475,6 +500,22 @@ module ReactOnRails
               message = render_error_for(error).message
               expect(message).not_to include("synthetic-secret")
               expect(message).to include("renderer.internal:3800")
+            end
+          end
+        end
+
+        context "when renderer env credentials are absorbed into an unknown apparent scheme" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          %w[REACT_RENDERER_URL RENDERER_URL].each do |renderer_env|
+            it "fails closed through the userinfo delimiter for #{renderer_env}" do
+              ENV[renderer_env] = "synthetic-secrethtps://apikey@renderer.internal:3800"
+
+              message = render_error_for(error).message
+              expect(message).not_to include("synthetic-secret")
+              expect(message).not_to include("apikey")
+              expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
+              expect(message).to include(%(#{renderer_env} is currently "renderer.internal:3800"))
             end
           end
         end
@@ -984,6 +1025,15 @@ module ReactOnRails
         end
 
         context "when a configured local bundle value is a scheme-less credential authority" do
+          it "redacts token-style userinfo while retaining the host and path" do
+            server_bundle_path = "apikey@cdn.example.com/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("apikey")
+            expect(message).to include("cdn.example.com/bundle.js")
+          end
+
           it "redacts credentials while retaining the host and path" do
             server_bundle_path =
               "synthetic-user:synthetic-secret@cdn.example.com/bundle.js"
@@ -1323,7 +1373,7 @@ module ReactOnRails
         end
 
         context "when a configured typo-scheme bundle authority embeds credentials" do
-          it "redacts the credentials while retaining the scheme, host, and path" do
+          it "redacts the credentials while retaining the host and path" do
             server_bundle_path =
               "htps://synthetic-user:synthetic-secret@renderer.example/bundle.js"
             stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
@@ -1331,7 +1381,7 @@ module ReactOnRails
             message = bundle_load_error_message
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
-            expect(message).to include("htps://renderer.example/bundle.js")
+            expect(message).to include("renderer.example/bundle.js")
           end
 
           ["/", "?", "#"].each do |delimiter|
@@ -1343,7 +1393,7 @@ module ReactOnRails
               message = bundle_load_error_message
               expect(message).not_to include("synthetic-user")
               expect(message).not_to include("synthetic-secret")
-              expect(message).to include("htps://renderer.example/bundle.js")
+              expect(message).to include("renderer.example/bundle.js")
             end
           end
 
@@ -1357,7 +1407,7 @@ module ReactOnRails
             expect(message).not_to include("synthetic-prefix")
             expect(message).not_to include("synthetic-middle")
             expect(message).not_to include("synthetic-secret")
-            expect(message).to include("htps://renderer.example/path")
+            expect(message).to include("renderer.example/path")
           end
 
           it "fails closed when a path at sign could be delayed userinfo" do
@@ -1367,7 +1417,7 @@ module ReactOnRails
             message = bundle_load_error_message
             expect(message).not_to include("renderer.example")
             expect(message).not_to include("renderer.example/bundle")
-            expect(message).to include("htps://example.js")
+            expect(message).to include("example.js")
           end
 
           it "preserves a scheme-only value without masking the bundle-load diagnostic" do
@@ -1387,7 +1437,7 @@ module ReactOnRails
             message = bundle_load_error_message
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
-            expect(message).to include("http_://renderer.example/bundle.js")
+            expect(message).to include("renderer.example/bundle.js")
           end
 
           [["a percent sign", "http%"], ["only digits", "123"]].each do |description, scheme|
@@ -1399,7 +1449,7 @@ module ReactOnRails
               message = bundle_load_error_message
               expect(message).not_to include("synthetic-user")
               expect(message).not_to include("synthetic-secret")
-              expect(message).to include("#{scheme}://renderer.example/bundle.js")
+              expect(message).to include("renderer.example/bundle.js")
             end
           end
 
@@ -1411,7 +1461,7 @@ module ReactOnRails
             message = bundle_load_error_message
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
-            expect(message).to include("y://renderer.example/bundle.js")
+            expect(message).to include("renderer.example/bundle.js")
           end
         end
 
@@ -1437,7 +1487,7 @@ module ReactOnRails
             expect(message).not_to include("outer.example")
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
-            expect(message).to include("htps://renderer.example/bundle.js")
+            expect(message).to include("renderer.example/bundle.js")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -613,12 +613,14 @@ module ReactOnRails
           end
         end
 
-        context "when a configured URL has an at sign only in its path" do
-          it "preserves the URL because the configured value parses without userinfo" do
+        context "when a configured URL has an at sign after the authority" do
+          it "fails closed because the path could contain delayed userinfo" do
             server_bundle_url = "http://host/path@example"
             stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            expect(bundle_load_error_message).to include(server_bundle_url)
+            message = bundle_load_error_message
+            expect(message).not_to include("host/path")
+            expect(message).to include("http://example")
           end
         end
 
@@ -942,11 +944,27 @@ module ReactOnRails
             expect(message).to include("htps://renderer.example/bundle.js")
           end
 
-          it "preserves an at sign that belongs only to the path" do
+          ["/", "?", "#"].each do |delimiter|
+            it "fails closed when #{delimiter.inspect} precedes a delayed userinfo delimiter" do
+              server_bundle_path =
+                "htps://synthetic-user#{delimiter}synthetic-secret@renderer.example/bundle.js"
+              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("htps://renderer.example/bundle.js")
+            end
+          end
+
+          it "fails closed when a path at sign could be delayed userinfo" do
             server_bundle_path = "htps://renderer.example/bundle@example.js"
             stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
 
-            expect(bundle_load_error_message).to include(server_bundle_path)
+            message = bundle_load_error_message
+            expect(message).not_to include("renderer.example")
+            expect(message).not_to include("renderer.example/bundle")
+            expect(message).to include("htps://example.js")
           end
 
           it "preserves a scheme-only value without masking the bundle-load diagnostic" do
@@ -954,6 +972,19 @@ module ReactOnRails
             stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
 
             expect(bundle_load_error_message).to include(server_bundle_path)
+          end
+        end
+
+        context "when a configured bundle authority uses an invalid scheme spelling" do
+          it "redacts credentials after an underscore in the scheme" do
+            server_bundle_path =
+              "http_://synthetic-user:synthetic-secret@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("http_://renderer.example/bundle.js")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -216,6 +216,40 @@ module ReactOnRails
           end
         end
 
+        context "when REACT_RENDERER_URL is a scheme-less credential authority" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          before do
+            ENV["REACT_RENDERER_URL"] =
+              "synthetic-user:synthetic-secret@renderer.internal:3800"
+          end
+
+          it "fails closed through the userinfo delimiter while retaining the host and port" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
+            expect(message).to include('REACT_RENDERER_URL is currently "renderer.internal:3800"')
+          end
+        end
+
+        context "when scheme-less renderer credentials contain a scheme-like substring" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          before do
+            ENV["REACT_RENDERER_URL"] =
+              "synthetic-user:synthetic-secrethttps://suffix@renderer.internal:3800"
+          end
+
+          it "does not mistake the userinfo substring for a leading URL scheme" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
+            expect(message).to include('REACT_RENDERER_URL is currently "renderer.internal:3800"')
+          end
+        end
+
         context "when a configured typo-scheme renderer authority has multiple at signs" do
           let(:error) { Errno::ECONNREFUSED.new }
 
@@ -265,6 +299,40 @@ module ReactOnRails
             message = render_error_for(error).message
             expect(message).to include('RENDERER_URL is currently "http://legacy-host:3800"')
             expect(message).not_to include("REACT_RENDERER_URL is not set")
+          end
+        end
+
+        context "when only RENDERER_URL is a scheme-less credential authority" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          before do
+            ENV["RENDERER_URL"] =
+              "synthetic-user:synthetic-secret@renderer.internal:3800"
+          end
+
+          it "fails closed through the userinfo delimiter while retaining the host and port" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
+            expect(message).to include('RENDERER_URL is currently "renderer.internal:3800"')
+          end
+        end
+
+        context "when scheme-less RENDERER_URL credentials contain a scheme-like substring" do
+          let(:error) { Errno::ECONNREFUSED.new }
+
+          before do
+            ENV["RENDERER_URL"] =
+              "synthetic-user:synthetic-secrethttps://suffix@renderer.internal:3800"
+          end
+
+          it "does not mistake the userinfo substring for a leading URL scheme" do
+            message = render_error_for(error).message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("could not connect to the Node renderer at renderer.internal:3800")
+            expect(message).to include('RENDERER_URL is currently "renderer.internal:3800"')
           end
         end
 
@@ -676,6 +744,23 @@ module ReactOnRails
             stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
 
             expect(bundle_load_error_message).to include(failure_message)
+          end
+
+          it "preserves a scheme-less credential-shaped token byte for byte" do
+            failure_message =
+              "Failure loading synthetic-user:synthetic-secret@renderer.internal:3800"
+            stub_local_bundle_failure(failure_message, bundle_path: "/tmp/server.js")
+
+            expect(bundle_load_error_message).to include(failure_message)
+          end
+        end
+
+        context "when an ordinary local bundle path contains an at sign" do
+          it "preserves the configured path byte for byte" do
+            server_bundle_path = "/tmp/releases/build@2026/server-bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            expect(bundle_load_error_message).to include(server_bundle_path)
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -1012,6 +1012,17 @@ module ReactOnRails
               expect(message).to include("#{scheme}://renderer.example/bundle.js")
             end
           end
+
+          it "redacts credentials when URI parsing treats the value as opaque" do
+            server_bundle_path =
+              "x:y://synthetic-user:synthetic-secret@renderer.example/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("x:y://renderer.example/bundle.js")
+          end
         end
 
         context "when the configured scheme parser discards userinfo" do


### PR DESCRIPTION
## Why

Release 17.1 must not disclose credentials from malformed or typo-scheme renderer URLs. The first release repair covered supported HTTP URL parsing, but issue #4825's adversarial cases showed that configured unsupported scheme-like authorities could still survive in diagnostics.

## What changed

- structurally redact userinfo through the final `@` for malformed or ambiguous configured authorities
- redact scheme-less credential authorities from scraped renderer-connection targets, caught connection errors, configured renderer environment values, and configured local-bundle diagnostics
- fail closed when credential text is absorbed into an apparent scheme such as `synthetic-secrethttps://...`, including empty userinfo and wrapped connection-error forms
- discard unregistered apparent-scheme text when a later `@` makes it ambiguous credential material
- classify and sanitize bounded `Connection`/`Time out`/generic renderer-request wrappers, preserving the exact raw capture for replacement while sanitizing a separate display target
- select structured renderer targets in message order, with prefix-specific tie breaking and generic HTTP prose only as a fallback
- treat punctuation-separated repeated renderer prefixes as independent targets while keeping delimiter-free spans fail-closed
- preserve safe labels such as `URL=`, standalone empty-userinfo reporter tokens, ordinary absolute/relative POSIX and Windows local `@` paths, and existing free-form reporter semantics
- cover delayed `/`, `?`, and `#` delimiters plus invalid, opaque, nested, parser-discarded, and scheme-less forms without changing routing or configuration behavior

## Verification

- exact head: `e4275d174261c755b4b35f01716aad372225babb`
- public TDD for both `REACT_RENDERER_URL` and `RENDERER_URL`: bare apparent-scheme credentials were RED (2 failures) then GREEN (2 passing)
- public configured-bundle safe-label regression: `URL=synthetic-secrethttps://apikey@...` was RED (1 failure) then GREEN (1 passing)
- public renderer diagnostics with empty userinfo were RED (2 new failures in a 4-example context) then GREEN (4 passing)
- public wrapped connection-error diagnostic was RED (1 failure) then GREEN (1 passing)
- public cause-chain target characterization caught and fixed token over-capture: RED (1 failure) then GREEN (2 focused passing with the wrapped-error case)
- public scraped connection-target diagnostic with token-style scheme-less userinfo was RED (1 failure) then GREEN (1 passing); the token is absent from the entire message and `renderer.internal:3800` remains
- public unknown apparent-scheme ENV diagnostics were RED for both `REACT_RENDERER_URL` and `RENDERER_URL` (2 failures) then GREEN (2 passing); questionable scheme text is discarded and the host remains
- public configured local-bundle bare-token authority was RED (1 failure) then GREEN (1 passing), while all seven explicit filesystem `@` paths remain byte-for-byte unchanged
- public wrapper-only scheme-less authority was RED (1 failure) then GREEN (1 passing); a bare-token wrapper characterization also passes
- public timeout-wrapper bare-token authority was RED (1 failure) then GREEN (1 passing); extraction remains anchored to the entire supported wrapper message
- public quote-bearing, generic lowercase, prefixed, and trailing-context wrapper variants were RED (4 failures) then GREEN (4 passing); raw targets remain available for exact caught-error substitution
- review-found real Pro timeout request-path promotion regression was RED (1 failure) then GREEN (1 passing); headline/listening guidance falls back to the configured renderer authority
- review-found wrapper-context-before-credential-URL precedence regression was RED (1 failure) then GREEN (1 passing); the existing prefixed-URL sanitizer wins before the wrapper fallback
- quote-bearing HTTP wrapper ordering regression was RED (1 failure) then GREEN as part of the six-example wrapper matrix
- public Connection and Time out wrappers with comma-bearing malformed userinfo were RED (2 failures) then GREEN (2 passing); post-authority comma and comma-plus-prose boundaries also pass
- public Connection and Time out wrappers with right-parenthesis-bearing malformed userinfo were RED through the first Connection regression (1 failure) then GREEN for both forms (2 passing); the post-authority right-parenthesis boundary also passes
- public targetless `error on renderer request` classification was RED (1 failure) then GREEN; the exact marker, colon-only, and colon-plus-whitespace base-parity forms all pass without making target capture optional
- public `connect(2)` and TCP targets with comma/right-parenthesis-bearing malformed userinfo share one credential-aware grammar: the first public `connect(2)` regression was RED (1 failure), then all 4 vulnerable forms and 4 post-authority punctuation controls were GREEN (8 passing)
- public configured local-bundle scoped-package paths were RED for `node_modules/@org/pkg/dist/server-bundle.js` (1 failure), then both that path and `@org/pkg/server-bundle.js` were preserved byte for byte while `apikey@cdn.example.com/bundle.js` remained redacted (3 focused passing)
- public `connect(2)`/TCP/Connection/Time out whitespace-spanning credentials were RED through the first `connect(2)` regression (1 failure), then all 4 vulnerable forms and 4 safe host-before-`ops@example.com` controls were GREEN (8 passing)
- review-found Connection/Time out targets after LF, CR, and CRLF were RED (6 failures) then GREEN (6 passing); a targetless first socket prefix before a later credential-bearing prefix was RED for `connect(2)` and TCP (2 failures) then GREEN (2 passing)
- review-found typo-scheme first-token boundary and later scheme-less authority with a request path were independently RED (1 failure each) then GREEN (1 passing each); only HTTP(S) URLs establish a safe first-token URL boundary, while host:numeric-port suffixes retain safe path/query/fragment context
- public HTTP/HTTPS wrapper diagnostics followed by `while notifying ops@example.com` were RED as one aggregate example with 2 subfailures (`http[s]://example.com` replaced the caught text), then GREEN with exact caught-error parity; credential-bearing HTTP/HTTPS controls also pass with both canaries absent
- exact target-range tracking fixed an earlier-duplicate-URL regression: RED as one aggregate example with 2 subfailures, then GREEN without collision-prone placeholder substitution
- cross-boundary renderer credentials after a valid URL were RED as one aggregate example with 4 subfailures for numeric-port forms and 8 subfailures for portless/host-path forms, then GREEN while preserving the explicit safe notification-email control
- a later credential-bearing renderer wrapper was RED (1 failure) then GREEN; notification-shaped credential text was independently RED (1 failure) then GREEN without broadening free-form reporter scanning
- exact review found recursive suffix processing could raise `SystemStackError` with 5,000 later structured URLs; the public regression was RED (1 failure) then GREEN through an iterative range pass, completing in about 0.09 seconds in the full suite
- exact review found malformed first-target credentials crossing a newline and delayed userinfo in a later malformed HTTP target; each public regression was RED (1 failure) then GREEN, with all canaries absent and safe `renderer.internal:3800` context retained
- public mixed-prefix message ordering was RED in the full focused file (219 examples, 1 failure) when an earlier credential-bearing wrapper preceded a later `connect(2)` target, then GREEN for wrapper/connect/TCP permutations (4 passing) plus coincident-start specificity controls (3 passing)
- exact review found that unrelated earlier HTTP prose could mask a later credentialed wrapper and that a request-path wrapper could mask a repeated credential-bearing wrapper; the public regressions were RED (2 examples, 2 failures) then GREEN (2 passing), preserving the docs URL and redacting every canary
- public repeated same-family `connect(2)`/TCP/wrapper diagnostics were independently RED (1 failure each) because a later credential target displaced the first safe target, then GREEN together (3 passing) with the first target retained and later credentials redacted
- exact review independently found that delimiter-free repeated family text could incorrectly preserve an apparent first HTTP host; public wrapper regression was RED (1 failure), then the wrapper/connect/TCP matrix was GREEN with no canaries after requiring an explicit punctuation-plus-whitespace boundary (1 aggregate passing)
- lazy candidate scanning stress check: 2,000 structured targets / 52,891 bytes completed in 0.198 seconds after the repeated-family repair
- public 5,000-URL diagnostic stress regression: 1 example, 0 failures in 0.091 seconds
- focused RSpec: 231 examples, 0 failures
- focused RuboCop: 2 files, 0 offenses
- full OSS RuboCop: 252 files, 0 offenses
- explicit local-path matrix: absolute, dot-relative, and parent-relative POSIX paths plus Windows drive, dot-relative, parent-relative, and UNC paths containing `@` remain byte-for-byte unchanged
- free-form apparent-scheme reporter characterization remains on the pre-existing HTTP-token scanning path
- `git diff --check`: passed
- pre-commit hooks: trailing newlines and focused RuboCop passed
- pre-push hooks: branch RuboCop 15 files/0 offenses; Markdown links 1,247 total/0 errors
- exact-commit second-model review found and drove the newline-wrapper, repeated-targetless-prefix, typo-scheme-boundary, authority-path, HTTP-prose precedence, and repeated-wrapper fixes above
- exact-commit review at `83de73def124038739f4a2a92a0f917398157503` found the delimiter-free repeated-prefix leak above; independent validation confirmed the regression against parent `c9e264adcdda84d3ecbe58b276e6ba54762a70c1`, and the finding was fixed before publication
- final exact-commit review at `e4275d174261c755b4b35f01716aad372225babb` exceeded its bounded window without a final verdict or another actionable finding; the documented fallback captured its independent 231/0 focused replay and separator-control probes; fresh hosted exact-head review remains mandatory
- prior broad `.agents/bin/validate` reached the release base's known unrelated RBS instrumentation mismatch (`Configuration#node_modules_location=` expects `String?`, receives `Pathname`); the sanitizer suite is green at this head

Fixes #4825
