### PR TITLE
Benchmarks: discover v2 Node Renderer bundles

### DIFF
--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -77,6 +77,7 @@ VEGETA_DURATION_UNITS_IN_SECONDS = {
   "m" => 60,
   "h" => 3600
 }.freeze
+V2_BUNDLE_ID_PATTERN = /\Arorp-v2-([sr])-[a-f0-9]{64}\z/
 
 # Local wrapper for add_summary_line to use local constant
 def add_to_summary(*parts)
@@ -88,10 +89,18 @@ def bundle_entry_mtime(bundles_dir, entry)
 end
 
 def newest_v2_bundles_by_role(bundles_dir, candidates)
-  candidates.group_by { |entry| entry[/\Arorp-v2-([sr])-/, 1] }
-            .values
-            .map do |role_entries|
-    role_entries.max_by { |entry| bundle_entry_mtime(bundles_dir, entry) }
+  candidates.group_by { |entry| entry[V2_BUNDLE_ID_PATTERN, 1] }
+            .map do |role, role_entries|
+    entries_by_mtime = role_entries.group_by { |entry| bundle_entry_mtime(bundles_dir, entry) }
+    newest_mtime, newest_entries = entries_by_mtime.max_by { |mtime, _entries| mtime }
+    if newest_entries.size > 1
+      raise format(
+        "Ambiguous newest node renderer bundles for role %<role>s: %<entries>s (shared mtime %<mtime>s)",
+        role:, entries: newest_entries.sort.join(", "), mtime: newest_mtime.to_f
+      )
+    end
+
+    newest_entries.first
   end
 end
 
@@ -100,7 +109,7 @@ def validate_bundle_payloads!(bundles_dir, bundles)
     payload_path = File.join(bundles_dir, entry, "#{entry}.js")
     next if File.file?(payload_path)
 
-    role = entry[/\Arorp-v2-([sr])-/, 1]
+    role = entry[V2_BUNDLE_ID_PATTERN, 1]
     message = if role
                 "Newest node renderer bundle for role #{role} is missing its payload: #{payload_path}"
               else
@@ -125,7 +134,7 @@ def find_all_production_bundles
   bundle_dirs = Dir.children(bundles_dir).select do |entry|
     File.directory?(File.join(bundles_dir, entry))
   end
-  v2_candidates = bundle_dirs.grep(/\Arorp-v2-[sr]-[a-f0-9]{64}\z/)
+  v2_candidates = bundle_dirs.grep(V2_BUNDLE_ID_PATTERN)
 
   bundles = if v2_candidates.empty?
               bundle_dirs.grep(/\A[a-f0-9]+-production\z/)

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -147,7 +147,7 @@ def find_all_production_bundles
 
   raise "No production bundles found in #{bundles_dir}" if bundles.empty?
 
-  validate_bundle_payloads!(bundles_dir, bundles)
+  validate_bundle_payloads!(bundles_dir, bundles) unless v2_candidates.empty?
 
   bundles
 end

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -83,6 +83,33 @@ def add_to_summary(*parts)
   add_summary_line(SUMMARY_TXT, *parts)
 end
 
+def bundle_entry_mtime(bundles_dir, entry)
+  File.mtime(File.join(bundles_dir, entry))
+end
+
+def newest_v2_bundles_by_role(bundles_dir, candidates)
+  candidates.group_by { |entry| entry[/\Arorp-v2-([sr])-/, 1] }
+            .values
+            .map do |role_entries|
+    role_entries.max_by { |entry| bundle_entry_mtime(bundles_dir, entry) }
+  end
+end
+
+def validate_bundle_payloads!(bundles_dir, bundles)
+  bundles.each do |entry|
+    payload_path = File.join(bundles_dir, entry, "#{entry}.js")
+    next if File.file?(payload_path)
+
+    role = entry[/\Arorp-v2-([sr])-/, 1]
+    message = if role
+                "Newest node renderer bundle for role #{role} is missing its payload: #{payload_path}"
+              else
+                "Node renderer bundle #{entry} is missing its payload: #{payload_path}"
+              end
+    raise message
+  end
+end
+
 # Find all production bundles in the node-renderer bundles directory
 def find_all_production_bundles
   bundles_dir = File.join(
@@ -95,14 +122,23 @@ def find_all_production_bundles
           "Make sure the Pro dummy app has been compiled with NODE_ENV=production"
   end
 
-  # Bundle directories have format: <hash>-<environment> (e.g., 623229694671afc1ac9137f2715bb654-production)
-  # Filter to only include production bundles with hash-like names
-  bundles = Dir.children(bundles_dir).select do |entry|
-    File.directory?(File.join(bundles_dir, entry)) &&
-      entry.match?(/^[a-f0-9]+-production$/)
+  bundle_dirs = Dir.children(bundles_dir).select do |entry|
+    File.directory?(File.join(bundles_dir, entry))
+  end
+  v2_candidates = bundle_dirs.grep(/\Arorp-v2-[sr]-[a-f0-9]{64}\z/)
+
+  bundles = if v2_candidates.empty?
+              bundle_dirs.grep(/\A[a-f0-9]+-production\z/)
+            else
+              newest_v2_bundles_by_role(bundles_dir, v2_candidates)
+            end
+  bundles.sort_by! do |entry|
+    -bundle_entry_mtime(bundles_dir, entry).to_f
   end
 
   raise "No production bundles found in #{bundles_dir}" if bundles.empty?
+
+  validate_bundle_payloads!(bundles_dir, bundles)
 
   bundles
 end

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe "bench-node-renderer" do
         expect(find_all_production_bundles).to eq([new_legacy, old_legacy])
       end
     end
+
+    it "does not add eager payload validation to legacy discovery" do
+      Dir.mktmpdir do |root|
+        bundles_dir = File.join(root, "react_on_rails_pro/spec/dummy/.node-renderer-bundles")
+        old_legacy = "#{'a' * 32}-production"
+        new_legacy = "#{'b' * 32}-production"
+        create_renderer_bundle(bundles_dir, old_legacy, mtime: Time.at(10), payload: false)
+        create_renderer_bundle(bundles_dir, new_legacy, mtime: Time.at(20))
+        allow(self).to receive(:workspace_root).and_return(root)
+
+        expect(find_all_production_bundles).to eq([new_legacy, old_legacy])
+      end
+    end
   end
 
   describe "#validate_node_renderer_benchmark_config!" do

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe "bench-node-renderer" do
       end
     end
 
+    it "raises when multiple v2 candidates for a role share the newest mtime" do
+      Dir.mktmpdir do |root|
+        bundles_dir = File.join(root, "react_on_rails_pro/spec/dummy/.node-renderer-bundles")
+        first_server = "rorp-v2-s-#{'a' * 64}"
+        second_server = "rorp-v2-s-#{'b' * 64}"
+        create_renderer_bundle(bundles_dir, first_server, mtime: Time.at(50))
+        create_renderer_bundle(bundles_dir, second_server, mtime: Time.at(50))
+        allow(self).to receive(:workspace_root).and_return(root)
+
+        expect { find_all_production_bundles }
+          .to raise_error(/Ambiguous newest node renderer bundles for role s: #{first_server}, #{second_server}/)
+      end
+    end
+
     it "keeps legacy production bundles newest-first when no v2 candidates exist" do
       Dir.mktmpdir do |root|
         bundles_dir = File.join(root, "react_on_rails_pro/spec/dummy/.node-renderer-bundles")

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "tmpdir"
 require_relative "spec_helper"
 require_relative "../bench-node-renderer"
 
@@ -12,6 +13,70 @@ require_relative "../bench-node-renderer"
 RSpec.describe "bench-node-renderer" do
   def process_status(success:, exitstatus: nil, termsig: nil)
     instance_double(Process::Status, success?: success, exitstatus:, termsig:)
+  end
+
+  def create_renderer_bundle(bundles_dir, entry, mtime:, payload: true)
+    entry_dir = File.join(bundles_dir, entry)
+    FileUtils.mkdir_p(entry_dir)
+    File.write(File.join(entry_dir, "#{entry}.js"), "") if payload
+    File.utime(mtime, mtime, entry_dir)
+  end
+
+  describe "#find_all_production_bundles" do
+    it "finds only the newest renderer-ready v2 bundle for each encoded role" do
+      Dir.mktmpdir do |root|
+        bundles_dir = File.join(root, "react_on_rails_pro/spec/dummy/.node-renderer-bundles")
+        old_server = "rorp-v2-s-#{'a' * 64}"
+        old_rsc = "rorp-v2-r-#{'b' * 64}"
+        new_server = "rorp-v2-s-#{'c' * 64}"
+        new_rsc = "rorp-v2-r-#{'d' * 64}"
+        legacy = "#{'e' * 32}-production"
+        bundle_mtimes = {
+          old_server => 10, new_rsc => 40, "not-a-bundle" => 80,
+          new_server => 50, legacy => 30,
+          "rorp-v2-x-#{'0' * 64}" => 70, "rorp-v2-s-#{'1' * 63}" => 90, old_rsc => 20
+        }
+        bundle_mtimes.each do |entry, mtime|
+          create_renderer_bundle(bundles_dir, entry, mtime: Time.at(mtime))
+        end
+
+        allow(self).to receive(:workspace_root).and_return(root)
+
+        expect(find_all_production_bundles).to eq([new_server, new_rsc])
+      end
+    end
+
+    it "raises when the newest v2 candidate for a role is missing its payload" do
+      Dir.mktmpdir do |root|
+        bundles_dir = File.join(root, "react_on_rails_pro/spec/dummy/.node-renderer-bundles")
+        old_server = "rorp-v2-s-#{'a' * 64}"
+        old_rsc = "rorp-v2-r-#{'b' * 64}"
+        new_server = "rorp-v2-s-#{'c' * 64}"
+        new_rsc = "rorp-v2-r-#{'d' * 64}"
+        { old_server => 10, old_rsc => 20, new_server => 50, new_rsc => 40 }.each do |entry, mtime|
+          create_renderer_bundle(bundles_dir, entry, mtime: Time.at(mtime), payload: entry != new_server)
+        end
+        allow(self).to receive(:workspace_root).and_return(root)
+        expected_payload = File.join(bundles_dir, new_server, "#{new_server}.js")
+
+        expect { find_all_production_bundles }
+          .to raise_error("Newest node renderer bundle for role s is missing its payload: #{expected_payload}")
+      end
+    end
+
+    it "keeps legacy production bundles newest-first when no v2 candidates exist" do
+      Dir.mktmpdir do |root|
+        bundles_dir = File.join(root, "react_on_rails_pro/spec/dummy/.node-renderer-bundles")
+        old_legacy = "#{'a' * 32}-production"
+        new_legacy = "#{'b' * 32}-production"
+        create_renderer_bundle(bundles_dir, old_legacy, mtime: Time.at(10))
+        create_renderer_bundle(bundles_dir, "not-a-bundle", mtime: Time.at(30))
+        create_renderer_bundle(bundles_dir, new_legacy, mtime: Time.at(20))
+        allow(self).to receive(:workspace_root).and_return(root)
+
+        expect(find_all_production_bundles).to eq([new_legacy, old_legacy])
+      end
+    end
   end
 
   describe "#validate_node_renderer_benchmark_config!" do


### PR DESCRIPTION
## Why

The unattended 05:00 HST run associated with closed issue #4073 reached Pro Node Renderer setup at merge commit `65a8269ed41ddba0b0ec351f1496aef6e5fb9124`, but its benchmark harness reported that no production bundles existed.

The cache was not empty. Pro pre-seeding had staged canonical v2 artifact directories named `rorp-v2-s-<64 hex>` and `rorp-v2-r-<64 hex>`, while `bench-node-renderer.rb` still accepted only legacy `<hex>-production` names. That matcher returned zero entries and produced the misleading empty-bundle failure.

This is follow-up work for #4073 and PR #4853. It intentionally does not reopen or auto-close the already-completed issue.

## What changed

- Recognize only the strict canonical v2 server and RSC artifact names.
- Select the newest candidate independently for each encoded role, preventing persistent-cache leftovers from being benchmarked as current output.
- Fail closed when same-role candidates share the exact newest mtime instead of choosing one nondeterministically.
- Validate each selected candidate's exact `<id>/<id>.js` payload and fail closed if the newest artifact is incomplete; never fall back to an older readable artifact.
- Preserve newest-first legacy discovery only when no v2 candidates exist.
- Add regression coverage for v2 roles, malformed names, persistent stale entries, fail-closed payload validation, and legacy fallback.

No Pro runtime, scheduler, workflow, dependency, lockfile, or credential handling changed. No Pro license was requested or exposed.

## Validation

- `bundle exec rspec benchmarks/spec/bench_node_renderer_spec.rb` — 18 examples, 0 failures
- `bundle exec rspec benchmarks/spec` — 350 examples, 0 failures
- `.agents/bin/validate --changed` — passed docs sidebar, Ruby/benchmark RuboCop, package build, ESLint, Prettier, and type checking
- `.agents/bin/lint` — passed, including 260 runs / 2,258 assertions with no failures or errors
- `git diff --check` — clean
- Focused RuboCop — 2 files inspected, no offenses

## Review and churn

- The first independent Codex review found one real priority issue: accepting every v2 directory could benchmark stale persistent-cache artifacts. The implementation was narrowed to newest-per-role selection with fail-closed payload validation, and regression tests were added.
- The refined uncommitted review and the committed-diff review both returned clean.
- The first hosted review wave found one real P2 edge case: tied newest mtimes for one role made Ruby's `max_by` choice nondeterministic. The final review-fix commit now rejects that ambiguous state and adds a regression test. A low-risk hosted Claude DRY suggestion was batched into the same necessary commit by centralizing the strict role matcher.
- The final uncommitted review returned clean.
- The next hosted Claude wave found one real legacy-compatibility regression: eager payload validation changed the pre-existing legacy discovery contract. The review's supporting claim that the later live categorizer skips HTTP 410 responses was disproved during independent QA (`curl` does not use `--fail`), so this PR does not expand into that separate pre-existing behavior. The final review-fix confines exact-payload fail-closed validation to v2 discovery and adds a red/green example proving no eager validation was added to the legacy path.
- Independent read-only QA at exact head `922d693226c2ea7c305140b58b1eb9e66a609c98` returned CLEAN: focused finder specs 5/0, focused file 18/0, full benchmark specs 350/0, scoped RuboCop clean, and issue #4073 still CLOSED.
- The configured Claude Opus 4.8 review and simplify pass were unavailable because that provider reported its weekly limit, resetting Aug 10 at 21:00 HST. No result is inferred from the unavailable pass.
- Post-push fix cycles: 2; tied-mtime/DRY feedback was handled in `278f51f1a2ab8f45341ebe74b4d9604fac3394ad`, and legacy discovery compatibility was restored in `922d693226c2ea7c305140b58b1eb9e66a609c98`.

## Changelog

Not user-visible: this is a narrow internal benchmark-harness compatibility fix.

## Remaining operational receipt

The repository fix is not the final operational proof. After merge, the next unattended 05:00 HST run must record one exact-main receipt in which Core, Pro, and Pro Node Renderer all complete and upload. That receipt will be added durably while issue #4073 remains closed.

### QA Evidence

- QA lane: `rord-4073-qa-sol`, read-only QA in the implementation worktree, target claim covered by the batch claim; final heartbeat status `done`
- Scope checked: both changed benchmark files, exact-head discovery semantics, the persistent-cache failure shape, and closed issue state
- Tested at: `922d693226c2ea7c305140b58b1eb9e66a609c98` on base `f4a1bde1e880b5ea69c08c55f620fbf6c10afe19`
- Automated checks: focused finder specs 5/0; focused file 18/0; full benchmark specs 350/0; scoped RuboCop clean; `git diff --check` clean
- Manual checks: metadata-only audit found four canonical v2 directories and zero legacy-regex matches; a payload-less legacy fixture remained discoverable exactly as on the base branch; the separate legacy live-classification path was confirmed unchanged and left out of scope; no credential contents were read
- Findings: none after the stale-fallback finding was fixed and re-reviewed
- QA required: yes
- QA required rationale: unattended benchmark execution and persistent renderer-cache selection are operationally sensitive
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: script

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 922d693226c2ea7c305140b58b1eb9e66a609c98
tested_at: base f4a1bde1e880b5ea69c08c55f620fbf6c10afe19 at exact PR head 922d693226c2ea7c305140b58b1eb9e66a609c98
scope: benchmark Node Renderer v2 discovery, persistent-cache selection, tied-newest ambiguity, legacy fallback tolerance, and issue 4073 closed state
automated_checks: focused finder specs 5/0; focused file 18/0; full benchmark specs 350/0; scoped RuboCop clean; git diff --check clean
manual_checks: metadata-only cache audit found four canonical v2 directories and zero legacy-regex matches; payload-less legacy fixture matched base discovery behavior; unchanged legacy live classification left out of scope; no credential contents read
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no rendered UI changed
interaction_change: no
interaction_evidence: not applicable: no interaction behavior changed
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: benchmark harness discovery changed, not product runtime or a measured performance result
findings: none after fixed stale-fallback, tied-mtime, and eager-legacy-validation findings; incorrect legacy-410 skip premise rejected against base behavior
release_blocking: clear
process_gap_disposition: script
-->

<!-- priority-finding-dispositions v1
head_sha: 922d693226c2ea7c305140b58b1eb9e66a609c98
finding: url=https://github.com/shakacode/react_on_rails/pull/4858#discussion_r3742064859 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/commit/278f51f1a2ab8f45341ebe74b4d9604fac3394ad | waiver=not_applicable
finding: url=https://github.com/shakacode/react_on_rails/pull/4858#discussion_r3742115735 | severity=Must-Fix | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/commit/922d693226c2ea7c305140b58b1eb9e66a609c98 | waiver=not_applicable
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bundle discovery for rendering benchmarks by selecting the newest valid bundles.
  * Added validation for missing or ambiguous bundle payloads, providing clearer failures.
  * Preserved compatibility with legacy production bundles when newer bundles are unavailable.

* **Tests**
  * Added coverage for bundle selection, ordering, invalid entries, missing payloads, and ambiguity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Merge readiness

Confidence note:
- Validated: focused benchmark file 18/0; full benchmark specs 350/0; `.agents/bin/validate --changed`; `.agents/bin/lint`; scoped RuboCop; `git diff --check`; exact-head required gate, hosted lint/build, benchmark specs, CodeQL, CodeRabbit, and Claude review all passed.
- Evidence: exact head `922d693226c2ea7c305140b58b1eb9e66a609c98`; full-history address-review summary https://github.com/shakacode/react_on_rails/pull/4858#issuecomment-5229087333; all four review threads resolved; strict `script/pr-merge-ledger` completed with no violations or unknown fields.
- UNKNOWN: none affecting merge safety.
- Residual risk: the merged `main` commit has not yet been exercised by the real unattended 05:00 HST benchmark; that known post-merge operational receipt remains required and is not waived.

Decision points: 0 during implementation and review processing.

Merge authority: explicit maintainer approval for exact head `922d693226c2ea7c305140b58b1eb9e66a609c98`; state: `authorized-for-guarded-merge`; durable receipt: https://github.com/shakacode/react_on_rails/pull/4858#issuecomment-5229271155.

