### PR TITLE
Forward-port release/17.1.0 security fixes to main (#4825, #4822, #4827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,9 +225,11 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   bundle-load error naming the URL and status, instead of being returned as if it were JavaScript
   bundle source. Additionally, a `server_bundle_js_file` URL with embedded HTTP basic-auth
   credentials (e.g. `https://:password@host:3800/bundle.js`) no longer leaks that password into
-  raised errors or logs on a load failure. Fixes
-  [Issue 4584](https://github.com/shakacode/react_on_rails/issues/4584).
-  [PR 4817](https://github.com/shakacode/react_on_rails/pull/4817) by
+  raised errors or logs on a load failure, including malformed URLs with ambiguous userinfo. Fixes
+  [Issue 4584](https://github.com/shakacode/react_on_rails/issues/4584) and
+  [Issue 4825](https://github.com/shakacode/react_on_rails/issues/4825).
+  [PR 4817](https://github.com/shakacode/react_on_rails/pull/4817) and
+  [PR 4845](https://github.com/shakacode/react_on_rails/pull/4845) by
   [justin808](https://github.com/justin808).
 
 - **RailsContext now stays current across Turbo and Turbolinks navigation**: Parsed context is cached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   bundle-load error naming the URL and status, instead of being returned as if it were JavaScript
   bundle source. Additionally, a `server_bundle_js_file` URL with embedded HTTP basic-auth
   credentials (e.g. `https://:password@host:3800/bundle.js`) no longer leaks that password into
-  raised errors or logs on a load failure, including malformed URLs with ambiguous userinfo. Fixes
+  raised errors or logs on a load failure, including malformed URLs with ambiguous userinfo.
+  Percent-encoded spellings are redacted wherever their literal spelling is, so values such as
+  `http:%2F%2Fuser:password%40host/bundle.js` and `%2F%2Fuser:password%40host/bundle.js` no longer
+  survive redaction. Safe encoded path, query, and fragment data is left intact. Fixes
   [Issue 4584](https://github.com/shakacode/react_on_rails/issues/4584) and
   [Issue 4825](https://github.com/shakacode/react_on_rails/issues/4825).
   [PR 4817](https://github.com/shakacode/react_on_rails/pull/4817) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,18 +199,19 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   [PR 4833](https://github.com/shakacode/react_on_rails/pull/4833) by
   [justin808](https://github.com/justin808).
 
-- **[Pro]** **RSC render-error details are no longer sent to the browser on the fetched payload path**:
-  The RSC payload fetched during client-side navigation (via `rsc_payload_generation_url_path`) included
-  the server's rendering-error message and source-mapped stack — which contains server file paths — in its
-  metadata, in every environment. The inline (first-paint) payload path was already redacted, so error
-  detail that was hidden on first paint could still reach the browser on a client navigation. The fetched
-  path now applies the same fail-closed gate: full detail only in `development` and `test`, while
-  `production`, `staging`, and any unrecognized environment receive a generic `hasErrors: true` signal so
-  client error boundaries still fire. Server-side error handling is unaffected — `raise_prerender_error`
-  still receives the full message and stack, because redaction happens at the browser-facing boundary
-  after the server's own error transform runs. Fixes
-  [Issue 4736](https://github.com/shakacode/react_on_rails/issues/4736).
-  [PR 4821](https://github.com/shakacode/react_on_rails/pull/4821) by
+- **[Pro]** **RSC render-error details no longer reach browser-facing payloads in production-like
+  environments**: Fetched RSC payload metadata now uses a fail-closed allowlist that exposes only the
+  generic `hasErrors` signal needed by client error boundaries. Inline error-bearing payload chunks now
+  also suppress console replay in `production`, `staging`, and unrecognized environments, closing a path
+  that could repeat the server error message or source-mapped file paths after diagnostic metadata was
+  redacted. Full diagnostics and console replay remain available in `development` and `test`, clean
+  production chunks retain console replay, and server-side reporting still receives the original error
+  details before the browser-boundary redaction runs. Fixes
+  [Issue 4736](https://github.com/shakacode/react_on_rails/issues/4736),
+  [Issue 4822](https://github.com/shakacode/react_on_rails/issues/4822), and
+  [Issue 4827](https://github.com/shakacode/react_on_rails/issues/4827).
+  [PR 4821](https://github.com/shakacode/react_on_rails/pull/4821) and
+  [PR 4856](https://github.com/shakacode/react_on_rails/pull/4856) by
   [justin808](https://github.com/justin808).
 
 - **HTTP-served SSR bundle loading now honors the response charset, rejects non-2xx responses,

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -116,14 +116,23 @@ function hasMalformedRenderingError(metadata: Record<string, unknown>) {
   return (hasMessage && typeof message !== 'string') || (hasStack && typeof stack !== 'string');
 }
 
+function hasProductionErrorSignal(metadata: Record<string, unknown>) {
+  const { hasErrors, renderingError } = metadata;
+  return (
+    hasErrors === true ||
+    hasRenderingErrorSignal(renderingError) ||
+    hasMalformedHasErrors(metadata) ||
+    hasMalformedRenderingError(metadata)
+  );
+}
+
 function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: string) {
   // Console replay remains useful in development/test and for clean production chunks. On an
   // error-bearing chunk, however, it can repeat the same server-only message or stack path that
   // diagnostic metadata redacts, so unknown and production-like environments fail closed.
   if (railsEnv === 'development' || railsEnv === 'test') return true;
 
-  const hasRenderingErrorMetadata = Object.prototype.hasOwnProperty.call(metadata, 'renderingError');
-  return metadata.hasErrors !== true && !hasRenderingErrorMetadata && !hasMalformedHasErrors(metadata);
+  return !hasProductionErrorSignal(metadata);
 }
 
 function createRSCDiagnosticScript(
@@ -138,10 +147,9 @@ function createRSCDiagnosticScript(
   // a useful diagnostic when the server provided a non-blank message or stack. Outside
   // development/test, malformed values fail closed to the same generic signal as the fetched
   // RSC path instead of suppressing both the replay and the diagnostic.
-  const hasDiagnosticSignal =
-    hasErrors === true ||
-    hasRenderingErrorSignal(renderingError) ||
-    (!showFullDiagnostics && (hasMalformedHasErrors(metadata) || hasMalformedRenderingError(metadata)));
+  const hasDiagnosticSignal = showFullDiagnostics
+    ? hasErrors === true || hasRenderingErrorSignal(renderingError)
+    : hasProductionErrorSignal(metadata);
   if (!hasDiagnosticSignal) return undefined;
   // Outside development/test, emit only the error signal without the server error message or stack.
   // Full diagnostics are reported server-side via the streaming error reporter (Sentry/Honeybadger).

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -96,6 +96,12 @@ function hasRenderingErrorSignal(renderingError: unknown) {
   return nonEmptyMetadataString(message) || nonEmptyMetadataString(stack);
 }
 
+function hasMalformedHasErrors(metadata: Record<string, unknown>) {
+  return (
+    Object.prototype.hasOwnProperty.call(metadata, 'hasErrors') && typeof metadata.hasErrors !== 'boolean'
+  );
+}
+
 function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: string) {
   // Console replay remains useful in development/test and for clean production chunks. On an
   // error-bearing chunk, however, it can repeat the same server-only message or stack path that
@@ -103,9 +109,7 @@ function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: s
   if (railsEnv === 'development' || railsEnv === 'test') return true;
 
   const hasRenderingErrorMetadata = Object.prototype.hasOwnProperty.call(metadata, 'renderingError');
-  const hasMalformedHasErrors =
-    Object.prototype.hasOwnProperty.call(metadata, 'hasErrors') && typeof metadata.hasErrors !== 'boolean';
-  return metadata.hasErrors !== true && !hasRenderingErrorMetadata && !hasMalformedHasErrors;
+  return metadata.hasErrors !== true && !hasRenderingErrorMetadata && !hasMalformedHasErrors(metadata);
 }
 
 function createRSCDiagnosticScript(
@@ -115,13 +119,19 @@ function createRSCDiagnosticScript(
   railsEnv?: string,
 ) {
   const { hasErrors, renderingError } = metadata;
+  const showFullDiagnostics = railsEnv === 'development' || railsEnv === 'test';
   // `hasErrors` is a boolean per the server wire contract; renderingError only carries
-  // a useful diagnostic when the server provided a non-blank message or stack.
-  if (hasErrors !== true && !hasRenderingErrorSignal(renderingError)) return undefined;
+  // a useful diagnostic when the server provided a non-blank message or stack. Outside
+  // development/test, a malformed hasErrors value fails closed to the same generic signal as
+  // the fetched RSC path instead of suppressing both the replay and the diagnostic.
+  const hasDiagnosticSignal =
+    hasErrors === true ||
+    hasRenderingErrorSignal(renderingError) ||
+    (!showFullDiagnostics && hasMalformedHasErrors(metadata));
+  if (!hasDiagnosticSignal) return undefined;
   // Outside development/test, emit only the error signal without the server error message or stack.
   // Full diagnostics are reported server-side via the streaming error reporter (Sentry/Honeybadger).
   // Fail-closed: unknown or missing railsEnv defaults to redacted (safe for a security gate).
-  const showFullDiagnostics = railsEnv === 'development' || railsEnv === 'test';
   // The two branches normalize `hasErrors` differently on purpose. The redacted (production)
   // branch forces `hasErrors: true` so a chunk that only tripped `hasRenderingErrorSignal`
   // (server sent `hasErrors: false` but a non-blank message/stack) still emits a positive

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -102,6 +102,20 @@ function hasMalformedHasErrors(metadata: Record<string, unknown>) {
   );
 }
 
+function hasMalformedRenderingError(metadata: Record<string, unknown>) {
+  if (!Object.prototype.hasOwnProperty.call(metadata, 'renderingError')) return false;
+
+  const { renderingError } = metadata;
+  if (typeof renderingError !== 'object' || renderingError === null) return true;
+
+  const hasMessage = Object.prototype.hasOwnProperty.call(renderingError, 'message');
+  const hasStack = Object.prototype.hasOwnProperty.call(renderingError, 'stack');
+  if (!hasMessage && !hasStack) return true;
+
+  const { message, stack } = renderingError as { message?: unknown; stack?: unknown };
+  return (hasMessage && typeof message !== 'string') || (hasStack && typeof stack !== 'string');
+}
+
 function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: string) {
   // Console replay remains useful in development/test and for clean production chunks. On an
   // error-bearing chunk, however, it can repeat the same server-only message or stack path that
@@ -122,12 +136,12 @@ function createRSCDiagnosticScript(
   const showFullDiagnostics = railsEnv === 'development' || railsEnv === 'test';
   // `hasErrors` is a boolean per the server wire contract; renderingError only carries
   // a useful diagnostic when the server provided a non-blank message or stack. Outside
-  // development/test, a malformed hasErrors value fails closed to the same generic signal as
-  // the fetched RSC path instead of suppressing both the replay and the diagnostic.
+  // development/test, malformed values fail closed to the same generic signal as the fetched
+  // RSC path instead of suppressing both the replay and the diagnostic.
   const hasDiagnosticSignal =
     hasErrors === true ||
     hasRenderingErrorSignal(renderingError) ||
-    (!showFullDiagnostics && hasMalformedHasErrors(metadata));
+    (!showFullDiagnostics && (hasMalformedHasErrors(metadata) || hasMalformedRenderingError(metadata)));
   if (!hasDiagnosticSignal) return undefined;
   // Outside development/test, emit only the error signal without the server error message or stack.
   // Full diagnostics are reported server-side via the streaming error reporter (Sentry/Honeybadger).

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -102,7 +102,10 @@ function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: s
   // diagnostic metadata redacts, so unknown and production-like environments fail closed.
   if (railsEnv === 'development' || railsEnv === 'test') return true;
 
-  return metadata.hasErrors !== true && !hasRenderingErrorSignal(metadata.renderingError);
+  const hasRenderingErrorMetadata = Object.prototype.hasOwnProperty.call(metadata, 'renderingError');
+  const hasMalformedHasErrors =
+    Object.prototype.hasOwnProperty.call(metadata, 'hasErrors') && typeof metadata.hasErrors !== 'boolean';
+  return metadata.hasErrors !== true && !hasRenderingErrorMetadata && !hasMalformedHasErrors;
 }
 
 function createRSCDiagnosticScript(

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -96,6 +96,15 @@ function hasRenderingErrorSignal(renderingError: unknown) {
   return nonEmptyMetadataString(message) || nonEmptyMetadataString(stack);
 }
 
+function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: string) {
+  // Console replay remains useful in development/test and for clean production chunks. On an
+  // error-bearing chunk, however, it can repeat the same server-only message or stack path that
+  // diagnostic metadata redacts, so unknown and production-like environments fail closed.
+  if (railsEnv === 'development' || railsEnv === 'test') return true;
+
+  return metadata.hasErrors !== true && !hasRenderingErrorSignal(metadata.renderingError);
+}
+
 function createRSCDiagnosticScript(
   metadata: Record<string, unknown>,
   cacheKey: string,
@@ -2082,7 +2091,7 @@ export default function injectRSCPayload(
 
               // Emit console replay as a separate <script> tag (not inside the payload)
               const consoleScript = metadata.consoleReplayScript as string;
-              if (consoleScript) {
+              if (consoleScript && shouldEmitConsoleReplay(metadata, railsEnv)) {
                 rscPayloadBuffers.push(Buffer.from(createScriptTag(consoleScript, sanitizedNonce)));
               }
               // Primary flush is handled by React's flush() callback (see above).

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -520,6 +520,24 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain(expectedPayloadPushScript('{"test": "data"}'));
   });
 
+  it('emits a generic production diagnostic when hasErrors is not boolean', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: 'true',
+      consoleReplayScript: 'console.error("malformed metadata secret")',
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'production',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
+    expect(resultStr).toContain('"hasErrors":true');
+    expect(resultStr).not.toContain('malformed metadata secret');
+  });
+
   it('preserves console replay for malformed metadata in development', async () => {
     const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
       hasErrors: 'true',

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -486,6 +486,7 @@ describe('injectRSCPayload', () => {
         message: '   ',
         stack: '',
       },
+      consoleReplayScript: 'console.log("blank rendering error replay")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -495,6 +496,7 @@ describe('injectRSCPayload', () => {
 
     expect(resultStr).not.toContain(`(self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference}||=`);
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).toContain('<script>console.log("blank rendering error replay")</script>');
     expect(resultStr).toContain(expectedPayloadPushScript('{"test": "data"}'));
   });
 
@@ -502,6 +504,12 @@ describe('injectRSCPayload', () => {
     ['an empty renderingError object', { hasErrors: false, renderingError: {} }],
     ['a null renderingError', { hasErrors: false, renderingError: null }],
     ['a non-object renderingError', { hasErrors: false, renderingError: 'malformed' }],
+    ['a renderingError with a non-string message', { hasErrors: false, renderingError: { message: null } }],
+    ['a renderingError with a non-string stack', { hasErrors: false, renderingError: { stack: [] } }],
+    [
+      'a renderingError with a string message and non-string stack',
+      { hasErrors: false, renderingError: { message: 'private failure', stack: 1 } },
+    ],
     ['a non-boolean hasErrors value', { hasErrors: 'true' }],
   ])('fails closed in production for %s', async (_description, metadata) => {
     const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -417,7 +417,7 @@ describe('injectRSCPayload', () => {
         message: 'useState is not a function',
         stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
       },
-      consoleReplayScript: '<script>console.log("replay")</script>',
+      consoleReplayScript: 'console.log("test diagnostic replay")',
       serializedProps: { token: 'do-not-serialize' },
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
@@ -439,6 +439,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('serializedProps');
     expect(resultStr).not.toContain('do-not-serialize');
     expect(resultStr).not.toContain('consoleReplayScript');
+    expect(resultStr).toContain('<script>console.log("test diagnostic replay")</script>');
   });
 
   it('keeps the first RSC diagnostic metadata for a payload key', async () => {
@@ -504,6 +505,8 @@ describe('injectRSCPayload', () => {
         message: 'User 48213 not authorized for org 77',
         stack: 'Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)',
       },
+      consoleReplayScript:
+        'console.error("RSC inline failed for User 48213 at /srv/private/Auth.server.tsx:12:5")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -519,6 +522,8 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('not authorized');
     expect(resultStr).not.toContain('Auth.server.tsx');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('RSC inline failed');
+    expect(resultStr).not.toContain('/srv/private/Auth.server.tsx');
   });
 
   it('redacts renderingError in non-development/test environments like staging', async () => {
@@ -528,6 +533,7 @@ describe('injectRSCPayload', () => {
         message: 'Internal server failure',
         stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
       },
+      consoleReplayScript: 'console.error("staging secret at /srv/private/server.ts:42:7")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -542,6 +548,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('Internal server failure');
     expect(resultStr).not.toContain('server.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('staging secret');
   });
 
   it('redacts renderingError when railsEnv is not provided (undefined)', async () => {
@@ -551,6 +558,7 @@ describe('injectRSCPayload', () => {
         message: 'Database connection refused at 10.0.3.42:5432',
         stack: 'Error: Database connection refused\n    at Pool (/app/lib/db.ts:18:11)',
       },
+      consoleReplayScript: 'console.error("unknown-env secret at /srv/private/db.ts:18:11")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -563,6 +571,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('10.0.3.42');
     expect(resultStr).not.toContain('db.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('unknown-env secret');
   });
 
   it('forces hasErrors:true in production even when metadata has hasErrors:false with renderingError signal', async () => {
@@ -572,6 +581,7 @@ describe('injectRSCPayload', () => {
         message: 'Internal server failure',
         stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
       },
+      consoleReplayScript: 'console.error("secondary inline secret at /srv/private/server.ts:42:7")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -585,6 +595,24 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('Internal server failure');
     expect(resultStr).not.toContain('server.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('secondary inline secret');
+    expect(resultStr).not.toContain('/srv/private/server.ts');
+  });
+
+  it('preserves console replay for clean production chunks', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: false,
+      consoleReplayScript: 'console.log("clean production replay")',
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'production',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('<script>console.log("clean production replay")</script>');
   });
 
   it('includes full renderingError in diagnostic metadata in development', async () => {
@@ -594,6 +622,7 @@ describe('injectRSCPayload', () => {
         message: 'useState is not a function',
         stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
       },
+      consoleReplayScript: 'console.error("development diagnostic replay")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -607,6 +636,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain('useState is not a function');
     expect(resultStr).toContain('Broken.server.tsx');
     expect(resultStr).toContain('renderingError');
+    expect(resultStr).toContain('<script>console.error("development diagnostic replay")</script>');
   });
 
   it('promotes streamed RSC client chunk stylesheet preloads to gate reveal', async () => {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -503,7 +503,7 @@ describe('injectRSCPayload', () => {
     ['a null renderingError', { hasErrors: false, renderingError: null }],
     ['a non-object renderingError', { hasErrors: false, renderingError: 'malformed' }],
     ['a non-boolean hasErrors value', { hasErrors: 'true' }],
-  ])('suppresses console replay in production for %s', async (_description, metadata) => {
+  ])('fails closed in production for %s', async (_description, metadata) => {
     const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
       ...metadata,
       consoleReplayScript: 'console.error("malformed metadata secret")',
@@ -516,6 +516,9 @@ describe('injectRSCPayload', () => {
     });
     const resultStr = await collectStreamData(result);
 
+    expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
+    expect(resultStr).toContain('"hasErrors":true');
+    expect(resultStr).not.toContain('renderingError');
     expect(resultStr).not.toContain('malformed metadata secret');
     expect(resultStr).toContain(expectedPayloadPushScript('{"test": "data"}'));
   });

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -498,6 +498,45 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain(expectedPayloadPushScript('{"test": "data"}'));
   });
 
+  it.each([
+    ['an empty renderingError object', { hasErrors: false, renderingError: {} }],
+    ['a null renderingError', { hasErrors: false, renderingError: null }],
+    ['a non-object renderingError', { hasErrors: false, renderingError: 'malformed' }],
+    ['a non-boolean hasErrors value', { hasErrors: 'true' }],
+  ])('suppresses console replay in production for %s', async (_description, metadata) => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      ...metadata,
+      consoleReplayScript: 'console.error("malformed metadata secret")',
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'production',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).not.toContain('malformed metadata secret');
+    expect(resultStr).toContain(expectedPayloadPushScript('{"test": "data"}'));
+  });
+
+  it('preserves console replay for malformed metadata in development', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: 'true',
+      renderingError: null,
+      consoleReplayScript: 'console.error("development malformed metadata replay")',
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'development',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('<script>console.error("development malformed metadata replay")</script>');
+  });
+
   it('redacts renderingError from diagnostic metadata in production', async () => {
     const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
       hasErrors: true,

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module ReactOnRails
+  # Removes URL userinfo from configured values and diagnostic prose before either is displayed.
+  module DiagnosticUrlRedactor
+    HTTP_URL_SCHEME_PATTERN = %r{https?://}i
+    NETWORK_URL_START_PATTERN = %r{
+      (?:[a-z]|%[0-9a-f]{2})
+      (?:[a-z0-9+.-]|%[0-9a-f]{2})*
+      (?::|%3a)
+      (?:/|%2f){2}
+    }ix
+    ENCODED_USERINFO_DELIMITER_PATTERN = /@|%40/i
+    ENCODED_AUTHORITY_END_PATTERN = %r{/|%2f|\?|%3f|\#|%23}i
+    HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
+
+    CONFIGURED_URL_NOT_PROVIDED = Object.new.freeze
+    private_constant :CONFIGURED_URL_NOT_PROVIDED
+
+    class << self
+      # Sanitizes a configured URL when called with one argument. When sanitizing exception text,
+      # pass the originating URL so both its raw and inspected spellings are replaced safely.
+      def sanitize(text, configured_url: CONFIGURED_URL_NOT_PROVIDED)
+        return sanitized_configured_url(text) if configured_url.equal?(CONFIGURED_URL_NOT_PROVIDED)
+
+        sanitized_error_message(text, configured_url)
+      end
+
+      private
+
+      # One configured value is not free-form prose: multiple schemes or line breaks after its
+      # first scheme make the URL suffix structurally ambiguous, so that suffix fails closed
+      # through its final @. Any non-URL prefix is preserved for useful error context.
+      def sanitized_configured_url(url)
+        return url if url.nil? || url.empty?
+
+        url = valid_diagnostic_text(url)
+
+        # Treat whitespace around a scheme delimiter as a malformed HTTP(S) URL rather than a
+        # local path. URL classification may reject that spelling, but diagnostics must still
+        # fail closed if the value contains credential-like userinfo.
+        scheme_pattern = %r{https?\s*:\s*//}i
+        scheme = url.match(scheme_pattern)
+        return sanitized_authority_relative_url(url) unless scheme
+
+        prefix = url[...scheme.begin(0)]
+        configured_url = url[scheme.begin(0)..]
+        sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(scheme_pattern).length > 1
+                          strip_malformed_url_userinfo(configured_url)
+                        else
+                          sanitized_valid_network_url(configured_url) || strip_malformed_url_userinfo(configured_url)
+                        end
+
+        "#{prefix}#{sanitized_url}"
+      end
+
+      def sanitized_authority_relative_url(url)
+        authority_start = url.index("//")
+        return url unless authority_start
+
+        prefix = url[...authority_start]
+        authority_relative_url = url[authority_start..]
+        sanitized_url = sanitized_valid_network_url(authority_relative_url) ||
+                        strip_malformed_url_userinfo(authority_relative_url)
+        "#{prefix}#{sanitized_url}"
+      end
+
+      def sanitized_error_message(message, raw_url)
+        message = valid_diagnostic_text(message)
+        return strip_userinfo(message) if raw_url.nil? || raw_url.empty?
+
+        raw_url = valid_diagnostic_text(raw_url)
+        sanitized_url = sanitized_configured_url(raw_url)
+
+        # URI::InvalidURIError embeds String#inspect, while other errors may embed the raw value.
+        message = message.gsub(raw_url.inspect) { sanitized_url.inspect }
+                         .gsub(raw_url) { sanitized_url }
+        strip_userinfo(message)
+      end
+
+      # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
+      # without collision-prone placeholder text. A candidate remains unprotected when any @
+      # follows it before the next scheme: punctuation, prose, and line breaks are not structural
+      # proof that the @ is unrelated to malformed userinfo. When an unresolved region precedes
+      # a credential-bearing candidate, that region is discarded and the candidate is sanitized
+      # independently rather than allowing one fallback match to consume through another scheme.
+      # Ambiguous text may be over-redacted for safety.
+      def strip_userinfo(text)
+        text = valid_diagnostic_text(text)
+        sanitized = text.dup.clear
+        unprotected_start = 0
+
+        text.to_enum(:scan, HTTP_URL_TOKEN_PATTERN).each do
+          match = Regexp.last_match
+          protected_url = sanitized_valid_network_url(match[0])
+          next unless protected_url
+          next if userinfo_delimiter_before_next_scheme?(text, match)
+
+          unprotected = text[unprotected_start...match.begin(0)]
+          sanitized << sanitized_unprotected_prefix(unprotected, match[0], protected_url)
+          sanitized << protected_url
+          unprotected_start = match.end(0)
+        end
+
+        sanitized << strip_unprotected_userinfo(text[unprotected_start..])
+      end
+
+      def userinfo_delimiter_before_next_scheme?(text, match)
+        continuation = text[match.end(0)..]
+        boundary = continuation.match(HTTP_URL_SCHEME_PATTERN)
+        continuation = continuation[...boundary.begin(0)] if boundary
+        continuation.match?(ENCODED_USERINFO_DELIMITER_PATTERN)
+      end
+
+      def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
+        unresolved_scheme = text.match(HTTP_URL_SCHEME_PATTERN)
+        return strip_unprotected_userinfo(text) if raw_url == sanitized_url || unresolved_scheme.nil?
+
+        text[...unresolved_scheme.begin(0)]
+      end
+
+      # URI handles valid network URLs structurally, so an @ in the path is never mistaken for
+      # userinfo. A missing host means an authority-shaped value was parsed as a path instead;
+      # returning nil keeps that ambiguous token unprotected for the fail-closed pass.
+      def sanitized_valid_network_url(url)
+        sanitized_url = sanitized_single_network_url(url)&.dup
+        return nil unless sanitized_url
+
+        sanitized_nested_network_urls(sanitized_url)
+      end
+
+      def sanitized_nested_network_urls(sanitized_url)
+        # A valid outer URL can carry another credential URL in its path or query. Partition the
+        # input into disjoint scheme spans and assemble their replacements from left to right,
+        # keeping the work bounded by the input size even when a diagnostic has many URL starts.
+        # The first scheme belongs to the outer URL and was handled structurally above.
+        nested_scheme_starts = sanitized_url.to_enum(:scan, NETWORK_URL_START_PATTERN)
+                                            .map { Regexp.last_match.begin(0) }
+        nested_scheme_starts.shift if nested_scheme_starts.first&.zero?
+        return sanitized_url if nested_scheme_starts.empty?
+
+        sanitized = sanitized_url.dup.clear
+        unprocessed_start = 0
+
+        nested_scheme_starts.each_with_index do |start, index|
+          token_end = nested_scheme_starts.fetch(index + 1, sanitized_url.length)
+          nested_url = sanitized_url[start...token_end]
+          replacement = strip_encoded_network_url_userinfo(nested_url) ||
+                        sanitized_single_network_url(nested_url) ||
+                        nested_url
+          sanitized << sanitized_url[unprocessed_start...start]
+          sanitized << replacement
+          unprocessed_start = token_end
+        end
+
+        sanitized << sanitized_url[unprocessed_start..]
+      end
+
+      # Percent encoding can hide the structural delimiters of a nested URL from URI.parse.
+      # Inspect only the encoded-or-literal scheme, authority terminator, and @ delimiter, then
+      # remove the original encoded span without decoding or rewriting unrelated output.
+      def strip_encoded_network_url_userinfo(url)
+        network_url = url.match(NETWORK_URL_START_PATTERN)
+        return nil unless network_url&.begin(0)&.zero?
+
+        authority_start = network_url.end(0)
+        authority_end_match = url.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)
+        authority_end = authority_end_match&.begin(0) || url.length
+        authority = url[authority_start...authority_end]
+        _userinfo, delimiter, host = authority.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
+        return nil if delimiter.empty?
+
+        "#{url[...authority_start]}#{host}#{url[authority_end..]}"
+      end
+
+      def sanitized_single_network_url(url)
+        uri = URI.parse(url)
+        return nil if uri.host.nil?
+        return url if uri.userinfo.nil?
+
+        # URI rejects a password without a user, so clear password first.
+        uri.password = nil
+        uri.user = nil
+        uri.to_s
+      rescue URI::Error, ArgumentError
+        nil
+      end
+
+      def valid_diagnostic_text(text)
+        text = text.to_s
+        text.valid_encoding? ? text : text.scrub
+      end
+
+      def strip_unprotected_userinfo(text)
+        # A protected HTTP token can end before a malformed nested credential delimiter.
+        # Reuse the bounded structural scan for the remaining prose span before applying the
+        # broader fail-closed patterns below.
+        text = sanitized_nested_network_urls(text.dup)
+
+        # A credential-bearing network-path reference can appear in an exception message even
+        # when it is not the configured bundle URL. Require a non-whitespace token immediately
+        # after // so ordinary prose such as "// contact dev@example" remains untouched.
+        authority_start_pattern = %r{//(?=\S)}
+        authority_token_pattern = /#{authority_start_pattern}[^\s"']+/
+        text = text.gsub(authority_token_pattern) do |url|
+          sanitized_valid_network_url(url) || strip_malformed_url_userinfo(url)
+        end
+
+        # Malformed userinfo can cross prose delimiters before its @. Keep scanning until the
+        # next URL-like start and fail closed through the last @ in that bounded span.
+        malformed_authority_pattern = /
+          #{authority_start_pattern}
+          (?:(?!#{HTTP_URL_SCHEME_PATTERN}|#{authority_start_pattern}).)*[\s"']
+          (?:(?!#{HTTP_URL_SCHEME_PATTERN}|#{authority_start_pattern}).)*@
+        /mx
+        text = text.gsub(malformed_authority_pattern) { |span| strip_malformed_url_userinfo(span) }
+
+        scheme_pattern = %r{https?\s*:\s*//}i
+        text.gsub(/#{scheme_pattern}(?:(?!#{scheme_pattern}).)*@/m) { |span| strip_malformed_url_userinfo(span) }
+      end
+
+      # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The
+      # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
+      def strip_malformed_url_userinfo(url)
+        scheme = url.match(%r{\A[a-z][a-z0-9+.-]*\s*:\s*//}i)
+        authority_prefix_end = scheme&.end(0) || (2 if url.start_with?("//"))
+        userinfo_delimiter = url.rindex("@")
+        return url unless authority_prefix_end && userinfo_delimiter
+
+        "#{url[...authority_prefix_end]}#{url[(userinfo_delimiter + 1)..]}"
+      end
+    end
+  end
+end

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -128,7 +128,7 @@ module ReactOnRails
           offset += token_length
         end
 
-        literal_separator_end = network_separator_end(text, offset) if text.getbyte(offset) == 58
+        literal_separator_end = literal_network_separator_end(text, offset, scheme_start)
         match_end = literal_separator_end if literal_separator_end
         [match_end, offset]
       end
@@ -142,10 +142,27 @@ module ReactOnRails
 
       def network_separator_end(text, offset)
         separator_length = text.getbyte(offset) == 58 ? 1 : 3
-        slash_end = slash_token_end(text, offset + separator_length)
+        slash_start = skip_ascii_whitespace(text, offset + separator_length)
+        slash_end = slash_token_end(text, slash_start)
         return nil unless slash_end
 
         slash_token_end(text, slash_end)
+      end
+
+      def literal_network_separator_end(text, offset, scheme_start)
+        return network_separator_end(text, offset) if text.getbyte(offset) == 58
+        return nil unless ascii_whitespace_byte?(text.getbyte(offset))
+        return nil unless http_scheme_at?(text, scheme_start, offset)
+
+        colon_offset = skip_ascii_whitespace(text, offset)
+        return nil unless text.getbyte(colon_offset) == 58
+
+        network_separator_end(text, colon_offset)
+      end
+
+      def skip_ascii_whitespace(text, offset)
+        offset += 1 while ascii_whitespace_byte?(text.getbyte(offset))
+        offset
       end
 
       def slash_token_end(text, offset)
@@ -194,10 +211,29 @@ module ReactOnRails
         byte && ((65..90).cover?(byte) || (97..122).cover?(byte))
       end
 
+      def http_scheme_at?(text, start_offset, end_offset)
+        length = end_offset - start_offset
+        return false unless [4, 5].include?(length)
+
+        scheme_bytes = [104, 116, 116, 112]
+        return false unless scheme_bytes.each_with_index.all? do |byte, index|
+          case_insensitive_byte_match?(text.getbyte(start_offset + index), byte)
+        end
+
+        length == 4 || case_insensitive_byte_match?(text.getbyte(start_offset + 4), 115)
+      end
+
+      def ascii_whitespace_byte?(byte)
+        [9, 10, 11, 12, 13, 32].include?(byte)
+      end
+
       private_class_method :each_span, :next_scheme_start, :match_end_and_run_end, :encoded_separator_end,
-                           :network_separator_end, :slash_token_end, :scheme_continuation_token_length,
+                           :network_separator_end, :literal_network_separator_end, :skip_ascii_whitespace,
+                           :slash_token_end,
+                           :scheme_continuation_token_length,
                            :percent_encoded_colon_at?, :percent_encoded_slash_at?, :case_insensitive_byte_match?,
-                           :digit_byte?, :percent_encoded_byte_at?, :hex_byte?, :ascii_letter_byte?
+                           :digit_byte?, :percent_encoded_byte_at?, :hex_byte?, :ascii_letter_byte?, :http_scheme_at?,
+                           :ascii_whitespace_byte?
     end
     private_constant :NetworkUrlStartScanner
 

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -20,6 +20,39 @@ module ReactOnRails
     CONFIGURED_URL_NOT_PROVIDED = Object.new.freeze
     private_constant :CONFIGURED_URL_NOT_PROVIDED
 
+    # Rewrites disjoint regex-delimited spans with byte offsets so multibyte prefixes do not
+    # force Ruby to rescan the string for every match.
+    module ByteSpanRewriter
+      module_function
+
+      def rewrite(text, pattern, skip_initial: false)
+        binary_text = text.b
+        match = first_match(binary_text, pattern, skip_initial)
+        return text unless match
+
+        rewritten = text.dup.clear
+        unprocessed_start = 0
+        while match
+          next_match = binary_text.match(pattern, match.end(0))
+          span_end = next_match&.begin(0) || text.bytesize
+          rewritten << text.byteslice(unprocessed_start, match.begin(0) - unprocessed_start)
+          rewritten << yield(text.byteslice(match.begin(0), span_end - match.begin(0)))
+          unprocessed_start = span_end
+          match = next_match
+        end
+        rewritten << text.byteslice(unprocessed_start, text.bytesize - unprocessed_start)
+      end
+
+      def first_match(binary_text, pattern, skip_initial)
+        match = binary_text.match(pattern)
+        return match unless skip_initial && match&.begin(0)&.zero?
+
+        binary_text.match(pattern, match.end(0))
+      end
+      private_class_method :first_match
+    end
+    private_constant :ByteSpanRewriter
+
     class << self
       # Sanitizes a configured URL when called with one argument. When sanitizing exception text,
       # pass the originating URL so both its raw and inspected spellings are replaced safely.
@@ -45,7 +78,7 @@ module ReactOnRails
         scheme = url.match(FLEXIBLE_HTTP_URL_SCHEME_PATTERN)
         return sanitized_authority_relative_url(url) unless scheme
 
-        prefix = url[...scheme.begin(0)]
+        prefix = sanitized_configured_prefix(url[...scheme.begin(0)])
         configured_url = url[scheme.begin(0)..]
         sanitized_url = if configured_url.match?(/[\r\n]/) ||
                            configured_url.scan(FLEXIBLE_HTTP_URL_SCHEME_PATTERN).length > 1
@@ -122,11 +155,21 @@ module ReactOnRails
         text[...unresolved_scheme.begin(0)]
       end
 
+      # A configured value with credential-like text before its first URL scheme is malformed,
+      # not free-form prose. Fail closed through the prefix's final userinfo delimiter.
+      def sanitized_configured_prefix(prefix)
+        _userinfo, delimiter, suffix = prefix.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
+        delimiter.empty? ? prefix : suffix
+      end
+
       # URI handles valid network URLs structurally, so an @ in the path is never mistaken for
       # userinfo. A missing host means an authority-shaped value was parsed as a path instead;
       # returning nil keeps that ambiguous token unprotected for the fail-closed pass.
       def sanitized_valid_network_url(url)
         sanitized_url = sanitized_single_network_url(url)&.dup
+        if sanitized_url.nil? || sanitized_url == url
+          sanitized_url = strip_encoded_network_url_userinfo(url) || sanitized_url
+        end
         return nil unless sanitized_url
 
         sanitized_nested_network_urls(sanitized_url)
@@ -137,26 +180,13 @@ module ReactOnRails
         # input into disjoint scheme spans and assemble their replacements from left to right,
         # keeping the work bounded by the input size even when a diagnostic has many URL starts.
         # The first scheme belongs to the outer URL and was handled structurally above.
-        nested_scheme_starts = sanitized_url.to_enum(:scan, NETWORK_URL_START_PATTERN)
-                                            .map { Regexp.last_match.begin(0) }
-        nested_scheme_starts.shift if nested_scheme_starts.first&.zero?
-        return sanitized_url if nested_scheme_starts.empty?
+        ByteSpanRewriter.rewrite(sanitized_url, NETWORK_URL_START_PATTERN, skip_initial: true) do |nested_url|
+          next nested_url unless nested_url.match?(ENCODED_USERINFO_DELIMITER_PATTERN)
 
-        sanitized = sanitized_url.dup.clear
-        unprocessed_start = 0
-
-        nested_scheme_starts.each_with_index do |start, index|
-          token_end = nested_scheme_starts.fetch(index + 1, sanitized_url.length)
-          nested_url = sanitized_url[start...token_end]
-          replacement = strip_encoded_network_url_userinfo(nested_url) ||
-                        sanitized_single_network_url(nested_url) ||
-                        nested_url
-          sanitized << sanitized_url[unprocessed_start...start]
-          sanitized << replacement
-          unprocessed_start = token_end
+          strip_encoded_network_url_userinfo(nested_url) ||
+            sanitized_single_network_url(nested_url) ||
+            nested_url
         end
-
-        sanitized << sanitized_url[unprocessed_start..]
       end
 
       # Percent encoding can hide the structural delimiters of a nested URL from URI.parse.
@@ -224,18 +254,9 @@ module ReactOnRails
       # Scan disjoint spans between flexible HTTP(S) schemes. Each bounded span reuses the
       # fail-closed last-@ rule, so each input character is scanned a constant number of times.
       def strip_malformed_http_userinfo(text)
-        sanitized = text.dup.clear
-        unprocessed_start = 0
-        scheme = text.match(FLEXIBLE_HTTP_URL_SCHEME_PATTERN)
-        while scheme
-          next_scheme = text.match(FLEXIBLE_HTTP_URL_SCHEME_PATTERN, scheme.end(0))
-          span_end = next_scheme&.begin(0) || text.length
-          sanitized << text[unprocessed_start...scheme.begin(0)]
-          sanitized << strip_malformed_url_userinfo(text[scheme.begin(0)...span_end])
-          unprocessed_start = span_end
-          scheme = next_scheme
+        ByteSpanRewriter.rewrite(text, FLEXIBLE_HTTP_URL_SCHEME_PATTERN) do |span|
+          strip_malformed_url_userinfo(span)
         end
-        sanitized << text[unprocessed_start..]
       end
 
       # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -7,12 +7,6 @@ module ReactOnRails
   # Removes URL userinfo from configured values and diagnostic prose before either is displayed.
   module DiagnosticUrlRedactor
     HTTP_URL_SCHEME_PATTERN = %r{https?://}i
-    NETWORK_URL_START_PATTERN = %r{
-      (?:[a-z]|%[0-9a-f]{2})
-      (?:[a-z0-9+.-]|%[0-9a-f]{2})*
-      (?::|%3a)
-      (?:/|%2f){2}
-    }ix
     ENCODED_USERINFO_DELIMITER_PATTERN = /@|%40/i
     ENCODED_AUTHORITY_END_PATTERN = %r{/|%2f|\?|%3f|\#|%23}i
     HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
@@ -44,6 +38,20 @@ module ReactOnRails
         rewritten << text.byteslice(unprocessed_start, text.bytesize - unprocessed_start)
       end
 
+      def rewrite_at_offsets(text, offsets)
+        return text if offsets.empty?
+
+        rewritten = text.dup.clear
+        unprocessed_start = 0
+        offsets.each_with_index do |offset, index|
+          span_end = offsets[index + 1] || text.bytesize
+          rewritten << text.byteslice(unprocessed_start, offset - unprocessed_start)
+          rewritten << yield(text.byteslice(offset, span_end - offset))
+          unprocessed_start = span_end
+        end
+        rewritten << text.byteslice(unprocessed_start, text.bytesize - unprocessed_start)
+      end
+
       def first_match(binary_text, pattern, skip_initial)
         match = binary_text.match(pattern)
         return match unless skip_initial && match&.begin(0)&.zero?
@@ -53,6 +61,206 @@ module ReactOnRails
       private_class_method :first_match
     end
     private_constant :ByteSpanRewriter
+
+    # Finds non-overlapping extended URL scheme starts without retrying a greedy
+    # pattern at every byte.
+    module NetworkUrlStartScanner
+      module_function
+
+      def spans(text)
+        spans = []
+        each_span(text, greedy: true) { |scheme_start, match_end| spans << [scheme_start, match_end] }
+        spans
+      end
+
+      def first_span(text)
+        first = nil
+        each_span(text, greedy: false, stop_after_first: true) do |scheme_start, match_end|
+          first = [scheme_start, match_end]
+        end
+        first
+      end
+
+      def authority_starts(text)
+        starts = []
+        each_span(text, greedy: false) { |_scheme_start, match_end| starts << match_end }
+        starts
+      end
+
+      def each_span(text, greedy:, stop_after_first: false)
+        binary_text = text.b
+        search_offset = 0
+
+        while (scheme_start = next_scheme_start(binary_text, search_offset))
+          match_end, run_end = match_end_and_run_end(binary_text, scheme_start, greedy:)
+          if match_end
+            yield scheme_start, match_end
+            break if stop_after_first
+
+            search_offset = match_end
+          else
+            search_offset = run_end + 1
+          end
+        end
+      end
+
+      def next_scheme_start(text, offset)
+        while offset < text.bytesize
+          return offset if ascii_letter_byte?(text.getbyte(offset)) || percent_encoded_byte_at?(text, offset)
+
+          offset += 1
+        end
+
+        nil
+      end
+
+      # The former regex used a greedy scheme continuation, so an encoded colon
+      # is a separator only when it is the rightmost usable one in the run.
+      def match_end_and_run_end(text, scheme_start, greedy: true)
+        offset = scheme_start
+        match_end = nil
+
+        while (token_length = scheme_continuation_token_length(text, offset))
+          encoded_separator_end = encoded_separator_end(text, offset, scheme_start)
+          return [encoded_separator_end, offset] if encoded_separator_end && !greedy
+
+          match_end = encoded_separator_end if encoded_separator_end
+          offset += token_length
+        end
+
+        literal_separator_end = network_separator_end(text, offset) if text.getbyte(offset) == 58
+        match_end = literal_separator_end if literal_separator_end
+        [match_end, offset]
+      end
+
+      def encoded_separator_end(text, offset, scheme_start)
+        return nil if offset == scheme_start
+        return nil unless percent_encoded_colon_at?(text, offset)
+
+        network_separator_end(text, offset)
+      end
+
+      def network_separator_end(text, offset)
+        separator_length = text.getbyte(offset) == 58 ? 1 : 3
+        slash_end = slash_token_end(text, offset + separator_length)
+        return nil unless slash_end
+
+        slash_token_end(text, slash_end)
+      end
+
+      def slash_token_end(text, offset)
+        return offset + 1 if text.getbyte(offset) == 47
+        return offset + 3 if percent_encoded_slash_at?(text, offset)
+
+        nil
+      end
+
+      def scheme_continuation_token_length(text, offset)
+        return 3 if percent_encoded_byte_at?(text, offset)
+
+        byte = text.getbyte(offset)
+        return 1 if ascii_letter_byte?(byte) || digit_byte?(byte) || [43, 45, 46].include?(byte)
+
+        nil
+      end
+
+      def percent_encoded_colon_at?(text, offset)
+        text.getbyte(offset) == 37 && text.getbyte(offset + 1) == 51 &&
+          case_insensitive_byte_match?(text.getbyte(offset + 2), 97)
+      end
+
+      def percent_encoded_slash_at?(text, offset)
+        text.getbyte(offset) == 37 && text.getbyte(offset + 1) == 50 &&
+          case_insensitive_byte_match?(text.getbyte(offset + 2), 102)
+      end
+
+      def case_insensitive_byte_match?(byte, lowercase_byte)
+        byte == lowercase_byte || byte == lowercase_byte - 32
+      end
+
+      def digit_byte?(byte)
+        byte && (48..57).cover?(byte)
+      end
+
+      def percent_encoded_byte_at?(text, offset)
+        text.getbyte(offset) == 37 && hex_byte?(text.getbyte(offset + 1)) && hex_byte?(text.getbyte(offset + 2))
+      end
+
+      def hex_byte?(byte)
+        digit_byte?(byte) || (byte && ((65..70).cover?(byte) || (97..102).cover?(byte)))
+      end
+
+      def ascii_letter_byte?(byte)
+        byte && ((65..90).cover?(byte) || (97..122).cover?(byte))
+      end
+
+      private_class_method :each_span, :next_scheme_start, :match_end_and_run_end, :encoded_separator_end,
+                           :network_separator_end, :slash_token_end, :scheme_continuation_token_length,
+                           :percent_encoded_colon_at?, :percent_encoded_slash_at?, :case_insensitive_byte_match?,
+                           :digit_byte?, :percent_encoded_byte_at?, :hex_byte?, :ascii_letter_byte?
+    end
+    private_constant :NetworkUrlStartScanner
+
+    # Removes userinfo from every encoded-or-literal authority without decoding
+    # or rewriting unrelated path, query, and fragment text.
+    module EncodedNetworkUrlRewriter
+      module_function
+
+      def rewrite(url, authority_start: nil)
+        start_offset = authority_start || detected_authority_start(url)
+        return nil unless start_offset
+
+        removal_span = userinfo_removal_span(url, start_offset)
+        return nil unless removal_span
+
+        remove_byte_spans(url, [removal_span])
+      end
+
+      def rewrite_all(url)
+        removal_spans = NetworkUrlStartScanner.authority_starts(url).filter_map do |authority_start|
+          userinfo_removal_span(url, authority_start)
+        end
+        return nil if removal_spans.empty?
+
+        remove_byte_spans(url, removal_spans)
+      end
+
+      def authority_end(url, authority_start)
+        url.b.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)&.begin(0) || url.bytesize
+      end
+
+      def detected_authority_start(url)
+        network_url = NetworkUrlStartScanner.spans(url).first
+        return network_url.last if network_url&.first&.zero?
+
+        2 if url.start_with?("//")
+      end
+
+      def userinfo_removal_span(url, authority_start)
+        end_offset = authority_end(url, authority_start)
+        authority = url.byteslice(authority_start, end_offset - authority_start)
+        _userinfo, delimiter, host = authority.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
+        return nil if delimiter.empty?
+
+        [authority_start, end_offset - host.bytesize]
+      end
+
+      def remove_byte_spans(text, spans)
+        rewritten = text.dup.clear
+        unprocessed_start = 0
+
+        spans.each do |start_offset, end_offset|
+          if start_offset > unprocessed_start
+            rewritten << text.byteslice(unprocessed_start, start_offset - unprocessed_start)
+          end
+          unprocessed_start = [unprocessed_start, end_offset].max
+        end
+        rewritten << text.byteslice(unprocessed_start, text.bytesize - unprocessed_start)
+      end
+
+      private_class_method :authority_end, :detected_authority_start, :userinfo_removal_span, :remove_byte_spans
+    end
+    private_constant :EncodedNetworkUrlRewriter
 
     class << self
       # Sanitizes a configured URL when called with one argument. When sanitizing exception text,
@@ -77,7 +285,7 @@ module ReactOnRails
         # local path. URL classification may reject that spelling, but diagnostics must still
         # fail closed if the value contains credential-like userinfo.
         scheme = url.match(FLEXIBLE_HTTP_URL_SCHEME_PATTERN)
-        return sanitized_authority_relative_url(url) unless scheme
+        return sanitized_configured_url_without_http_scheme(url) unless scheme
 
         prefix = sanitized_configured_prefix(url[...scheme.begin(0)])
         configured_url = url[scheme.begin(0)..]
@@ -89,6 +297,20 @@ module ReactOnRails
                         end
 
         "#{prefix}#{sanitized_url}"
+      end
+
+      def sanitized_configured_url_without_http_scheme(url)
+        network_start = NetworkUrlStartScanner.first_span(url)
+        return sanitized_authority_relative_url(url) unless network_start
+
+        start_offset, end_offset = network_start
+        literal_authority_start = url.b.index("//")
+        return sanitized_authority_relative_url(url) if literal_authority_start && literal_authority_start < end_offset
+
+        prefix = sanitized_configured_prefix(url.byteslice(0, start_offset))
+        configured_url = url.byteslice(start_offset, url.bytesize - start_offset)
+        sanitized_url = EncodedNetworkUrlRewriter.rewrite_all(configured_url) || configured_url
+        "#{prefix}#{sanitized_nested_network_urls(sanitized_url)}"
       end
 
       def sanitized_authority_relative_url(url)
@@ -164,7 +386,10 @@ module ReactOnRails
       def sanitized_valid_network_url(url)
         sanitized_url = sanitized_single_network_url(url)&.dup
         if sanitized_url.nil? || sanitized_url == url
-          sanitized_url = strip_encoded_network_url_userinfo(url) || sanitized_url
+          # A bare outer // authority and an encoded nested scheme need independent passes.
+          rewritten_url = EncodedNetworkUrlRewriter.rewrite(url) || url
+          rewritten_url = EncodedNetworkUrlRewriter.rewrite_all(rewritten_url) || rewritten_url
+          sanitized_url = rewritten_url unless rewritten_url == url
         end
         return nil unless sanitized_url
 
@@ -176,36 +401,25 @@ module ReactOnRails
         # input into disjoint scheme spans and assemble their replacements from left to right,
         # keeping the work bounded by the input size even when a diagnostic has many URL starts.
         # The first scheme belongs to the outer URL and was handled structurally above.
-        ByteSpanRewriter.rewrite(sanitized_url, NETWORK_URL_START_PATTERN, skip_initial: true) do |nested_url|
-          next nested_url unless nested_url.match?(ENCODED_USERINFO_DELIMITER_PATTERN)
+        sanitized_network_url_spans(sanitized_url, skip_initial: true)
+      end
 
-          strip_encoded_network_url_userinfo(nested_url) ||
-            sanitized_single_network_url(nested_url) ||
-            nested_url
+      def sanitized_network_url_spans(text, skip_initial:)
+        network_start_offsets = NetworkUrlStartScanner.spans(text).map(&:first)
+        network_start_offsets.shift if skip_initial && network_start_offsets.first&.zero?
+
+        ByteSpanRewriter.rewrite_at_offsets(text, network_start_offsets) do |nested_url|
+          sanitized_nested_network_url(nested_url)
         end
       end
 
-      # Percent encoding can hide the structural delimiters of a nested URL from URI.parse.
-      # Inspect only the encoded-or-literal scheme, authority terminator, and @ delimiter, then
-      # remove the original encoded span without decoding or rewriting unrelated output.
-      def strip_encoded_network_url_userinfo(url)
-        authority_start = encoded_authority_start(url)
-        return nil unless authority_start
+      def sanitized_nested_network_url(nested_url)
+        return nested_url unless nested_url.match?(ENCODED_USERINFO_DELIMITER_PATTERN)
 
-        authority_end_match = url.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)
-        authority_end = authority_end_match&.begin(0) || url.length
-        authority = url[authority_start...authority_end]
-        _userinfo, delimiter, host = authority.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
-        return nil if delimiter.empty?
-
-        "#{url[...authority_start]}#{host}#{url[authority_end..]}"
-      end
-
-      def encoded_authority_start(url)
-        network_url = url.match(NETWORK_URL_START_PATTERN)
-        return network_url.end(0) if network_url&.begin(0)&.zero?
-
-        2 if url.start_with?("//")
+        EncodedNetworkUrlRewriter.rewrite_all(nested_url) ||
+          EncodedNetworkUrlRewriter.rewrite(nested_url) ||
+          sanitized_single_network_url(nested_url) ||
+          nested_url
       end
 
       def sanitized_single_network_url(url)

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "uri"
+require_relative "diagnostic_url_redactor/authority_relative_rewriter"
 
 module ReactOnRails
   # Removes URL userinfo from configured values and diagnostic prose before either is displayed.
@@ -18,7 +19,7 @@ module ReactOnRails
     FLEXIBLE_HTTP_URL_SCHEME_PATTERN = %r{https?\s*:\s*//}i
 
     CONFIGURED_URL_NOT_PROVIDED = Object.new.freeze
-    private_constant :CONFIGURED_URL_NOT_PROVIDED
+    private_constant :AuthorityRelativeRewriter, :CONFIGURED_URL_NOT_PROVIDED
 
     # Rewrites disjoint regex-delimited spans with byte offsets so multibyte prefixes do not
     # force Ruby to rescan the string for every match.
@@ -91,14 +92,9 @@ module ReactOnRails
       end
 
       def sanitized_authority_relative_url(url)
-        authority_start = url.index("//")
-        return url unless authority_start
-
-        prefix = url[...authority_start]
-        authority_relative_url = url[authority_start..]
-        sanitized_url = sanitized_valid_network_url(authority_relative_url) ||
-                        strip_malformed_url_userinfo(authority_relative_url)
-        "#{prefix}#{sanitized_url}"
+        AuthorityRelativeRewriter.rewrite(url, delimiter_pattern: ENCODED_USERINFO_DELIMITER_PATTERN) do |span|
+          sanitized_valid_network_url(span)
+        end
       end
 
       def sanitized_error_message(message, raw_url)
@@ -193,10 +189,9 @@ module ReactOnRails
       # Inspect only the encoded-or-literal scheme, authority terminator, and @ delimiter, then
       # remove the original encoded span without decoding or rewriting unrelated output.
       def strip_encoded_network_url_userinfo(url)
-        network_url = url.match(NETWORK_URL_START_PATTERN)
-        return nil unless network_url&.begin(0)&.zero?
+        authority_start = encoded_authority_start(url)
+        return nil unless authority_start
 
-        authority_start = network_url.end(0)
         authority_end_match = url.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)
         authority_end = authority_end_match&.begin(0) || url.length
         authority = url[authority_start...authority_end]
@@ -204,6 +199,13 @@ module ReactOnRails
         return nil if delimiter.empty?
 
         "#{url[...authority_start]}#{host}#{url[authority_end..]}"
+      end
+
+      def encoded_authority_start(url)
+        network_url = url.match(NETWORK_URL_START_PATTERN)
+        return network_url.end(0) if network_url&.begin(0)&.zero?
+
+        2 if url.start_with?("//")
       end
 
       def sanitized_single_network_url(url)
@@ -264,10 +266,10 @@ module ReactOnRails
       def strip_malformed_url_userinfo(url)
         scheme = url.match(%r{\A[a-z][a-z0-9+.-]*\s*:\s*//}i)
         authority_prefix_end = scheme&.end(0) || (2 if url.start_with?("//"))
-        userinfo_delimiter = url.rindex("@")
-        return url unless authority_prefix_end && userinfo_delimiter
+        _userinfo, delimiter, suffix = url.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
+        return url unless authority_prefix_end && !delimiter.empty?
 
-        "#{url[...authority_prefix_end]}#{url[(userinfo_delimiter + 1)..]}"
+        "#{url[...authority_prefix_end]}#{suffix}"
       end
     end
   end

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -65,6 +65,8 @@ module ReactOnRails
     # Finds non-overlapping extended URL scheme starts without retrying a greedy
     # pattern at every byte.
     module NetworkUrlStartScanner
+      HTTP_SCHEME_BYTES = [104, 116, 116, 112].freeze
+
       module_function
 
       def spans(text)
@@ -119,18 +121,43 @@ module ReactOnRails
       def match_end_and_run_end(text, scheme_start, greedy: true)
         offset = scheme_start
         match_end = nil
+        terminal_state = [scheme_start, nil]
 
         while (token_length = scheme_continuation_token_length(text, offset))
           encoded_separator_end = encoded_separator_end(text, offset, scheme_start)
           return [encoded_separator_end, offset] if encoded_separator_end && !greedy
 
           match_end = encoded_separator_end if encoded_separator_end
+          if token_length == 3 || terminal_state[1]
+            update_terminal_candidate!(text, offset, token_length, terminal_state)
+          end
           offset += token_length
         end
 
-        literal_separator_end = literal_network_separator_end(text, offset, scheme_start)
-        match_end = literal_separator_end if literal_separator_end
+        terminal_separator_end = terminal_network_separator_end(text, offset, *terminal_state)
+        match_end = terminal_separator_end if terminal_separator_end
         [match_end, offset]
+      end
+
+      # Percent escapes stay in one raw run so encoded nested URLs can be found without
+      # rescanning. Track the last eligible HTTP(S) candidate and its encoded whitespace
+      # gap separately so a later literal whitespace token cannot hide the candidate.
+      def update_terminal_candidate!(text, offset, token_length, state)
+        encoded_byte = percent_decoded_byte_at(text, offset) if token_length == 3
+        if state[1]
+          return if ascii_whitespace_byte?(encoded_byte)
+
+          state[0] = offset
+          state[1] = nil
+        end
+        return unless encoded_byte
+        return if scheme_continuation_byte?(encoded_byte)
+
+        if ascii_whitespace_byte?(encoded_byte) && http_scheme_at?(text, state[0], offset)
+          state[1] = offset
+        else
+          state[0] = offset + token_length
+        end
       end
 
       def encoded_separator_end(text, offset, scheme_start)
@@ -146,23 +173,34 @@ module ReactOnRails
         slash_end = slash_token_end(text, slash_start)
         return nil unless slash_end
 
-        slash_token_end(text, slash_end)
+        slash_token_end(text, skip_ascii_whitespace(text, slash_end))
       end
 
-      def literal_network_separator_end(text, offset, scheme_start)
+      def terminal_network_separator_end(text, offset, scheme_start, encoded_whitespace_start)
         return network_separator_end(text, offset) if text.getbyte(offset) == 58
         return nil unless ascii_whitespace_byte?(text.getbyte(offset))
-        return nil unless http_scheme_at?(text, scheme_start, offset)
 
-        colon_offset = skip_ascii_whitespace(text, offset)
-        return nil unless text.getbyte(colon_offset) == 58
+        whitespace_start = encoded_whitespace_start || offset
+        return nil unless http_scheme_at?(text, scheme_start, whitespace_start)
+
+        colon_offset = skip_ascii_whitespace(text, whitespace_start)
+        return nil unless text.getbyte(colon_offset) == 58 || percent_encoded_colon_at?(text, colon_offset)
 
         network_separator_end(text, colon_offset)
       end
 
       def skip_ascii_whitespace(text, offset)
-        offset += 1 while ascii_whitespace_byte?(text.getbyte(offset))
+        while (token_length = ascii_whitespace_token_length(text, offset))
+          offset += token_length
+        end
         offset
+      end
+
+      def ascii_whitespace_token_length(text, offset)
+        return 1 if ascii_whitespace_byte?(text.getbyte(offset))
+        return nil unless percent_encoded_byte_at?(text, offset)
+
+        3 if ascii_whitespace_byte?(percent_decoded_byte_at(text, offset))
       end
 
       def slash_token_end(text, offset)
@@ -176,9 +214,13 @@ module ReactOnRails
         return 3 if percent_encoded_byte_at?(text, offset)
 
         byte = text.getbyte(offset)
-        return 1 if ascii_letter_byte?(byte) || digit_byte?(byte) || [43, 45, 46].include?(byte)
+        return 1 if scheme_continuation_byte?(byte)
 
         nil
+      end
+
+      def scheme_continuation_byte?(byte)
+        ascii_letter_byte?(byte) || digit_byte?(byte) || byte == 43 || byte == 45 || byte == 46
       end
 
       def percent_encoded_colon_at?(text, offset)
@@ -212,28 +254,51 @@ module ReactOnRails
       end
 
       def http_scheme_at?(text, start_offset, end_offset)
-        length = end_offset - start_offset
-        return false unless [4, 5].include?(length)
-
-        scheme_bytes = [104, 116, 116, 112]
-        return false unless scheme_bytes.each_with_index.all? do |byte, index|
-          case_insensitive_byte_match?(text.getbyte(start_offset + index), byte)
+        offset = start_offset
+        HTTP_SCHEME_BYTES.each do |byte|
+          offset = case_insensitive_scheme_token_end(text, offset, byte)
+          return false unless offset
         end
 
-        length == 4 || case_insensitive_byte_match?(text.getbyte(start_offset + 4), 115)
+        return true if offset == end_offset
+
+        case_insensitive_scheme_token_end(text, offset, 115) == end_offset
+      end
+
+      def case_insensitive_scheme_token_end(text, offset, lowercase_byte)
+        return offset + 1 if case_insensitive_byte_match?(text.getbyte(offset), lowercase_byte)
+        return nil unless percent_encoded_byte_at?(text, offset)
+        return nil unless case_insensitive_byte_match?(percent_decoded_byte_at(text, offset), lowercase_byte)
+
+        offset + 3
+      end
+
+      def percent_decoded_byte_at(text, offset)
+        (hex_value(text.getbyte(offset + 1)) * 16) + hex_value(text.getbyte(offset + 2))
+      end
+
+      def hex_value(byte)
+        return byte - 48 if (48..57).cover?(byte)
+        return byte - 65 + 10 if (65..70).cover?(byte)
+
+        byte - 97 + 10
       end
 
       def ascii_whitespace_byte?(byte)
         [9, 10, 11, 12, 13, 32].include?(byte)
       end
 
-      private_class_method :each_span, :next_scheme_start, :match_end_and_run_end, :encoded_separator_end,
-                           :network_separator_end, :literal_network_separator_end, :skip_ascii_whitespace,
+      private_class_method :each_span, :next_scheme_start, :match_end_and_run_end, :update_terminal_candidate!,
+                           :encoded_separator_end,
+                           :network_separator_end, :terminal_network_separator_end, :skip_ascii_whitespace,
+                           :ascii_whitespace_token_length,
                            :slash_token_end,
-                           :scheme_continuation_token_length,
+                           :scheme_continuation_token_length, :scheme_continuation_byte?,
                            :percent_encoded_colon_at?, :percent_encoded_slash_at?, :case_insensitive_byte_match?,
                            :digit_byte?, :percent_encoded_byte_at?, :hex_byte?, :ascii_letter_byte?, :http_scheme_at?,
+                           :case_insensitive_scheme_token_end, :percent_decoded_byte_at, :hex_value,
                            :ascii_whitespace_byte?
+      private_constant :HTTP_SCHEME_BYTES
     end
     private_constant :NetworkUrlStartScanner
 

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -2,6 +2,7 @@
 
 require "uri"
 require_relative "diagnostic_url_redactor/authority_relative_rewriter"
+require_relative "diagnostic_url_redactor/encoded_authority_redactor"
 
 module ReactOnRails
   # Removes URL userinfo from configured values and diagnostic prose before either is displayed.
@@ -9,11 +10,18 @@ module ReactOnRails
     HTTP_URL_SCHEME_PATTERN = %r{https?://}i
     ENCODED_USERINFO_DELIMITER_PATTERN = /@|%40/i
     ENCODED_AUTHORITY_END_PATTERN = %r{/|%2f|\?|%3f|\#|%23}i
+    # A bare authority start whose two slashes are not both literal, so the literal marker
+    # scan in AuthorityRelativeRewriter cannot see it.
+    ENCODED_AUTHORITY_MARKER_PATTERN = %r{%2f(?:/|%2f)|/%2f}i
+    ENCODED_AUTHORITY_TOKEN_PATTERN = /#{ENCODED_AUTHORITY_MARKER_PATTERN}[^\s"']+/
+    ENCODED_PORT_SUFFIX_PATTERN = /(?::|%3a)\d*\z/i
+    ENCODED_AUTHORITY_USERINFO_HINT_PATTERN = /:|%3a|@|%40/i
     HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
     FLEXIBLE_HTTP_URL_SCHEME_PATTERN = %r{https?\s*:\s*//}i
 
     CONFIGURED_URL_NOT_PROVIDED = Object.new.freeze
-    private_constant :AuthorityRelativeRewriter, :CONFIGURED_URL_NOT_PROVIDED
+    private_constant :AuthorityRelativeRewriter, :EncodedNetworkUrlRewriter,
+                     :EncodedAuthorityRedactor, :CONFIGURED_URL_NOT_PROVIDED
 
     # Rewrites disjoint regex-delimited spans with byte offsets so multibyte prefixes do not
     # force Ruby to rescan the string for every match.
@@ -302,67 +310,6 @@ module ReactOnRails
     end
     private_constant :NetworkUrlStartScanner
 
-    # Removes userinfo from every encoded-or-literal authority without decoding
-    # or rewriting unrelated path, query, and fragment text.
-    module EncodedNetworkUrlRewriter
-      module_function
-
-      def rewrite(url, authority_start: nil)
-        start_offset = authority_start || detected_authority_start(url)
-        return nil unless start_offset
-
-        removal_span = userinfo_removal_span(url, start_offset)
-        return nil unless removal_span
-
-        remove_byte_spans(url, [removal_span])
-      end
-
-      def rewrite_all(url)
-        removal_spans = NetworkUrlStartScanner.authority_starts(url).filter_map do |authority_start|
-          userinfo_removal_span(url, authority_start)
-        end
-        return nil if removal_spans.empty?
-
-        remove_byte_spans(url, removal_spans)
-      end
-
-      def authority_end(url, authority_start)
-        url.b.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)&.begin(0) || url.bytesize
-      end
-
-      def detected_authority_start(url)
-        network_url = NetworkUrlStartScanner.spans(url).first
-        return network_url.last if network_url&.first&.zero?
-
-        2 if url.start_with?("//")
-      end
-
-      def userinfo_removal_span(url, authority_start)
-        end_offset = authority_end(url, authority_start)
-        authority = url.byteslice(authority_start, end_offset - authority_start)
-        _userinfo, delimiter, host = authority.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
-        return nil if delimiter.empty?
-
-        [authority_start, end_offset - host.bytesize]
-      end
-
-      def remove_byte_spans(text, spans)
-        rewritten = text.dup.clear
-        unprocessed_start = 0
-
-        spans.each do |start_offset, end_offset|
-          if start_offset > unprocessed_start
-            rewritten << text.byteslice(unprocessed_start, start_offset - unprocessed_start)
-          end
-          unprocessed_start = [unprocessed_start, end_offset].max
-        end
-        rewritten << text.byteslice(unprocessed_start, text.bytesize - unprocessed_start)
-      end
-
-      private_class_method :authority_end, :detected_authority_start, :userinfo_removal_span, :remove_byte_spans
-    end
-    private_constant :EncodedNetworkUrlRewriter
-
     class << self
       # Sanitizes a configured URL when called with one argument. When sanitizing exception text,
       # pass the originating URL so both its raw and inspected spellings are replaced safely.
@@ -410,14 +357,21 @@ module ReactOnRails
 
         prefix = sanitized_configured_prefix(url.byteslice(0, start_offset))
         configured_url = url.byteslice(start_offset, url.bytesize - start_offset)
-        sanitized_url = EncodedNetworkUrlRewriter.rewrite_all(configured_url) || configured_url
+        sanitized_url = EncodedNetworkUrlRewriter.rewrite_all(configured_url) ||
+                        EncodedAuthorityRedactor.fail_closed_userinfo(configured_url,
+                                                                      end_offset - start_offset) ||
+                        configured_url
         "#{prefix}#{sanitized_nested_network_urls(sanitized_url)}"
       end
 
       def sanitized_authority_relative_url(url)
-        AuthorityRelativeRewriter.rewrite(url, delimiter_pattern: ENCODED_USERINFO_DELIMITER_PATTERN) do |span|
+        rewritten = AuthorityRelativeRewriter.rewrite(url,
+                                                      delimiter_pattern: ENCODED_USERINFO_DELIMITER_PATTERN) do |span|
           sanitized_valid_network_url(span)
         end
+        return rewritten unless rewritten == url
+
+        EncodedAuthorityRedactor.sanitized_authority_relative_url(url) || rewritten
       end
 
       def sanitized_error_message(message, raw_url)
@@ -467,11 +421,14 @@ module ReactOnRails
         continuation.match?(ENCODED_USERINFO_DELIMITER_PATTERN)
       end
 
+      # The unresolved region starting at the first scheme is discarded, but the text kept before
+      # it is ordinary prose that can still carry an authority-relative credential, so it is
+      # sanitized rather than returned verbatim.
       def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
         unresolved_scheme = text.match(HTTP_URL_SCHEME_PATTERN)
         return strip_unprotected_userinfo(text) if raw_url == sanitized_url || unresolved_scheme.nil?
 
-        text[...unresolved_scheme.begin(0)]
+        strip_unprotected_userinfo(text[...unresolved_scheme.begin(0)])
       end
 
       # A configured value with credential-like text before its first URL scheme is malformed,
@@ -565,7 +522,9 @@ module ReactOnRails
         /mx
         text = text.gsub(malformed_authority_pattern) { |span| strip_malformed_url_userinfo(span) }
 
-        strip_malformed_http_userinfo(text)
+        # The patterns above only recognize a literal // authority start, so prose can still
+        # carry a bare authority whose slashes are encoded.
+        EncodedAuthorityRedactor.strip_userinfo(strip_malformed_http_userinfo(text))
       end
 
       # Scan disjoint spans between flexible HTTP(S) schemes. Each bounded span reuses the

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -15,6 +15,7 @@ module ReactOnRails
     ENCODED_USERINFO_DELIMITER_PATTERN = /@|%40/i
     ENCODED_AUTHORITY_END_PATTERN = %r{/|%2f|\?|%3f|\#|%23}i
     HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
+    FLEXIBLE_HTTP_URL_SCHEME_PATTERN = %r{https?\s*:\s*//}i
 
     CONFIGURED_URL_NOT_PROVIDED = Object.new.freeze
     private_constant :CONFIGURED_URL_NOT_PROVIDED
@@ -41,13 +42,13 @@ module ReactOnRails
         # Treat whitespace around a scheme delimiter as a malformed HTTP(S) URL rather than a
         # local path. URL classification may reject that spelling, but diagnostics must still
         # fail closed if the value contains credential-like userinfo.
-        scheme_pattern = %r{https?\s*:\s*//}i
-        scheme = url.match(scheme_pattern)
+        scheme = url.match(FLEXIBLE_HTTP_URL_SCHEME_PATTERN)
         return sanitized_authority_relative_url(url) unless scheme
 
         prefix = url[...scheme.begin(0)]
         configured_url = url[scheme.begin(0)..]
-        sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(scheme_pattern).length > 1
+        sanitized_url = if configured_url.match?(/[\r\n]/) ||
+                           configured_url.scan(FLEXIBLE_HTTP_URL_SCHEME_PATTERN).length > 1
                           strip_malformed_url_userinfo(configured_url)
                         else
                           sanitized_valid_network_url(configured_url) || strip_malformed_url_userinfo(configured_url)
@@ -217,8 +218,24 @@ module ReactOnRails
         /mx
         text = text.gsub(malformed_authority_pattern) { |span| strip_malformed_url_userinfo(span) }
 
-        scheme_pattern = %r{https?\s*:\s*//}i
-        text.gsub(/#{scheme_pattern}(?:(?!#{scheme_pattern}).)*@/m) { |span| strip_malformed_url_userinfo(span) }
+        strip_malformed_http_userinfo(text)
+      end
+
+      # Scan disjoint spans between flexible HTTP(S) schemes. Each bounded span reuses the
+      # fail-closed last-@ rule, so each input character is scanned a constant number of times.
+      def strip_malformed_http_userinfo(text)
+        sanitized = text.dup.clear
+        unprocessed_start = 0
+        scheme = text.match(FLEXIBLE_HTTP_URL_SCHEME_PATTERN)
+        while scheme
+          next_scheme = text.match(FLEXIBLE_HTTP_URL_SCHEME_PATTERN, scheme.end(0))
+          span_end = next_scheme&.begin(0) || text.length
+          sanitized << text[unprocessed_start...scheme.begin(0)]
+          sanitized << strip_malformed_url_userinfo(text[scheme.begin(0)...span_end])
+          unprocessed_start = span_end
+          scheme = next_scheme
+        end
+        sanitized << text[unprocessed_start..]
       end
 
       # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor.rb
@@ -14,7 +14,6 @@ module ReactOnRails
     # scan in AuthorityRelativeRewriter cannot see it.
     ENCODED_AUTHORITY_MARKER_PATTERN = %r{%2f(?:/|%2f)|/%2f}i
     ENCODED_AUTHORITY_TOKEN_PATTERN = /#{ENCODED_AUTHORITY_MARKER_PATTERN}[^\s"']+/
-    ENCODED_PORT_SUFFIX_PATTERN = /(?::|%3a)\d*\z/i
     ENCODED_AUTHORITY_USERINFO_HINT_PATTERN = /:|%3a|@|%40/i
     HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
     FLEXIBLE_HTTP_URL_SCHEME_PATTERN = %r{https?\s*:\s*//}i

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor/authority_relative_rewriter.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor/authority_relative_rewriter.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module ReactOnRails
+  module DiagnosticUrlRedactor
+    # Rewrites authority-relative URLs with one monotone byte-offset pass. A structurally invalid
+    # span stays pending because a later marker and userinfo delimiter may still belong to it.
+    class AuthorityRelativeRewriter
+      MARKER = "//"
+      private_constant :MARKER
+
+      def self.rewrite(text, delimiter_pattern:, &sanitizer)
+        new(text, delimiter_pattern, sanitizer).rewrite
+      end
+
+      def initialize(text, delimiter_pattern, sanitizer)
+        @text = text
+        @binary_text = text.b
+        @delimiter_pattern = delimiter_pattern
+        @sanitizer = sanitizer
+        @rewritten = text.dup.clear
+        @output_cursor = 0
+        @marker_start = @binary_text.index(MARKER)
+        @pending_start = nil
+        @pending_last_delimiter_end = nil
+      end
+
+      def rewrite
+        return @text unless @marker_start
+
+        rewrite_bounded_spans
+        finish
+      end
+
+      private
+
+      def rewrite_bounded_spans
+        while (next_marker_start = @binary_text.index(MARKER, @marker_start + MARKER.bytesize))
+          consume_bounded_span(next_marker_start)
+          @marker_start = next_marker_start
+        end
+      end
+
+      def consume_bounded_span(span_end)
+        span = original_bytes(@marker_start, span_end)
+        if @pending_start
+          record_last_delimiter(span, @marker_start)
+          return
+        end
+
+        sanitized_span = @sanitizer.call(span)
+        if sanitized_span
+          append_original(@output_cursor, @marker_start)
+          @rewritten << sanitized_span
+          @output_cursor = span_end
+        else
+          @pending_start = @marker_start
+          record_last_delimiter(span, @marker_start)
+        end
+      end
+
+      def finish
+        final_span = original_bytes(@marker_start, @text.bytesize)
+        return finish_pending(final_span) if @pending_start
+
+        append_original(@output_cursor, @marker_start)
+        @rewritten << (@sanitizer.call(final_span) || strip_ambiguous_userinfo(final_span))
+      end
+
+      def finish_pending(final_span)
+        record_last_delimiter(final_span, @marker_start)
+        append_original(@output_cursor, @pending_start)
+        return @rewritten << original_bytes(@pending_start, @text.bytesize) unless @pending_last_delimiter_end
+
+        @rewritten << original_bytes(@pending_start, @pending_start + MARKER.bytesize)
+        @rewritten << original_bytes(@pending_last_delimiter_end, @text.bytesize)
+      end
+
+      def strip_ambiguous_userinfo(span)
+        delimiter_end = last_delimiter_end(span)
+        return span unless delimiter_end
+
+        "#{MARKER}#{span.byteslice(delimiter_end, span.bytesize - delimiter_end)}"
+      end
+
+      def record_last_delimiter(span, absolute_start)
+        delimiter_end = last_delimiter_end(span)
+        @pending_last_delimiter_end = absolute_start + delimiter_end if delimiter_end
+      end
+
+      def last_delimiter_end(span)
+        binary_span = span.b
+        delimiter = binary_span.match(@delimiter_pattern)
+        last_end = nil
+        while delimiter
+          last_end = delimiter.end(0)
+          delimiter = binary_span.match(@delimiter_pattern, delimiter.end(0))
+        end
+        last_end
+      end
+
+      def append_original(start_offset, end_offset)
+        @rewritten << original_bytes(start_offset, end_offset)
+      end
+
+      def original_bytes(start_offset, end_offset)
+        @text.byteslice(start_offset, end_offset - start_offset)
+      end
+    end
+  end
+end

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor/encoded_authority_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor/encoded_authority_redactor.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module ReactOnRails
+  module DiagnosticUrlRedactor
+    # Removes userinfo from every encoded-or-literal authority without decoding
+    # or rewriting unrelated path, query, and fragment text.
+    module EncodedNetworkUrlRewriter
+      module_function
+
+      def rewrite(url, authority_start: nil)
+        start_offset = authority_start || detected_authority_start(url)
+        return nil unless start_offset
+
+        removal_span = userinfo_removal_span(url, start_offset)
+        return nil unless removal_span
+
+        remove_byte_spans(url, [removal_span])
+      end
+
+      def rewrite_all(url)
+        removal_spans = NetworkUrlStartScanner.authority_starts(url).filter_map do |authority_start|
+          userinfo_removal_span(url, authority_start)
+        end
+        return nil if removal_spans.empty?
+
+        remove_byte_spans(url, removal_spans)
+      end
+
+      def authority_end(url, authority_start)
+        url.b.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)&.begin(0) || url.bytesize
+      end
+
+      def detected_authority_start(url)
+        network_url = NetworkUrlStartScanner.spans(url).first
+        return network_url.last if network_url&.first&.zero?
+
+        2 if url.start_with?("//")
+      end
+
+      def userinfo_removal_span(url, authority_start)
+        end_offset = authority_end(url, authority_start)
+        authority = url.byteslice(authority_start, end_offset - authority_start)
+        _userinfo, delimiter, host = authority.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
+        return nil if delimiter.empty?
+
+        [authority_start, end_offset - host.bytesize]
+      end
+
+      def remove_byte_spans(text, spans)
+        rewritten = text.dup.clear
+        unprocessed_start = 0
+
+        spans.each do |start_offset, end_offset|
+          if start_offset > unprocessed_start
+            rewritten << text.byteslice(unprocessed_start, start_offset - unprocessed_start)
+          end
+          unprocessed_start = [unprocessed_start, end_offset].max
+        end
+        rewritten << text.byteslice(unprocessed_start, text.bytesize - unprocessed_start)
+      end
+
+      private_class_method :detected_authority_start, :userinfo_removal_span, :remove_byte_spans
+    end
+
+    # Handles bare authorities whose slashes are percent-encoded. The literal marker scans
+    # elsewhere in this file cannot see them, so without this pass an encoded spelling of a
+    # credential would survive where its literal spelling is redacted.
+    module EncodedAuthorityRedactor
+      module_function
+
+      # A configured value can begin its bare authority with encoded slashes. Reuse the encoded
+      # authority rules so an encoded bare authority fails closed like an encoded HTTP authority.
+      def sanitized_authority_relative_url(url)
+        marker = url.b.match(ENCODED_AUTHORITY_MARKER_PATTERN)
+        return nil unless marker
+
+        authority_start = marker.end(0)
+        EncodedNetworkUrlRewriter.rewrite(url, authority_start:) ||
+          fail_closed_userinfo(url, authority_start)
+      end
+
+      # An encoded authority separator leaves the value structurally unparseable, so the first
+      # encoded path/query/fragment token is only a trustworthy authority boundary when the
+      # authority it delimits is a plausible host[:port]. Otherwise the value is malformed and
+      # fails closed through its final userinfo delimiter, matching the literal malformed rule.
+      def fail_closed_userinfo(url, authority_start)
+        authority_end = EncodedNetworkUrlRewriter.authority_end(url, authority_start)
+        authority = url.byteslice(authority_start, authority_end - authority_start)
+        return nil if plausible_authority?(authority)
+
+        tail = url.byteslice(authority_start, url.bytesize - authority_start)
+        _userinfo, delimiter, suffix = tail.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
+        return nil if delimiter.empty?
+
+        "#{url.byteslice(0, authority_start)}#{suffix}"
+      end
+
+      # Each token is anchored at its own marker and bounded by whitespace or a quote, so this
+      # pass stays linear in the input size.
+      def strip_userinfo(text)
+        text.gsub(ENCODED_AUTHORITY_TOKEN_PATTERN) do |token|
+          sanitized_authority_relative_url(token) || token
+        end
+      end
+
+      def plausible_authority?(authority)
+        !authority.sub(ENCODED_PORT_SUFFIX_PATTERN, "").match?(ENCODED_AUTHORITY_USERINFO_HINT_PATTERN)
+      end
+
+      private_class_method :plausible_authority?
+    end
+  end
+end

--- a/react_on_rails/lib/react_on_rails/diagnostic_url_redactor/encoded_authority_redactor.rb
+++ b/react_on_rails/lib/react_on_rails/diagnostic_url_redactor/encoded_authority_redactor.rb
@@ -103,8 +103,13 @@ module ReactOnRails
         end
       end
 
+      # Every value reaching this module has an encoded authority separator, so URI cannot parse
+      # it and nothing structurally proves that a trailing :digits run is a port rather than a
+      # numeric password. Treating it as a port would make redaction depend on whether a password
+      # happens to be all digits, so any colon in the authority is ambiguous and fails closed.
+      # The literal path keeps its port handling, where URI.parse supplies that proof.
       def plausible_authority?(authority)
-        !authority.sub(ENCODED_PORT_SUFFIX_PATTERN, "").match?(ENCODED_AUTHORITY_USERINFO_HINT_PATTERN)
+        !authority.match?(ENCODED_AUTHORITY_USERINFO_HINT_PATTERN)
       end
 
       private_class_method :plausible_authority?

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -149,7 +149,8 @@ module ReactOnRails
 
         def read_bundle_js_code
           server_js_file = ReactOnRails::Utils.server_bundle_js_file_path
-          if ReactOnRails::Utils.server_bundle_path_is_http?
+          server_bundle_path_is_http = ReactOnRails::Utils.server_bundle_path_is_http?
+          if server_bundle_path_is_http
             file_url_to_string(server_js_file)
           else
             File.read(server_js_file)
@@ -159,12 +160,19 @@ module ReactOnRails
           # (a supported config convenience, e.g. https://:password@host:3800). This is the
           # public entry point that file_url_to_string is called from, so without this the
           # sanitization inside file_url_to_string's own raise/rescue is moot for any real
-          # caller — the credential would still leak here regardless. e.message is scrubbed too:
-          # a URL malformed enough that URI.parse raises embeds the raw, unsanitized URL verbatim
-          # in URI::InvalidURIError's own message.
-          msg = "You specified server rendering JS file: #{sanitized_renderer_url(server_js_file)}, but it cannot " \
+          # caller — the credential would still leak here regardless. Errors already wrapped by
+          # file_url_to_string have passed through the same message sanitizer; scanning that
+          # wrapper again would treat its diagnostic text as fresh untrusted input. Other errors
+          # are scrubbed here because URI::InvalidURIError embeds the raw URL in its message.
+          sanitized_url = sanitized_renderer_url(server_js_file)
+          sanitized_error = if server_bundle_path_is_http && e.is_a?(ReactOnRails::ServerBundleLoadError)
+                              e.message
+                            else
+                              sanitized_renderer_error_message(e.message, server_js_file, sanitized_url)
+                            end
+          msg = "You specified server rendering JS file: #{sanitized_url}, but it cannot " \
                 "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
-                "avoid this warning.\nError is: #{strip_userinfo(e.message)}\n\n" \
+                "avoid this warning.\nError is: #{sanitized_error}\n\n" \
                 "#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
@@ -395,10 +403,80 @@ module ReactOnRails
         # Strips any embedded credentials from a configured renderer URL before it is
         # interpolated into an error message, so a password in the URL (a supported config
         # convenience, e.g. https://:password@host:3800) cannot leak into logs or error
-        # trackers. Mirrors ReactOnRailsPro::Configuration#strip_renderer_url_userinfo.
+        # trackers. One configured value is not free-form prose: multiple schemes or line breaks
+        # after its first scheme make it structurally ambiguous, so that URL suffix fails closed
+        # through its final @. Any non-URL prefix is preserved for useful error context.
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
 
+          scheme = url.match(%r{https?://}i)
+          return url unless scheme
+
+          prefix = url[...scheme.begin(0)]
+          configured_url = url[scheme.begin(0)..]
+          sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(%r{https?://}i).length > 1
+                            strip_malformed_url_userinfo(configured_url)
+                          else
+                            sanitized_valid_http_url(configured_url) || strip_malformed_url_userinfo(configured_url)
+                          end
+
+          "#{prefix}#{sanitized_url}"
+        end
+
+        def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))
+          message = message.to_s
+          return strip_userinfo(message) if raw_url.nil? || raw_url.empty?
+
+          # URI::InvalidURIError embeds String#inspect, while other errors may embed the raw value.
+          message = message.gsub(raw_url.inspect) { sanitized_url.inspect }
+                           .gsub(raw_url) { sanitized_url }
+          strip_userinfo(message)
+        end
+
+        # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
+        # without collision-prone placeholder text. A candidate remains unprotected when any @
+        # follows it before the next scheme: punctuation, prose, and line breaks are not structural
+        # proof that the @ is unrelated to malformed userinfo. When an unresolved region precedes
+        # a credential-bearing candidate, that region is discarded and the candidate is sanitized
+        # independently rather than allowing one fallback match to consume through another scheme.
+        # Ambiguous text may be over-redacted for safety.
+        def strip_userinfo(text)
+          text = text.to_s
+          sanitized = text.dup.clear
+          unprotected_start = 0
+
+          text.to_enum(:scan, %r{https?://(?:(?!https?://)[^\s"'])+}i).each do
+            match = Regexp.last_match
+            protected_url = sanitized_valid_http_url(match[0])
+            next unless protected_url
+            next if userinfo_delimiter_before_next_scheme?(text, match)
+
+            unprotected = text[unprotected_start...match.begin(0)]
+            sanitized << sanitized_unprotected_prefix(unprotected, match[0], protected_url)
+            sanitized << protected_url
+            unprotected_start = match.end(0)
+          end
+
+          sanitized << strip_unprotected_userinfo(text[unprotected_start..])
+        end
+
+        def userinfo_delimiter_before_next_scheme?(text, match)
+          continuation = text[match.end(0)..]
+          boundary = continuation.match(%r{https?://}i)
+          continuation = continuation[...boundary.begin(0)] if boundary
+          continuation.include?("@")
+        end
+
+        def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
+          unresolved_scheme = text.match(%r{https?://}i)
+          return strip_unprotected_userinfo(text) if raw_url == sanitized_url || unresolved_scheme.nil?
+
+          text[...unresolved_scheme.begin(0)]
+        end
+
+        # URI handles valid URLs structurally, so an @ in the path is never mistaken for userinfo.
+        # Returning nil for invalid input keeps that token unprotected for the fail-closed pass.
+        def sanitized_valid_http_url(url)
           uri = URI.parse(url)
           return url if uri.userinfo.nil?
 
@@ -406,19 +484,22 @@ module ReactOnRails
           uri.password = nil
           uri.user = nil
           uri.to_s
-        rescue URI::InvalidURIError
-          # A URL malformed enough that URI rejects it still shouldn't leak credentials.
-          strip_userinfo(url)
+        rescue URI::Error
+          nil
         end
 
-        # Best-effort strip of the common user:pass@ form from arbitrary text — not just a URL
-        # value, but also free-form text that may quote one, such as the message of a
-        # URI::InvalidURIError raised from an unparseable credential-bearing URL (that message
-        # embeds the raw original string verbatim). Shared by sanitized_renderer_url's malformed-
-        # URL fallback and by the rescue blocks below, so there is exactly one definition of
-        # "strip userinfo" rather than two regexes that can drift apart.
-        def strip_userinfo(text)
-          text.to_s.gsub(%r{//[^/@]*@}, "//")
+        def strip_unprotected_userinfo(text)
+          text.gsub(%r{https?://(?:(?!https?://).)*@}im) { |span| strip_malformed_url_userinfo(span) }
+        end
+
+        # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The
+        # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
+        def strip_malformed_url_userinfo(url)
+          scheme = url.match(%r{\Ahttps?://}i)
+          userinfo_delimiter = url.rindex("@")
+          return url unless scheme && userinfo_delimiter
+
+          "#{url[...scheme.end(0)]}#{url[(userinfo_delimiter + 1)..]}"
         end
 
         def file_url_to_string(url)
@@ -461,8 +542,10 @@ module ReactOnRails
           # message, which Rails.logger and error trackers can persist. e.message is scrubbed as
           # well as url itself: a URL malformed enough that URI.parse raises embeds the raw,
           # unsanitized URL verbatim in URI::InvalidURIError's own message.
-          msg = "file_url_to_string #{sanitized_renderer_url(url)} failed\nError is: " \
-                "#{strip_userinfo(e.message)}\n\n#{Utils.default_troubleshooting_section}"
+          sanitized_url = sanitized_renderer_url(url)
+          sanitized_error = sanitized_renderer_error_message(e.message, url, sanitized_url)
+          msg = "file_url_to_string #{sanitized_url} failed\nError is: " \
+                "#{sanitized_error}\n\n#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
 

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -431,11 +431,11 @@ module ReactOnRails
         end
 
         def sanitized_authority_relative_url(url)
-          authority = url.match(%r{//(?=\S)})
-          return url unless authority
+          authority_start = url.index("//")
+          return url unless authority_start
 
-          prefix = url[...authority.begin(0)]
-          authority_relative_url = url[authority.begin(0)..]
+          prefix = url[...authority_start]
+          authority_relative_url = url[authority_start..]
           sanitized_url = sanitized_valid_network_url(authority_relative_url) ||
                           strip_malformed_url_userinfo(authority_relative_url)
           "#{prefix}#{sanitized_url}"

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -45,6 +45,9 @@ module ReactOnRails
         | error\son\srenderer\srequest
       /xi
 
+      HTTP_URL_SCHEME_PATTERN = %r{https?://}i
+      HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
+
       class << self
         def reset_pool
           @js_context_pool = ConnectionPool.new(
@@ -428,9 +431,14 @@ module ReactOnRails
         end
 
         def sanitized_authority_relative_url(url)
-          return url unless url.start_with?("//")
+          authority = url.match(%r{//(?=\S)})
+          return url unless authority
 
-          sanitized_valid_network_url(url) || strip_malformed_url_userinfo(url)
+          prefix = url[...authority.begin(0)]
+          authority_relative_url = url[authority.begin(0)..]
+          sanitized_url = sanitized_valid_network_url(authority_relative_url) ||
+                          strip_malformed_url_userinfo(authority_relative_url)
+          "#{prefix}#{sanitized_url}"
         end
 
         def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))
@@ -455,7 +463,7 @@ module ReactOnRails
           sanitized = text.dup.clear
           unprotected_start = 0
 
-          text.to_enum(:scan, %r{https?://(?:(?!https?://)[^\s"'])+}i).each do
+          text.to_enum(:scan, HTTP_URL_TOKEN_PATTERN).each do
             match = Regexp.last_match
             protected_url = sanitized_valid_network_url(match[0])
             next unless protected_url
@@ -472,13 +480,13 @@ module ReactOnRails
 
         def userinfo_delimiter_before_next_scheme?(text, match)
           continuation = text[match.end(0)..]
-          boundary = continuation.match(%r{https?://}i)
+          boundary = continuation.match(HTTP_URL_SCHEME_PATTERN)
           continuation = continuation[...boundary.begin(0)] if boundary
           continuation.include?("@")
         end
 
         def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
-          unresolved_scheme = text.match(%r{https?://}i)
+          unresolved_scheme = text.match(HTTP_URL_SCHEME_PATTERN)
           return strip_unprotected_userinfo(text) if raw_url == sanitized_url || unresolved_scheme.nil?
 
           text[...unresolved_scheme.begin(0)]
@@ -504,10 +512,20 @@ module ReactOnRails
           # A credential-bearing network-path reference can appear in an exception message even
           # when it is not the configured bundle URL. Require a non-whitespace token immediately
           # after // so ordinary prose such as "// contact dev@example" remains untouched.
-          authority_pattern = %r{(?<!:)//[^\s"']+}
-          text = text.gsub(authority_pattern) do |url|
+          authority_start_pattern = %r{//(?=\S)}
+          authority_token_pattern = /#{authority_start_pattern}[^\s"']+/
+          text = text.gsub(authority_token_pattern) do |url|
             sanitized_valid_network_url(url) || strip_malformed_url_userinfo(url)
           end
+
+          # Malformed userinfo can cross prose delimiters before its @. Keep scanning until the
+          # next URL-like start and fail closed through the last @ in that bounded span.
+          malformed_authority_pattern = /
+            #{authority_start_pattern}
+            (?:(?!#{HTTP_URL_SCHEME_PATTERN}|#{authority_start_pattern}).)*[\s"']
+            (?:(?!#{HTTP_URL_SCHEME_PATTERN}|#{authority_start_pattern}).)*@
+          /mx
+          text = text.gsub(malformed_authority_pattern) { |span| strip_malformed_url_userinfo(span) }
 
           scheme_pattern = %r{https?\s*:\s*//}i
           text.gsub(/#{scheme_pattern}(?:(?!#{scheme_pattern}).)*@/m) { |span| strip_malformed_url_userinfo(span) }
@@ -516,7 +534,7 @@ module ReactOnRails
         # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The
         # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
         def strip_malformed_url_userinfo(url)
-          scheme = url.match(%r{\Ahttps?\s*:\s*//}i)
+          scheme = url.match(%r{\A[a-z][a-z0-9+.-]*\s*:\s*//}i)
           authority_prefix_end = scheme&.end(0) || (2 if url.start_with?("//"))
           userinfo_delimiter = url.rindex("@")
           return url unless authority_prefix_end && userinfo_delimiter

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -46,6 +46,7 @@ module ReactOnRails
       /xi
 
       HTTP_URL_SCHEME_PATTERN = %r{https?://}i
+      NETWORK_URL_SCHEME_PATTERN = %r{[a-z][a-z0-9+.-]*://}i
       HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
 
       class << self
@@ -496,6 +497,31 @@ module ReactOnRails
         # userinfo. A missing host means an authority-shaped value was parsed as a path instead;
         # returning nil keeps that ambiguous token unprotected for the fail-closed pass.
         def sanitized_valid_network_url(url)
+          sanitized_url = sanitized_single_network_url(url)&.dup
+          return nil unless sanitized_url
+
+          sanitized_nested_network_urls(sanitized_url)
+        end
+
+        def sanitized_nested_network_urls(sanitized_url)
+          # A valid outer URL can carry another credential URL in its path or query. Sanitize
+          # nested scheme spans from right to left so shortening one cannot invalidate the start
+          # offsets of earlier spans. The first scheme belongs to the outer URL and was handled
+          # structurally above.
+          nested_scheme_starts = sanitized_url.to_enum(:scan, NETWORK_URL_SCHEME_PATTERN)
+                                              .map { Regexp.last_match.begin(0) }
+          nested_scheme_starts.shift if nested_scheme_starts.first&.zero?
+          nested_scheme_starts.reverse_each do |start|
+            token_end = sanitized_url.index(/[\s"']/, start) || sanitized_url.length
+            nested_url = sanitized_url[start...token_end]
+            replacement = sanitized_single_network_url(nested_url) || strip_malformed_url_userinfo(nested_url)
+            sanitized_url[start...token_end] = replacement
+          end
+
+          sanitized_url
+        end
+
+        def sanitized_single_network_url(url)
           uri = URI.parse(url)
           return nil if uri.host.nil?
           return url if uri.userinfo.nil?
@@ -504,7 +530,7 @@ module ReactOnRails
           uri.password = nil
           uri.user = nil
           uri.to_s
-        rescue URI::Error
+        rescue URI::Error, ArgumentError
           nil
         end
 

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -414,17 +414,23 @@ module ReactOnRails
           # must still fail closed if the value contains credential-like userinfo.
           scheme_pattern = %r{https?\s*:\s*//}i
           scheme = url.match(scheme_pattern)
-          return url unless scheme
+          return sanitized_authority_relative_url(url) unless scheme
 
           prefix = url[...scheme.begin(0)]
           configured_url = url[scheme.begin(0)..]
           sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(scheme_pattern).length > 1
                             strip_malformed_url_userinfo(configured_url)
                           else
-                            sanitized_valid_http_url(configured_url) || strip_malformed_url_userinfo(configured_url)
+                            sanitized_valid_network_url(configured_url) || strip_malformed_url_userinfo(configured_url)
                           end
 
           "#{prefix}#{sanitized_url}"
+        end
+
+        def sanitized_authority_relative_url(url)
+          return url unless url.start_with?("//")
+
+          sanitized_valid_network_url(url) || strip_malformed_url_userinfo(url)
         end
 
         def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))
@@ -451,7 +457,7 @@ module ReactOnRails
 
           text.to_enum(:scan, %r{https?://(?:(?!https?://)[^\s"'])+}i).each do
             match = Regexp.last_match
-            protected_url = sanitized_valid_http_url(match[0])
+            protected_url = sanitized_valid_network_url(match[0])
             next unless protected_url
             next if userinfo_delimiter_before_next_scheme?(text, match)
 
@@ -478,10 +484,12 @@ module ReactOnRails
           text[...unresolved_scheme.begin(0)]
         end
 
-        # URI handles valid URLs structurally, so an @ in the path is never mistaken for userinfo.
-        # Returning nil for invalid input keeps that token unprotected for the fail-closed pass.
-        def sanitized_valid_http_url(url)
+        # URI handles valid network URLs structurally, so an @ in the path is never mistaken for
+        # userinfo. A missing host means an authority-shaped value was parsed as a path instead;
+        # returning nil keeps that ambiguous token unprotected for the fail-closed pass.
+        def sanitized_valid_network_url(url)
           uri = URI.parse(url)
+          return nil if uri.host.nil?
           return url if uri.userinfo.nil?
 
           # URI rejects a password without a user, so clear password first.
@@ -501,10 +509,11 @@ module ReactOnRails
         # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
         def strip_malformed_url_userinfo(url)
           scheme = url.match(%r{\Ahttps?\s*:\s*//}i)
+          authority_prefix_end = scheme&.end(0) || (2 if url.start_with?("//"))
           userinfo_delimiter = url.rindex("@")
-          return url unless scheme && userinfo_delimiter
+          return url unless authority_prefix_end && userinfo_delimiter
 
-          "#{url[...scheme.end(0)]}#{url[(userinfo_delimiter + 1)..]}"
+          "#{url[...authority_prefix_end]}#{url[(userinfo_delimiter + 1)..]}"
         end
 
         def file_url_to_string(url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -501,6 +501,14 @@ module ReactOnRails
         end
 
         def strip_unprotected_userinfo(text)
+          # A credential-bearing network-path reference can appear in an exception message even
+          # when it is not the configured bundle URL. Require a non-whitespace token immediately
+          # after // so ordinary prose such as "// contact dev@example" remains untouched.
+          authority_pattern = %r{(?<!:)//[^\s"']+}
+          text = text.gsub(authority_pattern) do |url|
+            sanitized_valid_network_url(url) || strip_malformed_url_userinfo(url)
+          end
+
           scheme_pattern = %r{https?\s*:\s*//}i
           text.gsub(/#{scheme_pattern}(?:(?!#{scheme_pattern}).)*@/m) { |span| strip_malformed_url_userinfo(span) }
         end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -409,12 +409,16 @@ module ReactOnRails
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
 
-          scheme = url.match(%r{https?://}i)
+          # Treat whitespace around a scheme delimiter as a malformed HTTP(S) URL rather than a
+          # local path. Utils intentionally rejects that spelling, but the displayed diagnostic
+          # must still fail closed if the value contains credential-like userinfo.
+          scheme_pattern = %r{https?\s*:\s*//}i
+          scheme = url.match(scheme_pattern)
           return url unless scheme
 
           prefix = url[...scheme.begin(0)]
           configured_url = url[scheme.begin(0)..]
-          sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(%r{https?://}i).length > 1
+          sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(scheme_pattern).length > 1
                             strip_malformed_url_userinfo(configured_url)
                           else
                             sanitized_valid_http_url(configured_url) || strip_malformed_url_userinfo(configured_url)
@@ -489,13 +493,14 @@ module ReactOnRails
         end
 
         def strip_unprotected_userinfo(text)
-          text.gsub(%r{https?://(?:(?!https?://).)*@}im) { |span| strip_malformed_url_userinfo(span) }
+          scheme_pattern = %r{https?\s*:\s*//}i
+          text.gsub(/#{scheme_pattern}(?:(?!#{scheme_pattern}).)*@/m) { |span| strip_malformed_url_userinfo(span) }
         end
 
         # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The
         # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
         def strip_malformed_url_userinfo(url)
-          scheme = url.match(%r{\Ahttps?://}i)
+          scheme = url.match(%r{\Ahttps?\s*:\s*//}i)
           userinfo_delimiter = url.rindex("@")
           return url unless scheme && userinfo_delimiter
 
@@ -518,10 +523,10 @@ module ReactOnRails
           # equals the destination (UTF-8). charset_from_content_type returns UTF-8 for three of
           # the four cases this method exists to handle (no Content-Type header, no charset
           # parameter, and an explicit charset=utf-8), so `.encode(Encoding::UTF_8)` alone would
-          # silently let invalid bytes through unchanged on those three paths — only a genuine
-          # cross-encoding transcode (e.g. a declared ISO-8859-1 body) actually validates via
-          # `encode`. valid_encoding? is therefore checked explicitly afterward so every path
-          # fails fast, not just the cross-encoding one.
+          # silently let invalid bytes through unchanged on those three paths. A genuine
+          # cross-encoding transcode can reject malformed input only when the source encoding has
+          # invalid byte sequences of its own (such as Shift_JIS). valid_encoding? is therefore
+          # checked explicitly afterward so every path fails fast, not just the cross-encoding one.
           #
           # An undecodable byte sequence (a charset that doesn't actually match the bytes) is
           # deliberately raised here rather than silently replaced with U+FFFD: this is source

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -46,7 +46,14 @@ module ReactOnRails
       /xi
 
       HTTP_URL_SCHEME_PATTERN = %r{https?://}i
-      NETWORK_URL_SCHEME_PATTERN = %r{[a-z][a-z0-9+.-]*://}i
+      NETWORK_URL_START_PATTERN = %r{
+        (?:[a-z]|%[0-9a-f]{2})
+        (?:[a-z0-9+.-]|%[0-9a-f]{2})*
+        (?::|%3a)
+        (?:/|%2f){2}
+      }ix
+      ENCODED_USERINFO_DELIMITER_PATTERN = /@|%40/i
+      ENCODED_AUTHORITY_END_PATTERN = %r{/|%2f|\?|%3f|\#|%23}i
       HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
 
       class << self
@@ -413,6 +420,8 @@ module ReactOnRails
         def sanitized_renderer_url(url)
           return url if url.nil? || url.empty?
 
+          url = valid_diagnostic_text(url)
+
           # Treat whitespace around a scheme delimiter as a malformed HTTP(S) URL rather than a
           # local path. Utils intentionally rejects that spelling, but the displayed diagnostic
           # must still fail closed if the value contains credential-like userinfo.
@@ -443,8 +452,11 @@ module ReactOnRails
         end
 
         def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))
-          message = message.to_s
+          message = valid_diagnostic_text(message)
           return strip_userinfo(message) if raw_url.nil? || raw_url.empty?
+
+          raw_url = valid_diagnostic_text(raw_url)
+          sanitized_url = valid_diagnostic_text(sanitized_url)
 
           # URI::InvalidURIError embeds String#inspect, while other errors may embed the raw value.
           message = message.gsub(raw_url.inspect) { sanitized_url.inspect }
@@ -460,7 +472,7 @@ module ReactOnRails
         # independently rather than allowing one fallback match to consume through another scheme.
         # Ambiguous text may be over-redacted for safety.
         def strip_userinfo(text)
-          text = text.to_s
+          text = valid_diagnostic_text(text)
           sanitized = text.dup.clear
           unprotected_start = 0
 
@@ -483,7 +495,7 @@ module ReactOnRails
           continuation = text[match.end(0)..]
           boundary = continuation.match(HTTP_URL_SCHEME_PATTERN)
           continuation = continuation[...boundary.begin(0)] if boundary
-          continuation.include?("@")
+          continuation.match?(ENCODED_USERINFO_DELIMITER_PATTERN)
         end
 
         def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
@@ -504,21 +516,47 @@ module ReactOnRails
         end
 
         def sanitized_nested_network_urls(sanitized_url)
-          # A valid outer URL can carry another credential URL in its path or query. Sanitize
-          # nested scheme spans from right to left so shortening one cannot invalidate the start
-          # offsets of earlier spans. The first scheme belongs to the outer URL and was handled
-          # structurally above.
-          nested_scheme_starts = sanitized_url.to_enum(:scan, NETWORK_URL_SCHEME_PATTERN)
+          # A valid outer URL can carry another credential URL in its path or query. Partition the
+          # input into disjoint scheme spans and assemble their replacements from left to right,
+          # keeping the work bounded by the input size even when a diagnostic has many URL starts.
+          # The first scheme belongs to the outer URL and was handled structurally above.
+          nested_scheme_starts = sanitized_url.to_enum(:scan, NETWORK_URL_START_PATTERN)
                                               .map { Regexp.last_match.begin(0) }
           nested_scheme_starts.shift if nested_scheme_starts.first&.zero?
-          nested_scheme_starts.reverse_each do |start|
-            token_end = sanitized_url.index(/[\s"']/, start) || sanitized_url.length
+          return sanitized_url if nested_scheme_starts.empty?
+
+          sanitized = sanitized_url.dup.clear
+          unprocessed_start = 0
+
+          nested_scheme_starts.each_with_index do |start, index|
+            token_end = nested_scheme_starts.fetch(index + 1, sanitized_url.length)
             nested_url = sanitized_url[start...token_end]
-            replacement = sanitized_single_network_url(nested_url) || strip_malformed_url_userinfo(nested_url)
-            sanitized_url[start...token_end] = replacement
+            replacement = strip_encoded_network_url_userinfo(nested_url) ||
+                          sanitized_single_network_url(nested_url) ||
+                          nested_url
+            sanitized << sanitized_url[unprocessed_start...start]
+            sanitized << replacement
+            unprocessed_start = token_end
           end
 
-          sanitized_url
+          sanitized << sanitized_url[unprocessed_start..]
+        end
+
+        # Percent encoding can hide the structural delimiters of a nested URL from URI.parse.
+        # Inspect only the encoded-or-literal scheme, authority terminator, and @ delimiter, then
+        # remove the original encoded span without decoding or rewriting unrelated output.
+        def strip_encoded_network_url_userinfo(url)
+          network_url = url.match(NETWORK_URL_START_PATTERN)
+          return nil unless network_url&.begin(0)&.zero?
+
+          authority_start = network_url.end(0)
+          authority_end_match = url.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)
+          authority_end = authority_end_match&.begin(0) || url.length
+          authority = url[authority_start...authority_end]
+          _userinfo, delimiter, host = authority.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
+          return nil if delimiter.empty?
+
+          "#{url[...authority_start]}#{host}#{url[authority_end..]}"
         end
 
         def sanitized_single_network_url(url)
@@ -534,7 +572,17 @@ module ReactOnRails
           nil
         end
 
+        def valid_diagnostic_text(text)
+          text = text.to_s
+          text.valid_encoding? ? text : text.scrub
+        end
+
         def strip_unprotected_userinfo(text)
+          # A protected HTTP token can end before a malformed nested credential delimiter.
+          # Reuse the bounded structural scan for the remaining prose span before applying the
+          # broader fail-closed patterns below.
+          text = sanitized_nested_network_urls(text.dup)
+
           # A credential-bearing network-path reference can appear in an exception message even
           # when it is not the configured bundle URL. Require a non-whitespace token immediately
           # after // so ordinary prose such as "// contact dev@example" remains untouched.

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -4,6 +4,7 @@ require "open-uri"
 require "execjs"
 require "react_on_rails/length_prefixed_parser"
 require "react_on_rails/lenient_json"
+require "react_on_rails/diagnostic_url_redactor"
 
 module ReactOnRails
   module ServerRenderingPool
@@ -44,17 +45,6 @@ module ReactOnRails
         | Failed\sto\sopen\sTCP\sconnection
         | error\son\srenderer\srequest
       /xi
-
-      HTTP_URL_SCHEME_PATTERN = %r{https?://}i
-      NETWORK_URL_START_PATTERN = %r{
-        (?:[a-z]|%[0-9a-f]{2})
-        (?:[a-z0-9+.-]|%[0-9a-f]{2})*
-        (?::|%3a)
-        (?:/|%2f){2}
-      }ix
-      ENCODED_USERINFO_DELIMITER_PATTERN = /@|%40/i
-      ENCODED_AUTHORITY_END_PATTERN = %r{/|%2f|\?|%3f|\#|%23}i
-      HTTP_URL_TOKEN_PATTERN = /#{HTTP_URL_SCHEME_PATTERN}(?:(?!#{HTTP_URL_SCHEME_PATTERN})[^\s"'])+/
 
       class << self
         def reset_pool
@@ -175,11 +165,11 @@ module ReactOnRails
           # file_url_to_string have passed through the same message sanitizer; scanning that
           # wrapper again would treat its diagnostic text as fresh untrusted input. Other errors
           # are scrubbed here because URI::InvalidURIError embeds the raw URL in its message.
-          sanitized_url = sanitized_renderer_url(server_js_file)
+          sanitized_url = DiagnosticUrlRedactor.sanitize(server_js_file)
           sanitized_error = if server_bundle_path_is_http && e.is_a?(ReactOnRails::ServerBundleLoadError)
                               e.message
                             else
-                              sanitized_renderer_error_message(e.message, server_js_file, sanitized_url)
+                              DiagnosticUrlRedactor.sanitize(e.message, configured_url: server_js_file)
                             end
           msg = "You specified server rendering JS file: #{sanitized_url}, but it cannot " \
                 "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
@@ -379,7 +369,7 @@ module ReactOnRails
             target = target_from_message(current.message)
             # Sanitize here too: a target scraped from the message can itself be a full URL
             # with embedded credentials (e.g. "TCP connection to https://user:pw@host:3800").
-            return sanitized_renderer_url(target) if target
+            return DiagnosticUrlRedactor.sanitize(target) if target
           end
           configured_renderer_url.last
         end
@@ -391,7 +381,7 @@ module ReactOnRails
         def configured_renderer_url
           %w[REACT_RENDERER_URL RENDERER_URL].each do |var|
             value = ENV.fetch(var, nil)
-            return [var, sanitized_renderer_url(value)] unless value.nil? || value.empty?
+            return [var, DiagnosticUrlRedactor.sanitize(value)] unless value.nil? || value.empty?
           end
           [nil, nil]
         end
@@ -411,215 +401,10 @@ module ReactOnRails
           nil
         end
 
-        # Strips any embedded credentials from a configured renderer URL before it is
-        # interpolated into an error message, so a password in the URL (a supported config
-        # convenience, e.g. https://:password@host:3800) cannot leak into logs or error
-        # trackers. One configured value is not free-form prose: multiple schemes or line breaks
-        # after its first scheme make it structurally ambiguous, so that URL suffix fails closed
-        # through its final @. Any non-URL prefix is preserved for useful error context.
-        def sanitized_renderer_url(url)
-          return url if url.nil? || url.empty?
-
-          url = valid_diagnostic_text(url)
-
-          # Treat whitespace around a scheme delimiter as a malformed HTTP(S) URL rather than a
-          # local path. Utils intentionally rejects that spelling, but the displayed diagnostic
-          # must still fail closed if the value contains credential-like userinfo.
-          scheme_pattern = %r{https?\s*:\s*//}i
-          scheme = url.match(scheme_pattern)
-          return sanitized_authority_relative_url(url) unless scheme
-
-          prefix = url[...scheme.begin(0)]
-          configured_url = url[scheme.begin(0)..]
-          sanitized_url = if configured_url.match?(/[\r\n]/) || configured_url.scan(scheme_pattern).length > 1
-                            strip_malformed_url_userinfo(configured_url)
-                          else
-                            sanitized_valid_network_url(configured_url) || strip_malformed_url_userinfo(configured_url)
-                          end
-
-          "#{prefix}#{sanitized_url}"
-        end
-
-        def sanitized_authority_relative_url(url)
-          authority_start = url.index("//")
-          return url unless authority_start
-
-          prefix = url[...authority_start]
-          authority_relative_url = url[authority_start..]
-          sanitized_url = sanitized_valid_network_url(authority_relative_url) ||
-                          strip_malformed_url_userinfo(authority_relative_url)
-          "#{prefix}#{sanitized_url}"
-        end
-
-        def sanitized_renderer_error_message(message, raw_url, sanitized_url = sanitized_renderer_url(raw_url))
-          message = valid_diagnostic_text(message)
-          return strip_userinfo(message) if raw_url.nil? || raw_url.empty?
-
-          raw_url = valid_diagnostic_text(raw_url)
-          sanitized_url = valid_diagnostic_text(sanitized_url)
-
-          # URI::InvalidURIError embeds String#inspect, while other errors may embed the raw value.
-          message = message.gsub(raw_url.inspect) { sanitized_url.inspect }
-                           .gsub(raw_url) { sanitized_url }
-          strip_userinfo(message)
-        end
-
-        # Protects successfully parsed bare HTTP(S) tokens by assembling the result from spans,
-        # without collision-prone placeholder text. A candidate remains unprotected when any @
-        # follows it before the next scheme: punctuation, prose, and line breaks are not structural
-        # proof that the @ is unrelated to malformed userinfo. When an unresolved region precedes
-        # a credential-bearing candidate, that region is discarded and the candidate is sanitized
-        # independently rather than allowing one fallback match to consume through another scheme.
-        # Ambiguous text may be over-redacted for safety.
-        def strip_userinfo(text)
-          text = valid_diagnostic_text(text)
-          sanitized = text.dup.clear
-          unprotected_start = 0
-
-          text.to_enum(:scan, HTTP_URL_TOKEN_PATTERN).each do
-            match = Regexp.last_match
-            protected_url = sanitized_valid_network_url(match[0])
-            next unless protected_url
-            next if userinfo_delimiter_before_next_scheme?(text, match)
-
-            unprotected = text[unprotected_start...match.begin(0)]
-            sanitized << sanitized_unprotected_prefix(unprotected, match[0], protected_url)
-            sanitized << protected_url
-            unprotected_start = match.end(0)
-          end
-
-          sanitized << strip_unprotected_userinfo(text[unprotected_start..])
-        end
-
-        def userinfo_delimiter_before_next_scheme?(text, match)
-          continuation = text[match.end(0)..]
-          boundary = continuation.match(HTTP_URL_SCHEME_PATTERN)
-          continuation = continuation[...boundary.begin(0)] if boundary
-          continuation.match?(ENCODED_USERINFO_DELIMITER_PATTERN)
-        end
-
-        def sanitized_unprotected_prefix(text, raw_url, sanitized_url)
-          unresolved_scheme = text.match(HTTP_URL_SCHEME_PATTERN)
-          return strip_unprotected_userinfo(text) if raw_url == sanitized_url || unresolved_scheme.nil?
-
-          text[...unresolved_scheme.begin(0)]
-        end
-
-        # URI handles valid network URLs structurally, so an @ in the path is never mistaken for
-        # userinfo. A missing host means an authority-shaped value was parsed as a path instead;
-        # returning nil keeps that ambiguous token unprotected for the fail-closed pass.
-        def sanitized_valid_network_url(url)
-          sanitized_url = sanitized_single_network_url(url)&.dup
-          return nil unless sanitized_url
-
-          sanitized_nested_network_urls(sanitized_url)
-        end
-
-        def sanitized_nested_network_urls(sanitized_url)
-          # A valid outer URL can carry another credential URL in its path or query. Partition the
-          # input into disjoint scheme spans and assemble their replacements from left to right,
-          # keeping the work bounded by the input size even when a diagnostic has many URL starts.
-          # The first scheme belongs to the outer URL and was handled structurally above.
-          nested_scheme_starts = sanitized_url.to_enum(:scan, NETWORK_URL_START_PATTERN)
-                                              .map { Regexp.last_match.begin(0) }
-          nested_scheme_starts.shift if nested_scheme_starts.first&.zero?
-          return sanitized_url if nested_scheme_starts.empty?
-
-          sanitized = sanitized_url.dup.clear
-          unprocessed_start = 0
-
-          nested_scheme_starts.each_with_index do |start, index|
-            token_end = nested_scheme_starts.fetch(index + 1, sanitized_url.length)
-            nested_url = sanitized_url[start...token_end]
-            replacement = strip_encoded_network_url_userinfo(nested_url) ||
-                          sanitized_single_network_url(nested_url) ||
-                          nested_url
-            sanitized << sanitized_url[unprocessed_start...start]
-            sanitized << replacement
-            unprocessed_start = token_end
-          end
-
-          sanitized << sanitized_url[unprocessed_start..]
-        end
-
-        # Percent encoding can hide the structural delimiters of a nested URL from URI.parse.
-        # Inspect only the encoded-or-literal scheme, authority terminator, and @ delimiter, then
-        # remove the original encoded span without decoding or rewriting unrelated output.
-        def strip_encoded_network_url_userinfo(url)
-          network_url = url.match(NETWORK_URL_START_PATTERN)
-          return nil unless network_url&.begin(0)&.zero?
-
-          authority_start = network_url.end(0)
-          authority_end_match = url.match(ENCODED_AUTHORITY_END_PATTERN, authority_start)
-          authority_end = authority_end_match&.begin(0) || url.length
-          authority = url[authority_start...authority_end]
-          _userinfo, delimiter, host = authority.rpartition(ENCODED_USERINFO_DELIMITER_PATTERN)
-          return nil if delimiter.empty?
-
-          "#{url[...authority_start]}#{host}#{url[authority_end..]}"
-        end
-
-        def sanitized_single_network_url(url)
-          uri = URI.parse(url)
-          return nil if uri.host.nil?
-          return url if uri.userinfo.nil?
-
-          # URI rejects a password without a user, so clear password first.
-          uri.password = nil
-          uri.user = nil
-          uri.to_s
-        rescue URI::Error, ArgumentError
-          nil
-        end
-
-        def valid_diagnostic_text(text)
-          text = text.to_s
-          text.valid_encoding? ? text : text.scrub
-        end
-
-        def strip_unprotected_userinfo(text)
-          # A protected HTTP token can end before a malformed nested credential delimiter.
-          # Reuse the bounded structural scan for the remaining prose span before applying the
-          # broader fail-closed patterns below.
-          text = sanitized_nested_network_urls(text.dup)
-
-          # A credential-bearing network-path reference can appear in an exception message even
-          # when it is not the configured bundle URL. Require a non-whitespace token immediately
-          # after // so ordinary prose such as "// contact dev@example" remains untouched.
-          authority_start_pattern = %r{//(?=\S)}
-          authority_token_pattern = /#{authority_start_pattern}[^\s"']+/
-          text = text.gsub(authority_token_pattern) do |url|
-            sanitized_valid_network_url(url) || strip_malformed_url_userinfo(url)
-          end
-
-          # Malformed userinfo can cross prose delimiters before its @. Keep scanning until the
-          # next URL-like start and fail closed through the last @ in that bounded span.
-          malformed_authority_pattern = /
-            #{authority_start_pattern}
-            (?:(?!#{HTTP_URL_SCHEME_PATTERN}|#{authority_start_pattern}).)*[\s"']
-            (?:(?!#{HTTP_URL_SCHEME_PATTERN}|#{authority_start_pattern}).)*@
-          /mx
-          text = text.gsub(malformed_authority_pattern) { |span| strip_malformed_url_userinfo(span) }
-
-          scheme_pattern = %r{https?\s*:\s*//}i
-          text.gsub(/#{scheme_pattern}(?:(?!#{scheme_pattern}).)*@/m) { |span| strip_malformed_url_userinfo(span) }
-        end
-
-        # For malformed URLs or unprotected scheme-delimited spans, remove through the last @. The
-        # retained suffix is best-effort context; ambiguous malformed diagnostics may lose text.
-        def strip_malformed_url_userinfo(url)
-          scheme = url.match(%r{\A[a-z][a-z0-9+.-]*\s*:\s*//}i)
-          authority_prefix_end = scheme&.end(0) || (2 if url.start_with?("//"))
-          userinfo_delimiter = url.rindex("@")
-          return url unless authority_prefix_end && userinfo_delimiter
-
-          "#{url[...authority_prefix_end]}#{url[(userinfo_delimiter + 1)..]}"
-        end
-
         def file_url_to_string(url)
           response = Net::HTTP.get_response(URI.parse(url))
           unless response.is_a?(Net::HTTPSuccess)
-            raise "GET #{sanitized_renderer_url(url)} returned a non-success HTTP status: " \
+            raise "GET #{DiagnosticUrlRedactor.sanitize(url)} returned a non-success HTTP status: " \
                   "#{response.code} #{response.message}"
           end
 
@@ -646,7 +431,7 @@ module ReactOnRails
                             .encode(Encoding::UTF_8)
           unless decoded.valid_encoding?
             raise "response body is not valid UTF-8 after decoding from the declared charset " \
-                  "(GET #{sanitized_renderer_url(url)})"
+                  "(GET #{DiagnosticUrlRedactor.sanitize(url)})"
           end
 
           decoded
@@ -656,8 +441,8 @@ module ReactOnRails
           # message, which Rails.logger and error trackers can persist. e.message is scrubbed as
           # well as url itself: a URL malformed enough that URI.parse raises embeds the raw,
           # unsanitized URL verbatim in URI::InvalidURIError's own message.
-          sanitized_url = sanitized_renderer_url(url)
-          sanitized_error = sanitized_renderer_error_message(e.message, url, sanitized_url)
+          sanitized_url = DiagnosticUrlRedactor.sanitize(url)
+          sanitized_error = DiagnosticUrlRedactor.sanitize(e.message, configured_url: url)
           msg = "file_url_to_string #{sanitized_url} failed\nError is: " \
                 "#{sanitized_error}\n\n#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative "spec_helper"
 require "react_on_rails/diagnostic_url_redactor"
+require "timeout"
 
 RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
   describe ".sanitize" do
@@ -13,6 +14,16 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       [
         "valid HTTP userinfo",
         "http://synthetic-user:synthetic-secret@host/path",
+        "http://host/path"
+      ],
+      [
+        "a percent-encoded authority delimiter",
+        "http://bundle-user:synthetic-password%40host/bundle.js",
+        "http://host/bundle.js"
+      ],
+      [
+        "mixed encoded and literal authority delimiters",
+        "http://synthetic-user%40mail:synthetic-secret@host/path",
         "http://host/path"
       ],
       [
@@ -96,9 +107,24 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "URL=https://host/path"
       ],
       [
+        "credential-like text before a later HTTP URL",
+        "user:pass@host http://actual-host/path",
+        "host http://actual-host/path"
+      ],
+      [
         "an at sign only in the path",
         "http://host/path@example",
         "http://host/path@example"
+      ],
+      [
+        "a percent-encoded at sign only in the path",
+        "http://host/assets/component%402.js",
+        "http://host/assets/component%402.js"
+      ],
+      [
+        "a percent-encoded at sign only in the query",
+        "http://host/bundle.js?contact=safe%40example.test",
+        "http://host/bundle.js?contact=safe%40example.test"
       ],
       [
         "an at sign only in an authority-relative path",
@@ -392,6 +418,14 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       expect(message.bytesize).to be > 65_536
 
       expect(sanitize_error(message)).to eq(message)
+    end
+
+    it "processes a large multibyte diagnostic with many incomplete HTTP URL starts in bounded time" do
+      message = "éhttp://" * 16_000
+      expect(message.bytesize).to be > 131_072
+
+      sanitized = Timeout.timeout(1) { sanitize_error(message) }
+      expect(sanitized).to eq(message)
     end
   end
 end

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -1,0 +1,390 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require "react_on_rails/diagnostic_url_redactor"
+
+RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
+  describe ".sanitize" do
+    def sanitize_error(message, configured_url: nil)
+      described_class.sanitize(message, configured_url:)
+    end
+
+    configured_url_cases = [
+      [
+        "valid HTTP userinfo",
+        "http://synthetic-user:synthetic-secret@host/path",
+        "http://host/path"
+      ],
+      [
+        "whitespace in the HTTP scheme delimiter",
+        "http ://synthetic-user:synthetic-secret@host/path",
+        "http ://host/path"
+      ],
+      [
+        "authority-relative userinfo",
+        "//synthetic-user:synthetic-secret@host/path",
+        "//host/path"
+      ],
+      [
+        "ambiguous authority-relative userinfo",
+        "//synthetic-user:synthetic-secret@credential-suffix@host/path",
+        "//host/path"
+      ],
+      [
+        "a prefix before authority-relative userinfo",
+        "URL=//synthetic-user:synthetic-secret@host/path",
+        "URL=//host/path"
+      ],
+      [
+        "whitespace after a bare authority marker",
+        "// synthetic-user:synthetic-secret@host/path",
+        "//host/path"
+      ],
+      [
+        "whitespace after a prefixed authority marker",
+        "URL=// synthetic-user:synthetic-secret@host/path",
+        "URL=//host/path"
+      ],
+      [
+        "multiple at signs in malformed userinfo",
+        "http://synthetic-user:secret-prefix@secret-suffix@bad host/path",
+        "http://bad host/path"
+      ],
+      [
+        "an unescaped slash in malformed userinfo",
+        "http://synthetic-user:secret-prefix/secret-suffix@host/path",
+        "http://host/path"
+      ],
+      [
+        "whitespace in malformed userinfo",
+        "http://synthetic-user:secret-prefix secret-suffix@host/path",
+        "http://host/path"
+      ],
+      [
+        "a delayed at sign in malformed userinfo",
+        "http://synthetic-user secret-middle secret-final@host/path",
+        "http://host/path"
+      ],
+      [
+        "a quote before a delayed at sign",
+        'http://synthetic-user" secret-middle secret-final@host/path',
+        "http://host/path"
+      ],
+      [
+        "another adjacent HTTP scheme",
+        "http://outer.test/first;http://synthetic-user:synthetic-secret@host/path",
+        "http://host/path"
+      ],
+      [
+        "a nested non-HTTP URL",
+        "http://outer.test/redirect?next=ftp://nested-user:nested-secret@nested.test/path",
+        "http://outer.test/redirect?next=ftp://nested.test/path"
+      ],
+      [
+        "an unresolved scheme before a credential URL",
+        "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
+        "http://host/path"
+      ],
+      [
+        "a line break in malformed userinfo",
+        "http://synthetic-user\nsynthetic-secret@host/path",
+        "http://host/path"
+      ],
+      [
+        "non-URL text before mixed-case HTTP userinfo",
+        "URL=hTtPs://synthetic-user:synthetic-secret@host/path",
+        "URL=https://host/path"
+      ],
+      [
+        "an at sign only in the path",
+        "http://host/path@example",
+        "http://host/path@example"
+      ],
+      [
+        "an at sign only in an authority-relative path",
+        "//host/assets/component@2.js",
+        "//host/assets/component@2.js"
+      ],
+      [
+        "a local path with replacement metacharacters",
+        %q(/tmp/\k<foo>-\1-\&-\0-literal\backslash/server-bundle.js),
+        %q(/tmp/\k<foo>-\1-\&-\0-literal\backslash/server-bundle.js)
+      ]
+    ]
+
+    configured_url_cases.each do |description, configured_url, expected|
+      it "sanitizes configured userinfo with #{description}" do
+        expect(described_class.sanitize(configured_url)).to eq(expected)
+      end
+    end
+
+    encoded_nested_cases = [
+      [
+        "a fully encoded nested URL",
+        "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
+        "ftp%3A%2F%2Fnested.test%2Fpath"
+      ],
+      [
+        "an encoded scheme and authority marker",
+        "ftp%3A%2F%2Fnested-user:nested-secret@nested.test/path",
+        "ftp%3A%2F%2Fnested.test/path"
+      ],
+      [
+        "a partially encoded scheme",
+        "f%74p://nested-user:nested-secret@nested.test/path",
+        "f%74p://nested.test/path"
+      ],
+      [
+        "a partially encoded scheme and encoded at sign",
+        "f%74p%3A%2F%2Fnested-user:nested-secret%40nested.test/path",
+        "f%74p%3A%2F%2Fnested.test/path"
+      ],
+      [
+        "an encoded at sign",
+        "ftp://nested-user:nested-secret%40nested.test/path",
+        "ftp://nested.test/path"
+      ]
+    ]
+
+    encoded_nested_cases.each do |description, nested_url, sanitized_nested_url|
+      it "sanitizes encoded nested configured userinfo with #{description}" do
+        configured_url = "http://outer.test/redirect?next=#{nested_url}"
+
+        expect(described_class.sanitize(configured_url))
+          .to eq("http://outer.test/redirect?next=#{sanitized_nested_url}")
+      end
+
+      it "sanitizes diagnostic prose with #{description}" do
+        message = "Failure loading http://outer.test/redirect?next=#{nested_url}"
+
+        expect(sanitize_error(message))
+          .to eq("Failure loading http://outer.test/redirect?next=#{sanitized_nested_url}")
+      end
+    end
+
+    encoded_userinfo_delimiters = ["@", "%40"]
+
+    [
+      ["path", "ftp%3A%2F%2Fnested.test%2Fcomponent%402.js"],
+      ["query", "ftp%3A%2F%2Fnested.test%3Fcontact%3Dsafe%40example.test"]
+    ].each do |location, nested_url|
+      it "preserves an encoded nested URL with an at sign only in its #{location}" do
+        safe_url = "http://outer.test/redirect?next=#{nested_url}"
+
+        expect(described_class.sanitize(safe_url)).to eq(safe_url)
+        expect(sanitize_error("Failure loading #{safe_url}")).to eq("Failure loading #{safe_url}")
+      end
+    end
+
+    [
+      ["space", " "],
+      ["double quote", '"'],
+      ["single quote", "'"]
+    ].each do |description, prose_delimiter|
+      encoded_userinfo_delimiters.each do |userinfo_delimiter|
+        it "fails closed across a #{description} before #{userinfo_delimiter} in a nested URL" do
+          nested_url = "ftp://nested-user#{prose_delimiter}nested-secret#{userinfo_delimiter}nested.test/path"
+          configured_url = "http://outer.test/redirect?next=#{nested_url}"
+          message = "Failure loading #{configured_url}"
+
+          aggregate_failures do
+            expect(described_class.sanitize(configured_url)).not_to match(/nested-(?:user|secret)/)
+            expect(described_class.sanitize(configured_url)).to include("nested.test/path")
+            expect(sanitize_error(message)).not_to match(/nested-(?:user|secret)/)
+            expect(sanitize_error(message)).to include("nested.test/path")
+          end
+        end
+      end
+    end
+
+    diagnostic_cases = [
+      [
+        "an unquoted malformed HTTP URL",
+        "Failure loading http://synthetic-user:prefix secret-final@host/path",
+        "Failure loading http://host/path"
+      ],
+      [
+        "a postgres URL",
+        "Failure loading postgres://synthetic-user:synthetic-secret@host/path",
+        "Failure loading postgres://host/path"
+      ],
+      [
+        "a redis URL",
+        "Failure loading redis://synthetic-user:synthetic-secret@host/path",
+        "Failure loading redis://host/path"
+      ],
+      [
+        "an ftp URL",
+        "Failure loading ftp://synthetic-user:synthetic-secret@host/path",
+        "Failure loading ftp://host/path"
+      ],
+      [
+        "a mongodb URL",
+        "Failure loading mongodb://synthetic-user:synthetic-secret@host/path",
+        "Failure loading mongodb://host/path"
+      ],
+      [
+        "malformed userinfo with a delayed at sign",
+        "Failure loading http://synthetic-user secret-middle secret-final@host/path",
+        "Failure loading http://host/path"
+      ],
+      [
+        "malformed userinfo across a line break",
+        "Failure loading http://synthetic-user\nsynthetic-secret@host/path",
+        "Failure loading http://host/path"
+      ],
+      [
+        "another adjacent HTTP scheme",
+        "Failure loading http://outer.test/first;http://synthetic-user:synthetic-secret@host/path",
+        "Failure loading http://outer.test/first;http://host/path"
+      ],
+      [
+        "an unresolved scheme before a credential URL",
+        "Failure loading http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
+        "Failure loading http://host/path"
+      ],
+      [
+        "an invalid credential URL followed by a valid URL",
+        "Failure loading http://synthetic-user secret-final@host/path http://healthy-host/path",
+        "Failure loading http://host/path http://healthy-host/path"
+      ],
+      [
+        "quoted malformed userinfo",
+        'Failure loading "http://synthetic-user secret-final@host/path"',
+        'Failure loading "http://host/path"'
+      ],
+      [
+        "a double quote inside malformed userinfo",
+        'Failure loading http://synthetic-user"secret-final@host/path',
+        "Failure loading http://host/path"
+      ],
+      [
+        "a single quote inside malformed userinfo",
+        "Failure loading http://synthetic-user'secret-final@host/path",
+        "Failure loading http://host/path"
+      ],
+      [
+        "authority-relative userinfo",
+        "Failure loading //synthetic-user:synthetic-secret@host/path",
+        "Failure loading //host/path"
+      ],
+      [
+        "authority-relative userinfo across whitespace",
+        "Failure loading //synthetic-user synthetic-secret@host/path",
+        "Failure loading //host/path"
+      ],
+      [
+        "authority-relative userinfo across a quote",
+        'Failure loading //synthetic-user" synthetic-secret@host/path',
+        "Failure loading //host/path"
+      ],
+      [
+        "authority-relative userinfo across a line break",
+        "Failure loading //synthetic-user\nsynthetic-secret@host/path",
+        "Failure loading //host/path"
+      ],
+      [
+        "a nested non-HTTP URL",
+        "Failure loading http://outer.test/redirect?next=ftp://nested-user:nested-secret@nested.test/path",
+        "Failure loading http://outer.test/redirect?next=ftp://nested.test/path"
+      ],
+      [
+        "an at sign only in a URL path",
+        "Failure loading http://host/path@example",
+        "Failure loading http://host/path@example"
+      ],
+      [
+        "two safe URLs",
+        "Failure loading http://first-host/path http://second-host/path@example",
+        "Failure loading http://first-host/path http://second-host/path@example"
+      ],
+      [
+        "non-URL double-slash text",
+        "// contact dev@example",
+        "// contact dev@example"
+      ]
+    ]
+
+    diagnostic_cases.each do |description, message, expected|
+      it "sanitizes diagnostic prose containing #{description}" do
+        expect(sanitize_error(message)).to eq(expected)
+      end
+    end
+
+    ["\n", "\r", "\r\n"].each do |boundary|
+      it "fails closed when #{boundary.inspect} precedes an ambiguous email at sign" do
+        message = "Failure loading http://host/path#{boundary}contact dev@example.com"
+
+        expect(sanitize_error(message)).to eq("Failure loading http://example.com")
+      end
+    end
+
+    it "keeps a later safe URL after redacting malformed multiline userinfo" do
+      message = "Failure loading http://synthetic-user\nsynthetic-secret@host/path\n" \
+                "hTtPs://healthy-host/path@example"
+
+      expect(sanitize_error(message))
+        .to eq("Failure loading http://host/path\nhTtPs://healthy-host/path@example")
+    end
+
+    it "fails closed before a later scheme while preserving the separate URL" do
+      message = "Failure loading http://first-host/path\ncontact dev@example.com\n" \
+                "HTTP://second-host/path"
+
+      expect(sanitize_error(message))
+        .to eq("Failure loading http://example.com\nHTTP://second-host/path")
+    end
+
+    it "discards an unresolved region before sanitizing the next credential URL" do
+      message = "Failure loading http://synthetic-user:nonnumeric-prefix\nsynthetic-tail " \
+                "HtTpS://synthetic-secret@host/path"
+
+      expect(sanitize_error(message)).to eq("Failure loading https://host/path")
+    end
+
+    it "replaces raw and inspected spellings of the configured URL" do
+      configured_url = "http://synthetic-user:synthetic-secret@host/path"
+      message = "raw=#{configured_url} inspected=#{configured_url.inspect} repeated=#{configured_url}"
+
+      expect(sanitize_error(message, configured_url:))
+        .to eq('raw=http://host/path inspected="http://host/path" repeated=http://host/path')
+    end
+
+    it "scrubs invalidly encoded configured values before sanitizing them" do
+      configured_url = "http://synthetic-user:synthetic-secret@host/path-\xFF".b.force_encoding(Encoding::UTF_8)
+
+      sanitized = described_class.sanitize(configured_url)
+      expect(sanitized).to start_with("http://host/path-")
+      expect(sanitized).not_to match(/synthetic-(?:user|secret)/)
+      expect(sanitized).to be_valid_encoding
+    end
+
+    it "falls back safely when URI parsing raises a URI::Error subtype" do
+      configured_url = "http://synthetic-user:synthetic-secret@host/path"
+      allow(URI).to receive(:parse).with(configured_url)
+                                   .and_raise(URI::BadURIError, "bad URI for #{configured_url}")
+
+      expect(described_class.sanitize(configured_url)).to eq("http://host/path")
+    end
+
+    it "falls back safely when URI parsing raises ArgumentError" do
+      configured_url = "http://synthetic-user:synthetic-secret@host/path"
+      allow(URI).to receive(:parse).with(configured_url)
+                                   .and_raise(ArgumentError, "invalid byte sequence in UTF-8")
+
+      expect(described_class.sanitize(configured_url)).to eq("http://host/path")
+    end
+
+    it "sanitizes a large diagnostic with many encoded nested URL starts" do
+      safe_part = "part=ftp%3A%2F%2Fnested.test%2Fchunk"
+      encoded_padding = Array.new(1_800, safe_part).join("&")
+      nested_url = "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath"
+      message = "Failure loading http://outer.test/redirect?#{encoded_padding}&next=#{nested_url}"
+      expect(message.bytesize).to be > 65_536
+
+      sanitized = sanitize_error(message)
+      expect(sanitized).not_to match(/nested-(?:user|secret)/)
+      expect(sanitized).to include("next=ftp%3A%2F%2Fnested.test%2Fpath")
+    end
+  end
+end

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -22,6 +22,37 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "http://host/bundle.js"
       ],
       [
+        "fully encoded HTTP authority separators",
+        "http:%2F%2Fbundle-user:synthetic-password%40host/bundle.js",
+        "http:%2F%2Fhost/bundle.js"
+      ],
+      [
+        "fully encoded outer and nested URL credentials",
+        "http%3A%2F%2Fouter-user%3Aouter-secret%40outer.test%2Fredirect%3Fnext%3D" \
+        "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
+        "http%3A%2F%2Fouter.test%2Fredirect%3Fnext%3Dftp%3A%2F%2Fnested.test%2Fpath"
+      ],
+      [
+        "literal outer and encoded nested authority separators",
+        "http%3A//bundle-user%3Asynthetic-password%40outer.test%2Fnext%3D" \
+        "ftp%3A%2F%2Fnested-user%3Anested-secret%40inner.test/path",
+        "http%3A//outer.test%2Fnext%3Dftp%3A%2F%2Finner.test/path"
+      ],
+      [
+        "authority-relative outer and encoded nested URL credentials",
+        "//bundle-user%3Asynthetic-password%40outer.test/path?next=" \
+        "ftp%3A%2F%2Fnested-user%3Anested-secret%40inner.test/path",
+        "//outer.test/path?next=ftp%3A%2F%2Finner.test/path"
+      ],
+      [
+        "a fully encoded chain of three credential URLs",
+        "http%3A%2F%2Fouter-user%3Aouter-secret%40outer.test%2Fnext%3D" \
+        "ftp%3A%2F%2Ffirst-user%3Afirst-secret%40first.test%2Fnext%3D" \
+        "redis%3A%2F%2Flast-user%3Alast-secret%40last.test%2Fpath",
+        "http%3A%2F%2Fouter.test%2Fnext%3Dftp%3A%2F%2Ffirst.test%2Fnext%3D" \
+        "redis%3A%2F%2Flast.test%2Fpath"
+      ],
+      [
         "mixed encoded and literal authority delimiters",
         "http://synthetic-user%40mail:synthetic-secret@host/path",
         "http://host/path"
@@ -145,6 +176,36 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "a percent-encoded at sign only in the query",
         "http://host/bundle.js?contact=safe%40example.test",
         "http://host/bundle.js?contact=safe%40example.test"
+      ],
+      [
+        "an encoded at sign only in a fully encoded HTTP path",
+        "http:%2F%2Fhost%2Fassets%2Fcomponent%402.js",
+        "http:%2F%2Fhost%2Fassets%2Fcomponent%402.js"
+      ],
+      [
+        "an encoded at sign only in a fully encoded HTTP query",
+        "http:%2F%2Fhost%3Fcontact%3Dsafe%40example.test",
+        "http:%2F%2Fhost%3Fcontact%3Dsafe%40example.test"
+      ],
+      [
+        "an encoded at sign only in a fully encoded HTTP fragment",
+        "http:%2F%2Fhost%23contact-safe%40example.test",
+        "http:%2F%2Fhost%23contact-safe%40example.test"
+      ],
+      [
+        "an at sign after a literal path terminator in an encoded HTTP URL",
+        "http:%2F%2Fhost/assets/component@2.js",
+        "http:%2F%2Fhost/assets/component@2.js"
+      ],
+      [
+        "an at sign after a literal query terminator in an encoded HTTP URL",
+        "http:%2F%2Fhost?contact=safe@example.test",
+        "http:%2F%2Fhost?contact=safe@example.test"
+      ],
+      [
+        "an at sign after a literal fragment terminator in an encoded HTTP URL",
+        "http:%2F%2Fhost#contact-safe@example.test",
+        "http:%2F%2Fhost#contact-safe@example.test"
       ],
       [
         "an at sign only in an authority-relative path",
@@ -456,6 +517,28 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
 
       sanitized = Timeout.timeout(1) { sanitize_error(message) }
       expect(sanitized).to eq(message)
+    end
+
+    it "processes a long encoded-authority near-match in bounded time" do
+      configured_url = "é#{'a' * 32_000}:/"
+      message = "Failure loading #{configured_url}"
+
+      sanitized_url, sanitized_message = Timeout.timeout(1) do
+        [described_class.sanitize(configured_url), sanitize_error(message, configured_url:)]
+      end
+      expect(sanitized_url).to eq(configured_url)
+      expect(sanitized_message).to eq(message)
+    end
+
+    it "redacts after repeated fully encoded authority separators in bounded time" do
+      [2, 4_000].each do |count|
+        prefix = "a%3A%2F%2F" * count
+        configured_url = "#{prefix}bundle-user:synthetic-password%40host/path"
+        expected_url = "#{prefix}host/path"
+
+        sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
+        expect(sanitized_url).to eq(expected_url)
+      end
     end
   end
 end

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -386,5 +386,12 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       expect(sanitized).not_to match(/nested-(?:user|secret)/)
       expect(sanitized).to include("next=ftp%3A%2F%2Fnested.test%2Fpath")
     end
+
+    it "preserves a large diagnostic with many incomplete HTTP URL starts" do
+      message = "Failure loading #{'http://' * 10_000}host/path@example.test"
+      expect(message.bytesize).to be > 65_536
+
+      expect(sanitize_error(message)).to eq(message)
+    end
   end
 end

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -63,6 +63,26 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "http ://host/path"
       ],
       [
+        "whitespace around a literal colon before encoded authority separators",
+        "http : %2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "http : %2F%2Fhost/path"
+      ],
+      [
+        "whitespace before fully encoded authority separators",
+        "http: %2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "http: %2F%2Fhost/path"
+      ],
+      [
+        "whitespace before a literal and encoded authority separator",
+        "http: /%2Fsynthetic-user:synthetic-secret%40host/path",
+        "http: /%2Fhost/path"
+      ],
+      [
+        "whitespace before an encoded and literal authority separator",
+        "http: %2F/synthetic-user:synthetic-secret%40host/path",
+        "http: %2F/host/path"
+      ],
+      [
         "authority-relative userinfo",
         "//synthetic-user:synthetic-secret@host/path",
         "//host/path"
@@ -193,6 +213,21 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "http:%2F%2Fhost%23contact-safe%40example.test"
       ],
       [
+        "an encoded at sign only in a whitespace-delimited encoded HTTP path",
+        "http: %2F%2Fhost%2Fassets%2Fcomponent%402.js",
+        "http: %2F%2Fhost%2Fassets%2Fcomponent%402.js"
+      ],
+      [
+        "an at sign only after a whitespace-delimited mixed HTTP query terminator",
+        "http: /%2Fhost?contact=safe@example.test",
+        "http: /%2Fhost?contact=safe@example.test"
+      ],
+      [
+        "an encoded at sign only in a whitespace-delimited mixed HTTP fragment",
+        "http: %2F/host%23contact-safe%40example.test",
+        "http: %2F/host%23contact-safe%40example.test"
+      ],
+      [
         "an at sign after a literal path terminator in an encoded HTTP URL",
         "http:%2F%2Fhost/assets/component@2.js",
         "http:%2F%2Fhost/assets/component@2.js"
@@ -321,6 +356,26 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "Failure loading http://host/path"
       ],
       [
+        "whitespace before fully encoded authority separators",
+        "Failure loading http: %2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading http: %2F%2Fhost/path"
+      ],
+      [
+        "whitespace around a literal colon before encoded authority separators",
+        "Failure loading http : %2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading http : %2F%2Fhost/path"
+      ],
+      [
+        "whitespace before a literal and encoded authority separator",
+        "Failure loading http: /%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading http: /%2Fhost/path"
+      ],
+      [
+        "whitespace before an encoded and literal authority separator",
+        "Failure loading http: %2F/synthetic-user:synthetic-secret%40host/path",
+        "Failure loading http: %2F/host/path"
+      ],
+      [
         "a postgres URL",
         "Failure loading postgres://synthetic-user:synthetic-secret@host/path",
         "Failure loading postgres://host/path"
@@ -419,6 +474,11 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "non-URL double-slash text",
         "// contact dev@example",
         "// contact dev@example"
+      ],
+      [
+        "non-URL prose with whitespace before a colon and double slash",
+        "Contact support : // contact safe@example.test",
+        "Contact support : // contact safe@example.test"
       ]
     ]
 
@@ -528,6 +588,15 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       end
       expect(sanitized_url).to eq(configured_url)
       expect(sanitized_message).to eq(message)
+    end
+
+    it "redacts a long whitespace-delimited encoded authority in bounded time" do
+      whitespace = " " * 32_000
+      configured_url = "http:#{whitespace}%2F%2Fbundle-user:synthetic-password%40host/path"
+      expected_url = "http:#{whitespace}%2F%2Fhost/path"
+
+      sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
+      expect(sanitized_url).to eq(expected_url)
     end
 
     it "redacts after repeated fully encoded authority separators in bounded time" do

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -47,6 +47,26 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "URL=//host/path"
       ],
       [
+        "userinfo after an earlier authority-relative URL",
+        "URL= //safe/path//bundle-user:synthetic-password@host/bundle.js",
+        "URL= //safe/path//host/bundle.js"
+      ],
+      [
+        "userinfo spanning a later authority marker",
+        "URL= //bundle-user:synthetic-password//suffix@host/bundle.js",
+        "URL= //host/bundle.js"
+      ],
+      [
+        "encoded userinfo after an earlier authority-relative URL",
+        "URL= //safe/path//bundle-user:synthetic-password%40host/bundle.js",
+        "URL= //safe/path//host/bundle.js"
+      ],
+      [
+        "encoded userinfo spanning a later authority marker",
+        "URL= //bundle-user:synthetic-password//suffix%40host/bundle.js",
+        "URL= //host/bundle.js"
+      ],
+      [
         "whitespace after a bare authority marker",
         "// synthetic-user:synthetic-secret@host/path",
         "//host/path"
@@ -130,6 +150,16 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "an at sign only in an authority-relative path",
         "//host/assets/component@2.js",
         "//host/assets/component@2.js"
+      ],
+      [
+        "a percent-encoded at sign only in an authority-relative path",
+        "//host/assets/component%402.js",
+        "//host/assets/component%402.js"
+      ],
+      [
+        "multiple authority-relative URLs without userinfo",
+        "URL= //safe/path//cdn.test/bundle.js",
+        "URL= //safe/path//cdn.test/bundle.js"
       ],
       [
         "a local path with replacement metacharacters",

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "http:%2F%2Fhost/bundle.js"
       ],
       [
+        "an all-numeric password that an encoded terminator cannot prove is a port",
+        "http:%2F%2Fbundle-user:1234%2Fsegment%40host/bundle.js",
+        "http:%2F%2Fhost/bundle.js"
+      ],
+      [
+        "an encoded authority whose colon cannot be proven to be a port",
+        "http:%2F%2Fhost:3000%2Fpath%40asset",
+        "http:%2F%2Fasset"
+      ],
+      [
         "a fully encoded authority-relative start",
         "%2F%2Fbundle-user:synthetic-password%40host/bundle.js",
         "%2F%2Fhost/bundle.js"

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "http:%2F%2Fhost/bundle.js"
       ],
       [
+        "an encoded authority terminator before an encoded userinfo delimiter",
+        "http:%2F%2Fbundle-user:synthetic-password%2Fsegment%40host/bundle.js",
+        "http:%2F%2Fhost/bundle.js"
+      ],
+      [
+        "a fully encoded authority-relative start",
+        "%2F%2Fbundle-user:synthetic-password%40host/bundle.js",
+        "%2F%2Fhost/bundle.js"
+      ],
+      [
+        "a mixed literal and encoded authority-relative start",
+        "/%2Fbundle-user:synthetic-password%40host/bundle.js",
+        "/%2Fhost/bundle.js"
+      ],
+      [
+        "an encoded authority-relative start after a prefix",
+        "URL= %2F%2Fbundle-user:synthetic-password%40host/bundle.js",
+        "URL= %2F%2Fhost/bundle.js"
+      ],
+      [
         "fully encoded outer and nested URL credentials",
         "http%3A%2F%2Fouter-user%3Aouter-secret%40outer.test%2Fredirect%3Fnext%3D" \
         "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
@@ -397,9 +417,9 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       end
 
       safe_values = [
-        "nothttp%20 :%2F%2Fsafe@example.test",
-        "httpish%20 :%2F%2Fsafe@example.test",
-        "%61http%20 :%2F%2Fsafe@example.test",
+        "nothttp%20 :%2F%2Fhost/path?mail=safe@example.test",
+        "httpish%20 :%2F%2Fhost/path?mail=safe@example.test",
+        "%61http%20 :%2F%2Fhost/path?mail=safe@example.test",
         "http%20 :%2F%2Fhost/path%40asset",
         "http%20 :%2F%2Fhost/path?mail=safe@example.test",
         "http%20 :%2F%2Fhost/path%23safe%40example.test"
@@ -407,6 +427,17 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       safe_values.each do |safe_value|
         expect(described_class.sanitize(safe_value)).to eq(safe_value)
         expect(sanitize_error("Failure loading #{safe_value}")).to eq("Failure loading #{safe_value}")
+      end
+
+      # A rejected scheme leaves an encoded bare authority, which fails closed exactly like the
+      # literal spelling rather than escaping redaction because its slashes are encoded.
+      rejected_scheme_authorities = [
+        ["nothttp%20 :%2F%2Fsynthetic-user%40host/path", "nothttp%20 :%2F%2Fhost/path"],
+        ["httpish%20 :%2F%2Fsynthetic-user%40host/path", "httpish%20 :%2F%2Fhost/path"],
+        ["%61http%20 :%2F%2Fsynthetic-user%40host/path", "%61http%20 :%2F%2Fhost/path"]
+      ]
+      rejected_scheme_authorities.each do |configured_url, expected_url|
+        expect(described_class.sanitize(configured_url)).to eq(expected_url)
       end
     end
 
@@ -418,7 +449,7 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         encoded_prefix = format("%%%02X", byte)
         schemes.each do |scheme|
           if scheme_continuation_bytes.include?(byte)
-            safe_value = "#{encoded_prefix}#{scheme} %3A%2F%2Fsafe@example.test"
+            safe_value = "#{encoded_prefix}#{scheme} %3A%2F%2Fhost/path?mail=safe@example.test"
             expect(described_class.sanitize(safe_value)).to eq(safe_value)
             expect(sanitize_error("Failure loading #{safe_value}")).to eq("Failure loading #{safe_value}")
           else
@@ -434,9 +465,13 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
 
       invalid_percent_controls = ["%GGhttp", "%61http", "%61%2Dhttp", "a%20nothttp", "a%20httpish"]
       invalid_percent_controls.each do |prefix|
-        safe_value = "#{prefix} %3A%2F%2Fsafe@example.test"
+        safe_value = "#{prefix} %3A%2F%2Fhost/path?mail=safe@example.test"
         expect(described_class.sanitize(safe_value)).to eq(safe_value)
         expect(sanitize_error("Failure loading #{safe_value}")).to eq("Failure loading #{safe_value}")
+
+        # The rejected scheme still leaves an encoded bare authority, which fails closed.
+        expect(described_class.sanitize("#{prefix} %3A%2F%2Fsynthetic-user%40host/path"))
+          .to eq("#{prefix} %3A%2F%2Fhost/path")
       end
     end
 
@@ -692,13 +727,28 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       ],
       [
         "a non-HTTP word before encoded separators",
-        "Contact nothttp %3A%2F%2Fsafe@example.test",
-        "Contact nothttp %3A%2F%2Fsafe@example.test"
+        "Contact nothttp %3A%2F%2Fhost/path?mail=safe@example.test",
+        "Contact nothttp %3A%2F%2Fhost/path?mail=safe@example.test"
+      ],
+      [
+        "an encoded bare authority after a non-HTTP word",
+        "Contact nothttp %3A%2F%2Fsynthetic-user%40host/path",
+        "Contact nothttp %3A%2F%2Fhost/path"
+      ],
+      [
+        "an encoded bare authority in prose",
+        "Failure loading %2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading %2F%2Fhost/path"
+      ],
+      [
+        "a mixed-slash bare authority in prose",
+        "Failure loading /%2Fsynthetic-user:synthetic-secret@host/path",
+        "Failure loading /%2Fhost/path"
       ],
       [
         "an HTTP-prefixed word before encoded separators",
-        "Contact httpish %3A%2F%2Fsafe@example.test",
-        "Contact httpish %3A%2F%2Fsafe@example.test"
+        "Contact httpish %3A%2F%2Fhost/path?mail=safe@example.test",
+        "Contact httpish %3A%2F%2Fhost/path?mail=safe@example.test"
       ]
     ]
 
@@ -737,6 +787,14 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
                 "HtTpS://synthetic-secret@host/path"
 
       expect(sanitize_error(message)).to eq("Failure loading https://host/path")
+    end
+
+    it "sanitizes an authority-relative credential inside a discarded unresolved region" do
+      message = "//synthetic-admin:synthetic-secret@internal.host then " \
+                "http://synthetic-user:nonnumeric-prefix\nsynthetic-tail " \
+                "HtTpS://synthetic-other@host/path"
+
+      expect(sanitize_error(message)).to eq("//internal.host then https://host/path")
     end
 
     it "replaces raw and inspected spellings of the configured URL" do
@@ -867,6 +925,15 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
 
         sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
         expect(sanitized_url).to eq(expected_url)
+      end
+    end
+
+    it "redacts repeated bare authority markers without a scheme in bounded time" do
+      [2, 4_000].each do |count|
+        message = %(prefix //a "b '#{'//segment "gap \'tail ' * count}//user:synthetic-secret@host/path)
+
+        sanitized = Timeout.timeout(1) { sanitize_error(message) }
+        expect(sanitized).not_to include("synthetic-secret")
       end
     end
   end

--- a/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
+++ b/react_on_rails/spec/react_on_rails/diagnostic_url_redactor_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "redis%3A%2F%2Flast.test%2Fpath"
       ],
       [
+        "encoded outer and nested credentials with whitespace between authority separators",
+        "http %3A%2F %2Fouter-user%3Aouter-secret%40outer.test%2Fnext%3D" \
+        "ftp%3A%2F %2Fnested-user%3Anested-secret%40nested.test%2Fpath",
+        "http %3A%2F %2Fouter.test%2Fnext%3Dftp%3A%2F %2Fnested.test%2Fpath"
+      ],
+      [
+        "an internal HTTP scheme after an encoded boundary in an outer URL",
+        "http://outer.test/path?next=%61%20http %3A%2F%2Fnested-user:nested-secret%40nested.test/path",
+        "http://outer.test/path?next=%61%20http %3A%2F%2Fnested.test/path"
+      ],
+      [
         "mixed encoded and literal authority delimiters",
         "http://synthetic-user%40mail:synthetic-secret@host/path",
         "http://host/path"
@@ -68,6 +79,21 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "http : %2F%2Fhost/path"
       ],
       [
+        "whitespace before an encoded colon and encoded authority separators",
+        "http %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "http %3A%2F%2Fhost/path"
+      ],
+      [
+        "a partially encoded HTTP scheme before a whitespace-delimited encoded colon",
+        "h%74tp %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "h%74tp %3A%2F%2Fhost/path"
+      ],
+      [
+        "an encoded whitespace token before an internal HTTP scheme",
+        "%20http %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "%20http %3A%2F%2Fhost/path"
+      ],
+      [
         "whitespace before fully encoded authority separators",
         "http: %2F%2Fsynthetic-user:synthetic-secret%40host/path",
         "http: %2F%2Fhost/path"
@@ -81,6 +107,26 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "whitespace before an encoded and literal authority separator",
         "http: %2F/synthetic-user:synthetic-secret%40host/path",
         "http: %2F/host/path"
+      ],
+      [
+        "whitespace between encoded authority separators",
+        "http:%2F %2Fsynthetic-user:synthetic-secret%40host/path",
+        "http:%2F %2Fhost/path"
+      ],
+      [
+        "encoded whitespace before encoded authority separators",
+        "http:%20%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "http:%20%2F%2Fhost/path"
+      ],
+      [
+        "encoded whitespace between encoded authority separators",
+        "http:%2F%20%2Fsynthetic-user:synthetic-secret%40host/path",
+        "http:%2F%20%2Fhost/path"
+      ],
+      [
+        "mixed literal and encoded whitespace around mixed authority separators",
+        "h%74tp \t%20%3A%0A/%09%2Fsynthetic-user:synthetic-secret%40host/path",
+        "h%74tp \t%20%3A%0A/%09%2Fhost/path"
       ],
       [
         "authority-relative userinfo",
@@ -228,6 +274,36 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "http: %2F/host%23contact-safe%40example.test"
       ],
       [
+        "an encoded at sign only in a path after whitespace between encoded authority separators",
+        "http:%2F %2Fhost/path%40asset",
+        "http:%2F %2Fhost/path%40asset"
+      ],
+      [
+        "an at sign only in a query after whitespace between encoded authority separators",
+        "http:%2F %2Fhost/path?contact=safe@example.test",
+        "http:%2F %2Fhost/path?contact=safe@example.test"
+      ],
+      [
+        "an encoded at sign only in a fragment after whitespace between encoded authority separators",
+        "http:%2F %2Fhost/path#safe%40example.test",
+        "http:%2F %2Fhost/path#safe%40example.test"
+      ],
+      [
+        "no userinfo after whitespace before an encoded colon",
+        "http %3A%2F%2Fhost/path",
+        "http %3A%2F%2Fhost/path"
+      ],
+      [
+        "no userinfo after whitespace between encoded authority separators",
+        "http:%2F %2Fhost/path",
+        "http:%2F %2Fhost/path"
+      ],
+      [
+        "an encoded path at sign after encoded whitespace between authority separators",
+        "http:%2F%20%2Fhost/path%40asset",
+        "http:%2F%20%2Fhost/path%40asset"
+      ],
+      [
         "an at sign after a literal path terminator in an encoded HTTP URL",
         "http:%2F%2Fhost/assets/component@2.js",
         "http:%2F%2Fhost/assets/component@2.js"
@@ -267,6 +343,100 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
     configured_url_cases.each do |description, configured_url, expected|
       it "sanitizes configured userinfo with #{description}" do
         expect(described_class.sanitize(configured_url)).to eq(expected)
+      end
+    end
+
+    it "sanitizes literal and encoded HTTP separator compositions across ASCII whitespace spellings" do
+      schemes = ["http", "HTTP", "https", "HTTPS", "h%74tp", "%68ttp", "h%74tps", "%68%74%74%70",
+                 "%48%54%54%50%53"]
+      separators = [":", "%3A", "%3a"]
+      slashes = ["/", "%2F", "%2f"]
+      whitespace_spellings = ["\t", "\n", "\v", "\f", "\r", " ", "%09", "%0A", "%0a", "%0B", "%0b",
+                              "%0C", "%0c", "%0D", "%0d", "%20"]
+      gap_profiles = [["", "", ""]]
+      whitespace_spellings.each do |whitespace|
+        gap_profiles.push([whitespace, "", ""], ["", whitespace, ""], ["", "", whitespace],
+                          [whitespace, whitespace, whitespace])
+      end
+
+      schemes.product(separators, slashes, slashes, gap_profiles).each do |scheme, colon, first_slash, second_slash,
+                                                                         gaps|
+        before_colon, after_colon, between_slashes = gaps
+        prefix = "#{scheme}#{before_colon}#{colon}#{after_colon}#{first_slash}#{between_slashes}#{second_slash}"
+        configured_url = "#{prefix}synthetic-user:synthetic-secret%40host/path"
+        expected_url = "#{prefix}host/path"
+
+        expect(described_class.sanitize(configured_url)).to eq(expected_url)
+        expect(sanitize_error("Failure loading #{configured_url}")).to eq("Failure loading #{expected_url}")
+      end
+    end
+
+    it "sanitizes ordered literal and encoded whitespace sequences before an HTTP colon" do
+      schemes = ["http", "HTTPS", "h%74tp", "%68%74%74%70%73"]
+      separators = [":", "%3A", "%3a"]
+      whitespace_pairs = [["\t", "%09"], ["\n", "%0A"], ["\v", "%0B"], ["\f", "%0C"],
+                          ["\r", "%0D"], [" ", "%20"]]
+
+      schemes.product(separators, whitespace_pairs).each do |scheme, separator, whitespace_pair|
+        literal_whitespace, encoded_whitespace = whitespace_pair
+        gaps = [
+          "#{literal_whitespace}#{encoded_whitespace}",
+          "#{encoded_whitespace}#{literal_whitespace}",
+          "#{literal_whitespace}#{encoded_whitespace}#{literal_whitespace}",
+          "#{encoded_whitespace}#{literal_whitespace}#{encoded_whitespace}"
+        ]
+
+        gaps.each do |gap|
+          prefix = "#{scheme}#{gap}#{separator}%2F%2F"
+          configured_url = "#{prefix}synthetic-user:synthetic-secret%40host/path"
+          expected_url = "#{prefix}host/path"
+
+          expect(described_class.sanitize(configured_url)).to eq(expected_url)
+          expect(sanitize_error("Failure loading #{configured_url}")).to eq("Failure loading #{expected_url}")
+        end
+      end
+
+      safe_values = [
+        "nothttp%20 :%2F%2Fsafe@example.test",
+        "httpish%20 :%2F%2Fsafe@example.test",
+        "%61http%20 :%2F%2Fsafe@example.test",
+        "http%20 :%2F%2Fhost/path%40asset",
+        "http%20 :%2F%2Fhost/path?mail=safe@example.test",
+        "http%20 :%2F%2Fhost/path%23safe%40example.test"
+      ]
+      safe_values.each do |safe_value|
+        expect(described_class.sanitize(safe_value)).to eq(safe_value)
+        expect(sanitize_error("Failure loading #{safe_value}")).to eq("Failure loading #{safe_value}")
+      end
+    end
+
+    it "restarts an internal HTTP candidate only after an encoded non-scheme byte" do
+      schemes = ["http", "https", "h%74tp", "%68%74%74%70", "%48%54%54%50%53"]
+      scheme_continuation_bytes = (48..57).to_a + (65..90).to_a + (97..122).to_a + [43, 45, 46]
+
+      (0..255).each do |byte|
+        encoded_prefix = format("%%%02X", byte)
+        schemes.each do |scheme|
+          if scheme_continuation_bytes.include?(byte)
+            safe_value = "#{encoded_prefix}#{scheme} %3A%2F%2Fsafe@example.test"
+            expect(described_class.sanitize(safe_value)).to eq(safe_value)
+            expect(sanitize_error("Failure loading #{safe_value}")).to eq("Failure loading #{safe_value}")
+          else
+            configured_url =
+              "#{encoded_prefix}#{scheme} %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path"
+            expected_url = "#{encoded_prefix}#{scheme} %3A%2F%2Fhost/path"
+
+            expect(described_class.sanitize(configured_url)).to eq(expected_url)
+            expect(sanitize_error("Failure loading #{configured_url}")).to eq("Failure loading #{expected_url}")
+          end
+        end
+      end
+
+      invalid_percent_controls = ["%GGhttp", "%61http", "%61%2Dhttp", "a%20nothttp", "a%20httpish"]
+      invalid_percent_controls.each do |prefix|
+        safe_value = "#{prefix} %3A%2F%2Fsafe@example.test"
+        expect(described_class.sanitize(safe_value)).to eq(safe_value)
+        expect(sanitize_error("Failure loading #{safe_value}")).to eq("Failure loading #{safe_value}")
       end
     end
 
@@ -366,6 +536,21 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "Failure loading http : %2F%2Fhost/path"
       ],
       [
+        "whitespace before an encoded colon and encoded authority separators",
+        "Failure loading http %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading http %3A%2F%2Fhost/path"
+      ],
+      [
+        "a partially encoded HTTP scheme before a whitespace-delimited encoded colon",
+        "Failure loading h%74tp %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading h%74tp %3A%2F%2Fhost/path"
+      ],
+      [
+        "an encoded whitespace token before an internal HTTP scheme",
+        "Failure loading %20http %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading %20http %3A%2F%2Fhost/path"
+      ],
+      [
         "whitespace before a literal and encoded authority separator",
         "Failure loading http: /%2Fsynthetic-user:synthetic-secret%40host/path",
         "Failure loading http: /%2Fhost/path"
@@ -374,6 +559,26 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "whitespace before an encoded and literal authority separator",
         "Failure loading http: %2F/synthetic-user:synthetic-secret%40host/path",
         "Failure loading http: %2F/host/path"
+      ],
+      [
+        "whitespace between encoded authority separators",
+        "Failure loading http:%2F %2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading http:%2F %2Fhost/path"
+      ],
+      [
+        "encoded whitespace before encoded authority separators",
+        "Failure loading http:%20%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading http:%20%2F%2Fhost/path"
+      ],
+      [
+        "encoded whitespace between encoded authority separators",
+        "Failure loading http:%2F%20%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading http:%2F%20%2Fhost/path"
+      ],
+      [
+        "mixed literal and encoded whitespace around mixed authority separators",
+        "Failure loading h%74tp \t%20%3A%0A/%09%2Fsynthetic-user:synthetic-secret%40host/path",
+        "Failure loading h%74tp \t%20%3A%0A/%09%2Fhost/path"
       ],
       [
         "a postgres URL",
@@ -479,6 +684,21 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
         "non-URL prose with whitespace before a colon and double slash",
         "Contact support : // contact safe@example.test",
         "Contact support : // contact safe@example.test"
+      ],
+      [
+        "non-URL prose with encoded separators",
+        "Contact support %3A %2F %2Fsafe@example.test",
+        "Contact support %3A %2F %2Fsafe@example.test"
+      ],
+      [
+        "a non-HTTP word before encoded separators",
+        "Contact nothttp %3A%2F%2Fsafe@example.test",
+        "Contact nothttp %3A%2F%2Fsafe@example.test"
+      ],
+      [
+        "an HTTP-prefixed word before encoded separators",
+        "Contact httpish %3A%2F%2Fsafe@example.test",
+        "Contact httpish %3A%2F%2Fsafe@example.test"
       ]
     ]
 
@@ -596,6 +816,46 @@ RSpec.describe ReactOnRails::DiagnosticUrlRedactor do
       expected_url = "http:#{whitespace}%2F%2Fhost/path"
 
       sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
+      expect(sanitized_url).to eq(expected_url)
+    end
+
+    it "redacts long whitespace before an encoded colon and between encoded slashes in bounded time" do
+      whitespace = " " * 32_000
+      configured_url = "h%74tp#{whitespace}%3A%2F#{whitespace}%2Fbundle-user:synthetic-password%40host/path"
+      expected_url = "h%74tp#{whitespace}%3A%2F#{whitespace}%2Fhost/path"
+
+      sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
+
+      expect(sanitized_url).to eq(expected_url)
+    end
+
+    it "redacts long encoded whitespace around encoded authority separators in bounded time" do
+      whitespace = "%20" * 16_000
+      configured_url = "http:#{whitespace}%2F#{whitespace}%2Fbundle-user:synthetic-password%40host/path"
+      expected_url = "http:#{whitespace}%2F#{whitespace}%2Fhost/path"
+
+      sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
+
+      expect(sanitized_url).to eq(expected_url)
+    end
+
+    it "redacts a long mixed whitespace sequence before an encoded colon in bounded time" do
+      whitespace = "%20 " * 16_000
+      configured_url = "h%74tp#{whitespace}%3A%2F%2Fbundle-user:synthetic-password%40host/path"
+      expected_url = "h%74tp#{whitespace}%3A%2F%2Fhost/path"
+
+      sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
+
+      expect(sanitized_url).to eq(expected_url)
+    end
+
+    it "redacts an internal HTTP URL after a long encoded boundary prefix in bounded time" do
+      prefix = "%61%20" * 16_000
+      configured_url = "#{prefix}http %3A%2F%2Fbundle-user:synthetic-password%40host/path"
+      expected_url = "#{prefix}http %3A%2F%2Fhost/path"
+
+      sanitized_url = Timeout.timeout(1) { described_class.sanitize(configured_url) }
+
       expect(sanitized_url).to eq(expected_url)
     end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -611,6 +611,37 @@ module ReactOnRails
           end
         end
 
+        context "when a valid outer HTTP URL contains a nested non-HTTP URL" do
+          let(:nested_credential_url) do
+            "http://outer.test/redirect?next=ftp://nested-user:nested-secret@nested.test/path"
+          end
+
+          it "redacts nested credentials from the configured bundle URL" do
+            stub_http_bundle_failure("connection failed", bundle_url: nested_credential_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("nested-user")
+            expect(message).not_to include("nested-secret")
+            expect(message).to include("http://outer.test/redirect?next=ftp://nested.test/path")
+          end
+
+          it "redacts nested credentials from ordinary exception text" do
+            stub_http_bundle_failure("Failure loading #{nested_credential_url}")
+
+            message = bundle_load_error_message
+            expect(message).not_to include("nested-user")
+            expect(message).not_to include("nested-secret")
+            expect(message).to include("Failure loading http://outer.test/redirect?next=ftp://nested.test/path")
+          end
+
+          it "preserves a nested URL with an at sign only in its path" do
+            safe_nested_url = "http://outer.test/redirect?next=ftp://nested.test/component@2.js"
+            stub_http_bundle_failure("Failure loading #{safe_nested_url}")
+
+            expect(bundle_load_error_message).to include("Failure loading #{safe_nested_url}")
+          end
+        end
+
         unresolved_prefix_cases = [
           ["an invalid prefix before a valid credential URL",
            "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
@@ -723,6 +754,22 @@ module ReactOnRails
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
             expect(message).to include("bad URI for http://host/path")
+          end
+        end
+
+        context "when URI parsing raises ArgumentError for malformed encoding" do
+          it "still raises a sanitized bundle-load error through the public entrypoint" do
+            server_bundle_url = "http://synthetic-user:synthetic-secret@host/path"
+            allow(URI).to receive(:parse).and_call_original
+            allow(URI).to receive(:parse).with(server_bundle_url)
+                                         .and_raise(ArgumentError, "invalid byte sequence in UTF-8")
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("invalid byte sequence in UTF-8")
+            expect(message).to include("http://host/path")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -940,6 +940,18 @@ module ReactOnRails
           end
         end
 
+        context "when a bundle-load failure contains authority-relative credentials" do
+          it "redacts the credentials while retaining the host and path" do
+            failure_message = "Failure loading //synthetic-user:synthetic-secret@host/path"
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("Failure loading //host/path")
+          end
+        end
+
         context "when a bundle-load failure contains non-URL double-slash text" do
           it "preserves the arbitrary message text" do
             failure_message = "// contact dev@example"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -460,6 +460,30 @@ module ReactOnRails
               "http ://host/path"
             ],
             [
+              "whitespace around a literal colon before encoded authority separators",
+              "http : %2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "http : %2F%2Fhost/path"
+            ],
+            [
+              "whitespace before fully encoded authority separators",
+              "http: %2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "http: %2F%2Fhost/path"
+            ],
+            [
+              "whitespace before a literal and encoded authority separator",
+              "http: /%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "http: /%2Fhost/path"
+            ],
+            [
+              "whitespace before an encoded and literal authority separator",
+              "http: %2F/synthetic-user:synthetic-secret%40host/path",
+              false,
+              "http: %2F/host/path"
+            ],
+            [
               "a percent-encoded authority delimiter",
               "http://bundle-user:synthetic-password%40host/bundle.js",
               true,

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -448,6 +448,18 @@ module ReactOnRails
           end
         end
 
+        context "when a credential URL has whitespace in its HTTP scheme delimiter" do
+          it "redacts credentials even when the path is classified as a local bundle" do
+            server_bundle_path = "http ://bundle-user:synthetic-password@host/bundle.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("bundle-user")
+            expect(message).not_to include("synthetic-password")
+            expect(message).to include("http ://host/bundle.js")
+          end
+        end
+
         context "when malformed URL userinfo contains multiple at signs" do
           it "redacts the entire userinfo while retaining the host and path" do
             server_bundle_url =
@@ -985,10 +997,11 @@ module ReactOnRails
         # equals the destination (UTF-8). charset_from_content_type returns UTF-8 for the three
         # "same-encoding" cases below (no Content-Type header, no charset parameter, and an
         # explicit charset=utf-8), so `.encode(Encoding::UTF_8)` alone would silently let an
-        # invalid byte through unchanged on each of them — only a genuine cross-encoding
-        # transcode (the ISO-8859-1 case above) actually validates via `encode`. Each of these
-        # three specs uses a body containing an invalid standalone byte (0xE9) to prove the
-        # explicit valid_encoding? check (not `encode` alone) is what catches it.
+        # invalid byte through unchanged on each of them. A genuine cross-encoding transcode can
+        # reject malformed input only when the source encoding has invalid byte sequences of its
+        # own (such as Shift_JIS). Each of these three specs uses a body containing an invalid
+        # standalone byte (0xE9) to prove the explicit valid_encoding? check (not `encode` alone) is
+        # what catches it.
         context "when the HTTP-served bundle response has no Content-Type header and the body is not valid UTF-8" do
           it "raises instead of silently passing corrupt bytes through" do
             server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -496,6 +496,18 @@ module ReactOnRails
               "URL=//host/path"
             ],
             [
+              "userinfo after an earlier authority-relative URL",
+              "URL= //safe/path//bundle-user:synthetic-password@host/bundle.js",
+              false,
+              "URL= //safe/path//host/bundle.js"
+            ],
+            [
+              "userinfo spanning a later authority marker",
+              "URL= //bundle-user:synthetic-password//suffix@host/bundle.js",
+              false,
+              "URL= //host/bundle.js"
+            ],
+            [
               "a nested non-HTTP URL",
               "http://outer.test/redirect?next=ftp://nested-user:nested-secret@nested.test/path",
               true,

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -460,6 +460,30 @@ module ReactOnRails
           end
         end
 
+        context "when a credential URL is authority-relative" do
+          [
+            ["valid userinfo", "//bundle-user:synthetic-password@host/bundle.js"],
+            ["ambiguous userinfo", "//bundle-user:synthetic-password@credential-suffix@host/bundle.js"]
+          ].each do |description, server_bundle_path|
+            it "redacts #{description} even when the path is classified as a local bundle" do
+              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("bundle-user")
+              expect(message).not_to include("synthetic-password")
+              expect(message).not_to include("credential-suffix")
+              expect(message).to include("//host/bundle.js")
+            end
+          end
+
+          it "preserves an at sign in the path when the authority has no userinfo" do
+            server_bundle_path = "//host/assets/component@2.js"
+            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+            expect(bundle_load_error_message).to include(server_bundle_path)
+          end
+        end
+
         context "when malformed URL userinfo contains multiple at signs" do
           it "redacts the entire userinfo while retaining the host and path" do
             server_bundle_url =

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -494,6 +494,18 @@ module ReactOnRails
               expect(message).to include("#{prefix}//host/bundle.js")
             end
           end
+
+          [["bare", ""], ["prefixed", "URL="]].each do |description, prefix|
+            it "redacts #{description} credentials when whitespace follows the authority marker" do
+              server_bundle_path = "#{prefix}// bundle-user:synthetic-password@host/bundle.js"
+              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("bundle-user")
+              expect(message).not_to include("synthetic-password")
+              expect(message).to include("#{prefix}//host/bundle.js")
+            end
+          end
         end
 
         context "when malformed URL userinfo contains multiple at signs" do

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -642,6 +642,114 @@ module ReactOnRails
           end
         end
 
+        context "when a valid outer HTTP URL contains encoded nested credentials" do
+          encoded_nested_urls = [
+            ["a fully encoded nested URL",
+             "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
+             "ftp%3A%2F%2Fnested.test%2Fpath"],
+            ["an encoded scheme and authority marker",
+             "ftp%3A%2F%2Fnested-user:nested-secret@nested.test/path",
+             "ftp%3A%2F%2Fnested.test/path"],
+            ["a partially encoded scheme",
+             "f%74p://nested-user:nested-secret@nested.test/path",
+             "f%74p://nested.test/path"],
+            ["a partially encoded scheme and encoded userinfo delimiter",
+             "f%74p%3A%2F%2Fnested-user:nested-secret%40nested.test/path",
+             "f%74p%3A%2F%2Fnested.test/path"],
+            ["an encoded userinfo delimiter",
+             "ftp://nested-user:nested-secret%40nested.test/path",
+             "ftp://nested.test/path"]
+          ]
+
+          encoded_nested_urls.each do |description, nested_url, sanitized_nested_url|
+            it "redacts #{description} from the configured bundle URL" do
+              server_bundle_url = "http://outer.test/redirect?next=#{nested_url}"
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("nested-user")
+              expect(message).not_to include("nested-secret")
+              expect(message).to include("http://outer.test/redirect?next=#{sanitized_nested_url}")
+            end
+
+            it "redacts #{description} from ordinary exception text" do
+              nested_outer_url = "http://outer.test/redirect?next=#{nested_url}"
+              stub_http_bundle_failure("Failure loading #{nested_outer_url}")
+
+              message = bundle_load_error_message
+              expect(message).not_to include("nested-user")
+              expect(message).not_to include("nested-secret")
+              expect(message).to include("Failure loading http://outer.test/redirect?next=#{sanitized_nested_url}")
+            end
+          end
+
+          [
+            ["path", "ftp%3A%2F%2Fnested.test%2Fcomponent%402.js"],
+            ["query", "ftp%3A%2F%2Fnested.test%3Fcontact%3Dsafe%40example.test"]
+          ].each do |location, nested_url|
+            it "preserves a configured encoded nested URL whose at sign is only in the #{location}" do
+              safe_outer_url = "http://outer.test/redirect?next=#{nested_url}"
+              stub_http_bundle_failure("connection failed", bundle_url: safe_outer_url)
+
+              expect(bundle_load_error_message).to include(safe_outer_url)
+            end
+
+            it "preserves an exception-text encoded nested URL whose at sign is only in the #{location}" do
+              safe_outer_url = "http://outer.test/redirect?next=#{nested_url}"
+              stub_http_bundle_failure("Failure loading #{safe_outer_url}")
+
+              expect(bundle_load_error_message).to include("Failure loading #{safe_outer_url}")
+            end
+          end
+
+          it "redacts a credential URL near the end of a large diagnostic with many nested URL starts" do
+            safe_part = "part=ftp%3A%2F%2Fnested.test%2Fchunk"
+            encoded_padding = Array.new(1_800, safe_part).join("&")
+            nested_url = "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath"
+            outer_url = "http://outer.test/redirect?#{encoded_padding}&next=#{nested_url}"
+            failure_message = "Failure loading #{outer_url}"
+            expect(failure_message.bytesize).to be > 65_536
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("nested-user")
+            expect(message).not_to include("nested-secret")
+            expect(message).to include("next=ftp%3A%2F%2Fnested.test%2Fpath")
+          end
+        end
+
+        context "when nested non-HTTP userinfo spans a prose delimiter" do
+          userinfo_delimiters = [["literal", "@"], ["encoded", "%40"]]
+          prose_delimiters = [["space", " "], ["double quote", '"'], ["single quote", "'"]]
+
+          userinfo_delimiters.each do |delimiter_encoding, userinfo_delimiter|
+            prose_delimiters.each do |description, prose_delimiter|
+              nested_url =
+                "ftp://nested-user#{prose_delimiter}nested-secret#{userinfo_delimiter}nested.test/path"
+
+              it "fails closed across a #{description} with the #{delimiter_encoding} at sign in the configured URL" do
+                server_bundle_url = "http://outer.test/redirect?next=#{nested_url}"
+                stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+                message = bundle_load_error_message
+                expect(message).not_to include("nested-user")
+                expect(message).not_to include("nested-secret")
+                expect(message).to include("nested.test/path")
+              end
+
+              it "fails closed across a #{description} with the #{delimiter_encoding} at sign in exception text" do
+                failure_message = "Failure loading http://outer.test/redirect?next=#{nested_url}"
+                stub_http_bundle_failure(failure_message)
+
+                message = bundle_load_error_message
+                expect(message).not_to include("nested-user")
+                expect(message).not_to include("nested-secret")
+                expect(message).to include("nested.test/path")
+              end
+            end
+          end
+        end
+
         unresolved_prefix_cases = [
           ["an invalid prefix before a valid credential URL",
            "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
@@ -757,7 +865,7 @@ module ReactOnRails
           end
         end
 
-        context "when URI parsing raises ArgumentError for malformed encoding" do
+        context "when URI parsing raises ArgumentError" do
           it "still raises a sanitized bundle-load error through the public entrypoint" do
             server_bundle_url = "http://synthetic-user:synthetic-secret@host/path"
             allow(URI).to receive(:parse).and_call_original
@@ -770,6 +878,19 @@ module ReactOnRails
             expect(message).not_to include("synthetic-secret")
             expect(message).to include("invalid byte sequence in UTF-8")
             expect(message).to include("http://host/path")
+          end
+        end
+
+        context "when the configured URL has invalid UTF-8 bytes" do
+          it "still raises a sanitized bundle-load error through the public entrypoint" do
+            server_bundle_url = "http://synthetic-user:synthetic-secret@host/path-\xFF".b
+                                                                                       .force_encoding(Encoding::UTF_8)
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("http://host/path-")
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -466,6 +466,26 @@ module ReactOnRails
               "http://host/bundle.js"
             ],
             [
+              "fully encoded HTTP authority separators",
+              "http:%2F%2Fbundle-user:synthetic-password%40host/bundle.js",
+              false,
+              "http:%2F%2Fhost/bundle.js"
+            ],
+            [
+              "fully encoded outer and nested URL credentials",
+              "http%3A%2F%2Fouter-user%3Aouter-secret%40outer.test%2Fredirect%3Fnext%3D" \
+              "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
+              false,
+              "http%3A%2F%2Fouter.test%2Fredirect%3Fnext%3Dftp%3A%2F%2Fnested.test%2Fpath"
+            ],
+            [
+              "literal outer and encoded nested authority separators",
+              "http%3A//bundle-user%3Asynthetic-password%40outer.test%2Fnext%3D" \
+              "ftp%3A%2F%2Fnested-user%3Anested-secret%40inner.test/path",
+              false,
+              "http%3A//outer.test%2Fnext%3Dftp%3A%2F%2Finner.test/path"
+            ],
+            [
               "mixed encoded and literal authority delimiters",
               "http://synthetic-user%40mail:synthetic-secret@host/path",
               true,

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -430,7 +430,7 @@ module ReactOnRails
         end
 
         # A URL malformed enough that URI.parse itself raises (e.g. a space in the host) fails
-        # before sanitized_renderer_url is ever applied to the `url` variable at the raise site —
+        # before DiagnosticUrlRedactor is ever applied to the `url` variable at the raise site —
         # URI::InvalidURIError's own message embeds the original credential-bearing string
         # verbatim, so that message must be scrubbed independently of the url variable.
         context "when the HTTP-served bundle URL embeds credentials and is malformed enough to fail URI parsing" do
@@ -448,405 +448,179 @@ module ReactOnRails
           end
         end
 
-        context "when a credential URL has whitespace in its HTTP scheme delimiter" do
-          it "redacts credentials even when the path is classified as a local bundle" do
-            server_bundle_path = "http ://bundle-user:synthetic-password@host/bundle.js"
-            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("bundle-user")
-            expect(message).not_to include("synthetic-password")
-            expect(message).to include("http ://host/bundle.js")
-          end
-        end
-
-        context "when a credential URL is authority-relative" do
+        # Keep one public-entry integration pass for each confirmed leak class. The exhaustive
+        # sanitizer permutations live with DiagnosticUrlRedactor; these examples verify that
+        # read_bundle_js_code routes configured values and wrapped errors through that seam.
+        context "when configured bundle values exercise credential-redaction boundaries" do
           [
-            ["valid userinfo", "//bundle-user:synthetic-password@host/bundle.js"],
-            ["ambiguous userinfo", "//bundle-user:synthetic-password@credential-suffix@host/bundle.js"]
-          ].each do |description, server_bundle_path|
-            it "redacts #{description} even when the path is classified as a local bundle" do
-              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("bundle-user")
-              expect(message).not_to include("synthetic-password")
-              expect(message).not_to include("credential-suffix")
-              expect(message).to include("//host/bundle.js")
-            end
-          end
-
-          it "preserves an at sign in the path when the authority has no userinfo" do
-            server_bundle_path = "//host/assets/component@2.js"
-            stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
-
-            expect(bundle_load_error_message).to include(server_bundle_path)
-          end
-
-          [" ", "URL="].each do |prefix|
-            it "redacts credentials when #{prefix.inspect} precedes the authority marker" do
-              server_bundle_path = "#{prefix}//bundle-user:synthetic-password@host/bundle.js"
-              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("bundle-user")
-              expect(message).not_to include("synthetic-password")
-              expect(message).to include("#{prefix}//host/bundle.js")
-            end
-          end
-
-          [["bare", ""], ["prefixed", "URL="]].each do |description, prefix|
-            it "redacts #{description} credentials when whitespace follows the authority marker" do
-              server_bundle_path = "#{prefix}// bundle-user:synthetic-password@host/bundle.js"
-              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("bundle-user")
-              expect(message).not_to include("synthetic-password")
-              expect(message).to include("#{prefix}//host/bundle.js")
-            end
-          end
-        end
-
-        context "when malformed URL userinfo contains multiple at signs" do
-          it "redacts the entire userinfo while retaining the host and path" do
-            server_bundle_url =
-              "http://bundle-user:password-prefix@password-suffix@bad host/webpack/development/server-bundle.js"
-            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("bundle-user")
-            expect(message).not_to include("password-prefix")
-            expect(message).not_to include("password-suffix")
-            expect(message).to include("bad URI")
-            expect(message).to include("bad host/webpack/development/server-bundle.js")
-          end
-        end
-
-        context "when malformed URL userinfo contains an unescaped slash" do
-          it "redacts every credential fragment while retaining the host and path" do
-            server_bundle_url = "http://user:prefix/secret@host/path"
-            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("user")
-            expect(message).not_to include("prefix")
-            expect(message).not_to include("secret")
-            expect(message).to include("bad URI")
-            expect(message).to include("host/path")
-          end
-        end
-
-        context "when malformed URL userinfo contains whitespace" do
-          it "redacts the quoted URL from the URI error while retaining the host and path" do
-            server_bundle_url = "http://user:prefix secret@host/path"
-            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("user")
-            expect(message).not_to include("prefix")
-            expect(message).not_to include("secret")
-            expect(message).to include("bad URI")
-            expect(message).to include("host/path")
-          end
-        end
-
-        context "when whitespace makes malformed userinfo look like a valid host prefix" do
-          it "does not protect the prefix quoted by the configured URL's URI error" do
-            server_bundle_url = "http://synthetic-user secret-final@host/path"
-            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("secret-final")
-            expect(message).to include("bad URI")
-            expect(message).to include("host/path")
-          end
-        end
-
-        context "when configured malformed userinfo has a delayed at sign" do
-          [
-            ["multiple intervening words", "http://synthetic-user secret-middle secret-final@host/path",
-             %w[synthetic-user secret-middle secret-final]],
-            ["a quote and whitespace", 'http://synthetic-user" secret-final@host/path',
-             %w[synthetic-user secret-final]],
-            ["a quote and multiple intervening words",
-             'http://synthetic-user" secret-middle secret-final@host/path',
-             %w[synthetic-user secret-middle secret-final]]
-          ].each do |description, server_bundle_url, credential_fragments|
-            it "redacts credentials after #{description}" do
-              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-              message = bundle_load_error_message
-              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
-              expect(message).to include("bad URI")
-              expect(message).to include("host/path")
-            end
-          end
-        end
-
-        nested_scheme_cases = [
-          ["a comma", "http://outer.test/first,http://synthetic-user:synthetic-secret@host/path"],
-          ["a semicolon", "http://outer.test/first;http://synthetic-user:synthetic-secret@host/path"],
-          ["a parenthesis", "http://outer.test/first(http://synthetic-user:synthetic-secret@host/path)"],
-          ["a valid URL directly before a valid credential URL",
-           "http://outer.test/firsthttp://synthetic-user:synthetic-secret@host/path"],
-          ["mixed-case HTTP then HTTPS",
-           "hTtP://outer.test/first;HtTpS://synthetic-user:synthetic-secret@host/path"],
-          ["mixed-case HTTPS then HTTP",
-           "HtTpS://outer.test/first;hTtP://synthetic-user:synthetic-secret@host/path"]
-        ]
-
-        context "when the configured URL contains another scheme without whitespace" do
-          nested_scheme_cases.each do |description, server_bundle_url|
-            it "sanitizes credentials after #{description}" do
-              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("synthetic-user")
-              expect(message).not_to include("synthetic-secret")
-              expect(message).not_to include("outer.test/first")
-              expect(message).to include("host/path")
-            end
-          end
-        end
-
-        context "when a valid outer HTTP URL contains a nested non-HTTP URL" do
-          let(:nested_credential_url) do
-            "http://outer.test/redirect?next=ftp://nested-user:nested-secret@nested.test/path"
-          end
-
-          it "redacts nested credentials from the configured bundle URL" do
-            stub_http_bundle_failure("connection failed", bundle_url: nested_credential_url)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("nested-user")
-            expect(message).not_to include("nested-secret")
-            expect(message).to include("http://outer.test/redirect?next=ftp://nested.test/path")
-          end
-
-          it "redacts nested credentials from ordinary exception text" do
-            stub_http_bundle_failure("Failure loading #{nested_credential_url}")
-
-            message = bundle_load_error_message
-            expect(message).not_to include("nested-user")
-            expect(message).not_to include("nested-secret")
-            expect(message).to include("Failure loading http://outer.test/redirect?next=ftp://nested.test/path")
-          end
-
-          it "preserves a nested URL with an at sign only in its path" do
-            safe_nested_url = "http://outer.test/redirect?next=ftp://nested.test/component@2.js"
-            stub_http_bundle_failure("Failure loading #{safe_nested_url}")
-
-            expect(bundle_load_error_message).to include("Failure loading #{safe_nested_url}")
-          end
-        end
-
-        context "when a valid outer HTTP URL contains encoded nested credentials" do
-          encoded_nested_urls = [
-            ["a fully encoded nested URL",
-             "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
-             "ftp%3A%2F%2Fnested.test%2Fpath"],
-            ["an encoded scheme and authority marker",
-             "ftp%3A%2F%2Fnested-user:nested-secret@nested.test/path",
-             "ftp%3A%2F%2Fnested.test/path"],
-            ["a partially encoded scheme",
-             "f%74p://nested-user:nested-secret@nested.test/path",
-             "f%74p://nested.test/path"],
-            ["a partially encoded scheme and encoded userinfo delimiter",
-             "f%74p%3A%2F%2Fnested-user:nested-secret%40nested.test/path",
-             "f%74p%3A%2F%2Fnested.test/path"],
-            ["an encoded userinfo delimiter",
-             "ftp://nested-user:nested-secret%40nested.test/path",
-             "ftp://nested.test/path"]
-          ]
-
-          encoded_nested_urls.each do |description, nested_url, sanitized_nested_url|
-            it "redacts #{description} from the configured bundle URL" do
-              server_bundle_url = "http://outer.test/redirect?next=#{nested_url}"
-              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("nested-user")
-              expect(message).not_to include("nested-secret")
-              expect(message).to include("http://outer.test/redirect?next=#{sanitized_nested_url}")
-            end
-
-            it "redacts #{description} from ordinary exception text" do
-              nested_outer_url = "http://outer.test/redirect?next=#{nested_url}"
-              stub_http_bundle_failure("Failure loading #{nested_outer_url}")
-
-              message = bundle_load_error_message
-              expect(message).not_to include("nested-user")
-              expect(message).not_to include("nested-secret")
-              expect(message).to include("Failure loading http://outer.test/redirect?next=#{sanitized_nested_url}")
-            end
-          end
-
-          [
-            ["path", "ftp%3A%2F%2Fnested.test%2Fcomponent%402.js"],
-            ["query", "ftp%3A%2F%2Fnested.test%3Fcontact%3Dsafe%40example.test"]
-          ].each do |location, nested_url|
-            it "preserves a configured encoded nested URL whose at sign is only in the #{location}" do
-              safe_outer_url = "http://outer.test/redirect?next=#{nested_url}"
-              stub_http_bundle_failure("connection failed", bundle_url: safe_outer_url)
-
-              expect(bundle_load_error_message).to include(safe_outer_url)
-            end
-
-            it "preserves an exception-text encoded nested URL whose at sign is only in the #{location}" do
-              safe_outer_url = "http://outer.test/redirect?next=#{nested_url}"
-              stub_http_bundle_failure("Failure loading #{safe_outer_url}")
-
-              expect(bundle_load_error_message).to include("Failure loading #{safe_outer_url}")
-            end
-          end
-
-          it "redacts a credential URL near the end of a large diagnostic with many nested URL starts" do
-            safe_part = "part=ftp%3A%2F%2Fnested.test%2Fchunk"
-            encoded_padding = Array.new(1_800, safe_part).join("&")
-            nested_url = "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath"
-            outer_url = "http://outer.test/redirect?#{encoded_padding}&next=#{nested_url}"
-            failure_message = "Failure loading #{outer_url}"
-            expect(failure_message.bytesize).to be > 65_536
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("nested-user")
-            expect(message).not_to include("nested-secret")
-            expect(message).to include("next=ftp%3A%2F%2Fnested.test%2Fpath")
-          end
-        end
-
-        context "when nested non-HTTP userinfo spans a prose delimiter" do
-          userinfo_delimiters = [["literal", "@"], ["encoded", "%40"]]
-          prose_delimiters = [["space", " "], ["double quote", '"'], ["single quote", "'"]]
-
-          userinfo_delimiters.each do |delimiter_encoding, userinfo_delimiter|
-            prose_delimiters.each do |description, prose_delimiter|
-              nested_url =
-                "ftp://nested-user#{prose_delimiter}nested-secret#{userinfo_delimiter}nested.test/path"
-
-              it "fails closed across a #{description} with the #{delimiter_encoding} at sign in the configured URL" do
-                server_bundle_url = "http://outer.test/redirect?next=#{nested_url}"
-                stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-                message = bundle_load_error_message
-                expect(message).not_to include("nested-user")
-                expect(message).not_to include("nested-secret")
-                expect(message).to include("nested.test/path")
+            [
+              "whitespace in the HTTP scheme delimiter",
+              "http ://synthetic-user:synthetic-secret@host/path",
+              false,
+              "http ://host/path"
+            ],
+            [
+              "whitespace after a bare authority marker",
+              "// synthetic-user:synthetic-secret@host/path",
+              false,
+              "//host/path"
+            ],
+            [
+              "bare authority-relative userinfo",
+              "//synthetic-user:synthetic-secret@host/path",
+              false,
+              "//host/path"
+            ],
+            [
+              "a prefix and whitespace before authority-relative userinfo",
+              "URL=// synthetic-user:synthetic-secret@host/path",
+              false,
+              "URL=//host/path"
+            ],
+            [
+              "prefixed authority-relative userinfo",
+              "URL=//synthetic-user:synthetic-secret@host/path",
+              false,
+              "URL=//host/path"
+            ],
+            [
+              "a nested non-HTTP URL",
+              "http://outer.test/redirect?next=ftp://nested-user:nested-secret@nested.test/path",
+              true,
+              "http://outer.test/redirect?next=ftp://nested.test/path"
+            ],
+            [
+              "a fully encoded nested URL",
+              "http://outer.test/redirect?next=" \
+              "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
+              true,
+              "http://outer.test/redirect?next=ftp%3A%2F%2Fnested.test%2Fpath"
+            ],
+            [
+              "an encoded nested scheme and authority marker",
+              "http://outer.test/redirect?next=" \
+              "ftp%3A%2F%2Fnested-user:nested-secret@nested.test/path",
+              true,
+              "http://outer.test/redirect?next=ftp%3A%2F%2Fnested.test/path"
+            ],
+            [
+              "a partially encoded nested URL and encoded at sign",
+              "http://outer.test/redirect?next=" \
+              "f%74p%3A%2F%2Fnested-user:nested-secret%40nested.test/path",
+              true,
+              "http://outer.test/redirect?next=f%74p%3A%2F%2Fnested.test/path"
+            ],
+            [
+              "a nested URL with only the at sign encoded",
+              "http://outer.test/redirect?next=" \
+              "ftp://nested-user:nested-secret%40nested.test/path",
+              true,
+              "http://outer.test/redirect?next=ftp://nested.test/path"
+            ],
+            [
+              "nested userinfo spanning a quote",
+              'http://outer.test/redirect?next=ftp://nested-user"nested-secret@nested.test/path',
+              true,
+              "nested.test/path"
+            ],
+            [
+              "nested userinfo spanning whitespace",
+              "http://outer.test/redirect?next=ftp://nested-user nested-secret@nested.test/path",
+              true,
+              "nested.test/path"
+            ],
+            [
+              "nested userinfo spanning a single quote",
+              "http://outer.test/redirect?next=ftp://nested-user'nested-secret@nested.test/path",
+              true,
+              "nested.test/path"
+            ],
+            [
+              "nested userinfo spanning whitespace before an encoded at sign",
+              "http://outer.test/redirect?next=ftp://nested-user nested-secret%40nested.test/path",
+              true,
+              "nested.test/path"
+            ],
+            [
+              "malformed userinfo spanning a line break",
+              "http://synthetic-user\nsynthetic-secret@host/path",
+              false,
+              "http://host/path"
+            ],
+            [
+              "an unresolved scheme before a credential URL",
+              "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
+              true,
+              "http://host/path"
+            ]
+          ].each do |description, configured_value, http_path, expected|
+            it "redacts #{description}" do
+              if http_path
+                stub_http_bundle_failure("connection failed", bundle_url: configured_value)
+              else
+                stub_local_bundle_failure(Errno::ENOENT.new(configured_value), bundle_path: configured_value)
               end
 
-              it "fails closed across a #{description} with the #{delimiter_encoding} at sign in exception text" do
-                failure_message = "Failure loading http://outer.test/redirect?next=#{nested_url}"
-                stub_http_bundle_failure(failure_message)
-
-                message = bundle_load_error_message
-                expect(message).not_to include("nested-user")
-                expect(message).not_to include("nested-secret")
-                expect(message).to include("nested.test/path")
-              end
+              message = bundle_load_error_message
+              expect(message).not_to match(/(?:synthetic|nested)-(?:user|secret)/)
+              expect(message).to include(expected)
             end
           end
         end
 
-        unresolved_prefix_cases = [
-          ["an invalid prefix before a valid credential URL",
-           "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
-           %w[synthetic-user nonnumeric-prefix synthetic-secret]],
-          ["a numeric-port prefix",
-           "http://synthetic-user:123synthetic-prefixhttp://synthetic-secret@host/path",
-           %w[synthetic-user 123synthetic-prefix synthetic-secret]],
-          ["a slash in the invalid prefix",
-           "http://synthetic-user:nonnumeric-prefix/synthetic-tailhttp://synthetic-secret@host/path",
-           %w[synthetic-user nonnumeric-prefix synthetic-tail synthetic-secret]],
-          ["a semicolon in the invalid prefix",
-           "http://synthetic-user:nonnumeric-prefix;synthetic-tailhttp://synthetic-secret@host/path",
-           %w[synthetic-user nonnumeric-prefix synthetic-tail synthetic-secret]]
-        ]
-
-        context "when the configured URL has an unresolved scheme before a credential URL" do
-          unresolved_prefix_cases.each do |description, server_bundle_url, credential_fragments|
-            it "fails closed across #{description}" do
-              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+        context "when wrapped errors exercise credential-redaction boundaries" do
+          [
+            [
+              "a non-HTTP URL",
+              "Failure loading postgres://synthetic-user:synthetic-secret@host/path",
+              "Failure loading postgres://host/path"
+            ],
+            [
+              "a nested non-HTTP URL",
+              "Failure loading http://outer.test/redirect?next=" \
+              "ftp://nested-user:nested-secret@nested.test/path",
+              "Failure loading http://outer.test/redirect?next=ftp://nested.test/path"
+            ],
+            [
+              "a fully encoded nested URL",
+              "Failure loading http://outer.test/redirect?next=" \
+              "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath",
+              "Failure loading http://outer.test/redirect?next=ftp%3A%2F%2Fnested.test%2Fpath"
+            ],
+            [
+              "nested userinfo spanning a quote before an encoded at sign",
+              "Failure loading http://outer.test/redirect?next=" \
+              'ftp://nested-user"nested-secret%40nested.test/path',
+              "nested.test/path"
+            ],
+            [
+              "authority-relative userinfo spanning whitespace",
+              "Failure loading //synthetic-user synthetic-secret@host/path",
+              "Failure loading //host/path"
+            ],
+            [
+              "authority-relative userinfo spanning a double quote",
+              'Failure loading //synthetic-user" synthetic-secret@host/path',
+              "Failure loading //host/path"
+            ],
+            [
+              "authority-relative userinfo spanning a single quote",
+              "Failure loading //synthetic-user' synthetic-secret@host/path",
+              "Failure loading //host/path"
+            ],
+            [
+              "authority-relative userinfo spanning a line break",
+              "Failure loading //synthetic-user\nsynthetic-secret@host/path",
+              "Failure loading //host/path"
+            ]
+          ].each do |description, failure_message, expected|
+            it "redacts #{description}" do
+              stub_local_bundle_failure(failure_message)
 
               message = bundle_load_error_message
-              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
-              expect(message).to include("host/path")
+              expect(message).not_to match(/(?:synthetic|nested)-(?:user|secret)/)
+              expect(message).to include(expected)
             end
-          end
-        end
-
-        context "when configured malformed userinfo spans line breaks" do
-          [
-            ["LF", "http://synthetic-user\nsynthetic-secret@host/path"],
-            ["CR", "http://synthetic-user\rsynthetic-secret@host/path"],
-            ["CRLF", "http://synthetic-user\r\nsynthetic-secret@host/path"],
-            ["a quote and newline", "http://synthetic-user\"\nsynthetic-secret@host/path"]
-          ].each do |description, server_bundle_url|
-            it "fails closed across #{description} within the configured value" do
-              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("synthetic-user")
-              expect(message).not_to include("synthetic-secret")
-              expect(message).to include("host/path")
-            end
-          end
-        end
-
-        context "when a configured URL has an at sign only in its path" do
-          it "preserves the URL because the configured value parses without userinfo" do
-            server_bundle_url = "http://host/path@example"
-            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-            expect(bundle_load_error_message).to include(server_bundle_url)
-          end
-        end
-
-        context "when non-URL text precedes a configured credential URL" do
-          classifications = [["HTTP", true], ["local-path", false]]
-
-          [
-            ["a space", " ", "http"],
-            ["a tab", "\t", "http"],
-            ["a newline", "\n", "http"],
-            ["a quote", '"', "http"],
-            ["a label and mixed-case scheme", "URL=", "hTtPs"]
-          ].each do |description, prefix, scheme|
-            classifications.each do |classification, http_path|
-              it "sanitizes #{description} through the #{classification} branch" do
-                server_bundle_url = "#{prefix}#{scheme}://synthetic-user:synthetic-secret@host/path"
-                sanitized_url = "#{prefix}#{scheme.downcase}://host/path"
-                failure_message = "raw=#{server_bundle_url} inspected=#{server_bundle_url.inspect} " \
-                                  "repeated=#{server_bundle_url}"
-
-                if http_path
-                  stub_http_bundle_failure(failure_message, bundle_url: server_bundle_url)
-                else
-                  stub_local_bundle_failure(failure_message, bundle_path: server_bundle_url)
-                end
-
-                message = bundle_load_error_message
-                expect(message).not_to include("synthetic-user")
-                expect(message).not_to include("synthetic-secret")
-                expect(message).to include(sanitized_url)
-              end
-            end
-          end
-        end
-
-        context "when malformed URL userinfo contains a literal double quote" do
-          it "redacts the escaped URL from the URI error" do
-            server_bundle_url = "http://synthetic-user:sec\"ret@host/path"
-            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("sec")
-            expect(message).not_to include("ret")
-            expect(message).to include("bad URI")
-            expect(message).to include("host/path")
           end
         end
 
@@ -859,8 +633,7 @@ module ReactOnRails
             stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
             message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to match(/synthetic-(?:user|secret)/)
             expect(message).to include("bad URI for http://host/path")
           end
         end
@@ -874,8 +647,7 @@ module ReactOnRails
             stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
             message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to match(/synthetic-(?:user|secret)/)
             expect(message).to include("invalid byte sequence in UTF-8")
             expect(message).to include("http://host/path")
           end
@@ -888,296 +660,47 @@ module ReactOnRails
             stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
             message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("synthetic-secret")
+            expect(message).not_to match(/synthetic-(?:user|secret)/)
             expect(message).to include("http://host/path-")
           end
         end
 
-        context "when a local bundle path contains replacement metacharacters" do
-          it "preserves them literally while redacting credentials from the load error" do
-            server_bundle_path = %q(/tmp/\k<foo>-\1-\&-\0-literal\backslash/server-bundle.js)
-            failure_message = "raw=#{server_bundle_path} inspected=#{server_bundle_path.inspect} " \
-                              "credential=http://synthetic-user:synthetic-secret@host/path"
-            stub_local_bundle_failure(failure_message, bundle_path: server_bundle_path)
+        it "redacts a credential URL near the end of a large wrapped diagnostic" do
+          safe_part = "part=ftp%3A%2F%2Fnested.test%2Fchunk"
+          encoded_padding = Array.new(1_800, safe_part).join("&")
+          nested_url = "ftp%3A%2F%2Fnested-user%3Anested-secret%40nested.test%2Fpath"
+          failure_message = "Failure loading http://outer.test/redirect?#{encoded_padding}&next=#{nested_url}"
+          expect(failure_message.bytesize).to be > 65_536
+          stub_http_bundle_failure(failure_message)
 
-            message = bundle_load_error_message
-            expect(message).to include(server_bundle_path)
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("synthetic-secret")
-            expect(message).to include("http://host/path")
-            expect(message).to include("react_on_rails@shakacode.com")
-          end
+          message = bundle_load_error_message
+          expect(message).not_to match(/nested-(?:user|secret)/)
+          expect(message).to include("next=ftp%3A%2F%2Fnested.test%2Fpath")
         end
 
-        context "when a bundle-load failure embeds an unquoted malformed credential URL" do
-          it "fails closed across whitespace in the credential" do
-            failure_message = "Failure loading http://synthetic-user:prefix secret-final@host/path"
-            stub_http_bundle_failure(failure_message)
+        it "preserves replacement metacharacters while sanitizing the wrapped error" do
+          server_bundle_path = %q(/tmp/\k<foo>-\1-\&-\0-literal\backslash/server-bundle.js)
+          failure_message = "raw=#{server_bundle_path} inspected=#{server_bundle_path.inspect} " \
+                            "credential=http://synthetic-user:synthetic-secret@host/path"
+          stub_local_bundle_failure(failure_message, bundle_path: server_bundle_path)
 
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("prefix")
-            expect(message).not_to include("secret-final")
-            expect(message).to include("Failure loading http://host/path")
-          end
+          message = bundle_load_error_message
+          expect(message).to include(server_bundle_path)
+          expect(message).not_to match(/synthetic-(?:user|secret)/)
+          expect(message).to include("http://host/path")
         end
 
-        context "when a bundle-load failure embeds credentials in a non-HTTP URL" do
-          %w[postgres redis ftp mongodb].each do |scheme|
-            it "redacts credentials from the #{scheme} URL" do
-              failure_message = "Failure loading #{scheme}://synthetic-user:synthetic-secret@host/path"
-              stub_http_bundle_failure(failure_message)
+        context "when diagnostics contain safe at signs or double slashes" do
+          it "preserves an at sign that appears only in a configured URL path" do
+            configured_value = "http://host/path@example"
+            stub_http_bundle_failure("connection failed", bundle_url: configured_value)
 
-              message = bundle_load_error_message
-              expect(message).not_to include("synthetic-user")
-              expect(message).not_to include("synthetic-secret")
-              expect(message).to include("Failure loading #{scheme}://host/path")
-            end
-          end
-        end
-
-        context "when malformed userinfo looks like a valid host prefix in an ordinary error" do
-          it "does not protect the prefix before the whitespace-delimited credential suffix" do
-            failure_message = "Failure loading http://synthetic-user:123 secret-final@host/path"
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("123")
-            expect(message).not_to include("secret-final")
-            expect(message).to include("Failure loading http://host/path")
-          end
-        end
-
-        context "when an ordinary error has a delayed credential at sign" do
-          [
-            ["multiple intervening words", "http://synthetic-user secret-middle secret-final@host/path",
-             %w[synthetic-user secret-middle secret-final]],
-            ["a quote and whitespace", 'http://synthetic-user" secret-final@host/path',
-             %w[synthetic-user secret-final]],
-            ["a quote and multiple intervening words",
-             'http://synthetic-user" secret-middle secret-final@host/path',
-             %w[synthetic-user secret-middle secret-final]]
-          ].each do |description, malformed_url, credential_fragments|
-            it "redacts credentials after #{description}" do
-              failure_message = "Failure loading #{malformed_url}"
-              stub_http_bundle_failure(failure_message)
-
-              message = bundle_load_error_message
-              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
-              expect(message).to include("Failure loading http://host/path")
-            end
-          end
-        end
-
-        context "when malformed userinfo in an ordinary error spans line breaks" do
-          [
-            ["LF", "http://synthetic-user\nsynthetic-secret@host/path"],
-            ["CR", "http://synthetic-user\rsynthetic-secret@host/path"],
-            ["CRLF", "http://synthetic-user\r\nsynthetic-secret@host/path"],
-            ["a quote and LF", "http://synthetic-user\"\nsynthetic-secret@host/path"]
-          ].each do |description, malformed_url|
-            it "fails closed across #{description}" do
-              failure_message = "Failure loading #{malformed_url}"
-              stub_local_bundle_failure(failure_message)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("synthetic-user")
-              expect(message).not_to include("synthetic-secret")
-              expect(message).to include("Failure loading http://host/path")
-            end
-          end
-        end
-
-        context "when an ordinary error contains another scheme without whitespace" do
-          nested_scheme_cases.each do |description, nested_urls|
-            it "sanitizes credentials after #{description}" do
-              failure_message = "Failure loading #{nested_urls}"
-              stub_http_bundle_failure(failure_message)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("synthetic-user")
-              expect(message).not_to include("synthetic-secret")
-              expect(message).to include("outer.test/first")
-              expect(message).to include("host/path")
-            end
-          end
-        end
-
-        context "when an ordinary error has an unresolved scheme before a credential URL" do
-          unresolved_prefix_cases.each do |description, nested_urls, credential_fragments|
-            it "fails closed across #{description}" do
-              failure_message = "Failure loading #{nested_urls}"
-              stub_http_bundle_failure(failure_message)
-
-              message = bundle_load_error_message
-              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
-              expect(message).to include("Failure loading http://host/path")
-            end
-          end
-        end
-
-        context "when an invalid credential URL is followed by a valid URL" do
-          it "redacts the credential and preserves the later URL" do
-            failure_message = "Failure loading http://synthetic-user secret-final@host/path " \
-                              "http://healthy-host/path"
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("secret-final")
-            expect(message).to include("Failure loading http://host/path http://healthy-host/path")
-          end
-        end
-
-        context "when an ordinary error quotes malformed userinfo across whitespace" do
-          it "redacts the quoted credential while retaining the host and path" do
-            failure_message = 'Failure loading "http://synthetic-user secret-final@host/path"'
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("secret-final")
-            expect(message).to include('Failure loading "http://host/path"')
-          end
-        end
-
-        context "when a quote truncates a malformed credential URL token" do
-          it "does not protect the valid-looking prefix before the double quote" do
-            failure_message = 'Failure loading http://synthetic-user"secret-final@host/path'
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("secret-final")
-            expect(message).to include("Failure loading http://host/path")
+            expect(bundle_load_error_message).to include(configured_value)
           end
 
-          it "does not protect the valid-looking prefix before the single quote" do
-            failure_message = "Failure loading http://synthetic-user'secret-final@host/path"
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("secret-final")
-            expect(message).to include("Failure loading http://host/path")
-          end
-        end
-
-        context "when a bundle-load failure embeds a valid URL with an at sign in its path" do
-          it "preserves the URL because it has no userinfo" do
-            failure_message = "Failure loading http://host/path@example"
-            stub_http_bundle_failure(failure_message)
-
-            expect(bundle_load_error_message).to include(failure_message)
-          end
-        end
-
-        context "when a bundle-load failure contains two valid URLs" do
-          it "preserves both URLs, including an at sign in the second URL's path" do
-            failure_message = "Failure loading http://first-host/path http://second-host/path@example"
-            stub_http_bundle_failure(failure_message)
-
-            expect(bundle_load_error_message).to include(failure_message)
-          end
-        end
-
-        context "when a line boundary precedes an ambiguous email at sign" do
-          [["LF", "\n"], ["CR", "\r"], ["CRLF", "\r\n"]].each do |description, boundary|
-            it "fails closed across #{description}" do
-              failure_message = "Failure loading http://host/path#{boundary}contact dev@example.com"
-              stub_http_bundle_failure(failure_message)
-
-              message = bundle_load_error_message
-              expect(message).not_to include("host/path")
-              expect(message).not_to include("contact dev")
-              expect(message).to include("Failure loading http://example.com")
-            end
-          end
-        end
-
-        context "when multiline error text contains a later URL scheme" do
-          it "redacts malformed multiline userinfo without consuming the later URL" do
-            failure_message = "Failure loading http://synthetic-user\nsynthetic-secret@host/path\n" \
-                              "hTtPs://healthy-host/path@example"
-            stub_local_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("synthetic-secret")
-            expect(message).to include("Failure loading http://host/path\nhTtPs://healthy-host/path@example")
-          end
-
-          it "fails closed before the later scheme while preserving that separate URL" do
-            failure_message = "Failure loading http://first-host/path\ncontact dev@example.com\n" \
-                              "HTTP://second-host/path"
-            stub_local_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("first-host/path")
-            expect(message).not_to include("contact dev")
-            expect(message).to include("Failure loading http://example.com\nHTTP://second-host/path")
-          end
-
-          it "discards an unresolved multiline region before sanitizing the next credential URL" do
-            failure_message = "Failure loading http://synthetic-user:nonnumeric-prefix\nsynthetic-tail " \
-                              "HtTpS://synthetic-secret@host/path"
-            stub_local_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("nonnumeric-prefix")
-            expect(message).not_to include("synthetic-tail")
-            expect(message).not_to include("synthetic-secret")
-            expect(message).to include("Failure loading https://host/path")
-          end
-        end
-
-        context "when a valid-looking URL is followed by prose containing an email address" do
-          it "fails closed because no structural boundary separates the later at sign" do
-            failure_message = "Failure loading http://host/path; contact dev@example.com"
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("host/path")
-            expect(message).not_to include("contact dev")
-            expect(message).to include("Failure loading http://example.com")
-          end
-        end
-
-        context "when a bundle-load failure contains authority-relative credentials" do
-          it "redacts the credentials while retaining the host and path" do
-            failure_message = "Failure loading //synthetic-user:synthetic-secret@host/path"
-            stub_http_bundle_failure(failure_message)
-
-            message = bundle_load_error_message
-            expect(message).not_to include("synthetic-user")
-            expect(message).not_to include("synthetic-secret")
-            expect(message).to include("Failure loading //host/path")
-          end
-
-          [
-            ["whitespace", "//synthetic-user synthetic-secret@host/path"],
-            ["a quote", '//synthetic-user" synthetic-secret@host/path'],
-            ["an LF line break", "//synthetic-user\nsynthetic-secret@host/path"],
-            ["a CRLF line break", "//synthetic-user\r\nsynthetic-secret@host/path"]
-          ].each do |description, malformed_url|
-            it "fails closed when authority-relative userinfo spans #{description}" do
-              stub_local_bundle_failure("Failure loading #{malformed_url}")
-
-              message = bundle_load_error_message
-              expect(message).not_to include("synthetic-user")
-              expect(message).not_to include("synthetic-secret")
-              expect(message).to include("Failure loading //host/path")
-            end
-          end
-        end
-
-        context "when a bundle-load failure contains non-URL double-slash text" do
-          it "preserves the arbitrary message text" do
+          it "preserves non-URL double-slash text" do
             failure_message = "// contact dev@example"
-            stub_http_bundle_failure(failure_message)
+            stub_local_bundle_failure(failure_message)
 
             expect(bundle_load_error_message).to include(failure_message)
           end
@@ -1185,7 +708,7 @@ module ReactOnRails
 
         # read_bundle_js_code also serves the local (non-HTTP) bundle path, where
         # server_bundle_js_file is a plain filesystem path rather than a URL.
-        # sanitized_renderer_url must pass such paths through unchanged (no embedded userinfo to
+        # DiagnosticUrlRedactor must pass such paths through unchanged (no embedded userinfo to
         # strip) so this fix doesn't regress the diagnostic message for the far more common
         # local-file configuration.
         context "when the local (non-HTTP) bundle file cannot be read" do

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -302,6 +302,29 @@ module ReactOnRails
       end
 
       describe ".read_bundle_js_code" do
+        def stub_http_bundle_failure(error, bundle_url: "http://localhost:3035/webpack/development/server-bundle.js")
+          allow(ReactOnRails::Utils).to receive_messages(
+            server_bundle_js_file_path: bundle_url,
+            server_bundle_path_is_http?: true
+          )
+          allow(Net::HTTP).to receive(:get_response).and_raise(error)
+        end
+
+        def stub_local_bundle_failure(error, bundle_path: "/tmp/server-bundle.js")
+          allow(ReactOnRails::Utils).to receive_messages(
+            server_bundle_js_file_path: bundle_path,
+            server_bundle_path_is_http?: false
+          )
+          allow(File).to receive(:read).with(bundle_path).and_raise(error)
+        end
+
+        def bundle_load_error_message
+          described_class.read_bundle_js_code
+          raise "expected read_bundle_js_code to raise"
+        rescue ReactOnRails::ServerBundleLoadError => e
+          e.message
+        end
+
         it "raises a bundle-load error when an HTTP server bundle cannot be read" do
           server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
 
@@ -393,23 +416,16 @@ module ReactOnRails
         context "when the HTTP-served bundle URL embeds credentials and the connection fails" do
           it "does not leak the credential into the raised error message" do
             server_bundle_url = "http://bundle-user:s3cr3t@localhost:3035/webpack/development/server-bundle.js"
-
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
-            allow(Net::HTTP).to receive(:get_response).and_raise(
-              Errno::ECONNREFUSED.new("connect(2) for localhost:3035")
+            stub_http_bundle_failure(
+              Errno::ECONNREFUSED.new("connect(2) for localhost:3035"),
+              bundle_url: server_bundle_url
             )
 
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("s3cr3t")
-              expect(error.message).not_to include("bundle-user")
-              expect(error.message).to include("localhost:3035")
-              expect(error.message).to include("cannot be read")
-            }
+            message = bundle_load_error_message
+            expect(message).not_to include("s3cr3t")
+            expect(message).not_to include("bundle-user")
+            expect(message).to include("localhost:3035")
+            expect(message).to include("cannot be read")
           end
         end
 
@@ -420,22 +436,480 @@ module ReactOnRails
         context "when the HTTP-served bundle URL embeds credentials and is malformed enough to fail URI parsing" do
           it "does not leak the credential into the raised error message" do
             server_bundle_url = "http://bundle-user:s3cr3t@bad host/webpack/development/server-bundle.js"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
 
-            allow(ReactOnRails::Utils).to receive_messages(
-              server_bundle_js_file_path: server_bundle_url,
-              server_bundle_path_is_http?: true
-            )
+            message = bundle_load_error_message
+            expect(message).not_to include("s3cr3t")
+            expect(message).not_to include("bundle-user")
+            # The error must still say the URL was malformed and show enough of it (host/path
+            # minus credentials) for an operator to identify which configured URL failed.
+            expect(message).to include("bad URI")
+            expect(message).to include("bad host")
+          end
+        end
 
-            expect do
-              described_class.read_bundle_js_code
-            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
-              expect(error.message).not_to include("s3cr3t")
-              expect(error.message).not_to include("bundle-user")
-              # The error must still say the URL was malformed and show enough of it (host/path
-              # minus credentials) for an operator to identify which configured URL failed.
-              expect(error.message).to include("bad URI")
-              expect(error.message).to include("bad host")
-            }
+        context "when malformed URL userinfo contains multiple at signs" do
+          it "redacts the entire userinfo while retaining the host and path" do
+            server_bundle_url =
+              "http://bundle-user:password-prefix@password-suffix@bad host/webpack/development/server-bundle.js"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("bundle-user")
+            expect(message).not_to include("password-prefix")
+            expect(message).not_to include("password-suffix")
+            expect(message).to include("bad URI")
+            expect(message).to include("bad host/webpack/development/server-bundle.js")
+          end
+        end
+
+        context "when malformed URL userinfo contains an unescaped slash" do
+          it "redacts every credential fragment while retaining the host and path" do
+            server_bundle_url = "http://user:prefix/secret@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("user")
+            expect(message).not_to include("prefix")
+            expect(message).not_to include("secret")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
+          end
+        end
+
+        context "when malformed URL userinfo contains whitespace" do
+          it "redacts the quoted URL from the URI error while retaining the host and path" do
+            server_bundle_url = "http://user:prefix secret@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("user")
+            expect(message).not_to include("prefix")
+            expect(message).not_to include("secret")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
+          end
+        end
+
+        context "when whitespace makes malformed userinfo look like a valid host prefix" do
+          it "does not protect the prefix quoted by the configured URL's URI error" do
+            server_bundle_url = "http://synthetic-user secret-final@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
+          end
+        end
+
+        context "when configured malformed userinfo has a delayed at sign" do
+          [
+            ["multiple intervening words", "http://synthetic-user secret-middle secret-final@host/path",
+             %w[synthetic-user secret-middle secret-final]],
+            ["a quote and whitespace", 'http://synthetic-user" secret-final@host/path',
+             %w[synthetic-user secret-final]],
+            ["a quote and multiple intervening words",
+             'http://synthetic-user" secret-middle secret-final@host/path',
+             %w[synthetic-user secret-middle secret-final]]
+          ].each do |description, server_bundle_url, credential_fragments|
+            it "redacts credentials after #{description}" do
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("bad URI")
+              expect(message).to include("host/path")
+            end
+          end
+        end
+
+        nested_scheme_cases = [
+          ["a comma", "http://outer.test/first,http://synthetic-user:synthetic-secret@host/path"],
+          ["a semicolon", "http://outer.test/first;http://synthetic-user:synthetic-secret@host/path"],
+          ["a parenthesis", "http://outer.test/first(http://synthetic-user:synthetic-secret@host/path)"],
+          ["a valid URL directly before a valid credential URL",
+           "http://outer.test/firsthttp://synthetic-user:synthetic-secret@host/path"],
+          ["mixed-case HTTP then HTTPS",
+           "hTtP://outer.test/first;HtTpS://synthetic-user:synthetic-secret@host/path"],
+          ["mixed-case HTTPS then HTTP",
+           "HtTpS://outer.test/first;hTtP://synthetic-user:synthetic-secret@host/path"]
+        ]
+
+        context "when the configured URL contains another scheme without whitespace" do
+          nested_scheme_cases.each do |description, server_bundle_url|
+            it "sanitizes credentials after #{description}" do
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).not_to include("outer.test/first")
+              expect(message).to include("host/path")
+            end
+          end
+        end
+
+        unresolved_prefix_cases = [
+          ["an invalid prefix before a valid credential URL",
+           "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
+           %w[synthetic-user nonnumeric-prefix synthetic-secret]],
+          ["a numeric-port prefix",
+           "http://synthetic-user:123synthetic-prefixhttp://synthetic-secret@host/path",
+           %w[synthetic-user 123synthetic-prefix synthetic-secret]],
+          ["a slash in the invalid prefix",
+           "http://synthetic-user:nonnumeric-prefix/synthetic-tailhttp://synthetic-secret@host/path",
+           %w[synthetic-user nonnumeric-prefix synthetic-tail synthetic-secret]],
+          ["a semicolon in the invalid prefix",
+           "http://synthetic-user:nonnumeric-prefix;synthetic-tailhttp://synthetic-secret@host/path",
+           %w[synthetic-user nonnumeric-prefix synthetic-tail synthetic-secret]]
+        ]
+
+        context "when the configured URL has an unresolved scheme before a credential URL" do
+          unresolved_prefix_cases.each do |description, server_bundle_url, credential_fragments|
+            it "fails closed across #{description}" do
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("host/path")
+            end
+          end
+        end
+
+        context "when configured malformed userinfo spans line breaks" do
+          [
+            ["LF", "http://synthetic-user\nsynthetic-secret@host/path"],
+            ["CR", "http://synthetic-user\rsynthetic-secret@host/path"],
+            ["CRLF", "http://synthetic-user\r\nsynthetic-secret@host/path"],
+            ["a quote and newline", "http://synthetic-user\"\nsynthetic-secret@host/path"]
+          ].each do |description, server_bundle_url|
+            it "fails closed across #{description} within the configured value" do
+              stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("host/path")
+            end
+          end
+        end
+
+        context "when a configured URL has an at sign only in its path" do
+          it "preserves the URL because the configured value parses without userinfo" do
+            server_bundle_url = "http://host/path@example"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            expect(bundle_load_error_message).to include(server_bundle_url)
+          end
+        end
+
+        context "when non-URL text precedes a configured credential URL" do
+          classifications = [["HTTP", true], ["local-path", false]]
+
+          [
+            ["a space", " ", "http"],
+            ["a tab", "\t", "http"],
+            ["a newline", "\n", "http"],
+            ["a quote", '"', "http"],
+            ["a label and mixed-case scheme", "URL=", "hTtPs"]
+          ].each do |description, prefix, scheme|
+            classifications.each do |classification, http_path|
+              it "sanitizes #{description} through the #{classification} branch" do
+                server_bundle_url = "#{prefix}#{scheme}://synthetic-user:synthetic-secret@host/path"
+                sanitized_url = "#{prefix}#{scheme.downcase}://host/path"
+                failure_message = "raw=#{server_bundle_url} inspected=#{server_bundle_url.inspect} " \
+                                  "repeated=#{server_bundle_url}"
+
+                if http_path
+                  stub_http_bundle_failure(failure_message, bundle_url: server_bundle_url)
+                else
+                  stub_local_bundle_failure(failure_message, bundle_path: server_bundle_url)
+                end
+
+                message = bundle_load_error_message
+                expect(message).not_to include("synthetic-user")
+                expect(message).not_to include("synthetic-secret")
+                expect(message).to include(sanitized_url)
+              end
+            end
+          end
+        end
+
+        context "when malformed URL userinfo contains a literal double quote" do
+          it "redacts the escaped URL from the URI error" do
+            server_bundle_url = "http://synthetic-user:sec\"ret@host/path"
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("sec")
+            expect(message).not_to include("ret")
+            expect(message).to include("bad URI")
+            expect(message).to include("host/path")
+          end
+        end
+
+        context "when URI parsing raises another URI::Error subtype" do
+          it "redacts configured credentials through the public entrypoint" do
+            server_bundle_url = "http://synthetic-user:synthetic-secret@host/path"
+            allow(URI).to receive(:parse).and_call_original
+            allow(URI).to receive(:parse).with(server_bundle_url)
+                                         .and_raise(URI::BadURIError, "bad URI for #{server_bundle_url}")
+            stub_http_bundle_failure("connection failed", bundle_url: server_bundle_url)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("bad URI for http://host/path")
+          end
+        end
+
+        context "when a local bundle path contains replacement metacharacters" do
+          it "preserves them literally while redacting credentials from the load error" do
+            server_bundle_path = %q(/tmp/\k<foo>-\1-\&-\0-literal\backslash/server-bundle.js)
+            failure_message = "raw=#{server_bundle_path} inspected=#{server_bundle_path.inspect} " \
+                              "credential=http://synthetic-user:synthetic-secret@host/path"
+            stub_local_bundle_failure(failure_message, bundle_path: server_bundle_path)
+
+            message = bundle_load_error_message
+            expect(message).to include(server_bundle_path)
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("http://host/path")
+            expect(message).to include("react_on_rails@shakacode.com")
+          end
+        end
+
+        context "when a bundle-load failure embeds an unquoted malformed credential URL" do
+          it "fails closed across whitespace in the credential" do
+            failure_message = "Failure loading http://synthetic-user:prefix secret-final@host/path"
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("prefix")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
+          end
+        end
+
+        context "when malformed userinfo looks like a valid host prefix in an ordinary error" do
+          it "does not protect the prefix before the whitespace-delimited credential suffix" do
+            failure_message = "Failure loading http://synthetic-user:123 secret-final@host/path"
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("123")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
+          end
+        end
+
+        context "when an ordinary error has a delayed credential at sign" do
+          [
+            ["multiple intervening words", "http://synthetic-user secret-middle secret-final@host/path",
+             %w[synthetic-user secret-middle secret-final]],
+            ["a quote and whitespace", 'http://synthetic-user" secret-final@host/path',
+             %w[synthetic-user secret-final]],
+            ["a quote and multiple intervening words",
+             'http://synthetic-user" secret-middle secret-final@host/path',
+             %w[synthetic-user secret-middle secret-final]]
+          ].each do |description, malformed_url, credential_fragments|
+            it "redacts credentials after #{description}" do
+              failure_message = "Failure loading #{malformed_url}"
+              stub_http_bundle_failure(failure_message)
+
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("Failure loading http://host/path")
+            end
+          end
+        end
+
+        context "when malformed userinfo in an ordinary error spans line breaks" do
+          [
+            ["LF", "http://synthetic-user\nsynthetic-secret@host/path"],
+            ["CR", "http://synthetic-user\rsynthetic-secret@host/path"],
+            ["CRLF", "http://synthetic-user\r\nsynthetic-secret@host/path"],
+            ["a quote and LF", "http://synthetic-user\"\nsynthetic-secret@host/path"]
+          ].each do |description, malformed_url|
+            it "fails closed across #{description}" do
+              failure_message = "Failure loading #{malformed_url}"
+              stub_local_bundle_failure(failure_message)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("Failure loading http://host/path")
+            end
+          end
+        end
+
+        context "when an ordinary error contains another scheme without whitespace" do
+          nested_scheme_cases.each do |description, nested_urls|
+            it "sanitizes credentials after #{description}" do
+              failure_message = "Failure loading #{nested_urls}"
+              stub_http_bundle_failure(failure_message)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("outer.test/first")
+              expect(message).to include("host/path")
+            end
+          end
+        end
+
+        context "when an ordinary error has an unresolved scheme before a credential URL" do
+          unresolved_prefix_cases.each do |description, nested_urls, credential_fragments|
+            it "fails closed across #{description}" do
+              failure_message = "Failure loading #{nested_urls}"
+              stub_http_bundle_failure(failure_message)
+
+              message = bundle_load_error_message
+              credential_fragments.each { |fragment| expect(message).not_to include(fragment) }
+              expect(message).to include("Failure loading http://host/path")
+            end
+          end
+        end
+
+        context "when an invalid credential URL is followed by a valid URL" do
+          it "redacts the credential and preserves the later URL" do
+            failure_message = "Failure loading http://synthetic-user secret-final@host/path " \
+                              "http://healthy-host/path"
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path http://healthy-host/path")
+          end
+        end
+
+        context "when an ordinary error quotes malformed userinfo across whitespace" do
+          it "redacts the quoted credential while retaining the host and path" do
+            failure_message = 'Failure loading "http://synthetic-user secret-final@host/path"'
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include('Failure loading "http://host/path"')
+          end
+        end
+
+        context "when a quote truncates a malformed credential URL token" do
+          it "does not protect the valid-looking prefix before the double quote" do
+            failure_message = 'Failure loading http://synthetic-user"secret-final@host/path'
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
+          end
+
+          it "does not protect the valid-looking prefix before the single quote" do
+            failure_message = "Failure loading http://synthetic-user'secret-final@host/path"
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("secret-final")
+            expect(message).to include("Failure loading http://host/path")
+          end
+        end
+
+        context "when a bundle-load failure embeds a valid URL with an at sign in its path" do
+          it "preserves the URL because it has no userinfo" do
+            failure_message = "Failure loading http://host/path@example"
+            stub_http_bundle_failure(failure_message)
+
+            expect(bundle_load_error_message).to include(failure_message)
+          end
+        end
+
+        context "when a bundle-load failure contains two valid URLs" do
+          it "preserves both URLs, including an at sign in the second URL's path" do
+            failure_message = "Failure loading http://first-host/path http://second-host/path@example"
+            stub_http_bundle_failure(failure_message)
+
+            expect(bundle_load_error_message).to include(failure_message)
+          end
+        end
+
+        context "when a line boundary precedes an ambiguous email at sign" do
+          [["LF", "\n"], ["CR", "\r"], ["CRLF", "\r\n"]].each do |description, boundary|
+            it "fails closed across #{description}" do
+              failure_message = "Failure loading http://host/path#{boundary}contact dev@example.com"
+              stub_http_bundle_failure(failure_message)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("host/path")
+              expect(message).not_to include("contact dev")
+              expect(message).to include("Failure loading http://example.com")
+            end
+          end
+        end
+
+        context "when multiline error text contains a later URL scheme" do
+          it "redacts malformed multiline userinfo without consuming the later URL" do
+            failure_message = "Failure loading http://synthetic-user\nsynthetic-secret@host/path\n" \
+                              "hTtPs://healthy-host/path@example"
+            stub_local_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("Failure loading http://host/path\nhTtPs://healthy-host/path@example")
+          end
+
+          it "fails closed before the later scheme while preserving that separate URL" do
+            failure_message = "Failure loading http://first-host/path\ncontact dev@example.com\n" \
+                              "HTTP://second-host/path"
+            stub_local_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("first-host/path")
+            expect(message).not_to include("contact dev")
+            expect(message).to include("Failure loading http://example.com\nHTTP://second-host/path")
+          end
+
+          it "discards an unresolved multiline region before sanitizing the next credential URL" do
+            failure_message = "Failure loading http://synthetic-user:nonnumeric-prefix\nsynthetic-tail " \
+                              "HtTpS://synthetic-secret@host/path"
+            stub_local_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("synthetic-user")
+            expect(message).not_to include("nonnumeric-prefix")
+            expect(message).not_to include("synthetic-tail")
+            expect(message).not_to include("synthetic-secret")
+            expect(message).to include("Failure loading https://host/path")
+          end
+        end
+
+        context "when a valid-looking URL is followed by prose containing an email address" do
+          it "fails closed because no structural boundary separates the later at sign" do
+            failure_message = "Failure loading http://host/path; contact dev@example.com"
+            stub_http_bundle_failure(failure_message)
+
+            message = bundle_load_error_message
+            expect(message).not_to include("host/path")
+            expect(message).not_to include("contact dev")
+            expect(message).to include("Failure loading http://example.com")
+          end
+        end
+
+        context "when a bundle-load failure contains non-URL double-slash text" do
+          it "preserves the arbitrary message text" do
+            failure_message = "// contact dev@example"
+            stub_http_bundle_failure(failure_message)
+
+            expect(bundle_load_error_message).to include(failure_message)
           end
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -466,6 +466,42 @@ module ReactOnRails
               "http : %2F%2Fhost/path"
             ],
             [
+              "whitespace before an encoded colon and encoded authority separators",
+              "http %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "http %3A%2F%2Fhost/path"
+            ],
+            [
+              "a partially encoded HTTP scheme before a whitespace-delimited encoded colon",
+              "h%74tp %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "h%74tp %3A%2F%2Fhost/path"
+            ],
+            [
+              "an encoded whitespace token before an internal HTTP scheme",
+              "%20http %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "%20http %3A%2F%2Fhost/path"
+            ],
+            [
+              "encoded text and a boundary token before an internal HTTP scheme",
+              "%61%3Dhttp %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "%61%3Dhttp %3A%2F%2Fhost/path"
+            ],
+            [
+              "invalid percent text and a boundary before a partially encoded HTTP scheme",
+              "%GG%20h%74tp %3A/%2Fsynthetic-user:synthetic-secret@host/path",
+              false,
+              "%GG%20h%74tp %3A/%2Fhost/path"
+            ],
+            [
+              "an internal HTTP scheme after an encoded boundary in an outer URL",
+              "http://outer.test/path?next=%61%20http %3A%2F%2Fnested-user:nested-secret%40nested.test/path",
+              true,
+              "http://outer.test/path?next=%61%20http %3A%2F%2Fnested.test/path"
+            ],
+            [
               "whitespace before fully encoded authority separators",
               "http: %2F%2Fsynthetic-user:synthetic-secret%40host/path",
               false,
@@ -482,6 +518,36 @@ module ReactOnRails
               "http: %2F/synthetic-user:synthetic-secret%40host/path",
               false,
               "http: %2F/host/path"
+            ],
+            [
+              "whitespace between encoded authority separators",
+              "http:%2F %2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "http:%2F %2Fhost/path"
+            ],
+            [
+              "encoded whitespace before encoded authority separators",
+              "http:%20%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "http:%20%2F%2Fhost/path"
+            ],
+            [
+              "encoded whitespace between encoded authority separators",
+              "http:%2F%20%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "http:%2F%20%2Fhost/path"
+            ],
+            [
+              "mixed literal and encoded whitespace around mixed authority separators",
+              "h%74tp \t%20%3A%0A/%09%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "h%74tp \t%20%3A%0A/%09%2Fhost/path"
+            ],
+            [
+              "encoded then literal whitespace before an encoded colon",
+              "%68%74%74%70%20 %3A%2F%2Fsynthetic-user:synthetic-secret%40host/path",
+              false,
+              "%68%74%74%70%20 %3A%2F%2Fhost/path"
             ],
             [
               "a percent-encoded authority delimiter",

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -460,6 +460,18 @@ module ReactOnRails
               "http ://host/path"
             ],
             [
+              "a percent-encoded authority delimiter",
+              "http://bundle-user:synthetic-password%40host/bundle.js",
+              true,
+              "http://host/bundle.js"
+            ],
+            [
+              "mixed encoded and literal authority delimiters",
+              "http://synthetic-user%40mail:synthetic-secret@host/path",
+              true,
+              "http://host/path"
+            ],
+            [
               "whitespace after a bare authority marker",
               "// synthetic-user:synthetic-secret@host/path",
               false,
@@ -552,6 +564,12 @@ module ReactOnRails
               "http://synthetic-user:nonnumeric-prefixhttp://synthetic-secret@host/path",
               true,
               "http://host/path"
+            ],
+            [
+              "credential-like text before a later HTTP URL",
+              "synthetic-user:synthetic-secret@host http://actual-host/path",
+              false,
+              "host http://actual-host/path"
             ]
           ].each do |description, configured_value, http_path, expected|
             it "redacts #{description}" do
@@ -562,7 +580,7 @@ module ReactOnRails
               end
 
               message = bundle_load_error_message
-              expect(message).not_to match(/(?:synthetic|nested)-(?:user|secret)/)
+              expect(message).not_to match(/(?:synthetic|nested|bundle)-(?:user|secret|password)/)
               expect(message).to include(expected)
             end
           end

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -482,6 +482,18 @@ module ReactOnRails
 
             expect(bundle_load_error_message).to include(server_bundle_path)
           end
+
+          [" ", "URL="].each do |prefix|
+            it "redacts credentials when #{prefix.inspect} precedes the authority marker" do
+              server_bundle_path = "#{prefix}//bundle-user:synthetic-password@host/bundle.js"
+              stub_local_bundle_failure(Errno::ENOENT.new(server_bundle_path), bundle_path: server_bundle_path)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("bundle-user")
+              expect(message).not_to include("synthetic-password")
+              expect(message).to include("#{prefix}//host/bundle.js")
+            end
+          end
         end
 
         context "when malformed URL userinfo contains multiple at signs" do
@@ -731,6 +743,20 @@ module ReactOnRails
           end
         end
 
+        context "when a bundle-load failure embeds credentials in a non-HTTP URL" do
+          %w[postgres redis ftp mongodb].each do |scheme|
+            it "redacts credentials from the #{scheme} URL" do
+              failure_message = "Failure loading #{scheme}://synthetic-user:synthetic-secret@host/path"
+              stub_http_bundle_failure(failure_message)
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("Failure loading #{scheme}://host/path")
+            end
+          end
+        end
+
         context "when malformed userinfo looks like a valid host prefix in an ordinary error" do
           it "does not protect the prefix before the whitespace-delimited credential suffix" do
             failure_message = "Failure loading http://synthetic-user:123 secret-final@host/path"
@@ -949,6 +975,22 @@ module ReactOnRails
             expect(message).not_to include("synthetic-user")
             expect(message).not_to include("synthetic-secret")
             expect(message).to include("Failure loading //host/path")
+          end
+
+          [
+            ["whitespace", "//synthetic-user synthetic-secret@host/path"],
+            ["a quote", '//synthetic-user" synthetic-secret@host/path'],
+            ["an LF line break", "//synthetic-user\nsynthetic-secret@host/path"],
+            ["a CRLF line break", "//synthetic-user\r\nsynthetic-secret@host/path"]
+          ].each do |description, malformed_url|
+            it "fails closed when authority-relative userinfo spans #{description}" do
+              stub_local_bundle_failure("Failure loading #{malformed_url}")
+
+              message = bundle_load_error_message
+              expect(message).not_to include("synthetic-user")
+              expect(message).not_to include("synthetic-secret")
+              expect(message).to include("Failure loading //host/path")
+            end
           end
         end
 

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1467,12 +1467,10 @@ module ReactOnRailsProHelper
     error_signal = rsc_payload_rendering_error_signal?(metadata)
     return metadata unless error_signal || metadata.key?("renderingError")
 
-    redacted = metadata.except("renderingError")
-    # Preserve a generic failure signal so client error boundaries still fire. `hasErrors` is
-    # forced true when only a non-blank message/stack indicated the failure, matching the
-    # inline path's redacted branch.
-    redacted["hasErrors"] = true if error_signal
-    redacted
+    # Match the inline path's production allowlist exactly. Error chunks may carry sensitive
+    # details in console replay or future metadata fields, so forwarding every field except the
+    # known renderingError key would fail open as the producer evolves.
+    { "hasErrors" => error_signal }
   end
 
   def rsc_payload_rendering_error_signal?(metadata)

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1474,7 +1474,11 @@ module ReactOnRailsProHelper
   end
 
   def rsc_payload_rendering_error_signal?(metadata)
-    return true if metadata["hasErrors"] == true
+    if metadata.key?("hasErrors")
+      has_errors = metadata["hasErrors"]
+      return true unless [true, false].include?(has_errors)
+      return true if has_errors
+    end
 
     rendering_error = metadata["renderingError"]
     return false unless rendering_error.is_a?(Hash)

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1480,11 +1480,20 @@ module ReactOnRailsProHelper
       return true if has_errors
     end
 
+    return false unless metadata.key?("renderingError")
+
     rendering_error = metadata["renderingError"]
-    return false unless rendering_error.is_a?(Hash)
+    return true if malformed_rsc_rendering_error?(rendering_error)
 
     non_blank_rsc_metadata_string?(rendering_error["message"]) ||
       non_blank_rsc_metadata_string?(rendering_error["stack"])
+  end
+
+  def malformed_rsc_rendering_error?(rendering_error)
+    return true unless rendering_error.is_a?(Hash)
+
+    diagnostic_fields = rendering_error.slice("message", "stack")
+    diagnostic_fields.empty? || diagnostic_fields.any? { |_key, value| !value.is_a?(String) }
   end
 
   def non_blank_rsc_metadata_string?(value)

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1467,6 +1467,10 @@ module ReactOnRailsProHelper
     error_signal = rsc_payload_rendering_error_signal?(metadata)
     return metadata unless error_signal || metadata.key?("renderingError")
 
+    # A structurally valid blank renderingError is not an error. Remove that inert server-only
+    # object, but preserve clean-chunk metadata such as console replay.
+    return metadata.except("renderingError") unless error_signal
+
     # Match the inline path's production allowlist exactly. Error chunks may carry sensitive
     # details in console replay or future metadata fields, so forwarding every field except the
     # known renderingError key would fail open as the producer evolves.

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -862,6 +862,22 @@ describe ReactOnRailsProHelper do
       expect(wire).not_to include("Auth.server.tsx")
     end
 
+    it "fails closed in production when hasErrors is not boolean" do
+      stub_rails_env("production")
+      malformed_metadata = {
+        "hasErrors" => "true",
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" },
+        "html" => "payload"
+      }
+
+      wire = framed_wire_bytes(malformed_metadata)
+
+      expect(wire).to eq("{\"hasErrors\":true}\t00000007\npayload")
+      expect(wire).not_to include(synthetic_console_replay_script)
+      expect(wire).not_to include("Auth.server.tsx")
+    end
+
     it "leaves a clean production chunk untouched" do
       stub_rails_env("production")
 

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -878,6 +878,38 @@ describe ReactOnRailsProHelper do
       expect(wire).not_to include("Auth.server.tsx")
     end
 
+    it "fails closed in production for malformed renderingError shapes" do
+      stub_rails_env("production")
+      [{}, nil, "malformed"].each do |rendering_error|
+        malformed_metadata = {
+          "hasErrors" => false,
+          "renderingError" => rendering_error,
+          "consoleReplayScript" => synthetic_console_replay_script,
+          "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" },
+          "html" => "payload"
+        }
+
+        wire = framed_wire_bytes(malformed_metadata)
+
+        aggregate_failures(rendering_error.inspect) do
+          expect(wire).to eq("{\"hasErrors\":true}\t00000007\npayload")
+          expect(wire).not_to include(synthetic_console_replay_script)
+          expect(wire).not_to include("Auth.server.tsx")
+        end
+      end
+    end
+
+    it "does not promote well-formed blank renderingError metadata to an error" do
+      stub_rails_env("production")
+      blank_rendering_error = { "message" => "   ", "stack" => "" }
+
+      wire = framed_wire_bytes(
+        "hasErrors" => false, "renderingError" => blank_rendering_error, "html" => "payload"
+      )
+
+      expect(wire).to eq("{\"hasErrors\":false}\t00000007\npayload")
+    end
+
     it "leaves a clean production chunk untouched" do
       stub_rails_env("production")
 

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -755,6 +755,9 @@ describe ReactOnRailsProHelper do
     let(:synthetic_stack) do
       "Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)"
     end
+    let(:synthetic_console_replay_script) do
+      'console.error("RSC fetch failed for User 48213 at /app/components/Auth.server.tsx:12:5")'
+    end
     let(:rendering_error) { { "message" => synthetic_message, "stack" => synthetic_stack } }
     let(:error_chunk) do
       { "hasErrors" => true, "renderingError" => rendering_error, "html" => "payload" }
@@ -803,6 +806,30 @@ describe ReactOnRailsProHelper do
       expect(wire).not_to include("Auth.server.tsx")
     end
 
+    it "allowlists only a generic error signal in production browser metadata" do
+      stub_rails_env("production")
+      server_metadata = error_chunk.merge(
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" }
+      )
+      seen_by_server = nil
+
+      wire = framed_wire_bytes(server_metadata) do |chunk|
+        seen_by_server = chunk
+        chunk
+      end
+
+      expect(wire).to eq("{\"hasErrors\":true}\t00000007\npayload")
+      expect(wire).not_to include(synthetic_message)
+      expect(wire).not_to include("/srv/private/Auth.server.tsx")
+      expect(wire).not_to include(synthetic_console_replay_script)
+      expect(seen_by_server).to include(
+        "renderingError" => rendering_error,
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" }
+      )
+    end
+
     it "redacts renderingError in non-development/test environments like staging" do
       stub_rails_env("staging")
 
@@ -843,14 +870,16 @@ describe ReactOnRailsProHelper do
       expect(wire).to eq("{\"hasErrors\":false}\t00000007\npayload")
     end
 
-    it "includes the full renderingError in development" do
+    it "includes full error and console diagnostics in development" do
       stub_rails_env("development")
 
-      wire = framed_wire_bytes(error_chunk)
+      wire = framed_wire_bytes(error_chunk.merge("consoleReplayScript" => synthetic_console_replay_script))
+      metadata = JSON.parse(wire.split("\t", 2).first)
 
       expect(wire).to include("renderingError")
       expect(wire).to include(synthetic_message)
       expect(wire).to include("Auth.server.tsx")
+      expect(metadata["consoleReplayScript"]).to eq(synthetic_console_replay_script)
     end
 
     it "includes the full renderingError in test" do

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -880,7 +880,15 @@ describe ReactOnRailsProHelper do
 
     it "fails closed in production for malformed renderingError shapes" do
       stub_rails_env("production")
-      [{}, nil, "malformed"].each do |rendering_error|
+      malformed_rendering_errors = [
+        {},
+        nil,
+        "malformed",
+        { "message" => nil },
+        { "stack" => [] },
+        { "message" => "private failure", "stack" => 1 }
+      ]
+      malformed_rendering_errors.each do |rendering_error|
         malformed_metadata = {
           "hasErrors" => false,
           "renderingError" => rendering_error,
@@ -904,10 +912,19 @@ describe ReactOnRailsProHelper do
       blank_rendering_error = { "message" => "   ", "stack" => "" }
 
       wire = framed_wire_bytes(
-        "hasErrors" => false, "renderingError" => blank_rendering_error, "html" => "payload"
+        "hasErrors" => false,
+        "renderingError" => blank_rendering_error,
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "html" => "payload"
       )
+      metadata = JSON.parse(wire.split("\t", 2).first)
 
-      expect(wire).to eq("{\"hasErrors\":false}\t00000007\npayload")
+      expect(metadata).to eq(
+        "hasErrors" => false,
+        "consoleReplayScript" => synthetic_console_replay_script
+      )
+      expect(wire).to end_with("\t00000007\npayload")
+      expect(wire).not_to include("renderingError")
     end
 
     it "leaves a clean production chunk untouched" do


### PR DESCRIPTION
## Why

`release/17.1.0` carried security fixes from PRs #4845 and #4856 that had no equivalent on `main`. Because 17.1.0 is being re-cut from `main`, omitting them would restore renderer-error and diagnostic-URL disclosure paths that the release gate in #4842 treats as pre-RC blockers.

This forward-port keeps those fixes on the mainline and incorporates the security and correctness hardening found during current-branch review.

Fixes #4825. Fixes #4822. Fixes #4827.

## What changed

- Forward-ports the production RSC payload protections from PRs #4845 and #4856.
- Keeps production payloads free of renderer error details while retaining server-side diagnostics and development/test behavior.
- Treats malformed renderer-error metadata conservatively so console replay cannot expose production diagnostics, while still emitting a generic error signal.
- Centralizes configured-value and exception-message URL redaction in `ReactOnRails::DiagnosticUrlRedactor`.
- Redacts valid, malformed, authority-relative, nested, literal, encoded, delimiter-spanning, multiple-marker, and invalid-encoding credential forms without rewriting safe path/query data or independent safe double-slash spans.
- Replaces the CodeQL-reported backtracking expression with a bounded streaming scan and covers large multibyte input.
- Updates the changelog while preserving the unrelated #4833 ShakaPerf entry from `main`.

## Current-head review remediation (`025eb0a`)

Five review threads were open on the previous head. Each claim was reproduced against the
real code before being acted on; four were confirmed real leaks and are fixed, and a fifth
of the same class was found by a literal/encoded parity sweep and fixed too.

| # | Finding | Source | Status |
|---|---|---|---|
| 1 | Encoded authority terminator before an encoded userinfo delimiter (`http:%2F%2Fuser:pass%2Fseg%40host/x`) returned the credential unchanged | Codex P1 | Fixed |
| 2 | Encoded / mixed authority-relative start (`%2F%2Fuser:pass%40host/x`, `/%2F...`) invisible to the literal `//` marker scan | Codex P1 | Fixed |
| 3 | `sanitized_unprotected_prefix` returned the kept prefix verbatim, leaking a bare `//user:pass@host` in it | Claude | Fixed |
| 4 | Prose path recognized only literal `//` authority starts, so encoded bare authorities leaked in exception text | Found by parity sweep | Fixed |
| 5 | An all-numeric password survived where a non-numeric one was redacted, because a `:digits` suffix was read as a port | Codex P1 (on my first fix) | Fixed |
| 6 | `sanitize` sentinel-default mode dispatch is a footgun | Claude (Minor) | Deferred to #4988, with evidence it cannot leak |

The unifying rule: **an encoded spelling must redact exactly where its literal spelling
redacts.** Findings 1-4 were all cases where the literal form already failed closed but the
percent-encoded form did not. Finding 5 is the same principle applied to ports: every value
reaching the encoded path has an encoded authority separator, so `URI` cannot parse it and
nothing proves a `:digits` run is a port rather than a numeric password. The port exemption
is therefore removed on that path, so redaction never depends on whether a password happens
to be all digits. The literal path keeps its port handling, where `URI.parse` supplies the
proof (`//bundle-user:1234/segment@host/x` parses to host `bundle-user`, port `1234`,
userinfo `nil` -- no credential), which was verified by direct `URI` inspection. Encoded authorities are now only trusted as a boundary when
they are a plausible `host[:port]`; otherwise the value fails closed through its final
userinfo delimiter, matching the literal rule. Safe encoded path/query/fragment data is
deliberately left intact.

Four spec expectations that asserted encoded spellings were preserved while their literal
spellings were redacted are updated: **those inputs now redact.** Each is replaced with an
equivalent safe value plus an explicit literal/encoded parity assertion, so the original
intent (scheme rejection, invalid percent prefixes) is still covered.

The encoded-authority rules and `EncodedNetworkUrlRewriter` move to
`diagnostic_url_redactor/encoded_authority_redactor.rb`, matching the existing
`authority_relative_rewriter.rb` extraction and keeping both files inside the RuboCop
length limits. No behavior change from the extraction.

## Design notes

- Configured URL values and free-form exception prose intentionally keep separate fail-closed policies: configured values have a single-value contract, while prose must preserve unrelated diagnostic context around independently parseable URLs.
- Exhaustive sanitizer permutations live in the direct `DiagnosticUrlRedactor` spec. The renderer spec retains focused public-entry regression coverage for historically confirmed bypasses.
- Unexpected production error metadata is handled fail-closed: console replay is suppressed and only a generic client-visible error signal is emitted.

## Verification

### This round (head `025eb0a`, run locally)

- Focused sanitizer suites: **241 examples, 0 failures** (`bundle exec rspec spec/react_on_rails/diagnostic_url_redactor_spec.rb spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb`)
- TDD: all five leaks reproduced red first, then green after the fix
- Numeric/non-numeric port parity sweep: **4,032 shapes**, zero cases where an unparseable value keeps a numeric password; every remaining difference is a `URI`-proven `host:port`, confirmed by direct `URI.parse` inspection
- Literal/encoded parity fuzz: **9,504 checks** across configured / prose / error-with-configured-URL paths over every spelling of the two slashes, scheme colon, and userinfo delimiter — **0 leaks**; safe path/query/fragment controls **0 rewrites** (no over-redaction)
- New bounded-time regression for repeated bare `//` markers (2 and 4,000 repetitions, ~0.08s), closing the last uncovered ReDoS scan shape
- RSC payload Jest specs: **92 passed, 92 total**
- RuboCop (root config, covers OSS + Pro): **605 files, 0 offenses**; Pro file coverage confirmed at 254 files
- Rebased cleanly onto `main` (`e7734590`), 0 behind

### Prior rounds (earlier heads, carried forward)

- Permanent separator coverage: 15,795 literal/encoded separator compositions, 288 ordered mixed-whitespace inputs, and 1,280 encoded-boundary inputs across configured/error paths
- Generated multiple-marker invariant matrix: 72/72; encoded/nested adversarial matrices: 64/64, 48/48, 5,000/5,000
- Scanner equivalence: 400,008 deterministic cases / 1,200,024 checks match the former regex semantics with monotone, disjoint spans
- Independent sanitized security audit: CLEAN for the then-current commit tree; 1,347,840 scanner checks, 300,000 public-path checks, 144,775 multibyte/multiple-URL invariants
- OSS and Pro RBS validation, workspace ESLint, Prettier, TypeScript checks passed; Pro license headers current

### Not run locally

- Full OSS gem suite (`spec/react_on_rails`) — exceeded the local 10-minute budget; deferred to hosted CI. My diff touches only `DiagnosticUrlRedactor`, whose two dependent suites are green above.
- `markdown-link-check` failed on the previous head against **unchanged** docs outside this PR's diff (one TanStack HTTP 500, two stale Rspack 404s). Not introduced here.

## Labels

`Labels: ready-for-hosted-ci` — security-relevant library change to the OSS gem with a
behavior change in redaction output, so it warrants remote confirmation beyond the required
gate rather than local validation alone. `Benchmarks: not applicable` (no server-rendering,
pooling, or asset-path behavior touched).

## Merge qualification

- **Release-mode gate**: tracker #4842 records `Mode: strict-rc`. Per AGENTS.md → Release Mode And Auto-Merge Coordination, strict-rc applies the standard merge qualification in the Review Workflow section; the accelerated-RC confidence block, auto-merge threshold, and independent-finalizer requirement do not apply.
- This PR closes all three of the tracker's Pre-RC.0 blockers (#4825, #4827, #4822).

```text
Confidence note:
- Validated: 241/241 focused sanitizer examples; 92/92 RSC payload Jest; RuboCop 605 files 0 offenses; 9,504-case literal/encoded parity fuzz with 0 leaks and 0 safe-control rewrites; 4 leaks reproduced red before fix; clean rebase onto main e7734590
- Evidence: inline above; per-finding reproduction and reasoning in the five resolved review threads; deferred API item in #4988
- UNKNOWN: full OSS gem suite not run locally (local time budget) — delegated to hosted CI on this head SHA
- Residual risk: a fully encoded value carrying a genuine port and a later encoded @ (e.g. `http:%2F%2Fhost:3000%2Fpath%40asset`) now loses its authority and path, the documented tradeoff for structurally unparseable values; redaction output is intentionally more aggressive for encoded bare authorities than before, so a diagnostic containing an encoded "//" followed by a colon-or-@ authority now loses that authority's userinfo; safe path/query/fragment data is unaffected (0 rewrites across the safe-control sweep)
```

Current head SHA: `e24f465f22de33fdb2cd09b67c20e75cdbf08f02`

