### PR TITLE
Preserve merge queue submission policy

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -2,7 +2,7 @@
 # Commands live as scripts in .agents/bin/ (see .agents/bin/README.md).
 base_branch: main
 merge_submission:
-  mode: direct
+  mode: merge_queue_only
 hosted_ci_trigger: "+ci-* PR-comment commands (+ci-status, +ci-run-hosted, +ci-force-full, +ci-stop-hosted, +ci-stop-full, +ci-skip-hosted [reason], +ci-help); labels ready-for-hosted-ci and force-full-hosted-ci; human helper bin/request-hosted-ci. Decision rules in the Review Workflow PR CI Labels section."
 ci_change_detector: "script/ci-changes-detector origin/main (or .agents/bin/ci-detect with an optional base ref) to inspect optimized suite routing."
 ci_parity_environment: "No dedicated act/local runner image; use bin/ci-local and script/ci-changes-detector origin/main for routing, then reproduce CI-only failures from the exact .github/workflows/** job (runs-on image, matrix, services, commands); record gaps as UNKNOWN."

--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,6 +1,8 @@
 # Non-command agent-workflow configuration for portable shared skills.
 # Commands live as scripts in .agents/bin/ (see .agents/bin/README.md).
 base_branch: main
+merge_submission:
+  mode: direct
 hosted_ci_trigger: "+ci-* PR-comment commands (+ci-status, +ci-run-hosted, +ci-force-full, +ci-stop-hosted, +ci-stop-full, +ci-skip-hosted [reason], +ci-help); labels ready-for-hosted-ci and force-full-hosted-ci; human helper bin/request-hosted-ci. Decision rules in the Review Workflow PR CI Labels section."
 ci_change_detector: "script/ci-changes-detector origin/main (or .agents/bin/ci-detect with an optional base ref) to inspect optimized suite routing."
 ci_parity_environment: "No dedicated act/local runner image; use bin/ci-local and script/ci-changes-detector origin/main for routing, then reproduce CI-only failures from the exact .github/workflows/** job (runs-on image, matrix, services, commands); record gaps as UNKNOWN."


### PR DESCRIPTION
### Summary

Explicitly declare `merge_submission.mode: merge_queue_only` in the repository agent-workflow seam.

The `main` branch has GitHub Merge Queue enabled. This policy keeps agent merge submission on that queue and fails closed if queue submission is unavailable. It changes only agent policy YAML; it does not change GitHub Merge Queue or any repository setting.

### Pull Request checklist

- [x] ~~Add/update test to cover these changes~~ — policy-only YAML; validated by YAML parsing and both seam doctors
- [x] ~~Update documentation~~ — the seam declaration is the configuration documentation
- [x] ~~Update CHANGELOG file~~ — internal maintainer workflow, not user-visible

### Validation

- Ruby YAML parse and exact `merge_submission.mode=merge_queue_only` assertion — PASS
- merged source `bin/agent-workflow-seam-doctor --root ... --shared ...` — PASS
- repository-pinned `.agents/bin/agent-workflow-seam-doctor --shared ...` — PASS
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` — PASS (250 files, no offenses)
- `git diff --check` — PASS
- `script/ci-changes-detector origin/main` — conservatively routes `.agents/**` to the full hosted suite

### Other Information

- Scope: one YAML file; two added policy lines relative to `main`
- Benchmarks: not applicable
- Labels: `ready-for-hosted-ci` after the final review-fix push because the repository CI detector treats `.agents/**` as generator-sensitive

<details>
<summary>Agent details</summary>

Prepared by Codex from live `main`. The final policy choice was verified against GitHub GraphQL: Merge Queue is enabled for the PR base branch.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated submission handling to use the merge queue exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->