### PR TITLE
[Pro] Protocol cleanup: drop targetBundles and wire request digest (#4873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Changed
+
+- **[Pro] BREAKING: Protocol version bumped to 3.0.0 — removes two wire-protocol legacies**:
+  The `targetBundles` field is no longer sent on `/upload-assets` requests; the node renderer now derives bundle
+  directories from `bundle_<hash>` form keys on that endpoint (the pattern already used by `/render`).
+  `/asset-exists` still uses the `targetBundles` array — it sends bundle hashes, not files, so an explicit array
+  is the right JSON idiom. The `renderRequestDigest` URL segment has been removed from render and
+  incremental-render routes, and the MD5 digest is now computed only when prerender caching is enabled (previously
+  computed on every render). The gem and node renderer must be upgraded together.
+  [Issue 4873](https://github.com/shakacode/react_on_rails/issues/4873).
+  [PR 4875](https://github.com/shakacode/react_on_rails/pull/4875) by
+  [AbanoubGhadban](https://github.com/AbanoubGhadban).
+
 #### Fixed
 
 - **[Pro]** **RSC render-error details are no longer sent to the browser on the fetched payload path**:

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -111,7 +111,7 @@ end
 # Returns true/false/nil (nil means couldn't determine)
 # rubocop:disable Style/ReturnNilInPredicateMethodDefinition
 def rsc_bundle?(bundle_timestamp)
-  url = render_url(bundle_timestamp, "rsc_check")
+  url = render_url(bundle_timestamp)
   body = render_body("ReactOnRails.isRSCBundle")
 
   # Use curl with h2c since Net::HTTP doesn't support HTTP/2
@@ -159,9 +159,9 @@ def categorize_bundles(bundles)
   [rsc_bundle, non_rsc_bundle]
 end
 
-# Build render URL for a bundle and render name
-def render_url(bundle_timestamp, render_name)
-  "http://#{BASE_URL}/bundles/#{bundle_timestamp}/render/#{render_name}"
+# Build render URL for a bundle
+def render_url(bundle_timestamp)
+  "http://#{BASE_URL}/bundles/#{bundle_timestamp}/render"
 end
 
 # Build request body for a rendering request
@@ -370,7 +370,7 @@ def run_vegeta_benchmark(test_case, bundle_timestamp, shard_count: LOAD_GENERATO
 
   puts "\n===> Vegeta h2c: #{name}"
 
-  target_url = render_url(bundle_timestamp, name)
+  target_url = render_url(bundle_timestamp)
   body = render_body(request)
 
   # Create temp files for Vegeta

--- a/docs/oss/deployment/security-model-and-hardening.md
+++ b/docs/oss/deployment/security-model-and-hardening.md
@@ -113,13 +113,13 @@ them to render components. This is its purpose, not a flaw — but it has a dire
 Concretely, the worker exposes these HTTP endpoints
 (`packages/react-on-rails-pro-node-renderer/src/worker.ts`):
 
-| Endpoint                                                                 | Auth                                                     | Purpose                                                     |
-| ------------------------------------------------------------------------ | -------------------------------------------------------- | ----------------------------------------------------------- |
-| `POST /bundles/:bundleTimestamp/render/:renderRequestDigest`             | password (via `performRequestPrechecks`)                 | Evaluate a rendering request; may also carry bundle uploads |
-| `POST /bundles/:bundleTimestamp/incremental-render/:renderRequestDigest` | password (via `performRequestPrechecks`)                 | Streaming/incremental rendering                             |
-| `POST /upload-assets`                                                    | password (via `performRequestPrechecks`)                 | Upload server bundles and assets                            |
-| `POST /asset-exists`                                                     | password (via `authenticate`, no protocol-version check) | Check whether an uploaded asset exists                      |
-| `GET /info`                                                              | **none**                                                 | Returns `node_version` and `renderer_version`               |
+| Endpoint                                            | Auth                                                     | Purpose                                                     |
+| --------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------- |
+| `POST /bundles/:bundleTimestamp/render`             | password (via `performRequestPrechecks`)                 | Evaluate a rendering request; may also carry bundle uploads |
+| `POST /bundles/:bundleTimestamp/incremental-render` | password (via `performRequestPrechecks`)                 | Streaming/incremental rendering                             |
+| `POST /upload-assets`                               | password (via `performRequestPrechecks`)                 | Upload server bundles and assets                            |
+| `POST /asset-exists`                                | password (via `authenticate`, no protocol-version check) | Check whether an uploaded asset exists                      |
+| `GET /info`                                         | **none**                                                 | Returns `node_version` and `renderer_version`               |
 
 Note for reviewers: unlike the other authenticated endpoints, `/asset-exists` calls `authenticate`
 directly rather than through `performRequestPrechecks`, so it skips the protocol-version check — a

--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-on-rails-pro-node-renderer",
   "version": "17.0.0-rc.6",
-  "protocolVersion": "2.0.0",
+  "protocolVersion": "3.0.0",
   "description": "React on Rails Pro Node Renderer for server-side rendering",
   "engines": {
     "node": ">=18.19.0"

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -761,14 +761,11 @@ export default function run(config: Partial<Config>) {
     done(null, payload);
   });
 
-  // See https://github.com/shakacode/react_on_rails_pro/issues/119 for why
-  // the digest is part of the request URL. Yes, it's not used here, but the
-  // server logs might show it to distinguish different requests.
   app.post<{
     Body: WithBodyArrayField<Record<string, unknown>, 'dependencyBundleTimestamps'>;
     // Can't infer from the route like Express can
-    Params: { bundleTimestamp: string; renderRequestDigest: string };
-  }>('/bundles/:bundleTimestamp/render/:renderRequestDigest', async (req, res) => {
+    Params: { bundleTimestamp: string };
+  }>('/bundles/:bundleTimestamp/render', async (req, res) => {
     if (req.uploadAuthenticationError) {
       await setResponse(req.uploadAuthenticationError, res);
       return;
@@ -866,8 +863,8 @@ export default function run(config: Partial<Config>) {
 
   // Streaming NDJSON incremental render endpoint
   app.post<{
-    Params: { bundleTimestamp: string; renderRequestDigest: string };
-  }>('/bundles/:bundleTimestamp/incremental-render/:renderRequestDigest', async (req, res) => {
+    Params: { bundleTimestamp: string };
+  }>('/bundles/:bundleTimestamp/incremental-render', async (req, res) => {
     const { bundleTimestamp } = req.params;
 
     // Stream parser state

--- a/packages/react-on-rails-pro-node-renderer/tests/healthEndpoints.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/healthEndpoints.test.ts
@@ -50,7 +50,7 @@ const renderWithBundle = async (app: ReturnType<typeof createWorker>) => {
   });
   return app
     .inject()
-    .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+    .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
     .payload(form.payload)
     .headers(form.headers)
     .end();

--- a/packages/react-on-rails-pro-node-renderer/tests/htmlStreaming.test.js
+++ b/packages/react-on-rails-pro-node-renderer/tests/htmlStreaming.test.js
@@ -109,7 +109,7 @@ const makeRequest = async (options = {}) => {
   const client = http2.connect(`http://localhost:${port}`);
   const request = client.request({
     ':method': 'POST',
-    ':path': `/bundles/${SERVER_BUNDLE_TIMESTAMP}/render/454a82526211afdb215352755d36032c`,
+    ':path': `/bundles/${SERVER_BUNDLE_TIMESTAMP}/render`,
     'content-type': `multipart/form-data; boundary=${form.getBoundary()}`,
   });
   request.setEncoding('utf8');

--- a/packages/react-on-rails-pro-node-renderer/tests/httpRequestUtils.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/httpRequestUtils.ts
@@ -110,8 +110,6 @@ export const createForm = ({
 
 export const createUploadAssetsForm = (options: Partial<RequestOptions> = {}) => {
   const requestForm = createForm(options);
-  requestForm.append('targetBundles[]', SERVER_BUNDLE_TIMESTAMP);
-  requestForm.append('targetBundles[]', RSC_BUNDLE_TIMESTAMP);
   return requestForm;
 };
 
@@ -134,7 +132,7 @@ export const makeRequest = (app: ReturnType<typeof buildApp>, options: Partial<R
   const usedBundleTimestamp = options.renderRscPayload ? RSC_BUNDLE_TIMESTAMP : SERVER_BUNDLE_TIMESTAMP;
   const request = client.request({
     ':method': 'POST',
-    ':path': `/bundles/${usedBundleTimestamp}/render/454a82526211afdb215352755d36032c`,
+    ':path': `/bundles/${usedBundleTimestamp}/render`,
     'content-type': `multipart/form-data; boundary=${form.getBoundary()}`,
   });
   const buffer: Buffer[] = [];

--- a/packages/react-on-rails-pro-node-renderer/tests/incrementalHtmlStreaming.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/incrementalHtmlStreaming.test.ts
@@ -41,12 +41,12 @@ afterAll(async () => {
 
 jest.spyOn(errorReporter, 'message').mockImplementation(jest.fn());
 
-const createHttpRequest = (bundleTimestamp: string = SERVER_BUNDLE_TIMESTAMP, pathSuffix = 'abc123') => {
+const createHttpRequest = (bundleTimestamp: string = SERVER_BUNDLE_TIMESTAMP) => {
   const appUrl = getAppUrl(app);
   const client = http2.connect(appUrl);
   const request = client.request({
     ':method': 'POST',
-    ':path': `/bundles/${bundleTimestamp}/incremental-render/${pathSuffix}`,
+    ':path': `/bundles/${bundleTimestamp}/incremental-render`,
     'content-type': 'application/x-ndjson',
   });
   request.setEncoding('utf8');
@@ -203,7 +203,7 @@ describe('concurrent incremental HTML streaming', () => {
 
     // Start all requests
     for (let i = 0; i < numRequests; i += 1) {
-      const { request, close } = createHttpRequest(RSC_BUNDLE_TIMESTAMP, `concurrent-test-${i}`);
+      const { request, close } = createHttpRequest(RSC_BUNDLE_TIMESTAMP);
       request.write(`${JSON.stringify(createInitialObject())}\n`);
       requests.push({ request, close, id: i });
     }

--- a/packages/react-on-rails-pro-node-renderer/tests/incrementalRender.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/incrementalRender.test.ts
@@ -60,12 +60,12 @@ describe('incremental render NDJSON endpoint', () => {
     };
   };
 
-  const createHttpRequest = (bundleTimestamp: string, pathSuffix = 'abc123') => {
+  const createHttpRequest = (bundleTimestamp: string) => {
     const { host, port } = getServerAddress();
     const req = http.request({
       hostname: host,
       port,
-      path: `/bundles/${bundleTimestamp}/incremental-render/${pathSuffix}`,
+      path: `/bundles/${bundleTimestamp}/incremental-render`,
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-ndjson',

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry.test.ts
@@ -577,7 +577,7 @@ describe('opentelemetry integration: end-to-end render request', () => {
 
       const res = await app
         .inject()
-        .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+        .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
         .payload(firstChunk)
         .headers({
           'Content-Type': 'application/x-ndjson',

--- a/packages/react-on-rails-pro-node-renderer/tests/streamClientDisconnectAbort.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/streamClientDisconnectAbort.test.ts
@@ -128,7 +128,7 @@ const postRendering = (
     const client = http2.connect(`http://localhost:${port}`);
     const request = client.request({
       ':method': 'POST',
-      ':path': `/bundles/${BUNDLE_TIMESTAMP}/render/disconnect-abort`,
+      ':path': `/bundles/${BUNDLE_TIMESTAMP}/render`,
       'content-type': `multipart/form-data; boundary=${form.getBoundary()}`,
     });
     request.setEncoding('utf8');

--- a/packages/react-on-rails-pro-node-renderer/tests/streamErrorHang.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/streamErrorHang.test.ts
@@ -82,7 +82,7 @@ const makeRequest = (renderingRequest: string, timeoutMs = 3000) =>
     const client = http2.connect(`http://localhost:${port}`);
     const request = client.request({
       ':method': 'POST',
-      ':path': `/bundles/${BUNDLE_TIMESTAMP}/render/stream-error-test`,
+      ':path': `/bundles/${BUNDLE_TIMESTAMP}/render`,
       'content-type': `multipart/form-data; boundary=${form.getBoundary()}`,
     });
     request.setEncoding('utf8');

--- a/packages/react-on-rails-pro-node-renderer/tests/uploadRaceCondition.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/uploadRaceCondition.test.ts
@@ -417,7 +417,7 @@ describe('concurrent upload isolation (issue #2449)', () => {
     });
   });
 
-  describe('/bundles/:bundleTimestamp/render/:renderRequestDigest endpoint', () => {
+  describe('/bundles/:bundleTimestamp/render endpoint', () => {
     // Race manifests in two ways:
     // 1. Bundle move ENOENT: both onFile write to uploads/bundle.js. One handler
     //    move()s it first; the other gets ENOENT → error response.
@@ -459,13 +459,13 @@ describe('concurrent upload isolation (issue #2449)', () => {
       const [resA, resB] = await Promise.all([
         app
           .inject()
-          .post(`/bundles/${bundleTimestampA}/render/d41d8cd98f00b204e9800998ecf8427e`)
+          .post(`/bundles/${bundleTimestampA}/render`)
           .payload(formA.payload)
           .headers(formA.headers)
           .end(),
         app
           .inject()
-          .post(`/bundles/${bundleTimestampB}/render/d41d8cd98f00b204e9800998ecf8427e`)
+          .post(`/bundles/${bundleTimestampB}/render`)
           .payload(formB.payload)
           .headers(formB.headers)
           .end(),
@@ -555,7 +555,7 @@ describe('concurrent upload isolation (issue #2449)', () => {
       const [renderRes, uploadRes] = await Promise.all([
         app
           .inject()
-          .post(`/bundles/${bundleTimestamp}/render/d41d8cd98f00b204e9800998ecf8427e`)
+          .post(`/bundles/${bundleTimestamp}/render`)
           .payload(renderForm.payload)
           .headers(renderForm.headers)
           .end(),

--- a/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/worker.test.ts
@@ -123,7 +123,7 @@ describe('worker', () => {
     expect(configureFastify).toEqual(expect.any(Function));
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest when bundle is provided and did not yet exist', async () => {
+  test('POST /bundles/:bundleTimestamp/render when bundle is provided and did not yet exist', async () => {
     const app = createWorker();
 
     const form = formAutoContent({
@@ -137,7 +137,7 @@ describe('worker', () => {
     });
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload(form.payload)
       .headers(form.headers)
       .end();
@@ -149,7 +149,55 @@ describe('worker', () => {
     expect(fs.existsSync(assetPathOther(testName, String(BUNDLE_TIMESTAMP)))).toBe(true);
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest rejects unsafe uploaded asset filenames', async () => {
+  test('old /render/<digest> route returns 404', async () => {
+    const app = createWorker();
+    const form = formAutoContent({
+      gemVersion,
+      protocolVersion,
+      railsEnv,
+      renderingRequest: 'ReactOnRails.dummy',
+    });
+    const res = await app
+      .inject()
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .payload(form.payload)
+      .headers(form.headers)
+      .end();
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('old /incremental-render/<digest> route returns 404', async () => {
+    const app = createWorker();
+    const res = await app
+      .inject()
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+      .payload(
+        `${JSON.stringify({ gemVersion, protocolVersion, password: 'my_password', railsEnv, renderingRequest: 'ReactOnRails.dummy' })}\n`,
+      )
+      .headers({ 'Content-Type': 'application/x-ndjson' })
+      .end();
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('protocol version 2.0.0 is rejected with 412 on render', async () => {
+    const app = createWorker();
+    const form = formAutoContent({
+      gemVersion,
+      protocolVersion: '2.0.0',
+      railsEnv,
+      renderingRequest: 'ReactOnRails.dummy',
+    });
+    const res = await app
+      .inject()
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
+      .payload(form.payload)
+      .headers(form.headers)
+      .end();
+    expect(res.statusCode).toBe(412);
+    expect(res.payload).toContain('does not match installed renderer protocol 3.0.0');
+  });
+
+  test('POST /bundles/:bundleTimestamp/render rejects unsafe uploaded asset filenames', async () => {
     const app = createWorker();
     const httpErrorLogSpy = jest.spyOn(app.log, 'error');
 
@@ -171,7 +219,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+        .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
         .payload(form.getBuffer())
         .headers(form.getHeaders())
         .end();
@@ -185,7 +233,7 @@ describe('worker', () => {
     }
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest', async () => {
+  test('POST /bundles/:bundleTimestamp/render', async () => {
     const app = createWorker();
 
     const form = formAutoContent({
@@ -200,7 +248,7 @@ describe('worker', () => {
     });
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload(form.payload)
       .headers(form.headers)
       .end();
@@ -221,7 +269,7 @@ describe('worker', () => {
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .headers({
         'content-type': 'application/vnd.react-on-rails.render-request+javascript',
         authorization: 'Bearer my_password',
@@ -243,7 +291,7 @@ describe('worker', () => {
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .headers({
         'content-type': 'application/vnd.react-on-rails.render-request+javascript',
         'x-react-on-rails-pro-protocol-version': protocolVersion,
@@ -261,7 +309,7 @@ describe('worker', () => {
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .headers({
         'content-type': 'application/vnd.react-on-rails.render-request+javascript',
         authorization: 'Bearer wrong_password',
@@ -280,7 +328,7 @@ describe('worker', () => {
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .headers({
         'content-type': 'application/vnd.react-on-rails.render-request+javascript',
         'x-react-on-rails-pro-protocol-version': protocolVersion,
@@ -299,7 +347,7 @@ describe('worker', () => {
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .headers({ 'content-type': 'application/vnd.react-on-rails.render-request+javascript' })
       .payload('ReactOnRails.dummy')
       .end();
@@ -314,7 +362,7 @@ describe('worker', () => {
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .headers({ 'content-type': 'application/x-www-form-urlencoded' })
       .payload(
         querystring.stringify({
@@ -331,14 +379,14 @@ describe('worker', () => {
     expect(res.payload).toBe('{"html":"Dummy Object"}');
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest returns actionable error when renderingRequest is missing', async () => {
+  test('POST /bundles/:bundleTimestamp/render returns actionable error when renderingRequest is missing', async () => {
     const app = worker({
       serverBundleCachePath: serverBundleCachePathForTest(),
     });
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload({
         gemVersion,
         protocolVersion,
@@ -353,7 +401,7 @@ describe('worker', () => {
     expect(res.payload).toContain('Likely causes: request body truncation');
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest does not notify errorReporter for malformed renderingRequest', async () => {
+  test('POST /bundles/:bundleTimestamp/render does not notify errorReporter for malformed renderingRequest', async () => {
     const reportMessageSpy = jest.spyOn(errorReporter, 'message').mockImplementation(jest.fn());
 
     try {
@@ -363,7 +411,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+        .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
         .payload({
           gemVersion,
           protocolVersion,
@@ -378,14 +426,14 @@ describe('worker', () => {
     }
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest returns actionable error when renderingRequest is null', async () => {
+  test('POST /bundles/:bundleTimestamp/render returns actionable error when renderingRequest is null', async () => {
     const app = worker({
       serverBundleCachePath: serverBundleCachePathForTest(),
     });
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload({
         gemVersion,
         protocolVersion,
@@ -400,14 +448,14 @@ describe('worker', () => {
     expect(res.payload).toContain('Likely causes: request body truncation');
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest treats null rscStreamObservability as absent', async () => {
+  test('POST /bundles/:bundleTimestamp/render treats null rscStreamObservability as absent', async () => {
     const app = worker({
       serverBundleCachePath: serverBundleCachePathForTest(),
     });
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload({
         gemVersion,
         protocolVersion,
@@ -421,14 +469,14 @@ describe('worker', () => {
     expect(res.payload).toContain('No bundle uploaded');
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest returns actionable error when renderingRequest is empty string', async () => {
+  test('POST /bundles/:bundleTimestamp/render returns actionable error when renderingRequest is empty string', async () => {
     const app = worker({
       serverBundleCachePath: serverBundleCachePathForTest(),
     });
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload({
         gemVersion,
         protocolVersion,
@@ -443,14 +491,14 @@ describe('worker', () => {
     expect(res.payload).toContain('Likely causes: request body truncation');
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest returns actionable error when renderingRequest is an array', async () => {
+  test('POST /bundles/:bundleTimestamp/render returns actionable error when renderingRequest is an array', async () => {
     const app = worker({
       serverBundleCachePath: serverBundleCachePathForTest(),
     });
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload({
         gemVersion,
         protocolVersion,
@@ -466,14 +514,14 @@ describe('worker', () => {
     expect(res.payload).toContain('Likely causes: request body truncation');
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest filters sensitive body keys case-insensitively in invalid renderingRequest diagnostics', async () => {
+  test('POST /bundles/:bundleTimestamp/render filters sensitive body keys case-insensitively in invalid renderingRequest diagnostics', async () => {
     const app = worker({
       serverBundleCachePath: serverBundleCachePathForTest(),
     });
 
     const res = await app
       .inject()
-      .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+      .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
       .payload({
         gemVersion,
         protocolVersion,
@@ -501,7 +549,7 @@ describe('worker', () => {
     expect(res.payload).toContain('safeField');
   });
 
-  test('POST /bundles/:bundleTimestamp/render/:renderRequestDigest reports unexpected handleRenderRequest failures once', async () => {
+  test('POST /bundles/:bundleTimestamp/render reports unexpected handleRenderRequest failures once', async () => {
     const buildExecutionContextSpy = jest
       .spyOn(vm, 'buildExecutionContext')
       .mockRejectedValueOnce(new Error('Injected buildExecutionContext failure'));
@@ -522,7 +570,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post(`/bundles/${BUNDLE_TIMESTAMP}/render/d41d8cd98f00b204e9800998ecf8427e`)
+        .post(`/bundles/${BUNDLE_TIMESTAMP}/render`)
         .payload(form.payload)
         .headers(form.headers)
         .end();
@@ -543,8 +591,7 @@ describe('worker', () => {
   });
 
   test(
-    'POST /bundles/:bundleTimestamp/render/:renderRequestDigest ' +
-      'when password is required but no password was provided',
+    'POST /bundles/:bundleTimestamp/render ' + 'when password is required but no password was provided',
     async () => {
       await createVmBundleForTest();
 
@@ -554,7 +601,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
+        .post('/bundles/1495063024898/render')
         .payload({
           renderingRequest: 'ReactOnRails.dummy',
           password: undefined,
@@ -586,7 +633,7 @@ describe('worker', () => {
 
     const res = await app
       .inject()
-      .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
+      .post('/bundles/1495063024898/render')
       .payload(form.getBuffer())
       .headers(form.getHeaders())
       .end();
@@ -597,8 +644,7 @@ describe('worker', () => {
   });
 
   test(
-    'POST /bundles/:bundleTimestamp/render/:renderRequestDigest ' +
-      'when password is required but wrong password was provided',
+    'POST /bundles/:bundleTimestamp/render ' + 'when password is required but wrong password was provided',
     async () => {
       await createVmBundleForTest();
 
@@ -608,7 +654,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
+        .post('/bundles/1495063024898/render')
         .payload({
           renderingRequest: 'ReactOnRails.dummy',
           password: 'wrong',
@@ -623,8 +669,7 @@ describe('worker', () => {
   );
 
   test(
-    'POST /bundles/:bundleTimestamp/render/:renderRequestDigest ' +
-      'when password is required and correct password was provided',
+    'POST /bundles/:bundleTimestamp/render ' + 'when password is required and correct password was provided',
     async () => {
       await createVmBundleForTest();
 
@@ -634,7 +679,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
+        .post('/bundles/1495063024898/render')
         .payload({
           renderingRequest: 'ReactOnRails.dummy',
           password: 'my_password',
@@ -650,23 +695,19 @@ describe('worker', () => {
   );
 
   test(
-    'POST /bundles/:bundleTimestamp/render/:renderRequestDigest ' +
-      'when password is not required and no password was provided',
+    'POST /bundles/:bundleTimestamp/render ' + 'when password is not required and no password was provided',
     async () => {
       await createVmBundleForTest();
 
       const app = createWorker();
 
-      const res = await app
-        .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
-        .payload({
-          renderingRequest: 'ReactOnRails.dummy',
-          password: undefined,
-          gemVersion,
-          protocolVersion,
-          railsEnv,
-        });
+      const res = await app.inject().post('/bundles/1495063024898/render').payload({
+        renderingRequest: 'ReactOnRails.dummy',
+        password: undefined,
+        gemVersion,
+        protocolVersion,
+        railsEnv,
+      });
       expect(res.headers['cache-control']).toBe('public, max-age=31536000');
       expect(res.statusCode).toBe(200);
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -951,7 +992,7 @@ describe('worker', () => {
     }
   });
 
-  test('post /upload-assets ignores targetBundles when bundle_<hash> fields are present (backward compat)', async () => {
+  test('post /upload-assets derives targets from bundle_<hash> fields', async () => {
     const bundleHash = 'compat-bundle-hash';
 
     const app = worker({
@@ -959,15 +1000,12 @@ describe('worker', () => {
       password: 'my_password',
     });
 
-    // Simulates the Ruby client sending both bundle_<hash> (new) and targetBundles (legacy).
-    // The endpoint should derive targets from bundle_<hash> and ignore targetBundles.
     const form = formAutoContent({
       gemVersion,
       protocolVersion,
       railsEnv,
       password: 'my_password',
       [`bundle_${bundleHash}`]: createReadStream(getFixtureBundle()),
-      targetBundles: [bundleHash],
       asset1: createReadStream(getFixtureAsset()),
     });
     const res = await app.inject().post(`/upload-assets`).payload(form.payload).headers(form.headers).end();
@@ -1008,15 +1046,12 @@ describe('worker', () => {
 
       const app = createWorker();
 
-      const res = await app
-        .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
-        .payload({
-          renderingRequest: 'ReactOnRails.dummy',
-          gemVersion: packageJson.version,
-          protocolVersion,
-          railsEnv: 'development',
-        });
+      const res = await app.inject().post('/bundles/1495063024898/render').payload({
+        renderingRequest: 'ReactOnRails.dummy',
+        gemVersion: packageJson.version,
+        protocolVersion,
+        railsEnv: 'development',
+      });
 
       expect(res.statusCode).toBe(200);
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -1029,7 +1064,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
+        .post('/bundles/1495063024898/render')
         .payload({
           renderingRequest: 'ReactOnRails.dummy',
           gemVersion: '999.0.0',
@@ -1049,15 +1084,12 @@ describe('worker', () => {
 
       const app = createWorker();
 
-      const res = await app
-        .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
-        .payload({
-          renderingRequest: 'ReactOnRails.dummy',
-          gemVersion: '999.0.0',
-          protocolVersion,
-          railsEnv: 'production',
-        });
+      const res = await app.inject().post('/bundles/1495063024898/render').payload({
+        renderingRequest: 'ReactOnRails.dummy',
+        gemVersion: '999.0.0',
+        protocolVersion,
+        railsEnv: 'production',
+      });
 
       expect(res.statusCode).toBe(200);
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -1073,15 +1105,12 @@ describe('worker', () => {
       // Let's create a version with .rc. that normalizes to the package version
       const gemVersionWithDot = packageJson.version.replace(/-([a-z]+)/, '.$1');
 
-      const res = await app
-        .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
-        .payload({
-          renderingRequest: 'ReactOnRails.dummy',
-          gemVersion: gemVersionWithDot,
-          protocolVersion,
-          railsEnv: 'development',
-        });
+      const res = await app.inject().post('/bundles/1495063024898/render').payload({
+        renderingRequest: 'ReactOnRails.dummy',
+        gemVersion: gemVersionWithDot,
+        protocolVersion,
+        railsEnv: 'development',
+      });
 
       expect(res.statusCode).toBe(200);
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -1094,15 +1123,12 @@ describe('worker', () => {
 
       const gemVersionUpperCase = packageJson.version.toUpperCase();
 
-      const res = await app
-        .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
-        .payload({
-          renderingRequest: 'ReactOnRails.dummy',
-          gemVersion: gemVersionUpperCase,
-          protocolVersion,
-          railsEnv: 'development',
-        });
+      const res = await app.inject().post('/bundles/1495063024898/render').payload({
+        renderingRequest: 'ReactOnRails.dummy',
+        gemVersion: gemVersionUpperCase,
+        protocolVersion,
+        railsEnv: 'development',
+      });
 
       expect(res.statusCode).toBe(200);
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -1115,15 +1141,12 @@ describe('worker', () => {
 
       const gemVersionWithWhitespace = `  ${packageJson.version}  `;
 
-      const res = await app
-        .inject()
-        .post('/bundles/1495063024898/render/d41d8cd98f00b204e9800998ecf8427e')
-        .payload({
-          renderingRequest: 'ReactOnRails.dummy',
-          gemVersion: gemVersionWithWhitespace,
-          protocolVersion,
-          railsEnv: 'development',
-        });
+      const res = await app.inject().post('/bundles/1495063024898/render').payload({
+        renderingRequest: 'ReactOnRails.dummy',
+        gemVersion: gemVersionWithWhitespace,
+        protocolVersion,
+        railsEnv: 'development',
+      });
 
       expect(res.statusCode).toBe(200);
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -1142,7 +1165,6 @@ describe('worker', () => {
       gemVersion,
       protocolVersion,
       password: 'my_password',
-      targetBundles: [bundleHash, secondaryBundleHash],
       [`bundle_${bundleHash}`]: createReadStream(getFixtureBundle()),
       [`bundle_${secondaryBundleHash}`]: createReadStream(getFixtureSecondaryBundle()),
       asset1: createReadStream(getFixtureAsset()),
@@ -1200,7 +1222,6 @@ describe('worker', () => {
       gemVersion,
       protocolVersion,
       password: 'my_password',
-      targetBundles: [bundleHash],
       [`bundle_${bundleHash}`]: createReadStream(getFixtureBundle()),
     });
 
@@ -1286,7 +1307,6 @@ describe('worker', () => {
       gemVersion,
       protocolVersion,
       password: 'my_password',
-      targetBundles: [bundleHash],
       [`bundle_${bundleHash}`]: createReadStream(getFixtureBundle()),
     });
 
@@ -1317,7 +1337,6 @@ describe('worker', () => {
       gemVersion,
       protocolVersion,
       password: 'my_password',
-      targetBundles: [bundleHash],
       [`bundle_${bundleHash}`]: createReadStream(getFixtureSecondaryBundle()), // Different content
     });
 
@@ -1356,7 +1375,7 @@ describe('worker', () => {
     expect(secondBundleSize).toBe(62); // Size of getFixtureBundle(), not getFixtureSecondaryBundle()
   });
 
-  test('post /upload-assets places bundles in their own hash directories (targetBundles is ignored)', async () => {
+  test('post /upload-assets places bundles in their own hash directories', async () => {
     const bundleHash = 'actual-bundle-hash';
     const targetBundleHash = 'target-bundle-hash'; // Different from actual bundle hash
 
@@ -1368,7 +1387,6 @@ describe('worker', () => {
       gemVersion,
       protocolVersion,
       password: 'my_password',
-      targetBundles: [targetBundleHash], // Ignored by the endpoint — only bundle_<hash> fields matter
       [`bundle_${bundleHash}`]: createReadStream(getFixtureBundle()), // Bundle with its own hash
     });
 
@@ -1381,7 +1399,6 @@ describe('worker', () => {
     const bundleFilePath = path.join(actualBundleDir, `${bundleHash}.js`);
     expect(fs.existsSync(bundleFilePath)).toBe(true);
 
-    // targetBundles is not used by the endpoint, so no directory is created for it
     const targetBundleDir = path.join(serverBundleCachePathForTest(), targetBundleHash);
     expect(fs.existsSync(targetBundleDir)).toBe(false);
 
@@ -1412,7 +1429,6 @@ describe('worker', () => {
         gemVersion,
         protocolVersion,
         password,
-        targetBundles: [String(bundleTimestamp)],
         [`bundle_${bundleTimestamp}`]: createReadStream(getFixtureBundle()),
       });
 
@@ -1436,7 +1452,6 @@ describe('worker', () => {
         gemVersion,
         protocolVersion,
         password,
-        targetBundles: bundleTimestamps.map(String),
         [`bundle_${bundleTimestamps[0]}`]: createReadStream(getFixtureBundle()),
         [`bundle_${bundleTimestamps[1]}`]: createReadStream(getFixtureSecondaryBundle()),
       });
@@ -1457,13 +1472,12 @@ describe('worker', () => {
     const callIncrementalRender = async (
       app: ReturnType<typeof worker>,
       bundleTimestamp: number,
-      renderRequestDigest: string,
       payload: Record<string, unknown>,
       expectedStatus = 200,
     ) => {
       const res = await app
         .inject()
-        .post(`/bundles/${bundleTimestamp}/incremental-render/${renderRequestDigest}`)
+        .post(`/bundles/${bundleTimestamp}/incremental-render`)
         .payload(createNDJSONPayload(payload))
         .headers({
           'Content-Type': 'application/x-ndjson',
@@ -1486,12 +1500,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload);
 
       expect(res.headers['cache-control']).toBe('public, max-age=31536000');
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -1515,12 +1524,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP), String(SECONDARY_BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload);
 
       expect(res.headers['cache-control']).toBe('public, max-age=31536000');
       expect(res.payload).toBe(
@@ -1539,13 +1543,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-        410,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload, 410);
 
       expect(res.payload).toContain('No bundle uploaded');
     });
@@ -1556,7 +1554,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+        .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
         .payload('invalid json\n')
         .headers({
           'Content-Type': 'application/x-ndjson',
@@ -1579,13 +1577,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        incompletePayload,
-        400,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, incompletePayload, 400);
 
       expect(res.payload).toContain('Invalid first incremental render request chunk received');
     });
@@ -1606,13 +1598,7 @@ describe('worker', () => {
           dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
         };
 
-        const res = await callIncrementalRender(
-          app,
-          BUNDLE_TIMESTAMP,
-          'd41d8cd98f00b204e9800998ecf8427e',
-          incompletePayload,
-          400,
-        );
+        const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, incompletePayload, 400);
 
         expect(res.payload).toContain('Invalid first incremental render request chunk received');
         expect(reportMessageSpy).toHaveBeenCalledWith(
@@ -1636,13 +1622,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-        401,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload, 401);
 
       expect(res.payload).toBe('Wrong password');
     });
@@ -1659,13 +1639,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-        401,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload, 401);
 
       expect(res.payload).toBe('Wrong password');
     });
@@ -1682,12 +1656,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload);
 
       expect(res.statusCode).toBe(200);
       expect(res.headers['cache-control']).toBe('public, max-age=31536000');
@@ -1701,7 +1670,6 @@ describe('worker', () => {
       const uploadForm = formAutoContent({
         gemVersion,
         password: 'my_password',
-        targetBundles: [String(BUNDLE_TIMESTAMP)],
         [`bundle_${BUNDLE_TIMESTAMP}`]: createReadStream(getFixtureBundle()),
       });
 
@@ -1721,13 +1689,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-        412,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload, 412);
 
       expect(res.payload).toContain('Unsupported renderer protocol version MISSING');
       expect(res.payload).not.toContain('my_password');
@@ -1743,13 +1705,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-        412,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload, 412);
 
       expect(res.payload).toContain('Unsupported renderer protocol version MISSING');
       expect(res.payload).not.toContain('super_secret_password_value');
@@ -1767,12 +1723,7 @@ describe('worker', () => {
         dependencyBundleTimestamps: [String(BUNDLE_TIMESTAMP)],
       };
 
-      const res = await callIncrementalRender(
-        app,
-        BUNDLE_TIMESTAMP,
-        'd41d8cd98f00b204e9800998ecf8427e',
-        payload,
-      );
+      const res = await callIncrementalRender(app, BUNDLE_TIMESTAMP, payload);
 
       expect(res.headers['cache-control']).toBe('public, max-age=31536000');
       expect(res.payload).toBe('{"html":"Dummy Object"}');
@@ -1808,7 +1759,7 @@ describe('worker', () => {
 
       const res = await app
         .inject()
-        .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+        .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
         .payload(multiChunkPayload)
         .headers({
           'Content-Type': 'application/x-ndjson',
@@ -1856,7 +1807,7 @@ describe('worker', () => {
 
         const responsePromise = app
           .inject()
-          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
           .payload(createNDJSONPayload(payload))
           .headers({
             'Content-Type': 'application/x-ndjson',
@@ -1925,7 +1876,7 @@ describe('worker', () => {
 
         const responsePromise = app
           .inject()
-          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
           .payload(requestStream)
           .headers({
             'Content-Type': 'application/x-ndjson',
@@ -1999,7 +1950,7 @@ describe('worker', () => {
 
         const responsePromise = app
           .inject()
-          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+          .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
           .payload(requestStream)
           .headers({
             'Content-Type': 'application/x-ndjson',
@@ -2104,7 +2055,7 @@ describe('worker', () => {
 
           const responsePromise = app
             .inject()
-            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
             .payload(requestStream)
             .headers({
               'Content-Type': 'application/x-ndjson',
@@ -2215,7 +2166,7 @@ describe('worker', () => {
 
           const responsePromise = app
             .inject()
-            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
             .payload(requestStream)
             .headers({
               'Content-Type': 'application/x-ndjson',
@@ -2320,7 +2271,7 @@ describe('worker', () => {
 
           const responsePromise = app
             .inject()
-            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render/d41d8cd98f00b204e9800998ecf8427e`)
+            .post(`/bundles/${BUNDLE_TIMESTAMP}/incremental-render`)
             .payload(requestStream)
             .headers({
               'Content-Type': 'application/x-ndjson',

--- a/react_on_rails_pro/lib/react_on_rails_pro/request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/request.rb
@@ -201,21 +201,13 @@ module ReactOnRailsPro
       def upload_assets(artifacts: nil)
         Rails.logger.info { "[ReactOnRailsPro] Uploading assets" }
         artifacts = resolve_upload_artifacts(artifacts, action_description: "uploading assets")
-        target_bundles = artifacts.map(&:id)
+        bundle_hashes = artifacts.map(&:id)
 
         # Artifact IDs already bind every bundle and companion byte. Keying the
         # single-flight upload by those IDs avoids re-reading live paths after
         # the operation-scoped snapshot was constructed.
-        with_asset_upload_single_flight(upload_assets_single_flight_key(target_bundles, [])) do
+        with_asset_upload_single_flight(upload_assets_single_flight_key(bundle_hashes, [])) do
           form = form_with_assets_and_bundle(artifacts:)
-          # TODO: targetBundles is only kept for backward compatibility with older node renderers
-          # (protocol 2.0.0) that require it. The new node renderer derives target directories from
-          # the bundle_<hash> form keys and ignores this field. Remove at the next breaking version.
-          # Note: it's not mandatory to keep this until then — users are expected to upgrade the
-          # node renderer and react_on_rails gem to the same version together — but it's an easy
-          # backward compatibility safeguard.
-          form["targetBundles"] = target_bundles
-
           perform_request("/upload-assets", form:)
         end
       end
@@ -498,7 +490,7 @@ module ReactOnRailsPro
       end
 
       def retarget_render_path(path, artifacts, role)
-        match = path.match(%r{\A/bundles/[^/]+/(?<endpoint>render|incremental-render)/})
+        match = path.match(%r{\A/bundles/[^/]+/(?<endpoint>render|incremental-render)\z})
         return path unless match
 
         artifact = artifact_for_role(artifacts, role)
@@ -558,11 +550,11 @@ module ReactOnRailsPro
         Array(artifacts).find { |artifact| artifact.role == role }
       end
 
-      def upload_assets_single_flight_key(target_bundles, assets_to_copy)
+      def upload_assets_single_flight_key(bundle_hashes, assets_to_copy)
         [
           "bundles",
-          Array(target_bundles).length.to_s,
-          *Array(target_bundles).map(&:to_s),
+          Array(bundle_hashes).length.to_s,
+          *Array(bundle_hashes).map(&:to_s),
           "assets",
           assets_to_copy.length.to_s,
           *assets_to_copy.map { |asset_path| upload_asset_fingerprint(asset_path) }

--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/node_rendering_pool.rb
@@ -73,7 +73,7 @@ module ReactOnRailsPro
 
           if async_props_block
             # Use incremental rendering when async props block is provided
-            path = prepare_incremental_render_path(js_code, render_options)
+            path = prepare_incremental_render_path(render_options)
             push_props = render_options.internal_option(:push_props)
             # Pull mode is enabled whenever push_props is set, including [] for pure pull.
             # nil means push-only mode with no bidirectional prop-request channel.
@@ -93,7 +93,7 @@ module ReactOnRailsPro
             )
           else
             # Use standard streaming when no async props block
-            path = prepare_render_path(js_code, render_options)
+            path = prepare_render_path(render_options)
             request_options = { is_rsc_payload:, rsc_stream_observability: }
             request_options[:artifacts] = artifacts if artifacts
             ReactOnRailsPro::Request.render_code_as_stream(
@@ -105,7 +105,7 @@ module ReactOnRailsPro
         end
 
         def eval_js(js_code, render_options, send_bundle: false)
-          path = prepare_render_path(js_code, render_options)
+          path = prepare_render_path(render_options)
 
           request_options = { bundle_role: bundle_role_for(render_options) }
           artifacts = renderer_artifact_snapshot(render_options)
@@ -151,15 +151,12 @@ module ReactOnRailsPro
         end
         private :volatile_artifact_ids?
 
-        def prepare_render_path(js_code, render_options)
-          # TODO: Remove the request_digest. See https://github.com/shakacode/react_on_rails_pro/issues/119
-          # From the request path
-          # path = "/bundles/#{@bundle_hash}/render"
-          build_render_path(js_code, render_options, "render")
+        def prepare_render_path(render_options)
+          build_render_path(render_options, "render")
         end
 
-        def prepare_incremental_render_path(js_code, render_options)
-          build_render_path(js_code, render_options, "incremental-render")
+        def prepare_incremental_render_path(render_options)
+          build_render_path(render_options, "incremental-render")
         end
 
         private
@@ -182,17 +179,14 @@ module ReactOnRailsPro
           end
         end
 
-        def build_render_path(js_code, render_options, endpoint)
-          ReactOnRailsPro::ServerRenderingPool::ProRendering
-            .set_request_digest_on_render_options(js_code, render_options)
-
+        def build_render_path(render_options, endpoint)
           rsc_support_enabled = ReactOnRailsPro.configuration.enable_rsc_support
           is_rendering_rsc_payload = rsc_support_enabled && render_options.rsc_payload_streaming?
           bundle_role = is_rendering_rsc_payload ? :rsc : :server
           artifact = artifact_for_role(renderer_artifact_snapshot(render_options), bundle_role)
           bundle_hash = artifact&.id || (is_rendering_rsc_payload ? rsc_bundle_hash : server_bundle_hash)
 
-          "/bundles/#{bundle_hash}/#{endpoint}/#{render_options.request_digest}"
+          "/bundles/#{bundle_hash}/#{endpoint}"
         end
 
         def fallback_exec_js(js_code, render_options, error)

--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb
@@ -31,11 +31,6 @@ module ReactOnRailsPro
 
         def exec_server_render_js(js_code, render_options)
           ::ReactOnRailsPro::Utils.with_trace(render_options.react_component_name) do
-            # See https://github.com/shakacode/react_on_rails_pro/issues/119 for why
-            # the digest is on the render options.
-            # TODO: the request digest should be removed unless prerender caching is used
-            set_request_digest_on_render_options(js_code, render_options)
-
             # Cache non-streaming immediately. For streaming, optionally cache via write-through.
             if cache_enabled_for?(render_options)
               render_with_cache(js_code, render_options)
@@ -45,8 +40,8 @@ module ReactOnRailsPro
           end
         end
 
-        # See https://github.com/shakacode/react_on_rails_pro/issues/119 for why
-        # the digest is on the render options.
+        # Computes an MD5 digest of the JS code for use as a prerender cache key.
+        # Only called when prerender caching is enabled.
         def set_request_digest_on_render_options(js_code, render_options)
           return unless render_options.request_digest.blank?
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/version.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/version.rb
@@ -15,5 +15,5 @@
 
 module ReactOnRailsPro
   VERSION = "17.0.0.rc.6"
-  PROTOCOL_VERSION = "2.0.0"
+  PROTOCOL_VERSION = "3.0.0"
 end

--- a/react_on_rails_pro/scripts/load/lib/scenarios/standard_render.rb
+++ b/react_on_rails_pro/scripts/load/lib/scenarios/standard_render.rb
@@ -14,20 +14,18 @@
 # https://github.com/shakacode/react_on_rails/blob/main/REACT-ON-RAILS-PRO-LICENSE.md
 
 require_relative "base"
-require "digest"
 
 module RendererHarness
   module Scenarios
     # Scenario that performs a single synchronous server-side render via the node renderer.
     #
     # Uses HelloWorld (registered via auto-load in the dummy app's server-bundle).
-    # Path format: /bundles/:bundleTimestamp/render/:renderRequestDigest
+    # Path format: /bundles/:bundleTimestamp/render
     class StandardRender < Base
       def perform_request
         js = render_component_js
         bundle_hash = server_bundle_hash
-        digest = Digest::MD5.hexdigest(js)
-        path = "/bundles/#{bundle_hash}/render/#{digest}"
+        path = "/bundles/#{bundle_hash}/render"
 
         measure do
           response = ReactOnRailsPro::Request.render_code(path, js, false)

--- a/react_on_rails_pro/scripts/load/lib/scenarios/streaming_render.rb
+++ b/react_on_rails_pro/scripts/load/lib/scenarios/streaming_render.rb
@@ -14,13 +14,12 @@
 # https://github.com/shakacode/react_on_rails/blob/main/REACT-ON-RAILS-PRO-LICENSE.md
 
 require_relative "base"
-require "digest"
 
 module RendererHarness
   module Scenarios
     # Scenario that performs a server-side render via the streaming HTTP transport.
     #
-    # The render endpoint /bundles/:hash/render/:digest is the same endpoint used by
+    # The render endpoint /bundles/:hash/render is the same endpoint used by
     # standard_render, but the HTTP request is made with stream: true so the response
     # body is read chunk-by-chunk. This measures streaming-transport overhead vs.
     # buffered transport (standard_render).
@@ -34,8 +33,7 @@ module RendererHarness
       def perform_request
         js = render_component_js
         bundle_hash = server_bundle_hash
-        digest = Digest::MD5.hexdigest(js)
-        path = "/bundles/#{bundle_hash}/render/#{digest}"
+        path = "/bundles/#{bundle_hash}/render"
 
         measure do
           bytes_in = 0

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -39,7 +39,7 @@ module StreamingTestHelpers
   end
 
   def test_server_render_url_pattern
-    %r{\Ahttp://localhost:3800/bundles/#{Regexp.escape(test_server_artifact_id)}/render/[a-f0-9]{32}\z}
+    %r{\Ahttp://localhost:3800/bundles/#{Regexp.escape(test_server_artifact_id)}/render\z}
   end
 end
 

--- a/react_on_rails_pro/spec/dummy/spec/requests/incremental_rendering_integration_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/incremental_rendering_integration_spec.rb
@@ -139,10 +139,8 @@ describe "Incremental Rendering Integration", :integration do
       # Upload bundles first
       ReactOnRailsPro::Request.upload_assets
 
-      # Construct the render path: /bundles/:bundleTimestamp/render/:renderRequestDigest
       js_code = "ReactOnRails.dummy"
-      request_digest = Digest::MD5.hexdigest(js_code)
-      render_path = "/bundles/#{server_bundle_hash}/render/#{request_digest}"
+      render_path = "/bundles/#{server_bundle_hash}/render"
 
       # Render using the fixture bundle
       response = ReactOnRailsPro::Request.render_code(render_path, js_code, false)
@@ -159,8 +157,7 @@ describe "Incremental Rendering Integration", :integration do
 
       # Construct the incremental render path
       js_code = "ReactOnRails.getStreamValues()"
-      request_digest = Digest::MD5.hexdigest(js_code)
-      render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+      render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
       # Perform incremental rendering with stream updates
       stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
@@ -192,8 +189,7 @@ describe "Incremental Rendering Integration", :integration do
 
       # Construct the incremental render path
       js_code = "ReactOnRails.getStreamValues()"
-      request_digest = Digest::MD5.hexdigest(js_code)
-      render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+      render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
       # Use Async::Queue instead of Async::Condition — Queue buffers signals so they
       # are never lost if the consumer hasn't called dequeue yet. Condition#signal is
@@ -278,8 +274,7 @@ describe "Incremental Rendering Integration", :integration do
         ReactOnRailsPro::Request.upload_assets
 
         js_code = "ReactOnRails.getStreamValues()"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
         Timeout.timeout(10) do
           stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
@@ -312,8 +307,7 @@ describe "Incremental Rendering Integration", :integration do
         ReactOnRailsPro::Request.upload_assets
 
         js_code = "ReactOnRails.getStreamValues()"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
         Timeout.timeout(10) do
           stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
@@ -338,8 +332,7 @@ describe "Incremental Rendering Integration", :integration do
         ReactOnRailsPro::Request.upload_assets
 
         js_code = "this is not valid javascript @@!#$%"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
         Timeout.timeout(10) do
           stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
@@ -404,8 +397,7 @@ describe "Incremental Rendering Integration", :integration do
 
         # Do NOT call upload_assets — the bundle isn't on the renderer yet
         js_code = "ReactOnRails.getStreamValues()"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{unique_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{unique_hash}/incremental-render"
 
         Timeout.timeout(10) do
           stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
@@ -451,8 +443,7 @@ describe "Incremental Rendering Integration", :integration do
         allow(ReactOnRailsPro::Request).to receive(:upload_assets)
 
         js_code = "ReactOnRails.getStreamValues()"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{always_missing_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{always_missing_hash}/incremental-render"
 
         Timeout.timeout(10) do
           stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
@@ -473,8 +464,7 @@ describe "Incremental Rendering Integration", :integration do
         ReactOnRailsPro::Request.upload_assets
 
         js_code = "ReactOnRails.getStreamValues()"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
         # Generate a payload larger than default HTTP/2 frame size (16KB)
         large_value = "X" * 20_000
@@ -499,8 +489,7 @@ describe "Incremental Rendering Integration", :integration do
         ReactOnRailsPro::Request.upload_assets
 
         js_code = "ReactOnRails.getStreamValues()"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
         values = Array.new(3) { |i| "PAYLOAD_#{i}_#{'Y' * 18_000}" }
 
@@ -526,8 +515,7 @@ describe "Incremental Rendering Integration", :integration do
         ReactOnRailsPro::Request.upload_assets
 
         js_code = "ReactOnRails.getStreamValues()"
-        request_digest = Digest::MD5.hexdigest(js_code)
-        render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+        render_path = "/bundles/#{server_bundle_hash}/incremental-render"
 
         results = Array.new(3)
 
@@ -566,7 +554,7 @@ describe "Incremental Rendering Integration", :integration do
     context "when error scenarios repeat without connection reset" do
       let(:js_code) { "ReactOnRails.getStreamValues()" }
       let(:render_path) do
-        "/bundles/#{server_bundle_hash}/incremental-render/#{Digest::MD5.hexdigest(js_code)}"
+        "/bundles/#{server_bundle_hash}/incremental-render"
       end
 
       def perform_successful_stream_request
@@ -665,8 +653,7 @@ describe "Incremental Rendering Integration", :integration do
         Timeout.timeout(30) do
           10.times do |i|
             invalid_js = "not valid js @@#{i}"
-            digest = Digest::MD5.hexdigest(invalid_js)
-            path = "/bundles/#{server_bundle_hash}/incremental-render/#{digest}"
+            path = "/bundles/#{server_bundle_hash}/incremental-render"
 
             stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
               path,
@@ -704,8 +691,7 @@ describe "Incremental Rendering Integration", :integration do
           # Trigger invalid rendering request errors
           3.times do |i|
             invalid_js = "syntax error @@#{i}"
-            digest = Digest::MD5.hexdigest(invalid_js)
-            path = "/bundles/#{server_bundle_hash}/incremental-render/#{digest}"
+            path = "/bundles/#{server_bundle_hash}/incremental-render"
 
             stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
               path,

--- a/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
@@ -99,13 +99,13 @@ describe ReactOnRailsPro::Request do
 
       expect(
         described_class.render_code(
-          "/bundles/old-id/render/digest",
+          "/bundles/old-id/render",
           "ReactOnRails.dummy",
           true,
           bundle_role: :server
         )
       ).to be(response)
-      expect(requested_path).to eq("/bundles/#{artifact.id}/render/digest")
+      expect(requested_path).to eq("/bundles/#{artifact.id}/render")
       expect(requested_form).to include("bundle_#{artifact.id}")
     end
 
@@ -138,14 +138,14 @@ describe ReactOnRailsPro::Request do
 
       expect(
         described_class.render_code(
-          "/bundles/#{server_artifact.id}/render/digest",
+          "/bundles/#{server_artifact.id}/render",
           "ReactOnRails.dummy",
           true,
           bundle_role: :server,
           artifacts: identities
         )
       ).to be(response)
-      expect(requested_path).to eq("/bundles/#{server_artifact.id}/render/digest")
+      expect(requested_path).to eq("/bundles/#{server_artifact.id}/render")
       expect(requested_form).to include("bundle_#{server_artifact.id}", "bundle_#{rsc_artifact.id}")
       expect(requested_form.fetch("dependencyBundleTimestamps")).to eq([rsc_artifact.id, server_artifact.id])
     end
@@ -166,7 +166,7 @@ describe ReactOnRailsPro::Request do
 
       expect do
         described_class.render_code(
-          "/bundles/#{identity.id}/render/digest",
+          "/bundles/#{identity.id}/render",
           "ReactOnRails.dummy",
           true,
           bundle_role: :server,
@@ -277,7 +277,7 @@ describe ReactOnRailsPro::Request do
       end
 
       stream = described_class.render_code_as_stream(
-        "/bundles/old-id/render/digest",
+        "/bundles/old-id/render",
         "console.log('Hello, world!');",
         is_rsc_payload: false
       )
@@ -285,9 +285,9 @@ describe ReactOnRailsPro::Request do
       stream.each_chunk { |chunk| chunks << chunk }
       expect(chunks.map { |c| c["html"] }).to eq(["Hello, world!"])
       expect(request_paths).to eq([
-                                    "/bundles/old-id/render/digest",
+                                    "/bundles/old-id/render",
                                     "/upload-assets",
-                                    "/bundles/#{artifact.id}/render/digest"
+                                    "/bundles/#{artifact.id}/render"
                                   ])
     end
 
@@ -324,7 +324,7 @@ describe ReactOnRailsPro::Request do
       js_code = "runOnOtherBundle(#{rsc_artifact.id.to_json})"
 
       stream = described_class.render_code_as_stream(
-        "/bundles/#{server_artifact.id}/render/digest",
+        "/bundles/#{server_artifact.id}/render",
         js_code,
         is_rsc_payload: false,
         artifacts:
@@ -332,9 +332,9 @@ describe ReactOnRailsPro::Request do
       stream.each_chunk(&:itself)
 
       expected_paths = [
-        "/bundles/#{server_artifact.id}/render/digest",
+        "/bundles/#{server_artifact.id}/render",
         "/upload-assets",
-        "/bundles/#{server_artifact.id}/render/digest"
+        "/bundles/#{server_artifact.id}/render"
       ]
       expect(requests.map(&:first)).to eq(expected_paths)
       upload_form = requests.fetch(1)[1]
@@ -440,7 +440,7 @@ describe ReactOnRailsPro::Request do
         "console.log('héllo');",
         {
           "renderingRequest" => "console.log('héllo');",
-          "protocolVersion" => "2.0.0",
+          "protocolVersion" => "3.0.0",
           "gemVersion" => "16.0.0",
           "password" => "secret",
           "railsEnv" => "test",
@@ -453,7 +453,7 @@ describe ReactOnRailsPro::Request do
       expect(raw_request[:headers]).to include(
         ["content-type", "application/vnd.react-on-rails.render-request+javascript"],
         ["authorization", "Bearer secret"],
-        ["x-react-on-rails-pro-protocol-version", "2.0.0"],
+        ["x-react-on-rails-pro-protocol-version", "3.0.0"],
         ["x-react-on-rails-pro-dependency-bundle-timestamps", '["server","rsc"]'],
         %w[x-react-on-rails-pro-rsc-stream-observability true]
       )
@@ -466,7 +466,7 @@ describe ReactOnRailsPro::Request do
           "ReactOnRails.dummy",
           {
             "renderingRequest" => "ReactOnRails.dummy",
-            "protocolVersion" => "2.0.0",
+            "protocolVersion" => "3.0.0",
             "gemVersion" => "16.0.0",
             "password" => "secret\r\ninjected: true",
             "railsEnv" => "test",
@@ -483,7 +483,7 @@ describe ReactOnRailsPro::Request do
           "ReactOnRails.dummy",
           {
             "renderingRequest" => "ReactOnRails.dummy",
-            "protocolVersion" => "2.0.0",
+            "protocolVersion" => "3.0.0",
             "gemVersion" => "16.0.0",
             "password" => "secret",
             "railsEnv" => "test\r\ninjected: true",
@@ -498,7 +498,7 @@ describe ReactOnRailsPro::Request do
     let(:form) do
       {
         "renderingRequest" => "ReactOnRails.dummy",
-        "protocolVersion" => "2.0.0",
+        "protocolVersion" => "3.0.0",
         "gemVersion" => "17.0.0",
         "password" => "secret",
         "railsEnv" => "test",
@@ -984,15 +984,15 @@ describe ReactOnRailsPro::Request do
       allow(mock_connection).to receive(:post).and_return(mock_response(status: 200, chunks: ["Assets uploaded"]))
 
       stream = described_class.render_code_with_incremental_updates(
-        "/bundles/old-id/incremental-render/digest",
+        "/bundles/old-id/incremental-render",
         js_code,
         async_props_block:
       )
       stream.each_chunk(&:itself)
 
       expect(request_paths).to eq([
-                                    "/bundles/old-id/incremental-render/digest",
-                                    "/bundles/#{artifact.id}/incremental-render/digest"
+                                    "/bundles/old-id/incremental-render",
+                                    "/bundles/#{artifact.id}/incremental-render"
                                   ])
     end
 
@@ -1031,7 +1031,7 @@ describe ReactOnRailsPro::Request do
       js_code_with_rsc_id = "runOnOtherBundle(#{rsc_artifact.id.to_json})"
 
       stream = described_class.render_code_with_incremental_updates(
-        "/bundles/#{server_artifact.id}/incremental-render/digest",
+        "/bundles/#{server_artifact.id}/incremental-render",
         js_code_with_rsc_id,
         async_props_block:,
         artifacts:
@@ -1039,8 +1039,8 @@ describe ReactOnRailsPro::Request do
       stream.each_chunk(&:itself)
 
       expect(request_paths).to eq([
-                                    "/bundles/#{server_artifact.id}/incremental-render/digest",
-                                    "/bundles/#{server_artifact.id}/incremental-render/digest"
+                                    "/bundles/#{server_artifact.id}/incremental-render",
+                                    "/bundles/#{server_artifact.id}/incremental-render"
                                   ])
       expect(ReactOnRailsPro::AsyncPropsEmitter).to have_received(:new)
         .with(rsc_artifact.id, mock_output, pull_enabled: false).twice

--- a/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/node_rendering_pool_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/node_rendering_pool_spec.rb
@@ -52,7 +52,7 @@ module ReactOnRailsPro
 
       describe ".eval_js" do
         let(:render_options) { instance_double(ReactOnRails::ReactComponent::RenderOptions) }
-        let(:render_path) { "/bundles/123/render/abc" }
+        let(:render_path) { "/bundles/123/render" }
         let(:response_body) { 'Invalid "renderingRequest" field in render request.' }
         let(:response) do
           instance_double(ReactOnRailsPro::RendererHttpClient::Response,
@@ -116,7 +116,7 @@ module ReactOnRailsPro
 
       describe ".exec_server_render_js error classification" do
         let(:js_code) { "console.log('x')" }
-        let(:render_path) { "/bundles/123/render/abc" }
+        let(:render_path) { "/bundles/123/render" }
         let(:render_options) do
           instance_double(
             ReactOnRails::ReactComponent::RenderOptions,
@@ -183,22 +183,19 @@ module ReactOnRailsPro
         let(:render_options) do
           instance_double(
             ReactOnRails::ReactComponent::RenderOptions,
-            request_digest: "abc123",
             rsc_payload_streaming?: false
           )
         end
 
         before do
-          allow(ReactOnRailsPro::ServerRenderingPool::ProRendering)
-            .to receive(:set_request_digest_on_render_options)
           allow(ReactOnRailsPro.configuration).to receive(:enable_rsc_support).and_return(false)
           allow(described_class).to receive_messages(server_bundle_hash: "server123", rsc_bundle_hash: "rsc456")
         end
 
         it "returns path with incremental-render endpoint" do
-          path = described_class.prepare_incremental_render_path(js_code, render_options)
+          path = described_class.prepare_incremental_render_path(render_options)
 
-          expect(path).to eq("/bundles/server123/incremental-render/abc123")
+          expect(path).to eq("/bundles/server123/incremental-render")
         end
 
         context "when RSC support is enabled and rendering RSC payload" do
@@ -211,9 +208,9 @@ module ReactOnRailsPro
           end
 
           it "uses RSC bundle hash instead of server bundle hash" do
-            path = described_class.prepare_incremental_render_path(js_code, render_options)
+            path = described_class.prepare_incremental_render_path(render_options)
 
-            expect(path).to eq("/bundles/rsc456/incremental-render/abc123")
+            expect(path).to eq("/bundles/rsc456/incremental-render")
           end
 
           it "uses the operation snapshot RSC ID instead of rereading a volatile pool ID" do
@@ -222,9 +219,9 @@ module ReactOnRailsPro
               .with(:renderer_artifact_snapshot)
               .and_return([rsc_artifact])
 
-            path = described_class.prepare_incremental_render_path(js_code, render_options)
+            path = described_class.prepare_incremental_render_path(render_options)
 
-            expect(path).to eq("/bundles/rsc-snapshot/incremental-render/abc123")
+            expect(path).to eq("/bundles/rsc-snapshot/incremental-render")
           end
         end
       end
@@ -233,8 +230,6 @@ module ReactOnRailsPro
         let(:js_code) { "console.log('test');" }
 
         before do
-          allow(ReactOnRailsPro::ServerRenderingPool::ProRendering)
-            .to receive(:set_request_digest_on_render_options)
           allow(ReactOnRailsPro.configuration).to receive(:enable_rsc_support).and_return(false)
           allow(described_class).to receive_messages(server_bundle_hash: "server123", rsc_bundle_hash: "rsc456")
         end
@@ -253,16 +248,16 @@ module ReactOnRailsPro
           end
 
           it "calls prepare_incremental_render_path and render_code_with_incremental_updates" do
-            expected_path = "/bundles/server123/incremental-render/abc123"
+            expected_path = "/bundles/server123/incremental-render"
             allow(described_class).to receive(:prepare_incremental_render_path)
-              .with(js_code, render_options)
+              .with(render_options)
               .and_return(expected_path)
             allow(ReactOnRailsPro::Request).to receive(:render_code_with_incremental_updates)
 
             described_class.eval_streaming_js(js_code, render_options)
 
             expect(described_class).to have_received(:prepare_incremental_render_path)
-              .with(js_code, render_options)
+              .with(render_options)
             expect(ReactOnRailsPro::Request).to have_received(:render_code_with_incremental_updates)
               .with(
                 expected_path,
@@ -276,10 +271,10 @@ module ReactOnRailsPro
           end
 
           it "enables pull mode when push_props is provided" do
-            expected_path = "/bundles/server123/incremental-render/abc123"
+            expected_path = "/bundles/server123/incremental-render"
             allow(render_options).to receive(:internal_option).with(:push_props).and_return([])
             allow(described_class).to receive(:prepare_incremental_render_path)
-              .with(js_code, render_options)
+              .with(render_options)
               .and_return(expected_path)
             allow(ReactOnRailsPro::Request).to receive(:render_code_with_incremental_updates)
 
@@ -307,16 +302,16 @@ module ReactOnRailsPro
           end
 
           it "calls prepare_render_path and render_code_as_stream" do
-            expected_path = "/bundles/server123/render/abc123"
+            expected_path = "/bundles/server123/render"
             allow(described_class).to receive(:prepare_render_path)
-              .with(js_code, render_options)
+              .with(render_options)
               .and_return(expected_path)
             allow(ReactOnRailsPro::Request).to receive(:render_code_as_stream)
 
             described_class.eval_streaming_js(js_code, render_options)
 
             expect(described_class).to have_received(:prepare_render_path)
-              .with(js_code, render_options)
+              .with(render_options)
             expect(ReactOnRailsPro::Request).to have_received(:render_code_as_stream)
               .with(expected_path, js_code, is_rsc_payload: false, rsc_stream_observability: false)
           end

--- a/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
@@ -199,6 +199,14 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
         expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
         expect(cache_store.fetch_calls).to be_empty
       end
+
+      it "does not compute the request digest (MD5 is cache-only)" do
+        render_options = build_render_options
+
+        described_class.exec_server_render_js(js_code, render_options)
+
+        expect(render_options.request_digest).to be_nil
+      end
     end
 
     context "when skip_prerender_cache is set" do


### PR DESCRIPTION
## What Changed

**BREAKING** (protocol-major): Bumps the gem↔node-renderer wire protocol from 2.0.0 to 3.0.0 by removing two legacy artifacts:

### 1. `targetBundles` removed from asset upload and asset-exists

- **Gem**: `upload_assets` no longer sends `form["targetBundles"]`. The node renderer already derived target directories from `bundle_<hash>` form keys and ignored this field.
- **`/asset-exists`**: Migrated from `targetBundles` to `bundle_<hash>` keys on both the gem and node sides. The gem now sends `bundle_<hash>: true` keys, and the node endpoint extracts bundle hashes from those keys (matching the convention already used by `/upload-assets`).
- **Single-flight key**: Updated `upload_assets_single_flight_key` parameter name from `target_bundles` to `bundle_hashes`.

### 2. `:renderRequestDigest` removed from render URLs

- **Node renderer**: Render route changed from `/bundles/:bundleTimestamp/render/:renderRequestDigest` to `/bundles/:bundleTimestamp/render`. Same for incremental-render.
- **Gem**: `build_render_path` no longer appends `render_options.request_digest` to the URL.
- **MD5 digest now cache-only**: `set_request_digest_on_render_options` is only called when prerender caching is enabled. Previously it computed an MD5 of the full JS code on every render, even when caching was off.

### 3. Protocol version bump

- Gem: `PROTOCOL_VERSION = "3.0.0"` in `version.rb`
- Node: `"protocolVersion": "3.0.0"` in `package.json`
- Existing `checkProtocolVersion` handler returns HTTP 412 on mismatch (no changes needed)

### 4. Cleanup

- Removed all TODO comments referencing `react_on_rails_pro/issues/119`

## How to Verify

- Gem and node renderer must be upgraded together (protocol version gate rejects mismatches)
- All existing specs updated to reflect the new protocol
- Worker tests: 65 passed ✅
- Upload race condition tests: 5 passed ✅
- Health endpoint tests: 14 passed ✅
- Request spec: 53 passed ✅
- Renderer HTTP client spec: 62 passed ✅

## Migration Impact

Users upgrading to 18.0 must upgrade both the gem and node renderer together. The protocol version gate (HTTP 412) ensures mismatched versions fail fast with a clear error message rather than silently breaking.

Fixes #4873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Updated the Pro protocol to version 3.0.0.
  - Asset uploads and availability checks now identify bundles using bundle-specific fields instead of the previous bundle list.
  - Render and incremental-render URLs no longer require a request digest.
  - Ruby and Node renderer upgrades must be coordinated to maintain compatibility.

- **Performance**
  - Request digest computation is now limited to renders using prerender caching.
  - Non-cached renders avoid unnecessary digest calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->