### PR TITLE
PPR: marker-in-content regression test and version-skew error message (#4890)

### DIFF
--- a/packages/react-on-rails-pro/tests/pprServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/pprServerRenderedReactComponent.test.jsx
@@ -75,6 +75,24 @@ const PprFullyStatic = () => (
   </div>
 );
 
+// Regression component for the in-band flaw (#4890): user content deliberately contains the
+// EXACT bytes of the old #4659 prototype delimiter. The metadata-based protocol must transport
+// the PostponedState correctly regardless of what the rendered HTML contains.
+// dangerouslySetInnerHTML bypasses React's escaping so the literal <!--PPR_POSTPONED_STATE-->
+// comment lands in the HTML output — the strongest possible regression for an in-band scanner.
+const PprMarkerInContent = (props) => (
+  <div>
+    <h1>{SHELL_HEADER_TEXT}</h1>
+    <div
+      dangerouslySetInnerHTML={{ __html: '<!--PPR_POSTPONED_STATE-->{"fake":"not real PostponedState"}' }}
+    />
+    <p>PPR_POSTPONED_STATE</p>
+    <React.Suspense fallback={<div>{HOLE_FALLBACK_TEXT}</div>}>
+      <DelayedHole {...props} />
+    </React.Suspense>
+  </div>
+);
+
 describe('pprServerRenderedReactComponent', () => {
   const testingRailsContext = {
     serverSideRSCPayloadParameters: {},
@@ -206,6 +224,39 @@ describe('pprServerRenderedReactComponent', () => {
 
     // The in-band delimiter of the #4659 prototype must not exist anywhere in the output.
     expect(html).not.toContain('PPR_POSTPONED_STATE');
+  });
+
+  it('round-trips correctly when rendered HTML contains the old in-band marker text (#4890 regression)', async () => {
+    // A component whose output contains the literal old delimiter text must not confuse the
+    // metadata-based protocol. This is the classic in-band signaling flaw: if the protocol
+    // scanned HTML for a marker, user content containing that marker would break the split.
+    const { chunks, errors } = await collectStreamResult(
+      runPrerender({ component: PprMarkerInContent, componentName: 'PprMarkerInContent' }),
+    );
+    const html = chunks.map((chunk) => chunk.html).join('');
+
+    expect(errors).toHaveLength(0);
+    // The marker text IS in the HTML — it's user content, not a protocol artifact.
+    expect(html).toContain('PPR_POSTPONED_STATE');
+    expect(html).toContain('<!--PPR_POSTPONED_STATE-->');
+
+    // The trailing protocol chunk still carries valid metadata — unaffected by the content.
+    const trailingChunk = chunks[chunks.length - 1];
+    expect(trailingChunk[PPR_PRERENDER_COMPLETE_CHUNK_KEY]).toBe(true);
+    expect(trailingChunk[PPR_RENDER_ERRORED_CHUNK_KEY]).toBeUndefined();
+    const postponedStateJson = trailingChunk[PPR_POSTPONED_STATE_CHUNK_KEY];
+    expect(typeof postponedStateJson).toBe('string');
+    const postponedState = JSON.parse(postponedStateJson);
+    expect(typeof postponedState).toBe('object');
+    expect(postponedState).not.toBeNull();
+
+    // The PostponedState round-trips through resume — the marker in content didn't corrupt it.
+    const { chunks: resumeChunks, errors: resumeErrors } = await collectStreamResult(
+      runResume({ component: PprMarkerInContent, componentName: 'PprMarkerInContent', postponedStateJson }),
+    );
+    expect(resumeErrors).toHaveLength(0);
+    const resumeHtml = resumeChunks.map((chunk) => chunk.html).join('');
+    expect(resumeHtml).toContain(HOLE_CONTENT_MARKER);
   });
 
   it('treats a fully static prerender (postponed === null) as a success with no PostponedState (D-04)', async () => {

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1465,12 +1465,16 @@ module ReactOnRailsProHelper
 
   # A prerender response with neither the completion metadata nor an error signal means the
   # server bundle does not speak the PPR protocol — surface that as a configuration error rather
-  # than caching a shell with no way to tell whether it is complete.
+  # than caching a shell with no way to tell whether it is complete. The message names both sides'
+  # expectations so version-skew (old renderer ↔ new Rails) is diagnosable (#4890).
   def ppr_check_prerender_protocol!(component_name, prerender_complete, had_render_error)
     return if prerender_complete || had_render_error
 
     raise ReactOnRailsPro::Error,
-          "PPR prerender for #{component_name} did not report completion metadata. " \
+          "PPR prerender for #{component_name} did not report completion metadata " \
+          "(expected chunk metadata key '#{ReactOnRailsPro::Ppr::PRERENDER_COMPLETE_CHUNK_KEY}'). " \
+          "Rails (react_on_rails_pro v#{ReactOnRailsPro::VERSION}) requires the renderer to emit " \
+          "a trailing protocol chunk with PPR metadata. " \
           "Ensure the server bundle is built with a react-on-rails-pro package that supports PPR, " \
           "that react and react-dom >= 19.2.7 < 20 are installed, and that the prerender stream " \
           "was not terminated abnormally."

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -2463,9 +2463,10 @@ describe ReactOnRailsProHelper do
         mock_ppr_responses(legacy_chunks)
         stub_render_with_ppr
 
+        version_pattern = Regexp.escape(ReactOnRailsPro::VERSION)
         expect { run_stream }.to raise_error(
           ReactOnRailsPro::Error,
-          /did not report completion metadata.*pprPrerenderComplete.*react_on_rails_pro v/
+          /did not report completion metadata.*pprPrerenderComplete.*react_on_rails_pro v#{version_pattern}/
         )
         expect(Rails.cache.read(computed_ppr_cache_key)).to be_nil
       end

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -2464,7 +2464,8 @@ describe ReactOnRailsProHelper do
         stub_render_with_ppr
 
         expect { run_stream }.to raise_error(
-          ReactOnRailsPro::Error, /did not report completion metadata/
+          ReactOnRailsPro::Error,
+          /did not report completion metadata.*pprPrerenderComplete.*react_on_rails_pro v/
         )
         expect(Rails.cache.read(computed_ppr_cache_key)).to be_nil
       end


### PR DESCRIPTION
## What

Closes #4890 — the remaining acceptance criteria after the core PostponedState-on-metadata work was absorbed by the pipeline re-land (#4888).

### 1. Marker-in-content regression test (JS)

Adds a test proving the metadata-based protocol is immune to the classic in-band signaling flaw: a component whose rendered HTML contains the literal old `PPR_POSTPONED_STATE` delimiter text (injected via `dangerouslySetInnerHTML` so the exact bytes land in the output) round-trips correctly through prerender **and** resume.

This is the test that would fail under the old #4659 prototype's delimiter-scanning approach — any rendered content containing the marker text would cause the split to land in the wrong place.

### 2. Version-skew error message (Ruby)

Improves the error message in `ppr_check_prerender_protocol!` to name both sides' expectations:
- The expected chunk metadata key (`pprPrerenderComplete`)
- The Rails gem version (`react_on_rails_pro vX.Y.Z`)

This makes version-skew scenarios (old renderer ↔ new Rails) diagnosable.

### Not included (by design)

**Parser stripping of PPR keys** — discussed and decided to skip. The current design correctly keeps the parser generic (`parseLengthPrefixedStream.ts` and `length_prefixed_parser.rb` strip only `payloadType`). PPR keys pass through as opaque metadata for the application layer, consistent with `hasErrors`, `consoleReplayScript`, etc. Stripping them would couple the generic parser to PPR-specific constants with no architectural benefit.

## Verification

- [x] JS PPR tests: 12/12 pass (`pnpm --filter react-on-rails-pro exec jest tests/pprServerRenderedReactComponent.test.jsx`)
- [x] Ruby version-skew test: 1/1 pass (`bundle exec rspec -e 'lacks the PPR protocol metadata'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)