### PR TITLE
PPR: versioned envelope, cache validation, and graceful degradation (#4891)

### DIFF
--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1682,7 +1682,8 @@ module ReactOnRailsProHelper
     Rails.cache.delete(cache_key, cache_write_options)
     ReactOnRailsPro::Ppr.instrument_degraded_pre_flush(component_name:, error:)
     Rails.logger.warn do
-      "[ReactOnRailsPro] PPR pre-flush degradation for #{component_name}: #{error.class}: #{error.message}. " \
+      safe_msg = ppr_sanitize_for_log(error.message)
+      "[ReactOnRailsPro] PPR pre-flush degradation for #{component_name}: #{error.class}: #{safe_msg}. " \
         "Evicted #{cache_key.inspect} and falling back to full SSR."
     end
   rescue StandardError => e
@@ -1702,13 +1703,21 @@ module ReactOnRailsProHelper
     end
     ReactOnRailsPro::Ppr.instrument_degraded_post_flush(component_name:, error:)
     Rails.logger.warn do
-      "[ReactOnRailsPro] PPR post-flush degradation for #{component_name}: #{error.class}: #{error.message}. " \
+      safe_msg = ppr_sanitize_for_log(error.message)
+      "[ReactOnRailsPro] PPR post-flush degradation for #{component_name}: #{error.class}: #{safe_msg}. " \
         "Stream terminated; entry evicted. Next request will prerender cleanly."
     end
   rescue StandardError => e
     Rails.logger.debug do
       "[ReactOnRailsPro] PPR post-flush degradation handler failed: #{e.class}: #{e.message}"
     end
+  end
+
+  # Sanitizes a string for safe interpolation into log messages. Strips newlines (which could
+  # inject fake log lines) and truncates to a reasonable length (preventing oversized log entries
+  # from error messages that dump full payloads).
+  def ppr_sanitize_for_log(value, max_length: 1024)
+    value.to_s.tr("\n\r", " ")[0, max_length]
   end
 
   # Async version of fetch_react_component. Handles cache lookup synchronously,

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -503,7 +503,9 @@ module ReactOnRailsProHelper
       cached_entry = ppr_read_cache_entry(cache_key, raw_cache_options)
 
       if cached_entry
-        ppr_cache_hit(component_name, render_options, cached_entry, &block)
+        ppr_cache_hit_with_fallback(
+          component_name, render_options, cached_entry, cache_key, raw_cache_options, &block
+        )
       else
         ppr_cache_miss(component_name, render_options, cache_key, raw_cache_options, &block)
       end
@@ -1368,23 +1370,78 @@ module ReactOnRailsProHelper
     )
   end
 
+  # Reads and validates the PPR cache envelope. Returns the validated envelope Hash on a good
+  # hit, nil on miss, and nil (with eviction + instrumentation) on a corrupt or stale entry.
   # A cache read error is treated as a miss: log and fall through to the prerender phase.
   def ppr_read_cache_entry(cache_key, raw_cache_options)
     cache_write_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
     entry = Rails.cache.read(cache_key, cache_write_options)
-    ppr_valid_cache_entry?(entry) ? entry : nil
+    return nil if entry.nil?
+
+    if ppr_valid_cache_envelope?(entry)
+      entry
+    else
+      ppr_evict_invalid_entry(cache_key, cache_write_options, entry)
+      nil
+    end
   rescue StandardError => e
     Rails.logger.warn("[ReactOnRailsPro] PPR cache read failed (treating as miss): #{e.class}: #{e.message}")
     nil
   end
 
-  # The paired record is one Hash: "shell_html" always present; "postponed_state" present only
-  # when the page has dynamic holes (a shell-only record is a fully static page). String keys —
-  # the record must survive non-Marshal cache serializers (e.g. JSON), which have no Symbol type.
-  # A malformed record is treated as a miss and re-prerendered.
-  def ppr_valid_cache_entry?(entry)
-    entry.is_a?(Hash) && entry["shell_html"].is_a?(String) &&
-      (entry["postponed_state"].nil? || entry["postponed_state"].is_a?(String))
+  # Validates the versioned cache envelope (issue #4891 Layer 2). The envelope wraps the cached
+  # shell + PostponedState with schema version, React version, and a SHA-256 checksum. String
+  # keys — the record must survive non-Marshal cache serializers (e.g. JSON).
+  #
+  # A valid envelope is a Hash with:
+  # - "schema" == PPR_ENVELOPE_SCHEMA (known format version)
+  # - "react"  == current react_version_cache_key (belt-and-suspenders with the cache key)
+  # - "shell_html" is a String
+  # - "postponed_state" is nil (fully static) or a String (dynamic holes)
+  # - "checksum" matches the recomputed SHA-256 over shell_html + postponed_state
+  def ppr_valid_cache_envelope?(entry)
+    return false unless entry.is_a?(Hash)
+    return false unless entry["schema"] == ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA
+    return false unless entry["shell_html"].is_a?(String)
+    return false unless entry["postponed_state"].nil? || entry["postponed_state"].is_a?(String)
+    return false unless entry["react"] == ReactOnRailsPro::Ppr.react_version_cache_key
+
+    expected = ReactOnRailsPro::Ppr.compute_checksum(entry["shell_html"], entry["postponed_state"])
+    entry["checksum"] == expected
+  end
+
+  # Evicts a corrupt or stale PPR cache entry and instruments the eviction so operators can
+  # monitor cache-health (issue #4891 Layer 2). Called when an entry is present but fails
+  # envelope validation — never for a clean miss.
+  def ppr_evict_invalid_entry(cache_key, cache_write_options, entry)
+    Rails.cache.delete(cache_key, cache_write_options)
+    reason = ppr_invalid_entry_reason(entry)
+    ReactOnRailsPro::Ppr.instrument_evict_invalid(component_name: "unknown", reason:)
+    Rails.logger.warn do
+      "[ReactOnRailsPro] PPR cache entry evicted (#{reason}): #{cache_key.inspect}"
+    end
+  rescue StandardError => e
+    # Eviction instrumentation must not mask the original miss path.
+    Rails.logger.debug do
+      "[ReactOnRailsPro] PPR eviction instrumentation failed: #{e.class}: #{e.message}"
+    end
+  end
+
+  # Returns a diagnostic reason string for why the envelope validation failed. Used in
+  # instrumentation payloads and log messages.
+  def ppr_invalid_entry_reason(entry)
+    return "malformed" unless entry.is_a?(Hash)
+
+    schema = entry["schema"]
+    return "unknown_schema" if schema.nil? || schema != ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA
+
+    return "malformed" unless entry["shell_html"].is_a?(String)
+    return "malformed" unless entry["postponed_state"].nil? || entry["postponed_state"].is_a?(String)
+
+    react = entry["react"]
+    return "react_version_mismatch" unless react == ReactOnRailsPro::Ppr.react_version_cache_key
+
+    "checksum_mismatch"
   end
 
   # Cold path: evaluate props, prerender the shell, persist the paired record, serve the shell,
@@ -1396,20 +1453,33 @@ module ReactOnRailsProHelper
     prerender_result = ppr_prerender(component_name, options)
     ppr_write_cache_entry(prerender_result, cache_key, raw_cache_options, render_options)
 
-    ppr_serve_shell(component_name, options, prerender_result, cache_hit: false)
+    ppr_serve_shell(component_name, options, prerender_result,
+                    cache_hit: false, cache_key:, raw_cache_options:)
+  end
+
+  # Pre-flush fallback wrapper (issue #4891 Layer 3a). The cache-hit path runs BEFORE the shell
+  # is committed to the HTTP response — if anything raises here, the response is still virgin and
+  # we can evict the suspect entry + fall through to a full streaming SSR (cache-miss path).
+  def ppr_cache_hit_with_fallback(component_name, render_options, cached_entry,
+                                  cache_key, raw_cache_options, &)
+    ppr_cache_hit(component_name, render_options, cached_entry, cache_key, raw_cache_options, &)
+  rescue StandardError => e
+    ppr_handle_pre_flush_degradation(component_name, cache_key, raw_cache_options, e)
+    ppr_cache_miss(component_name, render_options, cache_key, raw_cache_options, &)
   end
 
   # Warm path: serve the cached shell instantly (no prerender request) and resume the dynamic
   # holes with THIS request's fresh props. The component specification tag is regenerated per
   # request so client hydration receives the fresh props; only the raw prerendered shell HTML and
   # PostponedState are cached.
-  def ppr_cache_hit(component_name, render_options, cached_entry)
+  def ppr_cache_hit(component_name, render_options, cached_entry, cache_key, raw_cache_options)
     props = yield
     options = render_options.merge(props:, prerender: true, skip_prerender_cache: true)
 
     prerender_result = ppr_hit_prerender_result(component_name, options, cached_entry)
 
-    ppr_serve_shell(component_name, options, prerender_result, cache_hit: true)
+    ppr_serve_shell(component_name, options, prerender_result,
+                    cache_hit: true, cache_key:, raw_cache_options:)
   end
 
   # Builds the warm path's per-request render context (render options + component specification
@@ -1480,8 +1550,9 @@ module ReactOnRailsProHelper
           "was not terminated abnormally."
   end
 
-  # Persists shell + PostponedState as ONE atomic record — there is never a state without its
-  # shell, and mixing generations is impossible. The write is skipped entirely when the prerender
+  # Persists shell + PostponedState as a versioned envelope — schema version, React version,
+  # content, and a SHA-256 checksum over shell + state. There is never a state without its shell,
+  # and mixing generations is impossible. The write is skipped entirely when the prerender
   # reported a rendering error: a shell prerendered from a partially failed tree must never be
   # persisted and served to later visitors (the #4581 class of bug).
   def ppr_write_cache_entry(prerender_result, cache_key, raw_cache_options, render_options)
@@ -1494,13 +1565,19 @@ module ReactOnRailsProHelper
     end
     return if ReactOnRailsPro::Cache.cache_write_expired?(raw_cache_options)
 
+    shell_html = prerender_result[:shell_html]
+    postponed_state = prerender_result[:postponed_state]
+    envelope = {
+      "schema" => ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA,
+      "react" => ReactOnRailsPro::Ppr.react_version_cache_key,
+      "shell_html" => shell_html,
+      "postponed_state" => postponed_state,
+      "checksum" => ReactOnRailsPro::Ppr.compute_checksum(shell_html, postponed_state)
+    }
+
     cache_write_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
     normalized_cache_tags = ReactOnRailsPro::Cache.normalize_tags(render_options[:cache_tags])
-    Rails.cache.write(
-      cache_key,
-      { "shell_html" => prerender_result[:shell_html], "postponed_state" => prerender_result[:postponed_state] },
-      cache_write_options
-    )
+    Rails.cache.write(cache_key, envelope, cache_write_options)
     ReactOnRailsPro::Cache.register_normalized_tags(normalized_cache_tags, cache_key, cache_write_options)
   end
 
@@ -1509,7 +1586,11 @@ module ReactOnRailsProHelper
   # dynamic holes, starts the resume phase that streams them. A shell with no PostponedState is a
   # fully static page: SUCCESS with no resume request, counted by the ppr.static_shell counter —
   # unless the prerender reported a render error, which is a failed render, not a static page.
-  def ppr_serve_shell(component_name, options, prerender_result, cache_hit:)
+  #
+  # cache_key and raw_cache_options are threaded through to ppr_enqueue_resume_stream so the
+  # post-flush degradation handler (Layer 3b) can evict the entry on resume failure.
+  def ppr_serve_shell(component_name, options, prerender_result, cache_hit:,
+                      cache_key: nil, raw_cache_options: nil)
     shell_result = build_react_component_result_for_server_rendered_string(
       server_rendered_html: prerender_result[:shell_html],
       component_specification_tag: prerender_result[:tag],
@@ -1519,7 +1600,8 @@ module ReactOnRailsProHelper
 
     postponed_state = prerender_result[:postponed_state]
     if postponed_state.present?
-      ppr_enqueue_resume_stream(component_name, options, postponed_state)
+      ppr_enqueue_resume_stream(component_name, options, postponed_state,
+                                cache_key:, raw_cache_options:)
     elsif !prerender_result[:had_render_error]
       ReactOnRailsPro::Ppr.instrument_static_shell(component_name:, cache_hit:)
     end
@@ -1532,9 +1614,14 @@ module ReactOnRailsProHelper
   # synchronous return value, so nothing from the resume stream may be returned synchronously —
   # the previous design routed the first chunk through a promise and re-enqueued it from the
   # calling fiber, which dropped or reordered the first hole's content (#4659 review defect 4).
-  # Resume errors raise out of the barrier task and surface at @async_barrier.wait, matching the
-  # post-shell error semantics of streamed components.
-  def ppr_enqueue_resume_stream(component_name, options, postponed_state)
+  #
+  # Post-flush degradation (issue #4891 Layer 3b): if the resume phase raises after the shell has
+  # already been committed to the HTTP response, the error is caught here — the cache entry is
+  # evicted so the next request prerenders cleanly, and the stream terminates without appending a
+  # second document. The error does NOT re-raise: the user sees a truncated page that heals on
+  # reload, never a 500 caused by the PPR cache.
+  def ppr_enqueue_resume_stream(component_name, options, postponed_state,
+                                cache_key: nil, raw_cache_options: nil)
     renderer_server_timing_collector = ReactOnRailsPro::Stream.renderer_server_timing_collector
 
     @async_barrier.async do
@@ -1549,6 +1636,11 @@ module ReactOnRailsProHelper
       end
     rescue Async::Queue::ClosedError
       # Queue closed due to error/disconnect in another component — stop enqueuing.
+    rescue StandardError => e
+      # Post-flush: the shell already left the building — we cannot start over.
+      # Evict the entry so the next request gets a fresh prerender, but do NOT
+      # re-raise — that would surface as a 500 or append a second document.
+      ppr_handle_post_flush_degradation(component_name, cache_key, raw_cache_options, e)
     end
   end
 
@@ -1566,6 +1658,44 @@ module ReactOnRailsProHelper
       result_console_script = render_opts.replay_console ? wrap_console_script_with_nonce(console_script) : ""
       compose_react_component_html_with_spec_and_console("", chunk_json_result["html"] || "",
                                                          result_console_script)
+    end
+  end
+
+  # Pre-flush degradation handler (issue #4891 Layer 3a). Called when the cache-hit path raises
+  # before the shell has been committed to the HTTP response. Evicts the entry so the next request
+  # does not hit the same failure, instruments the event, and returns — the caller falls through
+  # to a full cache-miss prerender. Must not raise.
+  def ppr_handle_pre_flush_degradation(component_name, cache_key, raw_cache_options, error)
+    cache_write_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
+    Rails.cache.delete(cache_key, cache_write_options)
+    ReactOnRailsPro::Ppr.instrument_degraded_pre_flush(component_name:, error:)
+    Rails.logger.warn do
+      "[ReactOnRailsPro] PPR pre-flush degradation for #{component_name}: #{error.class}: #{error.message}. " \
+        "Evicted #{cache_key.inspect} and falling back to full SSR."
+    end
+  rescue StandardError => e
+    Rails.logger.debug do
+      "[ReactOnRailsPro] PPR pre-flush degradation handler failed: #{e.class}: #{e.message}"
+    end
+  end
+
+  # Post-flush degradation handler (issue #4891 Layer 3b). Called when the resume phase raises
+  # after the shell has already been written to the HTTP response. Evicts the cache entry so the
+  # next request prerenders cleanly — but does NOT re-raise, because the response is committed
+  # and a second document would produce Frankenstein HTML.
+  def ppr_handle_post_flush_degradation(component_name, cache_key, raw_cache_options, error)
+    if cache_key
+      cache_write_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
+      Rails.cache.delete(cache_key, cache_write_options)
+    end
+    ReactOnRailsPro::Ppr.instrument_degraded_post_flush(component_name:, error:)
+    Rails.logger.warn do
+      "[ReactOnRailsPro] PPR post-flush degradation for #{component_name}: #{error.class}: #{error.message}. " \
+        "Stream terminated; entry evicted. Next request will prerender cleanly."
+    end
+  rescue StandardError => e
+    Rails.logger.debug do
+      "[ReactOnRailsPro] PPR post-flush degradation handler failed: #{e.class}: #{e.message}"
     end
   end
 

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -500,7 +500,7 @@ module ReactOnRailsProHelper
 
       cache_key = ppr_cache_key(component_name, render_options)
       raw_cache_options = render_options[:cache_options] || {}
-      cached_entry = ppr_read_cache_entry(cache_key, raw_cache_options)
+      cached_entry = ppr_read_cache_entry(cache_key, raw_cache_options, component_name)
 
       if cached_entry
         ppr_cache_hit_with_fallback(
@@ -1373,7 +1373,7 @@ module ReactOnRailsProHelper
   # Reads and validates the PPR cache envelope. Returns the validated envelope Hash on a good
   # hit, nil on miss, and nil (with eviction + instrumentation) on a corrupt or stale entry.
   # A cache read error is treated as a miss: log and fall through to the prerender phase.
-  def ppr_read_cache_entry(cache_key, raw_cache_options)
+  def ppr_read_cache_entry(cache_key, raw_cache_options, component_name = "unknown")
     cache_write_options = ReactOnRailsPro::Cache.cache_write_options(raw_cache_options)
     entry = Rails.cache.read(cache_key, cache_write_options)
     return nil if entry.nil?
@@ -1381,7 +1381,7 @@ module ReactOnRailsProHelper
     if ppr_valid_cache_envelope?(entry)
       entry
     else
-      ppr_evict_invalid_entry(cache_key, cache_write_options, entry)
+      ppr_evict_invalid_entry(cache_key, cache_write_options, entry, component_name)
       nil
     end
   rescue StandardError => e
@@ -1413,10 +1413,10 @@ module ReactOnRailsProHelper
   # Evicts a corrupt or stale PPR cache entry and instruments the eviction so operators can
   # monitor cache-health (issue #4891 Layer 2). Called when an entry is present but fails
   # envelope validation — never for a clean miss.
-  def ppr_evict_invalid_entry(cache_key, cache_write_options, entry)
+  def ppr_evict_invalid_entry(cache_key, cache_write_options, entry, component_name = "unknown")
     Rails.cache.delete(cache_key, cache_write_options)
     reason = ppr_invalid_entry_reason(entry)
-    ReactOnRailsPro::Ppr.instrument_evict_invalid(component_name: "unknown", reason:)
+    ReactOnRailsPro::Ppr.instrument_evict_invalid(component_name:, reason:)
     Rails.logger.warn do
       "[ReactOnRailsPro] PPR cache entry evicted (#{reason}): #{cache_key.inspect}"
     end
@@ -1460,20 +1460,32 @@ module ReactOnRailsProHelper
   # Pre-flush fallback wrapper (issue #4891 Layer 3a). The cache-hit path runs BEFORE the shell
   # is committed to the HTTP response — if anything raises here, the response is still virgin and
   # we can evict the suspect entry + fall through to a full streaming SSR (cache-miss path).
+  #
+  # Props are evaluated OUTSIDE the degradation guard so a transient request-local failure
+  # (e.g. database timeout during props generation) does not evict a valid shared cache entry
+  # and does not double-evaluate the props block via the cache-miss fallback.
   def ppr_cache_hit_with_fallback(component_name, render_options, cached_entry,
-                                  cache_key, raw_cache_options, &)
-    ppr_cache_hit(component_name, render_options, cached_entry, cache_key, raw_cache_options, &)
-  rescue StandardError => e
-    ppr_handle_pre_flush_degradation(component_name, cache_key, raw_cache_options, e)
-    ppr_cache_miss(component_name, render_options, cache_key, raw_cache_options, &)
+                                  cache_key, raw_cache_options)
+    props = yield
+
+    begin
+      ppr_cache_hit(component_name, render_options, cached_entry,
+                    cache_key:, raw_cache_options:, props:)
+    rescue StandardError => e
+      ppr_handle_pre_flush_degradation(component_name, cache_key, raw_cache_options, e)
+      ppr_cache_miss(component_name, render_options, cache_key, raw_cache_options) { props }
+    end
   end
 
   # Warm path: serve the cached shell instantly (no prerender request) and resume the dynamic
   # holes with THIS request's fresh props. The component specification tag is regenerated per
   # request so client hydration receives the fresh props; only the raw prerendered shell HTML and
   # PostponedState are cached.
-  def ppr_cache_hit(component_name, render_options, cached_entry, cache_key, raw_cache_options)
-    props = yield
+  #
+  # Props are passed as a pre-evaluated value (not a block) so the pre-flush fallback wrapper
+  # can evaluate them once and reuse them in the cache-miss fallback without double evaluation.
+  def ppr_cache_hit(component_name, render_options, cached_entry,
+                    cache_key:, raw_cache_options:, props:)
     options = render_options.merge(props:, prerender: true, skip_prerender_cache: true)
 
     prerender_result = ppr_hit_prerender_result(component_name, options, cached_entry)

--- a/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
@@ -13,6 +13,7 @@
 # For licensing terms:
 # https://github.com/shakacode/react_on_rails/blob/main/REACT-ON-RAILS-PRO-LICENSE.md
 
+require "digest"
 require "json"
 
 module ReactOnRailsPro
@@ -29,14 +30,40 @@ module ReactOnRailsPro
     RENDER_ERRORED_CHUNK_KEY = "pprRenderErrored"
     # MIRROR VALUES END
 
-    # Version of the {shell_html:, postponed_state:} cache-record format. Part of every PPR cache
-    # key so a future storage-format change structurally misses instead of misparsing old entries.
-    CACHE_SCHEMA_VERSION = "ppr-schema-v2"
+    # Version of the cache-record format. Part of every PPR cache key so a storage-format change
+    # structurally misses instead of misparsing old entries. Bumped from v2 (bare record) to v3
+    # (versioned envelope with checksum) so pre-envelope entries become immediate misses.
+    CACHE_SCHEMA_VERSION = "ppr-schema-v3"
+
+    # Schema version stored INSIDE the cached envelope. Compared on read so an unknown schema
+    # (e.g. from a future code version that wrote a newer envelope format) is rejected rather
+    # than misparsed. Distinct from CACHE_SCHEMA_VERSION, which lives in the cache KEY.
+    PPR_ENVELOPE_SCHEMA = 1
 
     # ActiveSupport::Notifications event emitted each time a PPR render serves a fully-static
     # shell (prerender finished with `postponed == null`, so no resume phase runs). This is the
     # `ppr.static_shell` counter: subscribe and count events. Payload: :component_name, :cache_hit.
     STATIC_SHELL_NOTIFICATION = "ppr.static_shell.react_on_rails_pro"
+
+    # Instrumentation events for the three degradation paths (issue #4891):
+    #
+    # ppr.cache.evict_invalid — a cached entry failed envelope validation (unknown schema, React
+    # version mismatch, checksum mismatch, or malformed structure). The entry is evicted and the
+    # request falls through to a cache-miss prerender.
+    # Payload: :component_name, :reason
+    EVICT_INVALID_NOTIFICATION = "ppr.cache.evict_invalid.react_on_rails_pro"
+
+    # ppr.resume.degraded_pre_flush — the cache-hit path raised BEFORE the shell was written to
+    # the HTTP response. The entry is evicted and the request falls back to a full streaming SSR
+    # (cache-miss path) in the same request. The user sees a normal page, just slower.
+    # Payload: :component_name, :error
+    DEGRADED_PRE_FLUSH_NOTIFICATION = "ppr.resume.degraded_pre_flush.react_on_rails_pro"
+
+    # ppr.resume.degraded_post_flush — the resume phase failed AFTER the shell was already
+    # flushed to the client. The entry is evicted and the stream is terminated — no second
+    # document is appended. The client's next request is a structural miss → fresh render.
+    # Payload: :component_name, :error
+    DEGRADED_POST_FLUSH_NOTIFICATION = "ppr.resume.degraded_post_flush.react_on_rails_pro"
 
     # Cache-key term when the installed React version cannot be determined. The bundle digest in
     # the base cache key still invalidates PPR entries on any rebuild (which a React upgrade
@@ -62,11 +89,45 @@ module ReactOnRailsPro
         @react_version_cache_key = nil
       end
 
+      # SHA-256 checksum over the shell HTML and PostponedState. Used inside the cached envelope
+      # to detect truncation or corruption that slipped past the cache store. A type tag ("S:" for
+      # a string state, "N" for nil) prevents ambiguity between a nil state (fully static page)
+      # and an empty-string state; the null byte separators prevent collisions between
+      # (shell="a", state="b") and (shell="a\x00...", state="").
+      def compute_checksum(shell_html, postponed_state)
+        state_segment = postponed_state.nil? ? "N" : "S:#{postponed_state}"
+        Digest::SHA256.hexdigest("#{shell_html}\x00#{state_segment}")
+      end
+
       def instrument_static_shell(component_name:, cache_hit:)
         ActiveSupport::Notifications.instrument(
           STATIC_SHELL_NOTIFICATION,
           component_name:,
           cache_hit:
+        )
+      end
+
+      def instrument_evict_invalid(component_name:, reason:)
+        ActiveSupport::Notifications.instrument(
+          EVICT_INVALID_NOTIFICATION,
+          component_name:,
+          reason:
+        )
+      end
+
+      def instrument_degraded_pre_flush(component_name:, error:)
+        ActiveSupport::Notifications.instrument(
+          DEGRADED_PRE_FLUSH_NOTIFICATION,
+          component_name:,
+          error: error.message
+        )
+      end
+
+      def instrument_degraded_post_flush(component_name:, error:)
+        ActiveSupport::Notifications.instrument(
+          DEGRADED_POST_FLUSH_NOTIFICATION,
+          component_name:,
+          error: error.message
         )
       end
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
@@ -90,13 +90,15 @@ module ReactOnRailsPro
       end
 
       # SHA-256 checksum over the shell HTML and PostponedState. Used inside the cached envelope
-      # to detect truncation or corruption that slipped past the cache store. A type tag ("S:" for
-      # a string state, "N" for nil) prevents ambiguity between a nil state (fully static page)
-      # and an empty-string state; the null byte separators prevent collisions between
-      # (shell="a", state="b") and (shell="a\x00...", state="").
+      # to detect truncation or corruption that slipped past the cache store. The digest input is
+      # `"<bytesize>:<shell>\x00<state_segment>"` where `<bytesize>` is the decimal byte-length of
+      # `shell_html`. The length prefix pins the boundary between shell and state so that a shell
+      # containing `\x00` cannot slide the boundary and collide with a different (shell, state) pair.
+      # The state segment uses a type tag ("S:" for a string, "N" for nil) to prevent ambiguity
+      # between a nil state (fully static page) and an empty-string state.
       def compute_checksum(shell_html, postponed_state)
         state_segment = postponed_state.nil? ? "N" : "S:#{postponed_state}"
-        Digest::SHA256.hexdigest("#{shell_html}\x00#{state_segment}")
+        Digest::SHA256.hexdigest("#{shell_html.bytesize}:#{shell_html}\x00#{state_segment}")
       end
 
       def instrument_static_shell(component_name:, cache_hit:)

--- a/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
@@ -121,7 +121,7 @@ module ReactOnRailsPro
         ActiveSupport::Notifications.instrument(
           DEGRADED_PRE_FLUSH_NOTIFICATION,
           component_name:,
-          error: error.message
+          error: safe_error_summary(error)
         )
       end
 
@@ -129,11 +129,18 @@ module ReactOnRailsPro
         ActiveSupport::Notifications.instrument(
           DEGRADED_POST_FLUSH_NOTIFICATION,
           component_name:,
-          error: error.message
+          error: safe_error_summary(error)
         )
       end
 
       private
+
+      # Bounded, newline-stripped summary of an error for AS::Notifications payloads.
+      # PrerenderError#message can include renderer console output with request-derived values;
+      # truncating prevents PII from propagating through APM/logging subscribers.
+      def safe_error_summary(error)
+        error.message.to_s.tr("\n\r", " ")[0, 256]
+      end
 
       def detect_react_version_cache_key
         package_json_path = react_dom_package_json_path

--- a/react_on_rails_pro/spec/dummy/app/views/pages/xhr_refresh.js.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/pages/xhr_refresh.js.erb
@@ -18,3 +18,7 @@ container.innerHTML = "<%= escape_javascript(render partial: 'xhr_refresh_partia
 var event = document.createEvent('Event');
 event.initEvent('hydrate', true, true);
 document.dispatchEvent(event);
+
+// Signal that the XHR response has been applied and hydration dispatched.
+// Tests wait for this attribute before interacting with the refreshed DOM.
+container.setAttribute('data-refreshed', 'true');

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -2568,9 +2568,10 @@ describe ReactOnRailsProHelper do
           expect(chunks_read.count).to eq(ppr_shell_chunks.count + ppr_resume_chunks.count)
           expect(warm_chunks.join).to include("PPR shell")
 
-          # The eviction counter fired.
+          # The eviction counter fired with the component name (not "unknown").
           expect(evict_events.length).to eq(1)
           expect(evict_events.first.payload[:reason]).to eq("checksum_mismatch")
+          expect(evict_events.first.payload[:component_name]).to eq(component_name)
         ensure
           ActiveSupport::Notifications.unsubscribe(subscription)
         end

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -2300,12 +2300,15 @@ describe ReactOnRailsProHelper do
         expect(combined.scan("First hole content").length).to eq(1)
         expect(combined.scan("$RC(").length).to eq(1)
 
-        # Shell + PostponedState are stored as one atomic paired record, holding the RAW shell
-        # (no per-request spec tag or rails context baked in).
+        # Shell + PostponedState are stored as a versioned envelope holding the RAW shell
+        # (no per-request spec tag or rails context baked in), schema/react version, and checksum.
         cached_entry = Rails.cache.read(computed_ppr_cache_key)
-        expect(cached_entry).to eq(
-          "shell_html" => ppr_shell_chunks.first[:html],
-          "postponed_state" => ppr_postponed_state_json
+        expect(cached_entry["schema"]).to eq(ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA)
+        expect(cached_entry["react"]).to eq(ReactOnRailsPro::Ppr.react_version_cache_key)
+        expect(cached_entry["shell_html"]).to eq(ppr_shell_chunks.first[:html])
+        expect(cached_entry["postponed_state"]).to eq(ppr_postponed_state_json)
+        expect(cached_entry["checksum"]).to eq(
+          ReactOnRailsPro::Ppr.compute_checksum(ppr_shell_chunks.first[:html], ppr_postponed_state_json)
         )
       end
 
@@ -2371,9 +2374,12 @@ describe ReactOnRailsProHelper do
           expect(cold_chunks.join).to include("Fully static PPR shell")
           expect(cold_chunks.join).not_to include("$RC(")
           expect(chunks_read.count).to eq(ppr_static_shell_chunks.count)
-          expect(Rails.cache.read(computed_ppr_cache_key)).to eq(
-            "shell_html" => ppr_static_shell_chunks.first[:html],
-            "postponed_state" => nil
+          cached = Rails.cache.read(computed_ppr_cache_key)
+          expect(cached["schema"]).to eq(ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA)
+          expect(cached["shell_html"]).to eq(ppr_static_shell_chunks.first[:html])
+          expect(cached["postponed_state"]).to be_nil
+          expect(cached["checksum"]).to eq(
+            ReactOnRailsPro::Ppr.compute_checksum(ppr_static_shell_chunks.first[:html], nil)
           )
 
           # Warm request: served entirely from cache — NO renderer request at all.
@@ -2494,6 +2500,215 @@ describe ReactOnRailsProHelper do
         expect do
           ppr_react_component(component_name, cache_key: "ppr-key") { props }
         end.to raise_error(ReactOnRails::Error, /stream_view_containing_react_components/)
+      end
+
+      # --- Issue #4891: versioned envelope, validation, and graceful degradation ---
+
+      it "cold write produces a versioned envelope with schema, react, checksum" do
+        mock_ppr_responses(ppr_shell_chunks, ppr_resume_chunks)
+        stub_render_with_ppr
+
+        run_stream
+
+        cached = Rails.cache.read(computed_ppr_cache_key)
+        expect(cached).to be_a(Hash)
+        expect(cached["schema"]).to eq(ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA)
+        expect(cached["react"]).to eq(ReactOnRailsPro::Ppr.react_version_cache_key)
+        expect(cached["shell_html"]).to eq(ppr_shell_chunks.first[:html])
+        expect(cached["postponed_state"]).to eq(ppr_postponed_state_json)
+        expect(cached["checksum"]).to eq(
+          ReactOnRailsPro::Ppr.compute_checksum(
+            ppr_shell_chunks.first[:html], ppr_postponed_state_json
+          )
+        )
+      end
+
+      it "static shell produces a valid envelope with postponed_state nil and a correct checksum" do
+        mock_ppr_responses(ppr_static_shell_chunks)
+        stub_render_with_ppr
+
+        run_stream
+
+        cached = Rails.cache.read(computed_ppr_cache_key)
+        expect(cached["schema"]).to eq(ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA)
+        expect(cached["postponed_state"]).to be_nil
+        expect(cached["checksum"]).to eq(
+          ReactOnRailsPro::Ppr.compute_checksum(ppr_static_shell_chunks.first[:html], nil)
+        )
+
+        # Warm hit still works with nil PostponedState
+        reset_stream_buffers
+        warm_chunks = run_stream
+        expect(warm_chunks.join).to include("Fully static PPR shell")
+        expect(chunks_read.count).to eq(0)
+      end
+
+      it "evicts a corrupted entry (byte-flipped checksum) and re-prerenders" do
+        # Cold request: write a valid envelope
+        mock_ppr_responses(ppr_shell_chunks, ppr_resume_chunks, ppr_shell_chunks, ppr_resume_chunks)
+        stub_render_with_ppr
+        run_stream
+
+        # Corrupt the checksum in the cached entry
+        cache_key = computed_ppr_cache_key
+        corrupted = Rails.cache.read(cache_key)
+        corrupted["checksum"] = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        Rails.cache.write(cache_key, corrupted)
+
+        evict_events = []
+        subscription = ActiveSupport::Notifications.subscribe(
+          ReactOnRailsPro::Ppr::EVICT_INVALID_NOTIFICATION
+        ) { |event| evict_events << event }
+
+        begin
+          reset_stream_buffers
+          warm_chunks = run_stream
+
+          # Treated as a miss: the prerender phase ran again.
+          expect(chunks_read.count).to eq(ppr_shell_chunks.count + ppr_resume_chunks.count)
+          expect(warm_chunks.join).to include("PPR shell")
+
+          # The eviction counter fired.
+          expect(evict_events.length).to eq(1)
+          expect(evict_events.first.payload[:reason]).to eq("checksum_mismatch")
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
+      end
+
+      it "evicts an entry with an unknown schema version and re-prerenders" do
+        mock_ppr_responses(ppr_shell_chunks, ppr_resume_chunks, ppr_shell_chunks, ppr_resume_chunks)
+        stub_render_with_ppr
+        run_stream
+
+        # Tamper with the schema version
+        cache_key = computed_ppr_cache_key
+        tampered = Rails.cache.read(cache_key)
+        tampered["schema"] = 999
+        Rails.cache.write(cache_key, tampered)
+
+        evict_events = []
+        subscription = ActiveSupport::Notifications.subscribe(
+          ReactOnRailsPro::Ppr::EVICT_INVALID_NOTIFICATION
+        ) { |event| evict_events << event }
+
+        begin
+          reset_stream_buffers
+          run_stream
+          expect(chunks_read.count).to eq(ppr_shell_chunks.count + ppr_resume_chunks.count)
+          expect(evict_events.length).to eq(1)
+          expect(evict_events.first.payload[:reason]).to eq("unknown_schema")
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
+      end
+
+      it "evicts an entry whose react version mismatches the current install (belt-and-suspenders)" do
+        mock_ppr_responses(ppr_shell_chunks, ppr_resume_chunks, ppr_shell_chunks, ppr_resume_chunks)
+        stub_render_with_ppr
+        run_stream
+
+        # Tamper with the react version in the envelope (simulates a React upgrade that bypasses
+        # the cache key — belt-and-suspenders for the Layer 1 key)
+        cache_key = computed_ppr_cache_key
+        tampered = Rails.cache.read(cache_key)
+        tampered["react"] = "react-99.0.0"
+        Rails.cache.write(cache_key, tampered)
+
+        evict_events = []
+        subscription = ActiveSupport::Notifications.subscribe(
+          ReactOnRailsPro::Ppr::EVICT_INVALID_NOTIFICATION
+        ) { |event| evict_events << event }
+
+        begin
+          reset_stream_buffers
+          run_stream
+          expect(chunks_read.count).to eq(ppr_shell_chunks.count + ppr_resume_chunks.count)
+          expect(evict_events.length).to eq(1)
+          expect(evict_events.first.payload[:reason]).to eq("react_version_mismatch")
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
+      end
+
+      it "pre-flush fallback: cache-hit error evicts, instruments, and falls back to full SSR" do
+        # Cold request: write a valid envelope
+        mock_ppr_responses(ppr_shell_chunks, ppr_resume_chunks, ppr_shell_chunks, ppr_resume_chunks)
+        stub_render_with_ppr
+        run_stream
+
+        # Force the cache-hit path to blow up BEFORE the shell is committed
+        allow(self).to receive(:ppr_hit_prerender_result).and_raise(
+          RuntimeError, "deliberate pre-flush test failure"
+        )
+
+        pre_flush_events = []
+        subscription = ActiveSupport::Notifications.subscribe(
+          ReactOnRailsPro::Ppr::DEGRADED_PRE_FLUSH_NOTIFICATION
+        ) { |event| pre_flush_events << event }
+
+        begin
+          reset_stream_buffers
+          warm_chunks = run_stream
+
+          # Fell back to full SSR (cache miss path): prerender + resume both ran.
+          expect(chunks_read.count).to eq(ppr_shell_chunks.count + ppr_resume_chunks.count)
+          expect(warm_chunks.join).to include("PPR shell")
+
+          # The degradation counter fired.
+          expect(pre_flush_events.length).to eq(1)
+          expect(pre_flush_events.first.payload[:error]).to include("deliberate pre-flush test failure")
+
+          # The fallback's cache-miss path wrote a fresh envelope (the old entry was evicted
+          # first, then the fresh prerender wrote a new one). Verify the new entry is valid.
+          fresh_entry = Rails.cache.read(computed_ppr_cache_key)
+          expect(fresh_entry["schema"]).to eq(ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA)
+          expect(fresh_entry["shell_html"]).to be_a(String)
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
+      end
+
+      it "post-flush fallback: resume error terminates stream, evicts entry, no second document" do
+        # Cold request: write a valid envelope
+        mock_ppr_responses(ppr_shell_chunks, ppr_resume_chunks)
+        stub_render_with_ppr
+        run_stream
+
+        # Warm request: mock the resume response to raise
+        mock_ppr_responses([])
+        # Override the mock to raise when the resume stream is consumed
+        allow(self).to receive(:ppr_resume_stream).and_raise(
+          RuntimeError, "deliberate post-flush test failure"
+        )
+
+        post_flush_events = []
+        subscription = ActiveSupport::Notifications.subscribe(
+          ReactOnRailsPro::Ppr::DEGRADED_POST_FLUSH_NOTIFICATION
+        ) { |event| post_flush_events << event }
+
+        begin
+          reset_stream_buffers
+          warm_chunks = run_stream
+
+          # The shell was served from cache (it is part of the initial template chunk).
+          expect(warm_chunks.first).to include("PPR shell")
+
+          # No second document — exactly one shell in the response.
+          combined = warm_chunks.join
+          expect(combined.scan("PPR shell").length).to eq(1)
+          # No $RC reveal scripts (the resume never completed).
+          expect(combined).not_to include("$RC(")
+
+          # The degradation counter fired.
+          expect(post_flush_events.length).to eq(1)
+          expect(post_flush_events.first.payload[:error]).to include("deliberate post-flush test failure")
+
+          # The cache entry was evicted so the next request prerenders cleanly.
+          expect(Rails.cache.read(computed_ppr_cache_key)).to be_nil
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
       end
     end
 

--- a/react_on_rails_pro/spec/dummy/spec/react_on_rails_pro/ppr_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/react_on_rails_pro/ppr_spec.rb
@@ -76,6 +76,43 @@ describe ReactOnRailsPro::Ppr do
     end
   end
 
+  describe ".compute_checksum" do
+    it "returns a consistent SHA-256 hex digest for the same inputs" do
+      shell = "<div>shell</div>"
+      state = '{"nextSegmentId":1}'
+      checksum1 = described_class.compute_checksum(shell, state)
+      checksum2 = described_class.compute_checksum(shell, state)
+
+      expect(checksum1).to eq(checksum2)
+      expect(checksum1).to match(/\A[a-f0-9]{64}\z/)
+    end
+
+    it "differs when the shell HTML changes" do
+      state = '{"nextSegmentId":1}'
+      checksum_a = described_class.compute_checksum("<div>a</div>", state)
+      checksum_b = described_class.compute_checksum("<div>b</div>", state)
+
+      expect(checksum_a).not_to eq(checksum_b)
+    end
+
+    it "differs when the postponed state changes" do
+      shell = "<div>shell</div>"
+      checksum_a = described_class.compute_checksum(shell, '{"id":1}')
+      checksum_b = described_class.compute_checksum(shell, '{"id":2}')
+
+      expect(checksum_a).not_to eq(checksum_b)
+    end
+
+    it "handles nil postponed_state (fully static page)" do
+      shell = "<div>static</div>"
+      checksum = described_class.compute_checksum(shell, nil)
+
+      expect(checksum).to match(/\A[a-f0-9]{64}\z/)
+      # nil and "" must produce different checksums (the null separator prevents ambiguity)
+      expect(checksum).not_to eq(described_class.compute_checksum(shell, ""))
+    end
+  end
+
   describe ".instrument_static_shell" do
     it "emits the ppr.static_shell counter notification with its payload" do
       events = []
@@ -91,6 +128,66 @@ describe ReactOnRailsPro::Ppr do
 
       expect(events.length).to eq(1)
       expect(events.first.payload).to include(component_name: "PprPageForTesting", cache_hit: true)
+    end
+  end
+
+  describe ".instrument_evict_invalid" do
+    it "emits the ppr.cache.evict_invalid notification with component_name and reason" do
+      events = []
+      subscription = ActiveSupport::Notifications.subscribe(
+        described_class::EVICT_INVALID_NOTIFICATION
+      ) { |event| events << event }
+
+      begin
+        described_class.instrument_evict_invalid(component_name: "TestComponent", reason: "checksum_mismatch")
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscription)
+      end
+
+      expect(events.length).to eq(1)
+      expect(events.first.payload).to include(component_name: "TestComponent", reason: "checksum_mismatch")
+    end
+  end
+
+  describe ".instrument_degraded_pre_flush" do
+    it "emits the ppr.resume.degraded_pre_flush notification with the error message" do
+      events = []
+      subscription = ActiveSupport::Notifications.subscribe(
+        described_class::DEGRADED_PRE_FLUSH_NOTIFICATION
+      ) { |event| events << event }
+
+      begin
+        described_class.instrument_degraded_pre_flush(
+          component_name: "TestComponent",
+          error: RuntimeError.new("test failure")
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscription)
+      end
+
+      expect(events.length).to eq(1)
+      expect(events.first.payload).to include(component_name: "TestComponent", error: "test failure")
+    end
+  end
+
+  describe ".instrument_degraded_post_flush" do
+    it "emits the ppr.resume.degraded_post_flush notification with the error message" do
+      events = []
+      subscription = ActiveSupport::Notifications.subscribe(
+        described_class::DEGRADED_POST_FLUSH_NOTIFICATION
+      ) { |event| events << event }
+
+      begin
+        described_class.instrument_degraded_post_flush(
+          component_name: "TestComponent",
+          error: RuntimeError.new("resume exploded")
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscription)
+      end
+
+      expect(events.length).to eq(1)
+      expect(events.first.payload).to include(component_name: "TestComponent", error: "resume exploded")
     end
   end
 end

--- a/react_on_rails_pro/spec/dummy/spec/system/integration_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/system/integration_spec.rb
@@ -310,6 +310,10 @@ describe "Manual client hydration", :js do
     within("form") do
       click_on "refresh"
     end
+    # Wait for the async XHR response to replace the container content and dispatch
+    # hydration. Without this, Capybara can grab a stale DOM reference from the initial
+    # page load that innerHTML removes when the async response arrives.
+    expect(page).to have_css("#component-container[data-refreshed]", wait: 5)
     within("#HelloWorldRehydratable-react-component-1") do
       find("input").set "Should update"
       within("h3") do

--- a/script/convert
+++ b/script/convert
@@ -132,6 +132,7 @@ end
 # so exclude RSC/streaming/client tests that need React.use or testing-library helpers.
 minimum_pro_non_rsc_ignored_tests = %w[
   RSC
+  ppr
   stream
   registerServerComponent
   serverRenderReactComponent


### PR DESCRIPTION
## Summary

Implements PostponedState versioning, validation, and graceful degradation for PPR — the three defense layers from issue #4891 (D4: PostponedState durability).

### The problem

The PPR cache stored a raw `{ shell_html, postponed_state }` record with no integrity protection. React makes no cross-version stability guarantee for PostponedState — a bookmark written by React 19.2.7 can be garbage to 19.2.9. A corrupt or stale entry causes a 500 or Frankenstein HTML.

### The three layers of defense

**Layer 1 — Cache key** (already landed on ppr-integration): React version + PPR schema version in every cache key so staleness becomes a miss.

**Layer 2 — Versioned envelope** (this PR): The cached record is now a self-describing envelope:

```ruby
{
  "schema" => 1,                      # PPR_ENVELOPE_SCHEMA
  "react"  => "react-19.2.7",         # belt-and-suspenders vs Layer 1
  "shell_html" => "<div>...</div>",
  "postponed_state" => "{...}" | nil,  # nil = fully static
  "checksum" => "sha256:..."           # SHA-256 over shell + state
}
```

On read: unknown schema? checksum mismatch? react version changed? → **evict + treat as miss + instrument**.

**Layer 3a — Pre-flush fallback** (this PR): If the cache-hit path raises BEFORE the shell is committed to the response, the entry is evicted and the request falls back to a full streaming SSR in the same request. User sees a normal page, just slower.

**Layer 3b — Post-flush termination** (this PR): If the resume phase raises AFTER the shell has flushed, the entry is evicted and the stream terminates cleanly — no second document. The client's next request is a structural miss → fresh render.

### Instrumentation

Three `ActiveSupport::Notifications` events:
- `ppr.cache.evict_invalid` — envelope validation failure
- `ppr.resume.degraded_pre_flush` — pre-flush SSR fallback
- `ppr.resume.degraded_post_flush` — post-flush stream termination

### Concrete scenario this prevents

Friday: shell for `/product/42` cached under React 19.2.7. Saturday: ops bumps to 19.2.9 (no rebuild). Without this: cache hit → 19.2.9 chokes on 19.2.7 bookmark → every cached route broken. **With this**: Layer 1 → miss → fresh prerender → page normal.

## Changes

- **`ppr.rb`**: `PPR_ENVELOPE_SCHEMA`, `CACHE_SCHEMA_VERSION` bump (v2→v3), `compute_checksum`, instrumentation event constants + helpers
- **`react_on_rails_pro_helper.rb`**: Envelope write, validation on read, pre-flush fallback wrapper, post-flush termination in resume stream, cache_key/raw_cache_options threading
- **`ppr_spec.rb`**: Unit tests for checksum + instrumentation
- **`react_on_rails_pro_helper_spec.rb`**: Integration tests for all 5 acceptance criteria

## Test plan

All tests pass locally:

```
# Unit tests: 12 examples, 0 failures
bundle exec rspec spec/react_on_rails_pro/ppr_spec.rb

# Integration tests: 19 examples, 0 failures
bundle exec rspec spec/helpers/react_on_rails_pro_helper_spec.rb -e 'ppr_react_component'

# Lint: 4 files inspected, no offenses detected
```

Test coverage:
1. ✅ Corrupted entry (byte-flipped checksum) → evicted, logged, served via miss path
2. ✅ React-version change → structural miss (no resume attempt)
3. ✅ Poisoned-bookmark pre-flush → full-SSR fallback in the same request
4. ✅ Post-flush resume failure → terminated stream, exactly one document, next request healthy
5. ✅ All degradations counted via AS::Notifications

Closes #4891.