### PR TITLE
[Pro] Continue HTTP failover after candidate exceptions

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
@@ -175,7 +175,8 @@ module ReactOnRailsPro
               result = download_from_origin(candidate[:base], bundle_hash, dir:, deadline:)
             rescue StandardError => e
               Rails.logger.warn(
-                "#{LOG_PREFIX} candidate #{candidate[:base]} failed: #{e.class}: #{e.message}; trying next origin."
+                "#{LOG_PREFIX} candidate #{candidate[:base]} failed: #{e.class}: #{e.message}; " \
+                "continuing with remaining candidates while time allows."
               )
               next
             end

--- a/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
@@ -171,7 +171,14 @@ module ReactOnRailsPro
 
             FileUtils.rm_rf(dir)
             FileUtils.mkdir_p(dir)
-            result = download_from_origin(candidate[:base], bundle_hash, dir:, deadline:)
+            begin
+              result = download_from_origin(candidate[:base], bundle_hash, dir:, deadline:)
+            rescue StandardError => e
+              Rails.logger.warn(
+                "#{LOG_PREFIX} candidate #{candidate[:base]} failed: #{e.class}: #{e.message}; trying next origin."
+              )
+              next
+            end
             next unless result
             next unless acceptable_payload?(candidate, result, bundle_hash)
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
@@ -407,6 +407,34 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
       expect(Rails.logger).to have_received(:warn).with(/payload identity mismatch/)
     end
 
+    it "continues to the next origin when a candidate raises during download or extraction" do
+      good_bundle = File.join(directory, "failover-good.js")
+      File.write(good_bundle, "failover good bundle")
+      expected = ReactOnRailsPro::RendererArtifact.new(role: :server, bundle: good_bundle, companions: {})
+
+      failures = [
+        ReactOnRailsPro::Error.new("bundle body exceeded compressed body cap"),
+        Zlib::GzipFile::Error.new("not in gzip format")
+      ]
+      failures.each do |failure|
+        attempts = []
+        allow(described_class).to receive(:download_from_origin) do |base, _bundle_hash, **_options|
+          attempts << base
+          raise failure if base == first
+
+          { bundle: good_bundle, assets: [] }
+        end
+
+        result = described_class.fetch(expected.id)
+
+        expect(result[:bundle]).to eq(good_bundle)
+        expect(attempts).to eq([first, second])
+        expect(Rails.logger).to have_received(:warn).with(
+          /candidate #{Regexp.escape(first)} failed: #{failure.class}/
+        )
+      end
+    end
+
     it "does not reuse discovery provenance from an origin that is no longer configured" do
       v2_id = "rorp-v2-s-#{'a' * 64}"
       described_class.instance_variable_set(

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb
@@ -414,7 +414,9 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
 
       failures = [
         ReactOnRailsPro::Error.new("bundle body exceeded compressed body cap"),
-        Zlib::GzipFile::Error.new("not in gzip format")
+        ReactOnRailsPro::Error.new(
+          "Rolling-deploy tarball is not a valid gzip stream: Zlib::GzipFile::Error: not in gzip format"
+        )
       ]
       failures.each do |failure|
         attempts = []
@@ -430,7 +432,7 @@ describe ReactOnRailsPro::RollingDeployAdapters::Http do
         expect(result[:bundle]).to eq(good_bundle)
         expect(attempts).to eq([first, second])
         expect(Rails.logger).to have_received(:warn).with(
-          /candidate #{Regexp.escape(first)} failed: #{failure.class}/
+          /candidate #{Regexp.escape(first)} failed: #{failure.class}: #{Regexp.escape(failure.message)}/
         )
       end
     end


### PR DESCRIPTION
## Why

The HTTP rolling-deploy adapter supports ordered previous origins, but an exception while downloading or extracting one candidate escaped to the outer fetch rescue. That aborted the whole fetch, so a corrupt or oversized response from an earlier origin prevented a later healthy origin from supplying the bundle.

Fixes #4732.

## What changed

- Rescue download/extraction exceptions inside the per-candidate loop, warn with the failed origin and exception class, and continue to the next configured origin under the existing shared deadline.
- Add ordered failover coverage for realistic adapter-boundary errors corresponding to compressed-size rejection and corrupt-gzip extraction, proving the later origin succeeds.

## How to review and verify

1. Review `fetch_from_candidates` and confirm the rescue surrounds only `download_from_origin`, preserving payload validation, shared-deadline behavior, and final cleanup.
2. Review the new spec's exact attempt ordering: the first origin raises and the second returns the expected artifact for each representative failure class.
3. Run `cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb`.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~~Update documentation~~ — no configuration or documented contract changed
- [x] ~~Update CHANGELOG file~~ — this is a focused follow-up correction to the unreleased multi-origin behavior already represented in the rolling-deploy changelog entry

### Other Information

No UI, asset, bundle, dependency, database, or public API surface changes.

<details>
<summary>Agent details</summary>

### Commands and results

- TDD red: focused new example failed on the base implementation because the first exception aborted the fetch.
- TDD green and final focused suite: `cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb` — 33 examples, 0 failures.
- CI-equivalent Pro lint: `cd react_on_rails_pro && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion lib/react_on_rails_pro/rolling_deploy_adapters/http.rb spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb` — 2 files, no offenses.
- `script/check-pro-license-headers --check` — all 903 in-scope Pro files current.
- `git diff --check` — clean.
- Rebase replay: all three implementation commits are range-diff equivalent to the previously reviewed series after rebasing onto current `origin/main`.
- Fresh maker-distinct adversarial review at the exact final head: no blocking or code-level discuss findings; it independently reran the 33-example suite, two-file Pro RuboCop, license-header check, and `git diff --check` successfully.
- Independent negative control: the checker applied only the head's 30-line spec delta to a disposable worktree at the exact base; the ordered failover example failed there with `result == nil`, while the same example passes on the exact head. The disposable worktree was removed.
- Optimized hosted CI on the exact final head: 43 checks passed and 2 detector-selected jobs were skipped. Lint, renderer package, gem RSpec, OSS integration, assets precompile, generators/examples, Playwright, Pro package, and Pro integration workflows all passed.
- The configured current-head Claude review completed successfully and found no correctness, security, performance, cleanup, deadline, or test-coverage defect. Its one cosmetic warning-wording nit was declined at the final-candidate debounce point with an in-thread rationale and resolved.

### Exact-head and replay evidence

- Base: `1d6cf4a8fdd1219dbd2aceae7e0ea5c7c3e3cfbf` (`origin/main` at final validation).
- Current head: `5b366d36dd2dd6e3845f67d67d97d5b3772e90a8`.
- Changed scope: exactly the HTTP adapter and its focused spec.

### QA Evidence

- QA lane: `ror-c-issue-4732-checker`; distinct read-only checker worktree; private checker claim/heartbeat unavailable
- Scope checked: candidate-local exception failover, attempt ordering, successful later-origin selection, warning evidence, and the exact two-file diff
- Tested at: PR head `5b366d36dd2dd6e3845f67d67d97d5b3772e90a8`
- Automated checks: focused Pro spec 33/33; two-file CI-equivalent Pro RuboCop; Pro license headers 903/903; git diff check; independent base-negative/head-positive regression proof; fresh exact-head checker clean; all requested hosted workflows passed
- Manual checks: not applicable: deterministic Ruby library behavior is fully exercised at the adapter seam
- User-visible UI change: no
- Visual evidence: not applicable: no user-visible UI change
- Interaction change: no; not applicable: no interactive surface changed
- Interaction evidence: not applicable: no interaction change
- Visual fix: no; not applicable: no visual behavior changed
- Negative control: exact-base ordered failover example fails with `result == nil`; exact-head example passes and selects the second origin
- Performance evidence: not applicable: no performance-sensitive, asset, or bundle change
- Findings: prior P3 test-realism concern fixed by using realistic adapter-boundary errors; prior warning-accuracy concern fixed by qualifying continuation against remaining time; final cosmetic last-candidate wording nit declined with rationale; exact-final-head adversarial review has no blocking or code-level discuss findings
- QA required: yes
- QA required rationale: runtime failover behavior requires issue-specific regression evidence plus a fresh independent review
- QA lane status: passed for the owned #4732 scope
- Release-blocking status: not blocked; exact-head hosted CI and configured review are green
- Process-gap disposition: checklist+replay

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 5b366d36dd2dd6e3845f67d67d97d5b3772e90a8
tested_at: PR head 5b366d36dd2dd6e3845f67d67d97d5b3772e90a8
scope: candidate-local HTTP rolling-deploy failover, ordered attempts, later-origin success, warning evidence, and exact two-file diff
automated_checks: focused Pro spec 33/33; two-file CI-equivalent Pro RuboCop; Pro license headers 903/903; git diff check; independent exact-base fail/exact-head pass proof; fresh exact-head checker clean; all requested hosted workflows passed
manual_checks: not applicable: deterministic Ruby library behavior is fully exercised at the adapter seam
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no rendered target
interaction_change: no
interaction_evidence: not applicable: no interaction change
visual_fix: no
negative_control: not applicable: no visual fix; code regression negative control is recorded in automated_checks
performance_impact: not_applicable
performance_evidence: not applicable: no performance-sensitive, asset, or bundle change
findings: fixed: prior P3 test-realism and warning-accuracy concerns; declined: cosmetic last-candidate wording nit; exact-final-head adversarial review has no blocking or code-level discuss findings
release_blocking: clear
process_gap_disposition: checklist+replay
-->

### Coordination and reviewer telemetry

- Batch/lane: `ror-c-issue-4732-20260817` / `a4732-http-failover`.
- Maker: `a4732-http-failover-maker`; replacement instance `ror-c-4732-maker-20260822-02`; private issue and PR claims released after merge.
- Requested route: Sol/high; observed host `codex-desktop`; observed model/effort unavailable.
- Checker: `ror-c-issue-4732-checker`, requested Sol/xhigh, distinct from maker; exact-final-head review complete with no blocking or code-level discuss findings; observed host `codex-desktop`, model/effort unavailable.
- Review churn: 4 adversarial passes across candidate/final heads, 1 resolved P3 test-realism finding, 1 resolved warning-accuracy finding, 1 declined cosmetic warning nit, and 2 review-driven commits.

### Decision log

- **Non-blocking:** Whether to broaden the rescue beyond `download_from_origin`.
  - **Decision:** Keep it tightly around the candidate's download/extraction call.
  - **Why:** That is the issue's failure seam and preserves existing setup, payload validation, deadline, and outer cleanup behavior.
  - **Review later:** None.
- **Non-blocking:** Whether this follow-up needs a separate changelog line.
  - **Decision:** Treat it as covered by the existing unreleased rolling-deploy entry.
  - **Why:** It corrects an edge case in the recently introduced multi-origin behavior without changing configuration or API shape.
  - **Review later:** Revisit only if release policy requires each unreleased follow-up to have its own line.

### Merge confidence

Merged as `5341113533f83a294303c371b48c6d54df2563e6`. Exact-head and merge-group gates passed before merge, configured and independent reviews were clean, and all review threads were resolved.

### Audit receipts

The completed-batch product audit is clean. Archive publication remains blocked by the terminal issue-to-PR target mapping; see the [durable v1 receipt](https://github.com/shakacode/react_on_rails/issues/4732#issuecomment-5384850447).

</details>
