### PR TITLE
Fix Dependabot parsing for the Pro dummy Gemfile

### DIFF
--- a/react_on_rails/Gemfile
+++ b/react_on_rails/Gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 # Specify your gem"s dependencies in react_on_rails.gemspec
 gemspec
 
-eval_gemfile File.expand_path("./Gemfile.development_dependencies", __dir__)
+Dir.chdir(__dir__) { eval_gemfile "./Gemfile.development_dependencies" }

--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-eval_gemfile File.expand_path("../Gemfile.shared_dev_dependencies", __dir__)
+Dir.chdir(__dir__) { eval_gemfile "../Gemfile.shared_dev_dependencies" }
 
 gem "shakapacker", "10.3.0"
 gem "bootsnap", require: false

--- a/react_on_rails/spec/dummy/Gemfile
+++ b/react_on_rails/spec/dummy/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-eval_gemfile File.expand_path("../../Gemfile.development_dependencies", __dir__)
+Dir.chdir(__dir__) { eval_gemfile "../../Gemfile.development_dependencies" }
 
 gem "react_on_rails", path: "../.."

--- a/react_on_rails_pro/Gemfile
+++ b/react_on_rails_pro/Gemfile
@@ -18,4 +18,4 @@ source "https://rubygems.org"
 # Specify your gem"s dependencies in react_on_rails.gemspec
 gemspec
 
-eval_gemfile File.expand_path("./Gemfile.loader", __dir__)
+Dir.chdir(__dir__) { eval_gemfile "./Gemfile.loader" }

--- a/react_on_rails_pro/Gemfile.development_dependencies
+++ b/react_on_rails_pro/Gemfile.development_dependencies
@@ -15,7 +15,7 @@
 # frozen_string_literal: true
 
 # Shared dev dependencies (rubocop, etc.)
-eval_gemfile File.expand_path("../Gemfile.shared_dev_dependencies", __dir__)
+Dir.chdir(__dir__) { eval_gemfile "../Gemfile.shared_dev_dependencies" }
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 

--- a/react_on_rails_pro/Gemfile.loader
+++ b/react_on_rails_pro/Gemfile.loader
@@ -19,6 +19,13 @@ source_encoding_patterns = [
 ].freeze
 magic_comment_prefix_pattern = /\A(?:\xEF\xBB\xBF)?\s*#/n
 shebang_pattern = /\A(?:\xEF\xBB\xBF)?#!/n
+# Dependabot statically follows literal eval_gemfile calls, including inside
+# uncalled lambdas. The runtime loader below remains authoritative so local and
+# CI overrides can still replace base dependency declarations.
+_dependabot_dependency_files = lambda do
+  eval_gemfile "./Gemfile.development_dependencies"
+end
+
 unsupported_source_encoding = lambda do |path, detected_encoding, reason|
   raise ArgumentError, "#{path} declares unsupported source encoding #{detected_encoding.inspect}: #{reason}"
 end

--- a/react_on_rails_pro/spec/dummy/Gemfile
+++ b/react_on_rails_pro/spec/dummy/Gemfile
@@ -16,7 +16,7 @@
 source "https://rubygems.org"
 
 ENV["SPEC_DUMMY"] = "yes"
-eval_gemfile File.expand_path("../../Gemfile.loader", __dir__)
+Dir.chdir(__dir__) { eval_gemfile "../../Gemfile.loader" }
 
 gem "react_on_rails_pro", path: "../.."
 


### PR DESCRIPTION
## Why

Dependabot's Bundler parser cannot statically follow the dynamically constructed `eval_gemfile` paths used by the repository's nested Gemfiles. The single configured Ruby update covers five directories, and parsing the nested directories failed before Dependabot could calculate updates.

## What changed

- Replace dynamic `eval_gemfile File.expand_path(...)` arguments with literal paths across all five Bundler entrypoints. Each call is scoped with `Dir.chdir(__dir__)` so repository-root invocation remains compatible with Bundler 2.5.4 as well as Bundler 4.
- Expose the Pro development-dependency fragment through an intentionally uncalled literal `eval_gemfile` call for Dependabot's static discovery. The existing runtime loader and local/CI override behavior remain authoritative.
- Leave dependency declarations, dependency versions, lockfiles, and `.github/dependabot.yml` unchanged.

Fixes #4829.

## How to review and verify

1. Follow the literal path chain from each configured Dependabot directory and confirm that it reaches the shared/root dependencies.
2. In `react_on_rails_pro/Gemfile.loader`, verify that the documented discovery-only lambda does not replace the runtime fragment loader below it.
3. Confirm that the diff contains no dependency-version, lockfile, Dependabot configuration, workflow, public API, or user-facing behavior change.

### Pull Request checklist

- [x] Issue-specific regression evidence: official `dependabot-bundler` 0.391.0 `FileFetcher` + `FileParser` succeeds for all five configured directories.
- [x] Existing loader regression coverage: 20 examples, 0 failures.
- [x] Documentation not required: no documented user workflow changes.
- [x] Changelog not required: release-process/dependency-maintenance plumbing with no user-visible behavior change.

### Other Information

- Status: exact-head local QA, refreshed-base combined-tip validation, hosted CI, current-head review coverage, and the canonical CI-readiness replay are satisfied. Ordinary merge gates are clear; maintainer walkthrough and explicit merge authority remain.
- Benchmarks: not applicable; no runtime, rendered-page, asset, or performance-sensitive code changed.
- Churn: three logical commits and one consolidated post-push scope-expansion update; no further code pushes after the final candidate. Review findings were handled in one coordinated closeout round.
- Hosted CI: all nine explicitly requested optimized runs are exact-head, successful, non-stale, and complete. The live PR rollup reports 43 successful, 8 intentionally skipped, 0 failing, and 0 pending checks.

<details>
<summary>Agent details</summary>

### Commands and results

- Official `dependabot-bundler` 0.391.0 `FileFetcher` + `FileParser`: exact head passes for `/` (32 dependencies), `/react_on_rails` (149), `/react_on_rails/spec/dummy` (147), `/react_on_rails_pro` (173), and `/react_on_rails_pro/spec/dummy` (179). The base fails in all four nested directories on dynamic `File.expand_path` arguments.
- Runtime parity matrix: 60 comparisons across five entrypoints, three invocation forms, two CI modes, and Bundler 2.5.4/4.0.10 passed.
- Override-precedence matrix: 24 comparisons passed. Error/cwd restoration matrix: 24 comparisons passed. Ruby 4 frozen checks: 10 scenarios passed.
- Independent exact-base/exact-head frozen semantic comparison: 48/48 passed.
- Bare-literal negative control: repository-root invocation fails under supported Bundler 2.5.4; the scoped `Dir.chdir` form passes under Bundler 2.5.4 and Bundler 4.
- `react_on_rails_pro/spec/react_on_rails_pro/gemfile_loader_spec.rb`: 20 examples, 0 failures.
- OSS and Pro RuboCop on the changed files, Ruby syntax, diff checks, and Pro license-header checks passed.
- `.agents/bin/validate --changed`: passed except for the environment's initially unavailable local Redis. Re-running the two Redis-dependent Node Renderer suites against isolated Redis at `127.0.0.1:16379` passed 2 suites / 8 tests; the isolated service was then stopped.
- Refreshed-base combined-tip replay: clean merge tree against `5fa65253926dd55f266a521d13d0751bdbe07601`; official Dependabot parsing passed all five directories, all five `bundle check` invocations passed, loader specs passed 20/20, and changed-file RuboCop, syntax, and diff checks passed. A broad-validator RBS mismatch was reproduced identically on base and combined tip and is unrelated to this PR.

### Exact-head and replay evidence

- Independently reviewed base: `e9dd9cdbf9fdcdcad028622637b9147bc95abd1c`
- Refreshed live base: `5fa65253926dd55f266a521d13d0751bdbe07601`
- Head: `18ec45d716e577a681b3d26d65e87f22c5756032`
- Changed paths: seven authorized Gemfile-chain files only; no lockfile, dependency-version, Dependabot configuration, workflow, test, documentation, changelog, or public API changes.
- Independent checker verdict: `Implementation QA SATISFIED`; no blocking or discuss-level implementation finding.
- Local Codex review: clean on the final patch; final rebase was verified by exact range-diff and a repeated official Dependabot parser run.
- Current-head hosted Claude review completed and its three concerns were individually triaged: the original P2 is fixed; the discovery-lambda and `Dir.chdir` concerns are declined based on the exact-head parser and Bundler compatibility evidence above.
- Local Claude `/code-review ultra` was unavailable because the service reported exhausted usage credits; `/simplify origin/main` timed out without output or edits. These degraded local reviewer paths did not replace the independent checker or hosted exact-head review.

### QA Evidence

- QA lane: `ror-b-issue-4829-checker`; maker/checker independence satisfied.
- Scope checked: all five Dependabot directories, the complete literal dependency chain, supported Bundler/Ruby invocation variants, frozen behavior, local and CI overrides, cwd restoration, loader behavior, licensing, changelog classification, and UI/performance applicability.
- Tested at: exact head `18ec45d716e577a681b3d26d65e87f22c5756032`.
- Manual checks: not applicable; no interactive app or service surface. Deterministic CLI/parser checks cover the changed behavior.
- User-visible UI/visual/interaction change: no.
- Performance impact: not applicable.
- Findings: the original current-head P2 was fixed by exposing the complete static chain; the two later review concerns were declined after negative-control and exact-parser verification.
- Release-blocking status: clear; canonical `pr-ci-readiness` reports `READY` on the exact head after the superseded-check handling update from Agent Workflows PR #436.
- Process-gap disposition: `checklist+replay` — acceptance evidence exercises official `FileFetcher` + `FileParser`, not only `ChildGemfileFinder`; broad workflow mechanization is a non-goal.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 18ec45d716e577a681b3d26d65e87f22c5756032
tested_at: exact repository head 18ec45d716e577a681b3d26d65e87f22c5756032
scope: all five configured Dependabot directories; complete Gemfile chain; supported Bundler and Ruby invocation variants; frozen behavior; local and CI overrides; cwd restoration; loader behavior; licensing; changelog and UI/performance applicability
automated_checks: official dependabot-bundler 0.391.0 FileFetcher plus FileParser passes all five directories; 60-case runtime parity; 24-case override parity; 24-case error and cwd parity; 10 Ruby 4 frozen scenarios; independent 48 of 48 frozen semantic comparisons; loader spec 20 examples; changed-file RuboCop, syntax, diff, license, and isolated-Redis Node Renderer suites
manual_checks: not applicable: no interactive app or service surface; deterministic CLI and parser checks cover the changed behavior
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no rendered target
interaction_change: no
interaction_evidence: not applicable: no interaction behavior changed
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: no rendered-page, asset-delivery, bundle, or runtime-performance impact
findings: original P2 fixed; current-head discovery-lambda and Dir.chdir concerns declined after official parser and Bundler compatibility verification
release_blocking: clear
process_gap_disposition: checklist+replay
-->

### Priority finding dispositions

<!-- priority-finding-dispositions v1
head_sha: 18ec45d716e577a681b3d26d65e87f22c5756032
finding: url=https://github.com/shakacode/react_on_rails/pull/4900#discussion_r3794378362 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/commit/18ec45d716e577a681b3d26d65e87f22c5756032 | waiver=
-->

### Coordination and reviewer telemetry

- Batch/lane: `ror-b-issue-4829-20260817` / `a4829-dependabot`.
- Maker/checker: `a4829-dependabot-maker` / `ror-b-issue-4829-checker`.
- Claim holder/instance: `a4829-dependabot-maker` / `codex-a4829-dependabot-20260817-0009-01`; same holder resumed after bounded restart recovery.
- Preferred routes: maker `Sol/high`, checker `Sol/xhigh`; observed host/model/effort `codex/UNKNOWN/UNKNOWN`.
- Review systems: independent checker satisfied; local Codex clean; current-head hosted Claude completed with all findings triaged; CodeRabbit and Greptile completed current-head reviews with no actionable findings; all review threads are resolved.
- No dependency gate, cancellation, reassignment, claim supersession, or follow-up issue is required.

### Decision log

- **Scoped `Dir.chdir`: retained.** A bare literal succeeds under Bundler 4 but fails for repository-root invocation under supported Bundler 2.5.4. Gemfile evaluation is synchronous, the block restores cwd on success and failure, and the runtime/error matrices passed.
- **Discovery-only lambda: retained.** Dependabot requires a literal `eval_gemfile` edge to include the Pro fragment. The adjacent comment documents that runtime loading below remains authoritative, and the official current-version parser proves the full flow succeeds.
- **Dependabot configuration: unchanged.** Existing directory entries are correct once the dependency chain is statically discoverable.
- **CI readiness discrepancy: resolved in Agent Workflows PR #436.** The adopted helper now recognizes the superseded same-head pre-hosted failure and reports `READY` for exact head `18ec45d716e577a681b3d26d65e87f22c5756032`, while preserving genuinely current failing checks as blockers.

### Merge confidence

Implementation, local QA, refreshed-base combined-tip validation, hosted CI, canonical CI readiness, and current-head reviewer convergence are satisfied. Ordinary merge gates are clear. Merge still requires the maintainer walkthrough and Justin's explicit `merge_authority=ask` decision.

### Audit receipts

Completed-batch audit: product audit clean; publication follow-up remains for the legacy untyped coordination target mapping. [Durable receipt](https://github.com/shakacode/react_on_rails/issues/4829#issuecomment-5393835902).

</details>
