### PR TITLE
CI: test Pro gem on current and minimum Ruby versions

### DIFF
--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -48,6 +48,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
       non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
+      ruby_matrix: ${{ steps.set-ruby-matrix.outputs.matrix }}
       run_pro_lint: ${{ steps.detect.outputs.run_pro_lint }}
       run_pro_tests: ${{ steps.detect.outputs.run_pro_tests }}
       should_run_hosted_ci: ${{ steps.hosted-ci.outputs.should_run_hosted_ci }}
@@ -91,6 +92,25 @@ jobs:
           fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
+      - name: Read runtime versions
+        id: tool-versions
+        uses: ./.github/actions/read-tool-versions
+      - name: Set Pro Ruby matrix
+        id: set-ruby-matrix
+        env:
+          CURRENT_RUBY_VERSION: ${{ steps.tool-versions.outputs.ruby-version }}
+          MINIMUM_RUBY_VERSION: ${{ steps.tool-versions.outputs.minimum-ruby-version }}
+        run: |
+          matrix="$(jq -nc \
+            --arg current_ruby_version "$CURRENT_RUBY_VERSION" \
+            --arg minimum_ruby_version "$MINIMUM_RUBY_VERSION" \
+            '{
+              "include": [
+                {"ruby-version": $current_ruby_version},
+                {"ruby-version": $minimum_ruby_version}
+              ]
+            }')"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
       - name: Guard docs-only main pushes
         if: |
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -418,6 +438,9 @@ jobs:
     if: |
       needs.detect-changes.outputs.should_run_hosted_ci == 'true' &&
       needs.detect-changes.outputs.run_pro_tests == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect-changes.outputs.ruby_matrix) }}
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
@@ -425,15 +448,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Read runtime versions
-        id: tool-versions
-        uses: ./.github/actions/read-tool-versions
-
-      - name: Setup Ruby
-        uses: ./.github/actions/setup-ruby
+      - name: Install Ruby Gems for Pro package
+        uses: ./.github/actions/setup-bundle
         with:
-          ruby-version: ${{ steps.tool-versions.outputs.minimum-ruby-version }}
-          bundler-version: 2.5.4
+          working-directory: react_on_rails_pro
+          ruby-version: ${{ matrix.ruby-version }}
 
       - name: Print system information
         run: |
@@ -443,13 +462,6 @@ jobs:
           echo "Ruby version: "; ruby -v
           echo "Bundler version: "; bundle --version
 
-      - name: Install Ruby Gems for Pro package
-        uses: ./.github/actions/setup-bundle
-        with:
-          working-directory: react_on_rails_pro
-          ruby-version: ${{ steps.tool-versions.outputs.minimum-ruby-version }}
-          install-libyaml: 'false'
-
       - name: Run RSpec tests for Pro package
         run: bundle exec rspec spec/react_on_rails_pro
 
@@ -457,12 +469,12 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: pro-rspec-package-results-ruby${{ steps.tool-versions.outputs.minimum-ruby-version }}
+          name: pro-rspec-package-results-ruby${{ matrix.ruby-version }}
           path: ~/rspec
 
       - name: Store test log
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: pro-rspec-package-log-ruby${{ steps.tool-versions.outputs.minimum-ruby-version }}
+          name: pro-rspec-package-log-ruby${{ matrix.ruby-version }}
           path: react_on_rails_pro/log/test.log

--- a/react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb
+++ b/react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "json"
 require "fileutils"
 require "open3"
 require "shellwords"
@@ -100,10 +101,10 @@ RSpec.describe "Ruby version support" do
 
   # Only use this helper on workflows that hardcode `ruby-version` in steps. Matrix-driven
   # workflows store the unexpanded `${{ matrix.ruby-version }}` expression in that field.
-  def workflow_ruby_versions(path)
+  def workflow_ruby_versions(path, except_jobs: [])
     workflow = YAML.safe_load(read_repo_file(path), aliases: true)
 
-    workflow.fetch("jobs").values.flat_map do |job|
+    workflow.fetch("jobs").except(*except_jobs).values.flat_map do |job|
       # Jobs that call reusable workflows with `uses:` do not have their own steps.
       Array(job["steps"] || []).filter_map do |step|
         next unless ruby_setup_actions.include?(step["uses"])
@@ -111,6 +112,35 @@ RSpec.describe "Ruby version support" do
         step.dig("with", "ruby-version")
       end
     end
+  end
+
+  def run_workflow_step(run_script, env)
+    Dir.mktmpdir do |tmpdir|
+      github_output = File.join(tmpdir, "github-output")
+      stdout, stderr, status = Open3.capture3(
+        env.merge("GITHUB_OUTPUT" => github_output), "bash", "-c", run_script, chdir: repo_root
+      )
+
+      expect(status).to be_success, "#{stdout}\n#{stderr}"
+      File.read(github_output).lines.to_h { |line| line.strip.split("=", 2) }
+    end
+  end
+
+  def pro_ruby_matrix
+    workflow = YAML.safe_load(read_repo_file(".github/workflows/pro-test-package-and-gem.yml"), aliases: true)
+    matrix_step = workflow.fetch("jobs").fetch("detect-changes").fetch("steps")
+                          .find { |step| step["id"] == "set-ruby-matrix" }
+    latest_versions = tool_versions(".tool-versions")
+    minimum_versions = tool_versions(".minimum.tool-versions")
+    outputs = run_workflow_step(
+      matrix_step.fetch("run"),
+      {
+        "CURRENT_RUBY_VERSION" => latest_versions.fetch("ruby"),
+        "MINIMUM_RUBY_VERSION" => minimum_versions.fetch("ruby")
+      }
+    )
+
+    JSON.parse(outputs.fetch("matrix"))
   end
 
   it "uses the merge queue base SHA for merge_group change detection" do
@@ -235,8 +265,28 @@ RSpec.describe "Ruby version support" do
     expect(lint_ruby_versions).not_to be_empty
     expect(precompile_ruby_versions).to all(eq(expected_latest_ruby))
     expect(precompile_ruby_versions).not_to be_empty
-    expect(workflow_ruby_versions(".github/workflows/pro-test-package-and-gem.yml")).to all(eq(expected_minimum_ruby))
-    expect(read_repo_file(".github/workflows/pro-test-package-and-gem.yml")).not_to include("env.RUBY_VERSION")
+    pro_workflow_path = ".github/workflows/pro-test-package-and-gem.yml"
+    pro_workflow = YAML.safe_load(read_repo_file(pro_workflow_path), aliases: true)
+    pro_rspec_job = pro_workflow.fetch("jobs").fetch("rspec-gem-specs")
+    pro_non_matrix_ruby_versions = workflow_ruby_versions(pro_workflow_path, except_jobs: ["rspec-gem-specs"])
+
+    expect(pro_non_matrix_ruby_versions).to all(eq(expected_minimum_ruby))
+    expect(pro_non_matrix_ruby_versions).not_to be_empty
+    expect(pro_workflow.dig("jobs", "detect-changes", "outputs", "ruby_matrix"))
+      .to eq("${{ steps.set-ruby-matrix.outputs.matrix }}")
+    expect(pro_ruby_matrix).to eq(
+      "include" => [
+        { "ruby-version" => tool_versions(".tool-versions").fetch("ruby") },
+        { "ruby-version" => tool_versions(".minimum.tool-versions").fetch("ruby") }
+      ]
+    )
+    expect(pro_rspec_job.fetch("strategy")).to include(
+      "fail-fast" => false,
+      "matrix" => "${{ fromJson(needs.detect-changes.outputs.ruby_matrix) }}"
+    )
+    pro_rspec_setup = pro_rspec_job.fetch("steps").find { |step| step["uses"] == "./.github/actions/setup-bundle" }
+    expect(pro_rspec_setup.dig("with", "ruby-version")).to eq("${{ matrix.ruby-version }}")
+    expect(read_repo_file(pro_workflow_path)).not_to include("env.RUBY_VERSION")
 
     examples_workflow = read_repo_file(".github/workflows/examples.yml")
     playwright_workflow = read_repo_file(".github/workflows/playwright.yml")

--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -527,4 +527,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.4
+  4.0.10


### PR DESCRIPTION
## Why

The Pro gem RSpec job currently runs only the repository's minimum Ruby version. That leaves the current Ruby/toolchain combination unexercised, while the Pro lockfile also records an older Bundler version than the root and OSS lockfiles.

Fixes #4577.

## What changed

- Build a bounded two-row Ruby matrix from the repository's committed current and minimum tool versions, then run the existing Pro RSpec job and artifact upload once per row.
- Align `react_on_rails_pro/Gemfile.lock` with the repository-standard Bundler 4.0.10 lockfile version.
- Update the Ruby-version support regression spec to preserve minimum-Ruby coverage for non-matrix Pro jobs and execute/assert the Pro RSpec job's exact current/minimum matrix contract.

## How to review and verify

1. Confirm the detect job emits exactly the current and minimum Ruby rows from the committed tool-version outputs.
2. Confirm only the Pro RSpec job consumes the matrix, retains `fail-fast: false`, and gives each test artifact a unique Ruby-version suffix.
3. Confirm the existing setup-bundle action receives each matrix Ruby version and the workflow's triggers, permissions, secrets, and action versions are unchanged.
4. Confirm the regression spec executes the matrix-producing shell step and asserts both exact rows plus the RSpec setup expression.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~~Update documentation~~ — the change only expands maintainer CI coverage
- [x] ~~Update CHANGELOG file~~ — no user-visible product behavior changed

### Other Information

No UI, asset, bundle, runtime, database, dependency-resolution, or public API surface changes. Follow-up #4902 records the required post-merge workflow exercise.

<details>
<summary>Agent details</summary>

### Commands and results

- Focused OSS Ruby-version regression spec — 7 examples, 0 failures. Its pre-fix run reproduced the hosted minimum-only assertion failure.
- `actionlint` — passed; `yamllint` is unavailable in the local toolchain.
- Frozen Bundler 4.0.10 setup/check against `react_on_rails_pro/Gemfile.lock` — passed under Ruby 4.0.5 and 3.3.7.
- CI-equivalent OSS RuboCop — 247 files inspected, no offenses.
- CI detector — selected full OSS and Pro coverage for the exact three-file diff.
- Commit/pre-push hooks and `git diff --check` — passed.
- Trusted secure-workflow scan — candidate and exact base each report 377 findings with identical rule totals; no introduced or regressed finding.
- Maker-distinct adversarial review — approved this exact head with no BLOCKING or DISCUSS findings.
- Current-head review systems — Claude successful with no blocking issue; CodeRabbit successful; 0 unresolved threads and 0 review-driven commits.
- Optimized hosted CI — all 9 explicitly requested exact-head workflows passed: runs `32616367117`, `32616367118`, `32616367119`, `32616367158`, `32616367160`, `32616367172`, `32616367185`, `32616367214`, and `32616367224`.
- Issue-specific hosted evidence — `rspec-gem-specs (4.0.5)` and `rspec-gem-specs (3.3.7)` both passed in requested run `32616367160`; the OSS unit shard containing the updated regression spec passed in requested run `32616367214`.
- `pr-ci-readiness` — `READY` on the exact head.
- Strict merge ledger with `not_user_visible` changelog classification — no violations or UNKNOWN fields; `complete_allowed: true`.

### Exact-head and replay evidence

- Base: `1d6cf4a8fdd1219dbd2aceae7e0ea5c7c3e3cfbf` (fresh `origin/main` after exact-head CI).
- Head: `5e6b961c3dca05c3291e86fa547568936ca2b322`.
- Changed scope: exactly `.github/workflows/pro-test-package-and-gem.yml`, `react_on_rails_pro/Gemfile.lock`, and `react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb`.

### QA Evidence

- QA lane: `ror-f-issue-4577-checker`; maker-distinct read-only checker; maker claim active and renewed
- Scope checked: exact workflow matrix/config semantics, lockfile build metadata, regression-contract adequacy, secure GitHub Actions delta, dual-Ruby setup evidence, and the exact three-file diff
- Tested at: published PR head `5e6b961c3dca05c3291e86fa547568936ca2b322`
- Automated checks: focused OSS regression spec; actionlint; frozen Bundler 4.0.10 checks on Ruby 4.0.5 and 3.3.7; CI detector; OSS RuboCop; commit/pre-push hooks; git diff check; secure scan parity; all 9 requested optimized hosted workflows; exact Pro RSpec rows on Ruby 4.0.5 and 3.3.7; Claude and CodeRabbit current-head review checks; strict merge ledger
- Manual checks: workflow diff inspection confirmed no trigger, permission, secret, trusted-action, or action-version change
- User-visible UI change: no
- Visual evidence: not applicable: no user-visible UI change
- Interaction change: no; not applicable: no interactive surface changed
- Interaction evidence: not applicable: no interaction change
- Visual fix: no; not applicable: no visual behavior changed
- Negative control: not applicable: no visual fix
- Performance evidence: not applicable: no runtime, asset, bundle, or performance-sensitive surface changed
- Findings: no actionable current-head review or validation finding; local-only unchanged `prod_binstub_spec` environment failures are superseded by the green exact-head hosted Pro matrix
- QA required: yes
- QA required rationale: CI/tooling changes require issue-specific regression evidence, exact-head hosted CI, and a fresh independent checker
- QA lane status: completed
- Release-blocking status: clear
- Process-gap disposition: checklist+replay

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 5e6b961c3dca05c3291e86fa547568936ca2b322
tested_at: published PR head 5e6b961c3dca05c3291e86fa547568936ca2b322
scope: exact Pro workflow matrix and setup semantics, Pro lockfile Bundler metadata, Ruby-version regression contract, secure GitHub Actions delta, dual-Ruby local evidence, and exact three-file diff
automated_checks: focused OSS regression spec; actionlint; frozen Bundler 4.0.10 checks on Ruby 4.0.5 and 3.3.7; CI detector; OSS RuboCop; commit/pre-push hooks; git diff check; secure scan parity; all 9 requested optimized hosted workflows; exact Pro RSpec rows on Ruby 4.0.5 and 3.3.7; Claude and CodeRabbit current-head review checks; strict merge ledger
manual_checks: workflow diff inspection confirmed no trigger, permission, secret, trusted-action, or action-version change
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no rendered target
interaction_change: no
interaction_evidence: not applicable: no interaction change
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: no runtime, asset, bundle, or performance-sensitive surface changed
findings: no actionable current-head review or validation finding
release_blocking: clear
process_gap_disposition: checklist+replay
-->

<!-- priority-finding-dispositions v1
status: not_applicable
head_sha: 5e6b961c3dca05c3291e86fa547568936ca2b322
-->

### Coordination and reviewer telemetry

- Batch/lane: `ror-f-issue-4577-20260817` / `a4577-pro-ci-matrix`.
- Maker: `a4577-pro-ci-matrix-maker`; instance `codex-subagent-ror-f-issue-4577-oak-1`; private claim active.
- Requested maker route: Sol/high; observed host/model/effort: codex/UNKNOWN/UNKNOWN.
- Checker: `ror-f-issue-4577-checker`; requested Sol/xhigh; distinct from maker; observed host/model/effort: codex/UNKNOWN/UNKNOWN.
- Review churn: 2 maker-distinct exact-candidate review rounds across the initial and final heads, 0 blocking/discuss findings, 0 review-driven commits, 0 thread resolutions.

### Decision log

- **Non-blocking:** Whether to duplicate Ruby versions directly in the workflow.
  - **Decision:** Consume the committed current/minimum outputs from the existing tool-version action.
  - **Why:** The matrix stays bounded to two named compatibility points without adding another version source.
  - **Review later:** None.
- **Non-blocking:** Whether to request force-full hosted CI.
  - **Decision:** Use optimized hosted CI.
  - **Why:** The repository detector selected all 9 relevant OSS and Pro workflows, and every requested exact-head run passed.
  - **Review later:** None.
- **Required policy follow-up:** Exercise the semantic workflow change after merge.
  - **Decision:** Track the exercise in #4902.
  - **Why:** The repository requires durable post-merge exercise evidence for semantic workflow changes.
  - **Review later:** Close the tracker after the main-branch push or a bounded secondary verification PR proves both matrix rows.

### Merge confidence

All ordinary exact-head gates are clean. Merge authority is `ask`; the maintainer walkthrough and final decision remain intentionally outside this evidence update.

### Audit receipts

- Workflow Change Audit: https://github.com/shakacode/react_on_rails/pull/4901#issuecomment-5384073738
- Hosted-CI dispatch receipt: https://github.com/shakacode/react_on_rails/pull/4901#issuecomment-5384078542
- Current-head review triage: https://github.com/shakacode/react_on_rails/pull/4901#issuecomment-5384102116
- Post-merge exercise tracker: https://github.com/shakacode/react_on_rails/issues/4902

</details>
