### PR TITLE
PPR integration: port the HelloWorldRehydratable UJS/XHR rehydration fix (#4904)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,6 +650,9 @@ importers:
       '@loadable/webpack-plugin':
         specifier: ^5.15.2
         version: 5.15.2(webpack@5.104.1)
+      '@rails/ujs':
+        specifier: 7.1.3-4
+        version: 7.1.3-4
       '@rspack/cli':
         specifier: ~2.0.0
         version: 2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.1.0(@rspack/core@2.0.5)(selfsigned@5.5.0))
@@ -3135,6 +3138,9 @@ packages:
 
   '@rails/actioncable@8.1.200':
     resolution: {integrity: sha512-on0DSb7AFUkq1ocxivDNQhhGW/RQpY91zvRVyyaEWP4gOOZWy33P/UyxjQk74IENWNrTqs8+zOGHwTjiiFruRw==}
+
+  '@rails/ujs@7.1.3-4':
+    resolution: {integrity: sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA==}
 
   '@redis/bloom@5.10.0':
     resolution: {integrity: sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==}
@@ -12976,6 +12982,8 @@ snapshots:
       - supports-color
 
   '@rails/actioncable@8.1.200': {}
+
+  '@rails/ujs@7.1.3-4': {}
 
   '@redis/bloom@5.10.0(@redis/client@5.10.0)':
     dependencies:

--- a/react_on_rails_pro/spec/dummy/app/views/layouts/application.html.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/layouts/application.html.erb
@@ -64,6 +64,11 @@ https://github.com/shakacode/react_on_rails/blob/main/REACT-ON-RAILS-PRO-LICENSE
     <%= javascript_pack_tag('client-bundle', 'data-turbo-track': 'reload', async: true) %>
   <% end %>
   <%= csrf_meta_tags %>
+  <%# Exposes the per-request CSP nonce as <meta name="csp-nonce"> for rails-ujs:
+      it stamps the nonce onto the <script> element it injects to execute JS (SJR)
+      responses (e.g. pages/xhr_refresh.js.erb). Without it, the strict script-src
+      nonce policy in config/initializers/content_security_policy.rb blocks them. %>
+  <%= csp_meta_tag %>
 </head>
 <body class="app-body bg-white">
 <div class="app-shell flex flex-row h-screen w-screen">

--- a/react_on_rails_pro/spec/dummy/client/app/packs/client-bundle.js
+++ b/react_on_rails_pro/spec/dummy/client/app/packs/client-bundle.js
@@ -15,9 +15,18 @@
 
 import '../assets/styles/application.css';
 
+import Rails from '@rails/ujs';
 import ReactOnRails from 'react-on-rails-pro';
 import Turbolinks from 'turbolinks';
 import SharedReduxStore from '../stores/SharedReduxStore';
+
+// Start rails-ujs so `remote: true` forms submit via XHR instead of a native
+// full-page navigation (the manual rehydration demo at /xhr_refresh depends on
+// this to fetch and execute xhr_refresh.js.erb). Guard against double-start:
+// Rails.start() throws if UJS is already loaded on this page.
+if (!window._rails_loaded) {
+  Rails.start();
+}
 
 const urlParams = new URLSearchParams(window.location.search);
 const enableTurbolinks = urlParams.get('enableTurbolinks') === 'true';

--- a/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/HelloWorldRehydratable.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/HelloWorldRehydratable.jsx
@@ -28,6 +28,23 @@ class HelloWorldRehydratable extends React.Component {
     railsContext: PropTypes.object,
   };
 
+  // Static because rehydrating every instance is class-level work; each mounted
+  // instance's "hydrate" listener delegates here through forceClientHydration.
+  static rehydrateAllInstances() {
+    const registeredComponentName = 'HelloWorldRehydratable';
+
+    // Target all instances of the component in the DOM
+    const match = document.querySelectorAll(`[id^=${registeredComponentName}-react-component-]`);
+    // Not all browsers support forEach on NodeList so we go with a classic for-loop
+    for (let i = 0; i < match.length; i += 1) {
+      const component = match[i];
+      // Rehydrate through the Pro client lifecycle: it reads props from the component
+      // specification <script> tag for this dom id, unmounts the React root orphaned by
+      // the innerHTML replacement (cleaning up its listeners), and hydrates the new node.
+      ReactOnRails.reactOnRailsComponentLoaded(component.id);
+    }
+  }
+
   // Not necessary if we only call super, but we'll need to initialize state, etc.
   constructor(props) {
     super(props);
@@ -39,6 +56,14 @@ class HelloWorldRehydratable extends React.Component {
 
   componentDidMount() {
     document.addEventListener('hydrate', this.forceClientHydration);
+    // Mark the react_on_rails mount container once this instance's mount has committed.
+    // The innerHTML replacement in xhr_refresh.js.erb wipes the attribute together with
+    // the old node, so it re-appears only after the remounted component commits — tests
+    // wait for it before interacting with the refreshed DOM.
+    const container = this.nameDomRef.closest('[id^=HelloWorldRehydratable-react-component-]');
+    if (container) {
+      container.setAttribute('data-hydrated', 'true');
+    }
   }
 
   componentWillUnmount() {
@@ -55,21 +80,7 @@ class HelloWorldRehydratable extends React.Component {
   }
 
   forceClientHydration() {
-    const registeredComponentName = 'HelloWorldRehydratable';
-    const { railsContext } = this.props;
-
-    // Target all instances of the component in the DOM
-    const match = document.querySelectorAll(`[id^=${registeredComponentName}-react-component-]`);
-    // Not all browsers support forEach on NodeList so we go with a classic for-loop
-    for (let i = 0; i < match.length; i += 1) {
-      const component = match[i];
-      // Get component specification <script> tag
-      const componentSpecificationTag = document.querySelector(`script[data-dom-id=${component.id}]`);
-      // Read props from the component specification tag and merge railsContext
-      const mergedProps = { ...JSON.parse(componentSpecificationTag.textContent), railsContext };
-      // Hydrate
-      ReactOnRails.render(registeredComponentName, mergedProps, component.id, true);
-    }
+    this.constructor.rehydrateAllInstances();
   }
 
   render() {

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -18,6 +18,7 @@
     "@loadable/component": "^5.16.3",
     "@loadable/server": "^5.16.2",
     "@loadable/webpack-plugin": "^5.15.2",
+    "@rails/ujs": "7.1.3-4",
     "@rspack/cli": "~2.0.0",
     "@rspack/core": "~2.0.0",
     "@sentry/node": "^7.120.0",

--- a/react_on_rails_pro/spec/dummy/spec/system/integration_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/system/integration_spec.rb
@@ -307,13 +307,27 @@ describe "Manual client hydration", :js do
   before { visit "/xhr_refresh" }
 
   it "HelloWorldRehydratable onChange should trigger" do
+    # Readiness gate: prove the initial hydration has committed and the component's
+    # document-level "hydrate" listener is attached (componentDidMount) before clicking
+    # refresh. Otherwise the click can beat hydration and the refreshed markup would
+    # never rehydrate.
+    within("#HelloWorldRehydratable-react-component-1") do
+      find("input").set "Hydration check"
+      within("h3") do
+        expect(page).to have_content "Hydration check"
+      end
+    end
     within("form") do
       click_on "refresh"
     end
-    # Wait for the async XHR response to replace the container content and dispatch
-    # hydration. Without this, Capybara can grab a stale DOM reference from the initial
-    # page load that innerHTML removes when the async response arrives.
+    # Wait for the XHR response to run: it replaces the container content, dispatches
+    # the "hydrate" event, and then flags the container. Without this, Capybara can
+    # grab a DOM reference that the innerHTML replacement is about to invalidate.
     expect(page).to have_css("#component-container[data-refreshed]", wait: 5)
+    # Wait for the remounted component to commit: componentDidMount sets data-hydrated
+    # on the fresh mount container (the attribute was wiped with the old node), which
+    # proves the onChange handler is attached again.
+    expect(page).to have_css("#HelloWorldRehydratable-react-component-1[data-hydrated]", wait: 5)
     within("#HelloWorldRehydratable-react-component-1") do
       find("input").set "Should update"
       within("h3") do


### PR DESCRIPTION
Port of #4904 to `ppr-integration` (references #4903 — the issue closes via the `main` PR).

## Why

`ppr-integration` currently carries a **latent deterministic failure**: PR #4895 merged commit `ebfbc3ead`'s marker-wait (`expect(page).to have_css("#component-container[data-refreshed]", wait: 5)`), but the marker is set by `xhr_refresh.js.erb` — code that never executes because nothing on the page handles `remote: true` (jquery-ujs was removed in 2021 by PR #232, so the form does a native full-page navigation). The next `rspec-dummy-app-node-renderer` run against this branch fails that spec 100% (CI already showed it on the pre-merge head: run 32003954087). See #4904 for the full root-cause evidence.

## What this PR does

Ports #4904's two commits (`bb2678e8b`, `33b8b4e23`, cherry-picked with `-x`), which make the existing marker-wait valid and fix the rest of the race:

1. Restore UJS (`@rails/ujs` pinned `7.1.3-4`, guarded `Rails.start()`) so the form XHRs and `xhr_refresh.js.erb` executes again.
2. `csp_meta_tag` in the dummy layout — rails-ujs needs the `csp-nonce` meta to execute SJR responses under the strict per-request-nonce CSP.
3. Pre-click hydration gate + ordered `data-refreshed` → `data-hydrated` waits in the spec (the `data-refreshed` wait merged via #4895 is kept, now reachable).
4. Post-hydration commit marker in `HelloWorldRehydratable#componentDidMount`.
5. `forceClientHydration` via `ReactOnRails.reactOnRailsComponentLoaded` (unmounts the innerHTML-orphaned root — fixes the listener leak).

**Reconciliation with this branch** (verified byte-identical to #4904's final files where applicable): `xhr_refresh.js.erb` has no net delta (ebfbc3ead's marker lines already equal the final content); the spec conflict resolved to #4904's exact example body; `client-bundle.js` keeps this branch's `turbo: enableTurbolinks` line; the lockfile was regenerated (pnpm 10.33.4), not cherry-picked — delta is exactly the `@rails/ujs` entries.

No CHANGELOG entry: test-dummy-only change set (and per #4889, ppr-integration changes log once at the final merge to main).

<details>
<summary>Agent details</summary>

### QA evidence (all against final HEAD, local, this branch)

- Target spec: `1 example, 0 failures` (7.26s); fresh `log/test.log` shows `Processing by PagesController#xhr_refresh as JS`.
- Flake harness (mirrors the fixed spec body): idle `100 examples, 0 failures` (67s); loaded under 16 CPU burners `100 examples, 0 failures`, `stale_node_hits=0 stale_elem=0` (212s).
- Full dummy system suite: `72 examples, 0 failures, 2 pending` (both pending are pre-existing intentional skips) — better than the #4895 baseline, whose only failure was this spec.
- CSP diagnostic: `csp-nonce meta present: true`, `0` SEVERE console entries.
- Lint: eslint, prettier, rubocop clean; pro-license-headers 886/886. No RuboCop rule disabled.
- UJS side-effect scan on this branch's views: only hit is the fix target itself; PPR pages green in the full suite.

### Decision log

- Cherry-picked with `-x` from #4904 to preserve provenance; commits retain original messages.
- `pnpm-lock.yaml` excluded from the cherry-pick and regenerated with the repo-pinned pnpm to avoid cross-branch lock drift; resulting delta is the `@rails/ujs` entries only.
- The single conflict (`integration_spec.rb`) resolved by taking #4904's block wholesale; file verified byte-identical to #4904's final version afterward.

### Confidence note

High. Same statistical validation as #4904 (0/200 combined idle+loaded failures on this branch), plus proof the previously-unreachable `data-refreshed` wait now passes against the real XHR path.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
