### PR TITLE
Docs: document Pro 17 Console constant collision

### DIFF
--- a/docs/pro/updating.md
+++ b/docs/pro/updating.md
@@ -398,6 +398,11 @@ This affects render, streaming render, and asset upload requests.
 Before upgrading:
 
 - Run Ruby 3.3 or newer. The `async-http` dependency requires Ruby 3.3+.
+- Audit Rails console detection that calls `Rails.const_defined?(:Console)`. The `console` gem arrives through Pro's
+  `async` dependency, which was already present in Pro 16.x, and defines top-level `::Console`. Pro 17 loads `async` on
+  the ordinary render path, while Pro 16 loaded it only for streaming or async rendering, so the default lookup inherits
+  through `Object` and silently returns `true` outside a Rails console. Use `Rails.const_defined?(:Console, false)` to
+  set `inherit: false`.
 - Remove direct application assumptions about HTTPX-specific response or error classes in Pro renderer request paths.
 - Treat `config.ssr_timeout` as a per-read socket timeout. With the async-http client, this is applied as the
   read timeout on each renderer socket. It no longer wraps the entire request as a single task-level timeout.


### PR DESCRIPTION
### Summary

Documents how the Pro 17 ordinary renderer path loads the existing `async` dependency and defines top-level `::Console`, so applications can prevent inherited Rails console checks from silently returning true after an upgrade.

### Pull Request checklist

- [x] ~~Add/update test to cover these changes~~
- [x] Update documentation
- [x] ~~Update CHANGELOG file~~

### Other Information

The application-side fix is to use `Rails.const_defined?(:Console, false)` so constant lookup does not inherit through `Object`.

## Follow-ups

- none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an upgrade note explaining how to review `Rails.const_defined?(:Console)` checks when upgrading to Pro 17.
  * Recommended disabling ancestor lookup where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->