### PR TITLE
PPR: CSS/asset coordination between cached shell and resume stream (#4897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Added
+
+- **[Pro]** **PPR CSS/asset coordination between cached shell and resume stream**: The PPR resume
+  pass now suppresses duplicate `<link>` tags and init scripts that the cached shell already declared,
+  and gates hole-only CSS (stylesheets needed only by components inside Suspense holes) ahead of their
+  `$RC()` reveals to prevent FOUC. A small asset manifest captured at prerender time travels through
+  the cache envelope and pre-seeds the resume injector's dedup sets. Promoted streamed stylesheet
+  preload hrefs are also tracked so the manifest is complete even when `loadable-stats.json` is
+  unavailable. The manifest field is optional and excluded from the envelope checksum — an older
+  renderer or a missing field degrades gracefully to the previous behavior (no dedup). Resolves
+  [Issue 4897](https://github.com/shakacode/react_on_rails/issues/4897).
+  [PR 4907](https://github.com/shakacode/react_on_rails/pull/4907) by
+  [AbanoubGhadban](https://github.com/AbanoubGhadban).
+
 #### Fixed
 
 - **[Pro]** **Bounded Node Renderer VM retention now avoids old/new RSC rebuild thrash during rolling deploys**:

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -423,7 +423,6 @@ function stylesheetTagsForRSCClientChunks(
   emittedStylesheetHrefs: Set<string>,
 ) {
   const stylesheetTags: string[] = [];
-
   for (const match of flightData.matchAll(RSC_CLIENT_CHUNK_NAME_WITH_JS_ASSET)) {
     const chunkName = match[1];
     const stylesheetHrefs = stylesheetHrefsByChunkName.get(chunkName);
@@ -1557,6 +1556,7 @@ function applyStreamedStylesheetPreloadGating(
   incompleteHtmlTailMode: IncompleteHtmlTailMode,
   rscClientManifestStylesheetHrefs: ReadonlySet<string>,
   retainedTailScanState?: RetainedIncompleteHtmlTailScanState,
+  alreadyEmittedStylesheetHrefs?: ReadonlySet<string>,
 ) {
   let stringSafeHtmlBuffer = html;
   let incompleteUTF8TailBuffer: Buffer = Buffer.alloc(0);
@@ -1592,12 +1592,23 @@ function applyStreamedStylesheetPreloadGating(
       } = splitTrailingIncompleteHtmlTagTail(completeHtml));
     }
   }
+  // PPR: track hrefs of promoted preload tags so they appear in the asset manifest.
+  // Without this, promoted preloads would be missing from emittedRSCClientStylesheetHrefs
+  // and the resume pass would re-promote the same preloads (issue #4897).
+  const promotedPreloadHrefs: string[] = [];
   const gatedHtml = completeHtml.replace(
     /<link\b(?=[^>]*\brel=(["'])(?:(?!\1).)*\bpreload\b(?:(?!\1).)*\1)(?=[^>]*\bas=(["'])style\2)(?=[^>]*\bhref=(["'])(?:(?!\3).)+\3)[^>]*\/?>/gi,
-    (linkTag) =>
-      shouldPromoteStylesheetPreloadTag(linkTag, rscClientManifestStylesheetHrefs)
-        ? promoteStylesheetPreloadTag(linkTag)
-        : linkTag,
+    (linkTag) => {
+      if (shouldPromoteStylesheetPreloadTag(linkTag, rscClientManifestStylesheetHrefs)) {
+        const href = getQuotedAttribute(linkTag, 'href');
+        // PPR resume: skip promotion if the shell already declared this stylesheet. Without this
+        // check, the resume pass re-promotes preloads the cached shell already emitted as links.
+        if (href && alreadyEmittedStylesheetHrefs?.has(href)) return linkTag;
+        if (href) promotedPreloadHrefs.push(href);
+        return promoteStylesheetPreloadTag(linkTag);
+      }
+      return linkTag;
+    },
   );
   const completeHtmlByteLength = Buffer.byteLength(completeHtml, 'utf8');
   const completeHtmlBuffer =
@@ -1612,6 +1623,7 @@ function applyStreamedStylesheetPreloadGating(
     incompleteHtmlTailBuffer,
     incompleteHtmlTailScanState:
       incompleteHtmlTailBuffer.length > 0 ? nextIncompleteHtmlTailScanState : undefined,
+    promotedPreloadHrefs,
   };
 }
 
@@ -1771,12 +1783,19 @@ export default function injectRSCPayload(
       gatedHtmlBuffer,
       incompleteHtmlTailBuffer,
       incompleteHtmlTailScanState: nextRetainedHtmlTailScanState,
+      promotedPreloadHrefs,
     } = applyStreamedStylesheetPreloadGating(
       htmlBuffer,
       incompleteHtmlTailMode,
       rscClientManifestStylesheetHrefs,
       retainedHtmlTailScanState,
+      emittedRSCClientStylesheetHrefs,
     );
+    // PPR: record promoted preload hrefs in the dedup set so they appear in the asset
+    // manifest and the resume pass knows the shell already declared these stylesheets.
+    for (const href of promotedPreloadHrefs) {
+      emittedRSCClientStylesheetHrefs.add(href);
+    }
     const shouldDeferRevealHtml =
       rscPromise &&
       shouldInferRSCClientStylesheets &&

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -139,6 +139,18 @@ type LoadableStats = {
 };
 
 type RSCClientChunkStylesheetHrefsByChunkName = Map<string, string[]>;
+
+/**
+ * Asset state captured during a PPR prerender and stored in the cache envelope.
+ * The resume pass uses this to suppress duplicate CSS links and init scripts
+ * that the cached shell already declared.
+ */
+export type PPRShellAssetManifest = {
+  /** CSS hrefs emitted as <link> tags in the shell's output. */
+  stylesheetHrefs: string[];
+  /** RSC payload keys whose init scripts were emitted in the shell. */
+  initScriptKeys: string[];
+};
 type RSCClientChunkStylesheetHrefsLoadState =
   | {
       status: 'success';
@@ -1608,6 +1620,18 @@ type InjectRSCPayloadOptions = {
   rscClientChunkStylesheetHrefsByChunkName?: RSCClientChunkStylesheetHrefsByChunkName;
   rscStreamObservability?: boolean;
   railsEnv?: string;
+  /**
+   * PPR resume: assets already declared in the cached shell. Pre-seeds dedup sets so
+   * duplicate stylesheet links and init scripts are suppressed. New hole-only assets
+   * are still emitted and gated ahead of their reveals by the existing
+   * deferredRevealHtmlBuffer machinery.
+   */
+  shellAssetManifest?: PPRShellAssetManifest;
+  /**
+   * PPR prerender: callback invoked when the stream ends with the final asset state.
+   * Called after the last flush so all CSS hrefs and init script keys are finalized.
+   */
+  onAssetsEmitted?: (manifest: PPRShellAssetManifest) => void;
 };
 
 /**
@@ -1648,12 +1672,19 @@ export default function injectRSCPayload(
     rscClientChunkStylesheetHrefsByChunkName = loadRSCClientChunkStylesheetHrefsByChunkName(),
     rscStreamObservability = false,
     railsEnv,
+    shellAssetManifest,
+    onAssetsEmitted,
   } = options;
   const sanitizedNonce = sanitizeNonce(cspNonce);
   const htmlStream = new PassThrough();
   const resultStream = new PassThrough();
   let rscPromise: Promise<void> | null = null;
-  const emittedRSCClientStylesheetHrefs = new Set<string>();
+  // PPR: pre-seed the stylesheet dedup set from the cached shell's asset manifest so the resume
+  // pass suppresses CSS links the page already has. New hole-only CSS is still emitted normally.
+  const emittedRSCClientStylesheetHrefs = new Set<string>(shellAssetManifest?.stylesheetHrefs);
+  // PPR: track which RSC payload init scripts have been emitted. Pre-seeded from the shell
+  // manifest so the resume pass does not re-initialize arrays the cached shell already declared.
+  const emittedInitScriptKeys = new Set<string>(shellAssetManifest?.initScriptKeys);
   const shouldInferRSCClientStylesheets = rscClientChunkStylesheetHrefsByChunkName.size > 0;
   let pendingRSCClientStylesheetInferenceStreams = 0;
 
@@ -1891,6 +1922,14 @@ export default function injectRSCPayload(
       flushFallbackTimeout = null;
     }
     flush();
+    // PPR: fire asset capture callback after the final flush so all CSS hrefs and init script
+    // keys are finalized. The prerender uses this to store the manifest in the cache envelope.
+    if (onAssetsEmitted) {
+      onAssetsEmitted({
+        stylesheetHrefs: Array.from(emittedRSCClientStylesheetHrefs),
+        initScriptKeys: Array.from(emittedInitScriptKeys),
+      });
+    }
     if (!resultStream.writableEnded) {
       resultStream.end();
     }
@@ -1988,8 +2027,15 @@ export default function injectRSCPayload(
         // The initialization script clears stale diagnostics, then creates:
         // (self.REACT_ON_RAILS_RSC_PAYLOADS||={})[cacheKey]||=[]
         // This creates a global array that the client-side RSCProvider monitors for new chunks.
-        const initializationScript = createRSCPayloadInitializationScript(rscPayloadKey, sanitizedNonce);
-        rscInitializationBuffers.push(Buffer.from(initializationScript));
+        //
+        // PPR: skip if the cached shell already emitted this key's init script. The shell's
+        // `||=[]` created the array; re-emitting it is safe (||= is a no-op on existing arrays)
+        // but wastes bytes and the `delete` prefix would clear the shell's diagnostics.
+        if (!emittedInitScriptKeys.has(rscPayloadKey)) {
+          const initializationScript = createRSCPayloadInitializationScript(rscPayloadKey, sanitizedNonce);
+          rscInitializationBuffers.push(Buffer.from(initializationScript));
+          emittedInitScriptKeys.add(rscPayloadKey);
+        }
         let inferenceTimeout: NodeJS.Timeout | undefined;
         let hasResolvedRSCClientStylesheetInferenceForStream = !shouldInferRSCClientStylesheets;
         const resolveRSCClientStylesheetInferenceForStream = () => {

--- a/packages/react-on-rails-pro/src/pprServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/pprServerRenderedReactComponent.ts
@@ -25,7 +25,7 @@ import {
   StreamRenderState,
   StreamableComponentResult,
 } from 'react-on-rails/types';
-import injectRSCPayload from './injectRSCPayload.ts';
+import injectRSCPayload, { type PPRShellAssetManifest } from './injectRSCPayload.ts';
 import { getRSCClientManifestStylesheetHrefs } from './cache/manifestStylesheets.ts';
 import { isRSCRouteSSRFalseBailoutError } from './RSCRouteSSRFalseBailoutError.ts';
 import {
@@ -50,12 +50,16 @@ import { getRegisteredPPRApis, type RegisteredPPRApis } from './pprApiRegistry.t
  *   and skips the resume phase.
  * - `pprRenderErrored` (true): React's onError fired during the prerender. Ruby must not cache
  *   this render's shell (the #4581 class of bug).
+ * - `pprAssetManifest` (JSON string): the CSS hrefs and init-script keys emitted during the
+ *   prerender. Stored in the cache envelope so the resume pass can suppress duplicates and
+ *   gate hole-only CSS before reveals (issue #4897 — PPR CSS/asset coordination).
  *
  * MIRROR VALUES OF: react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
  */
 export const PPR_PRERENDER_COMPLETE_CHUNK_KEY = 'pprPrerenderComplete';
 export const PPR_POSTPONED_STATE_CHUNK_KEY = 'pprPostponedState';
 export const PPR_RENDER_ERRORED_CHUNK_KEY = 'pprRenderErrored';
+export const PPR_ASSET_MANIFEST_CHUNK_KEY = 'pprAssetManifest';
 // MIRROR VALUES END
 
 /**
@@ -307,6 +311,9 @@ const pprPrerenderRenderReactComponent = (
         // CSS links are part of the cached shell, exactly like the streaming path's shell.
         const rscClientManifestStylesheetHrefs =
           await rscClientManifestStylesheetHrefsFor(reactClientManifestFileName);
+        // PPR: capture the emitted CSS hrefs and init-script keys so they can be stored in the
+        // cache envelope and passed to the resume pass for duplicate suppression (#4897).
+        let capturedAssetManifest: PPRShellAssetManifest | null = null;
         const injectedStream = injectRSCPayload(
           prelude as unknown as import('react-on-rails/types').PipeableOrReadableStream,
           streamingTrackers.rscRequestTracker,
@@ -317,6 +324,9 @@ const pprPrerenderRenderReactComponent = (
             ...(reactClientManifestFileName ? {} : { rscClientChunkStylesheetHrefsByChunkName: new Map() }),
             rscStreamObservability: railsContext.rscStreamObservability,
             railsEnv: railsContext.railsEnv,
+            onAssetsEmitted: (manifest) => {
+              capturedAssetManifest = manifest;
+            },
           },
         );
 
@@ -348,6 +358,11 @@ const pprPrerenderRenderReactComponent = (
             [PPR_PRERENDER_COMPLETE_CHUNK_KEY]: true,
             ...(sawUnexpectedRenderError ? { [PPR_RENDER_ERRORED_CHUNK_KEY]: true } : {}),
             ...(postponed != null ? { [PPR_POSTPONED_STATE_CHUNK_KEY]: JSON.stringify(postponed) } : {}),
+            // PPR asset manifest: the onAssetsEmitted callback fires during endResultStream
+            // (before the 'end' event), so capturedAssetManifest is populated by this point.
+            ...(capturedAssetManifest != null
+              ? { [PPR_ASSET_MANIFEST_CHUNK_KEY]: JSON.stringify(capturedAssetManifest) }
+              : {}),
           });
 
           streamingTrackers.postSSRHookTracker.notifySSREnd({
@@ -501,6 +516,14 @@ const pprResumeRenderReactComponent = (
         // when the consumer is already gone, aborting the in-flight resume render.
         const rscClientManifestStylesheetHrefs =
           await rscClientManifestStylesheetHrefsFor(reactClientManifestFileName);
+
+        // PPR: parse the shell's asset manifest from railsContext so the resume injector
+        // suppresses duplicate CSS links and init scripts (#4897).
+        const shellAssetManifest: PPRShellAssetManifest | undefined =
+          typeof railsContext.pprShellAssets === 'string'
+            ? (JSON.parse(railsContext.pprShellAssets) as PPRShellAssetManifest)
+            : railsContext.pprShellAssets;
+
         const injectedResumeStream = injectRSCPayload(
           renderingStream,
           streamingTrackers.rscRequestTracker,
@@ -511,6 +534,7 @@ const pprResumeRenderReactComponent = (
             ...(reactClientManifestFileName ? {} : { rscClientChunkStylesheetHrefsByChunkName: new Map() }),
             rscStreamObservability: railsContext.rscStreamObservability,
             railsEnv: railsContext.railsEnv,
+            shellAssetManifest,
           },
         );
 

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -2352,6 +2352,119 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain('nonce="abc123"');
   });
 
+  it('fires onAssetsEmitted callback with captured stylesheet hrefs and init-script keys', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    let capturedManifest: { stylesheetHrefs: string[]; initScriptKeys: string[] } | null = null;
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      onAssetsEmitted: (manifest) => {
+        capturedManifest = manifest;
+      },
+    });
+
+    await collectStreamData(result);
+
+    expect(capturedManifest).not.toBeNull();
+    expect(Array.isArray(capturedManifest!.stylesheetHrefs)).toBe(true);
+    expect(Array.isArray(capturedManifest!.initScriptKeys)).toBe(true);
+    // The test component generates an RSC payload, so at least one init-script key is captured.
+    expect(capturedManifest!.initScriptKeys.length).toBeGreaterThan(0);
+  });
+
+  it('suppresses duplicate init scripts when shellAssetManifest is provided', async () => {
+    // Step 1: capture the manifest from a normal render
+    const mockRSC1 = createMockRSCStream(['{"test": "data"}']);
+    const mockHTML1 = createMockHTMLStream(['<html><body><div>Shell</div></body></html>']);
+    const { rscRequestTracker: tracker1, domNodeId } = setupTest(mockRSC1);
+
+    let shellManifest: { stylesheetHrefs: string[]; initScriptKeys: string[] } | null = null;
+    const result1 = injectRSCPayload(mockHTML1, tracker1, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      onAssetsEmitted: (manifest) => {
+        shellManifest = manifest;
+      },
+    });
+    const shellOutput = await collectStreamData(result1);
+
+    expect(shellManifest).not.toBeNull();
+    expect(shellManifest!.initScriptKeys.length).toBeGreaterThan(0);
+    // Shell should contain the init script
+    expect(shellOutput).toContain('REACT_ON_RAILS_RSC_PAYLOADS');
+
+    // Step 2: render with shellAssetManifest — init scripts for the same keys should be suppressed
+    const mockRSC2 = createMockRSCStream(['{"test": "resume data"}']);
+    const mockHTML2 = createMockHTMLStream(['<div>Resume</div>']);
+    const { rscRequestTracker: tracker2 } = setupTest(mockRSC2);
+
+    const result2 = injectRSCPayload(mockHTML2, tracker2, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      shellAssetManifest: shellManifest!,
+    });
+    const resumeOutput = await collectStreamData(result2);
+
+    // The resume should NOT contain the init script (suppressed by manifest)
+    expect(resumeOutput).not.toContain(expectedInitializationScript);
+    // But it should still contain the payload push script (the data itself is new)
+    expect(resumeOutput).toContain(expectedPayloadPushScript('{"test": "resume data"}'));
+  });
+
+  it('suppresses duplicate stylesheet links when shellAssetManifest provides pre-emitted hrefs', async () => {
+    const cssHref = '/css/client1-abc123.css';
+    const chunkStylesheets = new Map([['client1', [cssHref]]]);
+
+    // Simulate a Flight payload that references client1 chunk
+    const mockRSC = createMockRSCStream(['"client1","js/client1-abc123.chunk.js"']);
+    const mockHTML = createMockHTMLStream(['<div>Resume</div>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: chunkStylesheets,
+      // Pre-seed with the same href — simulates "the shell already declared this CSS"
+      shellAssetManifest: {
+        stylesheetHrefs: [cssHref],
+        initScriptKeys: [],
+      },
+    });
+    const output = await collectStreamData(result);
+
+    // The stylesheet link should NOT be emitted (pre-seeded in the dedup set)
+    expect(output).not.toContain(`href="${cssHref}"`);
+    expect(output).not.toContain('data-precedence="rsc-css"');
+  });
+
+  it('emits hole-only CSS links when shellAssetManifest does not include them', async () => {
+    const shellCssHref = '/css/client1-shell.css';
+    const holeCssHref = '/css/client2-hole-only.css';
+    const chunkStylesheets = new Map([
+      ['client1', [shellCssHref]],
+      ['client2', [holeCssHref]],
+    ]);
+
+    // Flight payload references only client2 (hole-only component)
+    const mockRSC = createMockRSCStream(['"client2","js/client2-abc123.chunk.js"']);
+    const mockHTML = createMockHTMLStream(['<div>Resume Hole Content</div>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: chunkStylesheets,
+      shellAssetManifest: {
+        // Shell had client1's CSS, NOT client2's
+        stylesheetHrefs: [shellCssHref],
+        initScriptKeys: [],
+      },
+    });
+    const output = await collectStreamData(result);
+
+    // Hole-only CSS (client2) SHOULD be emitted — it's new
+    expect(output).toContain(`href="${holeCssHref}"`);
+    expect(output).toContain('data-precedence="rsc-css"');
+    // Shell CSS (client1) should NOT be re-emitted
+    expect(output).not.toContain(`href="${shellCssHref}"`);
+  });
+
   it('adds valid nonce attribute to opt-in observability mark script tags', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}']);
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -2465,6 +2465,82 @@ describe('injectRSCPayload', () => {
     expect(output).not.toContain(`href="${shellCssHref}"`);
   });
 
+  it('includes promoted preload hrefs in the onAssetsEmitted manifest', async () => {
+    // When loadable-stats.json is unavailable, CSS arrives via React's streamed
+    // <link rel="preload" as="style"> tags. The promoted hrefs must appear in the
+    // asset manifest so the resume pass knows the shell already declared them.
+    const preloadHref = '/webpack/test/css/client1-46072b81.css?body=1';
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const mockHTML = createMockHTMLStream([
+      `<link rel="preload" as="style" href="${preloadHref}" crossorigin="anonymous"/>`,
+    ]);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    let capturedManifest: { stylesheetHrefs: string[]; initScriptKeys: string[] } | null = null;
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      onAssetsEmitted: (manifest) => {
+        capturedManifest = manifest;
+      },
+    });
+    await collectStreamData(result);
+
+    expect(capturedManifest).not.toBeNull();
+    // The promoted preload href should appear in the manifest's stylesheetHrefs
+    expect(capturedManifest!.stylesheetHrefs).toContain(preloadHref);
+  });
+
+  it('does not duplicate promoted preload hrefs when also inferred from loadable stats', async () => {
+    // When both loadable-stats inference AND preload promotion fire for the same href,
+    // the manifest should contain the href only once.
+    const cssHref = '/webpack/test/css/client1-46072b81.css';
+    const flightData = '"client1","js/client1-abc123.chunk.js"';
+    const mockRSC = createMockRSCStream([flightData]);
+    const mockHTML = createMockHTMLStream([
+      `<link rel="preload" as="style" href="${cssHref}" crossorigin="anonymous"/>`,
+    ]);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    let capturedManifest: { stylesheetHrefs: string[]; initScriptKeys: string[] } | null = null;
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map([['client1', [cssHref]]]),
+      onAssetsEmitted: (manifest) => {
+        capturedManifest = manifest;
+      },
+    });
+    await collectStreamData(result);
+
+    expect(capturedManifest).not.toBeNull();
+    // The href should appear exactly once, not duplicated
+    const hrefOccurrences = capturedManifest!.stylesheetHrefs.filter((h) => h === cssHref);
+    expect(hrefOccurrences).toHaveLength(1);
+  });
+
+  it('suppresses promoted preloads on resume when the href is in the shellAssetManifest', async () => {
+    const preloadHref = '/webpack/test/css/client1-46072b81.css?body=1';
+
+    // Resume render with shellAssetManifest containing the same href that React re-streams
+    const mockRSC = createMockRSCStream(['{"test": "resume data"}']);
+    const mockHTML = createMockHTMLStream([
+      `<link rel="preload" as="style" href="${preloadHref}" crossorigin="anonymous"/>`,
+    ]);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map(),
+      shellAssetManifest: {
+        stylesheetHrefs: [preloadHref],
+        initScriptKeys: [],
+      },
+    });
+    const output = await collectStreamData(result);
+
+    // The preload should NOT be promoted — the shell already declared this stylesheet.
+    // It should remain as a preload (harmless fetch hint, not a duplicate stylesheet link).
+    expect(output).toContain('rel="preload"');
+    expect(output).not.toContain('data-precedence="rsc-css"');
+  });
+
   it('adds valid nonce attribute to opt-in observability mark script tags', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}']);
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);

--- a/packages/react-on-rails-pro/tests/pprServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/pprServerRenderedReactComponent.test.jsx
@@ -24,6 +24,7 @@ import {
   PPR_PRERENDER_COMPLETE_CHUNK_KEY,
   PPR_POSTPONED_STATE_CHUNK_KEY,
   PPR_RENDER_ERRORED_CHUNK_KEY,
+  PPR_ASSET_MANIFEST_CHUNK_KEY,
 } from '../src/pprServerRenderedReactComponent.ts';
 import * as ComponentRegistry from '../src/ComponentRegistry.ts';
 import ReactOnRails from '../src/ReactOnRails.node.ts';
@@ -445,6 +446,69 @@ describe('pprServerRenderedReactComponent', () => {
     } finally {
       jest.resetModules();
     }
+  });
+
+  it('captures the asset manifest in the prerender trailing protocol chunk', async () => {
+    const { chunks, errors } = await collectStreamResult(runPrerender());
+    expect(errors).toHaveLength(0);
+
+    // The trailing protocol chunk carries the asset manifest alongside PostponedState.
+    const trailingChunk = chunks[chunks.length - 1];
+    expect(trailingChunk[PPR_PRERENDER_COMPLETE_CHUNK_KEY]).toBe(true);
+
+    const rawManifest = trailingChunk[PPR_ASSET_MANIFEST_CHUNK_KEY];
+    expect(typeof rawManifest).toBe('string');
+
+    const manifest = JSON.parse(rawManifest);
+    expect(manifest).toHaveProperty('stylesheetHrefs');
+    expect(manifest).toHaveProperty('initScriptKeys');
+    expect(Array.isArray(manifest.stylesheetHrefs)).toBe(true);
+    expect(Array.isArray(manifest.initScriptKeys)).toBe(true);
+  });
+
+  it('captures the asset manifest even when the prerender has no RSC payloads (empty arrays)', async () => {
+    // The test components are plain React (no RSC), so the manifest should have empty arrays —
+    // the manifest structure is still captured and stored for the resume pass.
+    const { chunks, errors } = await collectStreamResult(runPrerender());
+    expect(errors).toHaveLength(0);
+
+    const trailingChunk = chunks[chunks.length - 1];
+    const manifest = JSON.parse(trailingChunk[PPR_ASSET_MANIFEST_CHUNK_KEY]);
+
+    // Empty arrays are valid — the resume pass pre-seeds its dedup sets from them.
+    expect(manifest.stylesheetHrefs).toEqual([]);
+    expect(manifest.initScriptKeys).toEqual([]);
+  });
+
+  it('passes the shell asset manifest to the resume injector via railsContext.pprShellAssets', async () => {
+    // Step 1: prerender and capture the manifest
+    const { chunks: prerenderChunks } = await collectStreamResult(runPrerender());
+    const trailingChunk = prerenderChunks[prerenderChunks.length - 1];
+    const postponedStateJson = trailingChunk[PPR_POSTPONED_STATE_CHUNK_KEY];
+    const assetManifestJson = trailingChunk[PPR_ASSET_MANIFEST_CHUNK_KEY];
+
+    // Step 2: resume with the manifest — confirm it completes without errors.
+    // The resume receives pprShellAssets via railsContext and uses it to pre-seed dedup sets.
+    ReactOnRails.register({ PprShellWithHole });
+    const resumeResult = pprResumeServerRenderedReactComponent({
+      name: 'PprShellWithHole',
+      domNodeId: 'pprDomId',
+      trace: false,
+      props: {},
+      throwJsErrors: false,
+      railsContext: {
+        ...testingRailsContext,
+        pprPostponedState: postponedStateJson,
+        pprShellAssets: assetManifestJson,
+      },
+    });
+
+    const { chunks: resumeChunks, errors: resumeErrors } = await collectStreamResult(resumeResult);
+    expect(resumeErrors).toHaveLength(0);
+
+    // The resume should produce the hole content (the Suspense hole's async component resolves).
+    const resumeHtml = resumeChunks.map((c) => c.html).join('');
+    expect(resumeHtml).toContain(HOLE_CONTENT_MARKER);
   });
 
   it('raises a clear configuration error when react-dom does not satisfy the PPR version range', async () => {

--- a/packages/react-on-rails/src/types/index.ts
+++ b/packages/react-on-rails/src/types/index.ts
@@ -63,6 +63,10 @@ export type RailsContext = {
       // pinned wire contract between the Rails helper and the Pro renderer.
       pprSettleBudgetMs?: number;
       pprPostponedState?: string;
+      // Injected by React on Rails Pro for :ppr_resume renders: the CSS hrefs and init-script keys
+      // emitted during the prerender phase, so the resume pass can suppress duplicates and gate
+      // hole-only CSS before reveals (issue #4897 — PPR CSS/asset coordination).
+      pprShellAssets?: string | { stylesheetHrefs: string[]; initScriptKeys: string[] };
       getRSCPayloadStream: (componentName: string, props: unknown) => Promise<NodeJS.ReadableStream>;
     }
 );

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1504,6 +1504,7 @@ module ReactOnRailsProHelper
     {
       shell_html: cached_entry["shell_html"],
       postponed_state: cached_entry["postponed_state"],
+      asset_manifest: cached_entry["assets"],
       console_script: "",
       render_options:,
       tag: generate_component_script(render_options)
@@ -1517,33 +1518,44 @@ module ReactOnRailsProHelper
   def ppr_prerender(component_name, options)
     prerender_options = options.merge(render_mode: :ppr_prerender)
     internal_result = internal_react_component(component_name, prerender_options)
+    parsed = ppr_parse_prerender_chunks(internal_result[:result])
 
+    ppr_check_prerender_protocol!(component_name, parsed[:prerender_complete], parsed[:had_render_error])
+
+    {
+      shell_html: parsed[:shell_html],
+      postponed_state: parsed[:postponed_state],
+      asset_manifest: parsed[:asset_manifest],
+      had_render_error: parsed[:had_render_error],
+      console_script: parsed[:console_scripts].join("\n"),
+      render_options: internal_result[:render_options],
+      tag: internal_result[:tag]
+    }
+  end
+
+  # Consumes the chunked prerender response and extracts shell HTML, PostponedState, asset
+  # manifest, error flags, and console scripts from the metadata-based protocol.
+  def ppr_parse_prerender_chunks(chunked_result)
     shell_html = +""
     console_scripts = []
     postponed_state = nil
+    asset_manifest = nil
     had_render_error = false
     prerender_complete = false
 
-    internal_result[:result].each_chunk do |chunk|
+    chunked_result.each_chunk do |chunk|
       had_render_error ||= chunk["hasErrors"] == true ||
                            chunk[ReactOnRailsPro::Ppr::RENDER_ERRORED_CHUNK_KEY] == true
       prerender_complete ||= chunk[ReactOnRailsPro::Ppr::PRERENDER_COMPLETE_CHUNK_KEY] == true
       chunk_postponed_state = chunk[ReactOnRailsPro::Ppr::POSTPONED_STATE_CHUNK_KEY]
       postponed_state = chunk_postponed_state if chunk_postponed_state.is_a?(String)
+      chunk_asset_manifest = chunk[ReactOnRailsPro::Ppr::ASSET_MANIFEST_CHUNK_KEY]
+      asset_manifest = chunk_asset_manifest if chunk_asset_manifest.is_a?(String)
       shell_html << (chunk["html"] || "")
       console_scripts << chunk["consoleReplayScript"] if chunk["consoleReplayScript"].present?
     end
 
-    ppr_check_prerender_protocol!(component_name, prerender_complete, had_render_error)
-
-    {
-      shell_html:,
-      postponed_state:,
-      had_render_error:,
-      console_script: console_scripts.join("\n"),
-      render_options: internal_result[:render_options],
-      tag: internal_result[:tag]
-    }
+    { shell_html:, console_scripts:, postponed_state:, asset_manifest:, had_render_error:, prerender_complete: }
   end
 
   # A prerender response with neither the completion metadata nor an error signal means the
@@ -1626,16 +1638,27 @@ module ReactOnRailsProHelper
   # Builds the versioned cache envelope from a prerender result. The envelope holds both
   # shell_html and postponed_state in a single Hash — there is never a state without its
   # shell, and mixing generations is impossible (issue #4896 Part A).
+  #
+  # The optional "assets" field carries the CSS hrefs and init-script keys emitted during
+  # the prerender. The resume pass uses it to suppress duplicate CSS links and init scripts
+  # that the cached shell already declared (issue #4897 — PPR CSS/asset coordination).
+  # It is NOT included in the checksum: assets are metadata about the shell, derived from
+  # the same prerender pass. A missing assets field (e.g. from an older renderer) is a
+  # graceful degradation — the resume operates without dedup, which is the current behavior.
   def ppr_build_envelope(prerender_result)
     shell_html = prerender_result[:shell_html]
     postponed_state = prerender_result[:postponed_state]
-    {
+    envelope = {
       "schema" => ReactOnRailsPro::Ppr::PPR_ENVELOPE_SCHEMA,
       "react" => ReactOnRailsPro::Ppr.react_version_cache_key,
       "shell_html" => shell_html,
       "postponed_state" => postponed_state,
       "checksum" => ReactOnRailsPro::Ppr.compute_checksum(shell_html, postponed_state)
     }
+    # Asset manifest is optional — nil when the renderer does not emit it (graceful degradation).
+    asset_manifest = prerender_result[:asset_manifest]
+    envelope["assets"] = asset_manifest if asset_manifest.is_a?(String)
+    envelope
   end
 
   # Writes the envelope and registers cache tags. If the write fails (falsy return or exception),
@@ -1689,7 +1712,8 @@ module ReactOnRailsProHelper
     postponed_state = prerender_result[:postponed_state]
     if postponed_state.present?
       ppr_enqueue_resume_stream(component_name, options, postponed_state,
-                                cache_key:, raw_cache_options:)
+                                cache_key:, raw_cache_options:,
+                                asset_manifest: prerender_result[:asset_manifest])
     elsif !prerender_result[:had_render_error]
       ReactOnRailsPro::Ppr.instrument_static_shell(component_name:, cache_hit:)
     end
@@ -1709,12 +1733,13 @@ module ReactOnRailsProHelper
   # second document. The error does NOT re-raise: the user sees a truncated page that heals on
   # reload, never a 500 caused by the PPR cache.
   def ppr_enqueue_resume_stream(component_name, options, postponed_state,
-                                cache_key: nil, raw_cache_options: nil)
+                                cache_key: nil, raw_cache_options: nil, asset_manifest: nil)
     renderer_server_timing_collector = ReactOnRailsPro::Stream.renderer_server_timing_collector
 
     @async_barrier.async do
       ReactOnRailsPro::Stream.with_renderer_server_timing_collector(renderer_server_timing_collector) do
-        resume_stream = ppr_resume_stream(component_name, options, postponed_state)
+        resume_stream = ppr_resume_stream(component_name, options, postponed_state,
+                                          asset_manifest:)
         resume_stream.each_chunk do |chunk|
           # Client disconnected — stop streaming; the entry is already cached.
           break if response.stream.closed?
@@ -1737,8 +1762,12 @@ module ReactOnRailsProHelper
   # railsContext.pprPostponedState (the pinned wire key — see ServerRenderingJsCode). Chunks are
   # composed like non-first streamed chunks: no component div or spec tag, since the shell already
   # carries both.
-  def ppr_resume_stream(component_name, options, postponed_state)
-    resume_options = options.merge(render_mode: :ppr_resume, ppr_postponed_state: postponed_state)
+  def ppr_resume_stream(component_name, options, postponed_state, asset_manifest: nil)
+    resume_options = options.merge(
+      render_mode: :ppr_resume,
+      ppr_postponed_state: postponed_state,
+      ppr_shell_assets: asset_manifest
+    )
     result = internal_react_component(component_name, resume_options)
     render_opts = result[:render_options]
     result[:result].transform do |chunk_json_result|

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1504,7 +1504,7 @@ module ReactOnRailsProHelper
     {
       shell_html: cached_entry["shell_html"],
       postponed_state: cached_entry["postponed_state"],
-      asset_manifest: cached_entry["assets"],
+      asset_manifest: ppr_validated_asset_manifest(cached_entry["assets"]),
       console_script: "",
       render_options:,
       tag: generate_component_script(render_options)
@@ -1525,7 +1525,7 @@ module ReactOnRailsProHelper
     {
       shell_html: parsed[:shell_html],
       postponed_state: parsed[:postponed_state],
-      asset_manifest: parsed[:asset_manifest],
+      asset_manifest: ppr_validated_asset_manifest(parsed[:asset_manifest]),
       had_render_error: parsed[:had_render_error],
       console_script: parsed[:console_scripts].join("\n"),
       render_options: internal_result[:render_options],
@@ -1659,6 +1659,30 @@ module ReactOnRailsProHelper
     asset_manifest = prerender_result[:asset_manifest]
     envelope["assets"] = asset_manifest if asset_manifest.is_a?(String)
     envelope
+  end
+
+  # Validates the shape of a cached asset manifest string. Returns the string unchanged if it
+  # parses as JSON with the expected shape ({stylesheetHrefs: string[], initScriptKeys: string[]});
+  # returns nil (graceful degradation — resume operates without dedup) if the string is nil,
+  # not a String, or malformed. This guards against corrupted cache entries: the assets field is
+  # excluded from the envelope checksum, so a corrupted value would pass envelope validation
+  # and reach the renderer as raw JS without this check (issue #4897).
+  def ppr_validated_asset_manifest(raw)
+    return nil unless raw.is_a?(String)
+
+    parsed = JSON.parse(raw)
+    return nil unless parsed.is_a?(Hash)
+    return nil unless ppr_valid_string_array?(parsed["stylesheetHrefs"])
+    return nil unless ppr_valid_string_array?(parsed["initScriptKeys"])
+
+    raw
+  rescue JSON::ParserError
+    nil
+  end
+
+  # Returns true when +value+ is an Array whose elements are all Strings.
+  def ppr_valid_string_array?(value)
+    value.is_a?(Array) && value.all?(String)
   end
 
   # Writes the envelope and registers cache tags. If the write fails (falsy return or exception),

--- a/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/ppr.rb
@@ -28,6 +28,7 @@ module ReactOnRailsPro
     PRERENDER_COMPLETE_CHUNK_KEY = "pprPrerenderComplete"
     POSTPONED_STATE_CHUNK_KEY = "pprPostponedState"
     RENDER_ERRORED_CHUNK_KEY = "pprRenderErrored"
+    ASSET_MANIFEST_CHUNK_KEY = "pprAssetManifest"
     # MIRROR VALUES END
 
     # Version of the cache-record format. Part of every PPR cache key so a storage-format change

--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
@@ -205,9 +205,13 @@ module ReactOnRailsPro
           JS
         elsif render_options.ppr_resume?
           postponed_state = render_options.internal_option(:ppr_postponed_state)
-          <<-JS
-            railsContext.pprPostponedState = #{postponed_state.to_json};
-          JS
+          shell_assets = render_options.internal_option(:ppr_shell_assets)
+          js = +"railsContext.pprPostponedState = #{postponed_state.to_json};\n"
+          # PPR asset manifest: the CSS hrefs and init-script keys the cached shell emitted.
+          # The resume renderer uses this to suppress duplicate CSS links and init scripts
+          # (issue #4897 — PPR CSS/asset coordination). Gracefully omitted when absent.
+          js << "railsContext.pprShellAssets = #{shell_assets};\n" if shell_assets.is_a?(String)
+          js
         else
           ""
         end

--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
@@ -210,7 +210,7 @@ module ReactOnRailsPro
           # PPR asset manifest: the CSS hrefs and init-script keys the cached shell emitted.
           # The resume renderer uses this to suppress duplicate CSS links and init scripts
           # (issue #4897 — PPR CSS/asset coordination). Gracefully omitted when absent.
-          js << "railsContext.pprShellAssets = #{shell_assets};\n" if shell_assets.is_a?(String)
+          js << "railsContext.pprShellAssets = #{shell_assets.to_json};\n" if shell_assets.is_a?(String)
           js
         else
           ""


### PR DESCRIPTION
## Why

Resolves the **D6** design decision — the hardest unsolved item in PPR v1.

PPR splits one page across two renderer requests at different times. Each render
creates its own `injectRSCPayload` instance with independent CSS dedup sets and
init-script tracking. This causes:

1. **Duplicate `<link>` tags and init scripts** — inflated responses
2. **FOUC for hole-only CSS** — client components that exist only inside Suspense
   holes have CSS the shell never declared, and nothing guarantees the link
   arrives before the `$RC()` reveal

## What changed

Three-layer coordination: **capture → transport → suppress/gate**.

### Layer 1: Asset capture (`injectRSCPayload.ts`)
- New `PPRShellAssetManifest` type: `{ stylesheetHrefs: string[], initScriptKeys: string[] }`
- `onAssetsEmitted` callback fires after the final flush with the captured state
- `shellAssetManifest` option pre-seeds the resume dedup sets from the shell manifest
- Init-script keys are now tracked alongside stylesheet hrefs

### Layer 2: Protocol extension (`pprServerRenderedReactComponent.ts`)
- **Prerender**: captures emitted assets via `onAssetsEmitted`, includes the
  manifest in the trailing protocol chunk (`pprAssetManifest` key)
- **Resume**: reads `railsContext.pprShellAssets`, passes as `shellAssetManifest`
  to `injectRSCPayload`

### Layer 3: Envelope + transport (Ruby)
- `ASSET_MANIFEST_CHUNK_KEY` constant added to `Ppr` module
- Extracts asset manifest from prerender protocol chunk metadata
- Stores as optional `"assets"` field in cache envelope (additive — gracefully
  degraded if absent, no schema bump needed)
- Threads manifest through `serve_shell → enqueue_resume → resume_stream`
- Injects via `railsContext.pprShellAssets` in `server_rendering_js_code.rb`

### Design decisions
- **No checksum change**: assets are metadata about the shell, not integrity-critical
- **No schema bump**: additive field, old code ignores unknown Hash keys, cache key
  includes bundle digests for version isolation
- **Existing gating works**: the `deferredRevealHtmlBuffer` mechanism naturally handles
  hole-only CSS — new CSS (not in manifest) is emitted and gated before reveals

## How to review

1. Start with `injectRSCPayload.ts` — the new `shellAssetManifest`/`onAssetsEmitted`
   options and the dedup pre-seeding
2. Then `pprServerRenderedReactComponent.ts` — the capture (prerender) and consume (resume)
3. Then Ruby: `ppr.rb` → `react_on_rails_pro_helper.rb` → `server_rendering_js_code.rb`
4. Tests: 7 new tests across two test files

## Tests

- 4 new `injectRSCPayload` unit tests: callback, init-script suppression,
  stylesheet suppression, hole-only CSS emission
- 3 new `pprServerRenderedReactComponent` tests: manifest capture, empty manifest,
  full round-trip with `pprShellAssets`
- All 86 existing `injectRSCPayload` tests pass
- All 27 existing PPR integration tests pass
- TypeScript check passes across all 3 packages

## Remaining work (follow-up issues)

- [ ] FOUC visreg gate (ShakaPerf `test/shakaperf/rsc-fouc`) — needs the doc-09 fixture
- [ ] Turbo-navigation interaction statement (#3485)

Closes #4897

<details>
<summary>Agent details</summary>

**Confidence note:** High confidence — the changes are surgical, the existing
CSS-before-reveal machinery handles the hard case (hole-only CSS gating), and
every existing test passes. The main risk surface is the protocol extension
(new chunk metadata key), which is additive and backward-compatible.

**Decision log:**
- Chose additive envelope field over schema bump: the cache key already includes
  bundle digests, so version-crossing is impossible. No schema bump means no mass
  cache invalidation on upgrade.
- Chose callback-based asset capture over return-value change: preserves the
  `injectRSCPayload` return type (PassThrough stream) for all callers.
- Extracted `ppr_parse_prerender_chunks` to satisfy RuboCop ABC size limit.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)