### PR TITLE
[Pro] Avoid error spans for expected cold starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Expected Node Renderer cold starts no longer emit OpenTelemetry error spans**: The
+  `ror.bundle.build_execution_context` cache-first probe previously ended with status ERROR when a worker had not
+  compiled a bundle's VM context yet, even though the normal cache-miss path then rendered successfully. The probe
+  now treats that expected miss as normal control flow while preserving error spans for genuine failures.
+  [PR 4908](https://github.com/shakacode/react_on_rails/pull/4908) by
+  [sashakhar1](https://github.com/sashakhar1).
+
 - **[Pro]** **Hydrated Redux stores no longer leak across Turbo/Turbolinks navigations**: The hydrated-store
   registry is now cleared on client-side page unload (soft navigation), alongside the existing component
   teardown. Previously a leftover entry from the previous page made `getOrWaitForStore` resolve immediately

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
@@ -322,44 +322,36 @@ export async function handleRenderRequest({
     // Start before the first VM lookup so cache-hit and cache-miss timings cover
     // the same request span, including bundle upload on first deploy.
     const rendererServerTimingStartedAtMs = performance.now();
-    try {
-      const executionContext = await subSpan(
-        {
-          name: 'ror.bundle.build_execution_context',
-          attributes: {
-            'bundle.timestamp': String(bundleTimestamp),
-            'bundle.paths.count': allBundleFilePaths.length,
-            'cache.strategy': 'cache-first',
-          },
+    const cachedExecutionContext = await subSpan(
+      {
+        name: 'ror.bundle.build_execution_context',
+        attributes: {
+          'bundle.timestamp': String(bundleTimestamp),
+          'bundle.paths.count': allBundleFilePaths.length,
+          'cache.strategy': 'cache-first',
         },
-        async () => {
-          try {
-            return await buildExecutionContext(allBundleFilePaths, /* buildVmsIfNeeded */ false);
-          } catch (error) {
-            // Keep an ordinary cache miss from crossing the tracing boundary.
-            if (error instanceof VMContextNotFoundError) {
-              return undefined;
-            }
-            throw error;
+      },
+      async () => {
+        try {
+          return await buildExecutionContext(allBundleFilePaths, /* buildVmsIfNeeded */ false);
+        } catch (error) {
+          // Keep an ordinary cache miss from crossing the tracing boundary.
+          if (error instanceof VMContextNotFoundError) {
+            return undefined;
           }
-        },
+          throw error;
+        }
+      },
+    );
+    if (cachedExecutionContext) {
+      return await prepareResponseWithServerTiming(
+        renderingRequest,
+        bundleTimestamp,
+        entryBundleFilePath,
+        cachedExecutionContext,
+        rendererServerTimingStartedAtMs,
+        rscStreamObservability,
       );
-      if (executionContext) {
-        return await prepareResponseWithServerTiming(
-          renderingRequest,
-          bundleTimestamp,
-          entryBundleFilePath,
-          executionContext,
-          rendererServerTimingStartedAtMs,
-          rscStreamObservability,
-        );
-      }
-    } catch (e) {
-      // Ignore VMContextNotFoundError, it means the bundle does not exist.
-      // The following code will handle this case.
-      if (!(e instanceof VMContextNotFoundError)) {
-        throw e;
-      }
     }
 
     // If gem has posted updated bundle:

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
@@ -328,6 +328,7 @@ export async function handleRenderRequest({
         attributes: {
           'bundle.timestamp': String(bundleTimestamp),
           'bundle.paths.count': allBundleFilePaths.length,
+          // This labels probe intent, not whether the lookup hits or misses.
           'cache.strategy': 'cache-first',
         },
       },
@@ -335,7 +336,7 @@ export async function handleRenderRequest({
         try {
           return await buildExecutionContext(allBundleFilePaths, /* buildVmsIfNeeded */ false);
         } catch (error) {
-          // Keep an ordinary cache miss from crossing the tracing boundary.
+          // A missing VM is expected here; bundle validation below handles absent bundles.
           if (error instanceof VMContextNotFoundError) {
             return undefined;
           }

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
@@ -332,16 +332,28 @@ export async function handleRenderRequest({
             'cache.strategy': 'cache-first',
           },
         },
-        () => buildExecutionContext(allBundleFilePaths, /* buildVmsIfNeeded */ false),
+        async () => {
+          try {
+            return await buildExecutionContext(allBundleFilePaths, /* buildVmsIfNeeded */ false);
+          } catch (error) {
+            // Keep an ordinary cache miss from crossing the tracing boundary.
+            if (error instanceof VMContextNotFoundError) {
+              return undefined;
+            }
+            throw error;
+          }
+        },
       );
-      return await prepareResponseWithServerTiming(
-        renderingRequest,
-        bundleTimestamp,
-        entryBundleFilePath,
-        executionContext,
-        rendererServerTimingStartedAtMs,
-        rscStreamObservability,
-      );
+      if (executionContext) {
+        return await prepareResponseWithServerTiming(
+          renderingRequest,
+          bundleTimestamp,
+          entryBundleFilePath,
+          executionContext,
+          rendererServerTimingStartedAtMs,
+          rscStreamObservability,
+        );
+      }
     } catch (e) {
       // Ignore VMContextNotFoundError, it means the bundle does not exist.
       // The following code will handle this case.

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry.test.ts
@@ -452,6 +452,25 @@ describe('opentelemetry integration: end-to-end render request', () => {
     type: 'asset',
   });
 
+  const renderColdStart = async () => {
+    await createUploadedBundle(testName);
+
+    return trace(
+      () =>
+        handleRenderRequest({
+          renderingRequest: 'ReactOnRails.dummy',
+          bundleTimestamp: BUNDLE_TIMESTAMP,
+          providedNewBundles: [
+            {
+              bundle: uploadedBundleForTest(),
+              timestamp: BUNDLE_TIMESTAMP,
+            },
+          ],
+        }),
+      startSsrRequestOptions({ renderingRequest: 'ReactOnRails.dummy' }),
+    );
+  };
+
   beforeEach(async () => {
     exporter = new InMemorySpanExporter();
     __resetSubSpanForTest();
@@ -468,34 +487,19 @@ describe('opentelemetry integration: end-to-end render request', () => {
     await resetForTest(testName);
   });
 
-  test('cache-miss probe labels intent instead of reporting cache.hit=true on the error span', async () => {
+  test('cache-miss probe and build label intent without reporting cache.hit', async () => {
     init({
       tracing: true,
       spanProcessor: new SimpleSpanProcessor(exporter),
     });
 
-    await createUploadedBundle(testName);
-
-    await trace(
-      async () => {
-        const result = await handleRenderRequest({
-          renderingRequest: 'ReactOnRails.dummy',
-          bundleTimestamp: BUNDLE_TIMESTAMP,
-          providedNewBundles: [
-            {
-              bundle: uploadedBundleForTest(),
-              timestamp: BUNDLE_TIMESTAMP,
-            },
-          ],
-        });
-        expect(result.response.status).toBe(200);
-      },
-      startSsrRequestOptions({ renderingRequest: 'ReactOnRails.dummy' }),
-    );
+    const result = await renderColdStart();
+    expect(result.response.status).toBe(200);
 
     const spans = exporter.getFinishedSpans();
     const cacheMissProbeSpan = spans.find(
-      (s) => s.name === 'ror.bundle.build_execution_context' && s.status.code === 2,
+      (s) =>
+        s.name === 'ror.bundle.build_execution_context' && s.attributes['cache.strategy'] === 'cache-first',
     );
     const cacheMissBuildSpan = spans.find(
       (s) =>
@@ -507,6 +511,18 @@ describe('opentelemetry integration: end-to-end render request', () => {
     expect(cacheMissProbeSpan!.attributes).not.toHaveProperty('cache.hit');
     expect(cacheMissBuildSpan).toBeDefined();
     expect(cacheMissBuildSpan!.attributes).not.toHaveProperty('cache.hit');
+  });
+
+  test('cold-start render succeeds without error spans', async () => {
+    init({
+      tracing: true,
+      spanProcessor: new SimpleSpanProcessor(exporter),
+    });
+
+    const result = await renderColdStart();
+
+    expect(result.response.status).toBe(200);
+    expect(exporter.getFinishedSpans().filter((span) => span.status.code === 2)).toHaveLength(0);
   });
 
   test('invalid incremental update chunks do not create process_chunk error spans', async () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry.test.ts
@@ -507,7 +507,7 @@ describe('opentelemetry integration: end-to-end render request', () => {
     );
 
     expect(cacheMissProbeSpan).toBeDefined();
-    expect(cacheMissProbeSpan!.attributes['cache.strategy']).toBe('cache-first');
+    expect(cacheMissProbeSpan!.status.code).not.toBe(2);
     expect(cacheMissProbeSpan!.attributes).not.toHaveProperty('cache.hit');
     expect(cacheMissBuildSpan).toBeDefined();
     expect(cacheMissBuildSpan!.attributes).not.toHaveProperty('cache.hit');


### PR DESCRIPTION
### Summary

Prevents an expected Node Renderer cold-start VM cache miss from marking a successful OpenTelemetry span as an error.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~~Update documentation~~
- [x] Update CHANGELOG file

### Other Information

None.

## Follow-ups

- none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering when a cached execution context is unavailable, allowing requests to proceed through normal validation and cache-miss handling.
  * Preserved error reporting for unexpected failures.
  * Ensured cold-start renders complete successfully without generating error traces.

* **Tests**
  * Expanded coverage for cache misses, cold starts, and tracing behavior.

* **Documentation**
  * Updated release documentation to clarify cold-start tracing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->