### PR TITLE
Fix dead primercss.io link in style docs

### DIFF
--- a/docs/oss/misc/style.md
+++ b/docs/oss/misc/style.md
@@ -31,7 +31,7 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](https://sass-guidelin.es/) by Kitty Giraudel
-- [Github Front End Guidelines](http://primercss.io/guidelines/)
+- [GitHub Primer design system](https://primer.style/)
 
 ## Git Usage
 

--- a/internal/react_on_rails_pro/contributors-info/style.md
+++ b/internal/react_on_rails_pro/contributors-info/style.md
@@ -32,7 +32,7 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](http://sass-guidelin.es/) by [Hugo Giraudel](http://hugogiraudel.com/)
-- [GitHub Front End Guidelines](http://primercss.io/guidelines/)
+- [GitHub Primer design system](https://primer.style/)
 
 # Git Usage
 


### PR DESCRIPTION
`http://primercss.io/guidelines/` has been dead for a while and now returns HTTP 444, which fails the "Check Markdown Links" workflow on `main` and on every open PR. Because the merge queue uses the ALLGREEN strategy, that red check blocks merges even though the check is not in the required set.

GitHub's Primer moved to primer.style. Verified before committing: the old URL returns 444, `https://primer.style/` returns 200. `https://primer.style/css/` now redirects into a Storybook page and `https://primer.style/guides/` redirects to the site root, so the root is the honest target; the link text is updated to match where it actually goes.

Fixed both copies, including the one under `internal/` that the link checker does not currently scan, so the same dead URL does not sit there rotting.

## Follow-ups

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Sass coding standards references to link to the GitHub Primer design system.
  * Replaced outdated GitHub Front End Guidelines links in the relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->