### PR TITLE
Fix order-dependent flake in the Activity RSC request spec

### DIFF
--- a/react_on_rails_pro/spec/dummy/spec/requests/activity_rsc_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/activity_rsc_spec.rb
@@ -31,6 +31,16 @@ require "rails_helper"
 # IMPORTANT: like the other streamed RSC request specs, this requires the Pro
 # node renderer on :3800 (cd react_on_rails_pro/spec/dummy && pnpm run node-renderer).
 RSpec.describe "Activity inside a streamed RSC tree", :server_rendering do
+  # Stage the RSC manifests on the renderer before rendering. A bundle that an
+  # earlier non-RSC spec already staged does not carry
+  # react-server-client-manifest.json, and the gem does not re-upload assets for
+  # a bundle it considers present, so the RSC render fails with ENOENT on that
+  # manifest and the streamed subtree never reaches the HTML. Specs run in
+  # defined order and this file sorts first in spec/requests, so without this
+  # upload the example depends on whether something else happened to upload the
+  # manifests first - which is exactly how it used to fail intermittently.
+  before { ReactOnRailsPro::Request.upload_assets }
+
   it "renders the visible Activity boundary into HTML and keeps the hidden one payload-only" do
     get "/activity_rsc_tabs"
 


### PR DESCRIPTION
`spec/requests/activity_rsc_spec.rb` fails intermittently on `main` and on Pro PRs, taking the `rspec-dummy-app-node-renderer` job with it (and cascade-cancelling `dummy-app-rspack-rsc-runtime-gate`):

```
Failure/Error: expect(html_nodes.at_css('[data-testid="profile-server-sentinel"]')).not_to be_nil
  expected: not nil
       got: nil
# ./spec/requests/activity_rsc_spec.rb:43
```

## It is not a streaming race

The obvious reading is a race with the Fizz flush, but that is not it. The spec requests `/activity_rsc_tabs` with no query param, so `artificialDelay` clamps to 0, and `ProfileServerContent` is synchronous and lands in the shell. The sibling streamed-RSC request specs use the same `get` + `response.body` pattern and do not flake.

## What actually happens

From the `test.log` artifact of the failing run, at the failing request:

```
Started GET "/activity_rsc_tabs" ...
[ReactOnRailsPro] Perform rendering request as a stream /bundles/rorp-v2-s-<hash>/render/<hash>
[ReactOnRailsPro] Node Renderer responded
[react_on_rails] RENDERED RSCActivityTabsPage to dom node with id: RSCActivityTabsPage-react-component-0
[react_on_rails] Failed to load JSON file: .../.node-renderer-bundles/rorp-v2-s-<hash>/react-server-client-manifest.json
  {"errno":-2,"code":"ENOENT",...}
```

Note what is missing from that request: no `Sending bundle to the node renderer`, no `Uploading assets`. The renderer already had the bundle, staged by an earlier non-RSC spec, so the gem saw no reason to upload anything - but that staged bundle directory never received `react-server-client-manifest.json`. The RSC render cannot resolve client references, the streamed subtree fails, and the sentinel never reaches the HTML. The page still returns 200, which is why this surfaces as a missing element rather than an error.

Further down the same log a later spec performs the full upload:

```
[ReactOnRailsPro] Uploading assets
[ReactOnRailsPro] Uploading asset .../loadable-stats.json
[ReactOnRailsPro] Uploading asset .../server-bundle.js.map
[ReactOnRailsPro] Uploading asset .../react-client-manifest.json
[ReactOnRailsPro] Uploading asset .../react-server-client-manifest.json
```

and every RSC render after that point works.

Why this spec: `config.order = :random` is commented out in `spec/spec_helper.rb`, so files run in defined order and `activity_rsc_spec.rb` sorts first in `spec/requests`, making it the first real streamed RSC render. `incremental_rendering_integration_spec.rb` (later alphabetically) calls `ReactOnRailsPro::Request.upload_assets` explicitly, which is what repairs renderer state for everything after it. Whether this example passes depends on whether anything happened to upload the manifests before it ran - hence intermittent rather than always red.

Evidence it is not caused by any particular PR: main run 31939768747 failed with this exact assertion at head `beb8315810c2`, and runs 31939433383 and 31939405236 failed the same way, while 31939685608 and others on the same day passed.

## The fix

The spec now stages its own precondition with `ReactOnRailsPro::Request.upload_assets` in a `before` hook - the same call `incremental_rendering_integration_spec.rb` already uses - so it no longer inherits renderer state from whatever ran earlier. No sleep, no retry, no `pending`, no weakened assertions; all five original assertions are unchanged.

## Verification

The failure is deterministic when the file runs alone, because then nothing else has uploaded the manifests. Reproduction status is noted in the PR discussion below rather than claimed here.

No CHANGELOG entry: this changes only a spec, and the changelog tracks user-facing source changes (the docs-only PR #4906 likewise carries none).

## Follow-ups

- The same latent ordering dependency would hit whichever RSC request spec happens to run first if the suite order ever changes; a suite-level guarantee would be more robust than a per-spec hook.
- A render request that finds a staged bundle without its RSC manifest arguably indicates a gem-level gap: asset presence is not validated independently of bundle presence. Worth its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered page streaming by ensuring required React-on-Rails assets are available before rendering.
  * Prevented missing-manifest issues during streamed page requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->