### PR TITLE
Clarify Primer references and RSC test setup

### DIFF
--- a/docs/oss/misc/style.md
+++ b/docs/oss/misc/style.md
@@ -31,7 +31,8 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](https://sass-guidelin.es/) by Kitty Giraudel
-- [GitHub Primer CSS](https://github.com/primer/css) - reference implementation for GitHub's CSS conventions
+- [GitHub Primer design system](https://primer.style/) - GitHub's current design system
+- [GitHub Primer CSS](https://github.com/primer/css) - Sass implementation in maintenance mode; newer patterns live in [Primer React](https://github.com/primer/react) and [Primer ViewComponents](https://github.com/primer/view_components)
 
 ## Git Usage
 

--- a/docs/oss/misc/style.md
+++ b/docs/oss/misc/style.md
@@ -31,7 +31,7 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](https://sass-guidelin.es/) by Kitty Giraudel
-- [GitHub Primer CSS](https://github.com/primer/css)
+- [GitHub Primer CSS](https://github.com/primer/css) - reference implementation for GitHub's CSS conventions
 
 ## Git Usage
 

--- a/docs/oss/misc/style.md
+++ b/docs/oss/misc/style.md
@@ -31,7 +31,7 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](https://sass-guidelin.es/) by Kitty Giraudel
-- [GitHub Primer design system](https://primer.style/)
+- [GitHub Primer CSS](https://github.com/primer/css)
 
 ## Git Usage
 

--- a/internal/react_on_rails_pro/contributors-info/style.md
+++ b/internal/react_on_rails_pro/contributors-info/style.md
@@ -32,7 +32,7 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](http://sass-guidelin.es/) by [Hugo Giraudel](http://hugogiraudel.com/)
-- [GitHub Primer design system](https://primer.style/)
+- [GitHub Primer CSS](https://github.com/primer/css)
 
 # Git Usage
 

--- a/internal/react_on_rails_pro/contributors-info/style.md
+++ b/internal/react_on_rails_pro/contributors-info/style.md
@@ -32,7 +32,7 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](http://sass-guidelin.es/) by [Hugo Giraudel](http://hugogiraudel.com/)
-- [GitHub Primer CSS](https://github.com/primer/css)
+- [GitHub Primer CSS](https://github.com/primer/css) - reference implementation for GitHub's CSS conventions
 
 # Git Usage
 

--- a/internal/react_on_rails_pro/contributors-info/style.md
+++ b/internal/react_on_rails_pro/contributors-info/style.md
@@ -32,7 +32,8 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 ### Sass Coding Standards
 
 - [Sass Guidelines](http://sass-guidelin.es/) by [Hugo Giraudel](http://hugogiraudel.com/)
-- [GitHub Primer CSS](https://github.com/primer/css) - reference implementation for GitHub's CSS conventions
+- [GitHub Primer design system](https://primer.style/) - GitHub's current design system
+- [GitHub Primer CSS](https://github.com/primer/css) - Sass implementation in maintenance mode; newer patterns live in [Primer React](https://github.com/primer/react) and [Primer ViewComponents](https://github.com/primer/view_components)
 
 # Git Usage
 

--- a/react_on_rails_pro/spec/dummy/spec/requests/activity_rsc_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/activity_rsc_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe "Activity inside a streamed RSC tree", :server_rendering do
   # Some earlier cache setup specs remove `.node-renderer-bundles` after staging
   # assets. The renderer can retain its bundle VM in memory while the manifest
   # files are gone, so the first RSC render after the deletion needs to stage
-  # assets again before reading react-server-client-manifest.json from disk.
+  # assets again before reading react-server-client-manifest.json from disk. This
+  # file sorts first among the streamed RSC request specs in RSpec's defined
+  # order, so it restores the state that later RSC specs inherit.
   before { ReactOnRailsPro::Request.upload_assets }
 
   it "renders the visible Activity boundary into HTML and keeps the hidden one payload-only" do

--- a/react_on_rails_pro/spec/dummy/spec/requests/activity_rsc_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/activity_rsc_spec.rb
@@ -31,14 +31,10 @@ require "rails_helper"
 # IMPORTANT: like the other streamed RSC request specs, this requires the Pro
 # node renderer on :3800 (cd react_on_rails_pro/spec/dummy && pnpm run node-renderer).
 RSpec.describe "Activity inside a streamed RSC tree", :server_rendering do
-  # Stage the RSC manifests on the renderer before rendering. A bundle that an
-  # earlier non-RSC spec already staged does not carry
-  # react-server-client-manifest.json, and the gem does not re-upload assets for
-  # a bundle it considers present, so the RSC render fails with ENOENT on that
-  # manifest and the streamed subtree never reaches the HTML. Specs run in
-  # defined order and this file sorts first in spec/requests, so without this
-  # upload the example depends on whether something else happened to upload the
-  # manifests first - which is exactly how it used to fail intermittently.
+  # Some earlier cache setup specs remove `.node-renderer-bundles` after staging
+  # assets. The renderer can retain its bundle VM in memory while the manifest
+  # files are gone, so the first RSC render after the deletion needs to stage
+  # assets again before reading react-server-client-manifest.json from disk.
   before { ReactOnRailsPro::Request.upload_assets }
 
   it "renders the visible Activity boundary into HTML and keeps the hidden one payload-only" do


### PR DESCRIPTION
### Summary

Clarifies the current Primer design-system reference and its maintenance-mode Sass implementation, while documenting why the first streamed RSC request re-stages assets after cache cleanup.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] ~Update CHANGELOG file~

### Other Information

Corrects the historical RSC root-cause explanation: cache-directory deletion can coexist with an in-memory renderer VM, so the request restores the required manifests before later RSC specs run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Sass guidance by distinguishing GitHub Primer’s design system from its CSS implementation.
  - Added references to newer Primer React and Primer ViewComponents patterns.
  - Documented renderer bundle-cache behavior in request test comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->