### PR TITLE
CI: wait for Pro node renderer before integration tests

### DIFF
--- a/.github/actions/wait-for-h2c-service/action.yml
+++ b/.github/actions/wait-for-h2c-service/action.yml
@@ -9,12 +9,18 @@ inputs:
     description: Request path used for the readiness probe.
     required: true
   authority:
-    description: HTTP/2 cleartext authority, including scheme and port.
+    description: >-
+      Single HTTP/2 cleartext authority, including scheme and port. Keep the service bind,
+      client URL, and this authority pinned to the same IPv4 endpoint.
     required: true
   timeout-seconds:
     description: Maximum number of seconds to wait for readiness.
     required: false
     default: '300'
+  log-path:
+    description: Optional service log path to include in timeout diagnostics.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -25,8 +31,27 @@ runs:
         SERVICE_AUTHORITY: ${{ inputs.authority }}
         SERVICE_NAME: ${{ inputs.service-name }}
         SERVICE_PATH: ${{ inputs.path }}
+        SERVICE_LOG_PATH: ${{ inputs.log-path }}
         SERVICE_TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
       run: |
+        case "$SERVICE_TIMEOUT_SECONDS" in
+          ''|*[!0-9]*)
+            echo "::error::timeout-seconds must be a positive integer"
+            exit 1
+            ;;
+        esac
+        if [ "$SERVICE_TIMEOUT_SECONDS" -eq 0 ]; then
+          echo "::error::timeout-seconds must be a positive integer"
+          exit 1
+        fi
+        case "$SERVICE_PATH" in
+          /*) ;;
+          *)
+            echo "::error::path must start with /"
+            exit 1
+            ;;
+        esac
+
         timeout="$SERVICE_TIMEOUT_SECONDS"
         start=$SECONDS
 
@@ -119,6 +144,10 @@ runs:
         });
         request.end();
         NODE
+            if [ -n "$SERVICE_LOG_PATH" ] && [ -f "$SERVICE_LOG_PATH" ]; then
+              echo "Last 200 lines from $SERVICE_LOG_PATH:"
+              tail -n 200 "$SERVICE_LOG_PATH" || true
+            fi
             echo "::endgroup::"
             exit 1
           fi

--- a/.github/actions/wait-for-h2c-service/action.yml
+++ b/.github/actions/wait-for-h2c-service/action.yml
@@ -1,0 +1,125 @@
+name: Wait for h2c service
+description: Waits for an HTTP/2 cleartext endpoint to return a successful response.
+
+inputs:
+  service-name:
+    description: Human-readable service name used in readiness output.
+    required: true
+  path:
+    description: Request path used for the readiness probe.
+    required: true
+  authority:
+    description: HTTP/2 cleartext authority, including scheme and port.
+    required: true
+  timeout-seconds:
+    description: Maximum number of seconds to wait for readiness.
+    required: false
+    default: '300'
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for ${{ inputs.service-name }} to start
+      shell: bash
+      env:
+        SERVICE_AUTHORITY: ${{ inputs.authority }}
+        SERVICE_NAME: ${{ inputs.service-name }}
+        SERVICE_PATH: ${{ inputs.path }}
+        SERVICE_TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
+      run: |
+        timeout="$SERVICE_TIMEOUT_SECONDS"
+        start=$SECONDS
+
+        while true; do
+          if node - "$SERVICE_AUTHORITY" "$SERVICE_PATH" <<'NODE'
+        const http2 = require('node:http2');
+
+        const [authority, path] = process.argv.slice(2);
+        const client = http2.connect(authority);
+        const request = client.request({ ':method': 'GET', ':path': path });
+        let status;
+        let timeout;
+        let completed = false;
+
+        const finish = (exitCode, destroyClient = false) => {
+          if (completed) return;
+          completed = true;
+          clearTimeout(timeout);
+          if (destroyClient) {
+            client.destroy();
+          } else {
+            client.close();
+          }
+          process.exit(exitCode);
+        };
+
+        const fail = () => finish(1, true);
+
+        client.on('error', fail);
+        request.on('error', fail);
+        request.on('response', (headers) => {
+          status = headers[':status'];
+        });
+        request.on('data', () => {});
+        request.on('end', () => {
+          finish(status >= 200 && status < 300 ? 0 : 1);
+        });
+        request.end();
+        timeout = setTimeout(fail, 10000);
+        NODE
+          then
+            elapsed=$((SECONDS - start))
+            echo "${SERVICE_NAME} started at ${SERVICE_AUTHORITY}${SERVICE_PATH} after ${elapsed}s"
+            exit 0
+          fi
+
+          sleep 1
+          elapsed=$((SECONDS - start))
+          if [ "$elapsed" -ge "$timeout" ]; then
+            echo "Timeout waiting for ${SERVICE_NAME} to start after ${timeout}s"
+            echo "::group::${SERVICE_NAME} h2c readiness diagnostics"
+            echo "GET ${SERVICE_AUTHORITY}${SERVICE_PATH}"
+            node - "$SERVICE_AUTHORITY" "$SERVICE_PATH" <<'NODE' || true
+        const http2 = require('node:http2');
+
+        const [authority, path] = process.argv.slice(2);
+        const client = http2.connect(authority);
+        let body = '';
+        const timeout = setTimeout(() => {
+          console.error('diagnostic timeout without response');
+          client.destroy();
+          process.exit(1);
+        }, 5000);
+
+        const finish = (exitCode) => {
+          clearTimeout(timeout);
+          client.close();
+          process.exit(exitCode);
+        };
+
+        client.on('error', (error) => {
+          console.error(`connect error: ${error.message}`);
+          finish(1);
+        });
+        const request = client.request({ ':method': 'GET', ':path': path });
+        request.on('response', (headers) => {
+          console.log(`response headers: ${JSON.stringify(headers)}`);
+        });
+        request.on('data', (chunk) => {
+          body += chunk.toString();
+          body = body.slice(0, 500);
+        });
+        request.on('end', () => {
+          if (body) console.log(`response body: ${body}`);
+          finish(0);
+        });
+        request.on('error', (error) => {
+          console.error(`request error: ${error.message}`);
+          finish(1);
+        });
+        request.end();
+        NODE
+            echo "::endgroup::"
+            exit 1
+          fi
+        done

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -382,6 +382,11 @@ for (const jobName of proNodeRendererJobs) {
     readinessStep,
     /(?:^|\n)\s+(?:continue-on-error|if|timeout-seconds):/,
   );
+  assertMatches(
+    `${jobName} always preserves the renderer log`,
+    job,
+    /- name: Store Pro Node renderer log[\s\S]*uses: actions\/upload-artifact@v4[\s\S]*if: always\(\)[\s\S]*path: \$\{\{ runner\.temp \}\}\/node-renderer\.log[\s\S]*if-no-files-found: ignore/,
+  );
 }
 assert.equal(
   [...proIntegrationWorkflow.matchAll(/pnpm run node-renderer\b/g)].length,

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -39,6 +39,17 @@ function extractRunScript(workflow, stepName) {
   return scriptLines.join('\n');
 }
 
+function extractJob(workflow, jobName) {
+  const lines = workflow.split('\n');
+  const jobIndex = lines.findIndex((line) => line === `  ${jobName}:`);
+  assert.notEqual(jobIndex, -1, `workflow is missing the ${jobName} job`);
+
+  const nextJobIndex = lines.findIndex(
+    (line, index) => index > jobIndex && /^ {2}[a-zA-Z0-9_-]+:$/.test(line),
+  );
+  return lines.slice(jobIndex, nextJobIndex === -1 ? undefined : nextJobIndex).join('\n');
+}
+
 function runGemMatrix(script, { full, generators }) {
   const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'gem-tests-matrix-'));
   const outputPath = path.join(temporaryDirectory, 'github-output');
@@ -72,6 +83,8 @@ const hostedSelectorsAction = read('.github/actions/hosted-ci-selectors/action.y
 const ciCommandsWorkflow = read('.github/workflows/ci-commands.yml');
 const claudeWorkflow = read('.github/workflows/claude.yml');
 const shakaperfReleaseGateWorkflow = read('.github/workflows/shakaperf-release-gates.yml');
+const proIntegrationWorkflow = read('.github/workflows/pro-integration-tests.yml');
+const waitForH2cServiceAction = read('.github/actions/wait-for-h2c-service/action.yml');
 const rspackViteDxWorkflow = read('.github/workflows/rspack-vite-dx.yml');
 const gemTestsWorkflow = read('.github/workflows/gem-tests.yml');
 const hostedWorkflowFiles = [
@@ -312,6 +325,57 @@ assertDoesNotMatch(
   'generator subshards do not split shared setup by leaf-example hash',
   gemRspecScript,
   /Digest::SHA256\.hexdigest\(id\)\.to_i\(16\) % shard_count/,
+);
+
+const proNodeRendererJobs = [
+  'rspec-dummy-app-node-renderer',
+  'dummy-app-node-renderer-e2e-tests',
+  'dummy-app-rspack-rsc-runtime-gate',
+];
+for (const jobName of proNodeRendererJobs) {
+  const job = extractJob(proIntegrationWorkflow, jobName);
+  assertMatches(
+    `${jobName} waits for h2c readiness before its tests`,
+    job,
+    /pnpm run node-renderer &[\s\S]*uses: \.\/\.github\/actions\/wait-for-h2c-service[\s\S]*- name: (?:Run RSpec tests|Install Playwright dependencies)/,
+  );
+  assertMatches(`${jobName} checks the renderer info path`, job, /path: \/info/);
+  assertMatches(
+    `${jobName} checks the renderer IPv4 authority`,
+    job,
+    /authority: http:\/\/127\.0\.0\.1:3800/,
+  );
+}
+assert.equal(
+  [...proIntegrationWorkflow.matchAll(/pnpm run node-renderer &/g)].length,
+  proNodeRendererJobs.length,
+  'the complete set of Pro node renderer jobs should be covered by the readiness assertions',
+);
+assert.equal(
+  [...proIntegrationWorkflow.matchAll(/uses: \.\/\.github\/actions\/wait-for-h2c-service/g)].length,
+  proNodeRendererJobs.length,
+  'every Pro node renderer job should use the shared h2c readiness action exactly once',
+);
+assertDoesNotMatch(
+  'Pro integration workflow has no inline h2c helper',
+  proIntegrationWorkflow,
+  /wait_for_h2c_service\(\)/,
+);
+assertMatches('shared h2c action uses Node HTTP/2', waitForH2cServiceAction, /require\('node:http2'\)/);
+assertMatches(
+  'shared h2c action accepts successful responses',
+  waitForH2cServiceAction,
+  /status >= 200 && status < 300/,
+);
+assertMatches(
+  'shared h2c action keeps the 300 second timeout',
+  waitForH2cServiceAction,
+  /timeout-seconds:[\s\S]*default: '300'/,
+);
+assertDoesNotMatch(
+  'shared h2c action avoids a plain curl probe',
+  waitForH2cServiceAction,
+  /curl [^\n]*http:\/\/127\.0\.0\.1:3800\/info/,
 );
 
 assertMatches('ShakaPerf renderer h2c probe', shakaperfReleaseGateWorkflow, /require\('node:http2'\)/);

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -50,6 +50,19 @@ function extractJob(workflow, jobName) {
   return lines.slice(jobIndex, nextJobIndex === -1 ? undefined : nextJobIndex).join('\n');
 }
 
+function extractStep(job, stepName) {
+  const lines = job.split('\n');
+  const stepIndex = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
+  assert.notEqual(stepIndex, -1, `job is missing the ${stepName} step`);
+
+  const stepIndent = lines[stepIndex].match(/^\s*/)[0].length;
+  const nextStepIndex = lines.findIndex(
+    (line, index) =>
+      index > stepIndex && line.trim().startsWith('- ') && line.match(/^\s*/)[0].length === stepIndent,
+  );
+  return lines.slice(stepIndex, nextStepIndex === -1 ? undefined : nextStepIndex).join('\n');
+}
+
 function runGemMatrix(script, { full, generators }) {
   const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'gem-tests-matrix-'));
   const outputPath = path.join(temporaryDirectory, 'github-output');
@@ -334,20 +347,44 @@ const proNodeRendererJobs = [
 ];
 for (const jobName of proNodeRendererJobs) {
   const job = extractJob(proIntegrationWorkflow, jobName);
+  const readinessStep = extractStep(job, 'Wait for Pro Node renderer to start');
   assertMatches(
     `${jobName} waits for h2c readiness before its tests`,
     job,
-    /pnpm run node-renderer &[\s\S]*uses: \.\/\.github\/actions\/wait-for-h2c-service[\s\S]*- name: (?:Run RSpec tests|Install Playwright dependencies)/,
+    /pnpm run node-renderer\b[\s\S]*uses: \.\/\.github\/actions\/wait-for-h2c-service[\s\S]*- name: (?:Run RSpec tests|Install Playwright dependencies)/,
   );
-  assertMatches(`${jobName} checks the renderer info path`, job, /path: \/info/);
+  assertMatches(`${jobName} has a bounded job timeout`, job, /timeout-minutes: 30/);
+  assertMatches(`${jobName} pins the renderer URL`, job, /REACT_RENDERER_URL: http:\/\/127\.0\.0\.1:3800/);
+  assertMatches(`${jobName} pins the renderer host`, job, /RENDERER_HOST: 127\.0\.0\.1/);
+  assertMatches(
+    `${jobName} captures the renderer log`,
+    job,
+    /pnpm run node-renderer > "\$RUNNER_TEMP\/node-renderer\.log" 2>&1 &/,
+  );
+  assertMatches(
+    `${jobName} uses the shared h2c readiness action`,
+    readinessStep,
+    /uses: \.\/\.github\/actions\/wait-for-h2c-service/,
+  );
+  assertMatches(`${jobName} checks the renderer info path`, readinessStep, /path: \/info/);
   assertMatches(
     `${jobName} checks the renderer IPv4 authority`,
-    job,
+    readinessStep,
     /authority: http:\/\/127\.0\.0\.1:3800/,
+  );
+  assertMatches(
+    `${jobName} provides renderer logs to the readiness gate`,
+    readinessStep,
+    /log-path: \$\{\{ runner\.temp \}\}\/node-renderer\.log/,
+  );
+  assertDoesNotMatch(
+    `${jobName} cannot bypass or shorten the readiness gate`,
+    readinessStep,
+    /(?:^|\n)\s+(?:continue-on-error|if|timeout-seconds):/,
   );
 }
 assert.equal(
-  [...proIntegrationWorkflow.matchAll(/pnpm run node-renderer &/g)].length,
+  [...proIntegrationWorkflow.matchAll(/pnpm run node-renderer\b/g)].length,
   proNodeRendererJobs.length,
   'the complete set of Pro node renderer jobs should be covered by the readiness assertions',
 );
@@ -372,11 +409,14 @@ assertMatches(
   waitForH2cServiceAction,
   /timeout-seconds:[\s\S]*default: '300'/,
 );
-assertDoesNotMatch(
-  'shared h2c action avoids a plain curl probe',
+assertMatches(
+  'shared h2c action validates its timeout',
   waitForH2cServiceAction,
-  /curl [^\n]*http:\/\/127\.0\.0\.1:3800\/info/,
+  /timeout-seconds must be a positive integer/,
 );
+assertMatches('shared h2c action validates its path', waitForH2cServiceAction, /path must start with \//);
+assertMatches('shared h2c action tails renderer logs', waitForH2cServiceAction, /tail -n 200/);
+assertDoesNotMatch('shared h2c action avoids a plain curl probe', waitForH2cServiceAction, /\bcurl\b/);
 
 assertMatches('ShakaPerf renderer h2c probe', shakaperfReleaseGateWorkflow, /require\('node:http2'\)/);
 assertMatches(

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -211,8 +211,11 @@ jobs:
       needs.detect-changes.outputs.should_run_hosted_ci == 'true' &&
       needs.detect-changes.outputs.run_pro_dummy_tests == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      REACT_RENDERER_URL: http://127.0.0.1:3800
+      RENDERER_HOST: 127.0.0.1
     # Redis backs streamed RSC fixtures covered by the request specs.
     services:
       redis:
@@ -320,7 +323,7 @@ jobs:
       - name: Run Pro Node renderer in background
         run: |
           cd spec/dummy
-          pnpm run node-renderer &
+          pnpm run node-renderer > "$RUNNER_TEMP/node-renderer.log" 2>&1 &
 
       - name: Run Rails server in background
         run: |
@@ -347,6 +350,7 @@ jobs:
           service-name: Node renderer
           path: /info
           authority: http://127.0.0.1:3800
+          log-path: ${{ runner.temp }}/node-renderer.log
 
       - name: Run RSpec tests for Pro dummy app
         run: |
@@ -402,8 +406,11 @@ jobs:
       needs.detect-changes.outputs.should_run_hosted_ci == 'true' &&
       needs.detect-changes.outputs.run_pro_dummy_tests == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      REACT_RENDERER_URL: http://127.0.0.1:3800
+      RENDERER_HOST: 127.0.0.1
     # Redis service container
     services:
       redis:
@@ -511,7 +518,7 @@ jobs:
       - name: Run Pro Node renderer in background
         run: |
           cd spec/dummy
-          pnpm run node-renderer &
+          pnpm run node-renderer > "$RUNNER_TEMP/node-renderer.log" 2>&1 &
 
       - name: Run Rails server in background
         run: |
@@ -538,6 +545,7 @@ jobs:
           service-name: Node renderer
           path: /info
           authority: http://127.0.0.1:3800
+          log-path: ${{ runner.temp }}/node-renderer.log
 
       - name: Install Playwright dependencies
         run: cd spec/dummy && npx playwright install --with-deps
@@ -669,7 +677,7 @@ jobs:
       - name: Run Pro Node renderer in background
         run: |
           cd spec/dummy
-          pnpm run node-renderer &
+          pnpm run node-renderer > "$RUNNER_TEMP/node-renderer.log" 2>&1 &
 
       - name: Run Rails server in background
         run: |
@@ -706,14 +714,13 @@ jobs:
           # to read while the renderer can continue booting during the Rails poll.
           wait_for_service "Rails server" "http://127.0.0.1:3000/empty"
 
-      # Single IPv4 authority is intentional: RENDERER_HOST binds h2c to
-      # 127.0.0.1. Add ::1 here only if the renderer binding changes.
       - name: Wait for Pro Node renderer to start
         uses: ./.github/actions/wait-for-h2c-service
         with:
           service-name: Node renderer
           path: /info
           authority: http://127.0.0.1:3800
+          log-path: ${{ runner.temp }}/node-renderer.log
 
       - name: Install Playwright dependencies
         run: cd spec/dummy && npx playwright install --with-deps

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -341,6 +341,13 @@ jobs:
           done
           echo "Rails server started after ${elapsed}s"
 
+      - name: Wait for Pro Node renderer to start
+        uses: ./.github/actions/wait-for-h2c-service
+        with:
+          service-name: Node renderer
+          path: /info
+          authority: http://127.0.0.1:3800
+
       - name: Run RSpec tests for Pro dummy app
         run: |
           cd spec/dummy
@@ -525,6 +532,13 @@ jobs:
           done
           echo "Rails server started after ${elapsed}s"
 
+      - name: Wait for Pro Node renderer to start
+        uses: ./.github/actions/wait-for-h2c-service
+        with:
+          service-name: Node renderer
+          path: /info
+          authority: http://127.0.0.1:3800
+
       - name: Install Playwright dependencies
         run: cd spec/dummy && npx playwright install --with-deps
 
@@ -662,7 +676,7 @@ jobs:
           cd spec/dummy
           RAILS_ENV="test" bundle exec rails server &
 
-      - name: Wait for Rails server and Node renderer to start
+      - name: Wait for Rails server to start
         run: |
           wait_for_service() {
             name="$1"
@@ -688,118 +702,18 @@ jobs:
             done
           }
 
-          wait_for_h2c_service() {
-            name="$1"
-            path="$2"
-            shift 2
-            timeout=300
-            start=$SECONDS
-
-            while true; do
-              for authority in "$@"; do
-                if node - "$authority" "$path" <<'NODE'
-          const http2 = require('node:http2');
-
-          const [authority, path] = process.argv.slice(2);
-          const client = http2.connect(authority);
-          const request = client.request({ ':method': 'GET', ':path': path });
-          let status;
-          let timeout;
-          let completed = false;
-
-          const finish = (exitCode, destroyClient = false) => {
-            if (completed) return;
-            completed = true;
-            clearTimeout(timeout);
-            if (destroyClient) {
-              client.destroy();
-            } else {
-              client.close();
-            }
-            process.exit(exitCode);
-          };
-
-          const fail = () => finish(1, true);
-
-          client.on('error', fail);
-          request.on('error', fail);
-          request.on('response', (headers) => {
-            status = headers[':status'];
-          });
-          request.on('data', () => {});
-          request.on('end', () => {
-            finish(status >= 200 && status < 300 ? 0 : 1);
-          });
-          request.end();
-          timeout = setTimeout(fail, 10000);
-          NODE
-                then
-                  elapsed=$((SECONDS - start))
-                  echo "${name} started at ${authority}${path} after ${elapsed}s"
-                  return 0
-                fi
-              done
-
-              sleep 1
-              elapsed=$((SECONDS - start))
-              if [ $elapsed -ge $timeout ]; then
-                echo "Timeout waiting for ${name} to start after ${timeout}s"
-                echo "::group::${name} h2c readiness diagnostics"
-                for authority in "$@"; do
-                  echo "GET ${authority}${path}"
-                  node - "$authority" "$path" <<'NODE' || true
-          const http2 = require('node:http2');
-
-          const [authority, path] = process.argv.slice(2);
-          const client = http2.connect(authority);
-          let body = '';
-          const timeout = setTimeout(() => {
-            console.error('diagnostic timeout without response');
-            client.destroy();
-            process.exit(1);
-          }, 5000);
-
-          const finish = (exitCode) => {
-            clearTimeout(timeout);
-            client.close();
-            process.exit(exitCode);
-          };
-
-          client.on('error', (error) => {
-            console.error(`connect error: ${error.message}`);
-            finish(1);
-          });
-          const request = client.request({ ':method': 'GET', ':path': path });
-          request.on('response', (headers) => {
-            console.log(`response headers: ${JSON.stringify(headers)}`);
-          });
-          request.on('data', (chunk) => {
-            body += chunk.toString();
-            body = body.slice(0, 500);
-          });
-          request.on('end', () => {
-            if (body) console.log(`response body: ${body}`);
-            finish(0);
-          });
-          request.on('error', (error) => {
-            console.error(`request error: ${error.message}`);
-            finish(1);
-          });
-          request.end();
-          NODE
-                done
-                echo "::endgroup::"
-                exit 1
-              fi
-            done
-          }
-
           # Both processes are already running; sequential waits keep the logs easier
           # to read while the renderer can continue booting during the Rails poll.
           wait_for_service "Rails server" "http://127.0.0.1:3000/empty"
-          # Single IPv4 authority is intentional: RENDERER_HOST binds h2c to
-          # 127.0.0.1. Add ::1 here only if the renderer binding changes.
-          wait_for_h2c_service "Node renderer" "/info" "http://127.0.0.1:3800"
+
+      # Single IPv4 authority is intentional: RENDERER_HOST binds h2c to
+      # 127.0.0.1. Add ::1 here only if the renderer binding changes.
+      - name: Wait for Pro Node renderer to start
+        uses: ./.github/actions/wait-for-h2c-service
+        with:
+          service-name: Node renderer
+          path: /info
+          authority: http://127.0.0.1:3800
 
       - name: Install Playwright dependencies
         run: cd spec/dummy && npx playwright install --with-deps

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -362,6 +362,14 @@ jobs:
             --out ~/rspec/rspec.xml \
             --format documentation
 
+      - name: Store Pro Node renderer log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pro-rspec-node-renderer-log
+          path: ${{ runner.temp }}/node-renderer.log
+          if-no-files-found: ignore
+
       - name: Store test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -553,6 +561,14 @@ jobs:
       - name: Run Playwright E2E tests for Pro dummy app
         run: cd spec/dummy && pnpm e2e-test
 
+      - name: Store Pro Node renderer log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pro-playwright-node-renderer-log
+          path: ${{ runner.temp }}/node-renderer.log
+          if-no-files-found: ignore
+
       - name: Store test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -727,6 +743,14 @@ jobs:
 
       - name: Run RSC Playwright E2E tests for Pro dummy app
         run: cd spec/dummy && pnpm e2e-test:rsc
+
+      - name: Store Pro Node renderer log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pro-rspack-rsc-runtime-node-renderer-log
+          path: ${{ runner.temp }}/node-renderer.log
+          if-no-files-found: ignore
 
       - name: Store test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Summary

The three Pro integration jobs that start the Node renderer now share one bounded h2c `/info` readiness gate before their test suites begin. This closes the startup race while keeping the renderer bind, Rails client URL, and probe pinned to the same IPv4 endpoint.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

The shared gate preserves the existing Node `node:http2` probe and 300-second readiness budget. Renderer output is included in timeout diagnostics and retained as a job artifact for failures after readiness.

## Follow-ups

- Post-merge workflow exercise: #4912.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable HTTP/2 service readiness checks for integration workflows.
  * Added configurable startup timeouts, endpoint paths, and diagnostic log capture.

* **Improvements**
  * Integration jobs now use explicit renderer settings and bounded execution times.
  * Renderer startup logs are preserved as downloadable artifacts, including after failures.
  * Consolidated readiness checks improve consistency across test environments.

* **Tests**
  * Added safety validation covering timeout limits, readiness checks, logging, artifacts, and action configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->