### PR TITLE
Validate Pro React DOM server mappings

### DIFF
--- a/packages/react-on-rails-pro/jest.config.js
+++ b/packages/react-on-rails-pro/jest.config.js
@@ -70,10 +70,10 @@ export default {
             '^react/jsx-dev-runtime$': reactServerDependencies.entries['React JSX dev react-server'],
             '^react-dom$': reactServerDependencies.entries['React DOM react-server'],
             '^react/(.*)$': `${reactServerDependencies.reactPackageRoot}/$1`,
-            '^react-dom/client$': `${reactServerDependencies.reactDomPackageRoot}/client.react-server.js`,
-            '^react-dom/profiling$': `${reactServerDependencies.reactDomPackageRoot}/profiling.react-server.js`,
-            '^react-dom/server(\\..+)?$': `${reactServerDependencies.reactDomPackageRoot}/server.react-server.js`,
-            '^react-dom/static(\\..+)?$': `${reactServerDependencies.reactDomPackageRoot}/static.react-server.js`,
+            '^react-dom/client$': reactServerDependencies.entries['React DOM client react-server'],
+            '^react-dom/profiling$': reactServerDependencies.entries['React DOM profiling react-server'],
+            '^react-dom/server(\\..+)?$': reactServerDependencies.entries['React DOM server react-server'],
+            '^react-dom/static(\\..+)?$': reactServerDependencies.entries['React DOM static react-server'],
             '^react-dom/(.*)$': `${reactServerDependencies.reactDomPackageRoot}/$1`,
           }
         : {

--- a/packages/react-on-rails-pro/scripts/check-react-server-resolution.mjs
+++ b/packages/react-on-rails-pro/scripts/check-react-server-resolution.mjs
@@ -78,6 +78,10 @@ export const resolveReactServerDependencies = (fromUrl = import.meta.url) => {
     'React JSX react-server': path.join(reactPackageRoot, 'jsx-runtime.react-server.js'),
     'React JSX dev react-server': path.join(reactPackageRoot, 'jsx-dev-runtime.react-server.js'),
     'React DOM react-server': path.join(reactDomPackageRoot, 'react-dom.react-server.js'),
+    'React DOM client react-server': path.join(reactDomPackageRoot, 'client.react-server.js'),
+    'React DOM profiling react-server': path.join(reactDomPackageRoot, 'profiling.react-server.js'),
+    'React DOM server react-server': path.join(reactDomPackageRoot, 'server.react-server.js'),
+    'React DOM static react-server': path.join(reactDomPackageRoot, 'static.react-server.js'),
   };
 
   assertReactServerEntryFiles(entries);

--- a/packages/react-on-rails-pro/scripts/check-react-server-resolution.test.mjs
+++ b/packages/react-on-rails-pro/scripts/check-react-server-resolution.test.mjs
@@ -18,7 +18,11 @@ import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { assertReactServerEntryFiles, resolveRuntimeReactVersion } from './check-react-server-resolution.mjs';
+import {
+  assertReactServerEntryFiles,
+  resolveReactServerDependencies,
+  resolveRuntimeReactVersion,
+} from './check-react-server-resolution.mjs';
 
 const scriptPath = fileURLToPath(new URL('./check-react-server-resolution.mjs', import.meta.url));
 const jestConfigUrl = new URL('../jest.config.js', import.meta.url).href;
@@ -77,10 +81,11 @@ test('keeps condition-sensitive React DOM subpaths on react-server entries', () 
 
   assert.equal(result.status, 0, result.stderr);
   const mapper = JSON.parse(result.stdout);
-  assert.match(mapper['^react-dom/client$'], /client[.]react-server[.]js$/);
-  assert.match(mapper['^react-dom/profiling$'], /profiling[.]react-server[.]js$/);
-  assert.match(mapper['^react-dom/server(\\..+)?$'], /server[.]react-server[.]js$/);
-  assert.match(mapper['^react-dom/static(\\..+)?$'], /static[.]react-server[.]js$/);
+  const { entries } = resolveReactServerDependencies();
+  assert.equal(mapper['^react-dom/client$'], entries['React DOM client react-server']);
+  assert.equal(mapper['^react-dom/profiling$'], entries['React DOM profiling react-server']);
+  assert.equal(mapper['^react-dom/server(\\..+)?$'], entries['React DOM server react-server']);
+  assert.equal(mapper['^react-dom/static(\\..+)?$'], entries['React DOM static react-server']);
 
   const mapperPatterns = Object.keys(mapper);
   const catchAllIndex = mapperPatterns.indexOf('^react-dom/(.*)$');

--- a/packages/react-on-rails-pro/scripts/check-react-server-resolution.test.mjs
+++ b/packages/react-on-rails-pro/scripts/check-react-server-resolution.test.mjs
@@ -15,6 +15,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { basename } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
@@ -81,20 +82,38 @@ test('keeps condition-sensitive React DOM subpaths on react-server entries', () 
 
   assert.equal(result.status, 0, result.stderr);
   const mapper = JSON.parse(result.stdout);
-  const { entries } = resolveReactServerDependencies();
-  assert.equal(mapper['^react-dom/client$'], entries['React DOM client react-server']);
-  assert.equal(mapper['^react-dom/profiling$'], entries['React DOM profiling react-server']);
-  assert.equal(mapper['^react-dom/server(\\..+)?$'], entries['React DOM server react-server']);
-  assert.equal(mapper['^react-dom/static(\\..+)?$'], entries['React DOM static react-server']);
-
-  const mapperPatterns = Object.keys(mapper);
-  const catchAllIndex = mapperPatterns.indexOf('^react-dom/(.*)$');
+  const { entries } = resolveReactServerDependencies(jestConfigUrl);
   for (const pattern of [
     '^react-dom/client$',
     '^react-dom/profiling$',
     '^react-dom/server(\\..+)?$',
     '^react-dom/static(\\..+)?$',
   ]) {
-    assert.ok(mapperPatterns.indexOf(pattern) < catchAllIndex);
+    assert.ok(Object.hasOwn(mapper, pattern), `jest.config.js is missing ${pattern}`);
+  }
+
+  assert.equal(mapper['^react-dom/client$'], entries['React DOM client react-server']);
+  assert.equal(basename(mapper['^react-dom/client$']), 'client.react-server.js');
+  assert.equal(basename(mapper['^react-dom/profiling$']), 'profiling.react-server.js');
+  assert.equal(basename(mapper['^react-dom/server(\\..+)?$']), 'server.react-server.js');
+  assert.equal(basename(mapper['^react-dom/static(\\..+)?$']), 'static.react-server.js');
+  assert.equal(mapper['^react-dom/profiling$'], entries['React DOM profiling react-server']);
+  assert.equal(mapper['^react-dom/server(\\..+)?$'], entries['React DOM server react-server']);
+  assert.equal(mapper['^react-dom/static(\\..+)?$'], entries['React DOM static react-server']);
+
+  const mapperPatterns = Object.keys(mapper);
+  const catchAllIndex = mapperPatterns.indexOf('^react-dom/(.*)$');
+  assert.ok(catchAllIndex >= 0, 'react-dom catch-all mapping is missing');
+  for (const pattern of [
+    '^react-dom/client$',
+    '^react-dom/profiling$',
+    '^react-dom/server(\\..+)?$',
+    '^react-dom/static(\\..+)?$',
+  ]) {
+    const mappingIndex = mapperPatterns.indexOf(pattern);
+    assert.ok(
+      mappingIndex >= 0 && mappingIndex < catchAllIndex,
+      `${pattern} must precede the react-dom catch-all`,
+    );
   }
 });


### PR DESCRIPTION
### Summary

Follow up to #4915, which fixed the flake caused by React 19-only RSC tests leaking into the React 18 lane and by RSC Jest resolving React through inconsistent dependency roots.

This PR validates every React DOM server entry used by the Pro Jest mapper before the configuration consumes it. That preserves a loud setup failure when an installed server target is missing and prevents mapper regression coverage from passing when a mapping is dropped or points at a client build.

The preflight deliberately remains shared across the Pro Jest groups so an invalid React server installation fails before any group starts.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

None.

## Follow-ups

None.
