### PR TITLE
Log missing RSC loadable stats from the Node Renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Surfaced missing RSC loadable stats in Node Renderer logs**: The first missing
+  `loadable-stats.json` read now emits an actionable `INFO` diagnostic per renderer process while
+  preserving fallback and retry behavior without replaying the server path to the browser. Fixes
+  [Issue 4731](https://github.com/shakacode/react_on_rails/issues/4731).
+  [PR 4918](https://github.com/shakacode/react_on_rails/pull/4918) by
+  [justin808](https://github.com/justin808).
+
 - **[Pro]** **Expected Node Renderer cold starts no longer emit OpenTelemetry error spans**: The
   `ror.bundle.build_execution_context` cache-first probe previously ended with status ERROR when a worker had not
   compiled a bundle's VM context yet, even though the normal cache-miss path then rendered successfully. The probe

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
@@ -60,7 +60,12 @@ import {
 import type { CurrentGenerationBundlePathAlias } from './currentGenerationManifest.js';
 
 const readFileAsync = promisify(fs.readFile);
+// The Pro package resolves the host callback through this VM-global key. Keep its test probes in
+// packages/react-on-rails-pro-node-renderer/tests/vm.test.ts and
+// packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts in sync too.
+// MIRROR VALUES OF: packages/react-on-rails-pro/src/injectRSCPayload.ts
 const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
+// MIRROR VALUES END
 // This is process-scoped diagnostic state, not request data: every VM context
 // shares the same host callback and only the first missing-stats event logs.
 let hasReportedMissingLoadableStats = false;
@@ -632,7 +637,6 @@ async function buildVM(filePath: string): Promise<VMContext> {
       // TS/JS sources. Only resolves positions for registered bundle paths.
       const contextObject = {
         sharedConsoleHistory,
-        [LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY]: reportMissingLoadableStats,
         [SOURCE_MAP_LOOKUP_ATTEMPT_CONTEXT_KEY]: createSourceMapLookupAttempt,
         [SOURCE_MAP_RESOLVER_CONTEXT_KEY]: (
           fileName: unknown,
@@ -679,6 +683,14 @@ async function buildVM(filePath: string): Promise<VMContext> {
       if (additionalContextIsObject) {
         extendContext(contextObject, additionalContext);
       }
+      // Install this after every context extension so application configuration
+      // and bundle code cannot redirect the server path into replayed VM console history.
+      Object.defineProperty(contextObject, LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY, {
+        configurable: false,
+        enumerable: false,
+        value: reportMissingLoadableStats,
+        writable: false,
+      });
       const context = vm.createContext(contextObject);
 
       // Create explicit reference to global context, just in case (some libs can use it):

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
@@ -60,6 +60,19 @@ import {
 import type { CurrentGenerationBundlePathAlias } from './currentGenerationManifest.js';
 
 const readFileAsync = promisify(fs.readFile);
+const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
+// This is process-scoped diagnostic state, not request data: every VM context
+// shares the same host callback and only the first missing-stats event logs.
+let hasReportedMissingLoadableStats = false;
+
+function reportMissingLoadableStats(loadableStatsPath: unknown) {
+  if (hasReportedMissingLoadableStats || typeof loadableStatsPath !== 'string') return;
+
+  hasReportedMissingLoadableStats = true;
+  log.info(
+    `React on Rails Pro could not find ${loadableStatsPath}; RSC stylesheet inference is falling back to streamed preload tags and will retry. Verify that loadable-stats.json is emitted to the server bundle directory.`,
+  );
+}
 
 // Length of the `Module.wrap` prefix that is prepended to the first line of a
 // wrapped bundle. Needed to correct first-line stack-frame columns before
@@ -619,6 +632,7 @@ async function buildVM(filePath: string): Promise<VMContext> {
       // TS/JS sources. Only resolves positions for registered bundle paths.
       const contextObject = {
         sharedConsoleHistory,
+        [LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY]: reportMissingLoadableStats,
         [SOURCE_MAP_LOOKUP_ATTEMPT_CONTEXT_KEY]: createSourceMapLookupAttempt,
         [SOURCE_MAP_RESOLVER_CONTEXT_KEY]: (
           fileName: unknown,
@@ -1147,6 +1161,7 @@ export function resetVM() {
   vmPoolActivity.hardLimitEvictions = 0;
   vmPoolActivity.drainedContextRetirements = 0;
   lastPressureWarningAt = undefined;
+  hasReportedMissingLoadableStats = false;
   vmPoolClock = defaultVMPoolClock;
   activeSourceMapRequestCounts.clear();
   evictedSourceMapRegistrations.clear();

--- a/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
@@ -52,6 +52,8 @@ const uploadedSecondaryBundlePathForTest = () => uploadedSecondaryBundlePath(tes
 const createUploadedBundleForTest = () => createUploadedBundle(testName);
 const createUploadedSecondaryBundleForTest = () => createUploadedSecondaryBundle(testName);
 const createVmBundleForTest = () => createVmBundle(testName);
+// Test probe for the cross-package contract defined in src/worker/vm.ts and
+// packages/react-on-rails-pro/src/injectRSCPayload.ts; keep the corresponding Pro test probe in sync.
 const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
 
 describe('buildVM and runInVM', () => {
@@ -111,6 +113,62 @@ describe('buildVM and runInVM', () => {
   });
 
   describe('host diagnostics', () => {
+    test('protects the missing-stats diagnostic from context and bundle overrides', async () => {
+      getConfig().supportModules = false;
+      const additionalContextDiagnostic = jest.fn(() => {
+        throw new Error('additionalContext diagnostic should not run');
+      });
+      getConfig().additionalContext = {
+        [LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY]: additionalContextDiagnostic,
+      };
+      const infoSpy = jest.spyOn(log, 'info').mockImplementation(() => undefined);
+      await createUploadedBundleForTest();
+      const executionContext = await buildExecutionContext(
+        [uploadedBundlePathForTest()],
+        /* buildVmsIfNeeded */ true,
+      );
+      const missingLoadableStatsPath = '/srv/app/public/packs/loadable-stats.json';
+
+      expect(
+        await executionContext.runInVM(
+          `(() => {
+            const descriptor = Object.getOwnPropertyDescriptor(
+              globalThis,
+              ${JSON.stringify(LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY)},
+            );
+            const replaced = Reflect.set(
+              globalThis,
+              ${JSON.stringify(LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY)},
+              (value) => console.info(value),
+            );
+            return {
+              configurable: descriptor.configurable,
+              enumerable: descriptor.enumerable,
+              replaced,
+              writable: descriptor.writable,
+            };
+          })()`,
+          uploadedBundlePathForTest(),
+        ),
+      ).toBe(JSON.stringify({ configurable: false, enumerable: false, replaced: false, writable: false }));
+
+      expect(
+        await executionContext.runInVM(
+          `(() => {
+            ${LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY}(${JSON.stringify(missingLoadableStatsPath)});
+            return 'fallback-continues';
+          })()`,
+          uploadedBundlePathForTest(),
+        ),
+      ).toBe('fallback-continues');
+
+      expect(additionalContextDiagnostic).not.toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining(missingLoadableStatsPath));
+      expect(
+        executionContext.getVMContext(uploadedBundlePathForTest()).sharedConsoleHistory.getConsoleHistory(),
+      ).toEqual([]);
+    });
+
     test('reports missing loadable-stats at the default log level without console replay', async () => {
       getConfig().supportModules = false;
       const infoSpy = jest.spyOn(log, 'info').mockImplementation(() => undefined);

--- a/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/vm.test.ts
@@ -20,7 +20,9 @@ import { Readable } from 'stream';
 import { types as utilTypes } from 'util';
 import {
   uploadedBundlePath,
+  uploadedSecondaryBundlePath,
   createUploadedBundle,
+  createUploadedSecondaryBundle,
   readRenderingRequest,
   createVmBundle,
   mkdirAsync,
@@ -46,8 +48,11 @@ import * as errorReporter from '../src/shared/errorReporter';
 
 const testName = 'vm';
 const uploadedBundlePathForTest = () => uploadedBundlePath(testName);
+const uploadedSecondaryBundlePathForTest = () => uploadedSecondaryBundlePath(testName);
 const createUploadedBundleForTest = () => createUploadedBundle(testName);
+const createUploadedSecondaryBundleForTest = () => createUploadedSecondaryBundle(testName);
 const createVmBundleForTest = () => createVmBundle(testName);
+const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
 
 describe('buildVM and runInVM', () => {
   beforeEach(async () => {
@@ -102,6 +107,81 @@ describe('buildVM and runInVM', () => {
 
       result = await runInVM('typeof performance.now === "function"', uploadedBundlePathForTest());
       expect(result).toBe('true');
+    });
+  });
+
+  describe('host diagnostics', () => {
+    test('reports missing loadable-stats at the default log level without console replay', async () => {
+      getConfig().supportModules = false;
+      const infoSpy = jest.spyOn(log, 'info').mockImplementation(() => undefined);
+      await createUploadedBundleForTest();
+      const executionContext = await buildExecutionContext(
+        [uploadedBundlePathForTest()],
+        /* buildVmsIfNeeded */ true,
+      );
+      const missingLoadableStatsPath = '/srv/app/public/packs/loadable-stats.json';
+
+      expect(
+        await executionContext.runInVM(
+          `typeof ${LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY}`,
+          uploadedBundlePathForTest(),
+        ),
+      ).toBe('function');
+      await executionContext.runInVM(
+        `${LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY}(${JSON.stringify(missingLoadableStatsPath)})`,
+        uploadedBundlePathForTest(),
+      );
+
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining(missingLoadableStatsPath));
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Verify that loadable-stats.json is emitted to the server bundle directory'),
+      );
+      expect(
+        executionContext.getVMContext(uploadedBundlePathForTest()).sharedConsoleHistory.getConsoleHistory(),
+      ).toEqual([]);
+    });
+
+    test('reports only once across VM contexts until resetVM restores test isolation', async () => {
+      getConfig().supportModules = false;
+      const infoSpy = jest.spyOn(log, 'info').mockImplementation(() => undefined);
+      await Promise.all([createUploadedBundleForTest(), createUploadedSecondaryBundleForTest()]);
+      const firstExecutionContext = await buildExecutionContext(
+        [uploadedBundlePathForTest()],
+        /* buildVmsIfNeeded */ true,
+      );
+      const secondExecutionContext = await buildExecutionContext(
+        [uploadedSecondaryBundlePathForTest()],
+        /* buildVmsIfNeeded */ true,
+      );
+      const invokeDiagnostic = (bundlePath: string) =>
+        `${LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY}(${JSON.stringify(`${bundlePath}/loadable-stats.json`)})`;
+
+      await firstExecutionContext.runInVM(
+        invokeDiagnostic(uploadedBundlePathForTest()),
+        uploadedBundlePathForTest(),
+      );
+      await firstExecutionContext.runInVM(
+        invokeDiagnostic(uploadedBundlePathForTest()),
+        uploadedBundlePathForTest(),
+      );
+      await secondExecutionContext.runInVM(
+        invokeDiagnostic(uploadedSecondaryBundlePathForTest()),
+        uploadedSecondaryBundlePathForTest(),
+      );
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+
+      resetVM();
+      const resetExecutionContext = await buildExecutionContext(
+        [uploadedBundlePathForTest()],
+        /* buildVmsIfNeeded */ true,
+      );
+      await resetExecutionContext.runInVM(
+        invokeDiagnostic(uploadedBundlePathForTest()),
+        uploadedBundlePathForTest(),
+      );
+
+      expect(infoSpy).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -130,6 +130,7 @@ const LOADABLE_STATS_FILE_NAME = 'loadable-stats.json';
 const LOADABLE_STATS_INITIAL_READ_RETRY_DELAY_MS = 100;
 const LOADABLE_STATS_MAX_READ_RETRY_DELAY_MS = 30_000;
 const LOADABLE_STATS_UNEXPECTED_WARNING_INTERVAL_MS = LOADABLE_STATS_MAX_READ_RETRY_DELAY_MS;
+const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
 const RSC_CLIENT_STYLESHEET_INFERENCE_TIMEOUT_MS = 100;
 const STACK_FILE_LOCATION = /\(?((?:file:\/\/\/.+)|(?:\/.+)|(?:[A-Za-z]:[\\/].+)):\d+:\d+\)?\s*$/;
 
@@ -170,8 +171,16 @@ function isFileNotFoundError(error: unknown) {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }
 
+function reportMissingLoadableStats(loadableStatsPath: string) {
+  const hostDiagnostic = Reflect.get(globalThis, LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY) as unknown;
+  if (typeof hostDiagnostic === 'function') hostDiagnostic(loadableStatsPath);
+}
+
 function warnIfUnexpectedLoadableStatsFailure(error: unknown, loadableStatsPath: string) {
-  if (isFileNotFoundError(error)) return;
+  if (isFileNotFoundError(error)) {
+    reportMissingLoadableStats(loadableStatsPath);
+    return;
+  }
 
   const warningKey = `${loadableStatsPath}\n${error instanceof Error ? `${error.name}:${error.message}` : String(error)}`;
   const nowMs = rscClientChunkStylesheetHrefsRetryClockMs();

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -130,7 +130,12 @@ const LOADABLE_STATS_FILE_NAME = 'loadable-stats.json';
 const LOADABLE_STATS_INITIAL_READ_RETRY_DELAY_MS = 100;
 const LOADABLE_STATS_MAX_READ_RETRY_DELAY_MS = 30_000;
 const LOADABLE_STATS_UNEXPECTED_WARNING_INTERVAL_MS = LOADABLE_STATS_MAX_READ_RETRY_DELAY_MS;
+// The Node Renderer injects the host callback under this VM-global key. Keep its test probes in
+// packages/react-on-rails-pro-node-renderer/tests/vm.test.ts and
+// packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts in sync too.
+// MIRROR VALUES OF: packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
 const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
+// MIRROR VALUES END
 const RSC_CLIENT_STYLESHEET_INFERENCE_TIMEOUT_MS = 100;
 const STACK_FILE_LOCATION = /\(?((?:file:\/\/\/.+)|(?:\/.+)|(?:[A-Za-z]:[\\/].+)):\d+:\d+\)?\s*$/;
 

--- a/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
+++ b/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
@@ -72,6 +72,8 @@ const renderWithDefaultStylesheetInference = async (
 const missingLoadableStatsError = () =>
   Object.assign(new Error('loadable-stats.json not copied yet'), { code: 'ENOENT' });
 
+// Test probe for the cross-package contract defined in ../src/injectRSCPayload.ts and
+// packages/react-on-rails-pro-node-renderer/src/worker/vm.ts; keep the Node Renderer test probe in sync.
 const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
 
 describe('loadRSCClientChunkStylesheetHrefsByChunkName', () => {

--- a/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
+++ b/packages/react-on-rails-pro/tests/loadClientChunkStylesheetHrefs.test.ts
@@ -72,11 +72,38 @@ const renderWithDefaultStylesheetInference = async (
 const missingLoadableStatsError = () =>
   Object.assign(new Error('loadable-stats.json not copied yet'), { code: 'ENOENT' });
 
+const LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY = '__reactOnRailsProReportMissingLoadableStats';
+
 describe('loadRSCClientChunkStylesheetHrefsByChunkName', () => {
   afterEach(() => {
+    Reflect.deleteProperty(globalThis, LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY);
     jest.dontMock('fs');
     jest.resetModules();
     jest.restoreAllMocks();
+  });
+
+  it('reports missing loadable-stats through the host diagnostic while preserving fallback', async () => {
+    const reportMissingLoadableStats = jest.fn();
+    Reflect.set(globalThis, LOADABLE_STATS_MISSING_DIAGNOSTIC_CONTEXT_KEY, reportMissingLoadableStats);
+    const readFileSync = jest.fn(() => {
+      throw missingLoadableStatsError();
+    });
+
+    jest.doMock('fs', () => ({
+      ...jest.requireActual<typeof import('fs')>('fs'),
+      readFileSync,
+    }));
+    const { default: injectRSCPayload } = await import('../src/injectRSCPayload.ts');
+    const renderedHTML = await renderWithDefaultStylesheetInference(
+      injectRSCPayload,
+      '["client1","js/client1-12345678.chunk.js"]',
+    );
+
+    expect(renderedHTML).toContain('<main>ready</main>');
+    expect(renderedHTML).not.toContain('/webpack/test/css/client1-12345678.css');
+    expect(reportMissingLoadableStats).toHaveBeenCalledWith(
+      resolvePath(__dirname, '../src/loadable-stats.json'),
+    );
   });
 
   it('widens and caps the loadable-stats read retry backoff after repeated failures', async () => {


### PR DESCRIPTION
## Why

When the Pro RSC payload injector cannot find `loadable-stats.json`, its existing opportunistic fallback remains usable, but the Node Renderer previously gave operators no server-side clue that the file was missing. Logging through the VM console would either disappear at the default log level or risk replaying the absolute server path to the browser.

Closes #4731.

## What changed

- Added a renderer-owned host diagnostic callback to each VM context.
- Routed only `ENOENT` loadable-stats failures through that callback.
- Logged one actionable `INFO` diagnostic per renderer process, including the resolved path and recovery guidance.
- Kept the existing streamed-preload fallback and retry backoff unchanged.
- Kept the diagnostic out of `SharedConsoleHistory`, so the server path is not replayed to the browser.

## How to review

1. Start in `injectRSCPayload.ts`: the `ENOENT` branch reports to a host callback and returns into the existing retry/fallback flow.
2. Then inspect `worker/vm.ts`: the Node Renderer owns the callback, emits the first log at `INFO`, and suppresses later events process-wide.
3. Finish with the two focused test files, which cover the callback, fallback, default server log level, no browser replay, and once-per-process behavior.

## Verification

- TDD red evidence: the Pro callback assertion and Node VM callback/once-only assertions failed before implementation while fallback assertions remained green.
- `packages/react-on-rails-pro`: focused stylesheet-inference tests, 10/10 passing; package type-check passing.
- `packages/react-on-rails-pro-node-renderer`: focused VM tests, 49/49 passing; full suite, 45 suites / 668 tests passing; package type-check passing.
- Workspace TypeScript check, ESLint, Prettier, repository lint, Pro license-header check, and `git diff --check` passing.
- `.agents/bin/validate --all` passed installs, docs, RuboCop, builds, dummy packs, OSS, and Pro JS/RSC checks; the wrapper received an external SIGTERM during the long full Node Renderer phase, which was rerun separately and passed in full.
- Pre-push `codex review --commit dbea6f4e3b3c969e73af390432102110d6fbea8a`: clean; correctness, security/no-browser-leak, fallback compatibility, reliability, and focused test coverage inspected. The first review attempt self-terminated before verdict and was replaced; unrelated connector-auth warnings did not affect the completed review.
- Local Pro Node Renderer A/B on the same Apple M5 Max, 5 interleaved samples per side, 10 seconds/route, 10 connections, 100% successful responses: diagnostic-only/UNKNOWN because the strict quiet gate could not clear. Noisy medians were −5.9% `simple_eval` and −4.4% `react_ssr`, with baseline CVs 17.6% and 37.5%; no speedup or regression conclusion is claimed.

## CI and review

- Hosted CI: to be requested on exact final head `1b791e1de12007b0ec57e4e9a6ee01dcac57c722`.
- Independent adversarial review: required on the exact final head before merge readiness.
- Changelog classification: Pro runtime, entry required and added under `Unreleased` → `Fixed`.

## Churn notes

- Rebased once onto disjoint `origin/main` movement after PR publication; no conflict or semantic adaptation was required.
- Two earlier worker instances were replaced under the same one-issue lane before this maker completed the implementation; no competing implementation PR exists.
- Scope stayed within the six explicitly authorized paths; `packages/react-on-rails-pro/tests/injectRSCPayload.test.ts` was authorized but not needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational diagnostic when `loadable-stats.json` is missing, including the affected path.
  * Diagnostics are reported only once per process and resume after a renderer reset.
  * Existing fallback, retry, streamed preload tags, and stylesheet inference behavior remain unchanged.
* **Documentation**
  * Added an unreleased Pro changelog entry describing the new diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->