### PR TITLE
Stamp CHANGELOG for 17.1.0.rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.1.0.rc.0] - 2026-08-23
+
 #### Fixed
 
 - **[Pro]** **Expected Node Renderer cold starts no longer emit OpenTelemetry error spans**: The
@@ -3186,7 +3188,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.1...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.0...main
+[17.1.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v17.0.1...v17.1.0.rc.0
 [17.0.1]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...v17.0.1
 [17.0.0]: https://github.com/shakacode/react_on_rails/compare/v16.6.0...v17.0.0
 [16.6.0]: https://github.com/shakacode/react_on_rails/compare/v16.5.1...v16.6.0


### PR DESCRIPTION
Runs the repo's own `bundle exec rake "update_changelog[rc]"` on the `release/17.1.0` tip. The task auto-computed `17.1.0.rc.0`, stamped the header under `[Unreleased]`, and re-anchored the compare links.

All 38 accumulated entries since 17.0.1 now sit under the rc header - including both Simply Business fixes (#4908 cold-start error spans, the `::Console` upgrade-guide note) and the two security redaction changes that live only on the release branch (#4856, and the renderer URL credential redaction from #4845).

No hand-written entries; the content was already curated PR-by-PR. This is the prerequisite the release-train runbook requires before rc.0 can be cut (step 1b), and pushing it to `release/17.1.0` also triggers the automatic ShakaPerf pre-run for the branch tip.

Release-line lease held per the runbook: claim `release-line:17.1.0` active, heartbeat live, `require_live_release_line_lease` verified before this write.

## Follow-ups

None.