### PR TITLE
CI: extract required diff-base selection into script

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -87,6 +87,7 @@ jobs:
             bin/ci-rerun-failures \
             bin/request-hosted-ci \
             script/ci-changes-detector \
+            script/ci-required-diff-base \
             script/ci-required-diff-base-test.bash \
             script/ci-required-hosted-gate
           do
@@ -133,107 +134,7 @@ jobs:
           # the newlines rather than fold them (the continuation lines are more
           # indented than the first).
           EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
-        run: |
-          # For pull_request events actions/checkout resolves refs/pull/<n>/merge,
-          # so HEAD is the PR head merged into the CURRENT base tip. By contrast
-          # github.event.pull_request.base.sha is only refreshed when the PR is
-          # opened or synchronized, so on a branch that has not been pushed for a
-          # while it lags HEAD's own base parent. Diffing from that stale SHA folds
-          # every base-branch commit in between into the changed-file set, which is
-          # how a docs-only PR gets classified as a generator change and is then
-          # told to spend a hosted CI run it does not need (#4756).
-          #
-          # The merge commit's FIRST PARENT is the base commit the merge was
-          # actually computed against, so it is the only base that yields this PR's
-          # own diff. It is also always present locally (it is a parent of HEAD), so
-          # it cannot fall outside the shallow fetch window. bundle-size.yml derives
-          # its size baseline from the same first parent for the same reason.
-          base_ref="${EVENT_BASE_REF}"
-          base_source="event payload"
-
-          if [ -n "${PULL_REQUEST_BASE_SHA}" ]; then
-            base_ref="${PULL_REQUEST_BASE_SHA}"
-            base_source="workflow_dispatch input"
-          elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            parent_line="$(git rev-list --parents -n 1 HEAD 2>/dev/null || true)"
-            read -ra parents <<< "$parent_line"
-            # parents[0] = HEAD, [1] = first parent (base side), [2] = second parent (PR head)
-            if [ "${#parents[@]}" -eq 3 ]; then
-              if [ -n "${PULL_REQUEST_HEAD_SHA}" ] && [ "${parents[2]}" != "${PULL_REQUEST_HEAD_SHA}" ]; then
-                # Fail closed: this is the one state where no base can save us.
-                #
-                # Mind the direction of the error. A stale base only ADDS
-                # base-branch commits to the diff, over-selecting suites and
-                # wasting runner minutes, which is survivable. Missing changes is
-                # not: run_generators can come back false and this required gate
-                # can pass without the hosted run those changes needed.
-                #
-                # When the merge ref is stale, HEAD's TREE does not contain the
-                # current head's changes at all, so every base is diffed against a
-                # tree that is already missing them. Choosing a wider base cannot
-                # recover a file that is not in HEAD. The only honest outcomes are
-                # to classify the reported head instead (a network fetch plus a
-                # tree that no longer matches the rest of this job) or to refuse to
-                # classify. A required gate should refuse.
-                #
-                # This is a genuinely different situation from the single-parent
-                # branch below, which continues with a warning. There, HEAD is the
-                # real PR head, so a wide base still yields a complete diff. Here it
-                # does not. The condition is a race against GitHub recomputing
-                # refs/pull/<n>/merge, so a re-run clears it.
-                echo "::error::Checked-out merge commit's second parent (${parents[2]}) is not the PR head reported by this event (${PULL_REQUEST_HEAD_SHA}). GitHub's merge ref is stale, so HEAD's tree cannot contain the current head's changes and no diff base can produce a trustworthy classification. Re-run this job so GitHub recomputes refs/pull/<n>/merge, or push to the branch again."
-                exit 1
-              fi
-
-              base_ref="${parents[1]}"
-              base_source="PR merge commit first parent"
-            else
-              # bundle-size.yml hard-fails on an unexpected merge structure. This gate
-              # runs on every PR, so it warns instead: a new hard-fail path here would
-              # block more PRs than the misclassification it guards against. The
-              # changed-file list printed below makes a widened diff obvious anyway.
-              echo "::warning::HEAD is not the expected two-parent PR merge commit, so the changed-file classification is computed from ${base_ref} and may include base-branch drift. If this PR is routed to suites it does not touch, rebase it on its base branch."
-            fi
-          fi
-
-          echo "Diff base: ${base_ref} (source: ${base_source})"
-
-          script/ci-changes-detector "$base_ref"
-
-          # Show the exact file set behind the classification above so a widened
-          # diff is visible at a glance. The detector has already fetched and
-          # deepened as needed, so these calls add no network work.
-          if diff_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)"; then
-            # Capture the whole stream before truncating. Piping git diff straight
-            # into `head -50` lets head close the read end once it has its 50
-            # lines; git then takes SIGPIPE and exits 141, and because Actions runs
-            # run: steps under `bash --noprofile --norc -eo pipefail`, pipefail
-            # promotes that 141 to the pipeline's status and set -e fails this
-            # required gate. It would fire on large diffs, meaning the widened-diff
-            # case this output exists to expose. sed is used rather than head
-            # because sed reads its input to the end, so nothing can close the
-            # pipe early.
-            # The || guard is for the diagnostic, not for control flow. `set -e`
-            # DOES abort on a failed command substitution in a plain assignment
-            # (the masking people remember applies to declaration assignments such
-            # as `local x=$(false)`, not to this one), so the step would fail here
-            # either way. Without the guard it fails with a bare non-zero exit and
-            # git's own stderr; with it, the log names which refs the diff was
-            # between. Keep it for that message, not because the failure would
-            # otherwise pass unnoticed.
-            changed_files="$(git diff --name-only "$diff_base" HEAD)" || {
-              echo "::error::git diff failed for ${diff_base}..HEAD while listing changed files."
-              exit 1
-            }
-
-            if [ -z "$changed_files" ]; then
-              echo "Changed files the classification was computed from: none"
-            else
-              changed_total="$(printf '%s\n' "$changed_files" | wc -l | tr -d ' ')"
-              echo "Changed files the classification was computed from (${changed_total} total, showing up to 50):"
-              printf '%s\n' "$changed_files" | sed -n '1,50p'
-            fi
-          fi
+        run: script/ci-required-diff-base
 
       - name: Enforce hosted CI for generator changes
         env:

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -30,11 +30,12 @@ if ! MERGE_BASE=$(git_diff_base_resolve "$BASE_REF" "$CURRENT_REF" strict); then
   exit 1
 fi
 
-# Get list of changed files (committed + uncommitted). A failed git diff is now
-# fatal so CI does not silently skip every job when diff detection breaks.
-# Note: bash 'set -e' does NOT trigger on a failed command substitution in an
-# assignment, so the explicit '|| { exit 1 }' is required to catch errors here.
-# Do not "simplify" this away — removing it reintroduces the silent-failure bug.
+# Get list of changed files (committed + uncommitted). A failed git diff is fatal
+# so CI does not silently skip every job when diff detection breaks. In a plain
+# assignment, `set -e` already aborts on a failed command substitution (the
+# masking applies to declaration assignments such as `local x=$(false)`). Keep
+# the guard so the failure names the refs being diffed, not as the sole failure
+# mechanism.
 CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" "$CURRENT_REF") || {
   echo -e "${RED}Error: git diff failed for $MERGE_BASE..$CURRENT_REF${NC}" >&2
   exit 1

--- a/script/ci-required-diff-base
+++ b/script/ci-required-diff-base
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Selects the required-gate diff base and runs changed-file detection.
+# Test: bash script/ci-required-diff-base-test.bash
 
 set -eo pipefail
 

--- a/script/ci-required-diff-base
+++ b/script/ci-required-diff-base
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# For pull_request events actions/checkout resolves refs/pull/<n>/merge,
+# so HEAD is the PR head merged into the CURRENT base tip. By contrast
+# github.event.pull_request.base.sha is only refreshed when the PR is
+# opened or synchronized, so on a branch that has not been pushed for a
+# while it lags HEAD's own base parent. Diffing from that stale SHA folds
+# every base-branch commit in between into the changed-file set, which is
+# how a docs-only PR gets classified as a generator change and is then
+# told to spend a hosted CI run it does not need (#4756).
+#
+# The merge commit's FIRST PARENT is the base commit the merge was
+# actually computed against, so it is the only base that yields this PR's
+# own diff. It is also always present locally (it is a parent of HEAD), so
+# it cannot fall outside the shallow fetch window. bundle-size.yml derives
+# its size baseline from the same first parent for the same reason.
+base_ref="${EVENT_BASE_REF}"
+base_source="event payload"
+
+if [ -n "${PULL_REQUEST_BASE_SHA}" ]; then
+  base_ref="${PULL_REQUEST_BASE_SHA}"
+  base_source="workflow_dispatch input"
+elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+  parent_line="$(git rev-list --parents -n 1 HEAD 2>/dev/null || true)"
+  read -ra parents <<< "$parent_line"
+  # parents[0] = HEAD, [1] = first parent (base side), [2] = second parent (PR head)
+  if [ "${#parents[@]}" -eq 3 ]; then
+    if [ -n "${PULL_REQUEST_HEAD_SHA}" ] && [ "${parents[2]}" != "${PULL_REQUEST_HEAD_SHA}" ]; then
+      # Fail closed: this is the one state where no base can save us.
+      #
+      # Mind the direction of the error. A stale base only ADDS
+      # base-branch commits to the diff, over-selecting suites and
+      # wasting runner minutes, which is survivable. Missing changes is
+      # not: run_generators can come back false and this required gate
+      # can pass without the hosted run those changes needed.
+      #
+      # When the merge ref is stale, HEAD's TREE does not contain the
+      # current head's changes at all, so every base is diffed against a
+      # tree that is already missing them. Choosing a wider base cannot
+      # recover a file that is not in HEAD. The only honest outcomes are
+      # to classify the reported head instead (a network fetch plus a
+      # tree that no longer matches the rest of this job) or to refuse to
+      # classify. A required gate should refuse.
+      #
+      # This is a genuinely different situation from the single-parent
+      # branch below, which continues with a warning. There, HEAD is the
+      # real PR head, so a wide base still yields a complete diff. Here it
+      # does not. The condition is a race against GitHub recomputing
+      # refs/pull/<n>/merge, so a re-run clears it.
+      echo "::error::Checked-out merge commit's second parent (${parents[2]}) is not the PR head reported by this event (${PULL_REQUEST_HEAD_SHA}). GitHub's merge ref is stale, so HEAD's tree cannot contain the current head's changes and no diff base can produce a trustworthy classification. Re-run this job so GitHub recomputes refs/pull/<n>/merge, or push to the branch again."
+      exit 1
+    fi
+
+    base_ref="${parents[1]}"
+    base_source="PR merge commit first parent"
+  else
+    # bundle-size.yml hard-fails on an unexpected merge structure. This gate
+    # runs on every PR, so it warns instead: a new hard-fail path here would
+    # block more PRs than the misclassification it guards against. The
+    # changed-file list printed below makes a widened diff obvious anyway.
+    echo "::warning::HEAD is not the expected two-parent PR merge commit, so the changed-file classification is computed from ${base_ref} and may include base-branch drift. If this PR is routed to suites it does not touch, rebase it on its base branch."
+  fi
+fi
+
+echo "Diff base: ${base_ref} (source: ${base_source})"
+
+script/ci-changes-detector "$base_ref"
+
+# Show the exact file set behind the classification above so a widened
+# diff is visible at a glance. The detector has already fetched and
+# deepened as needed, so these calls add no network work.
+if diff_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)"; then
+  # Capture the whole stream before truncating. Piping git diff straight
+  # into `head -50` lets head close the read end once it has its 50
+  # lines; git then takes SIGPIPE and exits 141, and because Actions runs
+  # run: steps under `bash --noprofile --norc -eo pipefail`, pipefail
+  # promotes that 141 to the pipeline's status and set -e fails this
+  # required gate. It would fire on large diffs, meaning the widened-diff
+  # case this output exists to expose. sed is used rather than head
+  # because sed reads its input to the end, so nothing can close the
+  # pipe early.
+  # The || guard is for the diagnostic, not for control flow. `set -e`
+  # DOES abort on a failed command substitution in a plain assignment
+  # (the masking people remember applies to declaration assignments such
+  # as `local x=$(false)`, not to this one), so the step would fail here
+  # either way. Without the guard it fails with a bare non-zero exit and
+  # git's own stderr; with it, the log names which refs the diff was
+  # between. Keep it for that message, not because the failure would
+  # otherwise pass unnoticed.
+  changed_files="$(git diff --name-only "$diff_base" HEAD)" || {
+    echo "::error::git diff failed for ${diff_base}..HEAD while listing changed files."
+    exit 1
+  }
+
+  if [ -z "$changed_files" ]; then
+    echo "Changed files the classification was computed from: none"
+  else
+    changed_total="$(printf '%s\n' "$changed_files" | wc -l | tr -d ' ')"
+    echo "Changed files the classification was computed from (${changed_total} total, showing up to 50):"
+    printf '%s\n' "$changed_files" | sed -n '1,50p'
+  fi
+fi

--- a/script/ci-required-diff-base-test.bash
+++ b/script/ci-required-diff-base-test.bash
@@ -266,6 +266,30 @@ assert_rc 0 "merge_group"
 assert_contains "$LAST_OUTPUT" "Diff base: $OLD_MAIN (source: event payload)" "merge_group"
 assert_not_contains "$LAST_OUTPUT" "source: PR merge commit first parent" "merge_group"
 
+# Exercise the helper's guarded changed-file listing directly. The shim delegates
+# every other git invocation, including merge-base, to the captured real binary.
+REAL_GIT="$(command -v git)"
+GIT_SHIM_DIR="$WORKDIR/git-shim"
+mkdir -p "$GIT_SHIM_DIR"
+cat > "$GIT_SHIM_DIR/git" <<'SHIM'
+#!/usr/bin/env bash
+if [ "${1:-}" = "diff" ] && [ "${2:-}" = "--name-only" ]; then
+  exit 1
+fi
+exec "${REAL_GIT:?}" "$@"
+SHIM
+chmod +x "$GIT_SHIM_DIR/git"
+
+BASH_ENV=/dev/null \
+  PATH="$GIT_SHIM_DIR:$PATH" \
+  REAL_GIT="$REAL_GIT" \
+  run_case "changed-file listing failure names the diff refs" \
+  "$MERGE_REF" merge_group "" "" "$OLD_MAIN"
+assert_rc 1 "changed-file listing failure"
+assert_contains "$LAST_OUTPUT" \
+  "::error::git diff failed for $OLD_MAIN..HEAD while listing changed files." \
+  "changed-file listing failure"
+
 # Regression guard for the truncation pipe. Under pipefail an early-closing reader
 # makes git exit 141 and takes the whole required gate down with it.
 run_case "large changed-file list does not abort the step" \

--- a/script/ci-required-diff-base-test.bash
+++ b/script/ci-required-diff-base-test.bash
@@ -20,6 +20,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DIFF_BASE_SCRIPT="$REPO_ROOT/script/ci-required-diff-base"
+WORKFLOW="$REPO_ROOT/.github/workflows/ci-required.yml"
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -78,6 +79,37 @@ if [ ! -x "$DIFF_BASE_SCRIPT" ]; then
   echo "FAIL: executable diff-base script not found at $DIFF_BASE_SCRIPT" >&2
   exit 1
 fi
+
+test_workflow_wiring() {
+  local wiring_output
+
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> workflow delegates changed-file detection to the helper"
+
+  if ! wiring_output="$(ruby -ryaml - "$WORKFLOW" 2>&1 <<'RUBY'
+workflow = YAML.safe_load_file(ARGV.fetch(0), permitted_classes: [], aliases: false)
+steps = workflow.fetch("jobs").fetch("required-pr-gate").fetch("steps")
+matching_steps = steps.select { |step| step["name"] == "Run changed-files detector" }
+
+abort "expected exactly one Run changed-files detector step, found #{matching_steps.length}" unless matching_steps.length == 1
+
+step = matching_steps.fetch(0)
+expected_env = {
+  "PULL_REQUEST_BASE_SHA" => %q(${{ github.event.inputs.pull_request_base_sha || '' }}),
+  "PULL_REQUEST_HEAD_SHA" => %q(${{ github.event.pull_request.head.sha || '' }}),
+  "EVENT_BASE_REF" => %q(${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}),
+}
+
+abort "expected id=changes, got #{step['id'].inspect}" unless step["id"] == "changes"
+abort "expected run=script/ci-required-diff-base, got #{step['run'].inspect}" unless step["run"] == "script/ci-required-diff-base"
+abort "helper env bindings changed: #{step['env'].inspect}" unless step["env"] == expected_env
+RUBY
+  )"; then
+    fail "workflow wiring: $wiring_output"
+  fi
+}
+
+test_workflow_wiring
 
 git init -q "$REPO"
 mkdir -p "$REPO/script"

--- a/script/ci-required-diff-base-test.bash
+++ b/script/ci-required-diff-base-test.bash
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-# Test harness for the diff-base selection in the "Run changed-files detector"
-# step of .github/workflows/ci-required.yml.
+# Test harness for script/ci-required-diff-base.
 #
 # Run: bash script/ci-required-diff-base-test.bash
 # CI invokes it from the "Run CI gate tests" step of the same workflow.
 #
-# The step body is extracted from the committed workflow with a YAML parser and
-# executed against a synthetic repository, so the logic under test is exactly the
-# logic that ships. That matters because this branching decides which suites run
-# for every PR, and it lives inline in YAML rather than in script/.
+# The real script is executed against a synthetic repository, so the logic under
+# test is exactly the logic that ships.
 #
 # script/ci-changes-detector is stubbed here. Its own behavior is covered by
 # script/ci-changes-detector-test.bash; what this harness pins down is which base
@@ -22,7 +19,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKFLOW="$REPO_ROOT/.github/workflows/ci-required.yml"
+DIFF_BASE_SCRIPT="$REPO_ROOT/script/ci-required-diff-base"
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -75,19 +72,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-STEP="$WORKDIR/step.sh"
 REPO="$WORKDIR/repo"
 
-# Extract the step body. A rename of the step name is a real breakage of this
-# harness, so fail loudly rather than silently testing nothing.
-if ! ruby -ryaml -e '
-  workflow = YAML.safe_load_file(ARGV[0], permitted_classes: [], aliases: false)
-  steps = workflow.fetch("jobs").fetch("required-pr-gate").fetch("steps")
-  step = steps.find { |candidate| candidate["name"] == "Run changed-files detector" }
-  abort "step \"Run changed-files detector\" not found in #{ARGV[0]}" if step.nil?
-  File.write(ARGV[1], step.fetch("run"))
-' "$WORKFLOW" "$STEP"; then
-  echo "FAIL: could not extract the step body from $WORKFLOW" >&2
+if [ ! -x "$DIFF_BASE_SCRIPT" ]; then
+  echo "FAIL: executable diff-base script not found at $DIFF_BASE_SCRIPT" >&2
   exit 1
 fi
 
@@ -184,7 +172,7 @@ run_case() {
       PULL_REQUEST_BASE_SHA="$dispatch_base_sha" \
       PULL_REQUEST_HEAD_SHA="$pr_head_sha" \
       EVENT_BASE_REF="$event_base_ref" \
-      bash --noprofile --norc -eo pipefail "$STEP" 2>&1
+      bash --noprofile --norc -eo pipefail "$DIFF_BASE_SCRIPT" 2>&1
   )"
   LAST_RC=$?
 }
@@ -257,18 +245,6 @@ printed_files="$(printf '%s\n' "$LAST_OUTPUT" | grep -c "bigdir/${long_name}-")"
 if [ "$printed_files" -ne 50 ]; then
   fail "large changed-file list: expected 50 printed paths, got $printed_files"
 fi
-
-# NOT COVERED HERE: the `|| { echo ::error::; exit 1; }` guard on the
-# changed_files assignment. Exercising it needs a git that fails only on
-# `diff --name-only`, and injecting one via PATH does not survive into the child
-# shell in every developer environment, so a case for it would pass or fail for
-# reasons unrelated to the guard.
-#
-# The stakes are lower than they look: `set -e` aborts on a failed command
-# substitution in a plain assignment on its own, so the guard supplies a better
-# message rather than the only failure. Tracked with the extraction work in
-# #4824, where the logic moves into script/ and the guard becomes directly
-# callable.
 
 echo
 if [ "$TESTS_FAILED" -ne 0 ]; then


### PR DESCRIPTION
## Why

The required CI gate currently keeps its diff-base selection inside workflow YAML, which makes the routing logic awkward to test directly and easy for copied shell comments to drift from Bash behavior. This change moves that logic into an executable repository script without changing the selected base, detector inputs, or diagnostics.

Closes #4824.

## What changed

- Extracted the existing `Run changed-files detector` shell body into executable `script/ci-required-diff-base` and delegated the workflow step to it.
- Changed the regression harness to invoke the shipped helper directly across pull request, dispatch, merge-group, stale-ref, fallback, large-diff, and guarded diff-failure cases, plus an exact workflow-wiring contract.
- Corrected the comment on `script/ci-changes-detector`'s existing `git diff` guard: plain assignments already honor `set -e`; the guard remains because it adds the two refs to the failure diagnostic.
- Added the helper to the workflow's shell syntax validation list.

## How to review and verify

1. Compare `script/ci-required-diff-base` with the removed workflow step body; after the helper's shebang and shell options, they are byte-for-byte equivalent.
2. Review `script/ci-required-diff-base-test.bash` to see that it executes the real helper, pins the workflow wiring, and reports eight routing/error/contract cases.
3. Run `bash script/ci-required-diff-base-test.bash` and `bash script/ci-changes-detector-test.bash`.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

No user-facing runtime, UI, asset, or bundle behavior changes. This is an internal CI refactor, so documentation, changelog, visual, interaction, benchmark, and runtime-performance evidence are not applicable.

Post-merge workflow exercise: #4922.

<details>
<summary>Agent details</summary>

### Commands and results

- `bash script/ci-changes-detector-test.bash` -> 83/83 passed.
- `bash script/lib/git-diff-base-test.bash` -> 41/41 passed.
- `bash script/ci-required-diff-base-test.bash` -> 8/8 passed: one workflow-wiring contract plus seven behavioral cases, including stale merge-ref fail-closed, guarded `git diff` failure diagnostics, and the 3,000-file pipefail regression.
- `bash -n ...`, `shellcheck -x ...`, and `actionlint` -> passed for the changed workflow/scripts.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> 247 files inspected, no offenses.
- Required-gate focused block and `ruby bin/lint-mirrored-blocks` -> passed, including hosted-gate, CI-command, merge-ledger, drift-manifest, and readiness cases.
- Ruby safe-load -> all 47 workflow YAML files parsed.
- `python3 -m yamllint .github/` -> existing default-config baseline remains non-green (918 findings across 42 files); owned workflow comparison improved from 39 errors/3 warnings on base to 8 errors/3 warnings on candidate.
- `script/ci-changes-detector origin/main` -> CI-infrastructure routing; full tests without benchmarks.
- `git diff --check origin/main...HEAD` -> passed.
- Pre-push independent adversarial review -> clean PASS at every candidate head, including wiring negative controls and final-head mutations for the helper guard, exact diagnostic, and shim trigger; no BLOCKING/DISCUSS/OPTIONAL findings remain.
- Required Claude Code review -> no output within an eight-minute bounded window; stopped and recorded as timed out. No files changed.
- Report-only `/simplify` gate -> found one clear test-only simplification; the final review-fix commit reuses `run_case` with scoped environment assignments, and a fresh independent replay passed.

### Exact-head and replay evidence

- Base: `e9dd9cdbf9fdcdcad028622637b9147bc95abd1c`
- Head: `870e2245698b35b6146940d89ae30838176b0006`
- Scope: exactly `.github/workflows/ci-required.yml`, `script/ci-changes-detector`, `script/ci-required-diff-base`, and `script/ci-required-diff-base-test.bash`.
- Extraction equivalence SHA-256: `0beee5bcd1e813a9d76e2c2a8f33da3877dc7f8c321682b87306c2b43d5fa889`.
- Detector executable-lines equivalence SHA-256: `e5f23533c2b57fdd9c600f01ad516dd17d59627cd175a5181b3f348b876bf0a5`.
- Trusted workflow scanner parity: base and head each have 377 existing repository findings and the same two existing `ci-required.yml` allowlist findings.

### QA Evidence

- QA lane: `ror-g-issue-4824-checker`; detached worktree `/Users/justin/.codex/worktrees/ror-g-issue-4824-checker`; claim status UNKNOWN; last private heartbeat UNKNOWN
- Scope checked: exact four-file Issue #4824 diff; direct helper behavior, detector non-regression, workflow semantics/security, and error diagnostics
- Tested at: `870e2245698b35b6146940d89ae30838176b0006`
- Automated checks: 8-case helper/wiring harness, 83-case detector harness, 41-case diff-base library harness, exact-head required gate, required-gate block, RuboCop, Bash syntax, ShellCheck, Actionlint, YAML parse, CI routing, trusted scanner parity, and diff check
- Manual checks: exact extracted-body equivalence, comment-only detector executable equivalence, direct Bash `set -e` negative proof, scoped-environment/shim argv proof, three guard-test mutation controls, and workflow trigger/permission/action/secret/environment comparison
- User-visible UI change: no
- Visual evidence: not applicable: no user-visible UI change
- Interaction change: no; not applicable because CI routing semantics are preserved
- Interaction evidence: not applicable: no user interaction change
- Visual fix: no; not applicable because this is not a visual change
- Negative control: not applicable: no visual fix
- Performance evidence: not applicable: no runtime, bundle, asset, or user-performance path changed; the existing local-only diagnostic work is preserved
- Findings: Greptile's wiring-coverage P2 and Claude's guarded-diff completeness finding were fixed; CodeRabbit's root-Bundler suggestion was verified false-positive against the exact-head required gate and declined with evidence
- QA required: yes
- QA required rationale: CI routing is merge-sensitive, so focused exact-head regression evidence and a distinct adversarial checker were required
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: script

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 870e2245698b35b6146940d89ae30838176b0006
tested_at: 870e2245698b35b6146940d89ae30838176b0006
scope: exact four-file Issue #4824 diff covering helper extraction, detector comment-only correction, workflow delegation, wiring contract, and direct guarded-diff regression
automated_checks: 8-case helper/wiring harness; 83-case detector harness; 41-case diff-base harness; exact-head required gate; required-gate block; RuboCop; Bash syntax; ShellCheck; Actionlint; YAML parse; CI routing; scanner parity; diff check
manual_checks: exact extracted-body equivalence; detector executable equivalence; Bash set-e proof; scoped environment and shim argv proof; three mutation controls; workflow security comparison
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no painted or rendered target
interaction_change: no
interaction_evidence: not applicable: no user interaction change
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: no runtime, bundle, asset, or user-performance path changed
findings: fixed Greptile wiring P2 and Claude guarded-diff gap; CodeRabbit Bundler suggestion false-positive with exact-head gate evidence
release_blocking: clear
process_gap_disposition: script
-->

<!-- priority-finding-dispositions v1
head_sha: 870e2245698b35b6146940d89ae30838176b0006
finding: url=https://github.com/shakacode/react_on_rails/pull/4921#discussion_r3838198726 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4921#discussion_r3838236787 | waiver=not_applicable
finding: url=https://github.com/shakacode/react_on_rails/pull/4921#discussion_r3838240098 | severity=Must-Fix | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4921#discussion_r3838306798 | waiver=not_applicable
finding: url=https://github.com/shakacode/react_on_rails/pull/4921#discussion_r3838240819 | severity=Must-Fix | disposition=false_positive | evidence=https://github.com/shakacode/react_on_rails/pull/4921#discussion_r3838308015 | waiver=not_applicable
-->

### Coordination and reviewer telemetry

- Batch/lane: `ror-g-issue-4824-20260817` / `b4824-diff-base-helper`.
- Claim: active holder `b4824-diff-base-helper-maker`, instance `ror-g-issue-4824-ember-worker`, branch `jg-codex/ci-required-diff-base-helper`; claim generation UNKNOWN.
- Maker and checker were distinct. The checker reviewed clean detached checkouts at every candidate head and returned a clean PASS for final head `870e2245698b35b6146940d89ae30838176b0006`.
- Strict trust preflight passed; Issue #4824 remained open/unassigned; no competing implementation PR existed before publication.
- Exact-head required CI passed. Optimized hosted CI is in progress across all nine dispatched workflows.
- Current-head review coverage: Claude passed and CodeRabbit approved. Greptile is not working on the current head: no check, review, or comment appeared within the bounded five-minute window; its only artifact remains on `3402ea58de391cfe9fa882df29b63f841d60553f`. The configured-review floor is satisfied by two working current-head systems, with the distinct local checker as additional evidence.

### Decision log

- **Non-blocking:** Keep the explicit `git diff` guard after correcting its rationale.
  - **Decision:** Retain executable behavior and change only the comment in `script/ci-changes-detector`.
  - **Why:** Plain assignment already aborts under `set -e`, while the guard adds a useful ref-specific diagnostic.
  - **Review later:** None.
- **Non-blocking:** Test the executable helper directly instead of extracting YAML at test time.
  - **Decision:** The harness invokes `script/ci-required-diff-base`.
  - **Why:** This directly tests the shipped script and removes a second source of test harness complexity.
  - **Review later:** None.

### Merge confidence

Merge authority is maintainer-ask. Exact-head hosted CI, configured review systems, unresolved-thread replay, merge ledger, and the final maintainer walkthrough remain pending.

### Audit receipts

- Workflow security audit: triggers, permissions, secrets/credentials, third-party actions, checkout inputs, and `EVENT_BASE_REF` are unchanged; exact-head receipt: https://github.com/shakacode/react_on_rails/pull/4921#issuecomment-5385597566.
- Required post-merge workflow exercise tracker: #4922.
- Stage dependency gate: eligible at the exact head; no dependencies or blockers.
- Churn notes: one clean rebase after `origin/main` advanced; one user-authorized fourth-path comment correction; one batched review-fix commit for the wiring contract/header; one final guarded-diff regression commit simplified before its single push; no piecemeal review-fix pushes.
- Completed-batch audit: pending terminal merge outcome.

</details>
