### PR TITLE
CI: use verified diff bases in hosted workflows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -70,8 +70,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
           # optimized change selection. Hosted readiness alone stays path-based.
@@ -88,13 +89,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Guard docs-only main pushes
         if: |

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -73,8 +73,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
           # optimized change selection. Hosted readiness alone stays path-based.
@@ -92,13 +93,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Read runtime versions
         id: tool-versions

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -236,6 +236,8 @@ assertMatches(
 );
 for (const workflowFile of hostedWorkflowFiles) {
   const workflow = read(`.github/workflows/${workflowFile}`);
+  const detectChangesJob = extractJob(workflow, 'detect-changes');
+  const detectorStep = extractStep(detectChangesJob, 'Detect relevant changes');
   assertMatches(`${workflowFile} pull-request trigger`, workflow, /\n\s{2}pull_request:/);
   assertMatches(
     `${workflowFile} hosted selector`,
@@ -243,6 +245,27 @@ for (const workflowFile of hostedWorkflowFiles) {
     /uses: \.\/\.github\/actions\/hosted-ci-selectors/,
   );
   assertMatches(`${workflowFile} hosted gate`, workflow, /should_run_hosted_ci/);
+  assertMatches(`${workflowFile} verified diff-base helper`, detectorStep, /script\/ci-required-diff-base/);
+  assertMatches(
+    `${workflowFile} dispatch base SHA helper input`,
+    detectorStep,
+    /PULL_REQUEST_BASE_SHA: \$\{\{ inputs\.pull_request_base_sha \|\| '' \}\}/,
+  );
+  assertMatches(
+    `${workflowFile} pull-request head SHA helper input`,
+    detectorStep,
+    /PULL_REQUEST_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| '' \}\}/,
+  );
+  assertMatches(
+    `${workflowFile} event base helper input`,
+    detectorStep,
+    /EVENT_BASE_REF: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.merge_group\.base_sha \|\| github\.event\.before \|\| 'origin\/main' \}\}/,
+  );
+  assertDoesNotMatch(
+    `${workflowFile} direct changed-files detector wiring`,
+    detectorStep,
+    /script\/ci-changes-detector/,
+  );
 }
 
 assertMatches(

--- a/.github/workflows/hosted-ci-safety.test.cjs
+++ b/.github/workflows/hosted-ci-safety.test.cjs
@@ -234,6 +234,7 @@ assertMatches(
   hostedSelectorsAction,
   /shouldUseFullMatrix = [\s\S]*isTrustedReleaseTarget/,
 );
+const verifiedDiffBaseHelperCommand = /^[ \t]*script\/ci-required-diff-base[ \t]*$/m;
 for (const workflowFile of hostedWorkflowFiles) {
   const workflow = read(`.github/workflows/${workflowFile}`);
   const detectChangesJob = extractJob(workflow, 'detect-changes');
@@ -245,7 +246,21 @@ for (const workflowFile of hostedWorkflowFiles) {
     /uses: \.\/\.github\/actions\/hosted-ci-selectors/,
   );
   assertMatches(`${workflowFile} hosted gate`, workflow, /should_run_hosted_ci/);
-  assertMatches(`${workflowFile} verified diff-base helper`, detectorStep, /script\/ci-required-diff-base/);
+  assertMatches(`${workflowFile} verified diff-base helper`, detectorStep, verifiedDiffBaseHelperCommand);
+  const commentOnlyDetectorStep = detectorStep.replace(
+    /^([ \t]*)script\/ci-required-diff-base[ \t]*$/m,
+    '$1# script/ci-required-diff-base',
+  );
+  assert.notEqual(
+    commentOnlyDetectorStep,
+    detectorStep,
+    `${workflowFile} comment-only helper mutation did not replace the command`,
+  );
+  assertDoesNotMatch(
+    `${workflowFile} comment-only diff-base helper`,
+    commentOnlyDetectorStep,
+    verifiedDiffBaseHelperCommand,
+  );
   assertMatches(
     `${workflowFile} dispatch base SHA helper input`,
     detectorStep,

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -71,8 +71,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
           # optimized change selection. Hosted readiness alone stays path-based.
@@ -87,13 +88,7 @@ jobs:
               echo "non_runtime_only=false"
             } >> "$GITHUB_OUTPUT"
           else
-            if [ -n "$DISPATCH_BASE_SHA" ]; then
-              export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-              BASE_REF="$DISPATCH_BASE_SHA"
-            else
-              BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-            fi
-            script/ci-changes-detector "$BASE_REF"
+            script/ci-required-diff-base
           fi
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -62,8 +62,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
           # optimized change selection. Hosted readiness alone stays path-based.
@@ -80,13 +81,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Guard docs-only main pushes
         if: |

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -63,8 +63,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
           # optimized change selection. Hosted readiness alone stays path-based.
@@ -81,13 +82,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Guard docs-only main pushes
         if: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -64,8 +64,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
           # optimized change selection. Hosted readiness alone stays path-based.
@@ -78,13 +79,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Guard docs-only main pushes
         if: |

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -58,8 +58,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
           # optimized change selection. Hosted readiness alone stays path-based.
@@ -72,13 +73,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Guard docs-only main pushes
         if: |

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -68,8 +68,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         working-directory: .
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
@@ -85,13 +86,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Guard docs-only main pushes
         if: |

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -68,8 +68,9 @@ jobs:
       - name: Detect relevant changes
         id: detect
         env:
-          DISPATCH_BASE_REF: ${{ inputs.pull_request_base_ref || '' }}
-          DISPATCH_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_BASE_SHA: ${{ inputs.pull_request_base_sha || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}
         working-directory: .
         run: |
           # Force-full hosted CI is the explicit escape hatch that bypasses
@@ -84,13 +85,7 @@ jobs:
             exit 0
           fi
 
-          if [ -n "$DISPATCH_BASE_SHA" ]; then
-            export GITHUB_BASE_REF="$DISPATCH_BASE_REF"
-            BASE_REF="$DISPATCH_BASE_SHA"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || 'origin/main' }}"
-          fi
-          script/ci-changes-detector "$BASE_REF"
+          script/ci-required-diff-base
         shell: bash
       - name: Read runtime versions
         id: tool-versions


### PR DESCRIPTION
## Why

The nine hosted workflows used `pull_request.base.sha` directly when selecting
changed files. That SHA is fixed when a pull request opens, so a long-lived PR can
compare against a stale base and unnecessarily widen the hosted CI matrix.

## What changed

- Route changed-file detection in all nine affected workflows through the
  verified `script/ci-required-diff-base` helper merged by #4921.
- Preserve workflow-dispatch, pull-request, merge-group, push, and force-full
  behavior while passing the helper the event base and exact PR head inputs.
- Strengthen the hosted-workflow safety test so every affected detector step
  must use the helper and its three canonical environment bindings.

## Validation

- `node .github/workflows/hosted-ci-safety.test.cjs`
- `bash script/ci-required-diff-base-test.bash` — 8/8
- `bash script/ci-changes-detector-test.bash` — 83/83
- `actionlint`
- YAML safe-load of all nine edited workflows
- exact-path Prettier and `git diff --check`
- OSS RuboCop — 247 files, no offenses
- `.agents/bin/lint` — passed
- `.agents/bin/validate --changed` passed dependency setup, builds, type checks,
  OSS/Pro JavaScript suites, React compatibility suites, Pro node renderer, and
  most of the broad Ruby generator suite. A late unrelated generator pass was
  interrupted by fixture-only interactive state; the indicated RSC example was
  isolated and passed both normally and with the same RBS runtime checker.
- Independent adversarial review at exact head `7734d72`: PASS, no blocking or
  discussion findings
- Structured Codex review: no actionable findings

## Workflow security audit

- No trigger, permission, secret, action reference, runner, checkout credential,
  or trusted-actions changes.
- The trusted scanner reports the same 377 repository findings and the same 202
  touched-workflow findings on base and head; candidate-introduced deterministic
  findings: zero.
- Post-merge exercise tracker: #4926

## Churn notes

- One implementation commit; exactly the nine hosted workflows and their shared
  safety test.
- No review-fix commits or scope expansion before publication.
- No changelog entry: this is internal CI routing, not a user-visible product
  change.

Fixes #4818


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Standardized change detection across automated workflows for pull requests, manual runs, and other events.
  * Improved diff-base selection and validation for more consistent identification of required checks.
  * Added safeguards to verify that workflows use the approved change-detection process.
  * Reduced inconsistencies caused by event-specific configuration, improving the reliability of automated test and validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->