### PR TITLE
Warn when auto-loaded component CSS is not flushed

### DIFF
--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1469,7 +1469,7 @@ module ReactOnRails
 
     def eagerly_evaluated_unqualified_helper_call?(node, helper_name)
       return true if direct_unqualified_helper_call?(node, helper_name)
-      return true if direct_self_helper_call?(node, helper_name)
+      return true if eagerly_evaluated_self_helper_call?(node, helper_name)
       return eager_helper_call_in_method_arguments?(node, helper_name) if ast_node?(node, :method_add_arg)
       return eager_helper_call_in_arguments?(node[2], helper_name) if ast_node?(node, :command)
       return eager_helper_call_in_array?(node, helper_name) if ast_node?(node, :array)
@@ -1479,12 +1479,24 @@ module ReactOnRails
       false
     end
 
+    def eagerly_evaluated_self_helper_call?(node, helper_name)
+      direct_self_helper_call?(node, helper_name) || parenthesized_self_javascript_helper_call?(node, helper_name)
+    end
+
     def direct_self_helper_call?(node, helper_name)
       return false unless ast_node?(node, :call) || ast_node?(node, :command_call)
 
       receiver = node[1]
       self_token = receiver[1] if ast_node?(receiver, :var_ref)
       token_type?(self_token, :@kw) && self_token[1] == "self" && token_named?(node[3], helper_name)
+    end
+
+    def parenthesized_self_javascript_helper_call?(node, helper_name)
+      return false unless helper_name == "javascript_pack_tag" && ast_node?(node, :method_add_arg)
+
+      argument_parentheses = node[2]
+      ast_node?(argument_parentheses, :arg_paren) && argument_parentheses[1].nil? &&
+        direct_self_helper_call?(node[1], helper_name)
     end
 
     def eager_helper_call_in_method_arguments?(node, helper_name)
@@ -1655,9 +1667,28 @@ module ReactOnRails
     end
 
     def static_named_component_arguments(node, helper_name)
-      arguments = static_argument_values(static_call_arguments(node, helper_name))
+      node = static_self_component_hash_call(node) || node if helper_name == "react_component_hash"
+      call_arguments = static_call_arguments(node, helper_name) || static_self_call_arguments(node, helper_name)
+      arguments = static_argument_values(call_arguments)
       component_name = static_string_value(arguments.first) if arguments&.any?
       arguments if component_name&.match?(/\A[A-Za-z0-9_:]+\z/)
+    end
+
+    def static_self_call_arguments(node, helper_name)
+      return unless ast_node?(node, :method_add_arg) && direct_self_helper_call?(node[1], helper_name)
+
+      argument_parentheses = node[2]
+      argument_parentheses[1] if ast_node?(argument_parentheses, :arg_paren)
+    end
+
+    def static_self_component_hash_call(node)
+      return unless ast_node?(node, :aref)
+
+      call = node[1]
+      return unless ast_node?(call, :method_add_arg) && direct_self_helper_call?(call[1], "react_component_hash")
+
+      access_arguments = static_argument_values(node[2])
+      call if access_arguments&.one? && static_string_value(access_arguments.first) == "componentHtml"
     end
 
     def ripper_statements(source)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -76,6 +76,10 @@ module ReactOnRails
     TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
     ERB_EXPRESSION_PATTERN = /<%(?![#%])=?\s*(?<expression>.*?)%>/m
     ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)%>/m
+    ERB_NON_OUTPUT_EXPRESSION_PATTERN = /<%(?![#%=])\s*(?<expression>.*?)%>/m
+    ERB_CONTROL_FLOW_KEYWORDS = %w[
+      begin case do else elsif end ensure for if rescue then unless until when while
+    ].freeze
     REFLECTIVE_HELPER_DISPATCH_METHODS = %w[send public_send __send__ method].freeze
     REACT_ON_RAILS_INITIALIZER_PATH = "config/initializers/react_on_rails.rb"
 
@@ -1300,9 +1304,16 @@ module ReactOnRails
       assets = static_manifest_assets(entrypoint)
       stylesheet_assets = assets["css"] if assets.is_a?(Hash)
       return unless stylesheet_assets.is_a?(Array) && stylesheet_assets.any?
-      return unless stylesheet_assets.all? { |asset| asset.is_a?(String) && !asset.empty? }
 
-      stylesheet_assets
+      normalized_assets = stylesheet_assets.map { |asset| static_manifest_asset_path(asset) }
+      return if normalized_assets.any?(&:nil?)
+
+      normalized_assets
+    end
+
+    def static_manifest_asset_path(asset)
+      path = asset.is_a?(Hash) ? asset["src"] : asset
+      path if path.is_a?(String) && !path.empty?
     end
 
     def static_manifest_assets(entrypoint)
@@ -1435,33 +1446,105 @@ module ReactOnRails
     def erb_output_helper?(content, helper_name)
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
         statements = ripper_statements(expression)
-        statements.one? && direct_unqualified_helper_call?(statements.first, helper_name)
+        statements.one? && eagerly_evaluated_unqualified_helper_call?(statements.first, helper_name)
       end
+    end
+
+    def eagerly_evaluated_unqualified_helper_call?(node, helper_name)
+      return true if direct_unqualified_helper_call?(node, helper_name)
+      return eager_helper_call_in_method_arguments?(node, helper_name) if ast_node?(node, :method_add_arg)
+      return eager_helper_call_in_arguments?(node[2], helper_name) if ast_node?(node, :command)
+      return eager_helper_call_in_array?(node, helper_name) if ast_node?(node, :array)
+      return eager_helper_call_in_hash?(node, helper_name) if ast_node?(node, :hash) ||
+                                                              ast_node?(node, :bare_assoc_hash)
+
+      false
+    end
+
+    def eager_helper_call_in_method_arguments?(node, helper_name)
+      return false unless ast_node?(node[1], :fcall)
+
+      argument_parentheses = node[2]
+      return false unless ast_node?(argument_parentheses, :arg_paren)
+
+      eager_helper_call_in_arguments?(argument_parentheses[1], helper_name)
+    end
+
+    def eager_helper_call_in_array?(node, helper_name)
+      values = node[1]
+      return false unless values.is_a?(Array)
+
+      values.any? do |value|
+        eagerly_evaluated_unqualified_helper_call?(value, helper_name)
+      end
+    end
+
+    def eager_helper_call_in_hash?(node, helper_name)
+      associations = static_hash_associations(node)
+      associations&.any? do |association|
+        ast_node?(association, :assoc_new) &&
+          eagerly_evaluated_unqualified_helper_call?(association[2], helper_name)
+      end
+    end
+
+    def eager_helper_call_in_arguments?(node, helper_name)
+      arguments = static_argument_values(node)
+      arguments&.any? { |argument| eagerly_evaluated_unqualified_helper_call?(argument, helper_name) }
     end
 
     def erb_helper_mentioned?(content, helper_name)
       content.scan(ERB_EXPRESSION_PATTERN).any? do |(expression)|
-        Ripper.lex(expression).any? { |(_position, _event, token)| token == helper_name } ||
-          reflective_helper_dispatch?(ripper_statements(expression))
+        ripper_statements(expression).any? { |statement| helper_call_context_evidence?(statement, helper_name) }
       end
     end
 
-    def reflective_helper_dispatch?(node)
+    def helper_call_context_evidence?(node, helper_name)
       return false unless node.is_a?(Array)
-      return true if reflective_helper_dispatch_call?(node)
+      return true if helper_call_node?(node, helper_name)
+      return true if reflective_helper_dispatch_may_call?(node, helper_name)
 
       children = node.first.is_a?(Symbol) ? node.drop(1) : node
-      children.any? { |child| reflective_helper_dispatch?(child) }
+      children.any? { |child| helper_call_context_evidence?(child, helper_name) }
     end
 
-    def reflective_helper_dispatch_call?(node)
-      method_token = case node.first
-                     when :vcall, :fcall, :command
-                       node[1]
-                     when :call
-                       node[3]
-                     end
+    def helper_call_node?(node, helper_name)
+      method_token = call_method_token(node)
+      token_named?(method_token, helper_name)
+    end
+
+    def reflective_helper_dispatch_may_call?(node, helper_name)
+      arguments = reflective_dispatch_arguments(node)
+      return false unless arguments&.any?
+
+      dispatched_name = static_string_value(arguments.first) || static_symbol_value(arguments.first)
+      dispatched_name.nil? || dispatched_name == helper_name
+    end
+
+    def reflective_dispatch_arguments(node)
+      if ast_node?(node, :method_add_arg)
+        return unless reflective_dispatch_call?(node[1])
+
+        argument_parentheses = node[2]
+        return unless ast_node?(argument_parentheses, :arg_paren)
+
+        static_argument_values(argument_parentheses[1])
+      elsif ast_node?(node, :command) && reflective_dispatch_call?(node)
+        static_argument_values(node[2])
+      end
+    end
+
+    def reflective_dispatch_call?(node)
+      method_token = call_method_token(node)
       token_type?(method_token, :@ident) && REFLECTIVE_HELPER_DISPATCH_METHODS.include?(method_token[1])
+    end
+
+    def call_method_token(node)
+      case node&.first
+      when :vcall, :fcall, :command
+        node[1]
+      when :call
+        node[3]
+      end
     end
 
     def direct_unqualified_helper_call?(node, helper_name)
@@ -1475,12 +1558,30 @@ module ReactOnRails
     end
 
     def auto_loaded_component_names(content)
-      content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).filter_map do |(expression)|
-        arguments = static_react_component_arguments(expression)
-        next unless arguments && statically_auto_loaded_component?(arguments)
+      return [] if separate_erb_control_flow?(content)
+
+      auto_loaded_component_arguments(content).filter_map do |arguments|
+        next unless statically_auto_loaded_component?(arguments)
 
         static_string_value(arguments.first)&.camelize
       end.uniq
+    end
+
+    def auto_loaded_component_arguments(content)
+      expressions = content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).map(&:first)
+      hash_assignments = content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).map(&:first)
+      component_arguments = expressions.filter_map { |expression| static_react_component_arguments(expression) }
+      component_arguments.concat(
+        hash_assignments.filter_map { |expression| static_react_component_hash_assignment_arguments(expression) }
+      )
+    end
+
+    def separate_erb_control_flow?(content)
+      content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+        Ripper.lex(expression).any? do |(_position, event, token)|
+          event == :on_kw && ERB_CONTROL_FLOW_KEYWORDS.include?(token)
+        end
+      end
     end
 
     def statically_auto_loaded_component?(arguments)
@@ -1498,7 +1599,26 @@ module ReactOnRails
       statements = ripper_statements(expression)
       return unless statements.one?
 
-      arguments = static_argument_values(static_call_arguments(statements.first, "react_component"))
+      %w[react_component react_component_hash].filter_map do |helper_name|
+        static_named_component_arguments(statements.first, helper_name)
+      end.first
+    end
+
+    def static_react_component_hash_assignment_arguments(expression)
+      statements = ripper_statements(expression)
+      return unless statements.one?
+
+      assignment = statements.first
+      return unless ast_node?(assignment, :assign)
+
+      field = assignment[1]
+      return unless ast_node?(field, :var_field) && token_type?(field[1], :@ident)
+
+      static_named_component_arguments(assignment[2], "react_component_hash")
+    end
+
+    def static_named_component_arguments(node, helper_name)
+      arguments = static_argument_values(static_call_arguments(node, helper_name))
       component_name = static_string_value(arguments.first) if arguments&.any?
       arguments if component_name&.match?(/\A[A-Za-z0-9_:]+\z/)
     end
@@ -1600,9 +1720,13 @@ module ReactOnRails
     end
 
     def static_symbol_literal?(node)
+      !static_symbol_value(node).nil?
+    end
+
+    def static_symbol_value(node)
       symbol = node[1] if ast_node?(node, :symbol_literal)
       token = symbol[1] if ast_node?(symbol, :symbol)
-      token_type?(token, :@ident) || token_type?(token, :@op)
+      token[1] if token_type?(token, :@ident) || token_type?(token, :@op)
     end
 
     def static_numeric_unary_literal?(node)
@@ -1671,9 +1795,39 @@ module ReactOnRails
       statements = static_body_statements(block_body)
       return unless config_name && statements
       return unless statements.all? { |statement| direct_config_assignment?(statement, config_name) }
+      return unless statements.all? { |statement| static_literal_data_value?(statement[2]) }
       return unless ast_identifier_count(block_body, config_name) == statements.length
 
       statements
+    end
+
+    def static_literal_data_value?(node)
+      return true if static_literal_scalar_value?(node)
+      return static_literal_array?(node[1]) if ast_node?(node, :array)
+      return static_literal_hash?(node) if ast_node?(node, :hash)
+      return static_symbol_literal?(node) if ast_node?(node, :symbol_literal)
+      return static_numeric_unary_literal?(node) if ast_node?(node, :unary)
+
+      false
+    end
+
+    def static_literal_scalar_value?(node)
+      return true unless static_string_value(node).nil?
+      return true if token_type?(node, :@int) || token_type?(node, :@float)
+
+      keyword = node[1] if ast_node?(node, :var_ref)
+      token_type?(keyword, :@kw) && %w[true false nil].include?(keyword[1])
+    end
+
+    def static_literal_array?(values)
+      values.nil? || (values.is_a?(Array) && values.all? { |value| static_literal_data_value?(value) })
+    end
+
+    def static_literal_hash?(node)
+      associations = static_hash_associations(node)
+      associations&.all? do |association|
+        static_label_association?(association) && static_literal_data_value?(association[2])
+      end
     end
 
     def ast_identifier_count(node, identifier)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1350,6 +1350,7 @@ module ReactOnRails
 
           view_content = uncommented_template_content(File.read(view_path))
           next [] if stylesheet_pack_helper_evidence?(view_content)
+          next [] if erb_helper_mentioned?(view_content, "render")
 
           auto_loaded_component_names(view_content)
         end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -74,8 +74,8 @@ module ReactOnRails
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
     TEMPLATE_ERB_COMMENT_PATTERN = /<%#.*?%>/m
     TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
-    ERB_EXPRESSION_PATTERN = /<%(?![#%])=?\s*(?<expression>.*?)-?%>/m
-    ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)-?%>/m
+    ERB_EXPRESSION_PATTERN = /<%(?![#%])={0,2}\s*(?<expression>.*?)-?%>/m
+    ERB_OUTPUT_EXPRESSION_PATTERN = /<%={1,2}\s*(?<expression>.*?)-?%>/m
     ERB_NON_OUTPUT_EXPRESSION_PATTERN = /<%(?![#%=])\s*(?<expression>.*?)-?%>/m
     ERB_CONTROL_FLOW_KEYWORDS = %w[
       begin case do else elsif end ensure for if rescue return then unless until when while
@@ -1571,7 +1571,15 @@ module ReactOnRails
         static_argument_values(argument_parentheses[1])
       elsif ast_node?(node, :command) && reflective_dispatch_call?(node)
         static_argument_values(node[2])
+      elsif exact_self_reflective_command_call?(node)
+        static_argument_values(node[4])
       end
+    end
+
+    def exact_self_reflective_command_call?(node)
+      return false unless ast_node?(node, :command_call)
+
+      REFLECTIVE_HELPER_DISPATCH_METHODS.any? { |method_name| direct_self_helper_call?(node, method_name) }
     end
 
     def reflective_dispatch_call?(node)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -72,8 +72,7 @@ module ReactOnRails
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
     CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev].freeze
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
-    TEMPLATE_ERB_COMMENT_PATTERN = /<%#.*?%>/m
-    TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
+    TEMPLATE_COMMENT_PATTERN = /<!--.*?-->|<%#.*?%>/m
     ERB_EXPRESSION_PATTERN = /<%(?![#%])={0,2}\s*(?<expression>.*?)-?%>/m
     ERB_OUTPUT_EXPRESSION_PATTERN = /<%={1,2}\s*(?<expression>.*?)-?%>/m
     ERB_NON_OUTPUT_EXPRESSION_PATTERN = /<%(?![#%=])\s*(?<expression>.*?)-?%>/m
@@ -1605,7 +1604,12 @@ module ReactOnRails
 
     def uncommented_template_content(content)
       utf8_content = content.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-      utf8_content.gsub(TEMPLATE_HTML_COMMENT_PATTERN, "").gsub(TEMPLATE_ERB_COMMENT_PATTERN, "")
+      loop do
+        uncommented_content = utf8_content.gsub(TEMPLATE_COMMENT_PATTERN, "")
+        return uncommented_content if uncommented_content == utf8_content
+
+        utf8_content = uncommented_content
+      end
     rescue EncodingError
       ""
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1304,11 +1304,16 @@ module ReactOnRails
       assets = static_manifest_assets(entrypoint)
       stylesheet_assets = assets["css"] if assets.is_a?(Hash)
       return unless stylesheet_assets.is_a?(Array) && stylesheet_assets.any?
+      return unless homogeneous_manifest_css_schema?(stylesheet_assets)
 
       normalized_assets = stylesheet_assets.map { |asset| static_manifest_asset_path(asset) }
       return if normalized_assets.any?(&:nil?)
 
       normalized_assets
+    end
+
+    def homogeneous_manifest_css_schema?(assets)
+      assets.all?(String) || assets.all?(Hash)
     end
 
     def static_manifest_asset_path(asset)
@@ -1578,6 +1583,8 @@ module ReactOnRails
 
     def separate_erb_control_flow?(content)
       content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+        next true unless Ripper.sexp(expression)
+
         Ripper.lex(expression).any? do |(_position, event, token)|
           event == :on_kw && ERB_CONTROL_FLOW_KEYWORDS.include?(token)
         end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -80,7 +80,7 @@ module ReactOnRails
     ERB_CONTROL_FLOW_KEYWORDS = %w[
       begin case do else elsif end ensure for if rescue then unless until when while
     ].freeze
-    REFLECTIVE_HELPER_DISPATCH_METHODS = %w[send public_send __send__ method].freeze
+    REFLECTIVE_HELPER_DISPATCH_METHODS = %w[send public_send __send__ method public_method].freeze
     REACT_ON_RAILS_INITIALIZER_PATH = "config/initializers/react_on_rails.rb"
 
     # Deprecated-renderer-cache scan (used by check_deprecated_renderer_cache_task):
@@ -1280,6 +1280,7 @@ module ReactOnRails
 
     def check_unflushed_auto_loaded_component_css(layout_name, content)
       return unless erb_output_helper?(content, "javascript_pack_tag")
+      return if erb_helper_mentioned?(content, "render")
 
       component_names = auto_loaded_component_names(content)
       component_names.concat(auto_loaded_component_names_from_implicit_views(layout_name)).uniq.each do |component_name|
@@ -1297,7 +1298,17 @@ module ReactOnRails
 
     def stylesheet_pack_helper_evidence?(content)
       erb_output_helper?(content, "stylesheet_pack_tag") ||
-        erb_helper_mentioned?(content, "stylesheet_pack_tag")
+        stylesheet_pack_ambiguity_evidence?(content)
+    end
+
+    def stylesheet_pack_ambiguity_evidence?(content)
+      helper_call_context_in_expressions?(content.scan(ERB_OUTPUT_EXPRESSION_PATTERN), "stylesheet_pack_tag") ||
+        content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+          statements = ripper_statements(expression)
+          next false if statements.one? && direct_unqualified_helper_call?(statements.first, "stylesheet_pack_tag")
+
+          statements.any? { |statement| helper_call_context_evidence?(statement, "stylesheet_pack_tag") }
+        end
     end
 
     def static_stylesheet_assets(entrypoint)
@@ -1498,7 +1509,11 @@ module ReactOnRails
     end
 
     def erb_helper_mentioned?(content, helper_name)
-      content.scan(ERB_EXPRESSION_PATTERN).any? do |(expression)|
+      helper_call_context_in_expressions?(content.scan(ERB_EXPRESSION_PATTERN), helper_name)
+    end
+
+    def helper_call_context_in_expressions?(expressions, helper_name)
+      expressions.any? do |(expression)|
         ripper_statements(expression).any? { |statement| helper_call_context_evidence?(statement, helper_name) }
       end
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -74,11 +74,11 @@ module ReactOnRails
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
     TEMPLATE_ERB_COMMENT_PATTERN = /<%#.*?%>/m
     TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
-    ERB_EXPRESSION_PATTERN = /<%(?![#%])=?\s*(?<expression>.*?)%>/m
-    ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)%>/m
-    ERB_NON_OUTPUT_EXPRESSION_PATTERN = /<%(?![#%=])\s*(?<expression>.*?)%>/m
+    ERB_EXPRESSION_PATTERN = /<%(?![#%])=?\s*(?<expression>.*?)-?%>/m
+    ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)-?%>/m
+    ERB_NON_OUTPUT_EXPRESSION_PATTERN = /<%(?![#%=])\s*(?<expression>.*?)-?%>/m
     ERB_CONTROL_FLOW_KEYWORDS = %w[
-      begin case do else elsif end ensure for if rescue then unless until when while
+      begin case do else elsif end ensure for if rescue return then unless until when while
     ].freeze
     REFLECTIVE_HELPER_DISPATCH_METHODS = %w[send public_send __send__ method public_method].freeze
     REACT_ON_RAILS_INITIALIZER_PATH = "config/initializers/react_on_rails.rb"
@@ -1469,6 +1469,7 @@ module ReactOnRails
 
     def eagerly_evaluated_unqualified_helper_call?(node, helper_name)
       return true if direct_unqualified_helper_call?(node, helper_name)
+      return true if direct_self_helper_call?(node, helper_name)
       return eager_helper_call_in_method_arguments?(node, helper_name) if ast_node?(node, :method_add_arg)
       return eager_helper_call_in_arguments?(node[2], helper_name) if ast_node?(node, :command)
       return eager_helper_call_in_array?(node, helper_name) if ast_node?(node, :array)
@@ -1476,6 +1477,14 @@ module ReactOnRails
                                                               ast_node?(node, :bare_assoc_hash)
 
       false
+    end
+
+    def direct_self_helper_call?(node, helper_name)
+      return false unless ast_node?(node, :call) || ast_node?(node, :command_call)
+
+      receiver = node[1]
+      self_token = receiver[1] if ast_node?(receiver, :var_ref)
+      token_type?(self_token, :@kw) && self_token[1] == "self" && token_named?(node[3], helper_name)
     end
 
     def eager_helper_call_in_method_arguments?(node, helper_name)
@@ -1575,7 +1584,10 @@ module ReactOnRails
     end
 
     def uncommented_template_content(content)
-      content.gsub(TEMPLATE_HTML_COMMENT_PATTERN, "").gsub(TEMPLATE_ERB_COMMENT_PATTERN, "")
+      utf8_content = content.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+      utf8_content.gsub(TEMPLATE_HTML_COMMENT_PATTERN, "").gsub(TEMPLATE_ERB_COMMENT_PATTERN, "")
+    rescue EncodingError
+      ""
     end
 
     def auto_loaded_component_names(content)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -528,6 +528,7 @@ module ReactOnRails
       check_shakapacker_configuration_details
       check_react_on_rails_configuration_details
       check_server_bundle_prerender_consistency
+      check_layout_files
     end
 
     def check_bin_dev_launcher
@@ -1241,7 +1242,6 @@ module ReactOnRails
         )
       end
 
-      check_layout_files
       check_server_rendering_engine
     end
 
@@ -1462,7 +1462,7 @@ module ReactOnRails
 
     def erb_output_helper?(content, helper_name)
       unqualified_call_ambiguous = helper_name == "javascript_pack_tag" &&
-                                   non_output_erb_local_binding?(content, helper_name)
+                                   erb_local_binding?(content, helper_name)
 
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
         statements = ripper_statements(expression)
@@ -1481,8 +1481,8 @@ module ReactOnRails
       !unqualified_call_ambiguous && direct_unqualified_helper_call?(node, helper_name)
     end
 
-    def non_output_erb_local_binding?(content, local_name)
-      content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+    def erb_local_binding?(content, local_name)
+      content.scan(ERB_EXPRESSION_PATTERN).any? do |(expression)|
         ripper_statements(expression).any? { |statement| source_proven_local_binding?(statement, local_name) }
       end
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -76,6 +76,7 @@ module ReactOnRails
     TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
     ERB_EXPRESSION_PATTERN = /<%(?![#%])=?\s*(?<expression>.*?)%>/m
     ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)%>/m
+    REFLECTIVE_HELPER_DISPATCH_METHODS = %w[send public_send __send__ method].freeze
     REACT_ON_RAILS_INITIALIZER_PATH = "config/initializers/react_on_rails.rb"
 
     # Deprecated-renderer-cache scan (used by check_deprecated_renderer_cache_task):
@@ -1440,8 +1441,27 @@ module ReactOnRails
 
     def erb_helper_mentioned?(content, helper_name)
       content.scan(ERB_EXPRESSION_PATTERN).any? do |(expression)|
-        Ripper.lex(expression).any? { |(_position, _event, token)| token == helper_name }
+        Ripper.lex(expression).any? { |(_position, _event, token)| token == helper_name } ||
+          reflective_helper_dispatch?(ripper_statements(expression))
       end
+    end
+
+    def reflective_helper_dispatch?(node)
+      return false unless node.is_a?(Array)
+      return true if reflective_helper_dispatch_call?(node)
+
+      children = node.first.is_a?(Symbol) ? node.drop(1) : node
+      children.any? { |child| reflective_helper_dispatch?(child) }
+    end
+
+    def reflective_helper_dispatch_call?(node)
+      method_token = case node.first
+                     when :vcall, :fcall, :command
+                       node[1]
+                     when :call
+                       node[3]
+                     end
+      token_type?(method_token, :@ident) && REFLECTIVE_HELPER_DISPATCH_METHODS.include?(method_token[1])
     end
 
     def direct_unqualified_helper_call?(node, helper_name)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1571,15 +1571,16 @@ module ReactOnRails
         static_argument_values(argument_parentheses[1])
       elsif ast_node?(node, :command) && reflective_dispatch_call?(node)
         static_argument_values(node[2])
-      elsif exact_self_reflective_command_call?(node)
+      elsif reflective_command_call?(node)
         static_argument_values(node[4])
       end
     end
 
-    def exact_self_reflective_command_call?(node)
+    def reflective_command_call?(node)
       return false unless ast_node?(node, :command_call)
 
-      REFLECTIVE_HELPER_DISPATCH_METHODS.any? { |method_name| direct_self_helper_call?(node, method_name) }
+      method_token = node[3]
+      token_type?(method_token, :@ident) && REFLECTIVE_HELPER_DISPATCH_METHODS.include?(method_token[1])
     end
 
     def reflective_dispatch_call?(node)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1290,11 +1290,23 @@ module ReactOnRails
     end
 
     def static_stylesheet_assets(entrypoint)
-      stylesheet_assets = shakapacker_manifest_data&.dig("entrypoints", entrypoint, "assets", "css")
+      assets = static_manifest_assets(entrypoint)
+      stylesheet_assets = assets["css"] if assets.is_a?(Hash)
       return unless stylesheet_assets.is_a?(Array) && stylesheet_assets.any?
       return unless stylesheet_assets.all? { |asset| asset.is_a?(String) && !asset.empty? }
 
       stylesheet_assets
+    end
+
+    def static_manifest_assets(entrypoint)
+      manifest = shakapacker_manifest_data
+      return unless manifest.is_a?(Hash)
+
+      entrypoints = manifest["entrypoints"]
+      return unless entrypoints.is_a?(Hash)
+
+      entrypoint_data = entrypoints[entrypoint]
+      entrypoint_data["assets"] if entrypoint_data.is_a?(Hash)
     end
 
     def auto_loaded_component_names_from_implicit_views(layout_name)
@@ -1339,17 +1351,26 @@ module ReactOnRails
       action_visibilities = {}
 
       statements.each do |statement|
-        declaration = static_visibility_declaration(statement)
-        if declaration
-          declared_visibility, method_names = declaration
-          visibility = declared_visibility if method_names.empty?
-          method_names.each { |method_name| action_visibilities[method_name] = declared_visibility }
-        elsif (action_name = static_implicit_action_name(statement))
-          action_visibilities[action_name] = visibility
-        end
+        visibility = static_visibility_after_statement(statement, visibility, action_visibilities)
+        return [] unless visibility
       end
 
       action_visibilities.filter_map { |action_name, action_visibility| action_name if action_visibility == :public }
+    end
+
+    def static_visibility_after_statement(statement, visibility, action_visibilities)
+      declaration = static_visibility_declaration(statement)
+      return if declaration == :unresolved
+
+      unless declaration
+        action_name = static_implicit_action_name(statement)
+        action_visibilities[action_name] = visibility if action_name
+        return visibility
+      end
+
+      declared_visibility, method_names = declaration
+      method_names.each { |method_name| action_visibilities[method_name] = declared_visibility }
+      method_names.empty? ? declared_visibility : visibility
     end
 
     def static_visibility_declaration(node)
@@ -1357,7 +1378,7 @@ module ReactOnRails
       return unless visibility
 
       method_names = static_visibility_method_names(node, visibility)
-      [visibility.to_sym, method_names] if method_names
+      method_names ? [visibility.to_sym, method_names] : :unresolved
     end
 
     def static_visibility_method_names(node, visibility)
@@ -1366,8 +1387,12 @@ module ReactOnRails
       arguments = static_argument_values(static_call_arguments(node, visibility))
       return unless arguments
 
-      method_names = arguments.map { |argument| static_symbol_value(argument) }
+      method_names = arguments.map { |argument| static_method_name_value(argument) }
       method_names if method_names.all?
+    end
+
+    def static_method_name_value(node)
+      static_symbol_value(node) || static_string_value(node)
     end
 
     def static_symbol_value(node)
@@ -1382,6 +1407,7 @@ module ReactOnRails
 
       controller = statements.first
       return unless ast_node?(controller, :class)
+      return unless static_constant_reference(controller[2]) == "ApplicationController"
 
       relative_name = controller_file.delete_prefix("app/controllers/").delete_suffix("_controller.rb")
       expected_name = "#{relative_name.split('/').map(&:camelize).join('::')}Controller"
@@ -1448,7 +1474,9 @@ module ReactOnRails
 
     def erb_output_helper?(content, helper_name)
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
-        expression.match?(/\A#{Regexp.escape(helper_name)}(?:\s|\()/)
+        ripper_statements(expression).any? do |statement|
+          ast_method_call_count(statement, helper_name).positive?
+        end
       end
     end
 
@@ -1532,6 +1560,7 @@ module ReactOnRails
     def top_level_boolean_keyword(arguments, keyword)
       associations = static_hash_associations(arguments.last)
       return :omitted unless associations
+      return unless associations.all? { |association| static_label_association?(association) }
 
       matches = associations.select do |association|
         static_label_association?(association, "#{keyword}:")
@@ -1550,8 +1579,10 @@ module ReactOnRails
       association_list[1] if ast_node?(association_list, :assoclist_from_args)
     end
 
-    def static_label_association?(node, label)
-      ast_node?(node, :assoc_new) && ast_node?(node[1], :@label) && node[1][1] == label
+    def static_label_association?(node, label = nil)
+      return false unless ast_node?(node, :assoc_new) && ast_node?(node[1], :@label)
+
+      label.nil? || node[1][1] == label
     end
 
     def static_global_auto_load_bundle
@@ -1573,10 +1604,18 @@ module ReactOnRails
       statements = static_body_statements(configure_block.dig(2, 2))
       return unless config_name && statements
 
-      assignments = statements.select do |statement|
-        config_assignment?(statement, config_name, setting_name)
-      end
+      assignments = static_config_assignments(statements, config_name, setting_name)
       static_boolean_value(assignments.first[2]) if assignments.one?
+    end
+
+    def static_config_assignments(node, config_name, setting_name)
+      return [] unless node.is_a?(Array)
+
+      assignments = config_assignment?(node, config_name, setting_name) ? [node] : []
+      children = node.first.is_a?(Symbol) ? node.drop(1) : node
+      assignments + children.flat_map do |child|
+        static_config_assignments(child, config_name, setting_name)
+      end
     end
 
     def configure_block_parameter_name(node)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1304,7 +1304,8 @@ module ReactOnRails
       helper_call_context_in_expressions?(content.scan(ERB_OUTPUT_EXPRESSION_PATTERN), "stylesheet_pack_tag") ||
         content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
           statements = ripper_statements(expression)
-          next false if statements.one? && direct_unqualified_helper_call?(statements.first, "stylesheet_pack_tag")
+          next false if statements.one? &&
+                        discarded_top_level_helper_call?(statements.first, "stylesheet_pack_tag")
 
           statements.any? { |statement| helper_call_context_evidence?(statement, "stylesheet_pack_tag") }
         end
@@ -1600,6 +1601,13 @@ module ReactOnRails
       return token_named?(node[1], helper_name) if ast_node?(node, :vcall) || ast_node?(node, :command)
 
       ast_node?(node, :method_add_arg) && fcall_named?(node[1], helper_name)
+    end
+
+    def discarded_top_level_helper_call?(node, helper_name)
+      return true if direct_unqualified_helper_call?(node, helper_name)
+      return true if direct_self_helper_call?(node, helper_name)
+
+      ast_node?(node, :method_add_arg) && direct_self_helper_call?(node[1], helper_name)
     end
 
     def uncommented_template_content(content)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1495,8 +1495,7 @@ module ReactOnRails
       return false unless helper_name == "javascript_pack_tag" && ast_node?(node, :method_add_arg)
 
       argument_parentheses = node[2]
-      ast_node?(argument_parentheses, :arg_paren) && argument_parentheses[1].nil? &&
-        direct_self_helper_call?(node[1], helper_name)
+      ast_node?(argument_parentheses, :arg_paren) && direct_self_helper_call?(node[1], helper_name)
     end
 
     def eager_helper_call_in_method_arguments?(node, helper_name)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1461,26 +1461,48 @@ module ReactOnRails
     end
 
     def erb_output_helper?(content, helper_name)
+      unqualified_call_ambiguous = helper_name == "javascript_pack_tag" &&
+                                   non_output_erb_local_binding?(content, helper_name)
+
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
         statements = ripper_statements(expression)
-        statements.one? && eagerly_evaluated_unqualified_helper_call?(statements.first, helper_name)
+        statements.one? && emitted_top_level_helper_call?(
+          statements.first,
+          helper_name,
+          unqualified_call_ambiguous:
+        )
       end
     end
 
-    def eagerly_evaluated_unqualified_helper_call?(node, helper_name)
-      return true if direct_unqualified_helper_call?(node, helper_name)
-      return true if eagerly_evaluated_self_helper_call?(node, helper_name)
-      return eager_helper_call_in_method_arguments?(node, helper_name) if ast_node?(node, :method_add_arg)
-      return eager_helper_call_in_arguments?(node[2], helper_name) if ast_node?(node, :command)
-      return eager_helper_call_in_array?(node, helper_name) if ast_node?(node, :array)
-      return eager_helper_call_in_hash?(node, helper_name) if ast_node?(node, :hash) ||
-                                                              ast_node?(node, :bare_assoc_hash)
+    def emitted_top_level_helper_call?(node, helper_name, unqualified_call_ambiguous: false)
+      return true if direct_self_helper_call?(node, helper_name)
+      return true if parenthesized_self_javascript_helper_call?(node, helper_name)
 
-      false
+      !unqualified_call_ambiguous && direct_unqualified_helper_call?(node, helper_name)
     end
 
-    def eagerly_evaluated_self_helper_call?(node, helper_name)
-      direct_self_helper_call?(node, helper_name) || parenthesized_self_javascript_helper_call?(node, helper_name)
+    def non_output_erb_local_binding?(content, local_name)
+      content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+        ripper_statements(expression).any? { |statement| source_proven_local_binding?(statement, local_name) }
+      end
+    end
+
+    def source_proven_local_binding?(node, local_name)
+      return false unless node.is_a?(Array)
+      return true if local_variable_field_named?(node, local_name)
+      return true if required_parameter_named?(node, local_name)
+
+      children = node.first.is_a?(Symbol) ? node.drop(1) : node
+      children.any? { |child| source_proven_local_binding?(child, local_name) }
+    end
+
+    def local_variable_field_named?(node, local_name)
+      ast_node?(node, :var_field) && token_named?(node[1], local_name)
+    end
+
+    def required_parameter_named?(node, local_name)
+      ast_node?(node, :params) && node[1].is_a?(Array) &&
+        node[1].any? { |parameter| token_named?(parameter, local_name) }
     end
 
     def direct_self_helper_call?(node, helper_name)
@@ -1496,37 +1518,6 @@ module ReactOnRails
 
       argument_parentheses = node[2]
       ast_node?(argument_parentheses, :arg_paren) && direct_self_helper_call?(node[1], helper_name)
-    end
-
-    def eager_helper_call_in_method_arguments?(node, helper_name)
-      return false unless ast_node?(node[1], :fcall)
-
-      argument_parentheses = node[2]
-      return false unless ast_node?(argument_parentheses, :arg_paren)
-
-      eager_helper_call_in_arguments?(argument_parentheses[1], helper_name)
-    end
-
-    def eager_helper_call_in_array?(node, helper_name)
-      values = node[1]
-      return false unless values.is_a?(Array)
-
-      values.any? do |value|
-        eagerly_evaluated_unqualified_helper_call?(value, helper_name)
-      end
-    end
-
-    def eager_helper_call_in_hash?(node, helper_name)
-      associations = static_hash_associations(node)
-      associations&.any? do |association|
-        ast_node?(association, :assoc_new) &&
-          eagerly_evaluated_unqualified_helper_call?(association[2], helper_name)
-      end
-    end
-
-    def eager_helper_call_in_arguments?(node, helper_name)
-      arguments = static_argument_values(node)
-      arguments&.any? { |argument| eagerly_evaluated_unqualified_helper_call?(argument, helper_name) }
     end
 
     def erb_helper_mentioned?(content, helper_name)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1305,24 +1305,25 @@ module ReactOnRails
     end
 
     def stylesheet_pack_ambiguity_evidence?(content)
-      stylesheet_pack_output_ambiguity_evidence?(content) ||
+      ignored_bare_local = "stylesheet_pack_tag" if erb_local_binding?(content, "stylesheet_pack_tag")
+      stylesheet_pack_output_ambiguity_evidence?(content, ignored_bare_local:) ||
         content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
           statements = ripper_statements(expression)
           next false if statements.one? &&
                         discarded_top_level_helper_call?(statements.first, "stylesheet_pack_tag")
 
-          statements.any? { |statement| helper_call_context_evidence?(statement, "stylesheet_pack_tag") }
+          statements.any? do |statement|
+            helper_call_context_evidence?(statement, "stylesheet_pack_tag", ignored_bare_local:)
+          end
         end
     end
 
-    def stylesheet_pack_output_ambiguity_evidence?(content)
-      unqualified_call_ambiguous = erb_local_binding?(content, "stylesheet_pack_tag")
+    def stylesheet_pack_output_ambiguity_evidence?(content, ignored_bare_local: nil)
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
         statements = ripper_statements(expression)
-        next false if unqualified_call_ambiguous && statements.one? &&
-                      direct_unqualified_helper_call?(statements.first, "stylesheet_pack_tag")
-
-        statements.any? { |statement| helper_call_context_evidence?(statement, "stylesheet_pack_tag") }
+        statements.any? do |statement|
+          helper_call_context_evidence?(statement, "stylesheet_pack_tag", ignored_bare_local:)
+        end
       end
     end
 
@@ -1498,8 +1499,9 @@ module ReactOnRails
     def emitted_top_level_helper_call?(node, helper_name, unqualified_call_ambiguous: false)
       return true if direct_self_helper_call?(node, helper_name)
       return true if parenthesized_self_javascript_helper_call?(node, helper_name)
+      return false if unqualified_call_ambiguous && bare_unqualified_helper_vcall?(node, helper_name)
 
-      !unqualified_call_ambiguous && direct_unqualified_helper_call?(node, helper_name)
+      direct_unqualified_helper_call?(node, helper_name)
     end
 
     def erb_local_binding?(content, local_name)
@@ -1510,11 +1512,17 @@ module ReactOnRails
 
     def source_proven_local_binding?(node, local_name)
       return false unless node.is_a?(Array)
+      return source_proven_local_binding?(node[1], local_name) if ast_node?(node, :method_add_block)
+      return false if nested_local_binding_scope?(node)
       return true if local_variable_field_named?(node, local_name)
       return true if required_parameter_named?(node, local_name)
 
       children = node.first.is_a?(Symbol) ? node.drop(1) : node
       children.any? { |child| source_proven_local_binding?(child, local_name) }
+    end
+
+    def nested_local_binding_scope?(node)
+      %i[brace_block do_block lambda def defs].any? { |type| ast_node?(node, type) }
     end
 
     def local_variable_field_named?(node, local_name)
@@ -1551,13 +1559,14 @@ module ReactOnRails
       end
     end
 
-    def helper_call_context_evidence?(node, helper_name)
+    def helper_call_context_evidence?(node, helper_name, ignored_bare_local: nil)
       return false unless node.is_a?(Array)
+      return false if ignored_bare_local == helper_name && bare_unqualified_helper_vcall?(node, helper_name)
       return true if helper_call_node?(node, helper_name)
       return true if reflective_helper_dispatch_may_call?(node, helper_name)
 
       children = node.first.is_a?(Symbol) ? node.drop(1) : node
-      children.any? { |child| helper_call_context_evidence?(child, helper_name) }
+      children.any? { |child| helper_call_context_evidence?(child, helper_name, ignored_bare_local:) }
     end
 
     def helper_call_node?(node, helper_name)
@@ -1613,6 +1622,10 @@ module ReactOnRails
       return token_named?(node[1], helper_name) if ast_node?(node, :vcall) || ast_node?(node, :command)
 
       ast_node?(node, :method_add_arg) && fcall_named?(node[1], helper_name)
+    end
+
+    def bare_unqualified_helper_vcall?(node, helper_name)
+      ast_node?(node, :vcall) && token_named?(node[1], helper_name)
     end
 
     def discarded_top_level_helper_call?(node, helper_name)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1641,29 +1641,19 @@ module ReactOnRails
 
     def unique_top_level_configure_block(source)
       source_statements = ripper_statements(source)
-      configure_blocks = source_statements.select { |statement| react_on_rails_configure_block?(statement) }
-      return unless configure_blocks.one?
-      return unless react_on_rails_configure_block_count(source_statements) == 1
+      return unless source_statements.one?
 
-      configure_blocks.first
+      configure_block = source_statements.first
+      configure_block if react_on_rails_configure_block?(configure_block)
     end
 
     def static_direct_config_assignments(block_body, config_name)
       statements = static_body_statements(block_body)
       return unless config_name && statements
+      return unless statements.all? { |statement| direct_config_assignment?(statement, config_name) }
+      return unless ast_identifier_count(block_body, config_name) == statements.length
 
-      direct_assignments = statements.select { |statement| direct_config_assignment?(statement, config_name) }
-      return unless ast_identifier_count(block_body, config_name) == direct_assignments.length
-
-      direct_assignments
-    end
-
-    def react_on_rails_configure_block_count(node)
-      return 0 unless node.is_a?(Array)
-
-      count = react_on_rails_configure_block?(node) ? 1 : 0
-      children = node.first.is_a?(Symbol) ? node.drop(1) : node
-      count + children.sum { |child| react_on_rails_configure_block_count(child) }
+      statements
     end
 
     def ast_identifier_count(node, identifier)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3,6 +3,7 @@
 require "json"
 require "erb"
 require "open3"
+require "ripper"
 require "stringio"
 require "tempfile"
 require "timeout"
@@ -71,12 +72,10 @@ module ReactOnRails
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
     CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev].freeze
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
+    TEMPLATE_ERB_COMMENT_PATTERN = /<%#.*?%>/m
+    TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
     ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)%>/m
-    STATIC_REACT_COMPONENT_CALL_PATTERN = /
-      \Areact_component\s*(?:\(\s*)?
-      (?<quote>["'])(?<name>[A-Za-z0-9_:]+)\k<quote>
-      (?<arguments>.*)\z
-    /mx
+    REACT_ON_RAILS_INITIALIZER_PATH = "config/initializers/react_on_rails.rb"
 
     # Deprecated-renderer-cache scan (used by check_deprecated_renderer_cache_task):
     # look for references to the old pre_stage_bundle_for_node_renderer task in
@@ -1250,11 +1249,11 @@ module ReactOnRails
       layout_files.each do |layout_file|
         next unless File.exist?(layout_file)
 
-        content = File.read(layout_file)
-        has_stylesheet = content.include?("stylesheet_pack_tag")
-        has_javascript = content.include?("javascript_pack_tag")
+        content = uncommented_template_content(File.read(layout_file))
+        has_stylesheet = erb_output_helper?(content, "stylesheet_pack_tag")
+        has_javascript = erb_output_helper?(content, "javascript_pack_tag")
 
-        layout_name = File.basename(layout_file, ".html.erb")
+        layout_name = layout_file.delete_prefix("app/views/layouts/").delete_suffix(".html.erb")
 
         # Report detected pack helpers informationally. A JavaScript-only entrypoint
         # (no emitted CSS), a CSS-only pack, or a hybrid layout that loads CSS via
@@ -1276,10 +1275,11 @@ module ReactOnRails
     def check_unflushed_auto_loaded_component_css(layout_name, content)
       return unless erb_output_helper?(content, "javascript_pack_tag")
 
-      auto_loaded_component_names(content).each do |component_name|
+      component_names = auto_loaded_component_names(content)
+      component_names.concat(auto_loaded_component_names_from_implicit_views(layout_name)).uniq.each do |component_name|
         entrypoint = "generated/#{component_name}"
-        stylesheet_assets = shakapacker_manifest_data&.dig("entrypoints", entrypoint, "assets", "css")
-        next unless stylesheet_assets.is_a?(Array) && stylesheet_assets.any? && stylesheet_assets.all?(String)
+        stylesheet_assets = static_stylesheet_assets(entrypoint)
+        next unless stylesheet_assets
 
         checker.add_warning(
           "⚠️  #{layout_name}: auto-loaded component entrypoint #{entrypoint} emits CSS " \
@@ -1289,26 +1289,337 @@ module ReactOnRails
       end
     end
 
+    def static_stylesheet_assets(entrypoint)
+      stylesheet_assets = shakapacker_manifest_data&.dig("entrypoints", entrypoint, "assets", "css")
+      return unless stylesheet_assets.is_a?(Array) && stylesheet_assets.any?
+      return unless stylesheet_assets.all? { |asset| asset.is_a?(String) && !asset.empty? }
+
+      stylesheet_assets
+    end
+
+    def auto_loaded_component_names_from_implicit_views(layout_name)
+      Dir.glob("app/controllers/**/*_controller.rb").flat_map do |controller_file|
+        implicit_view_paths_for_layout(controller_file, layout_name).flat_map do |view_path|
+          next [] unless File.exist?(view_path)
+
+          auto_loaded_component_names(uncommented_template_content(File.read(view_path)))
+        end
+      rescue StandardError
+        []
+      end
+    rescue StandardError
+      []
+    end
+
+    def implicit_view_paths_for_layout(controller_file, layout_name)
+      statements = statically_associated_controller_statements(controller_file, layout_name)
+      return [] unless statements
+
+      view_directory = controller_file.delete_prefix("app/controllers/").delete_suffix("_controller.rb")
+      static_public_implicit_action_names(statements).map do |action_name|
+        "app/views/#{view_directory}/#{action_name}.html.erb"
+      end
+    rescue StandardError
+      []
+    end
+
+    def statically_associated_controller_statements(controller_file, layout_name)
+      return unless File.exist?(controller_file)
+
+      controller = static_controller_class(controller_file)
+      statements = static_body_statements(controller[3]) if controller
+      return unless statements
+
+      layout_declarations = statements.filter_map { |statement| static_layout_declaration(statement) }
+      statements if layout_declarations == [layout_name] && ast_method_call_count(controller, "layout") == 1
+    end
+
+    def static_public_implicit_action_names(statements)
+      visibility = :public
+      action_visibilities = {}
+
+      statements.each do |statement|
+        declaration = static_visibility_declaration(statement)
+        if declaration
+          declared_visibility, method_names = declaration
+          visibility = declared_visibility if method_names.empty?
+          method_names.each { |method_name| action_visibilities[method_name] = declared_visibility }
+        elsif (action_name = static_implicit_action_name(statement))
+          action_visibilities[action_name] = visibility
+        end
+      end
+
+      action_visibilities.filter_map { |action_name, action_visibility| action_name if action_visibility == :public }
+    end
+
+    def static_visibility_declaration(node)
+      visibility = %w[public protected private].find { |name| ast_method_call_count(node, name) == 1 }
+      return unless visibility
+
+      method_names = static_visibility_method_names(node, visibility)
+      [visibility.to_sym, method_names] if method_names
+    end
+
+    def static_visibility_method_names(node, visibility)
+      return [] if ast_node?(node, :vcall) && token_named?(node[1], visibility)
+
+      arguments = static_argument_values(static_call_arguments(node, visibility))
+      return unless arguments
+
+      method_names = arguments.map { |argument| static_symbol_value(argument) }
+      method_names if method_names.all?
+    end
+
+    def static_symbol_value(node)
+      symbol = node[1] if ast_node?(node, :symbol_literal)
+      token = symbol[1] if ast_node?(symbol, :symbol)
+      token[1] if token_type?(token, :@ident)
+    end
+
+    def static_controller_class(controller_file)
+      statements = ripper_statements(File.read(controller_file))
+      return unless statements.one?
+
+      controller = statements.first
+      return unless ast_node?(controller, :class)
+
+      relative_name = controller_file.delete_prefix("app/controllers/").delete_suffix("_controller.rb")
+      expected_name = "#{relative_name.split('/').map(&:camelize).join('::')}Controller"
+      controller if static_constant_name(controller[1]) == expected_name
+    end
+
+    def static_constant_name(node)
+      return unless node.is_a?(Array)
+
+      case node.first
+      when :const_ref, :top_const_ref
+        static_constant_token_value(node[1])
+      when :const_path_ref
+        namespace = static_constant_name(node[1])
+        constant = static_constant_token_value(node[2])
+        "#{namespace}::#{constant}" if namespace && constant
+      end
+    end
+
+    def static_constant_token_value(node)
+      node[1] if ast_node?(node, :@const)
+    end
+
+    def static_layout_declaration(node)
+      arguments = static_argument_values(static_call_arguments(node, "layout"))
+      return unless arguments&.one?
+
+      static_string_value(arguments.first)
+    end
+
+    def static_implicit_action_name(node)
+      return unless ast_node?(node, :def) && token_type?(node[1], :@ident)
+      return unless empty_method_parameters?(node[2])
+      return if ast_method_call_count(node[3], "render").positive?
+      return if ast_method_call_count(node[3], "layout").positive?
+
+      node[1][1]
+    end
+
+    def empty_method_parameters?(node)
+      ast_node?(node, :params) && node.drop(1).all?(&:nil?)
+    end
+
+    def static_body_statements(node)
+      statements = node[1] if ast_node?(node, :bodystmt)
+      statements if statements.is_a?(Array)
+    end
+
+    def ast_method_call_count(node, method_name)
+      return 0 unless node.is_a?(Array)
+
+      count =
+        case node.first
+        when :command, :fcall, :vcall
+          token_named?(node[1], method_name) ? 1 : 0
+        when :call, :command_call
+          token_named?(node[3], method_name) ? 1 : 0
+        else
+          0
+        end
+      children = node.first.is_a?(Symbol) ? node.drop(1) : node
+      count + children.sum { |child| ast_method_call_count(child, method_name) }
+    end
+
     def erb_output_helper?(content, helper_name)
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
         expression.match?(/\A#{Regexp.escape(helper_name)}(?:\s|\()/)
       end
     end
 
+    def uncommented_template_content(content)
+      content.gsub(TEMPLATE_HTML_COMMENT_PATTERN, "").gsub(TEMPLATE_ERB_COMMENT_PATTERN, "")
+    end
+
     def auto_loaded_component_names(content)
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).filter_map do |(expression)|
-        match = expression.match(STATIC_REACT_COMPONENT_CALL_PATTERN)
-        next unless match && statically_auto_loaded_component?(match[:arguments])
+        arguments = static_react_component_arguments(expression)
+        next unless arguments && statically_auto_loaded_component?(arguments)
 
-        match[:name].camelize
+        static_string_value(arguments.first)&.camelize
       end.uniq
     end
 
     def statically_auto_loaded_component?(arguments)
-      return true if arguments.match?(/\A\s*,\s*auto_load_bundle:\s*true\s*\)?\s*\z/)
-      return false unless arguments.match?(/\A\s*\)?\s*\z/)
+      component_option = top_level_boolean_keyword(arguments.drop(1), "auto_load_bundle")
+      return component_option == true unless component_option == :omitted
 
-      react_on_rails_runtime_configuration&.auto_load_bundle == true
+      static_global_auto_load_bundle == true
+    end
+
+    def static_react_component_arguments(expression)
+      statements = ripper_statements(expression)
+      return unless statements.one?
+
+      arguments = static_argument_values(static_call_arguments(statements.first, "react_component"))
+      component_name = static_string_value(arguments.first) if arguments&.any?
+      arguments if component_name&.match?(/\A[A-Za-z0-9_:]+\z/)
+    end
+
+    def ripper_statements(source)
+      program = Ripper.sexp(source)
+      statements = program[1] if ast_node?(program, :program)
+      statements.is_a?(Array) ? statements : []
+    end
+
+    def static_call_arguments(node, method_name)
+      return node[2] if ast_node?(node, :command) && token_named?(node[1], method_name)
+      return unless ast_node?(node, :method_add_arg) && fcall_named?(node[1], method_name)
+
+      argument_parentheses = node[2]
+      argument_parentheses[1] if ast_node?(argument_parentheses, :arg_paren)
+    end
+
+    def static_argument_values(node)
+      return unless ast_node?(node, :args_add_block) && node[2] == false
+
+      node[1] if node[1].is_a?(Array)
+    end
+
+    def ast_node?(node, type)
+      node.is_a?(Array) && node.first == type
+    end
+
+    def token_type?(node, type)
+      ast_node?(node, type) && node[1].is_a?(String)
+    end
+
+    def fcall_named?(node, name)
+      ast_node?(node, :fcall) && token_named?(node[1], name)
+    end
+
+    def token_named?(node, name)
+      token_type?(node, :@ident) && node[1] == name
+    end
+
+    def static_string_value(node)
+      return unless ast_node?(node, :string_literal)
+
+      content = node[1]
+      return unless ast_node?(content, :string_content)
+
+      parts = content.drop(1)
+      return unless parts.all? { |part| token_type?(part, :@tstring_content) }
+
+      parts.map { |part| part[1] }.join
+    end
+
+    def top_level_boolean_keyword(arguments, keyword)
+      associations = static_hash_associations(arguments.last)
+      return :omitted unless associations
+
+      matches = associations.select do |association|
+        static_label_association?(association, "#{keyword}:")
+      end
+      return :omitted if matches.empty?
+      return unless matches.one?
+
+      static_boolean_value(matches.first[2])
+    end
+
+    def static_hash_associations(node)
+      return node[1] if ast_node?(node, :bare_assoc_hash)
+      return unless ast_node?(node, :hash)
+
+      association_list = node[1]
+      association_list[1] if ast_node?(association_list, :assoclist_from_args)
+    end
+
+    def static_label_association?(node, label)
+      ast_node?(node, :assoc_new) && ast_node?(node[1], :@label) && node[1][1] == label
+    end
+
+    def static_global_auto_load_bundle
+      return @static_global_auto_load_bundle if defined?(@static_global_auto_load_bundle)
+      return (@static_global_auto_load_bundle = nil) unless File.exist?(REACT_ON_RAILS_INITIALIZER_PATH)
+
+      source = File.read(REACT_ON_RAILS_INITIALIZER_PATH)
+      @static_global_auto_load_bundle = static_configured_boolean(source, "auto_load_bundle")
+    rescue StandardError
+      @static_global_auto_load_bundle = nil
+    end
+
+    def static_configured_boolean(source, setting_name)
+      configure_blocks = ripper_statements(source).select { |statement| react_on_rails_configure_block?(statement) }
+      return unless configure_blocks.one?
+
+      configure_block = configure_blocks.first
+      config_name = configure_block_parameter_name(configure_block)
+      statements = static_body_statements(configure_block.dig(2, 2))
+      return unless config_name && statements
+
+      assignments = statements.select do |statement|
+        config_assignment?(statement, config_name, setting_name)
+      end
+      static_boolean_value(assignments.first[2]) if assignments.one?
+    end
+
+    def configure_block_parameter_name(node)
+      block_var = node.dig(2, 1)
+      parameters = block_var[1] if ast_node?(block_var, :block_var)
+      required = parameters[1] if ast_node?(parameters, :params)
+      required.first[1] if required&.one? && token_type?(required.first, :@ident)
+    end
+
+    def react_on_rails_configure_block?(node)
+      return false unless ast_node?(node, :method_add_block)
+
+      call = node[1]
+      block = node[2]
+      ast_node?(call, :call) && static_constant_reference(call[1]) == "ReactOnRails" &&
+        token_named?(call[3], "configure") && ast_node?(block, :do_block)
+    end
+
+    def static_constant_reference(node)
+      static_constant_token_value(node[1]) if ast_node?(node, :var_ref)
+    end
+
+    def config_assignment?(node, config_name, setting_name)
+      return false unless ast_node?(node, :assign)
+
+      field = node[1]
+      ast_node?(field, :field) && static_identifier_reference(field[1]) == config_name &&
+        token_named?(field[3], setting_name)
+    end
+
+    def static_identifier_reference(node)
+      token = node[1] if ast_node?(node, :var_ref)
+      token[1] if token_type?(token, :@ident)
+    end
+
+    def static_boolean_value(node)
+      return unless ast_node?(node, :var_ref)
+
+      keyword = node[1]
+      return true if token_type?(keyword, :@kw) && keyword[1] == "true"
+      return false if token_type?(keyword, :@kw) && keyword[1] == "false"
+
+      nil
     end
 
     def shakapacker_manifest_data

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -72,6 +72,7 @@ module ReactOnRails
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
     CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev].freeze
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
+    TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
     TEMPLATE_COMMENT_PATTERN = /<!--.*?-->|<%#.*?%>/m
     ERB_EXPRESSION_PATTERN = /<%(?![#%])={0,2}\s*(?<expression>.*?)-?%>/m
     ERB_OUTPUT_EXPRESSION_PATTERN = /<%={1,2}\s*(?<expression>.*?)-?%>/m
@@ -1254,7 +1255,9 @@ module ReactOnRails
       layout_files.each do |layout_file|
         next unless File.exist?(layout_file)
 
-        content = uncommented_template_content(File.read(layout_file))
+        template_content = File.read(layout_file)
+        ambiguous_commented_erb = html_comment_with_executable_erb?(template_content)
+        content = uncommented_template_content(template_content)
         has_stylesheet = stylesheet_pack_helper_evidence?(content)
         has_javascript = erb_output_helper?(content, "javascript_pack_tag")
 
@@ -1270,14 +1273,15 @@ module ReactOnRails
           checker.add_info("  ℹ️  #{layout_name}: has stylesheet_pack_tag")
         elsif has_javascript
           checker.add_info("  ℹ️  #{layout_name}: has javascript_pack_tag")
-          check_unflushed_auto_loaded_component_css(layout_name, content)
+          check_unflushed_auto_loaded_component_css(layout_name, content, ambiguous_commented_erb:)
         else
           checker.add_info("  ℹ️  #{layout_name}: no pack tags found")
         end
       end
     end
 
-    def check_unflushed_auto_loaded_component_css(layout_name, content)
+    def check_unflushed_auto_loaded_component_css(layout_name, content, ambiguous_commented_erb: false)
+      return if ambiguous_commented_erb
       return unless erb_output_helper?(content, "javascript_pack_tag")
       return if erb_helper_mentioned?(content, "render")
 
@@ -1301,7 +1305,7 @@ module ReactOnRails
     end
 
     def stylesheet_pack_ambiguity_evidence?(content)
-      helper_call_context_in_expressions?(content.scan(ERB_OUTPUT_EXPRESSION_PATTERN), "stylesheet_pack_tag") ||
+      stylesheet_pack_output_ambiguity_evidence?(content) ||
         content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
           statements = ripper_statements(expression)
           next false if statements.one? &&
@@ -1309,6 +1313,17 @@ module ReactOnRails
 
           statements.any? { |statement| helper_call_context_evidence?(statement, "stylesheet_pack_tag") }
         end
+    end
+
+    def stylesheet_pack_output_ambiguity_evidence?(content)
+      unqualified_call_ambiguous = erb_local_binding?(content, "stylesheet_pack_tag")
+      content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+        statements = ripper_statements(expression)
+        next false if unqualified_call_ambiguous && statements.one? &&
+                      direct_unqualified_helper_call?(statements.first, "stylesheet_pack_tag")
+
+        statements.any? { |statement| helper_call_context_evidence?(statement, "stylesheet_pack_tag") }
+      end
     end
 
     def static_stylesheet_assets(entrypoint)
@@ -1346,19 +1361,26 @@ module ReactOnRails
     def auto_loaded_component_names_from_implicit_views(layout_name)
       Dir.glob("app/controllers/**/*_controller.rb").flat_map do |controller_file|
         implicit_view_paths_for_layout(controller_file, layout_name).flat_map do |view_path|
-          next [] unless File.exist?(view_path)
-
-          view_content = uncommented_template_content(File.read(view_path))
-          next [] if stylesheet_pack_helper_evidence?(view_content)
-          next [] if erb_helper_mentioned?(view_content, "render")
-
-          auto_loaded_component_names(view_content)
+          auto_loaded_component_names_from_implicit_view(view_path)
         end
       rescue StandardError
         []
       end
     rescue StandardError
       []
+    end
+
+    def auto_loaded_component_names_from_implicit_view(view_path)
+      return [] unless File.exist?(view_path)
+
+      template_content = File.read(view_path)
+      return [] if html_comment_with_executable_erb?(template_content)
+
+      view_content = uncommented_template_content(template_content)
+      return [] if stylesheet_pack_helper_evidence?(view_content)
+      return [] if erb_helper_mentioned?(view_content, "render")
+
+      auto_loaded_component_names(view_content)
     end
 
     def implicit_view_paths_for_layout(controller_file, layout_name)
@@ -1461,8 +1483,7 @@ module ReactOnRails
     end
 
     def erb_output_helper?(content, helper_name)
-      unqualified_call_ambiguous = helper_name == "javascript_pack_tag" &&
-                                   erb_local_binding?(content, helper_name)
+      unqualified_call_ambiguous = erb_local_binding?(content, helper_name)
 
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
         statements = ripper_statements(expression)
@@ -1611,6 +1632,22 @@ module ReactOnRails
       end
     rescue EncodingError
       ""
+    end
+
+    def html_comment_with_executable_erb?(content)
+      utf8_content = content.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+      loop do
+        return true if utf8_content.scan(TEMPLATE_HTML_COMMENT_PATTERN).any? do |comment|
+          comment.match?(ERB_EXPRESSION_PATTERN)
+        end
+
+        uncommented_content = utf8_content.gsub(TEMPLATE_COMMENT_PATTERN, "")
+        return false if uncommented_content == utf8_content
+
+        utf8_content = uncommented_content
+      end
+    rescue EncodingError
+      true
     end
 
     def auto_loaded_component_names(content)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -71,6 +71,12 @@ module ReactOnRails
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
     CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev].freeze
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
+    ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)%>/m
+    STATIC_REACT_COMPONENT_CALL_PATTERN = /
+      \Areact_component\s*(?:\(\s*)?
+      (?<quote>["'])(?<name>[A-Za-z0-9_:]+)\k<quote>
+      (?<arguments>.*)\z
+    /mx
 
     # Deprecated-renderer-cache scan (used by check_deprecated_renderer_cache_task):
     # look for references to the old pre_stage_bundle_for_node_renderer task in
@@ -1260,10 +1266,59 @@ module ReactOnRails
           checker.add_info("  ℹ️  #{layout_name}: has stylesheet_pack_tag")
         elsif has_javascript
           checker.add_info("  ℹ️  #{layout_name}: has javascript_pack_tag")
+          check_unflushed_auto_loaded_component_css(layout_name, content)
         else
           checker.add_info("  ℹ️  #{layout_name}: no pack tags found")
         end
       end
+    end
+
+    def check_unflushed_auto_loaded_component_css(layout_name, content)
+      return unless erb_output_helper?(content, "javascript_pack_tag")
+
+      auto_loaded_component_names(content).each do |component_name|
+        entrypoint = "generated/#{component_name}"
+        stylesheet_assets = shakapacker_manifest_data&.dig("entrypoints", entrypoint, "assets", "css")
+        next unless stylesheet_assets.is_a?(Array) && stylesheet_assets.any? && stylesheet_assets.all?(String)
+
+        checker.add_warning(
+          "⚠️  #{layout_name}: auto-loaded component entrypoint #{entrypoint} emits CSS " \
+          "(#{stylesheet_assets.join(', ')}), but this React layout flushes javascript_pack_tag without " \
+          "stylesheet_pack_tag"
+        )
+      end
+    end
+
+    def erb_output_helper?(content, helper_name)
+      content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+        expression.match?(/\A#{Regexp.escape(helper_name)}(?:\s|\()/)
+      end
+    end
+
+    def auto_loaded_component_names(content)
+      content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).filter_map do |(expression)|
+        match = expression.match(STATIC_REACT_COMPONENT_CALL_PATTERN)
+        next unless match && statically_auto_loaded_component?(match[:arguments])
+
+        match[:name].camelize
+      end.uniq
+    end
+
+    def statically_auto_loaded_component?(arguments)
+      return true if arguments.match?(/\A\s*,\s*auto_load_bundle:\s*true\s*\)?\s*\z/)
+      return false unless arguments.match?(/\A\s*\)?\s*\z/)
+
+      react_on_rails_runtime_configuration&.auto_load_bundle == true
+    end
+
+    def shakapacker_manifest_data
+      return @shakapacker_manifest_data if defined?(@shakapacker_manifest_data)
+
+      require "shakapacker"
+      manifest_path = ::Shakapacker.config.manifest_path
+      @shakapacker_manifest_data = JSON.parse(manifest_path.read) if manifest_path&.file?
+    rescue LoadError, StandardError
+      @shakapacker_manifest_data = nil
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -74,6 +74,7 @@ module ReactOnRails
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
     TEMPLATE_ERB_COMMENT_PATTERN = /<%#.*?%>/m
     TEMPLATE_HTML_COMMENT_PATTERN = /<!--.*?-->/m
+    ERB_EXPRESSION_PATTERN = /<%(?![#%])=?\s*(?<expression>.*?)%>/m
     ERB_OUTPUT_EXPRESSION_PATTERN = /<%=\s*(?<expression>.*?)%>/m
     REACT_ON_RAILS_INITIALIZER_PATH = "config/initializers/react_on_rails.rb"
 
@@ -1291,7 +1292,7 @@ module ReactOnRails
 
     def stylesheet_pack_helper_evidence?(content)
       erb_output_helper?(content, "stylesheet_pack_tag") ||
-        erb_output_helper_mentioned?(content, "stylesheet_pack_tag")
+        erb_helper_mentioned?(content, "stylesheet_pack_tag")
     end
 
     def static_stylesheet_assets(entrypoint)
@@ -1319,7 +1320,10 @@ module ReactOnRails
         implicit_view_paths_for_layout(controller_file, layout_name).flat_map do |view_path|
           next [] unless File.exist?(view_path)
 
-          auto_loaded_component_names(uncommented_template_content(File.read(view_path)))
+          view_content = uncommented_template_content(File.read(view_path))
+          next [] if stylesheet_pack_helper_evidence?(view_content)
+
+          auto_loaded_component_names(view_content)
         end
       rescue StandardError
         []
@@ -1434,9 +1438,9 @@ module ReactOnRails
       end
     end
 
-    def erb_output_helper_mentioned?(content, helper_name)
-      content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
-        Ripper.lex(expression).any? { |(_position, event, token)| event == :on_ident && token == helper_name }
+    def erb_helper_mentioned?(content, helper_name)
+      content.scan(ERB_EXPRESSION_PATTERN).any? do |(expression)|
+        Ripper.lex(expression).any? { |(_position, _event, token)| token == helper_name }
       end
     end
 
@@ -1620,18 +1624,46 @@ module ReactOnRails
     end
 
     def static_configured_boolean(source, setting_name)
-      configure_blocks = ripper_statements(source).select { |statement| react_on_rails_configure_block?(statement) }
-      return unless configure_blocks.one?
+      configure_block = unique_top_level_configure_block(source)
+      return unless configure_block
 
-      configure_block = configure_blocks.first
       config_name = configure_block_parameter_name(configure_block)
       block_body = configure_block.dig(2, 2)
-      statements = static_body_statements(block_body)
-      return unless config_name && statements
+      direct_assignments = static_direct_config_assignments(block_body, config_name)
+      return unless direct_assignments
       return unless ast_identifier_count(block_body, setting_name) == 1
 
-      assignments = statements.select { |statement| config_assignment?(statement, config_name, setting_name) }
+      assignments = direct_assignments.select do |statement|
+        config_assignment?(statement, config_name, setting_name)
+      end
       static_boolean_value(assignments.first[2]) if assignments.one?
+    end
+
+    def unique_top_level_configure_block(source)
+      source_statements = ripper_statements(source)
+      configure_blocks = source_statements.select { |statement| react_on_rails_configure_block?(statement) }
+      return unless configure_blocks.one?
+      return unless react_on_rails_configure_block_count(source_statements) == 1
+
+      configure_blocks.first
+    end
+
+    def static_direct_config_assignments(block_body, config_name)
+      statements = static_body_statements(block_body)
+      return unless config_name && statements
+
+      direct_assignments = statements.select { |statement| direct_config_assignment?(statement, config_name) }
+      return unless ast_identifier_count(block_body, config_name) == direct_assignments.length
+
+      direct_assignments
+    end
+
+    def react_on_rails_configure_block_count(node)
+      return 0 unless node.is_a?(Array)
+
+      count = react_on_rails_configure_block?(node) ? 1 : 0
+      children = node.first.is_a?(Symbol) ? node.drop(1) : node
+      count + children.sum { |child| react_on_rails_configure_block_count(child) }
     end
 
     def ast_identifier_count(node, identifier)
@@ -1663,11 +1695,17 @@ module ReactOnRails
     end
 
     def config_assignment?(node, config_name, setting_name)
+      return false unless direct_config_assignment?(node, config_name)
+
+      field = node[1]
+      token_named?(field[3], setting_name)
+    end
+
+    def direct_config_assignment?(node, config_name)
       return false unless ast_node?(node, :assign)
 
       field = node[1]
-      ast_node?(field, :field) && static_identifier_reference(field[1]) == config_name &&
-        token_named?(field[3], setting_name)
+      ast_node?(field, :field) && static_identifier_reference(field[1]) == config_name
     end
 
     def static_identifier_reference(node)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1253,7 +1253,7 @@ module ReactOnRails
       checker.add_info("\n📄 Layout Files Analysis:")
 
       layout_files.each do |layout_file|
-        next unless File.exist?(layout_file)
+        next unless analyzable_layout_file?(layout_file)
 
         template_content = File.read(layout_file)
         ambiguous_commented_erb = html_comment_with_executable_erb?(template_content)
@@ -1278,6 +1278,10 @@ module ReactOnRails
           checker.add_info("  ℹ️  #{layout_name}: no pack tags found")
         end
       end
+    end
+
+    def analyzable_layout_file?(layout_file)
+      !File.basename(layout_file).start_with?("_") && File.exist?(layout_file)
     end
 
     def check_unflushed_auto_loaded_component_css(layout_name, content, ambiguous_commented_erb: false)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1250,7 +1250,7 @@ module ReactOnRails
         next unless File.exist?(layout_file)
 
         content = uncommented_template_content(File.read(layout_file))
-        has_stylesheet = erb_output_helper?(content, "stylesheet_pack_tag")
+        has_stylesheet = stylesheet_pack_helper_evidence?(content)
         has_javascript = erb_output_helper?(content, "javascript_pack_tag")
 
         layout_name = layout_file.delete_prefix("app/views/layouts/").delete_suffix(".html.erb")
@@ -1289,6 +1289,11 @@ module ReactOnRails
       end
     end
 
+    def stylesheet_pack_helper_evidence?(content)
+      erb_output_helper?(content, "stylesheet_pack_tag") ||
+        erb_output_helper_mentioned?(content, "stylesheet_pack_tag")
+    end
+
     def static_stylesheet_assets(entrypoint)
       assets = static_manifest_assets(entrypoint)
       stylesheet_assets = assets["css"] if assets.is_a?(Hash)
@@ -1324,81 +1329,34 @@ module ReactOnRails
     end
 
     def implicit_view_paths_for_layout(controller_file, layout_name)
-      statements = statically_associated_controller_statements(controller_file, layout_name)
-      return [] unless statements
+      action_names = statically_associated_action_names(controller_file, layout_name)
+      return [] unless action_names
 
       view_directory = controller_file.delete_prefix("app/controllers/").delete_suffix("_controller.rb")
-      static_public_implicit_action_names(statements).map do |action_name|
+      action_names.map do |action_name|
         "app/views/#{view_directory}/#{action_name}.html.erb"
       end
     rescue StandardError
       []
     end
 
-    def statically_associated_controller_statements(controller_file, layout_name)
+    def statically_associated_action_names(controller_file, layout_name)
       return unless File.exist?(controller_file)
 
       controller = static_controller_class(controller_file)
       statements = static_body_statements(controller[3]) if controller
       return unless statements
 
-      layout_declarations = statements.filter_map { |statement| static_layout_declaration(statement) }
-      statements if layout_declarations == [layout_name] && ast_method_call_count(controller, "layout") == 1
+      layouts = statements.filter_map { |statement| static_layout_declaration(statement) }
+      action_names = statements.filter_map { |statement| static_generated_action_name(statement) }
+      return unless exact_generated_controller_statements?(statements, layouts, action_names, layout_name)
+
+      action_names
     end
 
-    def static_public_implicit_action_names(statements)
-      visibility = :public
-      action_visibilities = {}
-
-      statements.each do |statement|
-        visibility = static_visibility_after_statement(statement, visibility, action_visibilities)
-        return [] unless visibility
-      end
-
-      action_visibilities.filter_map { |action_name, action_visibility| action_name if action_visibility == :public }
-    end
-
-    def static_visibility_after_statement(statement, visibility, action_visibilities)
-      declaration = static_visibility_declaration(statement)
-      return if declaration == :unresolved
-
-      unless declaration
-        action_name = static_implicit_action_name(statement)
-        action_visibilities[action_name] = visibility if action_name
-        return visibility
-      end
-
-      declared_visibility, method_names = declaration
-      method_names.each { |method_name| action_visibilities[method_name] = declared_visibility }
-      method_names.empty? ? declared_visibility : visibility
-    end
-
-    def static_visibility_declaration(node)
-      visibility = %w[public protected private].find { |name| ast_method_call_count(node, name) == 1 }
-      return unless visibility
-
-      method_names = static_visibility_method_names(node, visibility)
-      method_names ? [visibility.to_sym, method_names] : :unresolved
-    end
-
-    def static_visibility_method_names(node, visibility)
-      return [] if ast_node?(node, :vcall) && token_named?(node[1], visibility)
-
-      arguments = static_argument_values(static_call_arguments(node, visibility))
-      return unless arguments
-
-      method_names = arguments.map { |argument| static_method_name_value(argument) }
-      method_names if method_names.all?
-    end
-
-    def static_method_name_value(node)
-      static_symbol_value(node) || static_string_value(node)
-    end
-
-    def static_symbol_value(node)
-      symbol = node[1] if ast_node?(node, :symbol_literal)
-      token = symbol[1] if ast_node?(symbol, :symbol)
-      token[1] if token_type?(token, :@ident)
+    def exact_generated_controller_statements?(statements, layouts, action_names, layout_name)
+      layouts == [layout_name] && action_names.one? &&
+        statements.length == layouts.length + action_names.length
     end
 
     def static_controller_class(controller_file)
@@ -1438,13 +1396,26 @@ module ReactOnRails
       static_string_value(arguments.first)
     end
 
-    def static_implicit_action_name(node)
+    def static_generated_action_name(node)
       return unless ast_node?(node, :def) && token_type?(node[1], :@ident)
       return unless empty_method_parameters?(node[2])
-      return if ast_method_call_count(node[3], "render").positive?
-      return if ast_method_call_count(node[3], "layout").positive?
+      return unless static_generated_action_body?(node[3])
 
       node[1][1]
+    end
+
+    def static_generated_action_body?(node)
+      return false unless ast_node?(node, :bodystmt) && node.drop(2).all?(&:nil?)
+
+      statements = static_body_statements(node)
+      statements&.all? { |statement| ast_node?(statement, :void_stmt) || static_ivar_assignment?(statement) }
+    end
+
+    def static_ivar_assignment?(node)
+      return false unless ast_node?(node, :assign)
+
+      field = node[1]
+      ast_node?(field, :var_field) && token_type?(field[1], :@ivar) && static_data_value?(node[2])
     end
 
     def empty_method_parameters?(node)
@@ -1456,28 +1427,23 @@ module ReactOnRails
       statements if statements.is_a?(Array)
     end
 
-    def ast_method_call_count(node, method_name)
-      return 0 unless node.is_a?(Array)
-
-      count =
-        case node.first
-        when :command, :fcall, :vcall
-          token_named?(node[1], method_name) ? 1 : 0
-        when :call, :command_call
-          token_named?(node[3], method_name) ? 1 : 0
-        else
-          0
-        end
-      children = node.first.is_a?(Symbol) ? node.drop(1) : node
-      count + children.sum { |child| ast_method_call_count(child, method_name) }
-    end
-
     def erb_output_helper?(content, helper_name)
       content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
-        ripper_statements(expression).any? do |statement|
-          ast_method_call_count(statement, helper_name).positive?
-        end
+        statements = ripper_statements(expression)
+        statements.one? && direct_unqualified_helper_call?(statements.first, helper_name)
       end
+    end
+
+    def erb_output_helper_mentioned?(content, helper_name)
+      content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).any? do |(expression)|
+        Ripper.lex(expression).any? { |(_position, event, token)| event == :on_ident && token == helper_name }
+      end
+    end
+
+    def direct_unqualified_helper_call?(node, helper_name)
+      return token_named?(node[1], helper_name) if ast_node?(node, :vcall) || ast_node?(node, :command)
+
+      ast_node?(node, :method_add_arg) && fcall_named?(node[1], helper_name)
     end
 
     def uncommented_template_content(content)
@@ -1494,7 +1460,11 @@ module ReactOnRails
     end
 
     def statically_auto_loaded_component?(arguments)
-      component_option = top_level_boolean_keyword(arguments.drop(1), "auto_load_bundle")
+      options = static_component_options(arguments.drop(1))
+      return false unless options
+      return static_global_auto_load_bundle == true if options == :omitted
+
+      component_option = static_boolean_keyword(options, "auto_load_bundle")
       return component_option == true unless component_option == :omitted
 
       static_global_auto_load_bundle == true
@@ -1557,11 +1527,7 @@ module ReactOnRails
       parts.map { |part| part[1] }.join
     end
 
-    def top_level_boolean_keyword(arguments, keyword)
-      associations = static_hash_associations(arguments.last)
-      return :omitted unless associations
-      return unless associations.all? { |association| static_label_association?(association) }
-
+    def static_boolean_keyword(associations, keyword)
       matches = associations.select do |association|
         static_label_association?(association, "#{keyword}:")
       end
@@ -1571,11 +1537,69 @@ module ReactOnRails
       static_boolean_value(matches.first[2])
     end
 
+    def static_component_options(arguments)
+      return :omitted if arguments.empty?
+      return unless arguments.one?
+
+      associations = static_hash_associations(arguments.first)
+      associations if associations&.all? { |association| static_data_association?(association) }
+    end
+
+    def static_data_association?(node)
+      static_label_association?(node) && static_data_value?(node[2])
+    end
+
+    def static_data_value?(node)
+      return true if static_scalar_value?(node)
+
+      case node&.first
+      when :array
+        static_data_array?(node[1])
+      when :hash
+        static_data_hash?(node)
+      when :symbol_literal
+        static_symbol_literal?(node)
+      when :unary
+        static_numeric_unary_literal?(node)
+      else
+        false
+      end
+    end
+
+    def static_data_array?(values)
+      values.nil? || (values.is_a?(Array) && values.all? { |value| static_data_value?(value) })
+    end
+
+    def static_data_hash?(node)
+      associations = static_hash_associations(node)
+      associations&.all? { |association| static_data_association?(association) }
+    end
+
+    def static_symbol_literal?(node)
+      symbol = node[1] if ast_node?(node, :symbol_literal)
+      token = symbol[1] if ast_node?(symbol, :symbol)
+      token_type?(token, :@ident) || token_type?(token, :@op)
+    end
+
+    def static_numeric_unary_literal?(node)
+      %i[+@ -@].include?(node[1]) && (token_type?(node[2], :@int) || token_type?(node[2], :@float))
+    end
+
+    def static_scalar_value?(node)
+      return true unless static_string_value(node).nil?
+      return true if token_type?(node, :@int) || token_type?(node, :@float)
+
+      token = node[1] if ast_node?(node, :var_ref)
+      token_type?(token, :@ivar) || (token_type?(token, :@kw) && %w[true false nil].include?(token[1]))
+    end
+
     def static_hash_associations(node)
       return node[1] if ast_node?(node, :bare_assoc_hash)
       return unless ast_node?(node, :hash)
 
       association_list = node[1]
+      return [] unless association_list
+
       association_list[1] if ast_node?(association_list, :assoclist_from_args)
     end
 
@@ -1601,21 +1625,21 @@ module ReactOnRails
 
       configure_block = configure_blocks.first
       config_name = configure_block_parameter_name(configure_block)
-      statements = static_body_statements(configure_block.dig(2, 2))
+      block_body = configure_block.dig(2, 2)
+      statements = static_body_statements(block_body)
       return unless config_name && statements
+      return unless ast_identifier_count(block_body, setting_name) == 1
 
-      assignments = static_config_assignments(statements, config_name, setting_name)
+      assignments = statements.select { |statement| config_assignment?(statement, config_name, setting_name) }
       static_boolean_value(assignments.first[2]) if assignments.one?
     end
 
-    def static_config_assignments(node, config_name, setting_name)
-      return [] unless node.is_a?(Array)
+    def ast_identifier_count(node, identifier)
+      return 0 unless node.is_a?(Array)
 
-      assignments = config_assignment?(node, config_name, setting_name) ? [node] : []
+      count = token_named?(node, identifier) ? 1 : 0
       children = node.first.is_a?(Symbol) ? node.drop(1) : node
-      assignments + children.flat_map do |child|
-        static_config_assignments(child, config_name, setting_name)
-      end
+      count + children.sum { |child| ast_identifier_count(child, identifier) }
     end
 
     def configure_block_parameter_name(node)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1282,6 +1282,7 @@ module ReactOnRails
 
     def check_unflushed_auto_loaded_component_css(layout_name, content, ambiguous_commented_erb: false)
       return if ambiguous_commented_erb
+      return if separate_erb_control_flow?(content)
       return unless erb_output_helper?(content, "javascript_pack_tag")
       return if erb_helper_mentioned?(content, "render")
 

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1590,10 +1590,10 @@ module ReactOnRails
 
     def auto_loaded_component_arguments(content)
       expressions = content.scan(ERB_OUTPUT_EXPRESSION_PATTERN).map(&:first)
-      hash_assignments = content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).map(&:first)
+      assignments = content.scan(ERB_NON_OUTPUT_EXPRESSION_PATTERN).map(&:first)
       component_arguments = expressions.filter_map { |expression| static_react_component_arguments(expression) }
       component_arguments.concat(
-        hash_assignments.filter_map { |expression| static_react_component_hash_assignment_arguments(expression) }
+        assignments.filter_map { |expression| static_react_component_assignment_arguments(expression) }
       )
     end
 
@@ -1627,7 +1627,7 @@ module ReactOnRails
       end.first
     end
 
-    def static_react_component_hash_assignment_arguments(expression)
+    def static_react_component_assignment_arguments(expression)
       statements = ripper_statements(expression)
       return unless statements.one?
 
@@ -1637,7 +1637,9 @@ module ReactOnRails
       field = assignment[1]
       return unless ast_node?(field, :var_field) && token_type?(field[1], :@ident)
 
-      static_named_component_arguments(assignment[2], "react_component_hash")
+      %w[react_component react_component_hash].filter_map do |helper_name|
+        static_named_component_arguments(assignment[2], helper_name)
+      end.first
     end
 
     def static_named_component_arguments(node, helper_name)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -2317,6 +2317,39 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when public_send command syntax uses an arbitrary receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/static_dispatch.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= object.public_send :stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/dynamic_dispatch.html.erb" => <<~ERB,
+            <% helper_name = :stylesheet_pack_tag %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= object.public_send helper_name %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/unrelated_dispatch.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= object.public_send :content_tag, :div %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed for static or dynamic helper dispatch but not an unrelated static method" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("unrelated_dispatch", "generated/StyledComponent"))
+        )
+      end
+    end
+
     {
       "a concatenated public_send name" => '<%= public_send("stylesheet_" + "pack_tag") %>',
       "a variable send name" => "<%= send(pack_helper_name) %>",

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -2054,22 +2054,154 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
-    context "when javascript_pack_tag is nested in an eagerly evaluated helper argument" do
+    context "when JavaScript helper output is direct or nested" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
         stub_layouts(
-          "app/views/layouts/application.html.erb" => <<~ERB
+          "app/views/layouts/direct.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/direct_named.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag "application" %>
+          ERB
+          "app/views/layouts/direct_parenthesized.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag("application") %>
+          ERB
+          "app/views/layouts/exact_self.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag %>
+          ERB
+          "app/views/layouts/exact_self_parenthesized.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag() %>
+          ERB
+          "app/views/layouts/exact_self_named.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag("application") %>
+          ERB
+          "app/views/layouts/safe_join.html.erb" => <<~ERB,
             <%= react_component("StyledComponent", auto_load_bundle: true) %>
             <%= safe_join([javascript_pack_tag]) %>
+          ERB
+          "app/views/layouts/content_for.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% content_for :head do %>
+              <%= javascript_pack_tag %>
+            <% end %>
+          ERB
+          "app/views/layouts/discarded.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% javascript_pack_tag %>
+          ERB
+          "app/views/layouts/generic_wrapper.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= content_tag(:div, javascript_pack_tag) %>
+          ERB
+          "app/views/layouts/array.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= [javascript_pack_tag] %>
+          ERB
+          "app/views/layouts/hash.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= { pack: javascript_pack_tag } %>
+          ERB
+          "app/views/layouts/nested_self.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= safe_join([self.javascript_pack_tag]) %>
+          ERB
+          "app/views/layouts/reflective.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= public_send(:javascript_pack_tag) %>
+          ERB
+          "app/views/layouts/dynamic.html.erb" => <<~ERB
+            <% pack_helper_name = :javascript_pack_tag %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= safe_join([public_send(pack_helper_name)]) %>
           ERB
         )
       end
 
-      it "recognizes the nested JavaScript call as a proven flush" do
+      it "proves response emission only for top-level direct helper calls" do
         doctor.send(:check_layout_files)
 
-        expect(checker.messages).to include(
-          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("direct", "generated/StyledComponent")),
+          hash_including(content: a_string_including("direct_named", "generated/StyledComponent")),
+          hash_including(content: a_string_including("direct_parenthesized", "generated/StyledComponent")),
+          hash_including(content: a_string_including("exact_self", "generated/StyledComponent")),
+          hash_including(content: a_string_including("exact_self_parenthesized", "generated/StyledComponent")),
+          hash_including(content: a_string_including("exact_self_named", "generated/StyledComponent"))
+        )
+      end
+    end
+
+    context "when non-output ERB may bind the JavaScript helper name as a local" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/shadow_before.html.erb" => <<~ERB,
+            <% javascript_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/shadow_conditional.html.erb" => <<~ERB,
+            <% javascript_pack_tag = "shadow" if condition %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/shadow_after.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+            <% javascript_pack_tag = "shadow" %>
+          ERB
+          "app/views/layouts/block_local.html.erb" => <<~ERB,
+            <% ["shadow"].each { |javascript_pack_tag| nil } %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/exact_self_after_shadow.html.erb" => <<~ERB,
+            <% javascript_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag %>
+          ERB
+          "app/views/layouts/unrelated_local.html.erb" => <<~ERB,
+            <% other_pack_tag = "javascript_pack_tag" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/ivar_decoy.html.erb" => <<~ERB,
+            <% @javascript_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/string_decoy.html.erb" => <<~ERB,
+            <% label = "javascript_pack_tag = shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/comment_decoy.html.erb" => <<~ERB
+            <%# javascript_pack_tag = "shadow" %>
+            <!-- <% javascript_pack_tag = "shadow" %> -->
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails bare calls closed but preserves exact-self and non-binding evidence" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("exact_self_after_shadow", "generated/StyledComponent")),
+          hash_including(content: a_string_including("unrelated_local", "generated/StyledComponent")),
+          hash_including(content: a_string_including("ivar_decoy", "generated/StyledComponent")),
+          hash_including(content: a_string_including("string_decoy", "generated/StyledComponent")),
+          hash_including(content: a_string_including("comment_decoy", "generated/StyledComponent"))
         )
       end
     end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1328,6 +1328,26 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when react_component auto-loads CSS from a direct non-output local assignment" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <% component_html = react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns because invoking the exact helper eagerly queues the component bundle" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
     context "when react_component_hash auto-loads CSS from its documented assignment form" do
       before do
         stub_manifest_stylesheets("generated/HelmetComponent", ["/packs/generated/HelmetComponent-a1b2c3.css"])

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1316,6 +1316,43 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when valid raw-output ERB tags wrap component and pack helpers" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/raw_missing.html.erb" => <<~ERB,
+            <%== react_component("StyledComponent", auto_load_bundle: true) %>
+            <%== javascript_pack_tag %>
+          ERB
+          "app/views/layouts/raw_flushed.html.erb" => <<~ERB,
+            <%== react_component("StyledComponent", auto_load_bundle: true) %>
+            <%== stylesheet_pack_tag %>
+            <%== javascript_pack_tag %>
+          ERB
+          "app/views/layouts/raw_decoys.html.erb" => <<~ERB
+            <%%== react_component("StyledComponent", auto_load_bundle: true) %>
+            <%%== javascript_pack_tag %>
+            <!-- <%== react_component("StyledComponent", auto_load_bundle: true) %> -->
+            <!-- <%== stylesheet_pack_tag %> -->
+            <!-- <%== javascript_pack_tag %> -->
+          ERB
+        )
+      end
+
+      it "uses one output grammar while excluding escaped and commented raw tags" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("raw_missing", "generated/StyledComponent"))
+        )
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ✅ raw_flushed: has both stylesheet_pack_tag and javascript_pack_tag"),
+          hash_including(type: :info, content: "  ℹ️  raw_decoys: no pack tags found")
+        )
+      end
+    end
+
     context "when a template uses an ISO-8859-1 coding header and source bytes" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -2243,6 +2280,39 @@ RSpec.describe ReactOnRails::Doctor do
 
         expect(checker.messages).to include(
           hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
+    context "when public_send command syntax uses the exact self receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/static_dispatch.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.public_send :stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/dynamic_dispatch.html.erb" => <<~ERB,
+            <% helper_name = :stylesheet_pack_tag %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.public_send helper_name %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/unrelated_dispatch.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.public_send :content_tag, :div %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed for static or dynamic helper dispatch but not an unrelated static method" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("unrelated_dispatch", "generated/StyledComponent"))
         )
       end
     end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1289,8 +1289,8 @@ RSpec.describe ReactOnRails::Doctor do
             <%= react_component("StyledComponent", props: { card: { title: "Hello" } }, prerender: false, auto_load_bundle: true) %>
             <%# stylesheet_pack_tag %>
             <%# public_send("stylesheet_" + "pack_tag") %>
-            <!-- <%= stylesheet_pack_tag %> -->
-            <!-- <%= public_send(pack_helper_name) %> -->
+            <!-- stylesheet_pack_tag -->
+            <!-- <%%= public_send(pack_helper_name) %> -->
             <p>stylesheet_pack_tag is not configured here</p>
             <%= javascript_pack_tag %>
           ERB
@@ -2047,6 +2047,63 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when HTML comments contain executable ERB" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/commented_binding.html.erb" => <<~ERB,
+            <!-- <% stylesheet_pack_tag = "shadow" %> -->
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/erb_comment.html.erb" => <<~ERB,
+            <%# stylesheet_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/pure_html_comment.html.erb" => <<~ERB,
+            <!-- stylesheet_pack_tag = "shadow" -->
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/escaped_erb.html.erb" => <<~ERB,
+            <!-- <%% stylesheet_pack_tag = "shadow" %> -->
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/commented_css_output.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <!-- <%= stylesheet_pack_tag %> -->
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/commented_js_output.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <!-- <%= javascript_pack_tag %> -->
+          ERB
+          "app/views/layouts/overlapping_comment.html.erb" => <<~ERB
+            <!<!-- spacer -->-- <% stylesheet_pack_tag = "shadow" %> -->
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails the targeted proof closed without treating browser-comment output as active" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("erb_comment", "generated/StyledComponent")),
+          hash_including(content: a_string_including("pure_html_comment", "generated/StyledComponent")),
+          hash_including(content: a_string_including("escaped_erb", "generated/StyledComponent"))
+        )
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ℹ️  commented_css_output: has javascript_pack_tag"),
+          hash_including(type: :info, content: "  ℹ️  commented_js_output: no pack tags found")
+        )
+      end
+    end
+
     context "when the JavaScript flush helper appears only in template comments" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -2233,7 +2290,6 @@ RSpec.describe ReactOnRails::Doctor do
           ERB
           "app/views/layouts/comment_decoy.html.erb" => <<~ERB
             <%# javascript_pack_tag = "shadow" %>
-            <!-- <% javascript_pack_tag = "shadow" %> -->
             <%= react_component("StyledComponent", auto_load_bundle: true) %>
             <%= javascript_pack_tag %>
           ERB
@@ -2362,6 +2418,35 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when active ERB binds the stylesheet helper name as a local" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/shadowed.html.erb" => <<~ERB,
+            <% stylesheet_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/exact_self.html.erb" => <<~ERB
+            <% stylesheet_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not treat a shadowed bare call as CSS but preserves exact-self evidence" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("shadowed", "generated/StyledComponent")),
+          hash_including(type: :info, content: "  ✅ exact_self: has both stylesheet_pack_tag and javascript_pack_tag")
+        )
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -343,6 +343,39 @@ RSpec.describe ReactOnRails::Doctor do
       expect(checks["environment_prerequisites"]["fix_command"]).to be_nil
     end
 
+    it "routes layout warnings to configuration analysis with layout remediation" do
+      routing_doctor = described_class.new(format: :json)
+      checker = routing_doctor.instance_variable_get(:@checker)
+      routed_methods = %i[check_key_files check_configuration_details]
+      described_class::CHECK_SECTIONS.each do |section|
+        next if routed_methods.include?(section[:method])
+
+        allow(routing_doctor).to receive(section[:method])
+      end
+
+      allow(File).to receive(:exist?).and_return(true)
+      allow(routing_doctor).to receive_messages(
+        resolved_webpack_config_path: "config/webpack",
+        check_server_rendering_engine: nil,
+        check_shakapacker_configuration_details: nil,
+        check_react_on_rails_configuration_details: nil,
+        check_server_bundle_prerender_consistency: nil
+      )
+      expect(routing_doctor).to receive(:check_layout_files).once do
+        checker.add_warning("Auto-loaded component CSS is not flushed")
+      end
+
+      checks = run_and_parse_json(routing_doctor)["checks"].to_h { |check| [check["id"], check] }
+
+      expect(checks["key_configuration_files"]["status"]).to eq("pass")
+      expect(checks["configuration_analysis"]).to include(
+        "status" => "warn",
+        "message" => "Auto-loaded component CSS is not flushed"
+      )
+      expect(checks["configuration_analysis"].dig("remediation", "files")).to include("app/views/layouts")
+      expect(checks["configuration_analysis"].dig("remediation", "prompt")).to include("app/views/layouts")
+    end
+
     it "keeps checks and remediation output deterministic" do
       messages = { "testing_setup" => [{ type: :warning, content: "No test helper" }] }
       first_doctor = described_class.new(format: :json)
@@ -2139,7 +2172,7 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
-    context "when non-output ERB may bind the JavaScript helper name as a local" do
+    context "when active ERB may bind the JavaScript helper name as a local" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
         stub_layouts(
@@ -2150,6 +2183,16 @@ RSpec.describe ReactOnRails::Doctor do
           ERB
           "app/views/layouts/shadow_conditional.html.erb" => <<~ERB,
             <% javascript_pack_tag = "shadow" if condition %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/output_shadow.html.erb" => <<~ERB,
+            <%= javascript_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/raw_output_shadow.html.erb" => <<~ERB,
+            <%== javascript_pack_tag = "shadow" %>
             <%= react_component("StyledComponent", auto_load_bundle: true) %>
             <%= javascript_pack_tag %>
           ERB
@@ -2165,6 +2208,11 @@ RSpec.describe ReactOnRails::Doctor do
           ERB
           "app/views/layouts/exact_self_after_shadow.html.erb" => <<~ERB,
             <% javascript_pack_tag = "shadow" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag %>
+          ERB
+          "app/views/layouts/exact_self_after_output_shadow.html.erb" => <<~ERB,
+            <%= javascript_pack_tag = "shadow" %>
             <%= react_component("StyledComponent", auto_load_bundle: true) %>
             <%= self.javascript_pack_tag %>
           ERB
@@ -2198,6 +2246,7 @@ RSpec.describe ReactOnRails::Doctor do
         warning_messages = checker.messages.select { |message| message[:type] == :warning }
         expect(warning_messages).to contain_exactly(
           hash_including(content: a_string_including("exact_self_after_shadow", "generated/StyledComponent")),
+          hash_including(content: a_string_including("exact_self_after_output_shadow", "generated/StyledComponent")),
           hash_including(content: a_string_including("unrelated_local", "generated/StyledComponent")),
           hash_including(content: a_string_including("ivar_decoy", "generated/StyledComponent")),
           hash_including(content: a_string_including("string_decoy", "generated/StyledComponent")),

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -2229,6 +2229,196 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when nested Ruby scopes use pack-helper local names" do
+      let(:scoped_binding_expressions) do
+        {
+          "block_parameter" => "values.each { |%<helper>s| %<helper>s }",
+          "block_local" => "values.each { |; %<helper>s| %<helper>s = 'shadow' }",
+          "block_assignment" => "values.each { %<helper>s = 'shadow' }",
+          "lambda_parameter" => "->(%<helper>s) { %<helper>s }",
+          "lambda_assignment" => "-> { %<helper>s = 'shadow' }"
+        }
+      end
+
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        pack_types = %w[stylesheet javascript]
+        layouts = scoped_binding_expressions.each_with_object({}) do |(scope_name, expression), result|
+          pack_types.each do |pack_type|
+            helper_name = "#{pack_type}_pack_tag"
+            javascript_flush = "<%= javascript_pack_tag %>" if pack_type == "stylesheet"
+            result["app/views/layouts/#{pack_type}_#{scope_name}.html.erb"] = <<~ERB
+              <%= #{format(expression, helper: helper_name)} %>
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+              <%= #{helper_name} %>
+              #{javascript_flush}
+            ERB
+          end
+        end
+        layouts["app/views/layouts/stylesheet_nested_def.html.erb"] = <<~ERB
+          <% def scoped_helper(stylesheet_pack_tag); stylesheet_pack_tag = 'shadow'; end %>
+          <%= react_component("StyledComponent", auto_load_bundle: true) %>
+          <%= stylesheet_pack_tag %>
+          <%= javascript_pack_tag %>
+        ERB
+        layouts["app/views/layouts/javascript_nested_def.html.erb"] = <<~ERB
+          <% def scoped_helper(javascript_pack_tag); javascript_pack_tag = 'shadow'; end %>
+          <%= react_component("StyledComponent", auto_load_bundle: true) %>
+          <%= javascript_pack_tag %>
+        ERB
+        stub_layouts(layouts)
+      end
+
+      it "does not let nested-scope bindings shadow later template helper calls" do
+        doctor.send(:check_layout_files)
+
+        expected_warnings = scoped_binding_expressions.keys.map do |scope_name|
+          hash_including(content: a_string_including("javascript_#{scope_name}", "generated/StyledComponent"))
+        end
+        expected_css_info = scoped_binding_expressions.keys.map do |scope_name|
+          hash_including(
+            type: :info,
+            content: "  ✅ stylesheet_#{scope_name}: has both stylesheet_pack_tag and javascript_pack_tag"
+          )
+        end
+        expected_css_info << hash_including(
+          type: :info,
+          content: "  ✅ stylesheet_nested_def: has both stylesheet_pack_tag and javascript_pack_tag"
+        )
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to match_array(expected_warnings)
+        expect(checker.messages).to include(*expected_css_info)
+        expect(
+          doctor.send(
+            :erb_local_binding?,
+            "<% def scoped_helper(stylesheet_pack_tag); stylesheet_pack_tag = 'shadow'; end %>",
+            "stylesheet_pack_tag"
+          )
+        ).to be(false)
+        expect(
+          doctor.send(
+            :erb_local_binding?,
+            "<% def scoped_helper(javascript_pack_tag); javascript_pack_tag = 'shadow'; end %>",
+            "javascript_pack_tag"
+          )
+        ).to be(false)
+      end
+    end
+
+    context "when template-scope bindings coexist with explicit and nested helper syntax" do
+      let(:template_binding_expressions) do
+        {
+          "top_level" => "%<helper>s = 'shadow'",
+          "conditional" => "%<helper>s = 'shadow' if condition",
+          "for" => "for %<helper>s in values; nil; end",
+          "block_receiver" => "(%<helper>s = values).each {}"
+        }
+      end
+
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        bound_layout = lambda do |helper_name:, evidence:, javascript_flush: false, binding_expression: nil|
+          binding_expression ||= "#{helper_name} = 'shadow'"
+          flush = "<%= javascript_pack_tag %>" if javascript_flush
+          <<~ERB
+            <%= #{binding_expression} %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= #{evidence} %>
+            #{flush}
+          ERB
+        end
+
+        layouts = {
+          "app/views/layouts/css_nested_content_for.html.erb" => bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: "content_for(:head, stylesheet_pack_tag)",
+            javascript_flush: true
+          ),
+          "app/views/layouts/css_nested_array.html.erb" => bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: "[stylesheet_pack_tag]", javascript_flush: true
+          ),
+          "app/views/layouts/js_nested_content_for.html.erb" => bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: "content_for(:head, javascript_pack_tag)"
+          ),
+          "app/views/layouts/js_nested_array.html.erb" => bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: "[javascript_pack_tag]"
+          ),
+          "app/views/layouts/css_empty_parens.html.erb" => bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: "stylesheet_pack_tag()", javascript_flush: true
+          ),
+          "app/views/layouts/css_named_parens.html.erb" => bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: 'stylesheet_pack_tag("application")',
+            javascript_flush: true
+          ),
+          "app/views/layouts/css_command.html.erb" => bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: 'stylesheet_pack_tag "application"',
+            javascript_flush: true
+          ),
+          "app/views/layouts/css_exact_self.html.erb" => bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: "self.stylesheet_pack_tag", javascript_flush: true
+          ),
+          "app/views/layouts/js_empty_parens.html.erb" => bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: "javascript_pack_tag()"
+          ),
+          "app/views/layouts/js_named_parens.html.erb" => bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: 'javascript_pack_tag("application")'
+          ),
+          "app/views/layouts/js_command.html.erb" => bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: 'javascript_pack_tag "application"'
+          ),
+          "app/views/layouts/js_exact_self.html.erb" => bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: "self.javascript_pack_tag"
+          ),
+          "app/views/layouts/css_dynamic_reflection.html.erb" => bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: "public_send(pack_helper_name)",
+            javascript_flush: true,
+            binding_expression: "stylesheet_pack_tag = 'shadow'; pack_helper_name = :stylesheet_pack_tag"
+          ),
+          "app/views/layouts/js_dynamic_reflection.html.erb" => bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: "public_send(pack_helper_name)",
+            binding_expression: "javascript_pack_tag = 'shadow'; pack_helper_name = :javascript_pack_tag"
+          )
+        }
+        template_binding_expressions.each do |binding_name, binding_expression|
+          layouts["app/views/layouts/css_#{binding_name}_binding.html.erb"] = bound_layout.call(
+            helper_name: "stylesheet_pack_tag", evidence: "stylesheet_pack_tag", javascript_flush: true,
+            binding_expression: format(binding_expression, helper: "stylesheet_pack_tag")
+          )
+          layouts["app/views/layouts/js_#{binding_name}_binding.html.erb"] = bound_layout.call(
+            helper_name: "javascript_pack_tag", evidence: "javascript_pack_tag",
+            binding_expression: format(binding_expression, helper: "javascript_pack_tag")
+          )
+        end
+        stub_layouts(layouts)
+      end
+
+      it "ignores only bound bare vcalls while preserving explicit and ambiguous evidence" do
+        doctor.send(:check_layout_files)
+
+        warning_layouts = %w[
+          css_nested_content_for css_nested_array
+          js_empty_parens js_named_parens js_command js_exact_self
+          css_top_level_binding css_conditional_binding css_for_binding css_block_receiver_binding
+        ]
+        expected_warnings = warning_layouts.map do |layout_name|
+          hash_including(content: a_string_including(layout_name, "generated/StyledComponent"))
+        end
+        css_evidence_layouts = %w[
+          css_empty_parens css_named_parens css_command css_exact_self css_dynamic_reflection
+        ]
+        expected_css_info = css_evidence_layouts.map do |layout_name|
+          hash_including(
+            type: :info,
+            content: "  ✅ #{layout_name}: has both stylesheet_pack_tag and javascript_pack_tag"
+          )
+        end
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to match_array(expected_warnings)
+        expect(checker.messages).to include(*expected_css_info)
+      end
+    end
+
     context "when active ERB may bind the JavaScript helper name as a local" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -2258,7 +2448,7 @@ RSpec.describe ReactOnRails::Doctor do
             <%= javascript_pack_tag %>
             <% javascript_pack_tag = "shadow" %>
           ERB
-          "app/views/layouts/block_local.html.erb" => <<~ERB,
+          "app/views/layouts/block_parameter.html.erb" => <<~ERB,
             <% ["shadow"].each { |javascript_pack_tag| nil } %>
             <%= react_component("StyledComponent", auto_load_bundle: true) %>
             <%= javascript_pack_tag %>
@@ -2306,7 +2496,8 @@ RSpec.describe ReactOnRails::Doctor do
           hash_including(content: a_string_including("unrelated_local", "generated/StyledComponent")),
           hash_including(content: a_string_including("ivar_decoy", "generated/StyledComponent")),
           hash_including(content: a_string_including("string_decoy", "generated/StyledComponent")),
-          hash_including(content: a_string_including("comment_decoy", "generated/StyledComponent"))
+          hash_including(content: a_string_including("comment_decoy", "generated/StyledComponent")),
+          hash_including(content: a_string_including("block_parameter", "generated/StyledComponent"))
         )
       end
     end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -2983,6 +2983,64 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when an implicit view's named layout has separate ERB control flow around pack helpers" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/conditional_javascript.html.erb" => <<~ERB,
+            <% if false %>
+              <%= javascript_pack_tag %>
+            <% end %>
+          ERB
+          "app/views/layouts/conditional_stylesheet.html.erb" => <<~ERB
+            <% if false %>
+              <%= stylesheet_pack_tag %>
+            <% end %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+        stub_controllers_and_views(
+          controllers: {
+            "app/controllers/hello_world_controller.rb" => <<~RUBY,
+              class HelloWorldController < ApplicationController
+                layout "conditional_javascript"
+
+                def index
+                end
+              end
+            RUBY
+            "app/controllers/marketing_controller.rb" => <<~RUBY
+              class MarketingController < ApplicationController
+                layout "conditional_stylesheet"
+
+                def index
+                end
+              end
+            RUBY
+          },
+          views: {
+            "app/views/hello_world/index.html.erb" =>
+              '<%= react_component("StyledComponent", auto_load_bundle: true) %>',
+            "app/views/marketing/index.html.erb" =>
+              '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+          }
+        )
+      end
+
+      it "fails the targeted proof closed without changing informational helper analysis" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ℹ️  conditional_javascript: has javascript_pack_tag"),
+          hash_including(
+            type: :info,
+            content: "  ✅ conditional_stylesheet: has both stylesheet_pack_tag and javascript_pack_tag"
+          )
+        )
+      end
+    end
+
     context "when a generated controller's implicit component view renders an uninspected partial" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1429,6 +1429,34 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when a parent layout composes its React output through a layout partial" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB,
+            <%= stylesheet_pack_tag %>
+            <%= render "layouts/react" %>
+          ERB
+          "app/views/layouts/_react.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "analyzes the parent but does not treat its partial as an independent layout" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ℹ️  application: has stylesheet_pack_tag")
+        )
+        expect(checker.messages).not_to include(
+          hash_including(content: a_string_including("_react"))
+        )
+      end
+    end
+
     context "when globally enabled auto_load_bundle loads component CSS that the React layout does not flush" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1279,6 +1279,28 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when a component-bearing layout renders an uninspected static partial" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= render "shared/navigation" %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "keeps the layout info but fails the targeted missing-CSS proof closed" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ℹ️  application: has javascript_pack_tag")
+        )
+      end
+    end
+
     context "when globally enabled auto_load_bundle loads component CSS that the React layout does not flush" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1868,6 +1890,27 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when a direct non-output stylesheet helper result is discarded" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns because the discarded helper result cannot flush CSS" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
     {
       "a false conditional" => "stylesheet_pack_tag if false",
       "an arbitrary receiver" => "object.stylesheet_pack_tag"
@@ -1894,10 +1937,11 @@ RSpec.describe ReactOnRails::Doctor do
 
     {
       "public_send with the helper name" => '<%= public_send("stylesheet_pack_tag") %>',
-      "a method alias invoked later" => <<~ERB
+      "a method alias invoked later" => <<~ERB,
         <% css_pack = method(:stylesheet_pack_tag) %>
         <%= css_pack.call %>
       ERB
+      "a public method alias invoked inline" => "<%= public_method(:stylesheet_pack_tag).call %>"
     }.each do |description, stylesheet_template|
       context "when the stylesheet helper is referenced through #{description}" do
         before do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1255,7 +1255,9 @@ RSpec.describe ReactOnRails::Doctor do
           "app/views/layouts/application.html.erb" => <<~ERB
             <%= react_component("StyledComponent", props: { card: { title: "Hello" } }, prerender: false, auto_load_bundle: true) %>
             <%# stylesheet_pack_tag %>
+            <%# public_send("stylesheet_" + "pack_tag") %>
             <!-- <%= stylesheet_pack_tag %> -->
+            <!-- <%= public_send(pack_helper_name) %> -->
             <p>stylesheet_pack_tag is not configured here</p>
             <%= javascript_pack_tag %>
           ERB
@@ -1758,6 +1760,32 @@ RSpec.describe ReactOnRails::Doctor do
         end
 
         it "fails the missing-CSS proof closed on the active ambiguous reference" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
+      end
+    end
+
+    {
+      "a concatenated public_send name" => '<%= public_send("stylesheet_" + "pack_tag") %>',
+      "a variable send name" => "<%= send(pack_helper_name) %>",
+      "a variable __send__ name" => "<%= __send__(pack_helper_name) %>",
+      "a variable method name" => "<%= method(pack_helper_name).call %>"
+    }.each do |description, stylesheet_template|
+      context "when the stylesheet helper may be dispatched through #{description}" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+              #{stylesheet_template}
+              <%= javascript_pack_tag %>
+            ERB
+          )
+        end
+
+        it "fails the missing-CSS proof closed on active reflective dispatch" do
           doctor.send(:check_layout_files)
 
           expect(checker.warnings?).to be(false)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1182,12 +1182,84 @@ RSpec.describe ReactOnRails::Doctor do
 
   describe "#check_layout_files" do
     let(:checker) { doctor.instance_variable_get(:@checker) }
+    let(:manifest_directory) { Dir.mktmpdir }
+    let(:manifest_path) { Pathname.new(manifest_directory).join("manifest.json") }
+
+    after { FileUtils.remove_entry(manifest_directory) }
 
     def stub_layouts(layouts)
+      allow(File).to receive(:read).and_call_original
       allow(Dir).to receive(:glob).with("app/views/layouts/**/*.erb").and_return(layouts.keys)
       layouts.each do |path, content|
         allow(File).to receive(:exist?).with(path).and_return(true)
         allow(File).to receive(:read).with(path).and_return(content)
+      end
+    end
+
+    def stub_manifest_stylesheets(entrypoint, stylesheets)
+      File.write(
+        manifest_path,
+        JSON.generate(
+          "entrypoints" => {
+            entrypoint => { "assets" => { "js" => ["/packs/#{entrypoint}.js"], "css" => stylesheets } }
+          }
+        )
+      )
+      shakapacker_config = instance_double(Shakapacker::Configuration, manifest_path:)
+      allow(Shakapacker).to receive(:config).and_return(shakapacker_config)
+    end
+
+    context "when a component-level auto-loaded entrypoint emits CSS that the React layout does not flush" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns once and names the generated entrypoint and emitted stylesheet asset" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(
+            content: a_string_including(
+              "generated/StyledComponent",
+              "/packs/generated/StyledComponent-a1b2c3.css"
+            )
+          )
+        )
+      end
+    end
+
+    context "when globally enabled auto_load_bundle loads component CSS that the React layout does not flush" do
+      before do
+        runtime_config = instance_double(ReactOnRails::Configuration, auto_load_bundle: true)
+        allow(doctor).to receive(:react_on_rails_runtime_configuration).and_return(runtime_config)
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent") %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns once and names the generated entrypoint and emitted stylesheet asset" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(
+            content: a_string_including(
+              "generated/StyledComponent",
+              "/packs/generated/StyledComponent-a1b2c3.css"
+            )
+          )
+        )
       end
     end
 
@@ -1210,8 +1282,12 @@ RSpec.describe ReactOnRails::Doctor do
 
     context "when a layout is JavaScript-pack only" do
       before do
+        stub_manifest_stylesheets("generated/PlainComponent", [])
         stub_layouts(
-          "app/views/layouts/application.html.erb" => %(<%= javascript_pack_tag "application" %>)
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("PlainComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag "application" %>
+          ERB
         )
       end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1996,6 +1996,24 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when removing one HTML comment exposes an overlapping outer comment" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <!<!-- spacer -->-- <%= react_component("StyledComponent", auto_load_bundle: true) %> -->
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "removes comments to a fixed point before scanning component evidence" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when the JavaScript flush helper appears only in template comments" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -2227,6 +2227,61 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when exact-self stylesheet calls appear in non-output ERB" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/discarded_bare.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% self.stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/discarded_parenthesized.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% self.stylesheet_pack_tag() %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/discarded_command.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% self.stylesheet_pack_tag "application" %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/discarded_named_args.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% self.stylesheet_pack_tag(media: "all") %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/emitted.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/nested.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% safe_join([self.stylesheet_pack_tag]) %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/reflective.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% self.public_send(:stylesheet_pack_tag) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns only when a proven top-level helper result is discarded" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("discarded_bare", "generated/StyledComponent")),
+          hash_including(content: a_string_including("discarded_parenthesized", "generated/StyledComponent")),
+          hash_including(content: a_string_including("discarded_command", "generated/StyledComponent")),
+          hash_including(content: a_string_including("discarded_named_args", "generated/StyledComponent"))
+        )
+      end
+    end
+
     {
       "a false conditional" => "stylesheet_pack_tag if false",
       "an arbitrary receiver" => "object.stylesheet_pack_tag"

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1721,6 +1721,26 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when short-circuit punctuation spans separate ERB tags around a component" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <% false && ( %>
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% ) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed because the component's reachability is unresolved" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when auto-loaded component calls appear only in template comments" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -2582,6 +2602,30 @@ RSpec.describe ReactOnRails::Doctor do
             )
           )
         )
+      end
+    end
+
+    context "when the manifest CSS list mixes legacy strings and valid SRI asset objects" do
+      before do
+        stub_manifest_stylesheets(
+          "generated/StyledComponent",
+          [
+            "/packs/generated/StyledComponent-a1b2c3.css",
+            { "src" => "/packs/generated/StyledComponent-d4e5f6.css", "integrity" => "sha384-second" }
+          ]
+        )
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed for the heterogeneous stylesheet schema" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1256,6 +1256,7 @@ RSpec.describe ReactOnRails::Doctor do
             <%= react_component("StyledComponent", props: { card: { title: "Hello" } }, prerender: false, auto_load_bundle: true) %>
             <%# stylesheet_pack_tag %>
             <!-- <%= stylesheet_pack_tag %> -->
+            <p>stylesheet_pack_tag is not configured here</p>
             <%= javascript_pack_tag %>
           ERB
         )
@@ -1460,6 +1461,47 @@ RSpec.describe ReactOnRails::Doctor do
 
           ReactOnRails.configure do |config|
             config.auto_load_bundle = true
+          end
+        RUBY
+      ],
+      [
+        "the configure block variable is passed to an unresolved method",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+            mutate(config)
+          end
+        RUBY
+      ],
+      [
+        "the setting is overridden through send",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+            config.send(:auto_load_bundle=, false)
+          end
+        RUBY
+      ],
+      [
+        "the setting is overridden through public_send",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+            config.public_send(:auto_load_bundle=, false)
+          end
+        RUBY
+      ],
+      [
+        "a conditional configure block follows the direct configure block",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+          end
+
+          if enable_override?
+            ReactOnRails.configure do |config|
+              config.auto_load_bundle = false
+            end
           end
         RUBY
       ]
@@ -1675,6 +1717,33 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    {
+      "public_send with the helper name" => '<%= public_send("stylesheet_pack_tag") %>',
+      "a method alias invoked later" => <<~ERB
+        <% css_pack = method(:stylesheet_pack_tag) %>
+        <%= css_pack.call %>
+      ERB
+    }.each do |description, stylesheet_template|
+      context "when the stylesheet helper is referenced through #{description}" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+              #{stylesheet_template}
+              <%= javascript_pack_tag %>
+            ERB
+          )
+        end
+
+        it "fails the missing-CSS proof closed on the active ambiguous reference" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
+      end
+    end
+
     context "when the component's React layout actively flushes both pack queues" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1749,6 +1818,34 @@ RSpec.describe ReactOnRails::Doctor do
             )
           )
         )
+      end
+    end
+
+    context "when the generated controller's implicit view flushes the auto-loaded component CSS" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default"
+
+              def index
+                @hello_world_props = { name: "Stranger", items: [1, true] }
+              end
+            end
+          RUBY
+          view: <<~ERB
+            <%= react_component("StyledComponent", props: @hello_world_props, prerender: true) %>
+            <%= stylesheet_pack_tag %>
+          ERB
+        )
+        stub_global_auto_load_bundle(true)
+      end
+
+      it "does not report the selected view's flushed CSS as missing" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1218,13 +1218,17 @@ RSpec.describe ReactOnRails::Doctor do
     end
 
     def stub_manifest_stylesheets(entrypoint, stylesheets)
+      stub_manifest_data(
+        "entrypoints" => {
+          entrypoint => { "assets" => { "js" => ["/packs/#{entrypoint}.js"], "css" => stylesheets } }
+        }
+      )
+    end
+
+    def stub_manifest_data(data)
       File.write(
         manifest_path,
-        JSON.generate(
-          "entrypoints" => {
-            entrypoint => { "assets" => { "js" => ["/packs/#{entrypoint}.js"], "css" => stylesheets } }
-          }
-        )
+        JSON.generate(data)
       )
       shakapacker_config = instance_double(Shakapacker::Configuration, manifest_path:)
       allow(Shakapacker).to receive(:config).and_return(shakapacker_config)
@@ -1318,6 +1322,24 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when unresolved component options follow a literal auto_load_bundle option" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true, **options) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed because the later options can override the literal" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when the global auto_load_bundle setting is dynamic" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1335,6 +1357,32 @@ RSpec.describe ReactOnRails::Doctor do
       end
 
       it "fails closed instead of inferring that auto-loading is enabled" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when a conditional write can override a literal global auto_load_bundle setting" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", props: @props) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+        stub_react_on_rails_initializer(<<~RUBY)
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+            if Rails.env.development?
+              config.auto_load_bundle = development_auto_load_bundle
+            end
+          end
+        RUBY
+      end
+
+      it "fails closed instead of trusting the earlier literal" do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
@@ -1415,6 +1463,27 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when the JavaScript pack helper name is only assigned as a local variable" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag = "literal only" %>
+          ERB
+        )
+      end
+
+      it "does not treat the assignment as a JavaScript flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ℹ️  application: no pack tags found")
+        )
+      end
+    end
+
     context "when the component's React layout actively flushes both pack queues" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1431,6 +1500,28 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the stylesheet pack helper is nested in another active helper call" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= content_for(:head, stylesheet_pack_tag) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "recognizes the nested stylesheet call as an active CSS flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ✅ application: has both stylesheet_pack_tag and javascript_pack_tag")
+        )
       end
     end
 
@@ -1614,6 +1705,29 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when the matching controller does not inherit from ApplicationController" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < Object
+              layout "react_on_rails_default"
+
+              def index
+              end
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "does not infer the generated controller association" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when a controller's basename-only layout does not name a nested layout" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1706,6 +1820,56 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when the matching controller method is private through a string argument" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default"
+
+              def index
+              end
+
+              private "index"
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "does not treat the method as a controller action" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when controller visibility has an unresolved method argument" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default"
+
+              def index
+              end
+
+              private action_name
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "fails the controller association closed" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when a layout uses javascript_pack_tag with Propshaft stylesheet_link_tag (fresh RSC app)" do
       before do
         stub_layouts(
@@ -1776,6 +1940,31 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
+      end
+    end
+
+    {
+      "the manifest root is an array" => [],
+      "the manifest entrypoints container is an array" => { "entrypoints" => [] },
+      "the manifest assets container is an array" => {
+        "entrypoints" => { "generated/StyledComponent" => { "assets" => [] } }
+      }
+    }.each do |description, manifest_data|
+      context "when #{description}" do
+        before do
+          stub_manifest_data(manifest_data)
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+              <%= javascript_pack_tag %>
+            ERB
+          )
+        end
+
+        it "fails closed without raising" do
+          expect { doctor.send(:check_layout_files) }.not_to raise_error
+          expect(checker.warnings?).to be(false)
+        end
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1306,6 +1306,72 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when react_component_hash auto-loads CSS from its documented assignment form" do
+      before do
+        stub_manifest_stylesheets("generated/HelmetComponent", ["/packs/generated/HelmetComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <% helmet_data = react_component_hash("HelmetComponent", props: @props, auto_load_bundle: true) %>
+            <%= helmet_data["componentHtml"] %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns for the statically proven hash component entrypoint" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(
+            type: :warning,
+            content: a_string_including(
+              "generated/HelmetComponent",
+              "/packs/generated/HelmetComponent-a1b2c3.css"
+            )
+          )
+        )
+      end
+    end
+
+    context "when react_component_hash is a direct output helper call" do
+      before do
+        stub_manifest_stylesheets("generated/HelmetComponent", ["/packs/generated/HelmetComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component_hash("HelmetComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns for the exact direct helper AST" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/HelmetComponent"))
+        )
+      end
+    end
+
+    context "when react_component_hash appears only as data or a dynamic dispatch target" do
+      before do
+        stub_manifest_stylesheets("generated/HelmetComponent", ["/packs/generated/HelmetComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <% helper_name = "react_component_hash" %>
+            <%= public_send(helper_name, "HelmetComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not infer a component from helper-name text" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when component-level auto_load_bundle is explicitly false while the global setting is true" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1574,6 +1640,31 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when another generated configure assignment has a dynamic RHS" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent") %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+        stub_react_on_rails_initializer(<<~RUBY)
+          ReactOnRails.configure do |config|
+            config.server_bundle_js_file = resolve_server_bundle
+            config.auto_load_bundle = true
+            config.components_subdirectory = "ror_components"
+          end
+        RUBY
+      end
+
+      it "fails closed instead of evaluating the block as static configuration" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when auto_load_bundle appears only inside component props" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1604,6 +1695,26 @@ RSpec.describe ReactOnRails::Doctor do
       end
 
       it "fails closed" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when separate ERB control tags make the component conditional" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <% if show_component? %>
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% end %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed instead of inferring that the component is reachable" do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
@@ -1669,12 +1780,33 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when javascript_pack_tag is nested in an eagerly evaluated helper argument" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= safe_join([javascript_pack_tag]) %>
+          ERB
+        )
+      end
+
+      it "recognizes the nested JavaScript call as a proven flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
     {
       "a false conditional modifier" => "javascript_pack_tag if false",
       "an arbitrary receiver" => "object.javascript_pack_tag",
       "a defined check" => "defined?(javascript_pack_tag)",
       "a short-circuited boolean expression" => "true || javascript_pack_tag",
-      "a local-variable assignment" => "pack_tag = javascript_pack_tag"
+      "a local-variable assignment" => "pack_tag = javascript_pack_tag",
+      "dynamic reflective dispatch" => "public_send(pack_helper_name)"
     }.each do |description, javascript_expression|
       context "when the JavaScript helper appears through #{description}" do
         before do
@@ -1764,6 +1896,29 @@ RSpec.describe ReactOnRails::Doctor do
 
           expect(checker.warnings?).to be(false)
         end
+      end
+    end
+
+    context "when helper-name data and unrelated reflection do not call the stylesheet helper" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <% helper_name = "stylesheet_pack_tag" %>
+            <% helper_symbol = :stylesheet_pack_tag %>
+            <%= public_send(:content_tag, :div, helper_name) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns because static data and an unrelated call are not CSS flush evidence" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
       end
     end
 
@@ -2398,6 +2553,38 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when the manifest CSS list uses Shakapacker SRI asset objects" do
+      before do
+        stub_manifest_stylesheets(
+          "generated/StyledComponent",
+          [
+            { "src" => "/packs/generated/StyledComponent-a1b2c3.css", "integrity" => "sha384-first" },
+            { "src" => "/packs/generated/StyledComponent-d4e5f6.css", "integrity" => "sha384-second" }
+          ]
+        )
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns with the normalized stylesheet asset paths" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(
+            type: :warning,
+            content: a_string_including(
+              "/packs/generated/StyledComponent-a1b2c3.css",
+              "/packs/generated/StyledComponent-d4e5f6.css"
+            )
+          )
+        )
+      end
+    end
+
     context "when the manifest CSS list contains a malformed asset value" do
       before do
         stub_manifest_stylesheets(
@@ -2416,6 +2603,33 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
+      end
+    end
+
+    {
+      "an SRI object with an empty src" => [{ "src" => "", "integrity" => "sha384-empty" }],
+      "an SRI object without src" => [{ "integrity" => "sha384-missing" }],
+      "a valid SRI object mixed with a malformed entry" => [
+        { "src" => "/packs/generated/StyledComponent-a1b2c3.css", "integrity" => "sha384-valid" },
+        { "src" => nil, "integrity" => "sha384-invalid" }
+      ]
+    }.each do |description, stylesheets|
+      context "when the manifest CSS list contains #{description}" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", stylesheets)
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+              <%= javascript_pack_tag %>
+            ERB
+          )
+        end
+
+        it "fails closed for the entire stylesheet list" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1340,6 +1340,33 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    {
+      "a dynamic options variable" => 'react_component("StyledComponent", options)',
+      "a scalar options argument" => 'react_component("StyledComponent", 42)',
+      "a method call as an option value" => 'react_component("StyledComponent", props: build_props)',
+      "a hash-rocket option" => 'react_component("StyledComponent", { "auto_load_bundle" => true })',
+      "a dynamic option key" => 'react_component("StyledComponent", { option_key => true })'
+    }.each do |description, component_call|
+      context "when #{description} is passed to react_component" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= #{component_call} %>
+              <%= javascript_pack_tag %>
+            ERB
+          )
+          stub_global_auto_load_bundle(true)
+        end
+
+        it "fails closed for an unresolved component options shape" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
+      end
+    end
+
     context "when the global auto_load_bundle setting is dynamic" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1386,6 +1413,99 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
+      end
+    end
+
+    [
+      [
+        "the only setting write has a conditional modifier",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true if enable_auto_load_bundle?
+          end
+        RUBY
+      ],
+      [
+        "the setting write is deferred through a callback",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            callback { config.auto_load_bundle = true }
+          end
+        RUBY
+      ],
+      [
+        "a deferred setting reference follows the direct write",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+            callback { config.auto_load_bundle }
+          end
+        RUBY
+      ],
+      [
+        "the setting is assigned twice directly",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+            config.auto_load_bundle = true
+          end
+        RUBY
+      ],
+      [
+        "two top-level configure blocks assign the setting",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+          end
+
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+          end
+        RUBY
+      ]
+    ].each do |description, initializer|
+      context "when #{description}" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= react_component("StyledComponent") %>
+              <%= javascript_pack_tag %>
+            ERB
+          )
+          stub_react_on_rails_initializer(initializer)
+        end
+
+        it "fails closed for an unresolved initializer shape" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
+      end
+    end
+
+    context "when unrelated direct initializer assignments surround the static setting" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent") %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+        stub_react_on_rails_initializer(<<~RUBY)
+          ReactOnRails.configure do |config|
+            config.logging_on_server = false
+            config.auto_load_bundle = true
+            config.prerender_caching = false
+          end
+        RUBY
+      end
+
+      it "still proves the direct global setting" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(true)
       end
     end
 
@@ -1484,6 +1604,77 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    {
+      "a false conditional modifier" => "javascript_pack_tag if false",
+      "an arbitrary receiver" => "object.javascript_pack_tag",
+      "a defined check" => "defined?(javascript_pack_tag)",
+      "a short-circuited boolean expression" => "true || javascript_pack_tag",
+      "a local-variable assignment" => "pack_tag = javascript_pack_tag"
+    }.each do |description, javascript_expression|
+      context "when the JavaScript helper appears through #{description}" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+              <%= #{javascript_expression} %>
+              <%= pack_tag if defined?(pack_tag) %>
+            ERB
+          )
+        end
+
+        it "does not treat ambiguous JavaScript syntax as an active flush" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
+      end
+    end
+
+    context "when a stylesheet helper result flows through a local variable" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= css_tag = stylesheet_pack_tag %>
+            <%= css_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails the missing-CSS proof closed" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    {
+      "a false conditional" => "stylesheet_pack_tag if false",
+      "an arbitrary receiver" => "object.stylesheet_pack_tag"
+    }.each do |description, stylesheet_expression|
+      context "when the stylesheet helper appears through #{description}" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+          stub_layouts(
+            "app/views/layouts/application.html.erb" => <<~ERB
+              <%= react_component("StyledComponent", auto_load_bundle: true) %>
+              <%= #{stylesheet_expression} %>
+              <%= javascript_pack_tag %>
+            ERB
+          )
+        end
+
+        it "fails the missing-CSS proof closed on ambiguous stylesheet syntax" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
+      end
+    end
+
     context "when the component's React layout actively flushes both pack queues" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1534,11 +1725,12 @@ RSpec.describe ReactOnRails::Doctor do
               layout "react_on_rails_default"
 
               def index
+                @hello_world_props = { name: "Stranger", items: [1, true] }
               end
             end
           RUBY
           view: <<~ERB
-            <%= react_component("StyledComponent", props: @props, prerender: false) %>
+            <%= react_component("StyledComponent", props: @hello_world_props, prerender: true) %>
           ERB
         )
         stub_global_auto_load_bundle(true)
@@ -1648,6 +1840,144 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
+      end
+    end
+
+    [
+      [
+        "the action is redefined",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+              @hello_world_props = { name: "First" }
+            end
+
+            def index
+              @hello_world_props = { name: "Second" }
+            end
+          end
+        RUBY
+      ],
+      [
+        "the action body calls a method",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+              @hello_world_props = build_props
+            end
+          end
+        RUBY
+      ],
+      [
+        "the action body contains control flow",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+              if condition
+                @hello_world_props = { name: "Conditional" }
+              end
+            end
+          end
+        RUBY
+      ],
+      [
+        "remove_method invalidates the action",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+            end
+
+            remove_method :index
+          end
+        RUBY
+      ],
+      [
+        "send changes the action visibility",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+            end
+
+            send(:private, "index")
+          end
+        RUBY
+      ],
+      [
+        "send performs an explicit render",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+              send(:render, :other)
+            end
+          end
+        RUBY
+      ],
+      [
+        "the action is parameterized",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index(id)
+              @hello_world_props = { id: id }
+            end
+          end
+        RUBY
+      ],
+      [
+        "unknown top-level reflection follows the action",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+            end
+
+            define_method(:other) { index }
+          end
+        RUBY
+      ],
+      [
+        "a second distinct action is declared",
+        <<~RUBY
+          class HelloWorldController < ApplicationController
+            layout "react_on_rails_default"
+
+            def index
+            end
+
+            def other
+            end
+          end
+        RUBY
+      ]
+    ].each do |description, controller_source|
+      context "when #{description}" do
+        before do
+          stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+          stub_generated_controller_flow(
+            controller: controller_source,
+            view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+          )
+        end
+
+        it "fails closed under the exact generated controller grammar" do
+          doctor.send(:check_layout_files)
+
+          expect(checker.warnings?).to be(false)
+        end
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1279,6 +1279,64 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when valid ERB closing-trim markers are used around pack helpers" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/trimmed_missing.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) -%>
+            <%= javascript_pack_tag -%>
+          ERB
+          "app/views/layouts/trimmed_flushed.html.erb" => <<~ERB,
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= stylesheet_pack_tag -%>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/trimmed_assigned.html.erb" => <<~ERB
+            <% component_html = react_component("StyledComponent", auto_load_bundle: true) -%>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "normalizes trim markers before proving component and pack-helper calls" do
+        doctor.send(:check_layout_files)
+
+        warning_messages = checker.messages.select { |message| message[:type] == :warning }
+        expect(warning_messages).to contain_exactly(
+          hash_including(content: a_string_including("trimmed_missing", "generated/StyledComponent")),
+          hash_including(content: a_string_including("trimmed_assigned", "generated/StyledComponent"))
+        )
+        expect(checker.messages).to include(
+          hash_including(
+            type: :info,
+            content: "  ✅ trimmed_flushed: has both stylesheet_pack_tag and javascript_pack_tag"
+          )
+        )
+      end
+    end
+
+    context "when a template uses an ISO-8859-1 coding header and source bytes" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        encoded_layout = <<~ERB.encode(Encoding::ISO_8859_1).force_encoding(Encoding::UTF_8)
+          # encoding: ISO-8859-1
+          <p>Café</p>
+          <%= react_component("StyledComponent", auto_load_bundle: true) %>
+          <%= javascript_pack_tag %>
+        ERB
+        stub_layouts("app/views/layouts/application.html.erb" => encoded_layout)
+      end
+
+      it "preserves static helper evidence without aborting on non-UTF-8 bytes" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
     context "when a component-bearing layout renders an uninspected static partial" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1783,6 +1841,25 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when a separate ERB return makes the component unreachable" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <% return %>
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed instead of inferring that the component is reachable" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when auto-loaded component calls appear only in template comments" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1862,6 +1939,26 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when javascript_pack_tag is called through the proven self receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "recognizes the self call as a proven JavaScript flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
     {
       "a false conditional modifier" => "javascript_pack_tag if false",
       "an arbitrary receiver" => "object.javascript_pack_tag",
@@ -1907,6 +2004,28 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_layout_files)
 
         expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when stylesheet_pack_tag is a command call through the proven self receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.stylesheet_pack_tag "application" %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "recognizes the self command call as a proven stylesheet flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ✅ application: has both stylesheet_pack_tag and javascript_pack_tag")
+        )
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1386,6 +1386,44 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when react_component is called through the proven self receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= self.react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns for the exact self helper AST" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
+    context "when react_component is called through an arbitrary receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= object.react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not infer a component from the receiver's method name" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
     context "when react_component auto-loads CSS from a direct non-output local assignment" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
@@ -1450,6 +1488,48 @@ RSpec.describe ReactOnRails::Doctor do
         expect(checker.messages).to include(
           hash_including(type: :warning, content: a_string_including("generated/HelmetComponent"))
         )
+      end
+    end
+
+    context "when react_component_hash is called through self before direct componentHtml access" do
+      before do
+        stub_manifest_stylesheets("generated/HelmetComponent", ["/packs/generated/HelmetComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= self.react_component_hash("HelmetComponent", auto_load_bundle: true)["componentHtml"] %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "warns for the exact self hash-helper and access AST" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/HelmetComponent"))
+        )
+      end
+    end
+
+    context "when react_component_hash uses an arbitrary receiver or dynamic result access" do
+      before do
+        stub_manifest_stylesheets("generated/HelmetComponent", ["/packs/generated/HelmetComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/arbitrary_receiver.html.erb" => <<~ERB,
+            <%= object.react_component_hash("HelmetComponent", auto_load_bundle: true)["componentHtml"] %>
+            <%= javascript_pack_tag %>
+          ERB
+          "app/views/layouts/dynamic_access.html.erb" => <<~ERB
+            <%= self.react_component_hash("HelmetComponent", auto_load_bundle: true)[component_key] %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not infer a component outside the exact self hash-helper and access AST" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
       end
     end
 
@@ -1959,9 +2039,30 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when parenthesized javascript_pack_tag is called through the proven self receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag() %>
+          ERB
+        )
+      end
+
+      it "recognizes the parenthesized self call as a proven JavaScript flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
     {
       "a false conditional modifier" => "javascript_pack_tag if false",
       "an arbitrary receiver" => "object.javascript_pack_tag",
+      "a parenthesized arbitrary receiver" => "object.javascript_pack_tag()",
       "a defined check" => "defined?(javascript_pack_tag)",
       "a short-circuited boolean expression" => "true || javascript_pack_tag",
       "a local-variable assignment" => "pack_tag = javascript_pack_tag",

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -2059,10 +2059,31 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when named javascript_pack_tag is called through the proven self receiver" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= self.javascript_pack_tag("application") %>
+          ERB
+        )
+      end
+
+      it "recognizes the exact self call with arguments as a proven JavaScript flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(type: :warning, content: a_string_including("generated/StyledComponent"))
+        )
+      end
+    end
+
     {
       "a false conditional modifier" => "javascript_pack_tag if false",
       "an arbitrary receiver" => "object.javascript_pack_tag",
       "a parenthesized arbitrary receiver" => "object.javascript_pack_tag()",
+      "a named parenthesized arbitrary receiver" => 'object.javascript_pack_tag("application")',
       "a defined check" => "defined?(javascript_pack_tag)",
       "a short-circuited boolean expression" => "true || javascript_pack_tag",
       "a local-variable assignment" => "pack_tag = javascript_pack_tag",

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1188,12 +1188,33 @@ RSpec.describe ReactOnRails::Doctor do
     after { FileUtils.remove_entry(manifest_directory) }
 
     def stub_layouts(layouts)
+      allow(Dir).to receive(:glob).and_call_original
+      allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:read).and_call_original
       allow(Dir).to receive(:glob).with("app/views/layouts/**/*.erb").and_return(layouts.keys)
-      layouts.each do |path, content|
+      stub_file_contents(layouts)
+    end
+
+    def stub_controllers_and_views(controllers:, views:)
+      allow(Dir).to receive(:glob).with("app/controllers/**/*_controller.rb").and_return(controllers.keys)
+      stub_file_contents(controllers.merge(views))
+    end
+
+    def stub_file_contents(files)
+      files.each do |path, content|
         allow(File).to receive(:exist?).with(path).and_return(true)
         allow(File).to receive(:read).with(path).and_return(content)
       end
+    end
+
+    def stub_generated_controller_flow(controller:, view:)
+      stub_layouts(
+        "app/views/layouts/react_on_rails_default.html.erb" => "<%= javascript_pack_tag %>\n"
+      )
+      stub_controllers_and_views(
+        controllers: { "app/controllers/hello_world_controller.rb" => controller },
+        views: { "app/views/hello_world/index.html.erb" => view }
+      )
     end
 
     def stub_manifest_stylesheets(entrypoint, stylesheets)
@@ -1209,12 +1230,28 @@ RSpec.describe ReactOnRails::Doctor do
       allow(Shakapacker).to receive(:config).and_return(shakapacker_config)
     end
 
+    def stub_global_auto_load_bundle(value)
+      stub_react_on_rails_initializer(<<~RUBY)
+        ReactOnRails.configure do |config|
+          config.auto_load_bundle = #{value}
+        end
+      RUBY
+    end
+
+    def stub_react_on_rails_initializer(content)
+      initializer_path = "config/initializers/react_on_rails.rb"
+      allow(File).to receive(:exist?).with(initializer_path).and_return(true)
+      allow(File).to receive(:read).with(initializer_path).and_return(content)
+    end
+
     context "when a component-level auto-loaded entrypoint emits CSS that the React layout does not flush" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
         stub_layouts(
           "app/views/layouts/application.html.erb" => <<~ERB
-            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= react_component("StyledComponent", props: { card: { title: "Hello" } }, prerender: false, auto_load_bundle: true) %>
+            <%# stylesheet_pack_tag %>
+            <!-- <%= stylesheet_pack_tag %> -->
             <%= javascript_pack_tag %>
           ERB
         )
@@ -1237,15 +1274,14 @@ RSpec.describe ReactOnRails::Doctor do
 
     context "when globally enabled auto_load_bundle loads component CSS that the React layout does not flush" do
       before do
-        runtime_config = instance_double(ReactOnRails::Configuration, auto_load_bundle: true)
-        allow(doctor).to receive(:react_on_rails_runtime_configuration).and_return(runtime_config)
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
         stub_layouts(
           "app/views/layouts/application.html.erb" => <<~ERB
-            <%= react_component("StyledComponent") %>
+            <%= react_component("StyledComponent", props: @props, prerender: false) %>
             <%= javascript_pack_tag %>
           ERB
         )
+        stub_global_auto_load_bundle(true)
       end
 
       it "warns once and names the generated entrypoint and emitted stylesheet asset" do
@@ -1260,6 +1296,413 @@ RSpec.describe ReactOnRails::Doctor do
             )
           )
         )
+      end
+    end
+
+    context "when component-level auto_load_bundle is explicitly false while the global setting is true" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", props: @props, auto_load_bundle: false) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+        stub_global_auto_load_bundle(true)
+      end
+
+      it "honors the component-level opt-out" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the global auto_load_bundle setting is dynamic" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", props: @props) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+        stub_react_on_rails_initializer(<<~RUBY)
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = Rails.env.development?
+          end
+        RUBY
+      end
+
+      it "fails closed instead of inferring that auto-loading is enabled" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when auto_load_bundle appears only inside component props" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", props: { auto_load_bundle: true }) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not mistake the nested key for the helper option" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the auto-loaded component name is dynamic" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component(component_name, auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when auto-loaded component calls appear only in template comments" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%# react_component("StyledComponent", auto_load_bundle: true) %>
+            <!-- <%= react_component("StyledComponent", auto_load_bundle: true) %> -->
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not treat commented calls as rendered components" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the JavaScript flush helper appears only in template comments" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%# javascript_pack_tag %>
+            <!-- <%= javascript_pack_tag %> -->
+          ERB
+        )
+      end
+
+      it "does not treat a commented helper as an active flush" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the component's React layout actively flushes both pack queues" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= stylesheet_pack_tag %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not warn" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when a generated controller's implicit view uses its named React layout" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default"
+
+              def index
+              end
+            end
+          RUBY
+          view: <<~ERB
+            <%= react_component("StyledComponent", props: @props, prerender: false) %>
+          ERB
+        )
+        stub_global_auto_load_bundle(true)
+      end
+
+      it "warns with the generated entrypoint and emitted stylesheet asset" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(
+            type: :warning,
+            content: a_string_including(
+              "react_on_rails_default",
+              "generated/StyledComponent",
+              "/packs/generated/StyledComponent-a1b2c3.css"
+            )
+          )
+        )
+      end
+    end
+
+    context "when the controller's literal layout declaration is conditional" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default" if Rails.env.development?
+
+              def index
+              end
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "does not infer a view-to-layout association" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the controller layout is selected dynamically" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout -> { "react_on_rails_default" }
+
+              def index
+              end
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "does not infer a view-to-layout association" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the controller may inherit its layout" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              def index
+              end
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "does not assume which layout renders the view" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the action explicitly renders with a layout override" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default"
+
+              def index
+                render :index, layout: "application"
+              end
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "does not associate the implicit view with the controller layout" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the component call appears only in a partial" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/react_on_rails_default.html.erb" => "<%= javascript_pack_tag %>\n"
+        )
+        stub_controllers_and_views(
+          controllers: {
+            "app/controllers/hello_world_controller.rb" => <<~RUBY
+              class HelloWorldController < ApplicationController
+                layout "react_on_rails_default"
+
+                def index
+                end
+              end
+            RUBY
+          },
+          views: {
+            "app/views/hello_world/_card.html.erb" =>
+              '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+          }
+        )
+      end
+
+      it "does not infer that the partial renders through the named layout" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the controller class cannot be associated with its path" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class OtherController < ApplicationController
+              layout "react_on_rails_default"
+
+              def index
+              end
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "fails closed" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when a controller's basename-only layout does not name a nested layout" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/admin/foo.html.erb" => "<%= javascript_pack_tag %>\n"
+        )
+        stub_controllers_and_views(
+          controllers: {
+            "app/controllers/hello_world_controller.rb" => <<~RUBY
+              class HelloWorldController < ApplicationController
+                layout "foo"
+
+                def index
+                end
+              end
+            RUBY
+          },
+          views: {
+            "app/views/hello_world/index.html.erb" =>
+              '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+          }
+        )
+      end
+
+      it "does not associate the view with the nested layout" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when a controller names the exact nested layout path" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_layouts(
+          "app/views/layouts/admin/foo.html.erb" => "<%= javascript_pack_tag %>\n"
+        )
+        stub_controllers_and_views(
+          controllers: {
+            "app/controllers/hello_world_controller.rb" => <<~RUBY
+              class HelloWorldController < ApplicationController
+                layout "admin/foo"
+
+                def index
+                end
+              end
+            RUBY
+          },
+          views: {
+            "app/views/hello_world/index.html.erb" =>
+              '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+          }
+        )
+      end
+
+      it "warns for the exact controller-view-layout association" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.messages).to include(
+          hash_including(
+            type: :warning,
+            content: a_string_including("admin/foo", "generated/StyledComponent")
+          )
+        )
+      end
+    end
+
+    context "when the matching controller method is private" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default"
+
+              private
+
+              def index
+              end
+            end
+          RUBY
+          view: '<%= react_component("StyledComponent", auto_load_bundle: true) %>'
+        )
+      end
+
+      it "does not treat the method as a controller action" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
       end
     end
 
@@ -1293,6 +1736,45 @@ RSpec.describe ReactOnRails::Doctor do
 
       it "does not emit a symmetry warning" do
         doctor.send(:check_layout_files)
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the manifest CSS list contains only an empty asset string" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", [""])
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "does not claim that the entrypoint emits CSS" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+      end
+    end
+
+    context "when the manifest CSS list contains a malformed asset value" do
+      before do
+        stub_manifest_stylesheets(
+          "generated/StyledComponent",
+          ["/packs/generated/StyledComponent-a1b2c3.css", nil]
+        )
+        stub_layouts(
+          "app/views/layouts/application.html.erb" => <<~ERB
+            <%= react_component("StyledComponent", auto_load_bundle: true) %>
+            <%= javascript_pack_tag %>
+          ERB
+        )
+      end
+
+      it "fails closed" do
+        doctor.send(:check_layout_files)
+
         expect(checker.warnings?).to be(false)
       end
     end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1504,6 +1504,27 @@ RSpec.describe ReactOnRails::Doctor do
             end
           end
         RUBY
+      ],
+      [
+        "a reflective configure call follows the direct configure block",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+          end
+
+          ReactOnRails.public_send(:configure) do |other|
+            other.auto_load_bundle = false
+          end
+        RUBY
+      ],
+      [
+        "non-assignment code follows the direct setting assignment",
+        <<~RUBY
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+            eval("config.auto_load_bundle = false")
+          end
+        RUBY
       ]
     ].each do |description, initializer|
       context "when #{description}" do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -2089,6 +2089,36 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when a generated controller's implicit component view renders an uninspected partial" do
+      before do
+        stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])
+        stub_generated_controller_flow(
+          controller: <<~RUBY,
+            class HelloWorldController < ApplicationController
+              layout "react_on_rails_default"
+
+              def index
+                @hello_world_props = { name: "Stranger", items: [1, true] }
+              end
+            end
+          RUBY
+          view: <<~ERB
+            <%= react_component("StyledComponent", props: @hello_world_props, auto_load_bundle: true) %>
+            <%= render "shared/packs" %>
+          ERB
+        )
+      end
+
+      it "fails the implicit-view missing-CSS proof closed without resolving the partial" do
+        doctor.send(:check_layout_files)
+
+        expect(checker.warnings?).to be(false)
+        expect(checker.messages).to include(
+          hash_including(type: :info, content: "  ℹ️  react_on_rails_default: has javascript_pack_tag")
+        )
+      end
+    end
+
     context "when the generated controller's implicit view flushes the auto-loaded component CSS" do
       before do
         stub_manifest_stylesheets("generated/StyledComponent", ["/packs/generated/StyledComponent-a1b2c3.css"])


### PR DESCRIPTION
## Why

`auto_load_bundle` queues both JavaScript and CSS for generated component entrypoints. If a React layout flushes `javascript_pack_tag` but omits `stylesheet_pack_tag`, generated component CSS can be silently dropped. The former symmetric pack-tag warning sometimes noticed this, but it also warned on valid hybrid Propshaft/Shakapacker layouts and was removed in #4724.

This restores only the evidence-backed signal requested by #4727. Doctor warns when static evidence proves all of the following:

- `auto_load_bundle` is effective for a literal component;
- the generated component entrypoint has a nonempty CSS asset in the compiled manifest;
- a React layout flushes JavaScript but not CSS; and
- the component is in that layout itself or in a conservatively proven generated controller → implicit view → literal layout path.

Fixes #4727.

## What changed

- Add a targeted warning naming the generated entrypoint and emitted CSS asset(s).
- Parse only canonical, direct Ruby/ERB shapes with Ripper; do not boot the Rails environment or execute application code.
- Recognize the generated initializer and explicit component-level `auto_load_bundle: true` forms, including static data options.
- Read both string and SRI-object manifest CSS schemas, while rejecting empty, mixed, or malformed evidence.
- Preserve valid hybrid, JavaScript-only, CSS-only, fully flushed, commented, partial/rendered, dynamic, conditional, reflective, and otherwise ambiguous cases as no-warning paths.
- Skip layout partial files as standalone layouts while preserving their parent layout's informational analysis.
- Add an adversarial regression matrix covering the positive path and fail-closed boundaries.

## Deliberate boundary

The warning is intentionally incomplete rather than speculative. Doctor does not traverse partials, infer custom helper side effects, boot Rails to resolve runtime configuration/layout selection, model later separate initializer overrides, or diagnose stylesheet-before-component ordering. Dynamic or ambiguous syntax fails closed without a warning.

## Verification

- Full Doctor spec: 855 examples, 0 failures.
- Targeted layout matrix: 122 examples, 0 failures.
- Independent partial negative control and ordinary-layout positive control: 2 examples, 0 failures.
- Focused RuboCop: 2 files inspected, no offenses.
- Fast gem suite selected by the repository validator: 1,722 examples, 0 failures.
- Parser performance seam: 10,000 representative Ripper parses in 0.0489 seconds; 10,000 fixed-point comment scans in 0.0253 seconds.
- `git diff --check`: clean; worktree clean; diff limited to the two Issue #4727 paths.
- The repository changed-files validator reported its selected docs, lint, formatting, type, package build, JavaScript, and Ruby test stages green. The outer tool process hit its execution-window termination (143) immediately after the 1,722-example Ruby result, before printing its redundant final summary marker; exact focused and full Doctor checks were then replayed green independently.

Independent exact-head checks:

- Distinct checker: clean at `9d49b438aafb8085fd02364cc8e9d1a2864ed48e` after reproducing and verifying the layout-partial correction.
- Codex adversarial review (`gpt-5.6-sol`, high): no actionable finding inside the approved static contract. Its cross-initializer runtime concern is documented as a deliberate boundary rather than expanded into runtime/load-order analysis.
- Strict GitHub trust preflight: complete API coverage, no untrusted or hidden participants, no suspicious text findings, and no high-risk changed files.

## Changelog and churn

- Changelog classification: `deferred_to_update_changelog`; `$update-changelog` owns the user-visible entry before the next release candidate. The authorized implementation lane remains limited to the two Doctor paths.
- Pre-push review gate: distinct checker plus exact-head Codex adversarial review.
- Initial PR publication: 17 focused commits.
- Post-publication local review corrections consolidated into this single update: 8 focused commits covering fixed-point comments, discarded exact-self CSS results, top-level JavaScript emission, active bindings/JSON, ambiguous template evidence, Ruby scope, conditional helper flow, and layout partials.
- Final candidate diff: 2 files, 3,314 insertions, 14 deletions.

## QA applicability

This changes a command-line diagnostic, not UI or generated bundle output. The durable interaction is the Doctor warning/no-warning regression matrix. Visual negative-control evidence is not applicable; the no-warning cases are the diagnostic negative controls. Bundle performance behavior is unchanged; the relevant Ripper parsing seam is measured above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the Doctor diagnostic tool to analyze ERB templates, layouts, controllers, initializer settings, and asset manifests without running application code.
  * Detects automatically loaded components, nested layouts, helper usage, stylesheet configuration, and implicit view associations.
  * Reports missing stylesheet helpers and invalid or incomplete configuration with clearer warnings.
  * Handles dynamic, ambiguous, malformed, and encoding-invalid input conservatively to avoid misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Agent details</summary>

### Audit receipts

<!-- completed-batch-audit-summary:start -->
#### Completed-batch audit

**Status:** Follow-ups remain — see the durable receipt. [Durable receipt](https://github.com/shakacode/react_on_rails/pull/4927#issuecomment-5403724847).
<!-- completed-batch-audit-summary:end -->

</details>
