### PR TITLE
Fix release dry-run gate discovery

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -7419,6 +7419,11 @@ REQUIRED_CHECKS_JQ_QUERY = [
   "else .checks end)}"
 ].join(" ")
 REQUIRED_CHECK_DISCOVERY_UNKNOWN = Object.new.freeze
+BRANCH_RULES_PAGE_SIZE = 100
+BRANCH_RULES_API_HEADERS = [
+  "-H", "Accept: application/vnd.github+json",
+  "-H", "X-GitHub-Api-Version: 2022-11-28"
+].freeze
 
 # Upper bound on how many consecutive non-runtime-only commits the CI gate will
 # walk past when choosing which origin/main commit to evaluate. Bounds the git
@@ -7941,6 +7946,86 @@ def normalize_required_checks_payload(parsed)
   contexts.empty? && checks.empty? ? nil : { contexts:, checks: }
 end
 
+def valid_branch_rules_identity?(rule)
+  rule.is_a?(Hash) &&
+    rule["type"].is_a?(String) && !rule["type"].empty? &&
+    rule["ruleset_source_type"].is_a?(String) && !rule["ruleset_source_type"].empty? &&
+    rule["ruleset_source"].is_a?(String) && !rule["ruleset_source"].empty? &&
+    positive_github_id?(rule["ruleset_id"])
+end
+
+def valid_ruleset_required_check?(check)
+  return false unless check.is_a?(Hash)
+
+  context = check["context"]
+  integration_id = check["integration_id"]
+  context.is_a?(String) && !context.empty? && (integration_id.nil? || positive_github_id?(integration_id))
+end
+
+def valid_branch_rules_pages?(parsed_pages)
+  parsed_pages.is_a?(Array) && !parsed_pages.empty? && parsed_pages.all?(Array)
+end
+
+def ruleset_required_checks(rule)
+  return [] unless rule["type"] == "required_status_checks"
+
+  parameters = rule["parameters"]
+  checks = parameters["required_status_checks"] if parameters.is_a?(Hash)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless checks.is_a?(Array)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless checks.all? { |check| valid_ruleset_required_check?(check) }
+
+  checks.map { |check| { "context" => check["context"], "app_id" => check["integration_id"] } }
+end
+
+def required_checks_from_branch_rules(rules)
+  rules.each_with_object([]) do |rule, required_checks|
+    checks = ruleset_required_checks(rule)
+    return REQUIRED_CHECK_DISCOVERY_UNKNOWN if checks.equal?(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+    required_checks.concat(checks)
+  end
+end
+
+def normalize_branch_rules_pages(parsed_pages)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless valid_branch_rules_pages?(parsed_pages)
+
+  rules = parsed_pages.flatten(1)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless rules.all? { |rule| valid_branch_rules_identity?(rule) }
+
+  required_checks = required_checks_from_branch_rules(rules)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN if required_checks.equal?(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+  normalized = normalize_required_checks_payload("contexts" => [], "checks" => required_checks)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN if normalized.equal?(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+  { required_checks: normalized, active_rule_count: rules.length }
+end
+
+def branch_rules_required_checks(repo_slug:, encoded_branch:)
+  api_path = "repos/#{repo_slug}/rules/branches/#{encoded_branch}?per_page=#{BRANCH_RULES_PAGE_SIZE}"
+  output, status = capture_gh_output(
+    "api", "--paginate", "--slurp", *BRANCH_RULES_API_HEADERS, api_path
+  )
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless status.success?
+
+  normalize_branch_rules_pages(JSON.parse(output))
+rescue JSON::ParserError
+  REQUIRED_CHECK_DISCOVERY_UNKNOWN
+end
+
+def combine_required_check_discoveries(*discoveries)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN if discoveries.any? do |discovery|
+    discovery.equal?(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+  end
+
+  checks = discoveries.compact.flat_map { |discovery| discovery.fetch(:checks) }
+  contexts = discoveries.compact.flat_map { |discovery| discovery.fetch(:contexts) }
+  normalize_required_checks_payload(
+    "contexts" => contexts,
+    "checks" => checks.map { |check| { "context" => check.fetch(:context), "app_id" => check.fetch(:app_id) } }
+  )
+end
+
 def gh_included_json_response(output)
   header_block, body, newline = gh_included_response_parts(output)
   status = gh_included_response_status(header_block, newline:)
@@ -8022,24 +8107,6 @@ def gh_included_response_status(header_block, newline:)
   status_match[1].to_i
 end
 
-def known_branch_without_required_checks?(repo_slug:, branch_name:, encoded_branch:, required_status_checks_path:)
-  included_output, _included_error, included_status = capture_gh_stdout_and_stderr(
-    "api", "--include", required_status_checks_path
-  )
-  return false if included_status.success?
-
-  expected_protected = required_status_checks_protection_state(included_output)
-  return false if expected_protected.nil?
-
-  branch_output, branch_status = capture_gh_output("api", "repos/#{repo_slug}/branches/#{encoded_branch}")
-  return false unless branch_status.success?
-
-  branch = JSON.parse(branch_output)
-  branch.is_a?(Hash) && branch["name"] == branch_name && branch["protected"] == expected_protected
-rescue JSON::ParserError
-  false
-end
-
 def required_status_checks_protection_state(output)
   response = gh_included_json_response(output)
   return unless response&.dig(:status) == 404
@@ -8050,6 +8117,55 @@ def required_status_checks_protection_state(output)
   when "Required status checks not enabled"
     true
   end
+end
+
+def valid_branch_protection_payload?(branch, branch_name:)
+  branch.is_a?(Hash) && branch["name"] == branch_name && [true, false].include?(branch["protected"])
+end
+
+def classic_required_checks_absence_corroborated?(branch_protected:, expected_protected:, ruleset_active_rule_count:)
+  branch_protected == expected_protected ||
+    (!expected_protected && branch_protected && ruleset_active_rule_count.positive?)
+end
+
+def corroborated_classic_required_checks_absence(
+  repo_slug:, branch_name:, encoded_branch:, expected_protected:, ruleset_active_rule_count:
+)
+  branch_output, branch_status = capture_gh_output("api", "repos/#{repo_slug}/branches/#{encoded_branch}")
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless branch_status.success?
+
+  branch = JSON.parse(branch_output)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless valid_branch_protection_payload?(branch, branch_name:)
+  if classic_required_checks_absence_corroborated?(
+    branch_protected: branch["protected"], expected_protected:, ruleset_active_rule_count:
+  )
+    return nil
+  end
+
+  REQUIRED_CHECK_DISCOVERY_UNKNOWN
+rescue JSON::ParserError
+  REQUIRED_CHECK_DISCOVERY_UNKNOWN
+end
+
+def classic_required_checks_for_branch(
+  repo_slug:, branch_name:, encoded_branch:, required_status_checks_path:, ruleset_active_rule_count:
+)
+  output, status = capture_gh_output("api", "--jq", REQUIRED_CHECKS_JQ_QUERY, required_status_checks_path)
+  return normalize_required_checks_payload(JSON.parse(output)) if status.success?
+
+  included_output, _included_error, included_status = capture_gh_stdout_and_stderr(
+    "api", "--include", required_status_checks_path
+  )
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN if included_status.success?
+
+  expected_protected = required_status_checks_protection_state(included_output)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN if expected_protected.nil?
+
+  corroborated_classic_required_checks_absence(
+    repo_slug:, branch_name:, encoded_branch:, expected_protected:, ruleset_active_rule_count:
+  )
+rescue JSON::ParserError
+  REQUIRED_CHECK_DISCOVERY_UNKNOWN
 end
 
 def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "main")
@@ -8063,23 +8179,17 @@ def required_check_names_for_branch(monorepo_root:, repo_slug: nil, ci_branch: "
   # before `validate_main_ci_status!` calls this helper. The remaining failure
   # mode here is "branch protection unknown". Keep it distinct from a known
   # unprotected branch so exact-HEAD recovery can fail closed.
-  output, status = capture_gh_output("api", "--jq", REQUIRED_CHECKS_JQ_QUERY, api_path)
-  # Only a successful, structurally valid empty configuration means no required
-  # checks. API errors and malformed payloads leave required gates unknown.
-  return nil if !status.success? && known_branch_without_required_checks?(
+  ruleset_discovery = branch_rules_required_checks(repo_slug:, encoded_branch:)
+  return REQUIRED_CHECK_DISCOVERY_UNKNOWN if ruleset_discovery.equal?(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+
+  classic_discovery = classic_required_checks_for_branch(
     repo_slug:,
     branch_name: ci_branch.to_s,
     encoded_branch:,
-    required_status_checks_path: api_path
+    required_status_checks_path: api_path,
+    ruleset_active_rule_count: ruleset_discovery.fetch(:active_rule_count)
   )
-  return REQUIRED_CHECK_DISCOVERY_UNKNOWN unless status.success?
-
-  begin
-    parsed = JSON.parse(output)
-    normalize_required_checks_payload(parsed)
-  rescue JSON::ParserError
-    REQUIRED_CHECK_DISCOVERY_UNKNOWN
-  end
+  combine_required_check_discoveries(classic_discovery, ruleset_discovery.fetch(:required_checks))
 end
 
 def check_run_app_id(run)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -18921,6 +18921,7 @@ RSpec.describe "release.rake helper methods" do
         success_status = instance_double(Process::Status, success?: true)
         api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
         branch_path = "repos/shakacode/react_on_rails/branches/main"
+        rules_path = "repos/shakacode/react_on_rails/rules/branches/main?per_page=100"
         allow(self).to receive(:required_check_names_for_branch).and_call_original
         allow(self).to receive(:fetch_main_ci_checks)
           .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
@@ -18939,6 +18940,9 @@ RSpec.describe "release.rake helper methods" do
         allow(Open3).to receive(:capture2e)
           .with("gh", "api", branch_path)
           .and_return(['{"name":"main","protected":false}', success_status])
+        allow(Open3).to receive(:capture2e)
+          .with("gh", "api", "--paginate", "--slurp", *BRANCH_RULES_API_HEADERS, rules_path)
+          .and_return(["[[]]", success_status])
 
         output = nil
         expect do
@@ -18961,6 +18965,7 @@ RSpec.describe "release.rake helper methods" do
         success_status = instance_double(Process::Status, success?: true)
         api_path = "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
         branch_path = "repos/shakacode/react_on_rails/branches/main"
+        rules_path = "repos/shakacode/react_on_rails/rules/branches/main?per_page=100"
         allow(self).to receive(:required_check_names_for_branch).and_call_original
         allow(self).to receive(:fetch_main_ci_checks)
           .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
@@ -18979,6 +18984,9 @@ RSpec.describe "release.rake helper methods" do
         allow(Open3).to receive(:capture2e)
           .with("gh", "api", branch_path)
           .and_return(['{"name":"main","protected":true}', success_status])
+        allow(Open3).to receive(:capture2e)
+          .with("gh", "api", "--paginate", "--slurp", *BRANCH_RULES_API_HEADERS, rules_path)
+          .and_return(["[[]]", success_status])
 
         output = nil
         expect do
@@ -22338,14 +22346,138 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "execjs-compatible dummy release lock compatibility" do
+    let(:repo_root) { File.expand_path("../../..", __dir__) }
+    let(:dummy_root) { File.join(repo_root, "react_on_rails_pro", "spec", "execjs-compatible-dummy") }
+
+    it "bounds sqlite resolution and retains both source and native-platform variants" do
+      gemfile = File.read(File.join(dummy_root, "Gemfile"))
+      lockfile = File.read(File.join(dummy_root, "Gemfile.lock"))
+
+      expect(gemfile).to include('gem "sqlite3", "~> 1.7", force_ruby_platform:')
+      expect(lockfile).to match(/^    sqlite3 \(1\.7\.\d+\)$/)
+      expect(lockfile).to match(/^    sqlite3 \(1\.7\.\d+-arm64-darwin\)$/)
+      expect(lockfile).to match(/^  ruby$/)
+      expect(lockfile).to match(/^  sqlite3 \(~> 1\.7\)$/)
+      expect(lockfile).to match(/BUNDLED WITH\n   2\.5\.9\n\z/)
+    end
+  end
+
   describe "#required_check_names_for_branch" do
     let(:monorepo_root) { "/tmp/repo" }
     let(:success_status) { instance_double(Process::Status, success?: true) }
     let(:failure_status) { instance_double(Process::Status, success?: false) }
     let(:expected_jq) { REQUIRED_CHECKS_JQ_QUERY }
+    let(:branch_protection_path) do
+      "repos/shakacode/react_on_rails/branches/main/protection/required_status_checks"
+    end
+    let(:branch_rules_path) { "repos/shakacode/react_on_rails/rules/branches/main?per_page=100" }
+    let(:branch_rules_args) do
+      [
+        "gh", "api", "--paginate", "--slurp",
+        "-H", "Accept: application/vnd.github+json",
+        "-H", "X-GitHub-Api-Version: 2022-11-28",
+        branch_rules_path
+      ]
+    end
 
     before do
       allow(self).to receive(:github_repo_slug).with(monorepo_root).and_return("shakacode/react_on_rails")
+      allow(Open3).to receive(:capture2e)
+        .with(
+          "gh", "api", "--paginate", "--slurp",
+          "-H", "Accept: application/vnd.github+json",
+          "-H", "X-GitHub-Api-Version: 2022-11-28",
+          %r{\Arepos/shakacode/react_on_rails/rules/branches/.+\?per_page=100\z}
+        )
+        .and_return(["[[]]", success_status])
+    end
+
+    def stub_missing_classic_protection(branch_protection_path:, success_status:, failure_status:)
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", REQUIRED_CHECKS_JQ_QUERY, branch_protection_path)
+        .and_return(["HTTP 404: Branch not protected", failure_status])
+      allow(Open3).to receive(:capture3)
+        .with("gh", "api", "--include", branch_protection_path)
+        .and_return([
+                      "HTTP/2.0 404 Not Found\r\nContent-Type: application/json\r\n\r\n" \
+                      '{"message":"Branch not protected"}',
+                      "gh: branch protection is not enabled for this branch\n",
+                      failure_status
+                    ])
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "repos/shakacode/react_on_rails/branches/main")
+        .and_return(['{"name":"main","protected":true}', success_status])
+    end
+
+    it "discovers required checks from active branch rulesets when classic protection is absent" do
+      stub_missing_classic_protection(branch_protection_path:, success_status:, failure_status:)
+      rules = [
+        {
+          type: "required_status_checks",
+          parameters: {
+            required_status_checks: [{ context: "required-pr-gate", integration_id: 15_368 }]
+          },
+          ruleset_source_type: "Repository",
+          ruleset_source: "shakacode/react_on_rails",
+          ruleset_id: 21_350_286
+        }
+      ]
+      allow(Open3).to receive(:capture2e).with(*branch_rules_args).and_return([[rules].to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to eq(
+        contexts: [],
+        checks: [{ context: "required-pr-gate", app_id: 15_368 }]
+      )
+    end
+
+    it "combines required checks from every paginated ruleset response" do
+      stub_missing_classic_protection(branch_protection_path:, success_status:, failure_status:)
+      pages = [
+        [
+          {
+            type: "required_status_checks",
+            parameters: { required_status_checks: [{ context: "Lint", integration_id: nil }] },
+            ruleset_source_type: "Repository",
+            ruleset_source: "shakacode/react_on_rails",
+            ruleset_id: 11
+          }
+        ],
+        [
+          {
+            type: "required_status_checks",
+            parameters: { required_status_checks: [{ context: "Test", integration_id: 22 }] },
+            ruleset_source_type: "Organization",
+            ruleset_source: "shakacode",
+            ruleset_id: 12
+          }
+        ]
+      ]
+      allow(Open3).to receive(:capture2e).with(*branch_rules_args).and_return([pages.to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to eq(
+        contexts: [],
+        checks: [{ context: "Lint", app_id: nil }, { context: "Test", app_id: 22 }]
+      )
+    end
+
+    it "fails closed when a required-status-check ruleset is malformed" do
+      stub_missing_classic_protection(branch_protection_path:, success_status:, failure_status:)
+      malformed_pages = [[{ type: "required_status_checks", parameters: { required_status_checks: nil } }]]
+      allow(Open3).to receive(:capture2e)
+        .with(*branch_rules_args).and_return([malformed_pages.to_json, success_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
+    end
+
+    it "fails closed when active branch rules cannot be queried" do
+      allow(Open3).to receive(:capture2e)
+        .with("gh", "api", "--jq", expected_jq, branch_protection_path)
+        .and_return([{ contexts: ["Classic"], checks: [] }.to_json, success_status])
+      allow(Open3).to receive(:capture2e)
+        .with(*branch_rules_args).and_return(["HTTP 403: insufficient token scope", failure_status])
+
+      expect(required_check_names_for_branch(monorepo_root:)).to equal(REQUIRED_CHECK_DISCOVERY_UNKNOWN)
     end
 
     it "returns legacy required status contexts when branch protection is configured" do

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
@@ -28,7 +28,7 @@ gem "rails", "~> 7.1", ">= 7.1.3.2"
 gem "sprockets-rails"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4", force_ruby_platform: Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
+gem "sqlite3", "~> 1.7", force_ruby_platform: Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -318,6 +318,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-aarch64-linux)
     sqlite3 (1.7.3-arm-linux)
     sqlite3 (1.7.3-arm64-darwin)
@@ -349,6 +351,7 @@ PLATFORMS
   aarch64-linux
   arm-linux
   arm64-darwin
+  ruby
   x86-linux
   x86_64-darwin
   x86_64-linux
@@ -370,7 +373,7 @@ DEPENDENCIES
   selenium-webdriver
   shakapacker (= 10.3.0)
   sprockets-rails
-  sqlite3 (~> 1.4)
+  sqlite3 (~> 1.7)
   tzinfo-data
   web-console
 


### PR DESCRIPTION
## Why

The new one-command release dry run could not discover required CI checks on `release/17.1.0` because that branch is protected by GitHub Rulesets rather than the classic branch-protection endpoint. The dry run also failed while regenerating the execjs-compatible dummy lockfile under the pinned Ruby 4 release toolchain.

## What changed

- Discover required status checks from the paginated GitHub branch-rules endpoint, strictly validate the response, map Rulesets `integration_id` to the existing `app_id` matching contract, and union Rulesets requirements with classic branch protection.
- Fail closed when either required-check source is malformed or unavailable.
- Bound the execjs-compatible dummy to `sqlite3 ~> 1.7` and retain both source and native-platform lock variants so regeneration is deterministic on Ruby 4 while remaining compatible with the minimum Ruby 3.3 toolchain.
- Add regression coverage for Rulesets pagination/validation/failure behavior and cross-toolchain lock compatibility.

No release, tag, GitHub release, gem push, or npm publication was performed.

## Verification

- Independent QA Evidence v2: PASS at exact head `a30beb9fa3f4fd641d99b6b7ffa1d47022f9fae6`
- Focused RSpec: 29 examples, 0 failures
- Full release helper RSpec: 937 examples, 0 failures
- `script/release-test.bash`: 58/58 passed
- `script/release --doctor`: PASS
- Live Rulesets/helper discovery: `required-pr-gate`, app ID `15368`
- Ruby 4.0.5 and Ruby 3.3.7 frozen Bundler 2.5.9 installs: PASS; lockfile byte-stable
- Focused RuboCop: no offenses
- Pre-push branch lint and Markdown link checks: PASS

The full argumentless `script/release --dry-run` remains intentionally gated until this commit is the fetched `release/17.1.0` head with current-head hosted checks. It will be replayed immediately after merge before any publication is considered.

<details>
<summary>Agent details</summary>

### Audit receipts

<!-- completed-batch-audit-summary:start -->
#### Completed-batch audit

**Status:** Clean — no outstanding findings or follow-ups. [Durable receipt](https://github.com/shakacode/react_on_rails/pull/4935#issuecomment-5422905917).
<!-- completed-batch-audit-summary:end -->

</details>
