### PR TITLE
Scope `bin/dev kill` to the current app directory and verify shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,25 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **`bin/dev kill` now stops only the current app directory's processes, and verifies they are
+  gone**: the kill path matched command lines machine-wide (`pgrep -f rails`, `pgrep -f overmind`,
+  `pgrep -f ruby.*puma`, and friends) and scanned ports with an unfiltered `lsof -ti :PORT`, so
+  running it in one worktree could terminate a Rails server, a Webpack dev server, or an unrelated
+  client connection belonging to a different checkout — then printed "All processes terminated"
+  without checking that anything had actually stopped. `bin/dev` now claims a worktree-scoped,
+  `flock`-backed session file (`tmp/react_on_rails/dev-session.json`) recording the app root it
+  belongs to, the process group it leads, and the Overmind endpoint it would use. `bin/dev kill`
+  shuts that session down through its own Overmind control socket or its own process group,
+  escalating from `TERM` to `KILL` only for survivors, and reports success only after positively
+  observing that the owner, its process group, and its listeners are gone. Fallback port discovery
+  is restricted to LISTEN sockets whose process working directory is inside the current app root;
+  anything it cannot attribute is reported as a diagnostic and never signalled, and missing,
+  malformed, or foreign session state fails closed rather than falling back to a broad kill.
+  Processes that deliberately leave the group with `setsid`/daemonization remain out of scope, which
+  is why Overmind (whose tmux server daemonizes) is controlled through its socket. Fixes
+  [Issue 4846](https://github.com/shakacode/react_on_rails/issues/4846). PR NNNN (link added when the
+  PR is opened) by [justin808](https://github.com/justin808).
+
 - **[Pro]** **Surfaced missing RSC loadable stats in Node Renderer logs**: The first missing
   `loadable-stats.json` read now emits an actionable `INFO` diagnostic per renderer process while
   preserving fallback and retry behavior without replaying the server path to the browser. Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,21 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   observing that the owner, its process group, and its listeners are gone. Fallback port discovery
   is restricted to LISTEN sockets whose process working directory is inside the current app root;
   anything it cannot attribute is reported as a diagnostic and never signalled, and missing,
-  malformed, or foreign session state fails closed rather than falling back to a broad kill.
-  Processes that deliberately leave the group with `setsid`/daemonization remain out of scope, which
-  is why Overmind (whose tmux server daemonizes) is controlled through its socket. Fixes
-  [Issue 4846](https://github.com/shakacode/react_on_rails/issues/4846). PR NNNN (link added when the
-  PR is opened) by [justin808](https://github.com/justin808).
+  malformed, unreadable, or foreign session state fails closed rather than falling back to a broad
+  kill. The default-mode port list now covers the Shakapacker dev-server port
+  (`SHAKAPACKER_DEV_SERVER_PORT`, then `dev_server.port` in `config/shakapacker.yml`, then 3035)
+  instead of a hard-coded 3001, and a session records the ports it actually selected so a kill
+  verifies those rather than re-deriving a guess. Processes that deliberately leave the group with
+  `setsid`/daemonization remain out of scope, which is why Overmind (whose tmux server daemonizes) is
+  controlled through its socket. **Breaking API changes** for anyone calling
+  `ReactOnRails::Dev::ServerManager` directly: `.development_processes` and `.kill_running_processes`
+  are removed, `.kill_processes` now returns a status symbol (and `bin/dev kill` exits non-zero when
+  it refuses or cannot verify a shutdown, with `bin/dev clean` refusing to delete bundles in that
+  case), `.print_kill_summary` takes `(status_symbol, blockers_array)` instead of a boolean, and
+  `.kill_port_processes` / `.find_port_pids` only consider listening sockets attributable to the
+  current app root. Fixes [Issue 4846](https://github.com/shakacode/react_on_rails/issues/4846).
+  [PR 4937](https://github.com/shakacode/react_on_rails/pull/4937) by
+  [justin808](https://github.com/justin808).
 
 - **[Pro]** **Surfaced missing RSC loadable stats in Node Renderer logs**: The first missing
   `loadable-stats.json` read now emits an actionable `INFO` diagnostic per renderer process while

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -688,7 +688,16 @@ module ReactOnRails
         # attribution, and refusing to guess is fail-closed.
         def owned_process_group
           pgid = Process.getpgrp
-          pgid == Process.pid ? pgid : nil
+          # The `> 1` floor mirrors #valid_session_pgid? on the read side, and
+          # has to be here too or we write a document we then refuse to read.
+          # A minimal container with no init wrapper runs `bin/dev` as PID 1 and
+          # typically setsid()s it, giving pgid == pid == 1; recording that made
+          # valid_dev_session_document? reject the whole document, so every
+          # `bin/dev kill` printed "Refusing to signal anything". Group 1 is
+          # unusable anyway - `Process.kill(sig, -1)` broadcasts rather than
+          # targeting a group - so a nil pgid is the honest record, and shutdown
+          # falls back to the Overmind socket or cwd-attributed ports.
+          pgid == Process.pid && pgid > 1 ? pgid : nil
         rescue NotImplementedError, SystemCallError
           nil
         end
@@ -996,7 +1005,7 @@ module ReactOnRails
           blockers = shutdown_blockers(view, pgid, endpoint)
           return [:unverified, blockers] if blockers.any?
 
-          leftover = leftover_owned_listeners(view)
+          leftover = outstanding_shutdown_blockers(view)
           return [:unverified, leftover] if leftover.any?
 
           # The listener scan shells out to lsof once per port, and by the time
@@ -1014,6 +1023,14 @@ module ReactOnRails
           remove_dev_session_file(view)
           cleanup_socket_files
           [:verified, []]
+        end
+
+        # Everything that has to be positively observed as gone before a
+        # shutdown may be called verified: leftover listeners, ports that could
+        # not be scanned, and endpoints that could not be probed.
+        def outstanding_shutdown_blockers(view)
+          leftover_owned_listeners(view) +
+            unprobeable_endpoint_blockers(unprobeable_overmind_endpoints(view))
         end
 
         def owner_shutdown_complete?(view, pgid, endpoint)
@@ -1049,7 +1066,7 @@ module ReactOnRails
           when :alive
             ["the Overmind endpoint #{endpoint} is still accepting connections"]
           when :unknown
-            ["could not determine whether the Overmind endpoint #{endpoint} is still live"]
+            [unprobeable_endpoint_message(endpoint)]
           else
             []
           end
@@ -1148,8 +1165,11 @@ module ReactOnRails
           # found nothing" and "we could not look" must not collapse into the
           # same answer: with lsof missing, every relevant port goes uninspected
           # and reporting :nothing_running would let `bin/dev kill && bin/dev`
-          # start a second stack on top of a live one.
-          leftover = leftover_owned_listeners(view)
+          # start a second stack on top of a live one. The same holds for an
+          # in-root Overmind endpoint we could not probe - falling through to
+          # port-only cleanup would call the session gone without ever reaching
+          # it.
+          leftover = outstanding_shutdown_blockers(view)
           return [:unverified, leftover] if leftover.any?
 
           # Same rule as verify_owner_shutdown: the recorded ports outlive an
@@ -1208,10 +1228,38 @@ module ReactOnRails
         # value is a candidate, not an authority - each still has to clear the
         # containment and realpath checks below.
         def live_overmind_endpoint(root, recorded)
-          candidates = [recorded, owned_overmind_socket_path(root), default_overmind_socket_path(root)]
-          candidates.compact.uniq.find do |path|
-            overmind_endpoint_owned?(path, root) && overmind_endpoint_alive?(path)
+          scan_overmind_endpoints(root, recorded)[:alive]&.first
+        end
+
+        def overmind_endpoint_candidates(root, recorded)
+          [recorded, owned_overmind_socket_path(root), default_overmind_socket_path(root)].compact.uniq
+        end
+
+        # Probes every in-root candidate once and groups them by state, so a
+        # bounded connect runs at most once per candidate per pass.
+        def scan_overmind_endpoints(root, recorded)
+          owned = overmind_endpoint_candidates(root, recorded).select do |path|
+            overmind_endpoint_owned?(path, root)
           end
+          owned.group_by { |path| overmind_endpoint_state(path) }
+        end
+
+        # In-root endpoints whose liveness could not be determined. An
+        # unprobeable endpoint is not an absent one: the Overmind session behind
+        # it may still be running, along with workers that hold no listening
+        # socket and so never appear in the port scan. Same rule as everywhere
+        # else here - never report success from an observation that could not be
+        # made.
+        def unprobeable_overmind_endpoints(view)
+          scan_overmind_endpoints(view[:root], view.dig(:session, :overmind_socket))[:unknown] || []
+        end
+
+        def unprobeable_endpoint_blockers(endpoints)
+          Array(endpoints).map { |path| unprobeable_endpoint_message(path) }
+        end
+
+        def unprobeable_endpoint_message(path)
+          "could not determine whether the Overmind endpoint #{path} is still live"
         end
 
         # Containment check for a control endpoint. The path is resolved before

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -43,6 +43,14 @@ module ReactOnRails
       SHUTDOWN_KILL_GRACE_SECS = 5
       SHUTDOWN_POLL_INTERVAL_SECS = 0.2
 
+      # Markers that identify an app root when a command is run from a
+      # subdirectory. Checked nearest-first while walking up from the cwd.
+      APP_ROOT_MARKERS = [File.join("config", "environment.rb"), "Gemfile", DEV_SESSION_RELATIVE_PATH].freeze
+
+      # Shutdown outcomes that must never be reported as success: `bin/dev kill`
+      # exits non-zero on these, and `bin/dev clean` refuses to delete anything.
+      SHUTDOWN_FAILURE_STATUSES = %i[refused unverified].freeze
+
       DOCS_BASE_URL = "https://reactonrails.com/docs"
       DEV_SERVER_AND_TESTING_DOCS_URL = "#{DOCS_BASE_URL}/building-features/dev-server-and-testing/".freeze
       TESTING_CONFIGURATION_DOCS_URL = "#{DOCS_BASE_URL}/building-features/testing-configuration/".freeze
@@ -80,6 +88,8 @@ module ReactOnRails
         # nothing is signalled unless it can be positively attributed to the
         # current app root. See the "Scoped dev shutdown" section below for
         # the ownership model and its known limitation.
+        # Returns the shutdown status symbol so callers can distinguish a
+        # verified stop from a refusal. See SHUTDOWN_FAILURE_STATUSES.
         def kill_processes
           puts "🔪 Stopping this app's development processes..."
           puts "   #{current_app_root}"
@@ -87,12 +97,18 @@ module ReactOnRails
 
           status, blockers = shutdown_dev_session
           print_kill_summary(status, blockers)
+          status
         end
 
+        # Returns true when the cleanup ran to completion without warnings.
+        # Deleting bundles is refused outright when the dev processes could not
+        # be stopped - removing output from under a still-running dev server
+        # leaves it serving files this command just deleted.
         def clean_generated_assets_and_caches
           puts "🧹 Cleaning generated bundles and caches..."
           puts ""
-          kill_processes
+          return false if shutdown_failed?(kill_processes) && abort_clean_after_failed_shutdown
+
           puts ""
           print_shakapacker_config_status
           puts ""
@@ -105,6 +121,8 @@ module ReactOnRails
           else
             puts "⚠️  Cleanup completed with warnings"
           end
+
+          clean_finished_without_warnings
         end
 
         # Fallback port list for the port-scan kill path. Uses the base-port
@@ -146,12 +164,42 @@ module ReactOnRails
         end
 
         def default_killable_ports
-          ports = [3000, 3001]
+          ports = [default_rails_kill_port, default_dev_server_kill_port]
           if pro_renderer_active?
             renderer_port = configured_renderer_port_for_kill
             ports << renderer_port if renderer_port
           end
-          ports
+          ports.uniq
+        end
+
+        def default_rails_kill_port
+          raw = ENV.fetch("PORT", nil)
+          PortSelector.valid_port_string?(raw) ? raw.strip.to_i : PortSelector::DEFAULT_RAILS_PORT
+        end
+
+        # `Procfile.dev` runs `bin/shakapacker-dev-server`, whose port comes from
+        # SHAKAPACKER_DEV_SERVER_PORT or `dev_server.port` in
+        # config/shakapacker.yml and defaults to 3035 - it is NOT "the Rails port
+        # plus one". The hard-coded 3001 this replaced meant a default-mode kill
+        # neither stopped nor even looked at a dev server on 3035, so
+        # `bin/dev kill` could report a verified shutdown while it was still
+        # serving. Widening the scanned list is safe: the cwd-attribution filter
+        # still decides whether anything is actually signalled.
+        def default_dev_server_kill_port
+          raw = ENV.fetch("SHAKAPACKER_DEV_SERVER_PORT", nil)
+          return raw.strip.to_i if PortSelector.valid_port_string?(raw)
+
+          configured = configured_dev_server_port
+          return configured if configured
+
+          PortSelector::DEFAULT_WEBPACK_PORT
+        end
+
+        def configured_dev_server_port
+          value = development_dev_server_config["port"]
+          PortSelector.valid_port_string?(value.to_s) ? value.to_s.strip.to_i : nil
+        rescue StandardError
+          nil
         end
 
         def configured_renderer_port_for_kill
@@ -214,8 +262,9 @@ module ReactOnRails
         # signalled. Listeners that cannot be positively attributed are
         # reported as diagnostics and left alone.
         def kill_port_processes(ports)
-          owned, foreign = classify_port_listeners(ports)
+          owned, foreign, unavailable = classify_port_listeners(ports)
           report_foreign_listeners(foreign)
+          report_unavailable_port_probes(unavailable)
           return false if owned.empty?
 
           owned.each do |port, pids|
@@ -241,11 +290,28 @@ module ReactOnRails
         # also matched *client* sockets connected to the port (a browser tab, a
         # curl, another app's HTTP client), and those pids were then signalled.
         def find_port_pids(port)
-          stdout, _status = Open3.capture2("lsof", "-nP", "-t", "-iTCP:#{port}", "-sTCP:LISTEN", err: File::NULL)
-          stdout.split("\n").map(&:to_i).reject { |pid| pid <= 1 || pid == Process.pid }
+          probe_port_listeners(port).first
+        end
+
+        # Returns [pids, :ok] or [[], :unavailable].
+        #
+        # `find_port_pids` keeps the plain-Array contract for the public API and
+        # the signalling path, but verification needs to tell "lsof ran and found
+        # nothing" apart from "lsof could not run".
+        #
+        # Caveat, deliberately not papered over: lsof exits 1 both when it
+        # matches nothing and for some soft failures, so only a failure to run at
+        # all (missing binary, spawn failure) or an exit status above 1 can be
+        # reported as :unavailable.
+        def probe_port_listeners(port)
+          stdout, status = Open3.capture2("lsof", "-nP", "-t", "-iTCP:#{port}", "-sTCP:LISTEN", err: File::NULL)
+          exit_status = status.respond_to?(:exitstatus) ? status.exitstatus.to_i : 0
+          return [[], :unavailable] if exit_status > 1
+
+          [stdout.split("\n").map(&:to_i).reject { |pid| pid <= 1 || pid == Process.pid }, :ok]
         rescue StandardError
           # lsof command not found or other error (permission denied, etc.)
-          []
+          [[], :unavailable]
         end
 
         # Read-only probe used by `bin/dev test-watch` to notice an existing
@@ -357,9 +423,9 @@ module ReactOnRails
                                                          open_browser: options[:open_browser],
                                                          open_browser_once: options[:open_browser_once])
           when "kill"
-            kill_processes
+            exit 1 if shutdown_failed?(kill_processes)
           when "clean"
-            clean_generated_assets_and_caches
+            exit 1 unless clean_generated_assets_and_caches
           when "help"
             show_help
           when "test-watch"
@@ -414,12 +480,32 @@ module ReactOnRails
           File.join(root, DEV_SESSION_RELATIVE_PATH)
         end
 
-        # Absolute, symlink-resolved identity of the app directory `bin/dev`
-        # was invoked from. Every ownership decision is made against this.
+        # Absolute, symlink-resolved identity of the app directory this command
+        # belongs to. Every ownership decision is made against this.
+        #
+        # `bin/dev kill` is routinely run from a subdirectory (`../../bin/dev
+        # kill` from app/models). Anchoring on the cwd alone computed a root of
+        # <app>/app/models, found no session state there, and reported "nothing
+        # running" while the session was very much alive - so walk up to the
+        # nearest ancestor that looks like an app root and fall back to the cwd
+        # only when nothing matches.
         def current_app_root
-          File.realpath(Dir.pwd)
+          start = File.realpath(Dir.pwd)
+          app_root_ancestor(start) || start
         rescue SystemCallError
           File.expand_path(Dir.pwd)
+        end
+
+        def app_root_ancestor(start)
+          dir = start
+          loop do
+            return dir if APP_ROOT_MARKERS.any? { |marker| File.exist?(File.join(dir, marker)) }
+
+            parent = File.dirname(dir)
+            return nil if parent == dir
+
+            dir = parent
+          end
         end
 
         # Distinct from #path_inside_app_root? (used by `bin/dev clean`, which
@@ -460,6 +546,8 @@ module ReactOnRails
             file.close
             puts "   ℹ️  Another `bin/dev` already owns #{relative_to_app_root(path, root)}; " \
                  "leaving its session state untouched."
+            puts "   ⚠️  This run is NOT recorded, so `bin/dev kill` will control that other run, " \
+                 "not this one. Stop this one from its own terminal."
             return nil
           end
 
@@ -480,8 +568,20 @@ module ReactOnRails
             "pid" => Process.pid,
             "pgid" => owned_process_group,
             "overmind_socket" => owned_overmind_socket_path(root),
+            "ports" => selected_session_ports,
             "started_at" => Time.now.utc.iso8601
           }
+        end
+
+        # The ports this run actually selected, read after `configure_ports` has
+        # written them to ENV. Recording them means `bin/dev kill` verifies the
+        # session's real ports instead of re-deriving a guess from whatever
+        # environment the killing shell happens to have.
+        def selected_session_ports
+          %w[PORT SHAKAPACKER_DEV_SERVER_PORT RENDERER_PORT].filter_map do |var|
+            raw = ENV.fetch(var, nil)
+            PortSelector.valid_port_string?(raw) ? raw.strip.to_i : nil
+          end.uniq
         end
 
         # Only report a pgid we actually lead. When the shell's job control put
@@ -489,6 +589,16 @@ module ReactOnRails
         # `bin/dev` and its descendants and nothing else, so signalling it can
         # never reach the parent shell or a sibling job. If we are not the
         # group leader the group is somebody else's and is not ours to signal.
+        #
+        # We deliberately do NOT call `Process.setpgid`/`setpgrp` to manufacture
+        # a group when we do not already lead one: that detaches `bin/dev` from
+        # the terminal's foreground process group and breaks Ctrl-C, which is
+        # how people actually stop the dev server. When no group is owned (a
+        # non-job-control invocation, e.g. a plain background job in a script),
+        # the pgid is recorded as null and shutdown falls back to the Overmind
+        # socket or to cwd-attributed port cleanup. That is the
+        # Foreman-without-job-control case: still cleanable through port
+        # attribution, and refusing to guess is fail-closed.
         def owned_process_group
           pgid = Process.getpgrp
           pgid == Process.pid ? pgid : nil
@@ -523,12 +633,22 @@ module ReactOnRails
         # ---- kill path: reading and classifying the session ------------
 
         def shutdown_dev_session
-          view = dev_session_view(current_app_root).merge(ports: killable_ports)
+          view = dev_session_view(current_app_root)
+          view = view.merge(ports: shutdown_ports(view))
           begin
             dispatch_dev_shutdown(view)
           ensure
             close_session_handle(view)
           end
+        end
+
+        # Prefer the ports this session recorded at startup. The derived
+        # fallback only applies when there is no session to read them from, and
+        # a killing shell with a different base port must not override what the
+        # running session actually bound.
+        def shutdown_ports(view)
+          recorded = view.dig(:session, :ports)
+          recorded.is_a?(Array) && recorded.any? ? recorded : killable_ports
         end
 
         def dispatch_dev_shutdown(view)
@@ -541,20 +661,32 @@ module ReactOnRails
 
         def dev_session_view(root)
           path = dev_session_path(root)
-          file = open_dev_session(path)
-          return { kind: :absent, root:, path:, handle: nil } if file.nil?
+          outcome, payload = open_dev_session(path)
+          return { kind: :absent, root:, path:, handle: nil } if outcome == :absent
+          return { kind: :refused, root:, path:, handle: nil, blockers: [payload] } if outcome == :refused
 
-          kind, payload = classify_dev_session(root, path, file)
-          base = { kind:, root:, path:, handle: file }
-          kind == :refused ? base.merge(blockers: [payload]) : base.merge(session: payload)
+          kind, result = classify_dev_session(root, path, payload)
+          base = { kind:, root:, path:, handle: payload }
+          kind == :refused ? base.merge(blockers: [result]) : base.merge(session: result)
         end
 
-        # Missing state, an unreadable file and a permissions problem are all
-        # "no usable owner record", handled by the caller's no-owner path.
+        # Returns [:opened, File], [:absent, nil] or [:refused, message].
+        #
+        # Only a genuinely missing file means "no session here". Anything else -
+        # a permissions change, a read-only filesystem, a directory in the way -
+        # means we could not inspect a lock that may well be held, so it fails
+        # closed instead of letting the no-owner path go on to signal
+        # port-attributed processes and print success.
+        #
+        # Opened read-only: this handle is never written through, and `flock`
+        # works on a read-only descriptor, so requiring write access would
+        # refuse sessions we can perfectly well inspect.
         def open_dev_session(path)
-          File.open(path, File::RDWR)
-        rescue SystemCallError
-          nil
+          [:opened, File.open(path, File::RDONLY)]
+        rescue Errno::ENOENT
+          [:absent, nil]
+        rescue SystemCallError => e
+          [:refused, "could not open #{path} to determine dev session ownership (#{e.class})"]
         end
 
         def classify_dev_session(root, path, file)
@@ -569,12 +701,28 @@ module ReactOnRails
           when :error
             [:refused, "could not determine whether #{path} is still owned by a running `bin/dev`"]
           when :held
-            [:owner_alive, session]
+            confirm_locked_dev_session(path, file, session)
           else
             classify_released_dev_session(path, file, session)
           end
         rescue SystemCallError, IOError
           [:refused, "could not read #{path}"]
+        end
+
+        # `claim_dev_session` takes the lock and THEN truncates and writes, so
+        # the payload and the lock holder are not written atomically: a reader
+        # can see the previous owner's bytes while a NEW owner already holds the
+        # lock, which would turn a recycled pgid into "proven live" signal
+        # authority. Re-read under the lock verdict and require the payload to be
+        # unchanged; a mismatch, a truncated read, or an invalid document fails
+        # closed rather than signalling on the strength of a bare number.
+        def confirm_locked_dev_session(path, file, session)
+          file.rewind
+          confirmed = parse_dev_session(file.read)
+          return [:refused, "#{path} changed while its owner was being identified"] unless confirmed == session
+          return [:refused, "#{path} was replaced while it was being read"] if dev_session_replaced?(path, file)
+
+          [:owner_alive, confirmed]
         end
 
         # The owner released the lock: either it tidied up after itself or it
@@ -592,7 +740,7 @@ module ReactOnRails
           return nil unless valid_dev_session_document?(data)
 
           { app_root: data["app_root"], pid: data["pid"], pgid: data["pgid"],
-            overmind_socket: data["overmind_socket"] }
+            overmind_socket: data["overmind_socket"], ports: data["ports"] }
         rescue JSON::ParserError, TypeError
           nil
         end
@@ -606,10 +754,26 @@ module ReactOnRails
           return false unless data.is_a?(Hash)
           return false unless data["schema"] == DEV_SESSION_SCHEMA
           return false unless valid_session_root?(data["app_root"])
-          return false unless data["pid"].is_a?(Integer) && data["pid"] > 1
+          return false unless valid_session_pid?(data["pid"])
           return false unless valid_session_pgid?(data["pgid"])
+          return false unless valid_session_ports?(data["ports"])
 
-          data["overmind_socket"].nil? || data["overmind_socket"].is_a?(String)
+          valid_session_socket?(data["overmind_socket"])
+        end
+
+        def valid_session_pid?(value)
+          value.is_a?(Integer) && value > 1
+        end
+
+        def valid_session_socket?(value)
+          value.nil? || value.is_a?(String)
+        end
+
+        def valid_session_ports?(value)
+          return true if value.nil?
+          return false unless value.is_a?(Array)
+
+          value.all? { |port| port.is_a?(Integer) && port.between?(1, PortSelector::TCP_PORT_MAX) }
         end
 
         def valid_session_root?(value)
@@ -716,7 +880,7 @@ module ReactOnRails
 
         def shutdown_blockers(view, pgid, endpoint)
           blockers = []
-          blockers << "the `bin/dev` that owns #{view[:path]} is still running" unless owner_released?(view[:path])
+          blockers << "the `bin/dev` that owns #{view[:path]} is still running" unless owner_released?(view)
           blockers << "process group #{pgid} still has members" if pgid && process_group_alive?(pgid)
           if endpoint && overmind_endpoint_alive?(endpoint)
             blockers << "the Overmind endpoint #{endpoint} is still accepting connections"
@@ -726,10 +890,21 @@ module ReactOnRails
 
         # Positive re-observation of the owner: the state file is gone, or its
         # lock is now free. Anything we cannot observe counts as "still held".
-        def owner_released?(path)
+        #
+        # The re-check has to use the handle we already hold. `flock` locks
+        # attach to the open file description, not to the process, so a second
+        # descriptor on the same path can be denied by OUR OWN lock - reporting
+        # "the owner is still running" when we are the lock holder and the
+        # shutdown in fact succeeded. Re-locking the same description is
+        # idempotent, so it answers the question honestly.
+        def owner_released?(view)
+          path = view[:path]
           return true unless File.exist?(path)
 
-          File.open(path, File::RDWR) do |file|
+          handle = view[:handle]
+          return lock_dev_session(handle) == :acquired if handle && !handle.closed?
+
+          File.open(path, File::RDONLY) do |file|
             file.flock(File::LOCK_EX | File::LOCK_NB) ? true : false
           end
         rescue Errno::ENOENT
@@ -738,11 +913,18 @@ module ReactOnRails
           false
         end
 
+        # Verification is stricter than signalling. For signalling, "cannot
+        # attribute" correctly means "leave it alone"; for verification, a probe
+        # that could not run at all must not be reported as "nothing left", or a
+        # transient lsof failure silently upgrades a surviving listener to
+        # :verified.
         def leftover_owned_listeners(view)
-          owned, _foreign = classify_port_listeners(view[:ports])
-          owned.map do |port, pids|
+          owned, _foreign, unavailable = classify_port_listeners(view[:ports])
+          blockers = owned.map do |port, pids|
             "port #{port} is still held by this app directory (PIDs: #{pids.join(', ')})"
           end
+          unavailable.each { |port| blockers << "could not verify port #{port} is free (lsof unavailable)" }
+          blockers
         end
 
         def remove_dev_session_file(view)
@@ -786,6 +968,19 @@ module ReactOnRails
           verify_owner_shutdown(view, nil, endpoint)
         end
 
+        def shutdown_failed?(status)
+          SHUTDOWN_FAILURE_STATUSES.include?(status)
+        end
+
+        # Always returns true so the caller can read as a single guard clause.
+        def abort_clean_after_failed_shutdown
+          puts ""
+          puts "⛔ Not cleaning: this app directory's development processes could not be stopped."
+          puts "   Removing bundles and caches under a running dev server would leave it serving"
+          puts "   output this command just deleted. Resolve the shutdown above, then retry."
+          true
+        end
+
         def print_kill_failure(status, blockers)
           puts ""
           if status == :refused
@@ -809,8 +1004,18 @@ module ReactOnRails
           candidates.find { |path| overmind_endpoint_owned?(path, root) && overmind_endpoint_alive?(path) }
         end
 
+        # Containment check for a control endpoint. The path is resolved before
+        # comparing: `File.socket?` follows symlinks, so comparing the raw string
+        # let `<root>/.overmind.sock` be a symlink pointing at ANOTHER checkout's
+        # live endpoint and still pass as "ours" - and `overmind kill -s` would
+        # then tear down that other checkout's session, with no session-file
+        # tampering required because the default path is always a candidate.
+        # Resolving also collapses `..` escapes in a recorded path.
         def overmind_endpoint_owned?(path, root = current_app_root)
-          inside_dev_app_root?(path, root) && File.socket?(path)
+          return false unless path.is_a?(String) && !path.empty?
+          return false unless File.socket?(path)
+
+          inside_dev_app_root?(File.realpath(path), root)
         rescue SystemCallError
           false
         end
@@ -884,20 +1089,33 @@ module ReactOnRails
           true
         end
 
+        # Returns [owned, foreign, unavailable]. `unavailable` lists ports whose
+        # listener probe could not run at all, which the verification path must
+        # not read as "nothing left".
         def classify_port_listeners(ports)
+          root = current_app_root
           owned = {}
           foreign = {}
+          unavailable = []
 
           Array(ports).uniq.each do |port|
-            pids = find_port_pids(port)
+            pids, probe = probe_port_listeners(port)
+            next unavailable << port if probe == :unavailable
             next if pids.empty?
 
-            mine, theirs = pids.partition { |pid| pid_working_directory_owned?(pid) }
+            mine, theirs = pids.partition { |pid| pid_working_directory_owned?(pid, root) }
             owned[port] = mine if mine.any?
             foreign[port] = theirs if theirs.any?
           end
 
-          [owned, foreign]
+          [owned, foreign, unavailable]
+        end
+
+        def report_unavailable_port_probes(ports)
+          return if ports.empty?
+
+          puts "   ⚠️  Could not check port#{'s' if ports.size > 1} #{ports.join(', ')} " \
+               "for listeners (lsof unavailable)"
         end
 
         def report_foreign_listeners(foreign)
@@ -907,11 +1125,11 @@ module ReactOnRails
           end
         end
 
-        def pid_working_directory_owned?(pid)
+        def pid_working_directory_owned?(pid, root = current_app_root)
           cwd = working_directory_for_pid(pid)
           return false if cwd.nil?
 
-          inside_dev_app_root?(cwd)
+          inside_dev_app_root?(cwd, root)
         end
 
         # `lsof -a -p PID -d cwd -Fn` prints the process's working directory in
@@ -1442,8 +1660,8 @@ module ReactOnRails
               #{Rainbow('test-watch').green.bold}          #{Rainbow('Watch and rebuild test assets with smart defaults').white}
                                   #{Rainbow('→ Uses:').yellow} bin/shakapacker --watch (RAILS_ENV=test)
 
-              #{Rainbow('kill').red.bold}                #{Rainbow('Kill all development processes for a clean start').white}
-              #{Rainbow('clean').red.bold}               #{Rainbow('Kill dev processes and remove generated bundles/caches').white}
+              #{Rainbow('kill').red.bold}                #{Rainbow('Stop the dev processes owned by this app directory').white}
+              #{Rainbow('clean').red.bold}               #{Rainbow('Stop dev processes, then remove generated bundles/caches').white}
               #{Rainbow('help').blue.bold}                #{Rainbow('Show this help message').white}
           COMMANDS
         end

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -262,26 +262,34 @@ module ReactOnRails
         # signalled. Listeners that cannot be positively attributed are
         # reported as diagnostics and left alone.
         def kill_port_processes(ports)
-          owned, foreign, unavailable = classify_port_listeners(ports)
-          report_foreign_listeners(foreign)
-          report_unavailable_port_probes(unavailable)
-          return false if owned.empty?
+          scan = classify_port_listeners(ports)
+          report_unsignalled_listeners(scan)
+          return false if scan[:owned].empty?
 
-          owned.each do |port, pids|
+          scan[:owned].each do |port, pids|
             puts "   ☠️  Stopping this app's process on port #{port} (PIDs: #{pids.join(', ')})"
           end
 
-          pids = owned.values.flatten.uniq
+          stop_attributed_pids(scan[:owned].values.flatten.uniq)
+          true
+        end
+
+        # Everything the scan turned up that this app directory will not signal.
+        def report_unsignalled_listeners(scan)
+          report_foreign_listeners(scan[:foreign])
+          report_unattributable_listeners(scan[:unattributable])
+          report_unavailable_port_probes(scan[:unavailable])
+        end
+
+        def stop_attributed_pids(pids)
           terminate_processes(pids)
           wait_until(SHUTDOWN_TERM_GRACE_SECS) { pids.none? { |pid| process_alive?(pid) } }
           survivors = pids.select { |pid| process_alive?(pid) }
-          if survivors.any?
-            puts "   ☠️  Escalating to KILL for survivors (PIDs: #{survivors.join(', ')})"
-            terminate_processes(survivors, "KILL")
-            wait_until(SHUTDOWN_KILL_GRACE_SECS) { survivors.none? { |pid| process_alive?(pid) } }
-          end
+          return if survivors.empty?
 
-          true
+          puts "   ☠️  Escalating to KILL for survivors (PIDs: #{survivors.join(', ')})"
+          terminate_processes(survivors, "KILL")
+          wait_until(SHUTDOWN_KILL_GRACE_SECS) { survivors.none? { |pid| process_alive?(pid) } }
         end
 
         # Returns the pids holding a LISTEN socket on `port`.
@@ -339,7 +347,9 @@ module ReactOnRails
 
           files.each do |file|
             next unless File.exist?(file)
-            next if File.socket?(file) && overmind_endpoint_alive?(file)
+            # Remove a socket only when it is positively dead; an unreachable
+            # probe must not be taken as permission to delete a live endpoint.
+            next if File.socket?(file) && overmind_endpoint_state(file) != :gone
 
             puts "   🧹 Removing #{relative_to_app_root(file, root)}"
             File.delete(file)
@@ -542,22 +552,54 @@ module ReactOnRails
           path = dev_session_path(root)
           FileUtils.mkdir_p(File.dirname(path))
           file = File.open(path, File::RDWR | File::CREAT, 0o644)
-          unless file.flock(File::LOCK_EX | File::LOCK_NB)
-            file.close
-            puts "   ℹ️  Another `bin/dev` already owns #{relative_to_app_root(path, root)}; " \
-                 "leaving its session state untouched."
-            puts "   ⚠️  This run is NOT recorded, so `bin/dev kill` will control that other run, " \
-                 "not this one. Stop this one from its own terminal."
+          return warn_dev_session_contended(file, path, root) unless file.flock(File::LOCK_EX | File::LOCK_NB)
+
+          begin
+            write_dev_session(file, root)
+          rescue StandardError => e
+            discard_partial_dev_session(file, path)
+            warn_dev_session_unrecorded(e)
             return nil
           end
 
+          file
+        rescue SystemCallError, IOError => e
+          warn_dev_session_unrecorded(e)
+          nil
+        end
+
+        def write_dev_session(file, root)
           file.truncate(0)
           file.write(JSON.pretty_generate(dev_session_payload(root)))
           file.flush
-          file
-        rescue SystemCallError, IOError => e
-          warn "   ⚠️  Could not record dev session state (#{e.class}). " \
+        end
+
+        # A write that fails once the lock is held (a full filesystem, say) must
+        # not leave a locked handle and a truncated file behind: startup would
+        # announce port-scoped fallback while every later `bin/dev kill` found
+        # malformed *locked* state and refused, until GC happened to close the
+        # descriptor. Drop the file and the lock before degrading.
+        def discard_partial_dev_session(file, path)
+          return if file.nil?
+
+          File.delete(path) if File.exist?(path) && !dev_session_replaced?(path, file)
+          file.flock(File::LOCK_UN)
+          file.close
+        rescue SystemCallError, IOError
+          nil
+        end
+
+        def warn_dev_session_unrecorded(error)
+          warn "   ⚠️  Could not record dev session state (#{error.class}). " \
                "`bin/dev kill` will fall back to port-scoped cleanup."
+        end
+
+        def warn_dev_session_contended(file, path, root)
+          file.close
+          puts "   ℹ️  Another `bin/dev` already owns #{relative_to_app_root(path, root)}; " \
+               "leaving its session state untouched."
+          puts "   ⚠️  This run is NOT recorded, so `bin/dev kill` will control that other run, " \
+               "not this one. Stop this one from its own terminal."
           nil
         end
 
@@ -837,12 +879,24 @@ module ReactOnRails
         # precedes KILL, and KILL only ever reaches whatever survived TERM.
         def request_owner_shutdown(view, pgid, endpoint)
           shutdown_steps(pgid, endpoint).each do |label, grace, action|
+            # Never escalate against state a newer `bin/dev` has taken over: both
+            # the recorded pgid and the socket path can have been reused, so the
+            # next signal would land on somebody else's session.
+            return false if session_replaced?(view)
+
             puts "   #{label}"
             action.call
-            return true if wait_until(grace) { owner_shutdown_complete?(view, pgid, endpoint) }
+            return true if wait_until(grace) { shutdown_settled?(view, pgid, endpoint) }
           end
 
           false
+        end
+
+        # Stop waiting once the shutdown is complete OR the session has been
+        # replaced - polling out the rest of the grace window changes nothing
+        # and only delays the honest failure report.
+        def shutdown_settled?(view, pgid, endpoint)
+          session_replaced?(view) || owner_shutdown_complete?(view, pgid, endpoint)
         end
 
         def shutdown_steps(pgid, endpoint)
@@ -879,38 +933,83 @@ module ReactOnRails
         end
 
         def shutdown_blockers(view, pgid, endpoint)
-          blockers = []
-          blockers << "the `bin/dev` that owns #{view[:path]} is still running" unless owner_released?(view)
+          blockers = owner_state_blockers(view)
           blockers << "process group #{pgid} still has members" if pgid && process_group_alive?(pgid)
-          if endpoint && overmind_endpoint_alive?(endpoint)
-            blockers << "the Overmind endpoint #{endpoint} is still accepting connections"
-          end
+          blockers.concat(endpoint_blockers(endpoint))
           blockers
         end
 
-        # Positive re-observation of the owner: the state file is gone, or its
-        # lock is now free. Anything we cannot observe counts as "still held".
+        def owner_state_blockers(view)
+          case owner_release_state(view)
+          when :held
+            ["the `bin/dev` that owns #{view[:path]} is still running"]
+          when :replaced
+            ["#{view[:path]} was replaced by a newer `bin/dev` while this shutdown was running"]
+          else
+            []
+          end
+        end
+
+        def endpoint_blockers(endpoint)
+          return [] if endpoint.nil?
+
+          case overmind_endpoint_state(endpoint)
+          when :alive
+            ["the Overmind endpoint #{endpoint} is still accepting connections"]
+          when :unknown
+            ["could not determine whether the Overmind endpoint #{endpoint} is still live"]
+          else
+            []
+          end
+        end
+
+        # :released, :held, or :replaced.
         #
         # The re-check has to use the handle we already hold. `flock` locks
         # attach to the open file description, not to the process, so a second
         # descriptor on the same path can be denied by OUR OWN lock - reporting
         # "the owner is still running" when we are the lock holder and the
         # shutdown in fact succeeded. Re-locking the same description is
-        # idempotent, so it answers the question honestly.
-        def owner_released?(view)
+        # idempotent, so it answers that question honestly.
+        #
+        # But an old handle can also be an UNLINKED inode: if a newer `bin/dev`
+        # recreated and locked the path after the previous owner removed it, we
+        # would happily re-lock the dead inode and call it released - and the
+        # escalation ladder could then aim `overmind kill` at the new session
+        # through the reused socket path. So check for replacement first, and
+        # never treat it as success. Anything we cannot observe counts as held.
+        def owner_release_state(view)
           path = view[:path]
-          return true unless File.exist?(path)
+          return :released unless File.exist?(path)
 
           handle = view[:handle]
-          return lock_dev_session(handle) == :acquired if handle && !handle.closed?
+          if handle && !handle.closed?
+            return :replaced if dev_session_replaced?(path, handle)
+
+            return lock_dev_session(handle) == :acquired ? :released : :held
+          end
 
           File.open(path, File::RDONLY) do |file|
-            file.flock(File::LOCK_EX | File::LOCK_NB) ? true : false
+            file.flock(File::LOCK_EX | File::LOCK_NB) ? :released : :held
           end
         rescue Errno::ENOENT
-          true
+          :released
         rescue SystemCallError, IOError
-          false
+          :held
+        end
+
+        def owner_released?(view)
+          owner_release_state(view) == :released
+        end
+
+        # True once a newer `bin/dev` has claimed the path this shutdown was
+        # working against. Used to abandon the escalation ladder rather than
+        # keep signalling on behalf of state we no longer own.
+        def session_replaced?(view)
+          handle = view[:handle]
+          return false if handle.nil? || handle.closed?
+
+          File.exist?(view[:path]) && dev_session_replaced?(view[:path], handle)
         end
 
         # Verification is stricter than signalling. For signalling, "cannot
@@ -919,11 +1018,15 @@ module ReactOnRails
         # transient lsof failure silently upgrades a surviving listener to
         # :verified.
         def leftover_owned_listeners(view)
-          owned, _foreign, unavailable = classify_port_listeners(view[:ports])
-          blockers = owned.map do |port, pids|
+          scan = classify_port_listeners(view[:ports])
+          blockers = scan[:owned].map do |port, pids|
             "port #{port} is still held by this app directory (PIDs: #{pids.join(', ')})"
           end
-          unavailable.each { |port| blockers << "could not verify port #{port} is free (lsof unavailable)" }
+          scan[:unattributable].each do |port, pids|
+            blockers << "port #{port} still has a listener that could not be attributed " \
+                        "(PIDs: #{pids.join(', ')}), so it cannot be confirmed gone"
+          end
+          scan[:unavailable].each { |port| blockers << "could not verify port #{port} is free (lsof unavailable)" }
           blockers
         end
 
@@ -949,10 +1052,16 @@ module ReactOnRails
 
           cleaned = cleanup_socket_files
           killed = kill_port_processes(view[:ports])
-          return [:nothing_running, []] unless cleaned || killed || view[:kind] == :stale
 
+          # Verification runs even when nothing was signalled. "We looked and
+          # found nothing" and "we could not look" must not collapse into the
+          # same answer: with lsof missing, every relevant port goes uninspected
+          # and reporting :nothing_running would let `bin/dev kill && bin/dev`
+          # start a second stack on top of a live one.
           leftover = leftover_owned_listeners(view)
           return [:unverified, leftover] if leftover.any?
+
+          return [:nothing_running, []] unless cleaned || killed || view[:kind] == :stale
 
           killed ? [:verified, []] : [:recovered_stale, []]
         end
@@ -1020,14 +1129,24 @@ module ReactOnRails
           false
         end
 
-        def overmind_endpoint_alive?(path)
-          return false unless File.socket?(path)
+        # :alive, :gone, or :unknown. Same principle as the port probes: a
+        # refused connection is positive evidence the endpoint is dead, but a
+        # probe that could not run is not, and verification must not read the
+        # second as the first.
+        def overmind_endpoint_state(path)
+          return :gone unless File.socket?(path)
 
           socket = UNIXSocket.new(path)
           socket.close
-          true
+          :alive
+        rescue Errno::ECONNREFUSED, Errno::ENOENT, Errno::ENOTSOCK
+          :gone
         rescue SystemCallError, IOError
-          false
+          :unknown
+        end
+
+        def overmind_endpoint_alive?(path)
+          overmind_endpoint_state(path) == :alive
         end
 
         # Re-checks ownership immediately before handing control to Overmind,
@@ -1089,26 +1208,39 @@ module ReactOnRails
           true
         end
 
-        # Returns [owned, foreign, unavailable]. `unavailable` lists ports whose
-        # listener probe could not run at all, which the verification path must
-        # not read as "nothing left".
+        # Returns a scan hash with four buckets, keeping "someone else's" and
+        # "could not tell" strictly apart:
+        #
+        #   owned          Hash[port => pids]  positively this app directory's
+        #   foreign        Hash[port => pids]  positively somebody else's
+        #   unattributable Hash[port => pids]  the cwd probe failed
+        #   unavailable    Array[port]         the listener probe failed
+        #
+        # Signalling consumes `owned` only. Verification must block on
+        # `unattributable` and `unavailable` too: folding a failed probe into
+        # `foreign` is what let a surviving listener be reported as gone.
         def classify_port_listeners(ports)
           root = current_app_root
-          owned = {}
-          foreign = {}
-          unavailable = []
+          scan = { owned: {}, foreign: {}, unattributable: {}, unavailable: [] }
 
           Array(ports).uniq.each do |port|
             pids, probe = probe_port_listeners(port)
-            next unavailable << port if probe == :unavailable
+            next scan[:unavailable] << port if probe == :unavailable
             next if pids.empty?
 
-            mine, theirs = pids.partition { |pid| pid_working_directory_owned?(pid, root) }
-            owned[port] = mine if mine.any?
-            foreign[port] = theirs if theirs.any?
+            grouped = pids.group_by { |pid| attribute_pid(pid, root) }
+            scan[:owned][port] = grouped[:owned] if grouped[:owned]
+            scan[:foreign][port] = grouped[:foreign] if grouped[:foreign]
+            scan[:unattributable][port] = grouped[:unknown] if grouped[:unknown]
           end
 
-          [owned, foreign, unavailable]
+          scan
+        end
+
+        def report_unattributable_listeners(unattributable)
+          unattributable.each do |port, pids|
+            puts "   ⚠️  Could not determine who owns port #{port} (PIDs: #{pids.join(', ')}); leaving it alone"
+          end
         end
 
         def report_unavailable_port_probes(ports)
@@ -1125,11 +1257,15 @@ module ReactOnRails
           end
         end
 
-        def pid_working_directory_owned?(pid, root = current_app_root)
+        # :owned, :foreign, or :unknown when the working-directory probe itself
+        # failed. `working_directory_for_pid` returns nil for a missing tool, a
+        # permission error and unparsable output alike - none of which is
+        # evidence that the process belongs to somebody else.
+        def attribute_pid(pid, root)
           cwd = working_directory_for_pid(pid)
-          return false if cwd.nil?
+          return :unknown if cwd.nil?
 
-          inside_dev_app_root?(cwd, root)
+          inside_dev_app_root?(cwd, root) ? :owned : :foreign
         end
 
         # `lsof -a -p PID -d cwd -Fn` prints the process's working directory in

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -2,6 +2,7 @@
 
 require "English"
 require "fileutils"
+require "json"
 require "net/http"
 require "open3"
 require "optparse"
@@ -31,6 +32,17 @@ module ReactOnRails
       CLEAN_SHAKAPACKER_ENVIRONMENTS = %w[development test production].freeze
       OPEN_BROWSER_WAIT_TIMEOUT = 60
       OPEN_BROWSER_POLL_INTERVAL = 0.5
+
+      # Per-app-directory run state written by `bin/dev` and consumed by
+      # `bin/dev kill`. See the "Scoped dev shutdown" section further down.
+      DEV_SESSION_RELATIVE_PATH = File.join("tmp", "react_on_rails", "dev-session.json")
+      DEV_SESSION_SCHEMA = 1
+      # Grace given to a graceful stop (`overmind quit` / SIGTERM) before escalating.
+      SHUTDOWN_TERM_GRACE_SECS = 10
+      # Grace given to the forceful stop (`overmind kill` / SIGKILL) before giving up.
+      SHUTDOWN_KILL_GRACE_SECS = 5
+      SHUTDOWN_POLL_INTERVAL_SECS = 0.2
+
       DOCS_BASE_URL = "https://reactonrails.com/docs"
       DEV_SERVER_AND_TESTING_DOCS_URL = "#{DOCS_BASE_URL}/building-features/dev-server-and-testing/".freeze
       TESTING_CONFIGURATION_DOCS_URL = "#{DOCS_BASE_URL}/building-features/testing-configuration/".freeze
@@ -61,21 +73,20 @@ module ReactOnRails
           end
         end
 
+        # Stops the development processes owned by THIS app directory and
+        # verifies they are gone before reporting success.
+        #
+        # This is deliberately not an OS-wide development-process cleanup:
+        # nothing is signalled unless it can be positively attributed to the
+        # current app root. See the "Scoped dev shutdown" section below for
+        # the ownership model and its known limitation.
         def kill_processes
-          puts "🔪 Killing all development processes..."
+          puts "🔪 Stopping this app's development processes..."
+          puts "   #{current_app_root}"
           puts ""
 
-          # Run every cleanup step unconditionally so a successful first step
-          # (e.g. pattern-based kill) doesn't leave stale port-bound processes
-          # or socket/pid files behind. `.any?` still gives us the
-          # "anything actually got killed?" signal for the summary message.
-          killed_any = [
-            kill_running_processes,
-            kill_port_processes(killable_ports),
-            cleanup_socket_files
-          ].any?
-
-          print_kill_summary(killed_any)
+          status, blockers = shutdown_dev_session
+          print_kill_summary(status, blockers)
         end
 
         def clean_generated_assets_and_caches
@@ -182,44 +193,11 @@ module ReactOnRails
           end
         end
 
-        def development_processes
-          {
-            "rails" => "Rails server",
-            "node.*react[-_]on[-_]rails" => "React on Rails Node processes",
-            "overmind" => "Overmind process manager",
-            "foreman" => "Foreman process manager",
-            "ruby.*puma" => "Puma server",
-            "webpack-dev-server" => "Webpack dev server",
-            "bin/shakapacker-dev-server" => "Shakapacker dev server"
-          }
-        end
-
-        def kill_running_processes
-          killed_any = false
-
-          development_processes.each do |pattern, description|
-            pids = find_process_pids(pattern)
-            next unless pids.any?
-
-            puts "   ☠️  Killing #{description} (PIDs: #{pids.join(', ')})"
-            terminate_processes(pids)
-            killed_any = true
-          end
-
-          killed_any
-        end
-
-        def find_process_pids(pattern)
-          stdout, _status = Open3.capture2("pgrep", "-f", pattern, err: File::NULL)
-          stdout.split("\n").map(&:to_i).reject { |pid| pid == Process.pid }
-        rescue Errno::ENOENT
-          # pgrep command not found
-          []
-        end
-
-        def terminate_processes(pids)
+        # Signals every pid in `pids`. Callers must have already attributed
+        # each pid to this app directory - this helper does no filtering.
+        def terminate_processes(pids, signal = "TERM")
           pids.each do |pid|
-            Process.kill("TERM", pid)
+            Process.kill(signal, pid)
           rescue Errno::ESRCH, ArgumentError, RangeError
             # Process already stopped, or invalid signal/PID - silently skip
             nil
@@ -230,57 +208,97 @@ module ReactOnRails
           end
         end
 
+        # Last-resort path used when there is no live dev-session owner to
+        # control. Only LISTEN sockets are considered, and every candidate pid
+        # must have a working directory inside this app root before it is
+        # signalled. Listeners that cannot be positively attributed are
+        # reported as diagnostics and left alone.
         def kill_port_processes(ports)
-          killed_any = false
+          owned, foreign = classify_port_listeners(ports)
+          report_foreign_listeners(foreign)
+          return false if owned.empty?
 
-          ports.each do |port|
-            pids = find_port_pids(port)
-            next unless pids.any?
-
-            puts "   ☠️  Killing process on port #{port} (PIDs: #{pids.join(', ')})"
-            terminate_processes(pids)
-            killed_any = true
+          owned.each do |port, pids|
+            puts "   ☠️  Stopping this app's process on port #{port} (PIDs: #{pids.join(', ')})"
           end
 
-          killed_any
+          pids = owned.values.flatten.uniq
+          terminate_processes(pids)
+          wait_until(SHUTDOWN_TERM_GRACE_SECS) { pids.none? { |pid| process_alive?(pid) } }
+          survivors = pids.select { |pid| process_alive?(pid) }
+          if survivors.any?
+            puts "   ☠️  Escalating to KILL for survivors (PIDs: #{survivors.join(', ')})"
+            terminate_processes(survivors, "KILL")
+            wait_until(SHUTDOWN_KILL_GRACE_SECS) { survivors.none? { |pid| process_alive?(pid) } }
+          end
+
+          true
         end
 
+        # Returns the pids holding a LISTEN socket on `port`.
+        #
+        # `-sTCP:LISTEN` matters: the unfiltered `lsof -ti :PORT` this replaced
+        # also matched *client* sockets connected to the port (a browser tab, a
+        # curl, another app's HTTP client), and those pids were then signalled.
         def find_port_pids(port)
-          stdout, _status = Open3.capture2("lsof", "-ti", ":#{port}", err: File::NULL)
-          stdout.split("\n").map(&:to_i).reject { |pid| pid == Process.pid }
+          stdout, _status = Open3.capture2("lsof", "-nP", "-t", "-iTCP:#{port}", "-sTCP:LISTEN", err: File::NULL)
+          stdout.split("\n").map(&:to_i).reject { |pid| pid <= 1 || pid == Process.pid }
         rescue StandardError
           # lsof command not found or other error (permission denied, etc.)
           []
         end
 
+        # Read-only probe used by `bin/dev test-watch` to notice an existing
+        # Shakapacker watcher. Deliberately NOT part of the shutdown path:
+        # `pgrep -f` matches command lines machine-wide, so its results say
+        # nothing about which checkout a process belongs to and must never be
+        # used as signal authority.
+        def find_process_pids(pattern)
+          stdout, _status = Open3.capture2("pgrep", "-f", pattern, err: File::NULL)
+          stdout.split("\n").map(&:to_i).reject { |pid| pid == Process.pid }
+        rescue Errno::ENOENT
+          # pgrep command not found
+          []
+        end
+
+        # Removes this app's Overmind sockets and Rails pid file. Mirrors
+        # FileManager#cleanup_overmind_sockets so renamed/copied variants like
+        # overmind-4100.sock are removed during `bin/dev kill`, not just at
+        # startup. A socket that still answers is left in place - removing a
+        # live endpoint would strand the process manager behind it.
         def cleanup_socket_files
-          # Mirrors FileManager#cleanup_overmind_sockets so renamed/copied
-          # variants like overmind-4100.sock are removed during `bin/dev kill`,
-          # not just at startup.
-          overmind_sockets = Dir.glob("tmp/sockets/overmind*.sock")
-          files = [".overmind.sock", *overmind_sockets, "tmp/pids/server.pid"].uniq
-          killed_any = false
+          root = current_app_root
+          files = stale_cleanup_candidates(root)
+          cleaned_any = false
 
           files.each do |file|
             next unless File.exist?(file)
+            next if File.socket?(file) && overmind_endpoint_alive?(file)
 
-            puts "   🧹 Removing #{file}"
+            puts "   🧹 Removing #{relative_to_app_root(file, root)}"
             File.delete(file)
-            killed_any = true
+            cleaned_any = true
           rescue StandardError
             nil
           end
 
-          killed_any
+          cleaned_any
         end
 
-        def print_kill_summary(killed_any)
-          if killed_any
+        def print_kill_summary(status, blockers = [])
+          case status
+          when :verified
             puts ""
-            puts "✅ All processes terminated and sockets cleaned"
+            puts "✅ This app's development processes are stopped, and verified gone"
             puts "💡 You can now run 'bin/dev' for a clean start"
+          when :recovered_stale
+            puts ""
+            puts "✅ Cleaned up stale dev session state - nothing was running"
+            puts "💡 You can now run 'bin/dev' for a clean start"
+          when :nothing_running
+            puts "   ℹ️  No development processes owned by this app directory are running"
           else
-            puts "   ℹ️  No development processes found running"
+            print_kill_failure(status, blockers)
           end
         end
 
@@ -360,6 +378,576 @@ module ReactOnRails
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
         private
+
+        # =================================================================
+        # Scoped dev shutdown
+        #
+        # `bin/dev kill` must never terminate processes belonging to another
+        # checkout of the same app. Ownership is therefore established when the
+        # session STARTS rather than guessed at kill time:
+        #
+        #   * `bin/dev` claims `tmp/react_on_rails/dev-session.json` with an
+        #     exclusive `flock` that it holds for the whole session, and records
+        #     the absolute realpath of the app root it belongs to, its own pid,
+        #     the process group it leads (when it leads one), and the Overmind
+        #     endpoint it would use.
+        #   * `bin/dev kill` re-opens that file. Failing to take the lock is
+        #     positive proof the owner is still alive; taking it is positive
+        #     proof the owner is gone and the recorded numbers are stale. A bare
+        #     pid or pgid is never authority on its own, because pids are
+        #     recycled - the lock is the liveness proof, and the recorded app
+        #     root is the identity proof.
+        #   * Anything that cannot be positively attributed to this app root is
+        #     reported as a diagnostic and never signalled. Missing, malformed,
+        #     foreign or unreadable state fails closed: nothing is signalled and
+        #     no success is printed.
+        #
+        # Known limitation: the guarantee covers foreground Procfile processes
+        # and their ordinary descendants. A process that deliberately escapes
+        # its process group with `setsid`/daemonization is out of scope for this
+        # mechanism. Overmind's tmux server is exactly such a process, which is
+        # why an Overmind session is shut down through its own per-worktree
+        # control socket instead of by signalling the process group.
+        # =================================================================
+
+        def dev_session_path(root)
+          File.join(root, DEV_SESSION_RELATIVE_PATH)
+        end
+
+        # Absolute, symlink-resolved identity of the app directory `bin/dev`
+        # was invoked from. Every ownership decision is made against this.
+        def current_app_root
+          File.realpath(Dir.pwd)
+        rescue SystemCallError
+          File.expand_path(Dir.pwd)
+        end
+
+        # Distinct from #path_inside_app_root? (used by `bin/dev clean`, which
+        # anchors on the Shakapacker config base dir): shutdown ownership is
+        # decided against the symlink-resolved cwd, and the root itself counts
+        # as inside.
+        def inside_dev_app_root?(path, root = current_app_root)
+          return false unless path.is_a?(String) && !path.empty?
+
+          path == root || path.start_with?("#{root}#{File::SEPARATOR}")
+        end
+
+        def relative_to_app_root(path, root = current_app_root)
+          prefix = "#{root}#{File::SEPARATOR}"
+          path.start_with?(prefix) ? path[prefix.length..].to_s : path
+        end
+
+        # ---- start path: claiming the session -------------------------
+
+        # Wraps a foreground process-manager run so `bin/dev kill` has a
+        # trustworthy, worktree-scoped handle on it. Startup is never blocked by
+        # a bookkeeping failure - the kill path degrades to port-attributed
+        # cleanup instead.
+        def with_dev_session
+          handle = claim_dev_session(current_app_root)
+          begin
+            yield
+          ensure
+            release_dev_session(handle)
+          end
+        end
+
+        def claim_dev_session(root)
+          path = dev_session_path(root)
+          FileUtils.mkdir_p(File.dirname(path))
+          file = File.open(path, File::RDWR | File::CREAT, 0o644)
+          unless file.flock(File::LOCK_EX | File::LOCK_NB)
+            file.close
+            puts "   ℹ️  Another `bin/dev` already owns #{relative_to_app_root(path, root)}; " \
+                 "leaving its session state untouched."
+            return nil
+          end
+
+          file.truncate(0)
+          file.write(JSON.pretty_generate(dev_session_payload(root)))
+          file.flush
+          file
+        rescue SystemCallError, IOError => e
+          warn "   ⚠️  Could not record dev session state (#{e.class}). " \
+               "`bin/dev kill` will fall back to port-scoped cleanup."
+          nil
+        end
+
+        def dev_session_payload(root)
+          {
+            "schema" => DEV_SESSION_SCHEMA,
+            "app_root" => root,
+            "pid" => Process.pid,
+            "pgid" => owned_process_group,
+            "overmind_socket" => owned_overmind_socket_path(root),
+            "started_at" => Time.now.utc.iso8601
+          }
+        end
+
+        # Only report a pgid we actually lead. When the shell's job control put
+        # `bin/dev` at the head of its own process group, that group contains
+        # `bin/dev` and its descendants and nothing else, so signalling it can
+        # never reach the parent shell or a sibling job. If we are not the
+        # group leader the group is somebody else's and is not ours to signal.
+        def owned_process_group
+          pgid = Process.getpgrp
+          pgid == Process.pid ? pgid : nil
+        rescue NotImplementedError, SystemCallError
+          nil
+        end
+
+        # The endpoint Overmind will use for this run. Only recorded when it
+        # lives inside this app root - an OVERMIND_SOCKET pointing elsewhere is
+        # not ours to control.
+        def owned_overmind_socket_path(root)
+          configured = ENV.fetch("OVERMIND_SOCKET", nil).to_s.strip
+          path = configured.empty? ? default_overmind_socket_path(root) : File.expand_path(configured, root)
+          inside_dev_app_root?(path, root) ? path : nil
+        end
+
+        def default_overmind_socket_path(root)
+          File.join(root, ".overmind.sock")
+        end
+
+        def release_dev_session(handle)
+          return if handle.nil?
+
+          path = handle.path
+          File.delete(path) if File.exist?(path) && !dev_session_replaced?(path, handle)
+          handle.flock(File::LOCK_UN)
+          handle.close
+        rescue SystemCallError, IOError
+          nil
+        end
+
+        # ---- kill path: reading and classifying the session ------------
+
+        def shutdown_dev_session
+          view = dev_session_view(current_app_root).merge(ports: killable_ports)
+          begin
+            dispatch_dev_shutdown(view)
+          ensure
+            close_session_handle(view)
+          end
+        end
+
+        def dispatch_dev_shutdown(view)
+          case view[:kind]
+          when :refused then [:refused, view[:blockers]]
+          when :owner_alive then shutdown_live_owner(view)
+          else shutdown_without_owner(view)
+          end
+        end
+
+        def dev_session_view(root)
+          path = dev_session_path(root)
+          file = open_dev_session(path)
+          return { kind: :absent, root:, path:, handle: nil } if file.nil?
+
+          kind, payload = classify_dev_session(root, path, file)
+          base = { kind:, root:, path:, handle: file }
+          kind == :refused ? base.merge(blockers: [payload]) : base.merge(session: payload)
+        end
+
+        # Missing state, an unreadable file and a permissions problem are all
+        # "no usable owner record", handled by the caller's no-owner path.
+        def open_dev_session(path)
+          File.open(path, File::RDWR)
+        rescue SystemCallError
+          nil
+        end
+
+        def classify_dev_session(root, path, file)
+          session = parse_dev_session(file.read)
+          return [:refused, "#{path} is not readable React on Rails dev session state"] if session.nil?
+
+          unless session[:app_root] == root
+            return [:refused, "#{path} records app root #{session[:app_root]}, which is not #{root}"]
+          end
+
+          case lock_dev_session(file)
+          when :error
+            [:refused, "could not determine whether #{path} is still owned by a running `bin/dev`"]
+          when :held
+            [:owner_alive, session]
+          else
+            classify_released_dev_session(path, file, session)
+          end
+        rescue SystemCallError, IOError
+          [:refused, "could not read #{path}"]
+        end
+
+        # The owner released the lock: either it tidied up after itself or it
+        # died. Both mean the recorded pid/pgid are stale and must not be
+        # signalled. A file that was *replaced* under us is a contradiction, so
+        # that fails closed instead.
+        def classify_released_dev_session(path, file, session)
+          return [:refused, "#{path} was replaced while it was being read"] if dev_session_replaced?(path, file)
+
+          [:stale, session]
+        end
+
+        def parse_dev_session(raw)
+          data = JSON.parse(raw.to_s)
+          return nil unless valid_dev_session_document?(data)
+
+          { app_root: data["app_root"], pid: data["pid"], pgid: data["pgid"],
+            overmind_socket: data["overmind_socket"] }
+        rescue JSON::ParserError, TypeError
+          nil
+        end
+
+        # Validates the parsed shape before anything reads a key. `JSON.parse`
+        # happily returns a String, an Integer or nil for valid-but-wrong
+        # documents (`"x"`, `7`, `null`), so the Hash check has to come first -
+        # otherwise a well-formed but meaningless file would raise
+        # NoMethodError instead of being rejected as untrusted state.
+        def valid_dev_session_document?(data)
+          return false unless data.is_a?(Hash)
+          return false unless data["schema"] == DEV_SESSION_SCHEMA
+          return false unless valid_session_root?(data["app_root"])
+          return false unless data["pid"].is_a?(Integer) && data["pid"] > 1
+          return false unless valid_session_pgid?(data["pgid"])
+
+          data["overmind_socket"].nil? || data["overmind_socket"].is_a?(String)
+        end
+
+        def valid_session_root?(value)
+          value.is_a?(String) && !value.empty?
+        end
+
+        def valid_session_pgid?(value)
+          value.nil? || (value.is_a?(Integer) && value > 1)
+        end
+
+        # Returns :held when another process owns the lock (the owner is
+        # alive), :acquired when we took it (the owner is gone), :error when we
+        # cannot tell - which the caller treats as a refusal.
+        def lock_dev_session(file)
+          file.flock(File::LOCK_EX | File::LOCK_NB) ? :acquired : :held
+        rescue SystemCallError, IOError
+          :error
+        end
+
+        # True when the path now resolves to a different inode than the handle
+        # we read - i.e. a newer `bin/dev` replaced the state underneath us.
+        # A path that simply vanished is the owner tidying up after itself, not
+        # a replacement.
+        def dev_session_replaced?(path, file)
+          File.stat(path).ino != file.stat.ino
+        rescue Errno::ENOENT
+          false
+        rescue SystemCallError, IOError
+          true
+        end
+
+        def close_session_handle(view)
+          handle = view && view[:handle]
+          return if handle.nil?
+
+          handle.flock(File::LOCK_UN)
+          handle.close
+        rescue SystemCallError, IOError
+          nil
+        end
+
+        # ---- kill path: shutting down a live owner ---------------------
+
+        def shutdown_live_owner(view)
+          session = view[:session]
+          endpoint = live_overmind_endpoint(view[:root], session[:overmind_socket])
+          pgid = signalable_pgid(session[:pgid])
+          return [:refused, [unreachable_owner_message(view, session)]] if endpoint.nil? && pgid.nil?
+
+          request_owner_shutdown(view, pgid, endpoint)
+          verify_owner_shutdown(view, pgid, endpoint)
+        end
+
+        def unreachable_owner_message(view, session)
+          "`bin/dev` (pid #{session[:pid]}) still owns #{view[:path]}, but it recorded no process group " \
+            "and has no live Overmind endpoint. Stop it in its own terminal instead."
+        end
+
+        # Escalation ladder: each step runs only if the previous one did not
+        # produce a verified shutdown inside its grace window. TERM always
+        # precedes KILL, and KILL only ever reaches whatever survived TERM.
+        def request_owner_shutdown(view, pgid, endpoint)
+          shutdown_steps(pgid, endpoint).each do |label, grace, action|
+            puts "   #{label}"
+            action.call
+            return true if wait_until(grace) { owner_shutdown_complete?(view, pgid, endpoint) }
+          end
+
+          false
+        end
+
+        def shutdown_steps(pgid, endpoint)
+          steps = []
+          if endpoint
+            steps << ["🛑 Asking Overmind to quit via #{endpoint}", SHUTDOWN_TERM_GRACE_SECS,
+                      -> { overmind_control("quit", endpoint) }]
+            steps << ["☠️  Overmind did not quit in time; running `overmind kill`", SHUTDOWN_KILL_GRACE_SECS,
+                      -> { overmind_control("kill", endpoint) }]
+          end
+          if pgid
+            steps << ["🛑 Sending TERM to this app's process group (PGID #{pgid})", SHUTDOWN_TERM_GRACE_SECS,
+                      -> { signal_process_group(pgid, "TERM") }]
+            steps << ["☠️  Sending KILL to the survivors of PGID #{pgid}", SHUTDOWN_KILL_GRACE_SECS,
+                      -> { signal_process_group(pgid, "KILL") }]
+          end
+          steps
+        end
+
+        def verify_owner_shutdown(view, pgid, endpoint)
+          blockers = shutdown_blockers(view, pgid, endpoint)
+          return [:unverified, blockers] if blockers.any?
+
+          remove_dev_session_file(view)
+          cleanup_socket_files
+          leftover = leftover_owned_listeners(view)
+          return [:unverified, leftover] if leftover.any?
+
+          [:verified, []]
+        end
+
+        def owner_shutdown_complete?(view, pgid, endpoint)
+          shutdown_blockers(view, pgid, endpoint).empty?
+        end
+
+        def shutdown_blockers(view, pgid, endpoint)
+          blockers = []
+          blockers << "the `bin/dev` that owns #{view[:path]} is still running" unless owner_released?(view[:path])
+          blockers << "process group #{pgid} still has members" if pgid && process_group_alive?(pgid)
+          if endpoint && overmind_endpoint_alive?(endpoint)
+            blockers << "the Overmind endpoint #{endpoint} is still accepting connections"
+          end
+          blockers
+        end
+
+        # Positive re-observation of the owner: the state file is gone, or its
+        # lock is now free. Anything we cannot observe counts as "still held".
+        def owner_released?(path)
+          return true unless File.exist?(path)
+
+          File.open(path, File::RDWR) do |file|
+            file.flock(File::LOCK_EX | File::LOCK_NB) ? true : false
+          end
+        rescue Errno::ENOENT
+          true
+        rescue SystemCallError, IOError
+          false
+        end
+
+        def leftover_owned_listeners(view)
+          owned, _foreign = classify_port_listeners(view[:ports])
+          owned.map do |port, pids|
+            "port #{port} is still held by this app directory (PIDs: #{pids.join(', ')})"
+          end
+        end
+
+        def remove_dev_session_file(view)
+          handle = view[:handle]
+          path = view[:path]
+          return false if handle.nil? || !File.exist?(path)
+          return false if dev_session_replaced?(path, handle)
+
+          puts "   🧹 Removing #{relative_to_app_root(path, view[:root])}"
+          File.delete(path)
+          true
+        rescue SystemCallError
+          false
+        end
+
+        # ---- kill path: no live owner ----------------------------------
+
+        def shutdown_without_owner(view)
+          remove_dev_session_file(view) if view[:kind] == :stale
+          endpoint = live_overmind_endpoint(view[:root], view.dig(:session, :overmind_socket))
+          return shutdown_orphaned_overmind(view, endpoint) if endpoint
+
+          cleaned = cleanup_socket_files
+          killed = kill_port_processes(view[:ports])
+          return [:nothing_running, []] unless cleaned || killed || view[:kind] == :stale
+
+          leftover = leftover_owned_listeners(view)
+          return [:unverified, leftover] if leftover.any?
+
+          killed ? [:verified, []] : [:recovered_stale, []]
+        end
+
+        # An Overmind endpoint inside this app root that still answers is a
+        # live, worktree-scoped handle even though the `bin/dev` that started it
+        # is gone (its terminal was closed, or it was SIGKILLed). Controlling it
+        # natively is scoped; guessing at pids from the stale record is not, so
+        # the recorded pgid is deliberately not used here.
+        def shutdown_orphaned_overmind(view, endpoint)
+          puts "   ℹ️  Found an orphaned Overmind endpoint for this app directory; controlling it directly."
+          request_owner_shutdown(view, nil, endpoint)
+          verify_owner_shutdown(view, nil, endpoint)
+        end
+
+        def print_kill_failure(status, blockers)
+          puts ""
+          if status == :refused
+            puts "❌ Refusing to signal anything: this app's dev session state could not be trusted"
+          else
+            puts "❌ Shutdown could not be verified - some processes are still running"
+          end
+          Array(blockers).each { |blocker| puts "   • #{blocker}" }
+          puts ""
+          puts "💡 Inspect the processes above. Once you are certain nothing is running, remove"
+          puts "   #{DEV_SESSION_RELATIVE_PATH} and run `bin/dev kill` again."
+        end
+
+        # ---- process / endpoint observation ----------------------------
+
+        # Revalidates the recorded endpoint at control time rather than
+        # trusting what startup wrote: the socket must still live inside this
+        # app root, still be a socket, and still answer.
+        def live_overmind_endpoint(root, recorded)
+          candidates = [recorded, default_overmind_socket_path(root)].compact.uniq
+          candidates.find { |path| overmind_endpoint_owned?(path, root) && overmind_endpoint_alive?(path) }
+        end
+
+        def overmind_endpoint_owned?(path, root = current_app_root)
+          inside_dev_app_root?(path, root) && File.socket?(path)
+        rescue SystemCallError
+          false
+        end
+
+        def overmind_endpoint_alive?(path)
+          return false unless File.socket?(path)
+
+          socket = UNIXSocket.new(path)
+          socket.close
+          true
+        rescue SystemCallError, IOError
+          false
+        end
+
+        # Re-checks ownership immediately before handing control to Overmind,
+        # so a socket that was replaced or removed between validation and use
+        # cannot be acted on.
+        def overmind_control(subcommand, endpoint)
+          unless overmind_endpoint_owned?(endpoint)
+            puts "   ⚠️  Skipping `overmind #{subcommand}`: #{endpoint} is no longer this app's endpoint"
+            return false
+          end
+
+          system("overmind", subcommand, "-s", endpoint, out: File::NULL, err: File::NULL) ? true : false
+        rescue Errno::ENOENT, Interrupt
+          puts "   ⚠️  Could not run `overmind #{subcommand}` for #{endpoint}"
+          false
+        end
+
+        def signalable_pgid(pgid)
+          return nil unless pgid.is_a?(Integer) && pgid > 1
+          return nil if pgid == own_process_group
+
+          pgid
+        end
+
+        def own_process_group
+          Process.getpgrp
+        rescue NotImplementedError, SystemCallError
+          nil
+        end
+
+        def signal_process_group(pgid, signal)
+          Process.kill(signal, -pgid)
+          true
+        rescue Errno::ESRCH, ArgumentError, RangeError, NotImplementedError
+          false
+        rescue Errno::EPERM
+          puts "   ⚠️  Permission denied signalling process group #{pgid}"
+          false
+        end
+
+        # Fails closed: anything we cannot positively observe as gone counts
+        # as still alive, so an unverifiable shutdown is never reported as
+        # success.
+        def process_group_alive?(pgid)
+          Process.kill(0, -pgid)
+          true
+        rescue Errno::ESRCH
+          false
+        rescue Errno::EPERM, ArgumentError, RangeError, NotImplementedError
+          true
+        end
+
+        def process_alive?(pid)
+          Process.kill(0, pid)
+          true
+        rescue Errno::ESRCH, ArgumentError, RangeError
+          false
+        rescue Errno::EPERM
+          true
+        end
+
+        def classify_port_listeners(ports)
+          owned = {}
+          foreign = {}
+
+          Array(ports).uniq.each do |port|
+            pids = find_port_pids(port)
+            next if pids.empty?
+
+            mine, theirs = pids.partition { |pid| pid_working_directory_owned?(pid) }
+            owned[port] = mine if mine.any?
+            foreign[port] = theirs if theirs.any?
+          end
+
+          [owned, foreign]
+        end
+
+        def report_foreign_listeners(foreign)
+          foreign.each do |port, pids|
+            puts "   ℹ️  Leaving port #{port} alone (PIDs: #{pids.join(', ')}): " \
+                 "not attributable to this app directory"
+          end
+        end
+
+        def pid_working_directory_owned?(pid)
+          cwd = working_directory_for_pid(pid)
+          return false if cwd.nil?
+
+          inside_dev_app_root?(cwd)
+        end
+
+        # `lsof -a -p PID -d cwd -Fn` prints the process's working directory in
+        # a machine-readable form. Returning nil (tooling missing, permission
+        # denied, unparsable) means "not attributable", which keeps the pid out
+        # of the signal set.
+        def working_directory_for_pid(pid)
+          stdout, status = Open3.capture2("lsof", "-a", "-p", pid.to_s, "-d", "cwd", "-Fn", err: File::NULL)
+          return nil unless status.success?
+
+          line = stdout.split("\n").find { |entry| entry.start_with?("n") }
+          return nil if line.nil?
+
+          File.realpath(line[1..].to_s)
+        rescue StandardError
+          nil
+        end
+
+        def stale_cleanup_candidates(root)
+          overmind_sockets = Dir.glob(File.join(root, "tmp", "sockets", "overmind*.sock"))
+          [default_overmind_socket_path(root), *overmind_sockets, File.join(root, "tmp", "pids", "server.pid")].uniq
+        end
+
+        def wait_until(timeout_secs)
+          deadline = monotonic_now + timeout_secs
+          loop do
+            return true if yield
+            return false if monotonic_now >= deadline
+
+            sleep(SHUTDOWN_POLL_INTERVAL_SECS)
+          end
+        end
+
+        def monotonic_now
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
 
         def clean_targets
           deduplicate_clean_targets(
@@ -1181,7 +1769,7 @@ module ReactOnRails
                                                open_browser:,
                                                open_browser_once:)
             ProcessManager.ensure_procfile(procfile)
-            ProcessManager.run_with_process_manager(procfile)
+            with_dev_session { ProcessManager.run_with_process_manager(procfile) }
           else
             puts "❌ Asset precompilation failed"
             puts ""
@@ -1291,7 +1879,7 @@ module ReactOnRails
                                              open_browser:,
                                              open_browser_once:)
           ProcessManager.ensure_procfile(procfile)
-          ProcessManager.run_with_process_manager(procfile)
+          with_dev_session { ProcessManager.run_with_process_manager(procfile) }
         end
 
         def run_development(procfile, verbose: false, route: nil, skip_database_check: false,
@@ -1313,7 +1901,7 @@ module ReactOnRails
                                              open_browser:,
                                              open_browser_once:)
           ProcessManager.ensure_procfile(procfile)
-          ProcessManager.run_with_process_manager(procfile)
+          with_dev_session { ProcessManager.run_with_process_manager(procfile) }
         end
 
         def print_server_info(title, features, port = 3000, route: nil)

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -999,6 +999,18 @@ module ReactOnRails
           leftover = leftover_owned_listeners(view)
           return [:unverified, leftover] if leftover.any?
 
+          # The listener scan shells out to lsof once per port, and by the time
+          # it returns the path may belong to a newer `bin/dev`. That window is
+          # real rather than theoretical: the previous owner deletes its state
+          # on exit, so #owner_release_state returns :released without ever
+          # taking the lock, leaving the path free for anyone to claim. Reporting
+          # :verified here would tell `bin/dev kill && bin/dev` to start a second
+          # session on top of the one that just claimed this directory - and
+          # cleanup_socket_files below would delete that session's socket on the
+          # way out. Re-check and refuse instead of discarding the signal
+          # #remove_dev_session_file already computes.
+          return [:unverified, [session_replaced_blocker(view)]] if session_replaced?(view)
+
           remove_dev_session_file(view)
           cleanup_socket_files
           [:verified, []]
@@ -1015,12 +1027,16 @@ module ReactOnRails
           blockers
         end
 
+        def session_replaced_blocker(view)
+          "#{view[:path]} was replaced by a newer `bin/dev` while this shutdown was running"
+        end
+
         def owner_state_blockers(view)
           case owner_release_state(view)
           when :held
             ["the `bin/dev` that owns #{view[:path]} is still running"]
           when :replaced
-            ["#{view[:path]} was replaced by a newer `bin/dev` while this shutdown was running"]
+            [session_replaced_blocker(view)]
           else
             []
           end
@@ -1270,10 +1286,34 @@ module ReactOnRails
             return false
           end
 
-          system("overmind", subcommand, "-s", endpoint, out: File::NULL, err: File::NULL) ? true : false
+          return true if run_overmind_command([subcommand, "-s", endpoint])
+
+          puts "   ⚠️  `overmind #{subcommand}` did not run successfully for #{endpoint}"
+          false
         rescue Errno::ENOENT, Interrupt
           puts "   ⚠️  Could not run `overmind #{subcommand}` for #{endpoint}"
           false
+        end
+
+        # Control commands have to take the same route startup took.
+        #
+        # ProcessManager falls back to running the process outside the Bundler
+        # context when the system-installed binary is not usable inside it - and
+        # that is the documented install shape for this project: install the
+        # process manager globally and deliberately keep it OUT of the Gemfile.
+        # A bare `system("overmind", ...)` here just repeats the context that
+        # already failed at startup, so `quit` and `kill` both return false and
+        # the session becomes unkillable by the tool that started it. The
+        # process-group fallback cannot rescue it either: Overmind's tmux server
+        # daemonizes to PPID 1 in its own process group, out of reach of any
+        # group signal.
+        #
+        # This deliberately reaches ProcessManager's private runner rather than
+        # reimplementing its Bundler API-compat shim here. The spec pins the
+        # coupling so a rename fails loudly instead of silently reverting to the
+        # broken path.
+        def run_overmind_command(args)
+          ProcessManager.send(:run_process_if_available, "overmind", args) == true
         end
 
         def signalable_pgid(pgid)

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -42,6 +42,17 @@ module ReactOnRails
       # Grace given to the forceful stop (`overmind kill` / SIGKILL) before giving up.
       SHUTDOWN_KILL_GRACE_SECS = 5
       SHUTDOWN_POLL_INTERVAL_SECS = 0.2
+      # Bounded budget for the Overmind control-socket probe. `UNIXSocket.new`
+      # blocks indefinitely when the accept queue is full or the server is
+      # paused, which would hang `bin/dev kill` inside an otherwise bounded
+      # shutdown loop. Mirrors FileManager::SOCKET_PROBE_TIMEOUT_SECS.
+      OVERMIND_PROBE_TIMEOUT_SECS = 0.15
+      # O_NOFOLLOW so a symlink planted at the session path fails loudly rather
+      # than having its target silently truncated. `overmind_endpoint_owned?`
+      # resolves realpath for the same reason on the read side.
+      DEV_SESSION_OPEN_FLAGS = File::RDWR | File::CREAT |
+                               (defined?(File::NOFOLLOW) ? File::NOFOLLOW : 0)
+      DEV_SESSION_CLAIM_ATTEMPTS = 2
 
       # Markers that identify an app root when a command is run from a
       # subdirectory. Checked nearest-first while walking up from the cwd.
@@ -551,20 +562,54 @@ module ReactOnRails
         def claim_dev_session(root)
           path = dev_session_path(root)
           FileUtils.mkdir_p(File.dirname(path))
-          file = File.open(path, File::RDWR | File::CREAT, 0o644)
-          return warn_dev_session_contended(file, path, root) unless file.flock(File::LOCK_EX | File::LOCK_NB)
 
-          begin
-            write_dev_session(file, root)
-          rescue StandardError => e
-            discard_partial_dev_session(file, path)
-            warn_dev_session_unrecorded(e)
-            return nil
+          DEV_SESSION_CLAIM_ATTEMPTS.times do
+            file = File.open(path, DEV_SESSION_OPEN_FLAGS, 0o644)
+            return warn_dev_session_contended(file, path, root) unless file.flock(File::LOCK_EX | File::LOCK_NB)
+
+            # Holding the lock is not enough. The previous owner can unlink the
+            # path between our open and our flock, leaving us locking an inode
+            # that `dev-session.json` no longer names - we would then write
+            # state nothing can ever read back while running as though we were
+            # recorded. Mirror of the :replaced guard on the kill side.
+            return write_claimed_dev_session(file, path, root) unless dev_session_handle_detached?(path, file)
+
+            release_dev_session_lock(file)
           end
 
-          file
+          warn_dev_session_unrecorded("the session file kept being replaced")
+          nil
         rescue SystemCallError, IOError => e
-          warn_dev_session_unrecorded(e)
+          warn_dev_session_unrecorded(e.class)
+          nil
+        end
+
+        def write_claimed_dev_session(file, path, root)
+          write_dev_session(file, root)
+          file
+        rescue StandardError => e
+          discard_partial_dev_session(file, path)
+          warn_dev_session_unrecorded(e.class)
+          nil
+        end
+
+        # True when `path` no longer names this handle's inode, whether it was
+        # replaced or unlinked.
+        #
+        # Deliberately NOT the same question as #dev_session_replaced?, which
+        # treats a vanished path as "the owner tidied up after itself" rather
+        # than as a replacement. On the claim side a vanished path means our
+        # handle is orphaned, so it has to count. Do not merge the two.
+        def dev_session_handle_detached?(path, file)
+          File.stat(path).ino != file.stat.ino
+        rescue SystemCallError, IOError
+          true
+        end
+
+        def release_dev_session_lock(file)
+          file.flock(File::LOCK_UN)
+          file.close
+        rescue SystemCallError, IOError
           nil
         end
 
@@ -589,8 +634,8 @@ module ReactOnRails
           nil
         end
 
-        def warn_dev_session_unrecorded(error)
-          warn "   ⚠️  Could not record dev session state (#{error.class}). " \
+        def warn_dev_session_unrecorded(reason)
+          warn "   ⚠️  Could not record dev session state (#{reason}). " \
                "`bin/dev kill` will fall back to port-scoped cleanup."
         end
 
@@ -688,9 +733,25 @@ module ReactOnRails
         # fallback only applies when there is no session to read them from, and
         # a killing shell with a different base port must not override what the
         # running session actually bound.
+        # Union rather than "prefer recorded". Recorded ports capture what this
+        # run actually selected, but they only cover variables present in the
+        # parent environment - the generated Pro Procfile starts the renderer
+        # with `RENDERER_PORT=${RENDERER_PORT:-3800}`, so a defaulted renderer
+        # port is never recorded. Preferring recorded exclusively hid that port
+        # from both signalling and verification. A superset is strictly safer:
+        # signalling is cwd-gated, so a wider scan cannot signal anything this
+        # app root does not own, and verification only gains coverage.
+        #
+        # A refused view neither signals nor verifies, so skip the derivation
+        # entirely - `killable_ports` prints a base-port diagnostic that would
+        # otherwise land immediately before "Refusing to signal anything", for a
+        # value that is then discarded.
         def shutdown_ports(view)
+          return [] if view[:kind] == :refused
+
           recorded = view.dig(:session, :ports)
-          recorded.is_a?(Array) && recorded.any? ? recorded : killable_ports
+          recorded = [] unless recorded.is_a?(Array)
+          recorded | killable_ports
         end
 
         def dispatch_dev_shutdown(view)
@@ -803,8 +864,13 @@ module ReactOnRails
           valid_session_socket?(data["overmind_socket"])
         end
 
+        # `pid` is used only for identity and display (see
+        # #unreachable_owner_message), never for signalling, so every positive
+        # value is legitimate - including 1, which is exactly what `bin/dev`
+        # gets in a minimal Docker dev container with no init wrapper. Rejecting
+        # it there disabled the whole mechanism and made every kill refuse.
         def valid_session_pid?(value)
-          value.is_a?(Integer) && value > 1
+          value.is_a?(Integer) && value.positive?
         end
 
         def valid_session_socket?(value)
@@ -822,6 +888,9 @@ module ReactOnRails
           value.is_a?(String) && !value.empty?
         end
 
+        # Deliberately stricter than #valid_session_pid? above: this value IS
+        # signalled, and `Process.kill(sig, -1)` broadcasts to every process the
+        # user may signal. The asymmetry is load-bearing - do not harmonise it.
         def valid_session_pgid?(value)
           value.nil? || (value.is_a?(Integer) && value > 1)
         end
@@ -916,15 +985,22 @@ module ReactOnRails
           steps
         end
 
+        # Cleanup runs only once verification has fully succeeded. Removing the
+        # session file first destroyed the retry path: it carries the ports this
+        # run actually selected, so deleting it on the way to reporting
+        # :unverified meant the retry fell back to a re-derived guess - exactly
+        # the fidelity `selected_session_ports` exists to provide, lost on the
+        # one path where it matters most. It also made `print_kill_failure` tell
+        # the user to remove a file that was already gone.
         def verify_owner_shutdown(view, pgid, endpoint)
           blockers = shutdown_blockers(view, pgid, endpoint)
           return [:unverified, blockers] if blockers.any?
 
-          remove_dev_session_file(view)
-          cleanup_socket_files
           leftover = leftover_owned_listeners(view)
           return [:unverified, leftover] if leftover.any?
 
+          remove_dev_session_file(view)
+          cleanup_socket_files
           [:verified, []]
         end
 
@@ -1046,7 +1122,6 @@ module ReactOnRails
         # ---- kill path: no live owner ----------------------------------
 
         def shutdown_without_owner(view)
-          remove_dev_session_file(view) if view[:kind] == :stale
           endpoint = live_overmind_endpoint(view[:root], view.dig(:session, :overmind_socket))
           return shutdown_orphaned_overmind(view, endpoint) if endpoint
 
@@ -1061,6 +1136,9 @@ module ReactOnRails
           leftover = leftover_owned_listeners(view)
           return [:unverified, leftover] if leftover.any?
 
+          # Same rule as verify_owner_shutdown: the recorded ports outlive an
+          # unverified outcome so a retry still has them.
+          remove_dev_session_file(view) if view[:kind] == :stale
           return [:nothing_running, []] unless cleaned || killed || view[:kind] == :stale
 
           killed ? [:verified, []] : [:recovered_stale, []]
@@ -1108,9 +1186,16 @@ module ReactOnRails
         # Revalidates the recorded endpoint at control time rather than
         # trusting what startup wrote: the socket must still live inside this
         # app root, still be a socket, and still answer.
+        # Candidates in decreasing order of authority: what the session
+        # recorded, what OVERMIND_SOCKET names in the killing shell (only when
+        # it lands inside this app root), then the default path. A configured
+        # value is a candidate, not an authority - each still has to clear the
+        # containment and realpath checks below.
         def live_overmind_endpoint(root, recorded)
-          candidates = [recorded, default_overmind_socket_path(root)].compact.uniq
-          candidates.find { |path| overmind_endpoint_owned?(path, root) && overmind_endpoint_alive?(path) }
+          candidates = [recorded, owned_overmind_socket_path(root), default_overmind_socket_path(root)]
+          candidates.compact.uniq.find do |path|
+            overmind_endpoint_owned?(path, root) && overmind_endpoint_alive?(path)
+          end
         end
 
         # Containment check for a control endpoint. The path is resolved before
@@ -1136,13 +1221,40 @@ module ReactOnRails
         def overmind_endpoint_state(path)
           return :gone unless File.socket?(path)
 
-          socket = UNIXSocket.new(path)
-          socket.close
-          :alive
-        rescue Errno::ECONNREFUSED, Errno::ENOENT, Errno::ENOTSOCK
-          :gone
-        rescue SystemCallError, IOError
-          :unknown
+          begin
+            sockaddr = Socket.sockaddr_un(path)
+          rescue ArgumentError
+            # Only the "too long unix socket path" case (sun_path is capped at
+            # ~104/108 bytes); nothing could be listening there anyway.
+            return :gone
+          end
+
+          probe_unix_socket(sockaddr)
+        end
+
+        # Bounded connect. A blocking `UNIXSocket.new` hangs indefinitely when
+        # the server's accept queue is full or its process is paused, which
+        # could stall `bin/dev kill` outside any of its own timeouts. A probe
+        # that runs out of budget is :unknown, not :gone - it blocks
+        # verification rather than licensing a false "verified".
+        def probe_unix_socket(sockaddr)
+          socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
+          begin
+            socket.connect_nonblock(sockaddr)
+            :alive
+          rescue IO::WaitWritable
+            return :unknown unless socket.wait_writable(OVERMIND_PROBE_TIMEOUT_SECS)
+
+            socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR).int.zero? ? :alive : :gone
+          rescue Errno::EISCONN
+            :alive
+          rescue Errno::ECONNREFUSED, Errno::ENOENT, Errno::ENOTSOCK
+            :gone
+          rescue SystemCallError, IOError
+            :unknown
+          ensure
+            socket.close
+          end
         end
 
         def overmind_endpoint_alive?(path)

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -1219,6 +1219,14 @@ module ReactOnRails
         # Signalling consumes `owned` only. Verification must block on
         # `unattributable` and `unavailable` too: folding a failed probe into
         # `foreign` is what let a surviving listener be reported as gone.
+        #
+        # Known blind spot, measured rather than assumed: run as a normal user,
+        # `lsof` only attributes sockets it can correlate through the owning
+        # process, so a port held by ANOTHER user's process is reported as
+        # having no listener at all rather than as an unattributable one. Such a
+        # port reads as free here. That is not something this command could act
+        # on anyway - it could not signal that process either - but it does mean
+        # "verified" means "free of anything this user can see".
         def classify_port_listeners(ports)
           root = current_app_root
           scan = { owned: {}, foreign: {}, unattributable: {}, unavailable: [] }
@@ -1257,15 +1265,42 @@ module ReactOnRails
           end
         end
 
-        # :owned, :foreign, or :unknown when the working-directory probe itself
-        # failed. `working_directory_for_pid` returns nil for a missing tool, a
-        # permission error and unparsable output alike - none of which is
-        # evidence that the process belongs to somebody else.
+        # :owned, :foreign, :gone, or :unknown when nothing could be
+        # established. `working_directory_for_pid` returns nil for a missing
+        # tool, a permission error and unparsable output alike - none of which
+        # is evidence that the process belongs to somebody else - so an
+        # unreadable cwd falls through to a second, cheaper probe.
         def attribute_pid(pid, root)
           cwd = working_directory_for_pid(pid)
-          return :unknown if cwd.nil?
+          return inside_dev_app_root?(cwd, root) ? :owned : :foreign if cwd
 
-          inside_dev_app_root?(cwd, root) ? :owned : :foreign
+          signal_permission_attribution(pid)
+        end
+
+        # Fallback when the working-directory probe told us nothing.
+        # `Process.kill(0, pid)` runs the existence and permission checks
+        # without sending anything:
+        #
+        #   ESRCH  the pid is gone, so it is not a leftover at all
+        #   EPERM  it exists and we may not signal it, so its user differs from
+        #          ours; `bin/dev` starts every dev process as the invoking
+        #          user, so this is somebody else's process
+        #   ok     a signalable process whose cwd we still could not read:
+        #          genuinely unknown, and verification keeps blocking on it
+        #
+        # Narrow exception, deliberately accepted: a Procfile line that changes
+        # user (`sudo -u ...`, a setuid helper) yields one of our own processes
+        # that answers EPERM. We could not signal it either way, so the only
+        # choice is between reporting success while it survives and refusing
+        # forever - and it is still printed as a port left alone, with its pid,
+        # so it stays visible rather than silently dropped.
+        def signal_permission_attribution(pid)
+          Process.kill(0, pid)
+          :unknown
+        rescue Errno::ESRCH, ArgumentError, RangeError
+          :gone
+        rescue Errno::EPERM
+          :foreign
         end
 
         # `lsof -a -p PID -d cwd -Fn` prints the process's working directory in

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -10,6 +10,7 @@ require "rainbow"
 require "erb"
 require "rbconfig"
 require "socket"
+require "timeout"
 require "time"
 require "uri"
 require "yaml"
@@ -52,6 +53,21 @@ module ReactOnRails
       # resolves realpath for the same reason on the read side.
       DEV_SESSION_OPEN_FLAGS = File::RDWR | File::CREAT |
                                (defined?(File::NOFOLLOW) ? File::NOFOLLOW : 0)
+      # The read side needs the same O_NOFOLLOW guarantee as the write side: it
+      # is the path that leads to signalling, so a symlink here is worth more to
+      # an attacker than one on the write path. O_NONBLOCK additionally keeps a
+      # FIFO planted at this path from blocking the open forever - without it
+      # the "must be a regular file" check below is unreachable, because the
+      # open never returns.
+      DEV_SESSION_READ_FLAGS = File::RDONLY |
+                               (defined?(File::NOFOLLOW) ? File::NOFOLLOW : 0) |
+                               (defined?(File::NONBLOCK) ? File::NONBLOCK : 0)
+      # Bounded budget for an Overmind control command. The socket probe was
+      # already bounded; leaving the command that acts on it unbounded meant a
+      # wedged `overmind quit` blocked inside `action.call`, before
+      # `wait_until(grace)` ever started polling, so the KILL escalation was
+      # never reached. Mirrors ProcessManager::VERSION_CHECK_TIMEOUT.
+      OVERMIND_CONTROL_TIMEOUT_SECS = 10
       DEV_SESSION_CLAIM_ATTEMPTS = 2
 
       # Markers that identify an app root when a command is run from a
@@ -601,7 +617,10 @@ module ReactOnRails
         # than as a replacement. On the claim side a vanished path means our
         # handle is orphaned, so it has to count. Do not merge the two.
         def dev_session_handle_detached?(path, file)
-          File.stat(path).ino != file.stat.ino
+          # lstat, not stat: both opens are O_NOFOLLOW, so a handle can never
+          # refer to a symlink target. Resolving through a link here would let a
+          # symlink planted over the path still compare equal to our handle.
+          File.lstat(path).ino != file.stat.ino
         rescue SystemCallError, IOError
           true
         end
@@ -794,7 +813,19 @@ module ReactOnRails
         # works on a read-only descriptor, so requiring write access would
         # refuse sessions we can perfectly well inspect.
         def open_dev_session(path)
-          [:opened, File.open(path, File::RDONLY)]
+          file = File.open(path, DEV_SESSION_READ_FLAGS)
+          return [:opened, file] if file.stat.file?
+
+          file.close
+          [:refused, "#{path} is not a regular file, so it cannot be trusted as dev session state"]
+        rescue Errno::ELOOP
+          # A symlink here is never legitimate, and it is the highest-value
+          # target in this file: a link to a locked, valid-looking document
+          # naming this app root would otherwise be classified as a live owner
+          # and its pgid signalled. Refuse rather than fall through to :absent -
+          # :absent means "nothing here, carry on with port cleanup", which is
+          # the wrong disposition for state that is actively suspicious.
+          [:refused, "#{path} is a symlink; dev session state must be a regular file"]
         rescue Errno::ENOENT
           [:absent, nil]
         rescue SystemCallError => e
@@ -918,7 +949,10 @@ module ReactOnRails
         # A path that simply vanished is the owner tidying up after itself, not
         # a replacement.
         def dev_session_replaced?(path, file)
-          File.stat(path).ino != file.stat.ino
+          # lstat for the same reason as #dev_session_handle_detached?: a
+          # symlink appearing over the session path is a replacement, never a
+          # match.
+          File.lstat(path).ino != file.stat.ino
         rescue Errno::ENOENT
           false
         rescue SystemCallError, IOError
@@ -1098,7 +1132,9 @@ module ReactOnRails
             return lock_dev_session(handle) == :acquired ? :released : :held
           end
 
-          File.open(path, File::RDONLY) do |file|
+          # Same flags as #open_dev_session: this is the other read of the
+          # session path, and it decides whether a shutdown counts as verified.
+          File.open(path, DEV_SESSION_READ_FLAGS) do |file|
             file.flock(File::LOCK_EX | File::LOCK_NB) ? :released : :held
           end
         rescue Errno::ENOENT
@@ -1361,7 +1397,15 @@ module ReactOnRails
         # coupling so a rename fails loudly instead of silently reverting to the
         # broken path.
         def run_overmind_command(args)
-          ProcessManager.send(:run_process_if_available, "overmind", args) == true
+          Timeout.timeout(OVERMIND_CONTROL_TIMEOUT_SECS) do
+            ProcessManager.send(:run_process_if_available, "overmind", args) == true
+          end
+        rescue Timeout::Error
+          # Treated exactly like the runner reporting failure, so the escalation
+          # ladder moves on to the next step instead of hanging here forever.
+          puts "   ⚠️  `overmind #{args.first}` did not return within " \
+               "#{OVERMIND_CONTROL_TIMEOUT_SECS}s; moving on"
+          false
         end
 
         def signalable_pgid(pgid)

--- a/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
@@ -60,8 +60,11 @@ module ReactOnRails
       def self.with_dev_session: () { () -> untyped } -> untyped
       def self.claim_dev_session: (String) -> File?
       def self.write_dev_session: (File, String) -> void
+      def self.write_claimed_dev_session: (File, String, String) -> File?
+      def self.dev_session_handle_detached?: (String, File) -> bool
+      def self.release_dev_session_lock: (File) -> void
       def self.discard_partial_dev_session: (File?, String) -> void
-      def self.warn_dev_session_unrecorded: (Exception) -> void
+      def self.warn_dev_session_unrecorded: (untyped) -> void
       def self.warn_dev_session_contended: (File, String, String) -> nil
       def self.dev_session_payload: (String) -> Hash[String, untyped]
       def self.selected_session_ports: () -> Array[Integer]
@@ -110,6 +113,7 @@ module ReactOnRails
       def self.live_overmind_endpoint: (String, String?) -> String?
       def self.overmind_endpoint_owned?: (String, ?String) -> bool
       def self.overmind_endpoint_state: (String) -> Symbol
+      def self.probe_unix_socket: (String) -> Symbol
       def self.overmind_endpoint_alive?: (String) -> bool
       def self.overmind_control: (String, String) -> bool
       def self.signalable_pgid: (untyped) -> Integer?

--- a/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
@@ -97,6 +97,7 @@ module ReactOnRails
       def self.request_owner_shutdown: (dev_session_view, Integer?, String?) -> bool
       def self.shutdown_steps: (Integer?, String?) -> Array[untyped]
       def self.verify_owner_shutdown: (dev_session_view, Integer?, String?) -> shutdown_result
+      def self.outstanding_shutdown_blockers: (dev_session_view) -> Array[String]
       def self.owner_shutdown_complete?: (dev_session_view, Integer?, String?) -> bool
       def self.shutdown_settled?: (dev_session_view, Integer?, String?) -> bool
       def self.shutdown_blockers: (dev_session_view, Integer?, String?) -> Array[String]
@@ -112,6 +113,11 @@ module ReactOnRails
       def self.shutdown_orphaned_overmind: (dev_session_view, String) -> shutdown_result
       def self.print_kill_failure: (Symbol, Array[String]) -> void
       def self.live_overmind_endpoint: (String, String?) -> String?
+      def self.overmind_endpoint_candidates: (String, String?) -> Array[String]
+      def self.scan_overmind_endpoints: (String, String?) -> Hash[Symbol, Array[String]]
+      def self.unprobeable_overmind_endpoints: (dev_session_view) -> Array[String]
+      def self.unprobeable_endpoint_blockers: (Array[String]?) -> Array[String]
+      def self.unprobeable_endpoint_message: (String) -> String
       def self.overmind_endpoint_owned?: (String, ?String) -> bool
       def self.overmind_endpoint_state: (String) -> Symbol
       def self.probe_unix_socket: (String) -> Symbol

--- a/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
@@ -15,7 +15,10 @@ module ReactOnRails
       type shutdown_result = [Symbol, Array[String]]
 
       def self.start: (mode, String?, ?verbose: bool, ?route: String?, ?rails_env: String?) -> void
-      def self.kill_processes: () -> void
+      def self.kill_processes: () -> Symbol
+      def self.clean_generated_assets_and_caches: () -> bool
+      def self.killable_ports: () -> Array[Integer]
+      def self.default_killable_ports: () -> Array[Integer]
       def self.terminate_processes: (Array[Integer], ?String) -> void
       def self.kill_port_processes: (Array[Integer]) -> bool
       def self.find_port_pids: (Integer) -> Array[Integer]
@@ -47,25 +50,34 @@ module ReactOnRails
       # -- Scoped dev shutdown ------------------------------------------
       def self.dev_session_path: (String) -> String
       def self.current_app_root: () -> String
+      def self.app_root_ancestor: (String) -> String?
       def self.inside_dev_app_root?: (untyped, ?String) -> bool
       def self.relative_to_app_root: (String, ?String) -> String
       def self.with_dev_session: () { () -> untyped } -> untyped
       def self.claim_dev_session: (String) -> File?
       def self.dev_session_payload: (String) -> Hash[String, untyped]
+      def self.selected_session_ports: () -> Array[Integer]
       def self.owned_process_group: () -> Integer?
       def self.owned_overmind_socket_path: (String) -> String?
       def self.default_overmind_socket_path: (String) -> String
       def self.release_dev_session: (File?) -> void
       def self.shutdown_dev_session: () -> shutdown_result
+      def self.shutdown_ports: (dev_session_view) -> Array[Integer]
+      def self.shutdown_failed?: (Symbol?) -> bool
+      def self.abort_clean_after_failed_shutdown: () -> bool
       def self.dispatch_dev_shutdown: (dev_session_view) -> shutdown_result
       def self.dev_session_view: (String) -> dev_session_view
-      def self.open_dev_session: (String) -> File?
+      def self.open_dev_session: (String) -> [Symbol, untyped]
       def self.classify_dev_session: (String, String, File) -> [Symbol, untyped]
+      def self.confirm_locked_dev_session: (String, File, dev_session) -> [Symbol, untyped]
       def self.classify_released_dev_session: (String, File, dev_session) -> [Symbol, untyped]
       def self.parse_dev_session: (untyped) -> dev_session?
       def self.valid_dev_session_document?: (untyped) -> bool
       def self.valid_session_root?: (untyped) -> bool
+      def self.valid_session_pid?: (untyped) -> bool
       def self.valid_session_pgid?: (untyped) -> bool
+      def self.valid_session_ports?: (untyped) -> bool
+      def self.valid_session_socket?: (untyped) -> bool
       def self.lock_dev_session: (File) -> Symbol
       def self.dev_session_replaced?: (String, File) -> bool
       def self.close_session_handle: (dev_session_view?) -> void
@@ -76,7 +88,7 @@ module ReactOnRails
       def self.verify_owner_shutdown: (dev_session_view, Integer?, String?) -> shutdown_result
       def self.owner_shutdown_complete?: (dev_session_view, Integer?, String?) -> bool
       def self.shutdown_blockers: (dev_session_view, Integer?, String?) -> Array[String]
-      def self.owner_released?: (String) -> bool
+      def self.owner_released?: (dev_session_view) -> bool
       def self.leftover_owned_listeners: (dev_session_view) -> Array[String]
       def self.remove_dev_session_file: (dev_session_view) -> bool
       def self.shutdown_without_owner: (dev_session_view) -> shutdown_result
@@ -91,10 +103,15 @@ module ReactOnRails
       def self.signal_process_group: (Integer, String) -> bool
       def self.process_group_alive?: (Integer) -> bool
       def self.process_alive?: (Integer) -> bool
-      def self.classify_port_listeners: (Array[Integer]) -> [Hash[Integer, Array[Integer]], Hash[Integer, Array[Integer]]]
+      def self.classify_port_listeners: (Array[Integer]) -> [Hash[Integer, Array[Integer]], Hash[Integer, Array[Integer]], Array[Integer]]
       def self.report_foreign_listeners: (Hash[Integer, Array[Integer]]) -> void
-      def self.pid_working_directory_owned?: (Integer) -> bool
+      def self.report_unavailable_port_probes: (Array[Integer]) -> void
+      def self.pid_working_directory_owned?: (Integer, ?String) -> bool
       def self.working_directory_for_pid: (Integer) -> String?
+      def self.probe_port_listeners: (Integer) -> [Array[Integer], Symbol]
+      def self.default_rails_kill_port: () -> Integer
+      def self.default_dev_server_kill_port: () -> Integer
+      def self.configured_dev_server_port: () -> Integer?
       def self.stale_cleanup_candidates: (String) -> Array[String]
       def self.wait_until: (Numeric) { () -> untyped } -> bool
       def self.monotonic_now: () -> Float

--- a/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
@@ -14,6 +14,10 @@ module ReactOnRails
       # :nothing_running, :unverified, :refused.
       type shutdown_result = [Symbol, Array[String]]
 
+      # Four-bucket listener scan: :owned, :foreign and :unattributable map
+      # port => pids, :unavailable is a list of ports whose probe failed.
+      type port_listener_scan = Hash[Symbol, untyped]
+
       def self.start: (mode, String?, ?verbose: bool, ?route: String?, ?rails_env: String?) -> void
       def self.kill_processes: () -> Symbol
       def self.clean_generated_assets_and_caches: () -> bool
@@ -55,6 +59,10 @@ module ReactOnRails
       def self.relative_to_app_root: (String, ?String) -> String
       def self.with_dev_session: () { () -> untyped } -> untyped
       def self.claim_dev_session: (String) -> File?
+      def self.write_dev_session: (File, String) -> void
+      def self.discard_partial_dev_session: (File?, String) -> void
+      def self.warn_dev_session_unrecorded: (Exception) -> void
+      def self.warn_dev_session_contended: (File, String, String) -> nil
       def self.dev_session_payload: (String) -> Hash[String, untyped]
       def self.selected_session_ports: () -> Array[Integer]
       def self.owned_process_group: () -> Integer?
@@ -87,8 +95,13 @@ module ReactOnRails
       def self.shutdown_steps: (Integer?, String?) -> Array[untyped]
       def self.verify_owner_shutdown: (dev_session_view, Integer?, String?) -> shutdown_result
       def self.owner_shutdown_complete?: (dev_session_view, Integer?, String?) -> bool
+      def self.shutdown_settled?: (dev_session_view, Integer?, String?) -> bool
       def self.shutdown_blockers: (dev_session_view, Integer?, String?) -> Array[String]
+      def self.owner_release_state: (dev_session_view) -> Symbol
       def self.owner_released?: (dev_session_view) -> bool
+      def self.session_replaced?: (dev_session_view) -> bool
+      def self.owner_state_blockers: (dev_session_view) -> Array[String]
+      def self.endpoint_blockers: (String?) -> Array[String]
       def self.leftover_owned_listeners: (dev_session_view) -> Array[String]
       def self.remove_dev_session_file: (dev_session_view) -> bool
       def self.shutdown_without_owner: (dev_session_view) -> shutdown_result
@@ -96,6 +109,7 @@ module ReactOnRails
       def self.print_kill_failure: (Symbol, Array[String]) -> void
       def self.live_overmind_endpoint: (String, String?) -> String?
       def self.overmind_endpoint_owned?: (String, ?String) -> bool
+      def self.overmind_endpoint_state: (String) -> Symbol
       def self.overmind_endpoint_alive?: (String) -> bool
       def self.overmind_control: (String, String) -> bool
       def self.signalable_pgid: (untyped) -> Integer?
@@ -103,10 +117,13 @@ module ReactOnRails
       def self.signal_process_group: (Integer, String) -> bool
       def self.process_group_alive?: (Integer) -> bool
       def self.process_alive?: (Integer) -> bool
-      def self.classify_port_listeners: (Array[Integer]) -> [Hash[Integer, Array[Integer]], Hash[Integer, Array[Integer]], Array[Integer]]
+      def self.classify_port_listeners: (Array[Integer]) -> port_listener_scan
+      def self.report_unsignalled_listeners: (port_listener_scan) -> void
+      def self.stop_attributed_pids: (Array[Integer]) -> void
       def self.report_foreign_listeners: (Hash[Integer, Array[Integer]]) -> void
+      def self.report_unattributable_listeners: (Hash[Integer, Array[Integer]]) -> void
       def self.report_unavailable_port_probes: (Array[Integer]) -> void
-      def self.pid_working_directory_owned?: (Integer, ?String) -> bool
+      def self.attribute_pid: (Integer, String) -> Symbol
       def self.working_directory_for_pid: (Integer) -> String?
       def self.probe_port_listeners: (Integer) -> [Array[Integer], Symbol]
       def self.default_rails_kill_port: () -> Integer

--- a/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
@@ -3,16 +3,25 @@ module ReactOnRails
     class ServerManager
       type mode = :development | :production_like | :static | :hmr
 
+      # Validated `tmp/react_on_rails/dev-session.json` contents.
+      type dev_session = Hash[Symbol, untyped]
+
+      # Classified view of this app directory's dev session state, plus the
+      # ports the kill path may inspect.
+      type dev_session_view = Hash[Symbol, untyped]
+
+      # [status, blockers] - status is one of :verified, :recovered_stale,
+      # :nothing_running, :unverified, :refused.
+      type shutdown_result = [Symbol, Array[String]]
+
       def self.start: (mode, String?, ?verbose: bool, ?route: String?, ?rails_env: String?) -> void
       def self.kill_processes: () -> void
-      def self.development_processes: () -> Hash[String, String]
-      def self.kill_running_processes: () -> bool
-      def self.find_process_pids: (String) -> Array[Integer]
-      def self.terminate_processes: (Array[Integer]) -> void
+      def self.terminate_processes: (Array[Integer], ?String) -> void
       def self.kill_port_processes: (Array[Integer]) -> bool
       def self.find_port_pids: (Integer) -> Array[Integer]
+      def self.find_process_pids: (String) -> Array[Integer]
       def self.cleanup_socket_files: () -> bool
-      def self.print_kill_summary: (bool) -> void
+      def self.print_kill_summary: (Symbol, ?Array[String]) -> void
       def self.show_help: () -> void
       def self.run_from_command_line: (?Array[String]) -> void
 
@@ -34,6 +43,61 @@ module ReactOnRails
       def self.box_bottom: (Integer) -> String
       def self.box_empty_line: (Integer) -> String
       def self.format_box_line: (String, Integer) -> String
+
+      # -- Scoped dev shutdown ------------------------------------------
+      def self.dev_session_path: (String) -> String
+      def self.current_app_root: () -> String
+      def self.inside_dev_app_root?: (untyped, ?String) -> bool
+      def self.relative_to_app_root: (String, ?String) -> String
+      def self.with_dev_session: () { () -> untyped } -> untyped
+      def self.claim_dev_session: (String) -> File?
+      def self.dev_session_payload: (String) -> Hash[String, untyped]
+      def self.owned_process_group: () -> Integer?
+      def self.owned_overmind_socket_path: (String) -> String?
+      def self.default_overmind_socket_path: (String) -> String
+      def self.release_dev_session: (File?) -> void
+      def self.shutdown_dev_session: () -> shutdown_result
+      def self.dispatch_dev_shutdown: (dev_session_view) -> shutdown_result
+      def self.dev_session_view: (String) -> dev_session_view
+      def self.open_dev_session: (String) -> File?
+      def self.classify_dev_session: (String, String, File) -> [Symbol, untyped]
+      def self.classify_released_dev_session: (String, File, dev_session) -> [Symbol, untyped]
+      def self.parse_dev_session: (untyped) -> dev_session?
+      def self.valid_dev_session_document?: (untyped) -> bool
+      def self.valid_session_root?: (untyped) -> bool
+      def self.valid_session_pgid?: (untyped) -> bool
+      def self.lock_dev_session: (File) -> Symbol
+      def self.dev_session_replaced?: (String, File) -> bool
+      def self.close_session_handle: (dev_session_view?) -> void
+      def self.shutdown_live_owner: (dev_session_view) -> shutdown_result
+      def self.unreachable_owner_message: (dev_session_view, dev_session) -> String
+      def self.request_owner_shutdown: (dev_session_view, Integer?, String?) -> bool
+      def self.shutdown_steps: (Integer?, String?) -> Array[untyped]
+      def self.verify_owner_shutdown: (dev_session_view, Integer?, String?) -> shutdown_result
+      def self.owner_shutdown_complete?: (dev_session_view, Integer?, String?) -> bool
+      def self.shutdown_blockers: (dev_session_view, Integer?, String?) -> Array[String]
+      def self.owner_released?: (String) -> bool
+      def self.leftover_owned_listeners: (dev_session_view) -> Array[String]
+      def self.remove_dev_session_file: (dev_session_view) -> bool
+      def self.shutdown_without_owner: (dev_session_view) -> shutdown_result
+      def self.shutdown_orphaned_overmind: (dev_session_view, String) -> shutdown_result
+      def self.print_kill_failure: (Symbol, Array[String]) -> void
+      def self.live_overmind_endpoint: (String, String?) -> String?
+      def self.overmind_endpoint_owned?: (String, ?String) -> bool
+      def self.overmind_endpoint_alive?: (String) -> bool
+      def self.overmind_control: (String, String) -> bool
+      def self.signalable_pgid: (untyped) -> Integer?
+      def self.own_process_group: () -> Integer?
+      def self.signal_process_group: (Integer, String) -> bool
+      def self.process_group_alive?: (Integer) -> bool
+      def self.process_alive?: (Integer) -> bool
+      def self.classify_port_listeners: (Array[Integer]) -> [Hash[Integer, Array[Integer]], Hash[Integer, Array[Integer]]]
+      def self.report_foreign_listeners: (Hash[Integer, Array[Integer]]) -> void
+      def self.pid_working_directory_owned?: (Integer) -> bool
+      def self.working_directory_for_pid: (Integer) -> String?
+      def self.stale_cleanup_candidates: (String) -> Array[String]
+      def self.wait_until: (Numeric) { () -> untyped } -> bool
+      def self.monotonic_now: () -> Float
     end
   end
 end

--- a/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
@@ -124,6 +124,7 @@ module ReactOnRails
       def self.report_unattributable_listeners: (Hash[Integer, Array[Integer]]) -> void
       def self.report_unavailable_port_probes: (Array[Integer]) -> void
       def self.attribute_pid: (Integer, String) -> Symbol
+      def self.signal_permission_attribution: (Integer) -> Symbol
       def self.working_directory_for_pid: (Integer) -> String?
       def self.probe_port_listeners: (Integer) -> [Array[Integer], Symbol]
       def self.default_rails_kill_port: () -> Integer

--- a/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/server_manager.rbs
@@ -103,6 +103,7 @@ module ReactOnRails
       def self.owner_release_state: (dev_session_view) -> Symbol
       def self.owner_released?: (dev_session_view) -> bool
       def self.session_replaced?: (dev_session_view) -> bool
+      def self.session_replaced_blocker: (dev_session_view) -> String
       def self.owner_state_blockers: (dev_session_view) -> Array[String]
       def self.endpoint_blockers: (String?) -> Array[String]
       def self.leftover_owned_listeners: (dev_session_view) -> Array[String]
@@ -116,6 +117,7 @@ module ReactOnRails
       def self.probe_unix_socket: (String) -> Symbol
       def self.overmind_endpoint_alive?: (String) -> bool
       def self.overmind_control: (String, String) -> bool
+      def self.run_overmind_command: (Array[String]) -> bool
       def self.signalable_pgid: (untyped) -> Integer?
       def self.own_process_group: () -> Integer?
       def self.signal_process_group: (Integer, String) -> bool

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1378,6 +1378,46 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         ENV.delete("OVERMIND_SOCKET")
       end
 
+      # Round-trips the REAL write path rather than asserting on
+      # owned_process_group in isolation: the bug was that the writer emitted a
+      # pgid the reader then rejected, so only writing a document and reading it
+      # back can catch it. A minimal container with no init wrapper runs bin/dev
+      # as PID 1 and typically setsid()s it, giving pgid == pid == 1.
+      it "writes a document it can read back when bin/dev is PID 1 in its own session" do
+        root = app_root("pid-one-roundtrip")
+        allow(Process).to receive_messages(pid: 1, getpgrp: 1)
+
+        recorded = nil
+        Dir.chdir(root) do
+          described_class.send(:with_dev_session) do
+            recorded = JSON.parse(File.read(session_path(root)))
+          end
+        end
+
+        aggregate_failures do
+          expect(recorded["pid"]).to eq(1)
+          # Group 1 can never be signalled - Process.kill(sig, -1) broadcasts -
+          # so it must not be recorded at all.
+          expect(recorded["pgid"]).to be_nil
+          expect(described_class.send(:valid_dev_session_document?, recorded)).to be true
+          expect(described_class.send(:parse_dev_session, JSON.generate(recorded))).not_to be_nil
+        end
+      end
+
+      it "does not refuse the session document it wrote as PID 1" do
+        root = app_root("pid-one-kill")
+        allow(Process).to receive_messages(pid: 1, getpgrp: 1)
+        # with_dev_session removes the file on exit, so keep a copy of exactly
+        # what the real write path produced and restore it for the kill.
+        written = nil
+        Dir.chdir(root) do
+          described_class.send(:with_dev_session) { written = File.read(session_path(root)) }
+        end
+        File.write(session_path(root), written)
+
+        expect(kill_in(root)).not_to include("Refusing to signal anything")
+      end
+
       it "records the ports this run actually selected" do
         root = app_root("recorded-ports")
         ENV["PORT"] = "4000"
@@ -2207,6 +2247,44 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         blockers = described_class.send(:endpoint_blockers, socket_path)
 
         expect(blockers).to include(a_string_matching(/could not determine whether the Overmind endpoint/))
+      end
+
+      # An endpoint we could not probe is not an absent one. Falling through to
+      # port-only cleanup would call the session gone without ever reaching it,
+      # and Overmind workers that hold no listening socket never show up in the
+      # port scan.
+      it "reports unverified when an orphan endpoint could not be probed" do
+        root = app_root("op")
+        socket_path = File.join(root, ".overmind.sock")
+        servers << UNIXServer.new(socket_path)
+        allow(described_class).to receive(:overmind_endpoint_state).and_return(:unknown)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("could not determine whether the Overmind endpoint")
+          expect(output).not_to include("No development processes owned by this app directory")
+          expect(output).not_to include("verified gone")
+          # An unprobeable socket is retained, never deleted.
+          expect(File.socket?(socket_path)).to be true
+        end
+      end
+
+      it "reports unverified when a live owner's endpoint could not be probed" do
+        root = app_root("ou")
+        socket_path = File.join(root, ".overmind.sock")
+        servers << UNIXServer.new(socket_path)
+        start_owner(root)
+        allow(described_class).to receive(:overmind_endpoint_state).and_return(:unknown)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("could not determine whether the Overmind endpoint")
+          expect(output).not_to include("verified gone")
+        end
       end
 
       it "controls a live custom OVERMIND_SOCKET inside the app root" do

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -2,8 +2,13 @@
 
 require_relative "../spec_helper"
 require "react_on_rails/dev/server_manager"
+require "fileutils"
+require "json"
 require "open3"
+require "rbconfig"
+require "socket"
 require "stringio"
+require "tmpdir"
 
 RSpec.describe ReactOnRails::Dev::ServerManager do
   # Suppress stdout/stderr during tests
@@ -81,6 +86,12 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
   ensure
     $stdout = original_stdout
   end
+
+  # `.start` now wraps the process-manager run in a real, flock-backed dev
+  # session that writes tmp/react_on_rails/dev-session.json under the cwd. The
+  # session mechanics have dedicated coverage in "worktree-scoped dev sessions";
+  # everywhere else the wrapper is a pass-through.
+  before { allow(described_class).to receive(:with_dev_session).and_yield }
 
   describe ".start" do
     before { mock_system_calls }
@@ -1175,135 +1186,566 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     end
   end
 
-  describe ".kill_processes" do
+  describe "worktree-scoped dev sessions" do
     include_context "with clean port env"
 
+    # These examples deliberately use real processes, real process groups, real
+    # flocks and real Unix sockets. The bug they cover (machine-global
+    # `pgrep -f rails` plus an unfiltered `lsof -ti :PORT`) was invisible to
+    # mock-shaped tests: every stub agreed with the implementation while the
+    # implementation was signalling other people's checkouts.
+    let(:spawned) { [] }
+    let(:servers) { [] }
+    let(:handles) { [] }
+
+    around do |example|
+      Dir.mktmpdir("rk", short_tmp_root) do |tmpdir|
+        @dev_session_base = File.realpath(tmpdir)
+        example.run
+      end
+    end
+
     before do
-      allow_any_instance_of(Kernel).to receive(:`).and_return("")
-      allow(File).to receive(:exist?).and_return(false)
+      # The port fallback shells out to lsof against real ports; examples that
+      # exercise it opt in explicitly.
+      allow(described_class).to receive(:killable_ports).and_return([])
+      stub_const("#{described_class}::SHUTDOWN_TERM_GRACE_SECS", 3)
+      stub_const("#{described_class}::SHUTDOWN_KILL_GRACE_SECS", 2)
+      stub_const("#{described_class}::SHUTDOWN_POLL_INTERVAL_SECS", 0.05)
     end
 
-    it "attempts to kill development processes" do
-      # Mock Open3.capture2 calls that find_process_pids uses
-      allow(Open3).to receive(:capture2).with("pgrep", "-f", "rails", err: File::NULL).and_return(["1234\n5678", nil])
-      allow(Open3).to receive(:capture2)
-        .with("pgrep", "-f", "node.*react[-_]on[-_]rails", err: File::NULL)
-        .and_return(["2345", nil])
-      allow(Open3).to receive(:capture2).with("pgrep", "-f", "overmind", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("pgrep", "-f", "foreman", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("pgrep", "-f", "ruby.*puma", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2)
-        .with("pgrep", "-f", "webpack-dev-server", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2)
-        .with("pgrep", "-f", "bin/shakapacker-dev-server", err: File::NULL).and_return(["", nil])
-
-      # Mock lsof calls for port checking
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-
-      allow(Process).to receive(:pid).and_return(9999) # Current process PID
-      expect(Process).to receive(:kill).with("TERM", 1234)
-      expect(Process).to receive(:kill).with("TERM", 5678)
-      expect(Process).to receive(:kill).with("TERM", 2345)
-
-      described_class.kill_processes
+    after do
+      spawned.each do |pid|
+        Process.kill("KILL", -pid)
+      rescue Errno::ESRCH, Errno::EPERM
+        nil
+      end
+      servers.each do |server|
+        server.close
+      rescue IOError, SystemCallError
+        nil
+      end
+      handles.each do |handle|
+        handle.close
+      rescue IOError, SystemCallError
+        nil
+      end
     end
 
-    it "kills processes on ports 3000 and 3001" do
-      # No pattern-based processes
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
+    # macOS's default TMPDIR is deep enough that a Unix socket underneath it
+    # blows past the 104-byte sun_path limit, so anchor these fixtures on the
+    # shortest writable temp root available.
+    def short_tmp_root
+      base = ["/tmp", Dir.tmpdir].find { |dir| File.directory?(dir) && File.writable?(dir) } || Dir.tmpdir
+      File.realpath(base)
+    end
 
-      # Mock port processes
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["3456", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["3457\n3458", nil])
+    def app_root(name)
+      root = File.join(@dev_session_base, name)
+      FileUtils.mkdir_p(File.join(root, "tmp", "react_on_rails"))
+      root
+    end
 
+    def session_path(root)
+      File.join(root, "tmp", "react_on_rails", "dev-session.json")
+    end
+
+    # Stand-in for a running `bin/dev`: leads its own process group, holds the
+    # session flock for its whole life, and has a child of its own so
+    # descendant shutdown is genuinely exercised rather than asserted.
+    def owner_script(trap_term:)
+      <<~RUBY
+        require "json"
+        root, ready, socket = ARGV
+        #{trap_term ? 'Signal.trap("TERM") { nil }' : ''}
+        file = File.open(File.join(root, "tmp", "react_on_rails", "dev-session.json"),
+                         File::RDWR | File::CREAT)
+        file.flock(File::LOCK_EX)
+        file.truncate(0)
+        file.write(JSON.generate("schema" => 1, "app_root" => root, "pid" => Process.pid,
+                                 "pgid" => Process.getpgrp,
+                                 "overmind_socket" => (socket.empty? ? nil : socket),
+                                 "started_at" => "2026-01-01T00:00:00Z"))
+        file.flush
+        child = spawn("sleep", "120")
+        File.write(ready, child.to_s)
+        sleep 300
+      RUBY
+    end
+
+    def start_owner(root, socket: nil, trap_term: false)
+      ready = File.join(root, "owner-ready")
+      pid = Process.spawn(RbConfig.ruby, "-e", owner_script(trap_term:),
+                          root, ready, socket.to_s,
+                          pgroup: true, out: File::NULL, err: File::NULL)
+      spawned << pid
+      # Reap promptly: an unreaped zombie is still a process-group member, and
+      # would make the shutdown verification below read as "still running".
+      Process.detach(pid)
+      raise "dev session owner for #{root} never started" unless wait_for { owner_ready?(ready) }
+
+      { pid:, pgid: pid, child: Integer(File.read(ready).strip) }
+    end
+
+    def owner_ready?(ready)
+      File.exist?(ready) && !File.read(ready).strip.empty?
+    end
+
+    # Alive, leads its own process group, holds no session lock. Used to prove
+    # that stale recorded numbers never become signal authority.
+    def start_unrelated_process
+      pid = Process.spawn("sleep", "120", pgroup: true, out: File::NULL, err: File::NULL)
+      spawned << pid
+      Process.detach(pid)
+      { pid:, pgid: pid }
+    end
+
+    def wait_for(timeout = 5)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        return true if yield
+        return false if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+        sleep 0.02
+      end
+    end
+
+    def alive?(pid)
+      Process.kill(0, pid)
+      true
+    rescue Errno::ESRCH
+      false
+    end
+
+    def group_alive?(pgid)
+      Process.kill(0, -pgid)
+      true
+    rescue Errno::ESRCH
+      false
+    end
+
+    def write_session(root, overrides = {})
+      payload = { "schema" => 1, "app_root" => root, "pid" => 999_999, "pgid" => nil,
+                  "overmind_socket" => nil, "started_at" => "2026-01-01T00:00:00Z" }.merge(overrides)
+      File.write(session_path(root), JSON.generate(payload))
+    end
+
+    def kill_in(root)
+      capture_stdout { Dir.chdir(root) { described_class.kill_processes } }
+    end
+
+    describe ".with_dev_session" do
+      before { allow(described_class).to receive(:with_dev_session).and_call_original }
+
+      it "records worktree-scoped state, holds its lock, and removes it afterwards" do
+        root = app_root("start")
+        path = session_path(root)
+        recorded = nil
+        lock_taken = nil
+
+        Dir.chdir(root) do
+          described_class.send(:with_dev_session) do
+            recorded = JSON.parse(File.read(path))
+            lock_taken = File.open(path, File::RDWR) { |file| file.flock(File::LOCK_EX | File::LOCK_NB) }
+          end
+        end
+
+        aggregate_failures do
+          expect(recorded["schema"]).to eq(1)
+          expect(recorded["app_root"]).to eq(root)
+          expect(recorded["pid"]).to eq(Process.pid)
+          # Failing to take the lock is the liveness proof `bin/dev kill` relies on.
+          expect(lock_taken).to be false
+          expect(File.exist?(path)).to be false
+        end
+      end
+
+      it "records the Overmind endpoint it would use, and only when it is inside the app root" do
+        root = app_root("endpoint")
+        recorded = Dir.chdir(root) { described_class.send(:owned_overmind_socket_path, root) }
+        expect(recorded).to eq(File.join(root, ".overmind.sock"))
+
+        ENV["OVERMIND_SOCKET"] = File.join(@dev_session_base, "elsewhere.sock")
+        expect(Dir.chdir(root) { described_class.send(:owned_overmind_socket_path, root) }).to be_nil
+      ensure
+        ENV.delete("OVERMIND_SOCKET")
+      end
+
+      it "leaves state owned by another running bin/dev untouched" do
+        root = app_root("contended")
+        start_owner(root)
+        before_contents = File.read(session_path(root))
+
+        output = capture_stdout do
+          Dir.chdir(root) { described_class.send(:with_dev_session) { :ran } }
+        end
+
+        aggregate_failures do
+          expect(output).to include("Another `bin/dev` already owns")
+          expect(File.read(session_path(root))).to eq(before_contents)
+        end
+      end
+    end
+
+    describe ".kill_processes" do
+      it "stops this worktree's process tree and leaves another worktree running" do
+        root_a = app_root("worktree-a")
+        root_b = app_root("worktree-b")
+        owner_a = start_owner(root_a)
+        owner_b = start_owner(root_b)
+
+        output = kill_in(root_a)
+
+        aggregate_failures do
+          expect(wait_for { !group_alive?(owner_a[:pgid]) }).to be(true), "worktree A's process group survived"
+          expect(alive?(owner_a[:child])).to be false
+          expect(group_alive?(owner_b[:pgid])).to be(true), "worktree B's process group was killed"
+          expect(alive?(owner_b[:pid])).to be true
+          expect(alive?(owner_b[:child])).to be true
+          expect(File.exist?(session_path(root_b))).to be true
+          expect(JSON.parse(File.read(session_path(root_b)))["app_root"]).to eq(root_b)
+          expect(File.exist?(session_path(root_a))).to be false
+          expect(output).to include("verified gone")
+        end
+      end
+
+      it "sends TERM first and escalates to KILL only for the survivors" do
+        root = app_root("stubborn")
+        owner = start_owner(root, trap_term: true)
+        signals = []
+        allow(described_class).to receive(:signal_process_group).and_wrap_original do |original, pgid, signal|
+          signals << [pgid, signal]
+          original.call(pgid, signal)
+        end
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(signals.map(&:last)).to eq(%w[TERM KILL])
+          expect(signals.map(&:first).uniq).to eq([owner[:pgid]])
+          expect(wait_for { !group_alive?(owner[:pgid]) }).to be true
+          expect(output).to include("verified gone")
+        end
+      end
+
+      it "recovers stale session state without signalling the recorded pgid" do
+        root = app_root("stale")
+        unrelated = start_unrelated_process
+        write_session(root, "pgid" => unrelated[:pgid], "pid" => unrelated[:pid])
+        socket_path = File.join(root, ".overmind.sock")
+        UNIXServer.new(socket_path).close
+
+        expect(described_class).not_to receive(:signal_process_group)
+        expect(described_class).not_to receive(:terminate_processes)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(File.exist?(session_path(root))).to be false
+          expect(File.exist?(socket_path)).to be false
+          expect(alive?(unrelated[:pid])).to be true
+          expect(output).to include("Cleaned up stale dev session state")
+        end
+      end
+
+      it "reports nothing to do when this app directory has no session and no listeners" do
+        root = app_root("idle")
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("No development processes owned by this app directory")
+          expect(output).not_to include("verified gone")
+        end
+      end
+
+      [
+        ["malformed JSON", "{not json"],
+        ["a JSON number", "7"],
+        ["a JSON string", '"running"'],
+        ["JSON null", "null"],
+        ["an unknown schema", '{"schema":99,"app_root":"/x","pid":2,"pgid":null}'],
+        ["a non-integer pid", '{"schema":1,"app_root":"/x","pid":"2","pgid":null}']
+      ].each do |label, contents|
+        it "refuses to signal anything when the session state is #{label}" do
+          root = app_root("bad-#{label.gsub(/\W+/, '-')}")
+          File.write(session_path(root), contents)
+
+          expect(described_class).not_to receive(:signal_process_group)
+          expect(described_class).not_to receive(:terminate_processes)
+
+          output = kill_in(root)
+
+          aggregate_failures do
+            expect(output).to include("Refusing to signal anything")
+            expect(output).not_to include("verified gone")
+            # Fail closed: untrusted state is reported, never quietly discarded.
+            expect(File.exist?(session_path(root))).to be true
+          end
+        end
+      end
+
+      it "refuses session state recorded against a different app root" do
+        root = app_root("mine")
+        foreign = app_root("theirs")
+        unrelated = start_unrelated_process
+        write_session(root, "app_root" => foreign, "pgid" => unrelated[:pgid])
+
+        expect(described_class).not_to receive(:signal_process_group)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Refusing to signal anything")
+          expect(output).to include(foreign)
+          expect(alive?(unrelated[:pid])).to be true
+        end
+      end
+
+      it "refuses a live owner that recorded no controllable handle" do
+        root = app_root("no-handle")
+        path = session_path(root)
+        holder = File.open(path, File::RDWR | File::CREAT)
+        handles << holder
+        holder.flock(File::LOCK_EX)
+        holder.write(JSON.generate("schema" => 1, "app_root" => root, "pid" => Process.pid,
+                                   "pgid" => nil, "overmind_socket" => nil))
+        holder.flush
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Refusing to signal anything")
+          expect(output).to include("recorded no process group")
+          expect(File.exist?(path)).to be true
+        end
+      end
+
+      it "prints an explicit failure when the shutdown cannot be verified" do
+        root = app_root("unverified")
+        owner = start_owner(root)
+        allow(described_class).to receive(:signal_process_group).and_return(false)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("process group #{owner[:pgid]} still has members")
+          expect(output).not_to include("verified gone")
+          expect(group_alive?(owner[:pgid])).to be true
+          expect(File.exist?(session_path(root))).to be true
+        end
+      end
+
+      it "signals only listeners whose working directory is inside this app root" do
+        root = app_root("ports")
+        mine = start_unrelated_process
+        theirs = start_unrelated_process
+        allow(described_class).to receive(:killable_ports).and_return([4567, 4568])
+        allow(described_class).to receive(:find_port_pids) do |port|
+          case port
+          when 4567 then alive?(mine[:pid]) ? [mine[:pid]] : []
+          when 4568 then alive?(theirs[:pid]) ? [theirs[:pid]] : []
+          else []
+          end
+        end
+        allow(described_class).to receive(:working_directory_for_pid).with(mine[:pid]).and_return(root)
+        allow(described_class).to receive(:working_directory_for_pid)
+          .with(theirs[:pid]).and_return(File.join(@dev_session_base, "elsewhere"))
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(wait_for { !alive?(mine[:pid]) }).to be true
+          expect(alive?(theirs[:pid])).to be true
+          expect(output).to include("Leaving port 4568 alone")
+          expect(output).to include("not attributable to this app directory")
+        end
+      end
+
+      it "never signals a listener it cannot attribute to this app root" do
+        root = app_root("unattributable")
+        theirs = start_unrelated_process
+        allow(described_class).to receive(:killable_ports).and_return([4569])
+        allow(described_class).to receive(:find_port_pids).with(4569).and_return([theirs[:pid]])
+        # lsof unavailable / permission denied -> not attributable.
+        allow(described_class).to receive(:working_directory_for_pid).with(theirs[:pid]).and_return(nil)
+
+        expect(described_class).not_to receive(:terminate_processes)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(alive?(theirs[:pid])).to be true
+          expect(output).to include("Leaving port 4569 alone")
+        end
+      end
+    end
+
+    describe "Overmind endpoint handling" do
+      it "controls an orphaned endpoint instead of guessing at the stale pgid" do
+        root = app_root("orphan")
+        socket_path = File.join(root, ".overmind.sock")
+        server = UNIXServer.new(socket_path)
+        servers << server
+        unrelated = start_unrelated_process
+        write_session(root, "pgid" => unrelated[:pgid], "overmind_socket" => socket_path)
+
+        allow(described_class).to receive(:overmind_control) do |_subcommand, endpoint|
+          expect(endpoint).to eq(socket_path)
+          server.close
+          File.delete(socket_path)
+          true
+        end
+        expect(described_class).not_to receive(:signal_process_group)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("orphaned Overmind endpoint")
+          expect(output).to include("verified gone")
+          expect(alive?(unrelated[:pid])).to be true
+        end
+      end
+
+      it "refuses to control an endpoint outside this app root" do
+        root = app_root("outside")
+        outside = File.join(@dev_session_base, "other.sock")
+        servers << UNIXServer.new(outside)
+
+        result = nil
+        output = capture_stdout do
+          Dir.chdir(root) { result = described_class.send(:overmind_control, "quit", outside) }
+        end
+
+        aggregate_failures do
+          expect(result).to be false
+          expect(output).to include("no longer this app's endpoint")
+        end
+      end
+
+      it "revalidates the recorded endpoint immediately before control" do
+        root = app_root("revalidate")
+        socket_path = File.join(root, ".overmind.sock")
+        server = UNIXServer.new(socket_path)
+        servers << server
+        resolved = Dir.chdir(root) { described_class.send(:live_overmind_endpoint, root, socket_path) }
+        expect(resolved).to eq(socket_path)
+
+        server.close
+        File.delete(socket_path)
+
+        result = nil
+        output = capture_stdout do
+          Dir.chdir(root) { result = described_class.send(:overmind_control, "quit", socket_path) }
+        end
+
+        aggregate_failures do
+          expect(result).to be false
+          expect(output).to include("Skipping `overmind quit`")
+        end
+      end
+
+      it "ignores a recorded endpoint that no longer answers" do
+        root = app_root("dead-endpoint")
+        socket_path = File.join(root, ".overmind.sock")
+        UNIXServer.new(socket_path).close
+
+        resolved = Dir.chdir(root) { described_class.send(:live_overmind_endpoint, root, socket_path) }
+        expect(resolved).to be_nil
+      end
+
+      it "leaves a live socket in place while removing dead ones" do
+        root = app_root("sockets")
+        FileUtils.mkdir_p(File.join(root, "tmp", "sockets"))
+        live = File.join(root, "tmp", "sockets", "overmind-live.sock")
+        dead = File.join(root, "tmp", "sockets", "overmind-dead.sock")
+        servers << UNIXServer.new(live)
+        UNIXServer.new(dead).close
+
+        Dir.chdir(root) { capture_stdout { described_class.cleanup_socket_files } }
+
+        aggregate_failures do
+          expect(File.exist?(live)).to be true
+          expect(File.exist?(dead)).to be false
+        end
+      end
+    end
+
+    describe "process-group ownership" do
+      it "records a pgid only when bin/dev leads its own process group" do
+        allow(Process).to receive_messages(getpgrp: 4321, pid: 4321)
+        expect(described_class.send(:owned_process_group)).to eq(4321)
+
+        allow(Process).to receive(:pid).and_return(9999)
+        expect(described_class.send(:owned_process_group)).to be_nil
+      end
+
+      it "never signals its own process group or an impossible pgid" do
+        other = Process.getpgrp + 1
+
+        aggregate_failures do
+          expect(described_class.send(:signalable_pgid, Process.getpgrp)).to be_nil
+          expect(described_class.send(:signalable_pgid, 1)).to be_nil
+          expect(described_class.send(:signalable_pgid, 0)).to be_nil
+          expect(described_class.send(:signalable_pgid, nil)).to be_nil
+          expect(described_class.send(:signalable_pgid, "4321")).to be_nil
+          expect(described_class.send(:signalable_pgid, other)).to eq(other)
+        end
+      end
+
+      it "treats an unobservable process group as still alive" do
+        allow(Process).to receive(:kill).with(0, -4321).and_raise(Errno::EPERM)
+        expect(described_class.send(:process_group_alive?, 4321)).to be true
+      end
+    end
+  end
+
+  describe ".find_port_pids" do
+    it "asks lsof only for LISTEN sockets" do
+      # Regression: the previous `lsof -ti :PORT` also matched established
+      # client sockets (a browser tab, a curl), and those pids were signalled.
+      expect(Open3).to receive(:capture2)
+        .with("lsof", "-nP", "-t", "-iTCP:3000", "-sTCP:LISTEN", err: File::NULL)
+        .and_return(["1234\n5678", nil])
       allow(Process).to receive(:pid).and_return(9999)
-      expect(Process).to receive(:kill).with("TERM", 3456)
-      expect(Process).to receive(:kill).with("TERM", 3457)
-      expect(Process).to receive(:kill).with("TERM", 3458)
 
-      described_class.kill_processes
+      expect(described_class.find_port_pids(3000)).to eq([1234, 5678])
     end
 
-    it "cleans up socket files when they exist" do
-      # Make sure no processes are found so cleanup_socket_files gets called
-      allow(Open3).to receive(:capture2).and_return(["", nil])
-
-      allow(Dir).to receive(:glob).with("tmp/sockets/overmind*.sock").and_return([])
-      allow(File).to receive(:exist?).with(".overmind.sock").and_return(true)
-      allow(File).to receive(:exist?).with("tmp/pids/server.pid").and_return(false)
-      expect(File).to receive(:delete).with(".overmind.sock")
-
-      described_class.kill_processes
-    end
-
-    it "cleans up renamed/copied overmind sockets via the same glob FileManager uses" do
-      # Mirrors FileManager#cleanup_overmind_sockets: variants like
-      # overmind-4100.sock from copied app dirs must also be removed during
-      # `bin/dev kill`, not just at startup.
-      allow(Open3).to receive(:capture2).and_return(["", nil])
-
-      copied = "tmp/sockets/overmind-4100.sock"
-      allow(Dir).to receive(:glob).with("tmp/sockets/overmind*.sock").and_return([copied])
-      allow(File).to receive(:exist?).with(".overmind.sock").and_return(false)
-      allow(File).to receive(:exist?).with(copied).and_return(true)
-      allow(File).to receive(:exist?).with("tmp/pids/server.pid").and_return(false)
-      expect(File).to receive(:delete).with(copied)
-
-      described_class.kill_processes
-    end
-
-    # Regression: previously kill_processes used `||` which short-circuited
-    # subsequent cleanup steps as soon as one returned truthy. A successful
-    # pattern-based kill would leave stale port-bound processes and socket/pid
-    # files behind. All three cleanup helpers must always run.
-    it "runs port kills and socket cleanup even when pattern-based kill found processes" do
-      # The catch-all must be defined FIRST. RSpec uses the most-recently-defined
-      # matching stub regardless of specificity (`any_args` does not yield to a
-      # narrower matcher automatically), so the specific "rails" stub below wins
-      # because it is defined last. Reversing the order would cause
-      # `kill_running_processes` to always return false, missing the regression
-      # path this test covers (the old `||` short-circuit would have skipped the
-      # remaining cleanup steps once pattern-based kill returned truthy).
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("pgrep", "-f", "rails", err: File::NULL).and_return(["1234", nil])
+    it "excludes the current process and impossible pids" do
+      allow(Open3).to receive(:capture2).and_return(["1234\n9999\n0\n1", nil])
       allow(Process).to receive(:pid).and_return(9999)
-      allow(Process).to receive(:kill)
 
-      expect(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      expect(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-
-      socket = ".overmind.sock"
-      allow(Dir).to receive(:glob).with("tmp/sockets/overmind*.sock").and_return([])
-      allow(File).to receive(:exist?).with(socket).and_return(true)
-      allow(File).to receive(:exist?).with("tmp/pids/server.pid").and_return(false)
-      expect(File).to receive(:delete).with(socket)
-
-      described_class.kill_processes
+      expect(described_class.find_port_pids(3000)).to eq([1234])
     end
+
+    it "returns empty array when lsof is not found" do
+      allow(Open3).to receive(:capture2).and_raise(Errno::ENOENT)
+
+      expect(described_class.find_port_pids(3000)).to eq([])
+    end
+
+    it "returns empty array on permission denied" do
+      allow(Open3).to receive(:capture2).and_raise(Errno::EACCES)
+
+      expect(described_class.find_port_pids(3000)).to eq([])
+    end
+  end
+
+  describe ".killable_ports" do
+    include_context "with clean port env"
 
     it "targets base-port-derived ports when REACT_ON_RAILS_BASE_PORT is active" do
       # Without base-port awareness, `bin/dev kill` in a worktree running on
-      # 5000/5001/5002 would fall back to killing stale processes on 3000/3001
-      # instead — the actual ports would be left untouched. RENDERER_PORT is
-      # set so `pro_renderer_active?` returns true via `renderer_env_signal?`
-      # (the Pro gem isn't loaded in the open-source spec suite), exercising
-      # the base+2 inclusion path.
+      # 5000/5001/5002 would fall back to 3000/3001 and leave the actual ports
+      # untouched.
       ENV["RENDERER_PORT"] = "5002"
       allow(ReactOnRails::Dev::PortSelector)
         .to receive(:base_port_hash)
         .and_return({ rails: 5000, webpack: 5001, renderer: 5002, base_port_mode: true })
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":5000", err: File::NULL).and_return(["4501", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":5001", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":5002", err: File::NULL).and_return(["", nil])
-
-      allow(Process).to receive(:pid).and_return(9999)
-      expect(Process).to receive(:kill).with("TERM", 4501)
-
-      described_class.kill_processes
+      expect(described_class.killable_ports).to eq([5000, 5001, 5002])
     end
 
     it "skips the base-port-derived renderer port when Pro renderer support is inactive" do
@@ -1311,171 +1753,63 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         .to receive(:base_port_hash)
         .and_return({ rails: 5000, webpack: 5001, renderer: 5002, base_port_mode: true })
       allow(described_class).to receive(:pro_renderer_active?).and_return(false)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":5000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":5001", err: File::NULL).and_return(["", nil])
-      expect(Open3).not_to receive(:capture2).with("lsof", "-ti", ":5002", err: File::NULL)
-
-      described_class.kill_processes
+      expect(described_class.killable_ports).to eq([5000, 5001])
     end
 
-    it "includes the base-port-derived renderer port when Pro gem is loaded even without renderer env vars" do
-      # bin/dev kill is usually invoked from a fresh shell where RENDERER_PORT
-      # and REACT_RENDERER_URL aren't carried over. The Pro renderer runs as
-      # `node renderer/node-renderer.js` (see react_on_rails_pro Procfile.dev),
-      # which the development_processes pattern (`node.*react[-_]on[-_]rails`)
-      # does not match — so port-based killing is the only reliable path to
-      # reap a stale renderer on base+2. In base-port mode the user owns the
-      # port range, so the conservative env-var gate isn't needed.
+    it "includes the base-port-derived renderer port when the Pro gem is loaded without renderer env vars" do
       allow(ReactOnRails::Dev::PortSelector)
         .to receive(:base_port_hash)
         .and_return({ rails: 5000, webpack: 5001, renderer: 5002, base_port_mode: true })
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":5000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":5001", err: File::NULL).and_return(["", nil])
-      expect(Open3).to receive(:capture2).with("lsof", "-ti", ":5002", err: File::NULL).and_return(["", nil])
-
-      described_class.kill_processes
+      expect(capture_stdout { expect(described_class.killable_ports).to eq([5000, 5001, 5002]) })
+        .to include("Including renderer port 5002")
     end
 
-    it "does not widen kill scope to 3800 when the Pro gem is loaded but no renderer env vars are set" do
-      # Pro gem may be present in OSS+Pro-gem apps that never run the
-      # renderer. Without an explicit RENDERER_PORT / REACT_RENDERER_URL /
-      # RENDERER_URL signal, `bin/dev kill` must not target 3800 — that
-      # port could belong to an unrelated process.
+    it "does not widen scope to 3800 when the Pro gem is loaded but no renderer env vars are set" do
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-      expect(Open3).not_to receive(:capture2).with("lsof", "-ti", ":3800", err: File::NULL)
-
-      allow(Process).to receive(:pid).and_return(9999)
-      expect(Process).not_to receive(:kill).with("TERM", 3801)
-
-      described_class.kill_processes
+      expect(described_class.killable_ports).to eq([3000, 3001])
     end
 
-    it "targets 3800 when a localhost REACT_RENDERER_URL is set without an explicit :port" do
+    it "targets 3800 when a localhost REACT_RENDERER_URL is set without an explicit port" do
       ENV["REACT_RENDERER_URL"] = "http://localhost"
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3800", err: File::NULL).and_return(["3801", nil])
-
-      allow(Process).to receive(:pid).and_return(9999)
-      expect(Process).to receive(:kill).with("TERM", 3801)
-
-      described_class.kill_processes
+      expect(described_class.killable_ports).to eq([3000, 3001, 3800])
     end
 
     it "targets the configured renderer port when Pro renderer support is active without a base port" do
       ENV["RENDERER_PORT"] = "3900"
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-      expect(Open3).not_to receive(:capture2).with("lsof", "-ti", ":3800", err: File::NULL)
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3900", err: File::NULL).and_return(["3901", nil])
-
-      allow(Process).to receive(:pid).and_return(9999)
-      expect(Process).to receive(:kill).with("TERM", 3901)
-
-      described_class.kill_processes
+      expect(described_class.killable_ports).to eq([3000, 3001, 3900])
     end
 
     it "does not target the default renderer port for a remote renderer URL" do
       ENV["REACT_RENDERER_URL"] = "https://renderer.internal:3800"
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-      expect(Open3).not_to receive(:capture2).with("lsof", "-ti", ":3800", err: File::NULL)
-
-      described_class.kill_processes
+      expect(described_class.killable_ports).to eq([3000, 3001])
     end
 
     it "targets the local renderer URL port when RENDERER_PORT is not set" do
       ENV["REACT_RENDERER_URL"] = "http://localhost:3900"
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-      expect(Open3).not_to receive(:capture2).with("lsof", "-ti", ":3800", err: File::NULL)
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3900", err: File::NULL).and_return(["3901", nil])
-
-      allow(Process).to receive(:pid).and_return(9999)
-      expect(Process).to receive(:kill).with("TERM", 3901)
-
-      described_class.kill_processes
+      expect(described_class.killable_ports).to eq([3000, 3001, 3900])
     end
 
     it "does not treat userinfo digits as an explicit local renderer URL port" do
       ENV["REACT_RENDERER_URL"] = "http://user:3800@localhost"
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
-      # No pattern-based processes so kill_port_processes runs.
-      allow(Open3).to receive(:capture2).with("pgrep", any_args).and_return(["", nil])
 
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["", nil])
-      expect(Open3).not_to receive(:capture2).with("lsof", "-ti", ":80", err: File::NULL)
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3800", err: File::NULL).and_return(["3801", nil])
-
-      allow(Process).to receive(:pid).and_return(9999)
-      expect(Process).to receive(:kill).with("TERM", 3801)
-
-      described_class.kill_processes
-    end
-  end
-
-  describe ".find_port_pids" do
-    it "finds PIDs listening on a specific port" do
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["1234\n5678", nil])
-      allow(Process).to receive(:pid).and_return(9999)
-
-      pids = described_class.find_port_pids(3000)
-      expect(pids).to eq([1234, 5678])
-    end
-
-    it "excludes current process PID" do
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["1234\n9999", nil])
-      allow(Process).to receive(:pid).and_return(9999)
-
-      pids = described_class.find_port_pids(3000)
-      expect(pids).to eq([1234])
-    end
-
-    it "returns empty array when lsof is not found" do
-      allow(Open3).to receive(:capture2).and_raise(Errno::ENOENT)
-
-      pids = described_class.find_port_pids(3000)
-      expect(pids).to eq([])
-    end
-
-    it "returns empty array on permission denied" do
-      allow(Open3).to receive(:capture2).and_raise(Errno::EACCES)
-
-      pids = described_class.find_port_pids(3000)
-      expect(pids).to eq([])
+      expect(described_class.killable_ports).to eq([3000, 3001, 3800])
     end
   end
 
@@ -1787,23 +2121,34 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
   end
 
   describe ".kill_port_processes" do
-    it "kills processes on specified ports" do
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["1234", nil])
-      allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3001", err: File::NULL).and_return(["5678", nil])
-      allow(Process).to receive(:pid).and_return(9999)
+    it "signals only listeners whose working directory is inside this app root" do
+      allow(described_class).to receive(:find_port_pids).with(3000).and_return([1234])
+      allow(described_class).to receive(:find_port_pids).with(3001).and_return([5678])
+      allow(described_class).to receive(:working_directory_for_pid).with(1234).and_return(File.realpath(Dir.pwd))
+      allow(described_class).to receive(:working_directory_for_pid).with(5678).and_return("/somewhere/else")
+      allow(described_class).to receive(:process_alive?).and_return(false)
 
       expect(Process).to receive(:kill).with("TERM", 1234)
-      expect(Process).to receive(:kill).with("TERM", 5678)
+      expect(Process).not_to receive(:kill).with("TERM", 5678)
 
-      result = described_class.kill_port_processes([3000, 3001])
-      expect(result).to be true
+      output = capture_stdout { expect(described_class.kill_port_processes([3000, 3001])).to be true }
+      expect(output).to include("Leaving port 3001 alone")
     end
 
     it "returns false when no processes found on ports" do
-      allow(Open3).to receive(:capture2).and_return(["", nil])
+      allow(described_class).to receive(:find_port_pids).and_return([])
 
-      result = described_class.kill_port_processes([3000, 3001])
-      expect(result).to be false
+      expect(described_class.kill_port_processes([3000, 3001])).to be false
+    end
+
+    it "never signals a listener it cannot attribute to this app root" do
+      allow(described_class).to receive(:find_port_pids).with(3000).and_return([1234])
+      allow(described_class).to receive(:working_directory_for_pid).with(1234).and_return("/somewhere/else")
+
+      expect(Process).not_to receive(:kill)
+
+      output = capture_stdout { expect(described_class.kill_port_processes([3000])).to be false }
+      expect(output).to include("not attributable to this app directory")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1240,9 +1240,13 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       File.realpath(base)
     end
 
+    # A Gemfile makes the fixture look like a real app root, which is what
+    # `current_app_root` walks up to find when a command runs from a
+    # subdirectory.
     def app_root(name)
       root = File.join(@dev_session_base, name)
       FileUtils.mkdir_p(File.join(root, "tmp", "react_on_rails"))
+      File.write(File.join(root, "Gemfile"), "# fixture app root\n")
       root
     end
 
@@ -1371,6 +1375,29 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         ENV.delete("OVERMIND_SOCKET")
       end
 
+      it "records the ports this run actually selected" do
+        root = app_root("recorded-ports")
+        ENV["PORT"] = "4000"
+        ENV["SHAKAPACKER_DEV_SERVER_PORT"] = "4035"
+        recorded = nil
+
+        Dir.chdir(root) do
+          described_class.send(:with_dev_session) { recorded = JSON.parse(File.read(session_path(root))) }
+        end
+
+        expect(recorded["ports"]).to eq([4000, 4035])
+      end
+
+      it "prefers the recorded ports over the killing shell's derived guess" do
+        allow(described_class).to receive(:killable_ports).and_return([3000, 3035])
+
+        aggregate_failures do
+          expect(described_class.send(:shutdown_ports, { session: { ports: [4000, 4035] } })).to eq([4000, 4035])
+          expect(described_class.send(:shutdown_ports, { session: { ports: [] } })).to eq([3000, 3035])
+          expect(described_class.send(:shutdown_ports, {})).to eq([3000, 3035])
+        end
+      end
+
       it "leaves state owned by another running bin/dev untouched" do
         root = app_root("contended")
         start_owner(root)
@@ -1382,6 +1409,9 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
         aggregate_failures do
           expect(output).to include("Another `bin/dev` already owns")
+          # The untracked second run must say plainly that `bin/dev kill` will
+          # not control it.
+          expect(output).to include("This run is NOT recorded")
           expect(File.read(session_path(root))).to eq(before_contents)
         end
       end
@@ -1537,16 +1567,122 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         end
       end
 
+      it "detects a leftover listener on a recorded port instead of reporting success" do
+        root = app_root("leftover")
+        start_owner(root)
+        listener = start_unrelated_process
+        allow(described_class).to receive(:shutdown_ports).and_return([4567])
+        allow(described_class).to receive(:probe_port_listeners).with(4567).and_return([[listener[:pid]], :ok])
+        allow(described_class).to receive(:working_directory_for_pid).with(listener[:pid]).and_return(root)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("port 4567 is still held by this app directory")
+          expect(output).not_to include("verified gone")
+        end
+      end
+
+      it "does not claim verified when the listener probe could not run" do
+        root = app_root("lsof-down")
+        start_owner(root)
+        allow(described_class).to receive(:shutdown_ports).and_return([4567])
+        allow(described_class).to receive(:probe_port_listeners).with(4567).and_return([[], :unavailable])
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("could not verify port 4567 is free")
+          expect(output).not_to include("verified gone")
+        end
+      end
+
+      it "refuses when the session path exists but cannot be opened" do
+        root = app_root("unopenable")
+        # A self-referential symlink: open(2) fails with ELOOP, which is NOT
+        # ENOENT and so must not be read as "there is no session here" - that
+        # would bypass a lock we could not inspect and go on to signal.
+        File.symlink(session_path(root), session_path(root))
+
+        expect(described_class).not_to receive(:kill_port_processes)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Refusing to signal anything")
+          expect(output).to include("could not open")
+          expect(output).not_to include("No development processes owned by this app directory")
+        end
+      end
+
+      it "refuses when the payload changed under a freshly observed lock" do
+        # claim_dev_session locks, then truncates and writes, so a reader can
+        # see the previous owner's bytes while a NEW owner holds the lock. That
+        # must not turn a recycled pgid into proven-live signal authority.
+        root = app_root("payload-race")
+        write_session(root, "pgid" => 4321)
+        allow(described_class).to receive(:lock_dev_session).and_return(:held)
+        first_read = true
+        allow(described_class).to receive(:parse_dev_session).and_wrap_original do |original, raw|
+          parsed = original.call(raw)
+          next parsed unless first_read && parsed
+
+          first_read = false
+          parsed.merge(pgid: 9999)
+        end
+
+        expect(described_class).not_to receive(:signal_process_group)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Refusing to signal anything")
+          expect(output).to include("changed while its owner was being identified")
+        end
+      end
+
+      it "refuses when the payload is truncated under the lock" do
+        root = app_root("payload-truncated")
+        write_session(root)
+        allow(described_class).to receive(:lock_dev_session).and_return(:held)
+        reads = 0
+        allow(described_class).to receive(:parse_dev_session).and_wrap_original do |original, raw|
+          reads += 1
+          reads == 1 ? original.call(raw) : nil
+        end
+
+        expect(described_class).not_to receive(:signal_process_group)
+
+        expect(kill_in(root)).to include("Refusing to signal anything")
+      end
+
+      it "stops the session when run from a subdirectory of the app root" do
+        root = app_root("subdir")
+        nested = File.join(root, "app", "models")
+        FileUtils.mkdir_p(nested)
+        start_owner(root)
+
+        output = capture_stdout { Dir.chdir(nested) { described_class.kill_processes } }
+
+        aggregate_failures do
+          expect(output).to include(root)
+          expect(output).not_to include("No development processes owned by this app directory")
+          expect(output).to include("verified gone")
+        end
+      end
+
       it "signals only listeners whose working directory is inside this app root" do
         root = app_root("ports")
         mine = start_unrelated_process
         theirs = start_unrelated_process
         allow(described_class).to receive(:killable_ports).and_return([4567, 4568])
-        allow(described_class).to receive(:find_port_pids) do |port|
+        allow(described_class).to receive(:probe_port_listeners) do |port|
           case port
-          when 4567 then alive?(mine[:pid]) ? [mine[:pid]] : []
-          when 4568 then alive?(theirs[:pid]) ? [theirs[:pid]] : []
-          else []
+          when 4567 then [alive?(mine[:pid]) ? [mine[:pid]] : [], :ok]
+          when 4568 then [alive?(theirs[:pid]) ? [theirs[:pid]] : [], :ok]
+          else [[], :ok]
           end
         end
         allow(described_class).to receive(:working_directory_for_pid).with(mine[:pid]).and_return(root)
@@ -1567,7 +1703,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         root = app_root("unattributable")
         theirs = start_unrelated_process
         allow(described_class).to receive(:killable_ports).and_return([4569])
-        allow(described_class).to receive(:find_port_pids).with(4569).and_return([theirs[:pid]])
+        allow(described_class).to receive(:probe_port_listeners).with(4569).and_return([[theirs[:pid]], :ok])
         # lsof unavailable / permission denied -> not attributable.
         allow(described_class).to receive(:working_directory_for_pid).with(theirs[:pid]).and_return(nil)
 
@@ -1606,6 +1742,52 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
           expect(output).to include("verified gone")
           expect(alive?(unrelated[:pid])).to be true
         end
+      end
+
+      it "rejects an endpoint that symlinks outside this app root" do
+        # `File.socket?` follows symlinks, so comparing the unresolved string
+        # let <root>/.overmind.sock point at another checkout's live endpoint
+        # and still pass containment - no session-file tampering needed,
+        # because the default path is always a candidate.
+        root = app_root("symlink-escape")
+        other = app_root("symlink-target")
+        victim_socket = File.join(other, ".overmind.sock")
+        servers << UNIXServer.new(victim_socket)
+        File.symlink(victim_socket, File.join(root, ".overmind.sock"))
+
+        aggregate_failures do
+          expect(Dir.chdir(root) do
+            described_class.send(:overmind_endpoint_owned?, File.join(root, ".overmind.sock"))
+          end).to be false
+          expect(Dir.chdir(root) { described_class.send(:live_overmind_endpoint, root, nil) }).to be_nil
+        end
+      end
+
+      it "rejects a recorded endpoint that escapes the app root with .." do
+        root = app_root("dotdot-escape")
+        other = app_root("dotdot-target")
+        victim_socket = File.join(other, ".overmind.sock")
+        servers << UNIXServer.new(victim_socket)
+        escaped = File.join(root, "..", File.basename(other), ".overmind.sock")
+
+        aggregate_failures do
+          expect(Dir.chdir(root) { described_class.send(:overmind_endpoint_owned?, escaped) }).to be false
+          expect(Dir.chdir(root) { described_class.send(:live_overmind_endpoint, root, escaped) }).to be_nil
+        end
+      end
+
+      it "never tears down another checkout's session through a symlinked endpoint" do
+        root = app_root("attacker")
+        victim = app_root("victim")
+        victim_socket = File.join(victim, ".overmind.sock")
+        servers << UNIXServer.new(victim_socket)
+        File.symlink(victim_socket, File.join(root, ".overmind.sock"))
+
+        expect(described_class).not_to receive(:overmind_control)
+
+        kill_in(root)
+
+        expect(File.socket?(victim_socket)).to be true
       end
 
       it "refuses to control an endpoint outside this app root" do
@@ -1672,6 +1854,69 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    describe "app root discovery" do
+      it "anchors on the nearest ancestor that looks like an app root" do
+        root = app_root("anchor")
+        nested = File.join(root, "app", "assets", "config")
+        FileUtils.mkdir_p(nested)
+
+        expect(Dir.chdir(nested) { described_class.send(:current_app_root) }).to eq(root)
+      end
+
+      it "anchors on the app root itself when invoked there" do
+        root = app_root("anchor-self")
+
+        expect(Dir.chdir(root) { described_class.send(:current_app_root) }).to eq(root)
+      end
+
+      it "recognises a directory holding only dev session state" do
+        root = File.join(@dev_session_base, "session-only")
+        FileUtils.mkdir_p(File.join(root, "tmp", "react_on_rails"))
+        File.write(File.join(root, "tmp", "react_on_rails", "dev-session.json"), "{}")
+        nested = File.join(root, "lib")
+        FileUtils.mkdir_p(nested)
+
+        expect(Dir.chdir(nested) { described_class.send(:current_app_root) }).to eq(root)
+      end
+    end
+
+    describe "owner liveness re-observation" do
+      # `flock` locks attach to the open file description, not the process, so
+      # a second descriptor can be denied by our OWN lock - which would report
+      # a successful shutdown as "the owner is still running".
+      it "does not mistake this process's own lock for a live owner" do
+        root = app_root("own-lock")
+        write_session(root)
+        handle = File.open(session_path(root), File::RDONLY)
+        handles << handle
+        expect(described_class.send(:lock_dev_session, handle)).to eq(:acquired)
+
+        second_fd_result = File.open(session_path(root), File::RDONLY) do |file|
+          file.flock(File::LOCK_EX | File::LOCK_NB)
+        end
+
+        aggregate_failures do
+          expect(second_fd_result).to be false
+          expect(described_class.send(:owner_released?, { path: session_path(root), handle: })).to be true
+        end
+      end
+
+      it "reports a genuinely live owner as not released" do
+        root = app_root("live-lock")
+        start_owner(root)
+        handle = File.open(session_path(root), File::RDONLY)
+        handles << handle
+
+        expect(described_class.send(:owner_released?, { path: session_path(root), handle: })).to be false
+      end
+
+      it "treats a removed session file as released" do
+        root = app_root("gone-lock")
+
+        expect(described_class.send(:owner_released?, { path: session_path(root), handle: nil })).to be true
+      end
+    end
+
     describe "process-group ownership" do
       it "records a pgid only when bin/dev leads its own process group" do
         allow(Process).to receive_messages(getpgrp: 4321, pid: 4321)
@@ -1733,6 +1978,71 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     end
   end
 
+  describe ".probe_port_listeners" do
+    # Verification must distinguish "lsof ran and found nothing" from "lsof
+    # could not run": treating a failed probe as an empty result would silently
+    # upgrade a surviving listener to a verified shutdown.
+    it "reports a missing lsof as unavailable rather than as an empty result" do
+      allow(Open3).to receive(:capture2).and_raise(Errno::ENOENT)
+
+      expect(described_class.send(:probe_port_listeners, 3000)).to eq([[], :unavailable])
+    end
+
+    it "reports an lsof exit status above 1 as unavailable" do
+      allow(Open3).to receive(:capture2).and_return(["", instance_double(Process::Status, exitstatus: 127)])
+
+      expect(described_class.send(:probe_port_listeners, 3000)).to eq([[], :unavailable])
+    end
+
+    it "treats lsof exit 1 with no output as a genuine empty result" do
+      allow(Open3).to receive(:capture2).and_return(["", instance_double(Process::Status, exitstatus: 1)])
+
+      expect(described_class.send(:probe_port_listeners, 3000)).to eq([[], :ok])
+    end
+  end
+
+  describe "shutdown exit status" do
+    it "exits non-zero when `bin/dev kill` refuses to signal anything" do
+      allow(described_class).to receive(:kill_processes).and_return(:refused)
+
+      expect { described_class.run_from_command_line(["kill"]) }
+        .to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+    end
+
+    it "exits non-zero when the shutdown could not be verified" do
+      allow(described_class).to receive(:kill_processes).and_return(:unverified)
+
+      expect { described_class.run_from_command_line(["kill"]) }
+        .to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+    end
+
+    it "exits zero when the shutdown is verified" do
+      allow(described_class).to receive(:kill_processes).and_return(:verified)
+
+      expect { described_class.run_from_command_line(["kill"]) }.not_to raise_error
+    end
+
+    # `bin/dev clean` deletes pack outputs. Doing that after an explicit refusal
+    # would leave a still-running dev server serving files it just removed.
+    it "refuses to delete bundles when the shutdown could not be verified" do
+      allow(described_class).to receive(:kill_processes).and_return(:unverified)
+
+      expect(described_class).not_to receive(:remove_clean_targets)
+
+      output = capture_stdout { expect(described_class.clean_generated_assets_and_caches).to be false }
+      expect(output).to include("Not cleaning")
+    end
+
+    it "cleans normally once the shutdown is verified" do
+      allow(described_class).to receive_messages(kill_processes: :verified,
+                                                 print_shakapacker_config_status: nil,
+                                                 clean_targets: [], remove_clean_targets: true)
+
+      output = capture_stdout { expect(described_class.clean_generated_assets_and_caches).to be true }
+      expect(output).to include("Generated bundles and caches cleaned")
+    end
+  end
+
   describe ".killable_ports" do
     include_context "with clean port env"
 
@@ -1767,11 +2077,48 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         .to include("Including renderer port 5002")
     end
 
+    it "covers the Shakapacker dev-server port in default mode" do
+      # Regression: this list used to be [3000, 3001]. Shakapacker's dev server
+      # defaults to 3035 and `Procfile.dev` runs it, so a default-mode kill
+      # neither stopped it nor noticed it was still there - and because
+      # verification reuses the same list, `bin/dev kill` reported a verified
+      # shutdown while the dev server was still serving.
+      allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
+      allow(described_class).to receive(:pro_renderer_active?).and_return(false)
+
+      expect(described_class.killable_ports).to eq([3000, 3035])
+    end
+
+    it "prefers explicit PORT / SHAKAPACKER_DEV_SERVER_PORT over the defaults" do
+      ENV["PORT"] = "4000"
+      ENV["SHAKAPACKER_DEV_SERVER_PORT"] = "4035"
+      allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
+      allow(described_class).to receive(:pro_renderer_active?).and_return(false)
+
+      expect(described_class.killable_ports).to eq([4000, 4035])
+    end
+
+    it "falls back to the dev_server port configured in shakapacker.yml" do
+      allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
+      allow(described_class).to receive_messages(pro_renderer_active?: false,
+                                                 development_dev_server_config: { "port" => 3210 })
+
+      expect(described_class.killable_ports).to eq([3000, 3210])
+    end
+
+    it "ignores an unusable dev_server port in shakapacker.yml" do
+      allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
+      allow(described_class).to receive_messages(pro_renderer_active?: false,
+                                                 development_dev_server_config: { "port" => "auto" })
+
+      expect(described_class.killable_ports).to eq([3000, 3035])
+    end
+
     it "does not widen scope to 3800 when the Pro gem is loaded but no renderer env vars are set" do
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
 
-      expect(described_class.killable_ports).to eq([3000, 3001])
+      expect(described_class.killable_ports).to eq([3000, 3035])
     end
 
     it "targets 3800 when a localhost REACT_RENDERER_URL is set without an explicit port" do
@@ -1779,7 +2126,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
 
-      expect(described_class.killable_ports).to eq([3000, 3001, 3800])
+      expect(described_class.killable_ports).to eq([3000, 3035, 3800])
     end
 
     it "targets the configured renderer port when Pro renderer support is active without a base port" do
@@ -1787,21 +2134,21 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
 
-      expect(described_class.killable_ports).to eq([3000, 3001, 3900])
+      expect(described_class.killable_ports).to eq([3000, 3035, 3900])
     end
 
     it "does not target the default renderer port for a remote renderer URL" do
       ENV["REACT_RENDERER_URL"] = "https://renderer.internal:3800"
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
 
-      expect(described_class.killable_ports).to eq([3000, 3001])
+      expect(described_class.killable_ports).to eq([3000, 3035])
     end
 
     it "targets the local renderer URL port when RENDERER_PORT is not set" do
       ENV["REACT_RENDERER_URL"] = "http://localhost:3900"
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
 
-      expect(described_class.killable_ports).to eq([3000, 3001, 3900])
+      expect(described_class.killable_ports).to eq([3000, 3035, 3900])
     end
 
     it "does not treat userinfo digits as an explicit local renderer URL port" do
@@ -1809,7 +2156,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
       allow(described_class).to receive(:pro_renderer_active?).and_return(true)
 
-      expect(described_class.killable_ports).to eq([3000, 3001, 3800])
+      expect(described_class.killable_ports).to eq([3000, 3035, 3800])
     end
   end
 
@@ -2122,8 +2469,8 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
   describe ".kill_port_processes" do
     it "signals only listeners whose working directory is inside this app root" do
-      allow(described_class).to receive(:find_port_pids).with(3000).and_return([1234])
-      allow(described_class).to receive(:find_port_pids).with(3001).and_return([5678])
+      allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[1234], :ok])
+      allow(described_class).to receive(:probe_port_listeners).with(3001).and_return([[5678], :ok])
       allow(described_class).to receive(:working_directory_for_pid).with(1234).and_return(File.realpath(Dir.pwd))
       allow(described_class).to receive(:working_directory_for_pid).with(5678).and_return("/somewhere/else")
       allow(described_class).to receive(:process_alive?).and_return(false)
@@ -2136,13 +2483,13 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     end
 
     it "returns false when no processes found on ports" do
-      allow(described_class).to receive(:find_port_pids).and_return([])
+      allow(described_class).to receive(:probe_port_listeners).and_return([[], :ok])
 
       expect(described_class.kill_port_processes([3000, 3001])).to be false
     end
 
     it "never signals a listener it cannot attribute to this app root" do
-      allow(described_class).to receive(:find_port_pids).with(3000).and_return([1234])
+      allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[1234], :ok])
       allow(described_class).to receive(:working_directory_for_pid).with(1234).and_return("/somewhere/else")
 
       expect(Process).not_to receive(:kill)
@@ -2344,7 +2691,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     it "documents the clean command" do
       output = capture_stdout { described_class.show_help }
 
-      expect(output).to match(%r{clean\s+Kill dev processes and remove generated bundles/caches})
+      expect(output).to match(%r{clean\s+Stop dev processes, then remove generated bundles/caches})
     end
 
     it "links to the published documentation for dev server and testing guidance" do

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1269,6 +1269,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         file.write(JSON.generate("schema" => 1, "app_root" => root, "pid" => Process.pid,
                                  "pgid" => Process.getpgrp,
                                  "overmind_socket" => (socket.empty? ? nil : socket),
+                                 "ports" => [],
                                  "started_at" => "2026-01-01T00:00:00Z"))
         file.flush
         child = spawn("sleep", "120")
@@ -1390,14 +1391,77 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         expect(recorded["ports"]).to eq([4000, 4035])
       end
 
-      it "prefers the recorded ports over the killing shell's derived guess" do
+      it "verifies the union of the recorded and derived ports" do
         allow(described_class).to receive(:killable_ports).and_return([3000, 3035])
 
         aggregate_failures do
-          expect(described_class.send(:shutdown_ports, { session: { ports: [4000, 4035] } })).to eq([4000, 4035])
+          expect(described_class.send(:shutdown_ports, { session: { ports: [4000, 4035] } }))
+            .to eq([4000, 4035, 3000, 3035])
           expect(described_class.send(:shutdown_ports, { session: { ports: [] } })).to eq([3000, 3035])
           expect(described_class.send(:shutdown_ports, {})).to eq([3000, 3035])
+          expect(described_class.send(:shutdown_ports, { session: { ports: [3000] } })).to eq([3000, 3035])
         end
+      end
+
+      # Recorded ports only cover variables present in the parent environment.
+      # The generated Pro Procfile starts the renderer with
+      # `RENDERER_PORT=${RENDERER_PORT:-3800}`, so a defaulted renderer port is
+      # never recorded - preferring recorded exclusively hid it entirely.
+      it "still covers a renderer port the Procfile defaulted rather than exported" do
+        allow(ReactOnRails::Dev::PortSelector).to receive(:base_port_hash).and_return(nil)
+        allow(described_class).to receive_messages(pro_renderer_active?: true, killable_ports: [3000, 3035, 3800])
+
+        ports = described_class.send(:shutdown_ports, { session: { ports: [3000, 3035] } })
+
+        expect(ports).to include(3800)
+      end
+
+      it "derives no ports at all for a refused session" do
+        expect(described_class).not_to receive(:killable_ports)
+
+        expect(described_class.send(:shutdown_ports, { kind: :refused })).to eq([])
+      end
+
+      # The previous owner can unlink the path between our open and our flock,
+      # leaving us locking an inode `dev-session.json` no longer names.
+      it "retries when the session path is unlinked between open and lock" do
+        root = app_root("claim-detached")
+        path = session_path(root)
+        unlinked = false
+        allow(File).to receive(:open).and_wrap_original do |original, *args, &block|
+          handle = original.call(*args, &block)
+          if !unlinked && args.first == path
+            unlinked = true
+            File.delete(path)
+          end
+          handle
+        end
+
+        recorded = nil
+        Dir.chdir(root) do
+          described_class.send(:with_dev_session) do
+            recorded = File.exist?(path) ? JSON.parse(File.read(path)) : nil
+          end
+        end
+
+        aggregate_failures do
+          expect(unlinked).to be true
+          expect(recorded).to be_a(Hash)
+          expect(recorded["app_root"]).to eq(root)
+        end
+      end
+
+      it "refuses to write through a symlink planted at the session path" do
+        root = app_root("symlinked-session")
+        target = File.join(root, "target.json")
+        File.write(target, "original")
+        File.symlink(target, session_path(root))
+
+        expect do
+          Dir.chdir(root) { described_class.send(:with_dev_session) { :ran } }
+        end.to output(/Could not record dev session state/).to_stderr
+
+        expect(File.read(target)).to eq("original")
       end
 
       it "leaves no held lock and no partial file when the session write fails" do
@@ -1610,6 +1674,43 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
           expect(output).to include("Shutdown could not be verified")
           expect(output).to include("port 4567 is still held by this app directory")
           expect(output).not_to include("verified gone")
+        end
+      end
+
+      # The session file carries the ports this run actually selected, so it
+      # has to outlive an unverified outcome - otherwise the retry falls back to
+      # a re-derived guess, and the printed advice names a file already gone.
+      it "keeps the session file when a leftover listener blocks verification" do
+        root = app_root("leftover-retry")
+        start_owner(root)
+        listener = start_unrelated_process
+        allow(described_class).to receive(:shutdown_ports).and_return([4567])
+        allow(described_class).to receive(:probe_port_listeners).with(4567).and_return([[listener[:pid]], :ok])
+        allow(described_class).to receive(:working_directory_for_pid).with(listener[:pid]).and_return(root)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(File.exist?(session_path(root))).to be true
+          expect(JSON.parse(File.read(session_path(root)))).to have_key("ports")
+          expect(output).to include("dev-session.json")
+        end
+      end
+
+      it "keeps stale session state when a leftover listener blocks verification" do
+        root = app_root("stale-retry")
+        write_session(root, "ports" => [4568])
+        listener = start_unrelated_process
+        allow(described_class).to receive(:probe_port_listeners).with(4568).and_return([[listener[:pid]], :ok])
+        allow(described_class).to receive(:working_directory_for_pid).with(listener[:pid]).and_return(root)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(File.exist?(session_path(root))).to be true
+          expect(JSON.parse(File.read(session_path(root)))["ports"]).to eq([4568])
         end
       end
 
@@ -1972,17 +2073,45 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         end
       end
 
-      it "distinguishes a dead endpoint from one it could not probe" do
-        root = app_root("endpoint-states")
-        socket_path = File.join(root, ".overmind.sock")
-        UNIXServer.new(socket_path).close
+      it "distinguishes a live endpoint from a dead one" do
+        root = app_root("es")
+        live = File.join(root, "live.sock")
+        dead = File.join(root, "dead.sock")
+        servers << UNIXServer.new(live)
+        UNIXServer.new(dead).close
 
         aggregate_failures do
-          expect(described_class.send(:overmind_endpoint_state, socket_path)).to eq(:gone)
+          expect(described_class.send(:overmind_endpoint_state, live)).to eq(:alive)
+          expect(described_class.send(:overmind_endpoint_state, dead)).to eq(:gone)
           expect(described_class.send(:overmind_endpoint_state, File.join(root, "absent.sock"))).to eq(:gone)
+        end
+      end
 
-          allow(UNIXSocket).to receive(:new).and_raise(Errno::EACCES)
-          expect(described_class.send(:overmind_endpoint_state, socket_path)).to eq(:unknown)
+      it "treats an unprobeable endpoint as unknown rather than gone" do
+        root = app_root("eu")
+        socket_path = File.join(root, "u.sock")
+        servers << UNIXServer.new(socket_path)
+        allow_any_instance_of(Socket).to receive(:connect_nonblock).and_raise(Errno::EACCES)
+
+        expect(described_class.send(:overmind_endpoint_state, socket_path)).to eq(:unknown)
+      end
+
+      # A blocking `UNIXSocket.new` hangs indefinitely against a full accept
+      # queue, which would stall `bin/dev kill` outside any of its own timeouts.
+      it "gives up on a stalled connect within its budget and reports unknown" do
+        root = app_root("et")
+        socket_path = File.join(root, "t.sock")
+        servers << UNIXServer.new(socket_path)
+        allow_any_instance_of(Socket).to receive(:connect_nonblock).and_raise(IO::EAGAINWaitWritable)
+        allow_any_instance_of(Socket).to receive(:wait_writable).and_return(nil)
+
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        state = described_class.send(:overmind_endpoint_state, socket_path)
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+        aggregate_failures do
+          expect(state).to eq(:unknown)
+          expect(elapsed).to be < 2
         end
       end
 
@@ -1995,6 +2124,29 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         blockers = described_class.send(:endpoint_blockers, socket_path)
 
         expect(blockers).to include(a_string_matching(/could not determine whether the Overmind endpoint/))
+      end
+
+      it "controls a live custom OVERMIND_SOCKET inside the app root" do
+        root = app_root("cs")
+        custom = File.join(root, "custom.sock")
+        servers << UNIXServer.new(custom)
+        ENV["OVERMIND_SOCKET"] = custom
+
+        expect(Dir.chdir(root) { described_class.send(:live_overmind_endpoint, root, nil) }).to eq(custom)
+      ensure
+        ENV.delete("OVERMIND_SOCKET")
+      end
+
+      it "ignores a custom OVERMIND_SOCKET pointing outside the app root" do
+        root = app_root("co")
+        other = app_root("ct")
+        custom = File.join(other, "custom.sock")
+        servers << UNIXServer.new(custom)
+        ENV["OVERMIND_SOCKET"] = custom
+
+        expect(Dir.chdir(root) { described_class.send(:live_overmind_endpoint, root, nil) }).to be_nil
+      ensure
+        ENV.delete("OVERMIND_SOCKET")
       end
 
       it "ignores a recorded endpoint that no longer answers" do
@@ -2060,6 +2212,36 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
           expect(scan[:foreign]).to be_empty
           expect(scan[:unattributable]).to be_empty
           expect(scan[:unavailable]).to be_empty
+        end
+      end
+    end
+
+    describe "session document validation" do
+      # A minimal Docker dev container with no init wrapper runs bin/dev as
+      # PID 1. Rejecting that disabled the mechanism outright.
+      it "accepts a session recorded by a bin/dev running as PID 1" do
+        document = { "schema" => 1, "app_root" => "/app", "pid" => 1, "pgid" => nil,
+                     "overmind_socket" => nil, "ports" => [] }
+
+        expect(described_class.send(:valid_dev_session_document?, document)).to be true
+      end
+
+      it "does not refuse a session file written by a PID 1 owner" do
+        root = app_root("pid-one")
+        write_session(root, "pid" => 1)
+
+        expect(kill_in(root)).not_to include("Refusing to signal anything")
+      end
+
+      # The asymmetry is load-bearing: pid is identity only, pgid gets
+      # signalled and `Process.kill(sig, -1)` broadcasts.
+      it "keeps rejecting a pgid of 1 while accepting a pid of 1" do
+        aggregate_failures do
+          expect(described_class.send(:valid_session_pid?, 1)).to be true
+          expect(described_class.send(:valid_session_pgid?, 1)).to be false
+          expect(described_class.send(:valid_session_pid?, 0)).to be false
+          expect(described_class.send(:valid_session_pid?, -1)).to be false
+          expect(described_class.send(:valid_session_pgid?, nil)).to be true
         end
       end
     end

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1398,6 +1398,33 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         end
       end
 
+      it "leaves no held lock and no partial file when the session write fails" do
+        root = app_root("write-fails")
+        path = session_path(root)
+        allow(described_class).to receive(:write_dev_session).and_raise(Errno::ENOSPC)
+
+        Dir.chdir(root) { described_class.send(:with_dev_session) { :ran } }
+
+        aggregate_failures do
+          # No partial file left behind...
+          expect(File.exist?(path)).to be false
+          # ...and no lock still held, so a later kill is not stuck refusing.
+          lock_free = File.open(path, File::RDWR | File::CREAT) do |file|
+            file.flock(File::LOCK_EX | File::LOCK_NB)
+          end
+          expect(lock_free).to eq(0)
+        end
+      end
+
+      it "degrades to port-scoped cleanup after a failed session write" do
+        root = app_root("write-fails-warns")
+        allow(described_class).to receive(:write_dev_session).and_raise(Errno::ENOSPC)
+
+        expect do
+          Dir.chdir(root) { described_class.send(:with_dev_session) { :ran } }
+        end.to output(/Could not record dev session state/).to_stderr
+      end
+
       it "leaves state owned by another running bin/dev untouched" do
         root = app_root("contended")
         start_owner(root)
@@ -1699,13 +1726,14 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         end
       end
 
-      it "never signals a listener it cannot attribute to this app root" do
-        root = app_root("unattributable")
+      it "leaves a positively foreign listener alone without blocking verification" do
+        root = app_root("foreign-listener")
         theirs = start_unrelated_process
+        other_dir = app_root("foreign-listener-owner")
         allow(described_class).to receive(:killable_ports).and_return([4569])
         allow(described_class).to receive(:probe_port_listeners).with(4569).and_return([[theirs[:pid]], :ok])
-        # lsof unavailable / permission denied -> not attributable.
-        allow(described_class).to receive(:working_directory_for_pid).with(theirs[:pid]).and_return(nil)
+        # The cwd probe SUCCEEDED and says the listener belongs elsewhere.
+        allow(described_class).to receive(:working_directory_for_pid).with(theirs[:pid]).and_return(other_dir)
 
         expect(described_class).not_to receive(:terminate_processes)
 
@@ -1714,6 +1742,96 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         aggregate_failures do
           expect(alive?(theirs[:pid])).to be true
           expect(output).to include("Leaving port 4569 alone")
+          expect(output).not_to include("Shutdown could not be verified")
+        end
+      end
+
+      # This example fails if :unattributable is ever folded back into
+      # :foreign. A pid whose owner could not be determined is NOT evidence
+      # that this app directory's listener is gone.
+      it "blocks verification on a listener whose owner could not be determined" do
+        root = app_root("unattributable")
+        theirs = start_unrelated_process
+        allow(described_class).to receive(:killable_ports).and_return([4569])
+        allow(described_class).to receive(:probe_port_listeners).with(4569).and_return([[theirs[:pid]], :ok])
+        # The cwd probe FAILED: missing tool, permission denied, unparsable.
+        allow(described_class).to receive(:working_directory_for_pid).with(theirs[:pid]).and_return(nil)
+
+        expect(described_class).not_to receive(:terminate_processes)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(alive?(theirs[:pid])).to be true
+          expect(output).to include("Could not determine who owns port 4569")
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("could not be attributed")
+          expect(output).not_to include("No development processes owned by this app directory")
+          expect(output).not_to include("verified gone")
+        end
+      end
+
+      # A: the no-session path used to map "could not check" to "nothing was
+      # running", so `bin/dev kill && bin/dev` started a second stack on top of
+      # a live one whenever lsof was unavailable.
+      it "reports an unverified shutdown when no port could be inspected" do
+        root = app_root("probe-down")
+        allow(described_class).to receive_messages(killable_ports: [4570, 4571],
+                                                   probe_port_listeners: [
+                                                     [], :unavailable
+                                                   ])
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("could not verify port 4570 is free")
+          expect(output).to include("could not verify port 4571 is free")
+          expect(output).not_to include("No development processes owned by this app directory")
+        end
+      end
+
+      it "exits non-zero when no port could be inspected" do
+        root = app_root("probe-down-exit")
+        allow(described_class).to receive_messages(killable_ports: [4572], probe_port_listeners: [[], :unavailable])
+
+        expect do
+          capture_stdout { Dir.chdir(root) { described_class.run_from_command_line(["kill"]) } }
+        end.to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+      end
+
+      # B: an old handle can be an unlinked inode. Re-locking it would say
+      # "released" while a brand-new session holds the real file.
+      it "refuses instead of succeeding when a newer bin/dev replaces the session mid-shutdown" do
+        root = app_root("replaced")
+        owner = start_owner(root)
+        path = session_path(root)
+
+        # Once the owned group is gone, stand in for a newer `bin/dev`:
+        # unlink the old inode and put a fresh, locked file at the same path.
+        allow(described_class).to receive(:signal_process_group).and_wrap_original do |original, pgid, signal|
+          result = original.call(pgid, signal)
+          if signal == "TERM"
+            wait_for { !group_alive?(owner[:pgid]) }
+            File.delete(path)
+            replacement = File.open(path, File::RDWR | File::CREAT)
+            handles << replacement
+            replacement.flock(File::LOCK_EX | File::LOCK_NB)
+            replacement.write(JSON.generate("schema" => 1, "app_root" => root, "pid" => Process.pid,
+                                            "pgid" => nil, "overmind_socket" => nil, "ports" => []))
+            replacement.flush
+          end
+          result
+        end
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("was replaced by a newer `bin/dev`")
+          expect(output).not_to include("verified gone")
+          # The replacement's state must survive - it is a different session.
+          expect(File.exist?(path)).to be true
         end
       end
     end
@@ -1826,6 +1944,31 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
           expect(result).to be false
           expect(output).to include("Skipping `overmind quit`")
         end
+      end
+
+      it "distinguishes a dead endpoint from one it could not probe" do
+        root = app_root("endpoint-states")
+        socket_path = File.join(root, ".overmind.sock")
+        UNIXServer.new(socket_path).close
+
+        aggregate_failures do
+          expect(described_class.send(:overmind_endpoint_state, socket_path)).to eq(:gone)
+          expect(described_class.send(:overmind_endpoint_state, File.join(root, "absent.sock"))).to eq(:gone)
+
+          allow(UNIXSocket).to receive(:new).and_raise(Errno::EACCES)
+          expect(described_class.send(:overmind_endpoint_state, socket_path)).to eq(:unknown)
+        end
+      end
+
+      it "blocks verification when the endpoint state cannot be determined" do
+        root = app_root("endpoint-unknown")
+        socket_path = File.join(root, ".overmind.sock")
+        UNIXServer.new(socket_path).close
+        allow(described_class).to receive(:overmind_endpoint_state).and_return(:unknown)
+
+        blockers = described_class.send(:endpoint_blockers, socket_path)
+
+        expect(blockers).to include(a_string_matching(/could not determine whether the Overmind endpoint/))
       end
 
       it "ignores a recorded endpoint that no longer answers" do
@@ -2496,6 +2639,59 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
       output = capture_stdout { expect(described_class.kill_port_processes([3000])).to be false }
       expect(output).to include("not attributable to this app directory")
+    end
+
+    it "reports a listener whose owner could not be determined separately from a foreign one" do
+      allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[1234], :ok])
+      allow(described_class).to receive(:working_directory_for_pid).with(1234).and_return(nil)
+
+      expect(Process).not_to receive(:kill)
+
+      output = capture_stdout { expect(described_class.kill_port_processes([3000])).to be false }
+      aggregate_failures do
+        expect(output).to include("Could not determine who owns port 3000")
+        expect(output).not_to include("not attributable to this app directory")
+      end
+    end
+
+    it "reports an unavailable probe rather than silently finding nothing" do
+      allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[], :unavailable])
+
+      output = capture_stdout { expect(described_class.kill_port_processes([3000])).to be false }
+      expect(output).to include("Could not check port 3000 for listeners (lsof unavailable)")
+    end
+  end
+
+  describe ".classify_port_listeners" do
+    # The whole point of the four-bucket scan: "somebody else's" and "could not
+    # tell" must never share a bucket.
+    it "keeps foreign and unattributable listeners in separate buckets" do
+      allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[11, 22, 33], :ok])
+      allow(described_class).to receive(:working_directory_for_pid).with(11).and_return(File.realpath(Dir.pwd))
+      allow(described_class).to receive(:working_directory_for_pid).with(22).and_return("/somewhere/else")
+      allow(described_class).to receive(:working_directory_for_pid).with(33).and_return(nil)
+
+      scan = described_class.send(:classify_port_listeners, [3000])
+
+      aggregate_failures do
+        expect(scan[:owned]).to eq({ 3000 => [11] })
+        expect(scan[:foreign]).to eq({ 3000 => [22] })
+        expect(scan[:unattributable]).to eq({ 3000 => [33] })
+        expect(scan[:unavailable]).to eq([])
+      end
+    end
+
+    it "records a failed listener probe as an unavailable port" do
+      allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[], :unavailable])
+
+      scan = described_class.send(:classify_port_listeners, [3000])
+
+      aggregate_failures do
+        expect(scan[:unavailable]).to eq([3000])
+        expect(scan[:owned]).to be_empty
+        expect(scan[:foreign]).to be_empty
+        expect(scan[:unattributable]).to be_empty
+      end
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1319,6 +1319,8 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       true
     rescue Errno::ESRCH
       false
+    rescue Errno::EPERM
+      true
     end
 
     def group_alive?(pgid)
@@ -1746,6 +1748,30 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         end
       end
 
+      # A listener we may not signal cannot be one of this app's dev
+      # processes - `bin/dev` starts them all as the invoking user - so it must
+      # not block verification forever the way a genuinely unknown one does.
+      it "does not block verification on a listener owned by another user" do
+        root = app_root("other-user")
+        theirs = start_unrelated_process
+        allow(described_class).to receive_messages(killable_ports: [4573])
+        allow(described_class).to receive(:probe_port_listeners).with(4573).and_return([[theirs[:pid]], :ok])
+        allow(described_class).to receive(:working_directory_for_pid).with(theirs[:pid]).and_return(nil)
+        allow(Process).to receive(:kill).and_call_original
+        allow(Process).to receive(:kill).with(0, theirs[:pid]).and_raise(Errno::EPERM)
+
+        expect(described_class).not_to receive(:terminate_processes)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(alive?(theirs[:pid])).to be true
+          expect(output).to include("Leaving port 4573 alone")
+          expect(output).not_to include("Shutdown could not be verified")
+          expect(output).to include("No development processes owned by this app directory")
+        end
+      end
+
       # This example fails if :unattributable is ever folded back into
       # :foreign. A pid whose owner could not be determined is NOT evidence
       # that this app directory's listener is gone.
@@ -1993,6 +2019,47 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         aggregate_failures do
           expect(File.exist?(live)).to be true
           expect(File.exist?(dead)).to be false
+        end
+      end
+    end
+
+    describe "attributing a listener whose working directory is unreadable" do
+      # `Process.kill(0, pid)` runs the existence and permission checks without
+      # sending a signal, which is enough to separate "somebody else's" from
+      # "genuinely cannot tell" without parsing any more lsof output.
+      it "treats a process it may not signal as foreign" do
+        allow(described_class).to receive(:working_directory_for_pid).with(4242).and_return(nil)
+        allow(Process).to receive(:kill).with(0, 4242).and_raise(Errno::EPERM)
+
+        expect(described_class.send(:attribute_pid, 4242, "/app")).to eq(:foreign)
+      end
+
+      it "treats a process that has already exited as gone" do
+        allow(described_class).to receive(:working_directory_for_pid).with(4242).and_return(nil)
+        allow(Process).to receive(:kill).with(0, 4242).and_raise(Errno::ESRCH)
+
+        expect(described_class.send(:attribute_pid, 4242, "/app")).to eq(:gone)
+      end
+
+      it "keeps a signalable process with an unreadable cwd genuinely unknown" do
+        allow(described_class).to receive(:working_directory_for_pid).with(4242).and_return(nil)
+        allow(Process).to receive(:kill).with(0, 4242).and_return(1)
+
+        expect(described_class.send(:attribute_pid, 4242, "/app")).to eq(:unknown)
+      end
+
+      it "drops an exited listener from every bucket" do
+        allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[4242], :ok])
+        allow(described_class).to receive(:working_directory_for_pid).with(4242).and_return(nil)
+        allow(Process).to receive(:kill).with(0, 4242).and_raise(Errno::ESRCH)
+
+        scan = described_class.send(:classify_port_listeners, [3000])
+
+        aggregate_failures do
+          expect(scan[:owned]).to be_empty
+          expect(scan[:foreign]).to be_empty
+          expect(scan[:unattributable]).to be_empty
+          expect(scan[:unavailable]).to be_empty
         end
       end
     end
@@ -2644,8 +2711,13 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     it "reports a listener whose owner could not be determined separately from a foreign one" do
       allow(described_class).to receive(:probe_port_listeners).with(3000).and_return([[1234], :ok])
       allow(described_class).to receive(:working_directory_for_pid).with(1234).and_return(nil)
+      # Signalable, so not somebody else's - just unreadable. Signal 0 is a
+      # permission probe, not a signal, so only real signals are forbidden here.
+      allow(Process).to receive(:kill).and_call_original
+      allow(Process).to receive(:kill).with(0, 1234).and_return(1)
 
-      expect(Process).not_to receive(:kill)
+      expect(Process).not_to receive(:kill).with("TERM", anything)
+      expect(Process).not_to receive(:kill).with("KILL", anything)
 
       output = capture_stdout { expect(described_class.kill_port_processes([3000])).to be false }
       aggregate_failures do
@@ -2670,6 +2742,9 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       allow(described_class).to receive(:working_directory_for_pid).with(11).and_return(File.realpath(Dir.pwd))
       allow(described_class).to receive(:working_directory_for_pid).with(22).and_return("/somewhere/else")
       allow(described_class).to receive(:working_directory_for_pid).with(33).and_return(nil)
+      # Signalable, so pid 33 is genuinely unattributable rather than foreign.
+      allow(Process).to receive(:kill).and_call_original
+      allow(Process).to receive(:kill).with(0, 33).and_return(1)
 
       scan = described_class.send(:classify_port_listeners, [3000])
 

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1820,8 +1820,62 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
         aggregate_failures do
           expect(output).to include("Refusing to signal anything")
-          expect(output).to include("could not open")
+          expect(output).to include("must be a regular file")
           expect(output).not_to include("No development processes owned by this app directory")
+        end
+      end
+
+      # The security claim of this whole change: a symlink at the session path
+      # must never become authority to signal the process group it names.
+      it "refuses a symlinked session path instead of signalling the group it names" do
+        root = app_root("symlink-read")
+        victim = start_unrelated_process
+        # A locked, entirely valid-looking document that names THIS app root and
+        # an arbitrary pgid, reachable only through a symlink at the session path.
+        planted = File.join(root, "planted.json")
+        File.write(planted, JSON.generate("schema" => 1, "app_root" => root, "pid" => victim[:pid],
+                                          "pgid" => victim[:pgid], "overmind_socket" => nil, "ports" => []))
+        holder = File.open(planted, File::RDWR)
+        handles << holder
+        holder.flock(File::LOCK_EX | File::LOCK_NB)
+        File.symlink(planted, session_path(root))
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Refusing to signal anything")
+          expect(output).to include("must be a regular file")
+          # The point of the test: the planted group is untouched.
+          expect(group_alive?(victim[:pgid])).to be(true), "the planted process group was signalled"
+          expect(alive?(victim[:pid])).to be true
+        end
+      end
+
+      it "refuses a session path that is not a regular file" do
+        root = app_root("dir-session")
+        FileUtils.mkdir_p(session_path(root))
+
+        expect(described_class).not_to receive(:kill_port_processes)
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Refusing to signal anything")
+          expect(output).to include("not a regular file")
+        end
+      end
+
+      # Without O_NONBLOCK the open never returns, so the regular-file check
+      # below it is unreachable and `bin/dev kill` hangs outright.
+      it "refuses a FIFO at the session path without blocking on the open" do
+        root = app_root("fifo-session")
+        File.mkfifo(session_path(root))
+
+        output = Timeout.timeout(20) { kill_in(root) }
+
+        aggregate_failures do
+          expect(output).to include("Refusing to signal anything")
+          expect(output).to include("not a regular file")
         end
       end
 
@@ -2130,6 +2184,27 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
           .and_return(true)
 
         expect(Dir.chdir(root) { described_class.send(:overmind_control, "quit", socket_path) }).to be true
+      end
+
+      # The socket probe was bounded but the command acting on it was not, so a
+      # wedged `overmind quit` blocked inside action.call before wait_until ever
+      # started polling, and the KILL escalation was never reached.
+      it "gives up on a wedged Overmind control command so the ladder can proceed" do
+        stub_const("#{described_class}::OVERMIND_CONTROL_TIMEOUT_SECS", 0.2)
+        allow(ReactOnRails::Dev::ProcessManager).to receive(:run_process_if_available) { sleep 30 }
+
+        result = nil
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        output = capture_stdout do
+          result = described_class.send(:run_overmind_command, ["quit", "-s", "/tmp/none.sock"])
+        end
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+        aggregate_failures do
+          expect(result).to be false
+          expect(elapsed).to be < 5
+          expect(output).to include("did not return within")
+        end
       end
 
       it "reports an Overmind control command that could not be run" do

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1677,6 +1677,44 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         end
       end
 
+      # The previous owner deletes its state on exit, so owner_release_state
+      # returns :released without taking the lock - leaving the path free for a
+      # newer `bin/dev` to claim while the lsof-backed listener scan runs.
+      # Reporting :verified then would tell `bin/dev kill && bin/dev` to start a
+      # second session on top of the one that just claimed this directory.
+      it "refuses when a newer bin/dev claims the path during the listener scan" do
+        root = app_root("claimed-mid-scan")
+        path = session_path(root)
+        start_owner(root)
+        replacement = nil
+
+        # Stand in for the replacement appearing while lsof is out: the original
+        # inode is unlinked and a fresh, locked session file takes its place.
+        allow(described_class).to receive(:leftover_owned_listeners).and_wrap_original do |original, view|
+          result = original.call(view)
+          if replacement.nil?
+            FileUtils.rm_f(path)
+            replacement = File.open(path, File::RDWR | File::CREAT)
+            handles << replacement
+            replacement.flock(File::LOCK_EX | File::LOCK_NB)
+            replacement.write(JSON.generate("schema" => 1, "app_root" => root, "pid" => Process.pid,
+                                            "pgid" => nil, "overmind_socket" => nil, "ports" => []))
+            replacement.flush
+          end
+          result
+        end
+
+        output = kill_in(root)
+
+        aggregate_failures do
+          expect(output).to include("Shutdown could not be verified")
+          expect(output).to include("was replaced by a newer `bin/dev`")
+          expect(output).not_to include("verified gone")
+          # The replacement's own state must survive - it is a different session.
+          expect(File.exist?(path)).to be true
+        end
+      end
+
       # The session file carries the ports this run actually selected, so it
       # has to outlive an unverified outcome - otherwise the retry falls back to
       # a re-derived guess, and the printed advice names a file already gone.
@@ -2033,6 +2071,51 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         kill_in(root)
 
         expect(File.socket?(victim_socket)).to be true
+      end
+
+      # `bin/dev` starts the process manager through ProcessManager, which
+      # falls back to a Bundler-free context when the globally installed binary
+      # is not usable inside the bundle - the documented install shape for this
+      # project. A bare `system("overmind", ...)` here repeats the context that
+      # already failed, and the process-group fallback cannot reach an Overmind
+      # session because its tmux server daemonizes to PPID 1.
+      it "controls Overmind through the same runner startup uses" do
+        root = app_root("runner")
+        socket_path = File.join(root, "r.sock")
+        servers << UNIXServer.new(socket_path)
+
+        expect(ReactOnRails::Dev::ProcessManager)
+          .to receive(:run_process_if_available)
+          .with("overmind", ["quit", "-s", socket_path])
+          .and_return(true)
+
+        expect(Dir.chdir(root) { described_class.send(:overmind_control, "quit", socket_path) }).to be true
+      end
+
+      it "reports an Overmind control command that could not be run" do
+        root = app_root("runner-fail")
+        socket_path = File.join(root, "rf.sock")
+        servers << UNIXServer.new(socket_path)
+        # nil is what the runner returns when the binary is unusable in both
+        # the bundled and unbundled contexts.
+        allow(ReactOnRails::Dev::ProcessManager).to receive(:run_process_if_available).and_return(nil)
+
+        result = nil
+        output = capture_stdout do
+          Dir.chdir(root) { result = described_class.send(:overmind_control, "kill", socket_path) }
+        end
+
+        aggregate_failures do
+          expect(result).to be false
+          expect(output).to include("`overmind kill` did not run successfully")
+        end
+      end
+
+      # Pins the cross-class coupling: if ProcessManager renames this runner,
+      # this fails loudly instead of silently reverting to the broken bare
+      # `system` call.
+      it "depends on a runner ProcessManager still provides" do
+        expect(ReactOnRails::Dev::ProcessManager.respond_to?(:run_process_if_available, true)).to be true
       end
 
       it "refuses to control an endpoint outside this app root" do


### PR DESCRIPTION
### Summary

`bin/dev kill` could terminate another checkout's development processes.

Its discovery was machine-global: `pgrep -f rails`, `pgrep -f overmind`, `pgrep -f foreman`, `pgrep -f ruby.*puma`, `pgrep -f webpack-dev-server`, plus an unfiltered `lsof -ti :PORT` that matched client connections as readily as listeners. Every match got a `TERM`. Nothing checked whether a matched process belonged to the current app directory, nothing waited for descendants, and nothing verified that anything had actually stopped before printing `All processes terminated`. On a machine running concurrent Rails worktrees — the workflow this project explicitly supports through distinct base ports — running `bin/dev kill` in one worktree could kill your own unrelated work. This was observed on a real machine: `pgrep -f rails` matched an active Rails process whose working directory belonged to a different repository.

Distinct base ports prevented port collisions, but process-name discovery still crossed worktree boundaries.

**What changed.** Ownership is now established when the session *starts* rather than guessed at kill time.

`bin/dev` claims `tmp/react_on_rails/dev-session.json` and holds an exclusive `flock` on it for the whole run. The file records the app root's absolute, symlink-resolved path, the pid, the process group the runner leads (recorded only when it genuinely leads one), the Overmind endpoint it would use, and the ports actually selected at startup.

`bin/dev kill` re-opens that file, and the lock is the liveness proof: **failing to take it proves the owner is alive; taking it proves the owner is gone.** A recorded pid or pgid is never authority on its own, because pids are recycled. Shutdown then walks an explicit ladder — `overmind quit` → `overmind kill` against the session's own control socket, or group `TERM` → group `KILL` — and reports success only after positively re-observing that the lock is free, the process group has no members, the endpoint no longer answers, and no attributable listener remains.

Fallback port discovery is now restricted to LISTEN sockets, and each candidate pid is classified `owned` / `foreign` / `unattributable`. Only `owned` is ever signalled. Missing, malformed, or foreign session state fails closed into a recovery path that cleans files and sends no signals at all.

The machine-global `pgrep -f` kill discovery is deleted. That is a deliberate behavior change and the point of the issue.

**Two user-visible consequences worth knowing before you merge:**

- **`bin/dev kill` now exits non-zero when it refuses or cannot verify**, and `bin/dev clean` aborts rather than deleting bundles after a refusal. Previously both exited 0 unconditionally, so `bin/dev kill && bin/dev` could start a second stack on top of one that never stopped.
- **A shutdown is never reported verified from an observation that could not be made.** If `lsof` is missing or a probe fails, the command says so and exits 1 instead of claiming nothing was running.

**Scope boundary.** Processes that deliberately leave the group via `setsid`/daemonization are out of scope for this issue and documented as such in the code. That limitation is exactly why Overmind is driven through its control socket instead of a group signal: Overmind's tmux server daemonizes, running with `PPID 1` and its own process group, so no group signal can reach it.

Fixes #4846.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~ — no user-facing docs describe the kill internals; the behavior change is covered in the CHANGELOG, and the two docs pages that describe the old semantics are tracked in #4938
- [x] Update CHANGELOG file

### Other Information

**How to review this.** The interesting question is "can this ever signal something it does not own, or claim success it did not observe?", so the highest-value reading order is:

1. `valid_dev_session_document?` / `parse_dev_session` — every fail-closed rejection of untrusted state
2. `classify_dev_session` / `owner_release_state` — app-root match, lock verdict, and the session-replacement guard
3. `inside_dev_app_root?` and `overmind_endpoint_owned?` — path-component containment plus `File.realpath`, so neither `/tmp/app2` nor a symlinked socket can pass as inside `/tmp/app`
4. `attribute_pid` / `classify_port_listeners` — the `owned` / `foreign` / `unattributable` split
5. `verify_owner_shutdown` — the only path allowed to print success

The regression tests use real processes, real process groups, real `flock`s and real Unix sockets rather than mocks. That is deliberate: the original bug survived because the previous specs stubbed the exact global `pgrep`/`lsof` calls that were wrong, so a mock-shaped test could not have caught it. Each guard's test was additionally proven discriminating by reverting that guard alone and confirming the test goes red.

<details>
<summary>Agent details</summary>

### Release-mode gate

- Target branch `main` → release phase **beta** → gate is *confidence note + green required checks* (`AGENTS.md` → Release-Train Branching And Phase Gating).
- Active release tracker #4842 (17.1.0) is in mode **strict-rc**. Per `AGENTS.md`, `strict-rc` applies standard merge qualification; the accelerated-RC confidence block and its 8/10 threshold do **not** apply, so no `Agent Merge Confidence` block is required. The tracker's `Phase: rc` describes the `release/17.1.0` line, not `main` — no `release-mode-conflict`.
- `merge_authority: auto_merge_when_gates_pass`.

### Confidence note

- **Validated** — coordinator re-ran these independently at `b26819c19951339ce9a186a9b13bb8caf81cc60c`, rather than accepting the worker's pasted output:
  - `(cd react_on_rails && bundle exec rspec spec/react_on_rails/dev/)` → **533 examples, 0 failures**
  - `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/dev/server_manager.rb spec/react_on_rails/dev/server_manager_spec.rb)` → **2 files inspected, no offenses detected**
  - `(cd react_on_rails && bundle exec rake rbs:validate)` → **RBS validation passed**
  - `git diff --check` → clean
  - Scope confirmed: 8 commits, exactly 4 files, no create/delete/rename.
  - Worker additionally ran seeds 1001–11011 across rounds (no failures, no leaked processes or tmpdirs) and proved every new guard discriminating by reverting it alone and observing the matching test go red.
- **Evidence**: QA Evidence block below; `closeout-evidence-replay --expected-head-sha b26819c19951339ce9a186a9b13bb8caf81cc60c` → `overall_verdict: SATISFIED`.
- **UNKNOWN**:
  - `pack_sha` is `UNKNOWN` — the installed Agent Workflows pack is not a verified checkout.
  - The rake task's literal `RUBYOPT='-rrbs/test/setup'` form cannot run on this machine (`already activated json 2.21.2, but your Gemfile requires json 2.7.2`). It reproduces on untouched specs, so it is pre-existing; the equivalent `bundle exec ruby -rrbs/test/setup -S rspec` showed zero errors from new or changed signatures against an identical 110-error pre-existing baseline.
  - No real other-user *listener* could be constructed on this machine to exercise the `EPERM` attribution path end to end. This was measured, not assumed: non-root `lsof` attributes no other-user sockets here, and all 15 visible listener pids were signalable. The primitive itself was confirmed against 305 real other-user processes; the end-to-end path is covered by a stub.
  - Manual QA used synthetic Procfile app directories rather than `spec/dummy` (which needs a booted DB and `node_modules`). The mechanism exercised — Overmind, tmux, Procfile, real listeners, real process groups — is identical.
  - macOS only. `lsof -Fn` cwd probing and exit-status handling are untested on Linux; hosted CI covers Linux.
- **Residual risk**:
  - A Procfile line that changes user (`sudo -u …`, a setuid helper) produces one of our own processes that answers `EPERM` and is therefore reported `foreign` rather than blocking verification. It is unsignalable either way and stays visible in the output. Deliberate accepted trade, recorded in the source beside the code that makes it.
  - A port held by another user's process is invisible to non-root `lsof`, so "verified" means "free of anything this user can see". Documented where the scan is built.
  - `confirm_locked_dev_session` converts the microsecond claim window into a `:refused` rather than a wrong signal — fail-closed, but a user running `bin/dev kill` at the instant another `bin/dev` is claiming will see a refusal and need to retry.

### Review rounds

Seven review rounds, each with a shrinking finding set (10 → 4 → 1) and clear convergence. Every finding was verified in the source by the coordinator before being sent for fix; nothing was actioned on a bot's say-so.

**Round 1 — 10 findings.** An independent adversarial check returned FAIL on a reproduced P1, corroborated by Codex, Greptile and Claude. The two that mattered:

1. **P1 — the verification claim was false in default mode.** `default_killable_ports` was `[3000, 3001]`, but Shakapacker's dev server defaults to **3035**, and this PR deleted `main`'s `bin/shakapacker-dev-server` pgrep pattern. Because verification re-used the same port list, an orphaned dev server was neither signalled *nor detected* — "verified gone" printed while it was still serving. A coverage regression versus `main`. Ports are now derived (`SHAKAPACKER_DEV_SERVER_PORT` → `dev_server.port` → 3035) and the session records the ports actually selected.
2. **P1 security — symlink defeated endpoint containment.** Containment compared the unresolved path while `File.socket?` follows symlinks, so `<root>/.overmind.sock` pointing at another checkout's live socket would have let `overmind kill` stop *that* checkout — with no session-file tampering required. Now resolved via `File.realpath` first.

**Round 2 — 4 findings, one defect family.** Codex re-reviewed and found four more, all instances of *the verification path reporting success from an observation that could not be made*. Fixed structurally rather than per-instance: listener classification became four-state, and a fifth unreported instance was swept up in the process (`overmind_endpoint_alive?` collapsed "connection refused" into the same `false` as "probe failed", letting `cleanup_socket_files` unlink a live endpoint's socket).

**Round 3 — 1 finding, self-identified.** Blocking verification on `unattributable` over-blocked: an other-user listener on one of the app's ports would make `bin/dev kill` exit 1 permanently. Closed with a `Process.kill(0, pid)` probe — `EPERM` proves the process is not ours, so it classifies positively `foreign` while genuinely-unknown same-user cases still block.

### Decision log (non-blocking decisions made without maintainer input)

- **Authorized a fourth-file expansion before dispatch.** The issue named three paths; `server_manager.rbs` was added as a durable `expansion-path-reservation` because every public kill-path method is declared there and `rbs:validate` fails on drift. A prior attempt at this issue stalled with `authorized-scope-exhausted` because the RBS repair needed a path it was not allowed to touch.
- **Declined Greptile's concurrent-session restructure.** Refusing to start a second `bin/dev` in the same directory is wider than this issue, and the second run dies on socket/port collision anyway. The warning is now explicit that the run is unrecorded.
- **Declined Codex's "start Foreman in a dedicated process group".** `setpgid` would detach `bin/dev` from terminal job control and break Ctrl-C; `process_manager.rb` is also outside the authorized path set. Refusing is fail-closed, and the port-derivation fix mitigates the case. Recorded as a code comment.
- **Declined CodeRabbit's docstring-coverage warning** (39.51% vs its 80% threshold). Not a repository gate; the changed code is already densely commented.
- **Deferred docs drift to #4938** — two docs pages describe pre-4937 semantics, but `docs/` is outside this PR's authorized paths.
- **Filed #4939** — repo-local `.agents/` pins are stale relative to the installed Agent Workflows pack. This produced a real wrong answer during this batch: a worker checked the repo-local contract and reported that `qa-evidence v2` "does not exist in this repo". The pinned `closeout-evidence-replay` cannot parse v2 at all.

Decision points requiring maintainer input: **0**.

**Round 4 — 9 findings, then frozen.** Three were regressions caused by our own fixes: cleanup deleted the session file *before* verification was allowed to fail (destroying round 1's port-fidelity guarantee on the one retry path where it matters), the recorded-ports preference lost the Pro Procfile's implicit `RENDERER_PORT=${RENDERER_PORT:-3800}`, and `valid_session_pid?` rejected a legitimate `pid == 1`, disabling the mechanism in any minimal Docker dev container. Also fixed: an unbounded `UNIXSocket.new` probe that could hang `bin/dev kill` (replaced with the repo's existing bounded `connect_nonblock` pattern from `file_manager.rb`), a claim-side detach guard mirroring the kill-side one, custom `OVERMIND_SOCKET` in fallback candidates, `O_NOFOLLOW` on the session open, and lazy port derivation for refused views.

The port fix was taken further than reported: `shutdown_ports` now returns the **union** of recorded and derived ports rather than preferring recorded. Superset is strictly safer for verification, and signalling stays cwd-gated so a wider scan cannot signal anything this root does not own.

A convergence rule was set before this round and holds from here: only P0/P1 correctness findings will be actioned; anything else becomes a follow-up issue. Every guard added across all four rounds was proven discriminating by reverting it alone and confirming the matching test goes red — 9 such controls in round 4 alone.

**Round 5 — 4 findings, 2 fixed and 2 deferred under the convergence rule.** Fixed: `verify_owner_shutdown` discarded the replacement signal `remove_dev_session_file` already computes, yielding a false `:verified` when a new `bin/dev` claimed the path mid-scan (the window is genuinely open because `owner_release_state` early-returns `:released` for a non-existent path, which is the *normal* case since the owner deletes its state on exit); and Overmind control issued a bare `system` that repeated the Bundler context which had already failed at startup, so for users on the repo's own recommended global-install setup `bin/dev kill` could not stop a session `bin/dev` started — a silent, total failure, reproduced end to end and now routed through the same Bundler-aware runner used at startup.

Deferred to #4942 with rationale rather than restarting a green head's review-and-CI wave for cosmetics: an inaccurate comment about a fallback that does not exist, and `owner_released?` left dead by an earlier refactor. Also tracked there: the fix above reaches `ProcessManager`'s runner via `send`, pinned by a spec so a rename fails loudly; promoting it to a public API needs a fifth path.

**Round 6 — 3 findings, all fixed; final.** Claude and Codex independently found the same P1: `owned_process_group` had no floor, so in a container where `bin/dev` runs as PID 1 and is `setsid()`'d, it wrote `"pgid": 1` — which `valid_session_pgid?` then correctly rejects, failing the whole document. **We wrote a document we then refused to read**, reintroducing through `pgid` exactly the PID-1 breakage round 4 fixed through `pid`. The floor now lives on the writer, where it belongs; the reader's strictness is untouched, because rejecting group 1 is right (`Process.kill(sig, -1)` broadcasts).

Claude's diagnosis of *why* tests missed it drove the fix's coverage: validation was exercised in isolation and the write helper hardcoded `"pgid" => nil`, so the new test round-trips the real `with_dev_session` write path. That prompted a deliberate audit of every field `dev_session_payload` writes against `valid_dev_session_document?` — `pgid` was the only writer/reader disagreement.

Third finding: an `:unknown` Overmind endpoint probe was treated as no endpoint, so shutdown could report `:nothing_running` while the session lived. The worker found and fixed the unreported mirror of this on the live-owner path, where a `:verified` result could otherwise rest on the process group alone while Overmind's tmux tree — which escapes that group — survived.

**Round 7 — a P0 that stopped the merge, plus one batched P1; final.** The claim path got `O_NOFOLLOW` in round 4; `open_dev_session` — the **read** path, the one that leads to signalling — never did. A symlink at `dev-session.json` pointing at a locked, valid-looking document naming this app root with an arbitrary `pgid` was classified as a live owner, and `bin/dev kill` would signal that group. That is the exact harm this PR exists to prevent, reachable through the unprotected half of the pair.

Reproduced by hand against a real process group before and after: a sleeper at pid/pgid 48396 behind a planted symlink is now refused at exit 1 and confirmed still alive. `O_NONBLOCK` had to come along, because without it a FIFO at that path blocks the open forever and the regular-file check is unreachable. The negative control is worth recording: reverting `O_NOFOLLOW` alone was *not* enough to show harm, because a same-commit switch to `File.lstat` independently refuses the symlink — only reverting both guards (the true pre-commit state) reproduced `the planted process group was signalled`. The fix is defense-in-depth, not a single flag.

Batched alongside it: `overmind quit`/`kill` ran through an unbounded blocking `system`, and in `request_owner_shutdown` that call blocks *before* `wait_until(grace)` starts polling — so a wedged Overmind hung `bin/dev kill` forever and the KILL escalation was never reached. Now bounded at 10s, with a timeout treated as "the command did not run" so the ladder proceeds.

A file-open symmetry pass (the flag-level analogue of round 6's field-level audit) found two further disagreements beyond the reported one, both fixed: `owner_release_state`'s fallback opened with a bare `RDONLY`, and the inode-comparison helpers used `File.stat`, which resolves symlinks, while both opens are `O_NOFOLLOW` and can never hold a link.

Three findings were deliberately **not** fixed and are tracked instead: the lock-holder/payload binding limitation and the `:absent`-view same-directory race (#4943), and `owner_released?` dead code (#4942). The first is the known boundary of a trade accepted earlier in this review — closing it changes the on-disk session layout, which is a refactor rather than a patch to slip past a green head.

**Final triage.** Two last findings arrived on the merge candidate and were tracked rather than fixed, both in #4944: discovered `tmp/sockets/overmind-*.sock` endpoints are cleaned up but never enter the verification scan (a false-verified behind three stacked preconditions, not a wrong-kill), and the control `Timeout` bounds Ruby's `waitpid` rather than the child, so a timed-out `overmind quit` is left unreaped. The reviewer explicitly confirmed the second does not reintroduce the "claim success we did not observe" class, since final state is independently re-observed — which is what made it deferrable.

Full follow-up set from this PR: #4938 (docs drift), #4939 (stale `.agents/` pins), #4941 (locale-fragile specs, both directions), #4942 (inaccurate comment, dead `owner_released?`, `send` coupling), #4943 (lock-holder/payload binding, `:absent`-view race), #4944 (discovered-socket scan, unbounded control subprocess).

### QA Evidence

- QA lane: ror-4846-devkill-worker (instance ror-4846-devkill-worker-1), branch `jg/4846-scope-dev-kill-worktree`, isolated worktree; coordination claim held by the coordinator at generation 2, heartbeat live
- Scope checked: `bin/dev kill` app-directory scoping and shutdown verification (#4846, PR 4937) across three review rounds; live Overmind/tmux worktree isolation, unavailable-probe handling, and EPERM attribution
- Tested at: f2548949b356d4a8e6353ad613e3558760bf79e8, fcb9fc1c46d1fd63e7d2962a98be71ee8aa5172e, 31b1866fab8c92d2585eeee188c0359fbefd7c19, ebccf71853510c0102958bd8cb9fd8827dc2c785, 4c84f2a37a3174d9941977ef8edcbe6fe3ddc340
- Automated checks: coordinator-independent re-run at the final head plus worker seeded runs and per-guard negative controls
- Manual checks: nine live scenarios across the three heads (detail in the marker below)
- User-visible UI change: no
- Visual evidence: not applicable: CLI-only change, no rendered surface
- Interaction change: no
- Interaction evidence: not applicable: no UI interaction surface
- Visual fix: no
- Negative control: not applicable — no visual fix. Test-discrimination controls (each guard reverted individually to confirm its test goes red) are recorded under automated checks.
- Performance evidence: not applicable: shutdown-correctness change; added probes run only during `bin/dev kill`
- Findings: none outstanding; all 36 review findings dispositioned across f2548949b356d4a8e6353ad613e3558760bf79e8, fcb9fc1c46d1fd63e7d2962a98be71ee8aa5172e, 31b1866fab8c92d2585eeee188c0359fbefd7c19 and ebccf71853510c0102958bd8cb9fd8827dc2c785
- QA required: yes
- QA required rationale: the change alters which processes are signalled, when success is reported, and what exit code is returned, so it needs live listeners and a genuinely failing probe rather than mocks
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: not applicable

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: b26819c19951339ce9a186a9b13bb8caf81cc60c
tested_at: f2548949b356d4a8e6353ad613e3558760bf79e8, fcb9fc1c46d1fd63e7d2962a98be71ee8aa5172e, 31b1866fab8c92d2585eeee188c0359fbefd7c19, ebccf71853510c0102958bd8cb9fd8827dc2c785, 4c84f2a37a3174d9941977ef8edcbe6fe3ddc340, 664d09117490259ef34dabce75c51c60e0517e6b, b26819c19951339ce9a186a9b13bb8caf81cc60c
scope: bin/dev kill app-directory scoping and shutdown verification (issue 4846, PR 4937) across three review rounds - worktree isolation, Shakapacker dev-server port derivation, symlink endpoint containment, exit codes, subdirectory anchoring, stale recovery, unavailable-probe handling, session-replacement guard, partial-claim cleanup, and EPERM attribution
automated_checks: coordinator-independent run at final head b26819c19951339ce9a186a9b13bb8caf81cc60c - bundle exec rspec spec/react_on_rails/dev/ (533 examples, 0 failures); BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/dev/server_manager.rb spec/react_on_rails/dev/server_manager_spec.rb (2 files, no offenses); bundle exec rake rbs:validate (passed); git diff --check (clean); scope verified as 8 commits touching exactly 4 files with no create/delete/rename. Worker runs across rounds - seeds 1001/2002/3003/4004/5005/6006/7007/8008/9009/10010/11011 (0 failures each, no leaked processes or tmpdirs); RBS runtime checking via bundle exec ruby -rrbs/test/setup -S rspec (zero errors from new or changed signatures; 110 pre-existing .start errors unchanged); per-guard negative controls turned each matching test red when its guard alone was reverted (three-state attribution 3/3, nothing-running early return 2/2, session-replacement guard 1/1 printing "verified gone", partial-claim cleanup 2 failures, EPERM branch 2/2)
manual_checks: HEAD b26819c19951339ce9a186a9b13bb8caf81cc60c - a sleeper at pid/pgid 48396 in its own process group, with a locked valid-looking document naming /private/tmp/qa9/app and pgid 48396 reachable only through a symlink at tmp/react_on_rails/dev-session.json; bin/dev kill refused with "is a symlink; dev session state must be a regular file" at exit 1 and process group 48396 was confirmed still alive and never signalled; a FIFO planted at the same path was refused with "is not a regular file" at exit 1 in under a second rather than hanging the open. HEAD 664d09117490259ef34dabce75c51c60e0517e6b - not applicable this round; neither fix is reproducible on this machine (the pgid case needs a container running bin/dev as PID 1 with setsid, the unprobeable-endpoint case needs an Overmind control socket with a stalled accept queue), so both are covered by round-trip and end-to-end specs with negative controls rather than a simulated scenario. HEAD 4c84f2a37a3174d9941977ef8edcbe6fe3ddc340 - a real Overmind session in /private/tmp/qa7/app showed its tmux server at PPID 1 with its own pgid 10639, outside bin/dev's process group 10608, confirming no group signal could reach it; killing from a bundle-loaded process with overmind's directory dropped from the live PATH reported installed?(overmind) false and a bare system overmind quit returning nil, while the routed control quit the session and reported verified gone at exit 0 with the whole tree including the daemonized tmux server gone and port 3000 free. HEAD ebccf71853510c0102958bd8cb9fd8827dc2c785 - a real listener pid 77906 on port 4599 with cwd inside the app root plus a stale session recording pid 1 and ports [4599]; run 1 with lsof removed from PATH scanned ports 4599, 3000 and 3035 proving the union of recorded and derived ports, accepted the pid-1 document instead of refusing it, reported shutdown could not be verified at exit 1, and left tmp/react_on_rails/dev-session.json present with ports [4599] intact; run 2 with lsof available still knew port 4599 from that preserved file, stopped pid 77906, reported verified gone at exit 0 and only then removed the session file, with port 4599 free afterwards. HEAD 31b1866fab8c92d2585eeee188c0359fbefd7c19 - Process.kill(0, pid) returned EPERM for 305 of 315 real other-user processes sampled from ps, confirming the primitive against real processes; comparing netstat LISTEN against non-root lsof showed ports 53, 88, 8021, 49050, 49051, 50671 and 51740 visible to the kernel but unattributed by lsof and all 15 lsof-visible listener pids signalable, so an end-to-end other-user LISTENER case could not be constructed on this machine and is recorded as UNKNOWN. HEAD fcb9fc1c46d1fd63e7d2962a98be71ee8aa5172e - identical app directory with lsof available exited 0 reporting nothing running, while the same command with lsof removed from PATH exited 1 with per-port "could not verify port N is free" blockers; the bin/dev kill and bin/dev chain correctly stopped rather than starting a second stack; bin/dev clean under the same condition aborted at exit 1 leaving public/packs/keep.txt intact. HEAD f2548949b356d4a8e6353ad613e3558760bf79e8 - QA-1 default-mode orphan listener pid 6212 on port 3035 detected, stopped and verified (killable_ports now [3000, 3035] vs [3000, 3001] before); QA-2 listener pid 8030 on 3035 owned by d1 refused when killing from d2 and left alive; QA-3 and QA-6 worktree A default-mode (pgid 9826, ports [3000, 3035]) and worktree B base-port 5100 (pgid 9827, ports [5100, 5101]) under Overmind 2.5.1/tmux 3.6a, kill run from a/app/models anchored on /private/tmp/qa4846/a, quit A via its socket and reported verified gone while leaving B's 5100/5101 listeners, overmind, tmux and sh wrappers intact; QA-5 a/.overmind.sock symlinked to B's live control socket produced no overmind quit or kill and left B untouched; QA-4 stale session recording B's live pgid 9827 and ports [5100, 5101] cleaned three files, refused both ports as unattributable, signalled nothing and left B alive; QA-7 foreign-root session made bin/dev kill exit 1 and bin/dev clean abort at exit 1 with fixtures intact; teardown killed B cleanly with all four ports clear
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: CLI-only change with no rendered surface
paint_check: not applicable: no rendered target
interaction_change: no
interaction_evidence: not applicable: no UI interaction surface
visual_fix: no
negative_control: not applicable: no visual fix; this is a CLI change with no rendered surface
performance_impact: not_applicable
performance_evidence: not applicable: shutdown-correctness change; the extra verification scan and one signal-0 probe per unreadable listener run only during bin/dev kill
findings: none
release_blocking: clear
process_gap_disposition: not applicable
-->

<!-- priority-finding-dispositions v1
head_sha: b26819c19951339ce9a186a9b13bb8caf81cc60c
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861198931 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861459565
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861208032 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861459737
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861198925 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861459919
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861198936 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861460115
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861207356 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861460340
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861198948 | severity=P2 | disposition=not_applicable | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861456050
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861208022 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861456276
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861207940 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861460582
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861213420 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861460750
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861459611 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861742481
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861459616 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861742772
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861459621 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861742997
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861459631 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861743222
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861652195 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861899512
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861468744 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861899662
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861652863 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861899857
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861692178 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861900037
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861615003 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861900221
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861692185 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861900386
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861614996 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861900556
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861468432 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861900714
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861718135 | severity=P3 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861900910
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861916386 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3862255123
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861916393 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3862255290
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861914923 | severity=P3 | disposition=deferred_with_issue | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3862255472
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3861915584 | severity=P3 | disposition=deferred_with_issue | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3862255657
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3862281880 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863055999
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3862286596 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863056256
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3862286600 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863056509
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863084640 | severity=P0 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863302649
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863084456 | severity=P1 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863302900
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863084652 | severity=P2 | disposition=deferred_with_issue | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863303199
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863084663 | severity=P2 | disposition=deferred_with_issue | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863303532
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863085396 | severity=P3 | disposition=deferred_with_issue | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863303797
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863337992 | severity=P2 | disposition=deferred_with_issue | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863477262
finding: url=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863349892 | severity=P2 | disposition=deferred_with_issue | evidence=https://github.com/shakacode/react_on_rails/pull/4937#discussion_r3863477547
-->

</details>
