### PR TITLE
Fix release wrapper terminal job control

### DIFF
--- a/script/release
+++ b/script/release
@@ -780,8 +780,13 @@ class ReleaseSupervisor
   end
 
   def invoking_job_group_suspendable?(pgid)
-    pgid == Process.getpgrp && Process.getpgid(Process.ppid) != pgid
-  rescue Errno::ESRCH
+    return false unless pgid == Process.getpgrp
+
+    parent_pid = Process.ppid
+    return false unless Process.getsid(parent_pid) == Process.getsid(0)
+
+    Process.getpgid(parent_pid) != pgid
+  rescue SystemCallError
     false
   end
 
@@ -1015,7 +1020,10 @@ class ReleaseSupervisor
       raise SupervisorError, "interactive live release must run in the terminal foreground; use fg and retry"
     end
 
-    return if $stdin.tty? && $stdout.tty?
+    direct_terminal_io = $stdin.tty? && $stdout.tty? &&
+                         terminal_foreground_pgid($stdin.fileno) == foreground_pgid &&
+                         terminal_foreground_pgid($stdout.fileno) == foreground_pgid
+    return if direct_terminal_io
 
     raise SupervisorError,
           "live release requires direct terminal stdin and stdout when attached to a controlling terminal"

--- a/script/release
+++ b/script/release
@@ -30,6 +30,10 @@ class ReleaseSupervisor
   SIGNALS = %w[INT TERM HUP].freeze
   CLAIM_STATUSES = %w[active released].freeze
   PR_SET_CHILD_SUBREAPER = 36
+  CLAIM_CLEANUP_FAILED_MESSAGE =
+    "ERROR: release-line lease cleanup failed; verify coordination state before retrying"
+  CLAIM_RETAINED_MESSAGE =
+    "ERROR: retaining release-line lease because process-group termination was not proven"
 
   Identity = Data.define(:agent_id, :instance_id, :machine_id, :managed)
   ReleaseScope = Data.define(:version, :base_version, :repo, :target, :branch)
@@ -148,18 +152,22 @@ class ReleaseSupervisor
     ensure
       if managed_claim_cleanup_required && @managed_claim_release_safe
         cleanup_succeeded = release_managed_lease!(scope, identity, coordination_timeout:, termination_grace:)
-        unless cleanup_succeeded
-          @stderr.puts "ERROR: release-line lease cleanup failed; verify coordination state before retrying"
-        end
+        report_managed_cleanup_failure(CLAIM_CLEANUP_FAILED_MESSAGE, $ERROR_INFO) unless cleanup_succeeded
       elsif managed_claim_cleanup_required
         cleanup_succeeded = false
-        @stderr.puts "ERROR: retaining release-line lease because process-group termination was not proven"
+        report_managed_cleanup_failure(CLAIM_RETAINED_MESSAGE, $ERROR_INFO)
       end
       restore_signal_handlers(previous_signal_handlers)
     end
     return release_status if cleanup_succeeded
 
     1
+  end
+
+  def report_managed_cleanup_failure(message, active_exception)
+    with_sigttou_ignored { @stderr.puts message }
+  rescue StandardError
+    raise unless active_exception
   end
 
   def build_parser

--- a/script/release
+++ b/script/release
@@ -82,6 +82,7 @@ class ReleaseSupervisor
   def run_live(scope)
     doctor_environment!
     doctor_tools!
+    verify_live_terminal_foreground!
     identity = release_identity!(scope)
     intervals = supervisor_intervals
     validate_coordination_backend!(
@@ -982,6 +983,15 @@ class ReleaseSupervisor
     return unless foreground_pgid == Process.getpgrp
 
     TerminalHandoff.new(fd:, supervisor_pgid: foreground_pgid, release_pgid: nil)
+  end
+
+  def verify_live_terminal_foreground!
+    return unless $stdin.tty?
+
+    foreground_pgid = terminal_foreground_pgid($stdin.fileno)
+    return if foreground_pgid.nil? || foreground_pgid == Process.getpgrp
+
+    raise SupervisorError, "interactive live release must run in the terminal foreground; use fg and retry"
   end
 
   def hand_off_terminal_foreground(owner, release_pgid)

--- a/script/release
+++ b/script/release
@@ -32,6 +32,7 @@ class ReleaseSupervisor
 
   Identity = Data.define(:agent_id, :instance_id, :machine_id, :managed)
   ReleaseScope = Data.define(:version, :base_version, :repo, :target, :branch)
+  TerminalHandoff = Data.define(:fd, :supervisor_pgid, :release_pgid)
   ReleasePipes = Data.define(
     :liveness_reader,
     :liveness_writer,
@@ -587,6 +588,7 @@ class ReleaseSupervisor
     pgid = nil
     liveness_writer = nil
     death_writer = nil
+    terminal_handoff = nil
     unless heartbeat!(scope, identity, coordination_timeout:, termination_grace:)
       raise ReleaseLeaseGuard::LeaseError, "release lease heartbeat failed"
     end
@@ -594,7 +596,7 @@ class ReleaseSupervisor
     verify_existing_lease!(scope, identity, coordination_timeout:, termination_grace:)
 
     @managed_claim_release_safe = false if identity.managed
-    child_pid, pgid, liveness_writer, death_writer = spawn_release_group(
+    child_pid, pgid, liveness_writer, death_writer, terminal_handoff = spawn_release_group(
       scope, identity, handshake_timeout:, termination_grace:
     )
     @stdout.puts "Release process group #{pgid} started."
@@ -618,8 +620,12 @@ class ReleaseSupervisor
     cleanup_failed_release(pgid, child_pid, liveness_writer, termination_grace)
     raise
   ensure
-    liveness_writer&.close unless liveness_writer&.closed?
-    death_writer&.close unless death_writer&.closed?
+    begin
+      restore_terminal_foreground(terminal_handoff)
+    ensure
+      liveness_writer&.close unless liveness_writer&.closed?
+      death_writer&.close unless death_writer&.closed?
+    end
   end
 
   def supervise_loop(scope, identity, child_pid:, pgid:, liveness_writer:, next_heartbeat:, next_claim_renewal:,
@@ -689,7 +695,7 @@ class ReleaseSupervisor
                  "closed liveness channel and terminating process group #{pgid}."
     terminate_group(pgid, child_pid:, grace: termination_grace)
     @managed_claim_release_safe = true
-    report_group_handoff(pgid)
+    report_group_handoff(pgid, proven_dead: true)
     128 + Signal.list.fetch(@received_signal)
   end
 
@@ -704,7 +710,7 @@ class ReleaseSupervisor
     @managed_claim_release_safe = true
     exit_code = process_status_code(child_status)
     @stdout.puts "Release process group #{pgid} completed with status #{exit_code}."
-    report_group_handoff(pgid)
+    report_group_handoff(pgid, proven_dead: true)
     exit_code
   end
 
@@ -713,12 +719,13 @@ class ReleaseSupervisor
     @stderr.puts "Release lease refresh failed; closed liveness channel and terminating process group #{pgid}."
     terminate_group(pgid, child_pid:, grace: termination_grace)
     @managed_claim_release_safe = true
-    report_group_handoff(pgid)
+    report_group_handoff(pgid, proven_dead: true)
     1
   end
 
   def spawn_release_group(scope, identity, handshake_timeout:, termination_grace:)
     pipes = release_pipes
+    terminal_owner = foreground_terminal_owner
     child_pid = nil
     child_pid = fork_release_child(scope, identity, pipes)
     pipes.liveness_reader.close
@@ -730,7 +737,8 @@ class ReleaseSupervisor
       timeout: handshake_timeout,
       termination_grace:
     )
-    [child_pid, pgid, pipes.liveness_writer, pipes.death_writer]
+    terminal_handoff = hand_off_terminal_foreground(terminal_owner, pgid)
+    [child_pid, pgid, pipes.liveness_writer, pipes.death_writer, terminal_handoff]
   rescue StandardError
     begin
       close_release_pipes(pipes)
@@ -838,13 +846,81 @@ class ReleaseSupervisor
     io&.close unless io&.closed?
   end
 
+  def foreground_terminal_owner
+    return unless $stdin.tty?
+
+    fd = $stdin.fileno
+    foreground_pgid = terminal_foreground_pgid(fd)
+    return unless foreground_pgid == Process.getpgrp
+
+    TerminalHandoff.new(fd:, supervisor_pgid: foreground_pgid, release_pgid: nil)
+  end
+
+  def hand_off_terminal_foreground(owner, release_pgid)
+    return unless owner
+    return unless terminal_foreground_pgid(owner.fd, tolerate_missing_terminal: true) == owner.supervisor_pgid
+    return unless group_alive?(release_pgid)
+    return unless set_terminal_foreground_pgid(owner.fd, release_pgid, tolerate_dead_pgid: release_pgid)
+
+    signal_group("CONT", release_pgid)
+    owner.with(release_pgid:)
+  end
+
+  def restore_terminal_foreground(handoff)
+    return unless handoff
+
+    foreground_pgid = terminal_foreground_pgid(handoff.fd, tolerate_missing_terminal: true)
+    return if foreground_pgid.nil? || foreground_pgid == handoff.supervisor_pgid
+    return unless foreground_pgid == handoff.release_pgid
+
+    set_terminal_foreground_pgid(handoff.fd, handoff.supervisor_pgid)
+  end
+
+  def terminal_foreground_pgid(terminal_fd, tolerate_missing_terminal: false)
+    pgid = terminal_function("tcgetpgrp", 1).call(terminal_fd)
+    return pgid unless pgid == -1
+
+    errno = Fiddle.last_error
+    return nil if tolerate_missing_terminal && errno == Errno::ENOTTY::Errno
+
+    raise SupervisorError, "could not read the controlling terminal foreground process group (errno #{errno})"
+  end
+
+  def set_terminal_foreground_pgid(terminal_fd, pgid, tolerate_dead_pgid: nil)
+    result = with_sigttou_ignored do
+      terminal_function("tcsetpgrp", 2).call(terminal_fd, pgid)
+    end
+    return true if result.zero?
+
+    errno = Fiddle.last_error
+    return false if errno == Errno::ENOTTY::Errno
+    return false if tolerate_dead_pgid && !group_alive?(tolerate_dead_pgid)
+
+    raise SupervisorError, "could not set the controlling terminal foreground process group (errno #{errno})"
+  end
+
+  def terminal_function(name, argument_count)
+    require "fiddle"
+    argument_types = Array.new(argument_count, Fiddle::TYPE_INT)
+    Fiddle::Function.new(Fiddle::Handle::DEFAULT[name], argument_types, Fiddle::TYPE_INT)
+  rescue LoadError, Fiddle::DLError
+    raise SupervisorError, "controlling terminal job-control support is unavailable"
+  end
+
+  def with_sigttou_ignored
+    previous_handler = Signal.trap("TTOU", "IGNORE")
+    yield
+  ensure
+    Signal.trap("TTOU", previous_handler) if previous_handler
+  end
+
   def cleanup_failed_release(pgid, child_pid, liveness_writer, termination_grace)
     close_liveness(liveness_writer) if liveness_writer
   ensure
     if pgid && child_pid
       terminate_group(pgid, child_pid:, grace: termination_grace)
       @managed_claim_release_safe = true
-      report_group_handoff(pgid)
+      report_group_handoff(pgid, proven_dead: true)
     end
   end
 
@@ -996,6 +1072,8 @@ class ReleaseSupervisor
   end
 
   def signal_termination_target(signal, pgid, child_pid:, signal_direct_child:)
+    # A controlling-terminal read can stop the release child before shutdown begins.
+    signal_group("CONT", pgid)
     signal_group(signal, pgid)
     signal_child(signal, child_pid) if signal_direct_child
   end
@@ -1087,8 +1165,12 @@ class ReleaseSupervisor
     nil
   end
 
-  def report_group_handoff(pgid)
-    @stderr.puts "Release process group #{pgid} must be proven dead before handoff."
+  def report_group_handoff(pgid, proven_dead: false)
+    if proven_dead
+      @stderr.puts "Release process group #{pgid} was proven dead before handoff."
+    else
+      @stderr.puts "Release process group #{pgid} must be proven dead before handoff."
+    end
   end
 
   def process_status_code(status)

--- a/script/release
+++ b/script/release
@@ -602,7 +602,6 @@ class ReleaseSupervisor
     child_pid, pgid, liveness_writer, death_writer, terminal_handoff = spawn_release_group(
       scope, identity, handshake_timeout:, termination_grace:
     )
-    @stdout.puts "Release process group #{pgid} started."
     next_heartbeat = monotonic_time + heartbeat_interval
     next_claim_renewal = initial_claim_renewal_deadline(identity, claim_renewal_interval)
 
@@ -621,6 +620,7 @@ class ReleaseSupervisor
       coordination_timeout:
     )
   rescue StandardError
+    restore_terminal_after_release(terminal_handoff, $ERROR_INFO)
     cleanup_failed_release(pgid, child_pid, liveness_writer, termination_grace)
     raise
   ensure
@@ -637,7 +637,9 @@ class ReleaseSupervisor
   rescue StandardError
     raise unless active_exception
 
-    @stderr.puts "ERROR: terminal foreground restoration also failed while handling a release failure"
+    with_sigttou_ignored do
+      @stderr.puts "ERROR: terminal foreground restoration also failed while handling a release failure"
+    end
   end
 
   def supervise_loop(scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:, next_heartbeat:,
@@ -655,13 +657,17 @@ class ReleaseSupervisor
     end
   rescue Errno::ECHILD
     close_liveness(liveness_writer)
+    restore_terminal_foreground(terminal_handoff)
     report_group_handoff(pgid)
     1
   end
 
   def supervise_cycle(scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
                       heartbeat_interval:, claim_renewal_interval:, termination_grace:, coordination_timeout:)
-    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
+    if @received_signal
+      restore_terminal_foreground(terminal_handoff)
+      return interrupt_release(pgid, child_pid, liveness_writer, termination_grace)
+    end
 
     child_status = nonblocking_child_status(child_pid)
     if child_status&.stopped?
@@ -670,11 +676,14 @@ class ReleaseSupervisor
                          claim_renewal_interval:, termination_grace:, coordination_timeout:
       )
     end
-    return complete_release(pgid, liveness_writer, child_status, termination_grace) if child_status
+    if child_status
+      restore_terminal_foreground(terminal_handoff)
+      return complete_release(pgid, liveness_writer, child_status, termination_grace)
+    end
 
     refresh_or_wait(
-      scope, identity, state:, child_pid:, pgid:, liveness_writer:, heartbeat_interval:, claim_renewal_interval:,
-                       termination_grace:, coordination_timeout:
+      scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:, heartbeat_interval:,
+                       claim_renewal_interval:, termination_grace:, coordination_timeout:
     )
   end
 
@@ -687,7 +696,7 @@ class ReleaseSupervisor
     )
     if stop_result == :no_handoff
       return refresh_or_wait(
-        scope, identity, state:, child_pid:, pgid:, liveness_writer:, heartbeat_interval:,
+        scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:, heartbeat_interval:,
                          claim_renewal_interval:, termination_grace:, coordination_timeout:
       )
     end
@@ -700,8 +709,8 @@ class ReleaseSupervisor
     )
   end
 
-  def refresh_or_wait(scope, identity, state:, child_pid:, pgid:, liveness_writer:, heartbeat_interval:,
-                      claim_renewal_interval:, termination_grace:, coordination_timeout:)
+  def refresh_or_wait(scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
+                      heartbeat_interval:, claim_renewal_interval:, termination_grace:, coordination_timeout:)
     now = monotonic_time
     heartbeat_due = now >= state.next_heartbeat
     claim_renewal_due = managed_claim_renewal_due?(identity, now, state.next_claim_renewal)
@@ -713,8 +722,14 @@ class ReleaseSupervisor
     lease_live = refresh_lease?(
       scope, identity, renew_claim: claim_renewal_due, coordination_timeout:, termination_grace:
     )
-    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
-    return lose_lease(pgid, child_pid, liveness_writer, termination_grace) unless lease_live
+    if @received_signal
+      restore_terminal_foreground(terminal_handoff)
+      return interrupt_release(pgid, child_pid, liveness_writer, termination_grace)
+    end
+    unless lease_live
+      restore_terminal_foreground(terminal_handoff)
+      return lose_lease(pgid, child_pid, liveness_writer, termination_grace)
+    end
 
     SupervisionState.new(
       next_heartbeat: advanced_deadline(state.next_heartbeat, now, heartbeat_interval, heartbeat_due),
@@ -808,9 +823,11 @@ class ReleaseSupervisor
 
   def fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace)
     close_liveness(liveness_writer)
-    @stderr.puts "Release terminal resume failed; closed liveness channel and terminating process group #{pgid}."
     terminate_group(pgid, child_pid:, grace: termination_grace)
     @managed_claim_release_safe = true
+    with_sigttou_ignored do
+      @stderr.puts "Release terminal resume failed; closed liveness channel and terminated process group #{pgid}."
+    end
     report_group_handoff(pgid, proven_dead: true)
     1
   end
@@ -891,6 +908,7 @@ class ReleaseSupervisor
       timeout: handshake_timeout,
       termination_grace:
     )
+    @stdout.puts "Release process group #{pgid} started."
     terminal_handoff = hand_off_terminal_foreground(terminal_owner, pgid)
     raise SupervisorError, "initial terminal foreground transfer failed" if terminal_owner && !terminal_handoff
 
@@ -1352,10 +1370,12 @@ class ReleaseSupervisor
   end
 
   def report_group_handoff(pgid, proven_dead: false)
-    if proven_dead
-      @stderr.puts "Release process group #{pgid} was proven dead before handoff."
-    else
-      @stderr.puts "Release process group #{pgid} must be proven dead before handoff."
+    with_sigttou_ignored do
+      if proven_dead
+        @stderr.puts "Release process group #{pgid} was proven dead before handoff."
+      else
+        @stderr.puts "Release process group #{pgid} must be proven dead before handoff."
+      end
     end
   end
 

--- a/script/release
+++ b/script/release
@@ -740,7 +740,9 @@ class ReleaseSupervisor
     @stderr.puts "Release process group #{pgid} stopped; returning terminal control to the invoking shell."
     suspend_result = suspend_for_shell_job_control(terminal_handoff)
     return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if suspend_result == :interrupted
-    return fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace) if suspend_result == :terminal_lost
+    if %i[terminal_lost unsafe_job_group].include?(suspend_result)
+      return fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace)
+    end
 
     lease_live = refresh_lease?(
       scope,
@@ -762,14 +764,29 @@ class ReleaseSupervisor
     loop do
       return :interrupted if @received_signal
       return :terminal_lost if terminal_foreground_pgid(terminal_handoff.fd).nil?
+      return :unsafe_job_group unless invoking_job_group_suspendable?(terminal_handoff.supervisor_pgid)
 
-      with_default_tstp_handler { Process.kill("TSTP", Process.pid) }
+      with_default_tstp_handler do
+        return :interrupted if @received_signal
+
+        stop_invoking_job_group(terminal_handoff.supervisor_pgid)
+      end
       return :interrupted if @received_signal
 
       foreground_pgid = terminal_foreground_pgid(terminal_handoff.fd)
       return :terminal_lost if foreground_pgid.nil?
       return :foreground if foreground_pgid == terminal_handoff.supervisor_pgid
     end
+  end
+
+  def invoking_job_group_suspendable?(pgid)
+    pgid == Process.getpgrp && Process.getpgid(Process.ppid) != pgid
+  rescue Errno::ESRCH
+    false
+  end
+
+  def stop_invoking_job_group(pgid)
+    Process.kill("TSTP", -pgid)
   end
 
   def with_default_tstp_handler
@@ -989,12 +1006,27 @@ class ReleaseSupervisor
   end
 
   def verify_live_terminal_foreground!
-    return unless $stdin.tty?
+    controlling_terminal = open_controlling_terminal
+    return unless controlling_terminal
 
-    foreground_pgid = terminal_foreground_pgid($stdin.fileno)
-    return if foreground_pgid.nil? || foreground_pgid == Process.getpgrp
+    foreground_pgid = terminal_foreground_pgid(controlling_terminal.fileno)
+    return if foreground_pgid.nil?
+    unless foreground_pgid == Process.getpgrp
+      raise SupervisorError, "interactive live release must run in the terminal foreground; use fg and retry"
+    end
 
-    raise SupervisorError, "interactive live release must run in the terminal foreground; use fg and retry"
+    return if $stdin.tty? && $stdout.tty?
+
+    raise SupervisorError,
+          "live release requires direct terminal stdin and stdout when attached to a controlling terminal"
+  ensure
+    close_io(controlling_terminal)
+  end
+
+  def open_controlling_terminal
+    File.open("/dev/tty", File::RDONLY)
+  rescue Errno::ENXIO, Errno::ENODEV, Errno::ENOENT
+    nil
   end
 
   def hand_off_terminal_foreground(owner, release_pgid)

--- a/script/release
+++ b/script/release
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "English"
 require "io/wait"
 require "open3"
 require "optparse"
@@ -33,6 +34,7 @@ class ReleaseSupervisor
   Identity = Data.define(:agent_id, :instance_id, :machine_id, :managed)
   ReleaseScope = Data.define(:version, :base_version, :repo, :target, :branch)
   TerminalHandoff = Data.define(:fd, :supervisor_pgid, :release_pgid)
+  SupervisionState = Data.define(:next_heartbeat, :next_claim_renewal)
   ReleasePipes = Data.define(
     :liveness_reader,
     :liveness_writer,
@@ -609,6 +611,7 @@ class ReleaseSupervisor
       child_pid:,
       pgid:,
       liveness_writer:,
+      terminal_handoff:,
       next_heartbeat:,
       next_claim_renewal:,
       heartbeat_interval:,
@@ -621,43 +624,157 @@ class ReleaseSupervisor
     raise
   ensure
     begin
-      restore_terminal_foreground(terminal_handoff)
+      restore_terminal_after_release(terminal_handoff, $ERROR_INFO)
     ensure
       liveness_writer&.close unless liveness_writer&.closed?
       death_writer&.close unless death_writer&.closed?
     end
   end
 
-  def supervise_loop(scope, identity, child_pid:, pgid:, liveness_writer:, next_heartbeat:, next_claim_renewal:,
-                     heartbeat_interval:, claim_renewal_interval:, termination_grace:, coordination_timeout:)
+  def restore_terminal_after_release(terminal_handoff, active_exception)
+    restore_terminal_foreground(terminal_handoff)
+  rescue StandardError
+    raise unless active_exception
+
+    @stderr.puts "ERROR: terminal foreground restoration also failed while handling a release failure"
+  end
+
+  def supervise_loop(scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:, next_heartbeat:,
+                     next_claim_renewal:, heartbeat_interval:, claim_renewal_interval:, termination_grace:,
+                     coordination_timeout:)
+    state = SupervisionState.new(next_heartbeat:, next_claim_renewal:)
     loop do
-      return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
+      cycle_result = supervise_cycle(
+        scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:, heartbeat_interval:,
+                         claim_renewal_interval:, termination_grace:, coordination_timeout:
+      )
+      return cycle_result if cycle_result.is_a?(Integer)
 
-      child_status = nonblocking_child_status(child_pid)
-      return complete_release(pgid, liveness_writer, child_status, termination_grace) if child_status
-
-      now = monotonic_time
-      heartbeat_due = now >= next_heartbeat
-      claim_renewal_due = managed_claim_renewal_due?(identity, now, next_claim_renewal)
-      if lease_refresh_due?(heartbeat_due, claim_renewal_due)
-        lease_live = refresh_lease?(
-          scope, identity, renew_claim: claim_renewal_due, coordination_timeout:, termination_grace:
-        )
-        return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
-        return lose_lease(pgid, child_pid, liveness_writer, termination_grace) unless lease_live
-
-        next_heartbeat = advanced_deadline(next_heartbeat, now, heartbeat_interval, heartbeat_due)
-        next_claim_renewal = advanced_deadline(
-          next_claim_renewal, now, claim_renewal_interval, claim_renewal_due
-        )
-      end
-
-      sleep_duration = [POLL_INTERVAL, next_heartbeat - monotonic_time, next_claim_renewal - monotonic_time].min
-      sleep(sleep_duration) if sleep_duration.positive?
+      state = cycle_result
     end
   rescue Errno::ECHILD
     close_liveness(liveness_writer)
     report_group_handoff(pgid)
+    1
+  end
+
+  def supervise_cycle(scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
+                      heartbeat_interval:, claim_renewal_interval:, termination_grace:, coordination_timeout:)
+    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
+
+    child_status = nonblocking_child_status(child_pid)
+    if child_status&.stopped?
+      return resume_stopped_release(
+        scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:, heartbeat_interval:,
+                         claim_renewal_interval:, termination_grace:, coordination_timeout:
+      )
+    end
+    return complete_release(pgid, liveness_writer, child_status, termination_grace) if child_status
+
+    refresh_or_wait(
+      scope, identity, state:, child_pid:, pgid:, liveness_writer:, heartbeat_interval:, claim_renewal_interval:,
+                       termination_grace:, coordination_timeout:
+    )
+  end
+
+  def resume_stopped_release(scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
+                             heartbeat_interval:, claim_renewal_interval:, termination_grace:,
+                             coordination_timeout:)
+    stop_result = handle_release_stop(
+      scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:, termination_grace:,
+                       coordination_timeout:
+    )
+    return stop_result unless stop_result.nil?
+
+    now = monotonic_time
+    SupervisionState.new(
+      next_heartbeat: now + heartbeat_interval,
+      next_claim_renewal: initial_claim_renewal_deadline(identity, claim_renewal_interval)
+    )
+  end
+
+  def refresh_or_wait(scope, identity, state:, child_pid:, pgid:, liveness_writer:, heartbeat_interval:,
+                      claim_renewal_interval:, termination_grace:, coordination_timeout:)
+    now = monotonic_time
+    heartbeat_due = now >= state.next_heartbeat
+    claim_renewal_due = managed_claim_renewal_due?(identity, now, state.next_claim_renewal)
+    unless lease_refresh_due?(heartbeat_due, claim_renewal_due)
+      wait_for_next_supervision_poll(state)
+      return state
+    end
+
+    lease_live = refresh_lease?(
+      scope, identity, renew_claim: claim_renewal_due, coordination_timeout:, termination_grace:
+    )
+    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
+    return lose_lease(pgid, child_pid, liveness_writer, termination_grace) unless lease_live
+
+    SupervisionState.new(
+      next_heartbeat: advanced_deadline(state.next_heartbeat, now, heartbeat_interval, heartbeat_due),
+      next_claim_renewal: advanced_deadline(
+        state.next_claim_renewal, now, claim_renewal_interval, claim_renewal_due
+      )
+    )
+  end
+
+  def wait_for_next_supervision_poll(state)
+    sleep_duration = [
+      POLL_INTERVAL,
+      state.next_heartbeat - monotonic_time,
+      state.next_claim_renewal - monotonic_time
+    ].min
+    sleep(sleep_duration) if sleep_duration.positive?
+  end
+
+  def handle_release_stop(scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
+                          termination_grace:, coordination_timeout:)
+    return unless terminal_handoff
+
+    restore_terminal_foreground(terminal_handoff)
+    unless terminal_foreground_pgid(terminal_handoff.fd) == terminal_handoff.supervisor_pgid
+      return fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace)
+    end
+
+    @stderr.puts "Release process group #{pgid} stopped; returning terminal control to the invoking shell."
+    suspend_for_shell_job_control(terminal_handoff)
+    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
+
+    lease_live = refresh_lease?(
+      scope,
+      identity,
+      renew_claim: identity.managed,
+      coordination_timeout:,
+      termination_grace:
+    )
+    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
+    return lose_lease(pgid, child_pid, liveness_writer, termination_grace) unless lease_live
+
+    resumed_handoff = hand_off_terminal_foreground(terminal_handoff, pgid)
+    return fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace) unless resumed_handoff
+
+    nil
+  end
+
+  def suspend_for_shell_job_control(terminal_handoff)
+    loop do
+      with_default_tstp_handler { Process.kill("TSTP", Process.pid) }
+      return if terminal_foreground_pgid(terminal_handoff.fd) == terminal_handoff.supervisor_pgid
+    end
+  end
+
+  def with_default_tstp_handler
+    previous_handler = Signal.trap("TSTP", "DEFAULT")
+    yield
+  ensure
+    Signal.trap("TSTP", previous_handler) if previous_handler
+  end
+
+  def fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace)
+    close_liveness(liveness_writer)
+    @stderr.puts "Release terminal resume failed; closed liveness channel and terminating process group #{pgid}."
+    terminate_group(pgid, child_pid:, grace: termination_grace)
+    @managed_claim_release_safe = true
+    report_group_handoff(pgid, proven_dead: true)
     1
   end
 
@@ -700,7 +817,7 @@ class ReleaseSupervisor
   end
 
   def nonblocking_child_status(child_pid)
-    _waited_pid, child_status = Process.waitpid2(child_pid, Process::WNOHANG)
+    _waited_pid, child_status = Process.waitpid2(child_pid, Process::WNOHANG | Process::WUNTRACED)
     child_status
   end
 
@@ -858,7 +975,7 @@ class ReleaseSupervisor
 
   def hand_off_terminal_foreground(owner, release_pgid)
     return unless owner
-    return unless terminal_foreground_pgid(owner.fd, tolerate_missing_terminal: true) == owner.supervisor_pgid
+    return unless terminal_foreground_pgid(owner.fd) == owner.supervisor_pgid
     return unless group_alive?(release_pgid)
     return unless set_terminal_foreground_pgid(owner.fd, release_pgid, tolerate_dead_pgid: release_pgid)
 
@@ -869,19 +986,19 @@ class ReleaseSupervisor
   def restore_terminal_foreground(handoff)
     return unless handoff
 
-    foreground_pgid = terminal_foreground_pgid(handoff.fd, tolerate_missing_terminal: true)
+    foreground_pgid = terminal_foreground_pgid(handoff.fd)
     return if foreground_pgid.nil? || foreground_pgid == handoff.supervisor_pgid
     return unless foreground_pgid == handoff.release_pgid
 
     set_terminal_foreground_pgid(handoff.fd, handoff.supervisor_pgid)
   end
 
-  def terminal_foreground_pgid(terminal_fd, tolerate_missing_terminal: false)
+  def terminal_foreground_pgid(terminal_fd)
     pgid = terminal_function("tcgetpgrp", 1).call(terminal_fd)
     return pgid unless pgid == -1
 
     errno = Fiddle.last_error
-    return nil if tolerate_missing_terminal && errno == Errno::ENOTTY::Errno
+    return nil if errno == Errno::ENOTTY::Errno
 
     raise SupervisorError, "could not read the controlling terminal foreground process group (errno #{errno})"
   end

--- a/script/release
+++ b/script/release
@@ -665,7 +665,7 @@ class ReleaseSupervisor
     child_status = nonblocking_child_status(child_pid)
     if child_status&.stopped?
       return resume_stopped_release(
-        scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:, heartbeat_interval:,
+        scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:, heartbeat_interval:,
                          claim_renewal_interval:, termination_grace:, coordination_timeout:
       )
     end
@@ -677,14 +677,15 @@ class ReleaseSupervisor
     )
   end
 
-  def resume_stopped_release(scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
+  def resume_stopped_release(scope, identity, state:, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
                              heartbeat_interval:, claim_renewal_interval:, termination_grace:,
                              coordination_timeout:)
     stop_result = handle_release_stop(
       scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:, termination_grace:,
                        coordination_timeout:
     )
-    return stop_result unless stop_result.nil?
+    return state if stop_result == :no_handoff
+    return stop_result unless stop_result == :resumed
 
     now = monotonic_time
     SupervisionState.new(
@@ -728,7 +729,7 @@ class ReleaseSupervisor
 
   def handle_release_stop(scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:,
                           termination_grace:, coordination_timeout:)
-    return unless terminal_handoff
+    return :no_handoff unless terminal_handoff
 
     restore_terminal_foreground(terminal_handoff)
     unless terminal_foreground_pgid(terminal_handoff.fd) == terminal_handoff.supervisor_pgid
@@ -736,8 +737,9 @@ class ReleaseSupervisor
     end
 
     @stderr.puts "Release process group #{pgid} stopped; returning terminal control to the invoking shell."
-    suspend_for_shell_job_control(terminal_handoff)
-    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if @received_signal
+    suspend_result = suspend_for_shell_job_control(terminal_handoff)
+    return interrupt_release(pgid, child_pid, liveness_writer, termination_grace) if suspend_result == :interrupted
+    return fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace) if suspend_result == :terminal_lost
 
     lease_live = refresh_lease?(
       scope,
@@ -752,13 +754,17 @@ class ReleaseSupervisor
     resumed_handoff = hand_off_terminal_foreground(terminal_handoff, pgid)
     return fail_terminal_resume(pgid, child_pid, liveness_writer, termination_grace) unless resumed_handoff
 
-    nil
+    :resumed
   end
 
   def suspend_for_shell_job_control(terminal_handoff)
     loop do
       with_default_tstp_handler { Process.kill("TSTP", Process.pid) }
-      return if terminal_foreground_pgid(terminal_handoff.fd) == terminal_handoff.supervisor_pgid
+      return :interrupted if @received_signal
+
+      foreground_pgid = terminal_foreground_pgid(terminal_handoff.fd)
+      return :terminal_lost if foreground_pgid.nil?
+      return :foreground if foreground_pgid == terminal_handoff.supervisor_pgid
     end
   end
 
@@ -855,6 +861,8 @@ class ReleaseSupervisor
       termination_grace:
     )
     terminal_handoff = hand_off_terminal_foreground(terminal_owner, pgid)
+    raise SupervisorError, "initial terminal foreground transfer failed" if terminal_owner && !terminal_handoff
+
     [child_pid, pgid, pipes.liveness_writer, pipes.death_writer, terminal_handoff]
   rescue StandardError
     begin

--- a/script/release
+++ b/script/release
@@ -685,7 +685,12 @@ class ReleaseSupervisor
       scope, identity, child_pid:, pgid:, liveness_writer:, terminal_handoff:, termination_grace:,
                        coordination_timeout:
     )
-    return state if stop_result == :no_handoff
+    if stop_result == :no_handoff
+      return refresh_or_wait(
+        scope, identity, state:, child_pid:, pgid:, liveness_writer:, heartbeat_interval:,
+                         claim_renewal_interval:, termination_grace:, coordination_timeout:
+      )
+    end
     return stop_result unless stop_result == :resumed
 
     now = monotonic_time

--- a/script/release
+++ b/script/release
@@ -759,6 +759,9 @@ class ReleaseSupervisor
 
   def suspend_for_shell_job_control(terminal_handoff)
     loop do
+      return :interrupted if @received_signal
+      return :terminal_lost if terminal_foreground_pgid(terminal_handoff.fd).nil?
+
       with_default_tstp_handler { Process.kill("TSTP", Process.pid) }
       return :interrupted if @received_signal
 

--- a/script/release
+++ b/script/release
@@ -980,7 +980,10 @@ class ReleaseSupervisor
 
     fd = $stdin.fileno
     foreground_pgid = terminal_foreground_pgid(fd)
-    return unless foreground_pgid == Process.getpgrp
+    return if foreground_pgid.nil?
+    unless foreground_pgid == Process.getpgrp
+      raise SupervisorError, "terminal foreground ownership changed before release child spawn; use fg and retry"
+    end
 
     TerminalHandoff.new(fd:, supervisor_pgid: foreground_pgid, release_pgid: nil)
   end

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -494,9 +494,13 @@ class ExceptionTestSupervisor < ReleaseSupervisor
   def spawn_release_group(...)
     result = super
     File.write(ENV.fetch("TEST_EXCEPTION_GROUP_LOG"), "#{result.fetch(1)}\n")
+    result
+  end
+
+  def supervise_loop(...)
     raise Errno::EPIPE if ENV.fetch("FAKE_EXCEPTION_MODE") == "after-spawn"
 
-    result
+    super
   end
 
   def read_child_process_group!(...)
@@ -510,6 +514,14 @@ class ExceptionTestSupervisor < ReleaseSupervisor
   def restore_terminal_foreground(...)
     super
     raise SupervisorError, "injected terminal restoration failure" if ENV["FAKE_RESTORE_FAIL"] == "1"
+  end
+
+  def cleanup_failed_release(pgid, child_pid, liveness_writer, termination_grace)
+    if ENV.fetch("FAKE_EXCEPTION_MODE") == "after-spawn"
+      ownership = pgid && child_pid && liveness_writer ? "owned" : "unowned"
+      File.write(ENV.fetch("TEST_EXCEPTION_LIVENESS_LOG"), "#{ownership}\n")
+    end
+    super
   end
 
   def close_release_pipes(pipes)
@@ -3034,6 +3046,10 @@ for exception_mode in after-spawn after-handshake; do
       fail "${exception_mode} supervisor exception exited successfully"
     fi
     process_group="$(cat "${exception_group_log}")"
+    if test "${exception_mode}" = after-spawn && ! grep -Fx 'owned' "${exception_liveness_log}" >/dev/null; then
+      kill -KILL -- "-${process_group}" 2>/dev/null || true
+      fail "after-spawn exception reached cleanup without owning the spawned group resources"
+    fi
     assert_group_dead "${process_group}"
     assert_no_coordination_mutation
     assert_secret_absent

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -795,6 +795,184 @@ loop do
 end
 BACKGROUND_PTY_HARNESS
 
+  cat >"${fake_bin}/release-redirected-input-harness.rb" <<'REDIRECTED_INPUT_HARNESS'
+# frozen_string_literal: true
+
+require "fiddle"
+
+$stdout.sync = true
+tcsetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcsetpgrp"],
+  [Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+tcgetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcgetpgrp"],
+  [Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+set_foreground = lambda do |pgid|
+  previous_handler = Signal.trap("TTOU", "IGNORE")
+  raise "tcsetpgrp failed" unless tcsetpgrp.call($stdout.fileno, pgid).zero?
+ensure
+  Signal.trap("TTOU", previous_handler) if previous_handler
+end
+
+input_reader, input_writer = IO.pipe
+launch_reader, launch_writer = IO.pipe
+wrapper_pid = fork do
+  launch_writer.close
+  input_writer.close
+  Process.setpgid(0, 0)
+  launch_reader.read(1)
+  launch_reader.close
+  $stdin.reopen(input_reader)
+  input_reader.close
+  exec ENV.fetch("TEST_RELEASE_SCRIPT")
+end
+Process.setpgid(wrapper_pid, wrapper_pid)
+
+feeder_pid = fork do
+  launch_writer.close
+  input_reader.close
+  Process.setpgid(0, wrapper_pid)
+  launch_reader.read(1)
+  launch_reader.close
+  input_writer.write("y\n")
+  input_writer.close
+  exit! 0
+end
+Process.setpgid(feeder_pid, wrapper_pid)
+
+launch_reader.close
+input_reader.close
+input_writer.close
+puts "shell:redirected-input:#{wrapper_pid}"
+set_foreground.call(wrapper_pid)
+launch_writer.write("xx")
+launch_writer.close
+
+_wrapper_waited, wrapper_status = Process.waitpid2(wrapper_pid)
+_feeder_waited, feeder_status = Process.waitpid2(feeder_pid)
+set_foreground.call(Process.getpgrp)
+puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdout.fileno)}"
+raise "input feeder failed" unless feeder_status.success?
+
+exit(wrapper_status.exited? ? wrapper_status.exitstatus : 128 + wrapper_status.termsig)
+REDIRECTED_INPUT_HARNESS
+
+  cat >"${fake_bin}/release-output-pipeline-harness.rb" <<'OUTPUT_PIPELINE_HARNESS'
+# frozen_string_literal: true
+
+require "fiddle"
+
+$stdout.sync = true
+tcsetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcsetpgrp"],
+  [Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+tcgetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcgetpgrp"],
+  [Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+set_foreground = lambda do |pgid|
+  previous_handler = Signal.trap("TTOU", "IGNORE")
+  raise "tcsetpgrp failed" unless tcsetpgrp.call($stdin.fileno, pgid).zero?
+ensure
+  Signal.trap("TTOU", previous_handler) if previous_handler
+end
+
+pipeline_reader, pipeline_writer = IO.pipe
+launch_reader, launch_writer = IO.pipe
+wrapper_pid = fork do
+  launch_writer.close
+  pipeline_reader.close
+  Process.setpgid(0, 0)
+  launch_reader.read(1)
+  launch_reader.close
+  $stdout.reopen(pipeline_writer)
+  pipeline_writer.close
+  exec ENV.fetch("TEST_RELEASE_SCRIPT")
+end
+Process.setpgid(wrapper_pid, wrapper_pid)
+
+tee_pid = fork do
+  launch_writer.close
+  pipeline_writer.close
+  Process.setpgid(0, wrapper_pid)
+  launch_reader.read(1)
+  launch_reader.close
+  $stdin.reopen(pipeline_reader)
+  pipeline_reader.close
+  IO.copy_stream($stdin, $stdout)
+  exit! 0
+end
+Process.setpgid(tee_pid, wrapper_pid)
+
+launch_reader.close
+pipeline_reader.close
+pipeline_writer.close
+puts "shell:output-pipeline:#{wrapper_pid}"
+system("stty", "tostop") if ENV["FAKE_TOSTOP"] == "1"
+set_foreground.call(wrapper_pid)
+launch_writer.write("xx")
+launch_writer.close
+
+statuses = {}
+deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1.5
+until statuses.size == 2 || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+  [wrapper_pid, tee_pid].each do |pid|
+    next if statuses.key?(pid)
+
+    waited = Process.waitpid2(pid, Process::WNOHANG)
+    statuses[pid] = waited.fetch(1) if waited
+  rescue Errno::ECHILD
+    nil
+  end
+  sleep 0.01 if statuses.size < 2
+end
+
+set_foreground.call(Process.getpgrp)
+system("stty", "-tostop") if ENV["FAKE_TOSTOP"] == "1"
+unless statuses.size == 2
+  begin
+    Process.kill("CONT", -wrapper_pid)
+    Process.kill("TERM", -wrapper_pid)
+  rescue Errno::ESRCH
+    nil
+  end
+  bundle_entry = File.readlines(ENV.fetch("TEST_BUNDLE_LOG")).find { |line| line.start_with?("bundle:") }
+  release_pgid = bundle_entry&.split(":", 4)&.fetch(2, nil)&.to_i
+  begin
+    Process.kill("KILL", -release_pgid) if release_pgid&.positive?
+  rescue Errno::ESRCH
+    nil
+  end
+  [wrapper_pid, tee_pid].each do |pid|
+    next if statuses.key?(pid)
+
+    begin
+      Process.kill("KILL", pid)
+    rescue Errno::ESRCH
+      nil
+    end
+    begin
+      Process.wait(pid)
+    rescue Errno::ECHILD
+      nil
+    end
+  end
+  exit 124
+end
+
+puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
+raise "pipeline tee failed" unless statuses.fetch(tee_pid).success?
+wrapper_status = statuses.fetch(wrapper_pid)
+exit(wrapper_status.exited? ? wrapper_status.exitstatus : 128 + wrapper_status.termsig)
+OUTPUT_PIPELINE_HARNESS
+
   cat >"${fake_bin}/release-job-control-harness.rb" <<'JOB_CONTROL_HARNESS'
 # frozen_string_literal: true
 
@@ -835,12 +1013,27 @@ raise "wrapper did not stop for shell job control" unless stopped_status.stopped
 
 set_foreground.call(Process.getpgrp)
 puts "shell:wrapper-stopped"
+coordination_counts = lambda do
+  heartbeat_count = File.read(ENV.fetch("TEST_HEARTBEAT_COUNT_FILE")).strip
+  status_count = File.read(ENV.fetch("TEST_STATUS_COUNT_FILE")).strip
+  renewal_count = File.readlines(ENV.fetch("TEST_COORD_LOG")).count { |line| line.include?("--renew") }
+  [heartbeat_count, status_count, renewal_count]
+end
+stopped_before = coordination_counts.call
+sleep 0.3
+stopped_after = coordination_counts.call
+puts "shell:wrapper-stopped-coordination:#{[*stopped_before, *stopped_after].join(':')}"
+if ENV["FAKE_SIGNAL_STOPPED_WRAPPER"] == "1"
+  Process.kill("TERM", wrapper_pid)
+  puts "shell:wrapper-signal:TERM"
+end
 set_foreground.call(wrapper_pid)
 Process.kill("CONT", -wrapper_pid)
 puts "shell:wrapper-continued"
 
 _waited_pid, release_status = Process.waitpid2(wrapper_pid)
 set_foreground.call(Process.getpgrp)
+puts "shell:wrapper-final-coordination:#{coordination_counts.call.join(':')}"
 puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
 exit(release_status.exited? ? release_status.exitstatus : 128 + release_status.termsig)
 JOB_CONTROL_HARNESS
@@ -886,7 +1079,8 @@ JOB_CONTROL_HARNESS
   unset FAKE_DOCTOR_FAIL FAKE_DOCTOR_BACKEND FAKE_DOCTOR_PAYLOAD
   unset FAKE_BUNDLE_MODE FAKE_BUNDLE_START_DELAY FAKE_HANDSHAKE_MODE FAKE_EXCEPTION_MODE FAKE_RESTORE_FAIL
   unset FAKE_HANDSHAKE_IGNORE_TERM
-  unset FAKE_LATE_BACKGROUND FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND
+  unset FAKE_LATE_BACKGROUND FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND FAKE_TOSTOP
+  unset FAKE_SIGNAL_STOPPED_WRAPPER
   unset REACT_ON_RAILS_RELEASE_COORDINATION_TIMEOUT
   unset REACT_ON_RAILS_RELEASE_CLAIM_RENEWAL_INTERVAL
 }
@@ -943,6 +1137,15 @@ run_release_with_noncontrolling_tty() {
       master.close unless master.closed?
     end
     exit exit_code
+  ' >"${output_log}" 2>&1
+}
+
+run_release_headless_with_redirected_input() {
+  TEST_PTY_REPO="${fake_repo}" "${ruby_executable}" -e '
+    Process.setsid
+    $stdin.reopen("/dev/null")
+    Dir.chdir(ENV.fetch("TEST_PTY_REPO"))
+    exec ENV.fetch("TEST_RELEASE_SCRIPT")
   ' >"${output_log}" 2>&1
 }
 
@@ -1068,9 +1271,12 @@ run_background_release_in_pty() {
 }
 
 run_job_control_release_in_pty() {
+  job_control_harness="${1:-release-job-control-harness.rb}"
+  continuation_marker="${2:-shell:wrapper-continued}"
   TEST_PTY_REPO="${fake_repo}" TEST_PTY_OUTPUT="${output_log}" \
+    TEST_JOB_CONTROL_HARNESS="${job_control_harness}" TEST_CONTINUATION_MARKER="${continuation_marker}" \
     "${ruby_executable}" -rpty -e '
-    harness = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", "release-job-control-harness.rb")
+    harness = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", ENV.fetch("TEST_JOB_CONTROL_HARNESS"))
     reader, writer, child_pid = PTY.spawn(RbConfig.ruby, harness, chdir: ENV.fetch("TEST_PTY_REPO"))
     output = +""
     status = nil
@@ -1091,7 +1297,7 @@ run_job_control_release_in_pty() {
         writer.flush
         stop_sent = true
       end
-      if !confirmation_sent && output.include?("shell:wrapper-continued")
+      if !confirmation_sent && output.include?(ENV.fetch("TEST_CONTINUATION_MARKER"))
         writer.write("y\n")
         writer.flush
         confirmation_sent = true
@@ -1102,7 +1308,7 @@ run_job_control_release_in_pty() {
         break
       end
       if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-        process_groups = output.scan(/^shell:wrapper:(\d+)/).flatten.map(&:to_i)
+        process_groups = output.scan(/^shell:(?:wrapper|pipeline):(\d+)/).flatten.map(&:to_i)
         bundle_entry = File.readlines(ENV.fetch("TEST_BUNDLE_LOG")).find { |line| line.start_with?("bundle:") }
         process_groups << bundle_entry&.split(":", 4)&.fetch(2, nil)&.to_i
         process_groups.compact.select(&:positive?).uniq.each do |process_group|
@@ -1701,6 +1907,49 @@ assert_empty "${bundle_log}"
 assert_secret_absent
 pass "background interactive live release is refused before coordination mutation"
 
+setup_case redirected-input-controlling-terminal
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=interactive-confirm
+if run_release_in_pty '' release-redirected-input-harness.rb; then
+  fail "foreground live release accepted redirected stdin while attached to a controlling terminal"
+fi
+assert_contains "${output_log}" "shell:redirected-input:"
+assert_contains "${output_log}" "live release requires direct terminal stdin and stdout"
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_terminal_restored
+assert_secret_absent
+pass "foreground live release refuses redirected stdin before coordination mutation"
+
+setup_case output-pipeline-controlling-terminal
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=interactive-confirm
+if run_release_in_pty '' release-output-pipeline-harness.rb; then
+  fail "foreground live release accepted piped stdout while attached to a controlling terminal"
+fi
+assert_contains "${output_log}" "shell:output-pipeline:"
+assert_contains "${output_log}" "live release requires direct terminal stdin and stdout"
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_terminal_restored
+assert_secret_absent
+pass "foreground live release refuses an output pipeline before coordination mutation"
+
+setup_case output-pipeline-tostop-controlling-terminal
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=interactive-confirm
+export FAKE_TOSTOP=1
+if run_release_in_pty '' release-output-pipeline-harness.rb; then
+  fail "foreground live release accepted a TOSTOP output pipeline"
+fi
+assert_contains "${output_log}" "shell:output-pipeline:"
+assert_contains "${output_log}" "live release requires direct terminal stdin and stdout"
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_terminal_restored
+assert_secret_absent
+pass "foreground live release refuses a TOSTOP output pipeline before coordination mutation"
+
 setup_case spawn-time-terminal-ownership-race
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 if run_release_in_pty '' release-terminal-race-harness.rb; then
@@ -1792,6 +2041,14 @@ assert_no_coordination_mutation
 assert_secret_absent
 pass "live release allows a TTY without a controlling terminal"
 
+setup_case headless-redirected-input
+FAKE_BUNDLE_MODE=success run_release_headless_with_redirected_input || \
+  fail "headless live release rejected redirected stdin without a controlling terminal"
+assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
+assert_no_coordination_mutation
+assert_secret_absent
+pass "headless live release allows redirected stdin without a controlling terminal"
+
 setup_case job-control-resume-with-pending-signal
 if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
 load ENV.fetch("TEST_RELEASE_SCRIPT")
@@ -1831,6 +2088,53 @@ fi
 assert_no_coordination_mutation
 assert_secret_absent
 pass "job-control resume returns immediately when a termination signal is pending"
+
+setup_case job-control-signal-before-group-stop
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class SignalBeforeGroupStopSupervisor < ReleaseSupervisor
+  attr_reader :group_stop_attempts
+
+  def initialize
+    super([])
+    @group_stop_attempts = 0
+  end
+
+  private
+
+  def terminal_foreground_pgid(*)
+    123
+  end
+
+  def invoking_job_group_suspendable?(*)
+    true
+  end
+
+  def with_default_tstp_handler
+    @received_signal = "TERM"
+    yield
+  end
+
+  def stop_invoking_job_group(*)
+    @group_stop_attempts += 1
+  end
+
+  public :suspend_for_shell_job_control
+end
+
+handoff = ReleaseSupervisor::TerminalHandoff.new(fd: 0, supervisor_pgid: 123, release_pgid: 456)
+supervisor = SignalBeforeGroupStopSupervisor.new
+result = supervisor.suspend_for_shell_job_control(handoff)
+abort "signal before group stop did not interrupt resume" unless result == :interrupted
+abort "signal before group stop still suspended the invoking job" unless supervisor.group_stop_attempts.zero?
+RUBY
+then
+  fail "job-control resume suspended the invoking job after consuming a termination signal"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "termination signal consumed before group stop returns directly to cleanup"
 
 setup_case job-control-resume-with-lost-terminal
 if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
@@ -2008,6 +2312,16 @@ if ! run_job_control_release_in_pty; then
 fi
 assert_contains "${output_log}" "shell:wrapper-stopped"
 assert_contains "${output_log}" "shell:wrapper-continued"
+stopped_coordination="$(grep '^shell:wrapper-stopped-coordination:' "${output_log}" | tail -n 1 | tr -d '\r')"
+test "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f3)" = \
+  "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f6)" || \
+  fail "release heartbeat advanced while the direct invoking job was stopped"
+test "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f4)" = \
+  "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f7)" || \
+  fail "release fence status advanced while the direct invoking job was stopped"
+test "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f5)" = \
+  "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f8)" || \
+  fail "release claim renewed while the direct invoking job was stopped"
 assert_contains "${bundle_log}" "confirmation:y"
 continuation_record="$(grep '^job-control:continued:' "${bundle_log}" | tail -n 1)"
 continuation_heartbeats="$(printf '%s\n' "${continuation_record}" | cut -d: -f3)"
@@ -2023,6 +2337,36 @@ assert_contains "${coord_log}" $'claim-atomic|'
 assert_contains "${coord_log}" $'release|'
 assert_secret_absent
 pass "Ctrl-Z returns control to the shell and revalidates fencing before foreground resume"
+
+setup_case interactive-job-control-pending-signal
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=job-control-confirm
+export FAKE_SIGNAL_STOPPED_WRAPPER=1
+if run_job_control_release_in_pty; then
+  fail "termination signal pending on the stopped invoking job allowed release continuation"
+fi
+assert_contains "${output_log}" "shell:wrapper-stopped"
+assert_contains "${output_log}" "shell:wrapper-signal:TERM"
+assert_contains "${output_log}" "shell:wrapper-continued"
+stopped_coordination="$(grep '^shell:wrapper-stopped-coordination:' "${output_log}" | tail -n 1 | tr -d '\r')"
+final_coordination="$(grep '^shell:wrapper-final-coordination:' "${output_log}" | tail -n 1 | tr -d '\r')"
+test "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f6)" = \
+  "$(printf '%s\n' "${final_coordination}" | cut -d: -f3)" || \
+  fail "pending signal refreshed the heartbeat after the invoking job resumed"
+test "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f7)" = \
+  "$(printf '%s\n' "${final_coordination}" | cut -d: -f4)" || \
+  fail "pending signal refreshed the release fence after the invoking job resumed"
+test "$(printf '%s\n' "${stopped_coordination}" | cut -d: -f8)" = \
+  "$(printf '%s\n' "${final_coordination}" | cut -d: -f5)" || \
+  fail "pending signal renewed the release claim after the invoking job resumed"
+assert_not_contains "${bundle_log}" "confirmation:y"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_secret_absent
+pass "pending termination signal cleans up after foreground resume without refreshing the lease"
 
 setup_case interactive-job-control-lost-fence
 export FAKE_BUNDLE_MODE=job-control-confirm

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -1105,6 +1105,133 @@ puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
 exit(release_status.exited? ? release_status.exitstatus : 128 + release_status.termsig)
 JOB_CONTROL_HARNESS
 
+  cat >"${fake_bin}/release-managed-cleanup-tostop-supervisor" <<'CLEANUP_TOSTOP_SUPERVISOR'
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class ManagedCleanupTostopSupervisor < ReleaseSupervisor
+  private
+
+  def release_managed_lease!(...)
+    released = super
+    transfer_terminal_to_foreign_group
+    released
+  end
+
+  def nonblocking_child_status(child_pid)
+    return super unless ENV.fetch("FAKE_MANAGED_CLEANUP_MODE") == "unproven"
+
+    transfer_terminal_to_foreign_group
+    raise Errno::ECHILD
+  end
+
+  def transfer_terminal_to_foreign_group
+    return if @foreign_terminal_owner
+
+    foreign_pgid = Integer(ENV.fetch("TEST_FOREIGN_PGID"))
+    raise "could not install foreign terminal owner" unless set_terminal_foreground_pgid($stdin.fileno, foreign_pgid)
+
+    @foreign_terminal_owner = true
+  end
+end
+
+exit ManagedCleanupTostopSupervisor.new(ARGV).run
+CLEANUP_TOSTOP_SUPERVISOR
+
+  cat >"${fake_bin}/release-managed-cleanup-tostop-harness.rb" <<'CLEANUP_TOSTOP_HARNESS'
+# frozen_string_literal: true
+
+require "fiddle"
+require "rbconfig"
+
+$stdout.sync = true
+tcsetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcsetpgrp"],
+  [Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+tcgetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcgetpgrp"],
+  [Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+set_foreground = lambda do |pgid|
+  previous_handler = Signal.trap("TTOU", "IGNORE")
+  raise "tcsetpgrp failed" unless tcsetpgrp.call($stdin.fileno, pgid).zero?
+ensure
+  Signal.trap("TTOU", previous_handler) if previous_handler
+end
+
+raise "could not enable TOSTOP" unless system("stty", "tostop")
+shell_pgid = Process.getpgrp
+launch_reader, launch_writer = IO.pipe
+wrapper_pid = fork do
+  launch_writer.close
+  Process.setpgid(0, 0)
+  launch_reader.read(1)
+  launch_reader.close
+  ENV["TEST_FOREIGN_PGID"] = shell_pgid.to_s
+  supervisor = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", "release-managed-cleanup-tostop-supervisor")
+  exec RbConfig.ruby, supervisor
+end
+launch_reader.close
+begin
+  Process.setpgid(wrapper_pid, wrapper_pid)
+rescue Errno::EACCES, Errno::ESRCH
+  nil
+end
+puts "shell:wrapper:#{wrapper_pid}"
+set_foreground.call(wrapper_pid)
+launch_writer.write("x")
+launch_writer.close
+
+status = nil
+deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2.0
+loop do
+  waited = Process.waitpid2(wrapper_pid, Process::WNOHANG | Process::WUNTRACED)
+  if waited
+    status = waited.last
+    break
+  end
+  break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+  sleep 0.02
+end
+
+set_foreground.call(shell_pgid)
+if status&.stopped?
+  puts "shell:wrapper-stopped-by-tostop:#{status.stopsig}"
+  begin
+    Process.kill("CONT", -wrapper_pid)
+    Process.kill("KILL", -wrapper_pid)
+  rescue Errno::ESRCH
+    nil
+  end
+  Process.wait(wrapper_pid)
+  system("stty", "-tostop")
+  puts "terminal:#{shell_pgid}:#{tcgetpgrp.call($stdin.fileno)}"
+  exit 124
+end
+unless status
+  begin
+    Process.kill("KILL", -wrapper_pid)
+  rescue Errno::ESRCH
+    nil
+  end
+  Process.wait(wrapper_pid)
+  system("stty", "-tostop")
+  puts "shell:wrapper-timeout"
+  exit 125
+end
+
+system("stty", "-tostop")
+puts "shell:wrapper-exited:#{status.exitstatus}"
+puts "terminal:#{shell_pgid}:#{tcgetpgrp.call($stdin.fileno)}"
+exit(status.exited? ? status.exitstatus : 128 + status.termsig)
+CLEANUP_TOSTOP_HARNESS
+
   chmod +x "${fake_bin}/agent-coord" "${fake_bin}/bundle" "${fake_bin}/pnpm" \
     "${fake_bin}/release-handshake-harness" \
     "${fake_bin}/release-exception-harness" "${fake_bin}/release-subreaper-failure-harness" \
@@ -1147,6 +1274,7 @@ JOB_CONTROL_HARNESS
   unset FAKE_BUNDLE_MODE FAKE_BUNDLE_START_DELAY FAKE_HANDSHAKE_MODE FAKE_EXCEPTION_MODE FAKE_RESTORE_FAIL
   unset FAKE_HANDSHAKE_IGNORE_TERM
   unset FAKE_LATE_BACKGROUND FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND FAKE_TOSTOP TEST_PTY_CONFIRMATION_DELAY
+  unset FAKE_MANAGED_CLEANUP_MODE
   unset FAKE_SIGNAL_STOPPED_WRAPPER
   unset REACT_ON_RAILS_RELEASE_COORDINATION_TIMEOUT
   unset REACT_ON_RAILS_RELEASE_CLAIM_RENEWAL_INTERVAL
@@ -2548,6 +2676,71 @@ assert_contains "${output_log}" "Release process group ${process_group} was prov
 assert_no_coordination_mutation
 assert_secret_absent
 pass "TOSTOP restores the terminal before lease-loss cleanup output"
+
+setup_case managed-cleanup-failure-tostop
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=success
+export FAKE_RELEASE_FAIL=1
+export FAKE_MANAGED_CLEANUP_MODE=proven
+if run_release_in_pty '' release-managed-cleanup-tostop-harness.rb; then
+  fail "failed managed-claim cleanup exited successfully"
+fi
+assert_not_contains "${output_log}" "shell:wrapper-stopped-by-tostop"
+assert_contains "${output_log}" "shell:wrapper-exited:1"
+assert_contains "${output_log}" "release-line lease cleanup failed"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_secret_absent
+pass "failed managed-claim cleanup cannot SIGTTOU-stop after the release group is proven dead"
+
+setup_case managed-retained-claim-tostop
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=hold
+export FAKE_MANAGED_CLEANUP_MODE=unproven
+if run_release_in_pty '' release-managed-cleanup-tostop-harness.rb; then
+  fail "unproven managed release termination exited successfully"
+fi
+assert_not_contains "${output_log}" "shell:wrapper-stopped-by-tostop"
+assert_contains "${output_log}" "shell:wrapper-exited:1"
+assert_contains "${output_log}" "retaining release-line lease because process-group termination was not proven"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+wait_for_group_exit "${process_group}" || fail "death watch did not stop the unproven TOSTOP release group"
+assert_terminal_restored
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_not_contains "${coord_log}" $'release|'
+assert_secret_absent
+pass "retained-claim diagnostics cannot SIGTTOU-stop when release-group death is unproven"
+
+setup_case managed-cleanup-diagnostic-unwind
+if ! "${ruby_executable}" -e '
+  load ENV.fetch("TEST_RELEASE_SCRIPT")
+  failing_output = Object.new
+  def failing_output.puts(*)
+    raise Errno::EPIPE
+  end
+  supervisor = ReleaseSupervisor.new([], stderr: failing_output)
+  original = RuntimeError.new("original release failure")
+  observed = nil
+  begin
+    raise original
+  rescue RuntimeError
+    begin
+      supervisor.send(:report_managed_cleanup_failure, "cleanup failed", $ERROR_INFO)
+      raise
+    rescue StandardError => error
+      observed = error
+    end
+  end
+  abort "cleanup diagnostic masked the original exception" unless observed.equal?(original)
+'; then
+  fail "managed cleanup diagnostic masked the active release exception"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "managed cleanup diagnostic write failures preserve the active release exception"
 
 setup_case interactive-job-control-stop
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -672,7 +672,7 @@ class TerminalRaceSupervisor < ReleaseSupervisor
 
   def terminal_foreground_pgid(*)
     @terminal_reads += 1
-    @terminal_reads == 1 ? Process.getpgrp : Process.getpgrp + 10_000
+    @terminal_reads <= 3 ? Process.getpgrp : Process.getpgrp + 10_000
   end
 
   def fork_release_child(*)
@@ -860,6 +860,76 @@ raise "input feeder failed" unless feeder_status.success?
 
 exit(wrapper_status.exited? ? wrapper_status.exitstatus : 128 + wrapper_status.termsig)
 REDIRECTED_INPUT_HARNESS
+
+  cat >"${fake_bin}/release-alternate-input-pty-harness.rb" <<'ALTERNATE_INPUT_PTY_HARNESS'
+# frozen_string_literal: true
+
+require "fiddle"
+require "pty"
+
+$stdout.sync = true
+tcsetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcsetpgrp"],
+  [Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+tcgetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcgetpgrp"],
+  [Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+set_foreground = lambda do |pgid|
+  previous_handler = Signal.trap("TTOU", "IGNORE")
+  raise "tcsetpgrp failed" unless tcsetpgrp.call($stdout.fileno, pgid).zero?
+ensure
+  Signal.trap("TTOU", previous_handler) if previous_handler
+end
+
+alternate_master, alternate_slave = PTY.open
+wrapper_pid = fork do
+  alternate_master.close
+  Process.setpgid(0, 0)
+  $stdin.reopen(alternate_slave)
+  alternate_slave.close
+  exec ENV.fetch("TEST_RELEASE_SCRIPT")
+end
+Process.setpgid(wrapper_pid, wrapper_pid)
+alternate_slave.close
+puts "shell:alternate-input-pty:#{wrapper_pid}"
+set_foreground.call(wrapper_pid)
+
+status = nil
+deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2.0
+until status || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+  waited = Process.waitpid2(wrapper_pid, Process::WNOHANG)
+  status = waited.fetch(1) if waited
+  sleep 0.01 unless status
+end
+
+set_foreground.call(Process.getpgrp)
+unless status
+  bundle_entry = File.readlines(ENV.fetch("TEST_BUNDLE_LOG")).find { |line| line.start_with?("bundle:") }
+  release_pgid = bundle_entry&.split(":", 4)&.fetch(2, nil)&.to_i
+  [wrapper_pid, release_pgid].compact.select(&:positive?).uniq.each do |pgid|
+    begin
+      Process.kill("CONT", -pgid)
+      Process.kill("KILL", -pgid)
+    rescue Errno::ESRCH
+      nil
+    end
+  end
+  begin
+    Process.wait(wrapper_pid)
+  rescue Errno::ECHILD
+    nil
+  end
+  exit 124
+end
+
+alternate_master.close
+puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdout.fileno)}"
+exit(status.exited? ? status.exitstatus : 128 + status.termsig)
+ALTERNATE_INPUT_PTY_HARNESS
 
   cat >"${fake_bin}/release-output-pipeline-harness.rb" <<'OUTPUT_PIPELINE_HARNESS'
 # frozen_string_literal: true
@@ -1921,6 +1991,20 @@ assert_terminal_restored
 assert_secret_absent
 pass "foreground live release refuses redirected stdin before coordination mutation"
 
+setup_case alternate-input-pty-controlling-terminal
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=success
+if run_release_in_pty '' release-alternate-input-pty-harness.rb; then
+  fail "foreground live release accepted stdin from a different non-controlling TTY"
+fi
+assert_contains "${output_log}" "shell:alternate-input-pty:"
+assert_contains "${output_log}" "live release requires direct terminal stdin and stdout"
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_terminal_restored
+assert_secret_absent
+pass "foreground live release refuses stdin from a different TTY before coordination mutation"
+
 setup_case output-pipeline-controlling-terminal
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 export FAKE_BUNDLE_MODE=interactive-confirm
@@ -2243,6 +2327,41 @@ fi
 assert_no_coordination_mutation
 assert_secret_absent
 pass "job-control preflight avoids an actual non-orphan self-stop"
+
+setup_case job-control-refuses-cross-session-parent
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class CrossSessionSuspendSupervisor < ReleaseSupervisor
+  public :invoking_job_group_suspendable?
+end
+
+child_pid = Process.fork do
+  Process.setsid
+  supervisor = CrossSessionSuspendSupervisor.new([])
+  exit!(supervisor.invoking_job_group_suspendable?(Process.getpgrp) ? 2 : 0)
+end
+
+deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2.0
+status = nil
+until status || Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+  waited = Process.waitpid2(child_pid, Process::WNOHANG)
+  status = waited.fetch(1) if waited
+  sleep 0.01 unless status
+end
+unless status
+  Process.kill("KILL", child_pid)
+  Process.wait(child_pid)
+  abort "cross-session suspension probe did not exit"
+end
+abort "cross-session suspension probe accepted an orphaned job group" unless status.success?
+RUBY
+then
+  fail "job-control suspension accepted an invoking group whose parent is in another session"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "job-control suspension refuses an invoking group whose parent is in another session"
 
 setup_case non-tty-stop-preserves-fence-deadlines
 if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -2387,7 +2387,7 @@ scope = ReleaseSupervisor::ReleaseScope.new(
 identity = ReleaseSupervisor::Identity.new(
   agent_id: "agent", instance_id: "instance", machine_id: "machine", managed: true
 )
-state = ReleaseSupervisor::SupervisionState.new(next_heartbeat: 10.0, next_claim_renewal: 20.0)
+state = ReleaseSupervisor::SupervisionState.new(next_heartbeat: 1_010.0, next_claim_renewal: 1_020.0)
 result = NonTtyStoppedSupervisor.new([]).supervise_cycle(
   scope,
   identity,
@@ -2409,6 +2409,78 @@ fi
 assert_no_coordination_mutation
 assert_secret_absent
 pass "non-TTY stopped child preserves its existing fence deadlines"
+
+setup_case repeated-non-tty-stop-refreshes-supervision
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class RepeatedNonTtyStoppedSupervisor < ReleaseSupervisor
+  attr_reader :refreshes, :waits
+
+  def initialize
+    super([])
+    @now = 1_000.0
+    @refreshes = []
+    @waits = 0
+  end
+
+  private
+
+  def nonblocking_child_status(*)
+    Object.new.tap { |status| status.define_singleton_method(:stopped?) { true } }
+  end
+
+  def monotonic_time
+    @now
+  end
+
+  def wait_for_next_supervision_poll(*)
+    @waits += 1
+    @now = 1_011.0
+  end
+
+  def refresh_lease?(*, renew_claim:, **)
+    @refreshes << renew_claim
+    true
+  end
+
+  public :supervise_cycle
+end
+
+scope = ReleaseSupervisor::ReleaseScope.new(
+  version: "17.1.0", base_version: "17.1.0", repo: "repo", target: "target", branch: "branch"
+)
+identity = ReleaseSupervisor::Identity.new(
+  agent_id: "agent", instance_id: "instance", machine_id: "machine", managed: true
+)
+supervisor = RepeatedNonTtyStoppedSupervisor.new
+state = ReleaseSupervisor::SupervisionState.new(next_heartbeat: 1_010.0, next_claim_renewal: 1_010.0)
+cycle_arguments = {
+  child_pid: 11,
+  pgid: 12,
+  liveness_writer: nil,
+  terminal_handoff: nil,
+  heartbeat_interval: 60.0,
+  claim_renewal_interval: 120.0,
+  termination_grace: 1.0,
+  coordination_timeout: 1.0
+}
+
+first_result = supervisor.supervise_cycle(scope, identity, state:, **cycle_arguments)
+abort "first stopped cycle changed future deadlines" unless first_result.equal?(state)
+second_result = supervisor.supervise_cycle(scope, identity, state: first_result, **cycle_arguments)
+abort "repeated stopped cycle did not wait" unless supervisor.waits == 1
+abort "due stopped cycle did not refresh heartbeat and claim" unless supervisor.refreshes == [true]
+unless second_result.next_heartbeat == 1_071.0 && second_result.next_claim_renewal == 1_131.0
+  abort "validated stopped-cycle refresh advanced deadlines incorrectly"
+end
+RUBY
+then
+  fail "repeated non-TTY stopped-child cycles bypassed normal supervision"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "repeated non-TTY stopped-child cycles wait and refresh due coordination"
 
 setup_case interactive-confirmation
 export FAKE_BUNDLE_MODE=interactive-confirm

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -83,6 +83,9 @@ setup_case() {
   coordination_descendant_log="${case_dir}/coordination-descendant.log"
   exception_group_log="${case_dir}/exception-group.log"
   exception_liveness_log="${case_dir}/exception-liveness.log"
+  fork_attempt_log="${case_dir}/fork-attempt.log"
+  terminal_pause_file="${case_dir}/terminal-pause"
+  terminal_resume_file="${case_dir}/terminal-resume"
 
   mkdir -p "${fake_bin}" "${fake_repo}"
   cat >"${fake_bin}/pnpm" <<'FAKE_PNPM'
@@ -300,6 +303,14 @@ case "${command_name}" in
     test ! -f "${TEST_HEARTBEAT_COUNT_FILE}" || count="$(cat "${TEST_HEARTBEAT_COUNT_FILE}")"
     count=$((count + 1))
     printf '%s\n' "${count}" >"${TEST_HEARTBEAT_COUNT_FILE}"
+    if test "${FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND:-0}" = 1 && test "${count}" = 1; then
+      : >"${TEST_TERMINAL_PAUSE_FILE}"
+      for _attempt in $(seq 1 500); do
+        test ! -f "${TEST_TERMINAL_RESUME_FILE}" || break
+        sleep 0.01
+      done
+      test -f "${TEST_TERMINAL_RESUME_FILE}" || exit 95
+    fi
     if test -n "${FAKE_STALL_HEARTBEAT_AFTER:-}" && test "${count}" -gt "${FAKE_STALL_HEARTBEAT_AFTER}"; then
       process_group="$(ps -o pgid= -p "$$" | tr -d ' ')"
       printf '%s:%s\n' "$$" "${process_group}" >"${TEST_COORDINATION_PROCESS_LOG}"
@@ -646,21 +657,84 @@ puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
 exit(release_status.exited? ? release_status.exitstatus : 128 + release_status.termsig)
 PTY_HARNESS
 
+  cat >"${fake_bin}/release-terminal-race-harness.rb" <<'TERMINAL_RACE_HARNESS'
+# frozen_string_literal: true
+
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class TerminalRaceSupervisor < ReleaseSupervisor
+  def initialize(argv)
+    super
+    @terminal_reads = 0
+  end
+
+  private
+
+  def terminal_foreground_pgid(*)
+    @terminal_reads += 1
+    @terminal_reads == 1 ? Process.getpgrp : Process.getpgrp + 10_000
+  end
+
+  def fork_release_child(*)
+    File.write(ENV.fetch("TEST_FORK_ATTEMPT_LOG"), "attempted\n")
+    raise SupervisorError, "release child fork attempted after terminal ownership changed"
+  end
+end
+
+exit TerminalRaceSupervisor.new(ARGV).run
+TERMINAL_RACE_HARNESS
+
   cat >"${fake_bin}/release-background-pty-harness.rb" <<'BACKGROUND_PTY_HARNESS'
 # frozen_string_literal: true
 
+require "fiddle"
+
 $stdout.sync = true
+late_background = ENV["FAKE_LATE_BACKGROUND"] == "1"
+launch_reader, launch_writer = IO.pipe if late_background
+tcsetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcsetpgrp"],
+  [Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+set_foreground = lambda do |pgid|
+  previous_handler = Signal.trap("TTOU", "IGNORE")
+  raise "tcsetpgrp failed" unless tcsetpgrp.call($stdin.fileno, pgid).zero?
+ensure
+  Signal.trap("TTOU", previous_handler) if previous_handler
+end
 
 wrapper_pid = fork do
+  launch_writer&.close
   Process.setpgid(0, 0)
+  launch_reader&.read(1)
+  launch_reader&.close
   exec ENV.fetch("TEST_RELEASE_SCRIPT")
 end
+launch_reader&.close
 begin
   Process.setpgid(wrapper_pid, wrapper_pid)
 rescue Errno::EACCES, Errno::ESRCH
   nil
 end
 puts "shell:wrapper:#{wrapper_pid}"
+if late_background
+  set_foreground.call(wrapper_pid)
+  launch_writer.write("x")
+  launch_writer.close
+  pause_deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3.0
+  until File.exist?(ENV.fetch("TEST_TERMINAL_PAUSE_FILE"))
+    if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= pause_deadline
+      Process.kill("KILL", -wrapper_pid)
+      Process.wait(wrapper_pid)
+      raise "release setup did not reach the terminal transition point"
+    end
+    sleep 0.01
+  end
+  set_foreground.call(Process.getpgrp)
+  File.write(ENV.fetch("TEST_TERMINAL_RESUME_FILE"), "resume\n")
+  puts "shell:terminal-backgrounded"
+end
 
 deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2.0
 loop do
@@ -787,6 +861,9 @@ JOB_CONTROL_HARNESS
   export TEST_COORDINATION_DESCENDANT_LOG="${coordination_descendant_log}"
   export TEST_EXCEPTION_GROUP_LOG="${exception_group_log}"
   export TEST_EXCEPTION_LIVENESS_LOG="${exception_liveness_log}"
+  export TEST_FORK_ATTEMPT_LOG="${fork_attempt_log}"
+  export TEST_TERMINAL_PAUSE_FILE="${terminal_pause_file}"
+  export TEST_TERMINAL_RESUME_FILE="${terminal_resume_file}"
   export TEST_RELEASE_SCRIPT="${release_script}"
   export TEST_RELEASE_GUARD="${repo_root}/rakelib/release_lease_guard"
   export TEST_REPO="shakacode/react_on_rails"
@@ -809,6 +886,7 @@ JOB_CONTROL_HARNESS
   unset FAKE_DOCTOR_FAIL FAKE_DOCTOR_BACKEND FAKE_DOCTOR_PAYLOAD
   unset FAKE_BUNDLE_MODE FAKE_BUNDLE_START_DELAY FAKE_HANDSHAKE_MODE FAKE_EXCEPTION_MODE FAKE_RESTORE_FAIL
   unset FAKE_HANDSHAKE_IGNORE_TERM
+  unset FAKE_LATE_BACKGROUND FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND
   unset REACT_ON_RAILS_RELEASE_COORDINATION_TIMEOUT
   unset REACT_ON_RAILS_RELEASE_CLAIM_RENEWAL_INTERVAL
 }
@@ -823,26 +901,58 @@ run_release() {
 run_release_with_noncontrolling_tty() {
   TEST_PTY_REPO="${fake_repo}" "${ruby_executable}" -rpty -e '
     master, slave = PTY.open
-    child_pid = Process.fork do
-      master.close
-      Process.setsid
-      $stdin.reopen(slave)
+    child_pid = nil
+    status = nil
+    exit_code = 124
+    begin
+      child_pid = Process.fork do
+        master.close
+        Process.setsid
+        $stdin.reopen(slave)
+        slave.close unless slave.closed?
+        Dir.chdir(ENV.fetch("TEST_PTY_REPO"))
+        exec ENV.fetch("TEST_RELEASE_SCRIPT")
+      end
+      slave.close
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5.0
+      loop do
+        waited = Process.waitpid2(child_pid, Process::WNOHANG)
+        if waited
+          status = waited.fetch(1)
+          exit_code = status.exited? ? status.exitstatus : 128 + status.termsig
+          break
+        end
+        break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+        sleep 0.01
+      end
+    ensure
       slave.close unless slave.closed?
-      Dir.chdir(ENV.fetch("TEST_PTY_REPO"))
-      exec ENV.fetch("TEST_RELEASE_SCRIPT")
+      unless status || child_pid.nil?
+        begin
+          Process.kill("KILL", child_pid)
+        rescue Errno::ESRCH
+          nil
+        end
+        begin
+          Process.wait(child_pid)
+        rescue Errno::ECHILD
+          nil
+        end
+      end
+      master.close unless master.closed?
     end
-    slave.close
-    _waited_pid, status = Process.waitpid2(child_pid)
-    master.close
-    exit(status.exited? ? status.exitstatus : 128 + status.termsig)
+    exit exit_code
   ' >"${output_log}" 2>&1
 }
 
 run_release_in_pty() {
   pty_input="$1"
-  TEST_PTY_INPUT="${pty_input}" TEST_PTY_REPO="${fake_repo}" TEST_PTY_OUTPUT="${output_log}" \
+  pty_harness="${2:-release-pty-harness.rb}"
+  TEST_PTY_INPUT="${pty_input}" TEST_PTY_HARNESS="${pty_harness}" \
+    TEST_PTY_REPO="${fake_repo}" TEST_PTY_OUTPUT="${output_log}" \
     "${ruby_executable}" -rpty -e '
-    harness = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", "release-pty-harness.rb")
+    harness = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", ENV.fetch("TEST_PTY_HARNESS"))
     reader, writer, child_pid = PTY.spawn(RbConfig.ruby, harness, chdir: ENV.fetch("TEST_PTY_REPO"))
     output = +""
     status = nil
@@ -1586,11 +1696,46 @@ if grep -F 'shell:wrapper-still-running' "${output_log}" >/dev/null; then
 fi
 assert_contains "${output_log}" "shell:wrapper-exited:1"
 assert_contains "${output_log}" "interactive live release must run in the terminal foreground"
-assert_no_coordination_mutation
-assert_not_contains "${coord_log}" $'heartbeat|'
+assert_empty "${coord_log}"
 assert_empty "${bundle_log}"
 assert_secret_absent
 pass "background interactive live release is refused before coordination mutation"
+
+setup_case spawn-time-terminal-ownership-race
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+if run_release_in_pty '' release-terminal-race-harness.rb; then
+  fail "spawn-time terminal ownership race exited successfully"
+fi
+assert_empty "${fork_attempt_log}"
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_empty "${bundle_log}"
+assert_contains "${output_log}" "terminal foreground ownership changed before release child spawn"
+assert_secret_absent
+pass "spawn-time terminal ownership change fails before forking the release child"
+
+setup_case late-background-terminal-transition
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=interactive-confirm
+export FAKE_LATE_BACKGROUND=1
+export FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND=1
+if run_background_release_in_pty; then
+  fail "late-background interactive live release exited successfully"
+fi
+assert_contains "${output_log}" "shell:terminal-backgrounded"
+if grep -F 'shell:wrapper-still-running' "${output_log}" >/dev/null; then
+  assert_contains "${output_log}" "Proceed with release? [y/N]"
+  grep -E '^shell:child-state:T' "${output_log}" >/dev/null || \
+    fail "late-background release child was not stopped on its terminal read"
+  fail "late-background release remained supervised while its child was stopped"
+fi
+assert_contains "${output_log}" "shell:wrapper-exited:1"
+assert_contains "${output_log}" "terminal foreground ownership changed before release child spawn"
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_empty "${bundle_log}"
+assert_secret_absent
+pass "late terminal backgrounding releases the managed claim without forking a child"
 
 setup_case matching-state
 FAKE_BUNDLE_MODE=success run_release || fail "matching live release failed"

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -4,6 +4,7 @@ set -euo pipefail
 
 repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 release_script="${repo_root}/script/release"
+ruby_executable="$(ruby -rrbconfig -e 'puts RbConfig.ruby')"
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/react-on-rails-release-test.XXXXXX")"
 fake_secret="coord-secret-must-never-appear"
 tests_run=0
@@ -397,11 +398,25 @@ case "${FAKE_BUNDLE_MODE:-success}" in
       sleep 0.1
     done
     ;;
+  stopped-hold)
+    trap record_termination TERM INT HUP
+    printf 'stopped:%s\n' "$$" >>"${TEST_BUNDLE_LOG}"
+    kill -STOP "$$"
+    while :; do
+      sleep 0.1
+    done
+    ;;
   guard)
     exec ruby -e '
       require ENV.fetch("TEST_RELEASE_GUARD")
       ReleaseLeaseGuard.activate!(dry_run: false)
     '
+    ;;
+  interactive-confirm)
+    printf 'Proceed with release? [y/N] '
+    IFS= read -r answer || answer=""
+    printf 'confirmation:%s\n' "${answer}" >>"${TEST_BUNDLE_LOG}"
+    test "${answer}" = y
     ;;
   *)
     exit 95
@@ -572,6 +587,22 @@ end
 exit UnverifiedChildTestSupervisor.new([]).run
 UNVERIFIED_CHILD_HARNESS
 
+  cat >"${fake_bin}/release-pty-harness.rb" <<'PTY_HARNESS'
+# frozen_string_literal: true
+
+require "fiddle"
+
+system(ENV.fetch("TEST_RELEASE_SCRIPT"))
+release_status = $?
+tcgetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcgetpgrp"],
+  [Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
+exit(release_status.exited? ? release_status.exitstatus : 128 + release_status.termsig)
+PTY_HARNESS
+
   chmod +x "${fake_bin}/agent-coord" "${fake_bin}/bundle" "${fake_bin}/pnpm" \
     "${fake_bin}/release-handshake-harness" \
     "${fake_bin}/release-exception-harness" "${fake_bin}/release-subreaper-failure-harness" \
@@ -618,6 +649,67 @@ run_release() {
     cd "${fake_repo}"
     "${release_script}" "$@"
   ) >"${output_log}" 2>&1
+}
+
+run_release_in_pty() {
+  pty_input="$1"
+  TEST_PTY_INPUT="${pty_input}" TEST_PTY_REPO="${fake_repo}" TEST_PTY_OUTPUT="${output_log}" \
+    "${ruby_executable}" -rpty -e '
+    harness = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", "release-pty-harness.rb")
+    reader, writer, child_pid = PTY.spawn(RbConfig.ruby, harness, chdir: ENV.fetch("TEST_PTY_REPO"))
+    output = +""
+    status = nil
+    input_sent = false
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 3
+
+    loop do
+      begin
+        output << reader.read_nonblock(4096)
+      rescue IO::WaitReadable
+        nil
+      rescue EOFError, Errno::EIO
+        nil
+      end
+      if !input_sent && output.include?("Proceed with release? [y/N]")
+        writer.write(ENV.fetch("TEST_PTY_INPUT"))
+        writer.flush
+        input_sent = true
+      end
+      waited = Process.waitpid2(child_pid, Process::WNOHANG)
+      if waited
+        status = waited.last
+        break
+      end
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+        bundle_entry = File.readlines(ENV.fetch("TEST_BUNDLE_LOG")).find { |line| line.start_with?("bundle:") }
+        release_pgid = bundle_entry&.split(":", 4)&.fetch(2, nil)&.to_i
+        if release_pgid&.positive? && release_pgid != Process.getpgrp
+          begin
+            Process.kill("KILL", -release_pgid)
+          rescue Errno::ESRCH
+            nil
+          end
+        end
+        Process.kill("KILL", -child_pid)
+        File.binwrite(ENV.fetch("TEST_PTY_OUTPUT"), output)
+        exit! 124
+      end
+      IO.select([reader], nil, nil, 0.05)
+    end
+
+    loop do
+      begin
+        chunk = reader.read_nonblock(4096, exception: false)
+      rescue EOFError, Errno::EIO
+        break
+      end
+      break if chunk.nil? || chunk == :wait_readable
+
+      output << chunk
+    end
+    File.binwrite(ENV.fetch("TEST_PTY_OUTPUT"), output)
+    exit(status.exited? ? status.exitstatus : 128 + status.termsig)
+  '
 }
 
 run_handshake_release() {
@@ -687,6 +779,15 @@ assert_group_dead() {
     kill -KILL -- "-${group_id}" 2>/dev/null || true
     fail "process group ${group_id} survived wrapper shutdown"
   fi
+}
+
+assert_terminal_restored() {
+  terminal_record="$(grep '^terminal:' "${output_log}" | tail -n 1)"
+  supervisor_group="$(printf '%s\n' "${terminal_record}" | cut -d: -f2)"
+  foreground_group="$(printf '%s\n' "${terminal_record}" | cut -d: -f3 | tr -d '\r')"
+  test -n "${supervisor_group}" || fail "PTY harness did not record its process group"
+  test "${foreground_group}" = "${supervisor_group}" || \
+    fail "release wrapper did not restore terminal foreground ownership"
 }
 
 cleanup_stalled_wrapper() {
@@ -1171,6 +1272,48 @@ assert_no_coordination_mutation
 assert_secret_absent
 pass "matching state runs one identity-bound process group"
 
+setup_case interactive-confirmation
+export FAKE_BUNDLE_MODE=interactive-confirm
+if ! run_release_in_pty $'y\n'; then
+  fail "interactive confirmation did not complete through the controlling terminal"
+fi
+assert_contains "${bundle_log}" "confirmation:y"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_no_coordination_mutation
+assert_secret_absent
+pass "interactive confirmation completes in the supervised release process group"
+
+for confirmation_input in $'n\n' $'\n'; do
+  setup_case "declined-confirmation-${tests_run}"
+  export FAKE_BUNDLE_MODE=interactive-confirm
+  if run_release_in_pty "${confirmation_input}"; then
+    fail "declined interactive confirmation completed successfully"
+  fi
+  process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+  assert_group_dead "${process_group}"
+  assert_terminal_restored
+  assert_no_coordination_mutation
+  assert_secret_absent
+  pass "declined or default interactive confirmation remains fail-safe"
+done
+
+setup_case interactive-confirmation-interrupt
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=interactive-confirm
+if run_release_in_pty $'\003'; then
+  fail "interrupt at the interactive confirmation exited successfully"
+fi
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_contains "${output_log}" "process group ${process_group} was proven dead before handoff"
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_secret_absent
+pass "interactive interrupts prove the release group dead and restore the terminal"
+
 setup_case external-identity-ownership-before-heartbeat
 export FAKE_PREFLIGHT_STATUS_MODE=foreign-active
 if run_release; then
@@ -1552,6 +1695,36 @@ assert_contains "${coord_log}" $'release|'
 test "$(tail -n 1 "${coord_log}" | cut -d'|' -f1)" = release || fail "signal cleanup was not last"
 assert_secret_absent
 pass "signals terminate the release group and clean up the process-owned claim"
+
+if supervisor_case_enabled stopped-child; then
+  setup_case stopped-child-signal
+  unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+  export FAKE_BUNDLE_MODE=stopped-hold
+  (
+    cd "${fake_repo}"
+    exec "${release_script}"
+  ) >"${output_log}" 2>&1 &
+  wrapper_pid=$!
+  for _attempt in $(seq 1 100); do
+    grep -q '^stopped:' "${bundle_log}" 2>/dev/null && break
+    sleep 0.05
+  done
+  grep -q '^stopped:' "${bundle_log}" 2>/dev/null || fail "release child never entered stopped state"
+  kill -TERM "${wrapper_pid}"
+  if ! wait_for_process_exit "${wrapper_pid}"; then
+    cleanup_stalled_wrapper "${wrapper_pid}"
+    fail "signal did not clean up the stopped release child"
+  fi
+  wait "${wrapper_pid}" 2>/dev/null || true
+  process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+  assert_group_dead "${process_group}"
+  assert_contains "${bundle_log}" "liveness:eof"
+  assert_contains "${bundle_log}" "termination:signal"
+  assert_contains "${coord_log}" $'release|'
+  assert_contains "${output_log}" "process group ${process_group} was proven dead before handoff"
+  assert_secret_absent
+  pass "signals resume and terminate stopped release descendants before claim cleanup"
+fi
 
 if supervisor_case_enabled death-watch-reader-error; then
   if ! RELEASE_SCRIPT="${release_script}" ruby <<'RUBY'

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -646,6 +646,81 @@ puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
 exit(release_status.exited? ? release_status.exitstatus : 128 + release_status.termsig)
 PTY_HARNESS
 
+  cat >"${fake_bin}/release-background-pty-harness.rb" <<'BACKGROUND_PTY_HARNESS'
+# frozen_string_literal: true
+
+$stdout.sync = true
+
+wrapper_pid = fork do
+  Process.setpgid(0, 0)
+  exec ENV.fetch("TEST_RELEASE_SCRIPT")
+end
+begin
+  Process.setpgid(wrapper_pid, wrapper_pid)
+rescue Errno::EACCES, Errno::ESRCH
+  nil
+end
+puts "shell:wrapper:#{wrapper_pid}"
+
+deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2.0
+loop do
+  waited = Process.waitpid2(wrapper_pid, Process::WNOHANG)
+  if waited
+    status = waited.fetch(1)
+    exit_code = status.exited? ? status.exitstatus : 128 + status.termsig
+    puts "shell:wrapper-exited:#{exit_code}"
+    exit exit_code
+  end
+
+  if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+    bundle_entry = File.readlines(ENV.fetch("TEST_BUNDLE_LOG")).find { |line| line.start_with?("bundle:") }
+    release_pid, release_pgid = bundle_entry&.split(":", 4)&.values_at(1, 2)&.map(&:to_i)
+    release_state = if release_pid&.positive?
+                      IO.popen(["ps", "-o", "stat=", "-p", release_pid.to_s], &:read).strip
+                    end
+    heartbeat_count = File.exist?(ENV.fetch("TEST_HEARTBEAT_COUNT_FILE")) ?
+      File.read(ENV.fetch("TEST_HEARTBEAT_COUNT_FILE")).strip : "0"
+    puts "shell:wrapper-still-running"
+    puts "shell:child-state:#{release_state}"
+    puts "shell:heartbeat-count:#{heartbeat_count}"
+
+    Process.kill("TERM", wrapper_pid)
+    cleanup_deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2.0
+    wrapper_reaped = false
+    loop do
+      cleaned = Process.waitpid2(wrapper_pid, Process::WNOHANG)
+      if cleaned
+        wrapper_reaped = true
+        break
+      end
+      break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= cleanup_deadline
+
+      sleep 0.01
+    end
+    begin
+      Process.kill("KILL", -release_pgid) if release_pgid&.positive?
+    rescue Errno::ESRCH
+      nil
+    end
+    unless wrapper_reaped
+      begin
+        Process.kill("KILL", -wrapper_pid)
+      rescue Errno::ESRCH
+        nil
+      end
+      begin
+        Process.wait(wrapper_pid)
+      rescue Errno::ECHILD
+        nil
+      end
+    end
+    exit 124
+  end
+
+  sleep 0.01
+end
+BACKGROUND_PTY_HARNESS
+
   cat >"${fake_bin}/release-job-control-harness.rb" <<'JOB_CONTROL_HARNESS'
 # frozen_string_literal: true
 
@@ -745,6 +820,24 @@ run_release() {
   ) >"${output_log}" 2>&1
 }
 
+run_release_with_noncontrolling_tty() {
+  TEST_PTY_REPO="${fake_repo}" "${ruby_executable}" -rpty -e '
+    master, slave = PTY.open
+    child_pid = Process.fork do
+      master.close
+      Process.setsid
+      $stdin.reopen(slave)
+      slave.close unless slave.closed?
+      Dir.chdir(ENV.fetch("TEST_PTY_REPO"))
+      exec ENV.fetch("TEST_RELEASE_SCRIPT")
+    end
+    slave.close
+    _waited_pid, status = Process.waitpid2(child_pid)
+    master.close
+    exit(status.exited? ? status.exitstatus : 128 + status.termsig)
+  ' >"${output_log}" 2>&1
+}
+
 run_release_in_pty() {
   pty_input="$1"
   TEST_PTY_INPUT="${pty_input}" TEST_PTY_REPO="${fake_repo}" TEST_PTY_OUTPUT="${output_log}" \
@@ -787,6 +880,64 @@ run_release_in_pty() {
         Process.kill("KILL", -child_pid)
         File.binwrite(ENV.fetch("TEST_PTY_OUTPUT"), output)
         exit! 124
+      end
+      IO.select([reader], nil, nil, 0.05)
+    end
+
+    loop do
+      begin
+        chunk = reader.read_nonblock(4096, exception: false)
+      rescue EOFError, Errno::EIO
+        break
+      end
+      break if chunk.nil? || chunk == :wait_readable
+
+      output << chunk
+    end
+    File.binwrite(ENV.fetch("TEST_PTY_OUTPUT"), output)
+    exit(status.exited? ? status.exitstatus : 128 + status.termsig)
+  '
+}
+
+run_background_release_in_pty() {
+  TEST_PTY_REPO="${fake_repo}" TEST_PTY_OUTPUT="${output_log}" \
+    "${ruby_executable}" -rpty -e '
+    harness = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", "release-background-pty-harness.rb")
+    reader, _writer, child_pid = PTY.spawn(RbConfig.ruby, harness, chdir: ENV.fetch("TEST_PTY_REPO"))
+    output = +""
+    status = nil
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 6
+
+    loop do
+      begin
+        output << reader.read_nonblock(4096)
+      rescue IO::WaitReadable
+        nil
+      rescue EOFError, Errno::EIO
+        nil
+      end
+      waited = Process.waitpid2(child_pid, Process::WNOHANG)
+      if waited
+        status = waited.last
+        break
+      end
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+        process_groups = output.scan(/^shell:wrapper:(\d+)/).flatten.map(&:to_i)
+        bundle_entry = File.readlines(ENV.fetch("TEST_BUNDLE_LOG")).find { |line| line.start_with?("bundle:") }
+        process_groups << bundle_entry&.split(":", 4)&.fetch(2, nil)&.to_i
+        process_groups << child_pid
+        process_groups.compact.select(&:positive?).uniq.each do |process_group|
+          next if process_group == Process.getpgrp
+
+          begin
+            Process.kill("KILL", -process_group)
+          rescue Errno::ESRCH
+            nil
+          end
+        end
+        Process.wait(child_pid)
+        File.binwrite(ENV.fetch("TEST_PTY_OUTPUT"), output)
+        exit! 125
       end
       IO.select([reader], nil, nil, 0.05)
     end
@@ -1419,6 +1570,28 @@ assert_empty "${bundle_log}"
 assert_contains "${output_log}" "release/17.1.0"
 pass "accelerated reconciliation remains release-branch-only"
 
+setup_case background-controlling-terminal
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=interactive-confirm
+if run_background_release_in_pty; then
+  fail "background interactive live release exited successfully"
+fi
+if grep -F 'shell:wrapper-still-running' "${output_log}" >/dev/null; then
+  assert_contains "${output_log}" "Proceed with release? [y/N]"
+  grep -E '^shell:child-state:T' "${output_log}" >/dev/null || \
+    fail "background release child was not stopped on its terminal read"
+  assert_contains "${coord_log}" $'claim-atomic|'
+  assert_contains "${coord_log}" $'heartbeat|'
+  fail "background interactive live release remained supervised while its child was stopped"
+fi
+assert_contains "${output_log}" "shell:wrapper-exited:1"
+assert_contains "${output_log}" "interactive live release must run in the terminal foreground"
+assert_no_coordination_mutation
+assert_not_contains "${coord_log}" $'heartbeat|'
+assert_empty "${bundle_log}"
+assert_secret_absent
+pass "background interactive live release is refused before coordination mutation"
+
 setup_case matching-state
 FAKE_BUNDLE_MODE=success run_release || fail "matching live release failed"
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
@@ -1465,6 +1638,14 @@ fi
 assert_no_coordination_mutation
 assert_secret_absent
 pass "non-controlling TTY safely declines terminal foreground transfer"
+
+setup_case non-controlling-terminal-live-release
+FAKE_BUNDLE_MODE=success run_release_with_noncontrolling_tty || \
+  fail "live release rejected a TTY without a controlling terminal"
+assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
+assert_no_coordination_mutation
+assert_secret_absent
+pass "live release allows a TTY without a controlling terminal"
 
 setup_case job-control-resume-with-pending-signal
 if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -418,6 +418,20 @@ case "${FAKE_BUNDLE_MODE:-success}" in
     printf 'confirmation:%s\n' "${answer}" >>"${TEST_BUNDLE_LOG}"
     test "${answer}" = y
     ;;
+  job-control-confirm)
+    record_continuation() {
+      heartbeat_count="$(cat "${TEST_HEARTBEAT_COUNT_FILE}")"
+      status_count="$(cat "${TEST_STATUS_COUNT_FILE}")"
+      renewal_count="$(grep -c -- '--renew' "${TEST_COORD_LOG}" || true)"
+      printf 'job-control:continued:%s:%s:%s\n' \
+        "${heartbeat_count}" "${status_count}" "${renewal_count}" >>"${TEST_BUNDLE_LOG}"
+    }
+    trap record_continuation CONT
+    printf 'Proceed with release? [y/N] '
+    IFS= read -r answer || answer=""
+    printf 'confirmation:%s\n' "${answer}" >>"${TEST_BUNDLE_LOG}"
+    test "${answer}" = y
+    ;;
   *)
     exit 95
     ;;
@@ -488,6 +502,11 @@ class ExceptionTestSupervisor < ReleaseSupervisor
 
     File.write(ENV.fetch("TEST_EXCEPTION_GROUP_LOG"), "#{pgid}\n")
     raise SupervisorError, "injected failure after process-group handshake"
+  end
+
+  def restore_terminal_foreground(...)
+    super
+    raise SupervisorError, "injected terminal restoration failure" if ENV["FAKE_RESTORE_FAIL"] == "1"
   end
 end
 
@@ -603,6 +622,56 @@ puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
 exit(release_status.exited? ? release_status.exitstatus : 128 + release_status.termsig)
 PTY_HARNESS
 
+  cat >"${fake_bin}/release-job-control-harness.rb" <<'JOB_CONTROL_HARNESS'
+# frozen_string_literal: true
+
+require "fiddle"
+
+$stdout.sync = true
+tcsetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcsetpgrp"],
+  [Fiddle::TYPE_INT, Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+tcgetpgrp = Fiddle::Function.new(
+  Fiddle::Handle::DEFAULT["tcgetpgrp"],
+  [Fiddle::TYPE_INT],
+  Fiddle::TYPE_INT
+)
+set_foreground = lambda do |pgid|
+  previous_handler = Signal.trap("TTOU", "IGNORE")
+  raise "tcsetpgrp failed" unless tcsetpgrp.call($stdin.fileno, pgid).zero?
+ensure
+  Signal.trap("TTOU", previous_handler) if previous_handler
+end
+
+wrapper_pid = fork do
+  Process.setpgid(0, 0)
+  exec ENV.fetch("TEST_RELEASE_SCRIPT")
+end
+begin
+  Process.setpgid(wrapper_pid, wrapper_pid)
+rescue Errno::EACCES, Errno::ESRCH
+  nil
+end
+puts "shell:wrapper:#{wrapper_pid}"
+set_foreground.call(wrapper_pid)
+
+_waited_pid, stopped_status = Process.waitpid2(wrapper_pid, Process::WUNTRACED)
+raise "wrapper did not stop for shell job control" unless stopped_status.stopped?
+
+set_foreground.call(Process.getpgrp)
+puts "shell:wrapper-stopped"
+set_foreground.call(wrapper_pid)
+Process.kill("CONT", -wrapper_pid)
+puts "shell:wrapper-continued"
+
+_waited_pid, release_status = Process.waitpid2(wrapper_pid)
+set_foreground.call(Process.getpgrp)
+puts "terminal:#{Process.getpgrp}:#{tcgetpgrp.call($stdin.fileno)}"
+exit(release_status.exited? ? release_status.exitstatus : 128 + release_status.termsig)
+JOB_CONTROL_HARNESS
+
   chmod +x "${fake_bin}/agent-coord" "${fake_bin}/bundle" "${fake_bin}/pnpm" \
     "${fake_bin}/release-handshake-harness" \
     "${fake_bin}/release-exception-harness" "${fake_bin}/release-subreaper-failure-harness" \
@@ -638,7 +707,7 @@ PTY_HARNESS
   unset FAKE_RELEASE_FAIL FAKE_CLAIM_FAIL FAKE_STALL_CLAIM_AFTER_CREATE FAKE_ATOMIC_CLAIM_MODE
   unset FAKE_ATOMIC_RENEW_MODE
   unset FAKE_DOCTOR_FAIL FAKE_DOCTOR_BACKEND FAKE_DOCTOR_PAYLOAD
-  unset FAKE_BUNDLE_MODE FAKE_BUNDLE_START_DELAY FAKE_HANDSHAKE_MODE FAKE_EXCEPTION_MODE
+  unset FAKE_BUNDLE_MODE FAKE_BUNDLE_START_DELAY FAKE_HANDSHAKE_MODE FAKE_EXCEPTION_MODE FAKE_RESTORE_FAIL
   unset FAKE_HANDSHAKE_IGNORE_TERM
   unset REACT_ON_RAILS_RELEASE_COORDINATION_TIMEOUT
   unset REACT_ON_RAILS_RELEASE_CLAIM_RENEWAL_INTERVAL
@@ -686,6 +755,75 @@ run_release_in_pty() {
         if release_pgid&.positive? && release_pgid != Process.getpgrp
           begin
             Process.kill("KILL", -release_pgid)
+          rescue Errno::ESRCH
+            nil
+          end
+        end
+        Process.kill("KILL", -child_pid)
+        File.binwrite(ENV.fetch("TEST_PTY_OUTPUT"), output)
+        exit! 124
+      end
+      IO.select([reader], nil, nil, 0.05)
+    end
+
+    loop do
+      begin
+        chunk = reader.read_nonblock(4096, exception: false)
+      rescue EOFError, Errno::EIO
+        break
+      end
+      break if chunk.nil? || chunk == :wait_readable
+
+      output << chunk
+    end
+    File.binwrite(ENV.fetch("TEST_PTY_OUTPUT"), output)
+    exit(status.exited? ? status.exitstatus : 128 + status.termsig)
+  '
+}
+
+run_job_control_release_in_pty() {
+  TEST_PTY_REPO="${fake_repo}" TEST_PTY_OUTPUT="${output_log}" \
+    "${ruby_executable}" -rpty -e '
+    harness = File.join(ENV.fetch("TEST_PTY_REPO"), "..", "bin", "release-job-control-harness.rb")
+    reader, writer, child_pid = PTY.spawn(RbConfig.ruby, harness, chdir: ENV.fetch("TEST_PTY_REPO"))
+    output = +""
+    status = nil
+    stop_sent = false
+    confirmation_sent = false
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+
+    loop do
+      begin
+        output << reader.read_nonblock(4096)
+      rescue IO::WaitReadable
+        nil
+      rescue EOFError, Errno::EIO
+        nil
+      end
+      if !stop_sent && output.include?("Proceed with release? [y/N]")
+        writer.write("\x1a")
+        writer.flush
+        stop_sent = true
+      end
+      if !confirmation_sent && output.include?("shell:wrapper-continued")
+        writer.write("y\n")
+        writer.flush
+        confirmation_sent = true
+      end
+      waited = Process.waitpid2(child_pid, Process::WNOHANG)
+      if waited
+        status = waited.last
+        break
+      end
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+        process_groups = output.scan(/^shell:wrapper:(\d+)/).flatten.map(&:to_i)
+        bundle_entry = File.readlines(ENV.fetch("TEST_BUNDLE_LOG")).find { |line| line.start_with?("bundle:") }
+        process_groups << bundle_entry&.split(":", 4)&.fetch(2, nil)&.to_i
+        process_groups.compact.select(&:positive?).uniq.each do |process_group|
+          next if process_group == Process.getpgrp
+
+          begin
+            Process.kill("KILL", -process_group)
           rescue Errno::ESRCH
             nil
           end
@@ -1272,6 +1410,37 @@ assert_no_coordination_mutation
 assert_secret_absent
 pass "matching state runs one identity-bound process group"
 
+setup_case non-controlling-terminal
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+require "fiddle"
+
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class NonControllingTerminalSupervisor < ReleaseSupervisor
+  private
+
+  def terminal_function(*)
+    Object.new.tap do |function|
+      function.define_singleton_method(:call) do |*|
+        Fiddle.last_error = Errno::ENOTTY::Errno
+        -1
+      end
+    end
+  end
+
+  public :terminal_foreground_pgid
+end
+
+supervisor = NonControllingTerminalSupervisor.new([])
+abort "non-controlling TTY was not declined" unless supervisor.terminal_foreground_pgid(0).nil?
+RUBY
+then
+  fail "non-controlling TTY aborted foreground-owner discovery"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "non-controlling TTY safely declines terminal foreground transfer"
+
 setup_case interactive-confirmation
 export FAKE_BUNDLE_MODE=interactive-confirm
 if ! run_release_in_pty $'y\n'; then
@@ -1284,6 +1453,48 @@ assert_terminal_restored
 assert_no_coordination_mutation
 assert_secret_absent
 pass "interactive confirmation completes in the supervised release process group"
+
+setup_case interactive-job-control-stop
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_BUNDLE_MODE=job-control-confirm
+if ! run_job_control_release_in_pty; then
+  fail "Ctrl-Z did not hand terminal control back through the invoking shell"
+fi
+assert_contains "${output_log}" "shell:wrapper-stopped"
+assert_contains "${output_log}" "shell:wrapper-continued"
+assert_contains "${bundle_log}" "confirmation:y"
+continuation_record="$(grep '^job-control:continued:' "${bundle_log}" | tail -n 1)"
+continuation_heartbeats="$(printf '%s\n' "${continuation_record}" | cut -d: -f3)"
+continuation_statuses="$(printf '%s\n' "${continuation_record}" | cut -d: -f4)"
+continuation_renewals="$(printf '%s\n' "${continuation_record}" | cut -d: -f5)"
+test "${continuation_heartbeats}" -ge 2 || fail "release child continued before a fresh heartbeat"
+test "${continuation_statuses}" -ge 3 || fail "release child continued before a fresh authoritative fence"
+test "${continuation_renewals}" -ge 1 || fail "managed release child continued before exact claim renewal"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_secret_absent
+pass "Ctrl-Z returns control to the shell and revalidates fencing before foreground resume"
+
+setup_case interactive-job-control-lost-fence
+export FAKE_BUNDLE_MODE=job-control-confirm
+export FAKE_STATUS_CHANGE_AFTER=2
+export FAKE_STATUS_AFTER_FIRST=released
+export REACT_ON_RAILS_RELEASE_HEARTBEAT_INTERVAL=60
+if run_job_control_release_in_pty; then
+  fail "Ctrl-Z resume continued after the authoritative release fence was lost"
+fi
+assert_contains "${output_log}" "shell:wrapper-stopped"
+assert_contains "${output_log}" "Release lease refresh failed"
+assert_not_contains "${bundle_log}" "confirmation:y"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_no_coordination_mutation
+assert_secret_absent
+pass "Ctrl-Z resume terminates the stopped release group when fresh fencing fails"
 
 for confirmation_input in $'n\n' $'\n'; do
   setup_case "declined-confirmation-${tests_run}"
@@ -1499,6 +1710,37 @@ for exception_mode in after-spawn after-handshake; do
     pass "${exception_mode} supervisor exception terminates the release group"
   fi
 done
+
+if supervisor_case_enabled exception-restore; then
+  setup_case exception-restoration-during-unwind
+  export FAKE_EXCEPTION_MODE=after-spawn
+  export FAKE_RESTORE_FAIL=1
+  export FAKE_BUNDLE_MODE=hold
+  if run_exception_release; then
+    fail "release with nested terminal restoration failure exited successfully"
+  fi
+  process_group="$(cat "${exception_group_log}")"
+  assert_group_dead "${process_group}"
+  assert_contains "${output_log}" "release supervisor process operation failed"
+  assert_not_contains "${output_log}" "injected terminal restoration failure"
+  assert_no_coordination_mutation
+  assert_secret_absent
+  pass "terminal restoration failure does not mask the active release exception"
+
+  setup_case standalone-terminal-restoration-failure
+  export FAKE_EXCEPTION_MODE=restore-only
+  export FAKE_RESTORE_FAIL=1
+  export FAKE_BUNDLE_MODE=success
+  if run_exception_release; then
+    fail "standalone terminal restoration failure exited successfully"
+  fi
+  process_group="$(cat "${exception_group_log}")"
+  assert_group_dead "${process_group}"
+  assert_contains "${output_log}" "injected terminal restoration failure"
+  assert_no_coordination_mutation
+  assert_secret_absent
+  pass "standalone terminal restoration failure remains fail-closed"
+fi
 
 setup_case managed-echild-retains-claim
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -488,23 +488,14 @@ HANDSHAKE_HARNESS
 
 load ENV.fetch("TEST_RELEASE_SCRIPT")
 
-class FailingReleaseOutput
-  def puts(*)
-    raise Errno::EPIPE
-  end
-end
-
 class ExceptionTestSupervisor < ReleaseSupervisor
-  def initialize(argv)
-    stdout = ENV.fetch("FAKE_EXCEPTION_MODE") == "after-spawn" ? FailingReleaseOutput.new : $stdout
-    super(argv, stdout:)
-  end
-
   private
 
   def spawn_release_group(...)
     result = super
     File.write(ENV.fetch("TEST_EXCEPTION_GROUP_LOG"), "#{result.fetch(1)}\n")
+    raise Errno::EPIPE if ENV.fetch("FAKE_EXCEPTION_MODE") == "after-spawn"
+
     result
   end
 
@@ -646,8 +637,14 @@ UNVERIFIED_CHILD_HARNESS
 
 require "fiddle"
 
-system(ENV.fetch("TEST_RELEASE_SCRIPT"))
-release_status = $?
+tostop = ENV["FAKE_TOSTOP"] == "1"
+raise "could not enable TOSTOP" if tostop && !system("stty", "tostop")
+begin
+  system(ENV.fetch("TEST_RELEASE_SCRIPT"))
+  release_status = $?
+ensure
+  raise "could not disable TOSTOP" if tostop && !system("stty", "-tostop")
+end
 tcgetpgrp = Fiddle::Function.new(
   Fiddle::Handle::DEFAULT["tcgetpgrp"],
   [Fiddle::TYPE_INT],
@@ -1149,7 +1146,7 @@ JOB_CONTROL_HARNESS
   unset FAKE_DOCTOR_FAIL FAKE_DOCTOR_BACKEND FAKE_DOCTOR_PAYLOAD
   unset FAKE_BUNDLE_MODE FAKE_BUNDLE_START_DELAY FAKE_HANDSHAKE_MODE FAKE_EXCEPTION_MODE FAKE_RESTORE_FAIL
   unset FAKE_HANDSHAKE_IGNORE_TERM
-  unset FAKE_LATE_BACKGROUND FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND FAKE_TOSTOP
+  unset FAKE_LATE_BACKGROUND FAKE_PAUSE_HEARTBEAT_FOR_BACKGROUND FAKE_TOSTOP TEST_PTY_CONFIRMATION_DELAY
   unset FAKE_SIGNAL_STOPPED_WRAPPER
   unset REACT_ON_RAILS_RELEASE_COORDINATION_TIMEOUT
   unset REACT_ON_RAILS_RELEASE_CLAIM_RENEWAL_INTERVAL
@@ -1241,6 +1238,7 @@ run_release_in_pty() {
         nil
       end
       if !input_sent && output.include?("Proceed with release? [y/N]")
+        sleep Float(ENV.fetch("TEST_PTY_CONFIRMATION_DELAY", "0"))
         writer.write(ENV.fetch("TEST_PTY_INPUT"))
         writer.flush
         input_sent = true
@@ -2495,9 +2493,66 @@ assert_no_coordination_mutation
 assert_secret_absent
 pass "interactive confirmation completes in the supervised release process group"
 
+setup_case interactive-confirmation-tostop
+export FAKE_BUNDLE_MODE=interactive-confirm
+export FAKE_TOSTOP=1
+export TEST_PTY_CONFIRMATION_DELAY=0.3
+if ! run_release_in_pty $'y\n'; then
+  fail "TOSTOP stalled the supervisor while the release process group owned the terminal"
+fi
+assert_contains "${bundle_log}" "confirmation:y"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+started_line="$(grep -n 'Release process group .* started' "${output_log}" | cut -d: -f1)"
+prompt_line="$(grep -n 'Proceed with release? \[y/N\]' "${output_log}" | cut -d: -f1)"
+completed_line="$(grep -n 'Release process group .* completed with status 0' "${output_log}" | cut -d: -f1)"
+terminal_line="$(grep -n '^terminal:' "${output_log}" | cut -d: -f1)"
+test "${started_line}" -lt "${prompt_line}" || fail "release start output followed terminal handoff"
+test "${prompt_line}" -lt "${completed_line}" || fail "release completion output preceded child completion"
+test "${completed_line}" -lt "${terminal_line}" || fail "release completion output followed terminal restoration proof"
+test "$(cat "${heartbeat_count_file}")" -ge 2 || fail "supervisor heartbeat stalled while the child owned the terminal"
+assert_no_coordination_mutation
+assert_secret_absent
+pass "TOSTOP preserves supervision and orders output around terminal handoff"
+
+setup_case declined-confirmation-tostop
+export FAKE_BUNDLE_MODE=interactive-confirm
+export FAKE_TOSTOP=1
+if run_release_in_pty $'n\n'; then
+  fail "declined TOSTOP confirmation exited successfully"
+fi
+assert_contains "${bundle_log}" "confirmation:n"
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_contains "${output_log}" "Release process group ${process_group} completed with status 1"
+assert_no_coordination_mutation
+assert_secret_absent
+pass "TOSTOP restores the terminal before unsuccessful completion output"
+
+setup_case lease-failure-tostop
+export FAKE_BUNDLE_MODE=hold
+export FAKE_TOSTOP=1
+export FAKE_FAIL_HEARTBEAT_AFTER=1
+export REACT_ON_RAILS_RELEASE_HEARTBEAT_INTERVAL=0.5
+if run_release_in_pty ''; then
+  fail "TOSTOP lease failure exited successfully"
+fi
+process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+test -n "${process_group}" || fail "TOSTOP lease-failure case never started the release group"
+assert_group_dead "${process_group}"
+assert_terminal_restored
+assert_contains "${output_log}" "Release lease refresh failed"
+assert_contains "${output_log}" "Release process group ${process_group} was proven dead before handoff"
+assert_no_coordination_mutation
+assert_secret_absent
+pass "TOSTOP restores the terminal before lease-loss cleanup output"
+
 setup_case interactive-job-control-stop
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 export FAKE_BUNDLE_MODE=job-control-confirm
+export FAKE_TOSTOP=1
 if ! run_job_control_release_in_pty; then
   fail "Ctrl-Z did not hand terminal control back through the invoking shell"
 fi
@@ -2522,6 +2577,7 @@ test "${continuation_heartbeats}" -ge 2 || fail "release child continued before 
 test "${continuation_statuses}" -ge 3 || fail "release child continued before a fresh authoritative fence"
 test "${continuation_renewals}" -ge 1 || fail "managed release child continued before exact claim renewal"
 process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
+assert_contains "${output_log}" "Release process group ${process_group} stopped; returning terminal control"
 assert_group_dead "${process_group}"
 assert_terminal_restored
 assert_contains "${coord_log}" $'claim-atomic|'

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -1483,9 +1483,7 @@ class PendingSignalSuspendSupervisor < ReleaseSupervisor
 
   def with_default_tstp_handler
     @suspensions += 1
-    raise "suspension loop re-entered with a pending signal" if @suspensions > 1
-
-    yield
+    raise "pending signal attempted self-stop"
   end
 
   def terminal_foreground_pgid(*)
@@ -1499,7 +1497,7 @@ handoff = ReleaseSupervisor::TerminalHandoff.new(fd: 0, supervisor_pgid: 123, re
 supervisor = PendingSignalSuspendSupervisor.new
 result = supervisor.suspend_for_shell_job_control(handoff)
 abort "pending signal did not interrupt job-control resume" unless result == :interrupted
-abort "pending signal caused repeated suspension" unless supervisor.suspensions == 1
+abort "pending signal attempted self-stop" unless supervisor.suspensions.zero?
 RUBY
 then
   fail "job-control resume spun instead of honoring its pending signal"
@@ -1524,9 +1522,7 @@ class LostTerminalSuspendSupervisor < ReleaseSupervisor
 
   def with_default_tstp_handler
     @suspensions += 1
-    raise "suspension loop re-entered after terminal loss" if @suspensions > 1
-
-    yield
+    raise "lost terminal attempted self-stop"
   end
 
   def terminal_foreground_pgid(*)
@@ -1540,7 +1536,7 @@ handoff = ReleaseSupervisor::TerminalHandoff.new(fd: 0, supervisor_pgid: 123, re
 supervisor = LostTerminalSuspendSupervisor.new
 result = supervisor.suspend_for_shell_job_control(handoff)
 abort "terminal loss did not abort job-control resume" unless result == :terminal_lost
-abort "terminal loss caused repeated suspension" unless supervisor.suspensions == 1
+abort "terminal loss attempted self-stop" unless supervisor.suspensions.zero?
 RUBY
 then
   fail "job-control resume spun after losing its terminal"
@@ -1548,6 +1544,75 @@ fi
 assert_no_coordination_mutation
 assert_secret_absent
 pass "job-control resume returns immediately when its terminal is lost"
+
+setup_case job-control-preflight-avoids-actual-self-stop
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class ActualSuspendSupervisor < ReleaseSupervisor
+  def initialize(received_signal:, foreground_pgid:)
+    super([])
+    @received_signal = received_signal
+    @foreground_pgid = foreground_pgid
+  end
+
+  private
+
+  def terminal_foreground_pgid(*)
+    @foreground_pgid
+  end
+
+  public :suspend_for_shell_job_control
+end
+
+[
+  ["pending signal", "HUP", 123, :interrupted],
+  ["lost terminal", nil, nil, :terminal_lost]
+].each do |description, received_signal, foreground_pgid, expected_result|
+  child_pid = Process.fork do
+    Process.setpgid(0, 0)
+    handoff = ReleaseSupervisor::TerminalHandoff.new(
+      fd: 0, supervisor_pgid: Process.getpgrp, release_pgid: Process.getpgrp + 1
+    )
+    result = ActualSuspendSupervisor.new(
+      received_signal:, foreground_pgid:
+    ).suspend_for_shell_job_control(handoff)
+    exit!(result == expected_result ? 0 : 2)
+  end
+
+  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2.0
+  final_status = nil
+  stopped = false
+  loop do
+    waited = Process.waitpid2(child_pid, Process::WNOHANG | Process::WUNTRACED)
+    if waited
+      child_status = waited.fetch(1)
+      if child_status.stopped?
+        stopped = true
+        Process.kill("CONT", child_pid)
+      else
+        final_status = child_status
+        break
+      end
+    end
+    if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+      Process.kill("KILL", child_pid)
+      Process.wait(child_pid)
+      abort "#{description} preflight probe did not exit"
+    end
+    sleep 0.01
+  end
+
+  abort "#{description} preflight probe self-stopped" if stopped
+  abort "#{description} preflight probe failed" unless final_status.success?
+end
+RUBY
+then
+  fail "job-control preflight allowed an actual self-stop"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "job-control preflight avoids an actual non-orphan self-stop"
 
 setup_case non-tty-stop-preserves-fence-deadlines
 if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -82,6 +82,7 @@ setup_case() {
   coordination_process_log="${case_dir}/coordination-process.log"
   coordination_descendant_log="${case_dir}/coordination-descendant.log"
   exception_group_log="${case_dir}/exception-group.log"
+  exception_liveness_log="${case_dir}/exception-liveness.log"
 
   mkdir -p "${fake_bin}" "${fake_repo}"
   cat >"${fake_bin}/pnpm" <<'FAKE_PNPM'
@@ -508,6 +509,29 @@ class ExceptionTestSupervisor < ReleaseSupervisor
     super
     raise SupervisorError, "injected terminal restoration failure" if ENV["FAKE_RESTORE_FAIL"] == "1"
   end
+
+  def close_release_pipes(pipes)
+    super
+    return unless ENV.fetch("FAKE_EXCEPTION_MODE") == "initial-handoff-failure"
+
+    state = pipes.liveness_writer.closed? ? "closed" : "open"
+    File.write(ENV.fetch("TEST_EXCEPTION_LIVENESS_LOG"), "#{state}\n")
+  end
+
+  def foreground_terminal_owner
+    return super unless ENV.fetch("FAKE_EXCEPTION_MODE") == "initial-handoff-failure"
+
+    TerminalHandoff.new(fd: $stdin.fileno, supervisor_pgid: Process.getpgrp, release_pgid: nil)
+  end
+
+  def hand_off_terminal_foreground(_owner, release_pgid)
+    if ENV.fetch("FAKE_EXCEPTION_MODE") == "initial-handoff-failure"
+      File.write(ENV.fetch("TEST_EXCEPTION_GROUP_LOG"), "#{release_pgid}\n")
+      return nil
+    end
+
+    super
+  end
 end
 
 exit ExceptionTestSupervisor.new(ARGV).run
@@ -687,6 +711,7 @@ JOB_CONTROL_HARNESS
   export TEST_COORDINATION_PROCESS_LOG="${coordination_process_log}"
   export TEST_COORDINATION_DESCENDANT_LOG="${coordination_descendant_log}"
   export TEST_EXCEPTION_GROUP_LOG="${exception_group_log}"
+  export TEST_EXCEPTION_LIVENESS_LOG="${exception_liveness_log}"
   export TEST_RELEASE_SCRIPT="${release_script}"
   export TEST_RELEASE_GUARD="${repo_root}/rakelib/release_lease_guard"
   export TEST_REPO="shakacode/react_on_rails"
@@ -1441,6 +1466,136 @@ assert_no_coordination_mutation
 assert_secret_absent
 pass "non-controlling TTY safely declines terminal foreground transfer"
 
+setup_case job-control-resume-with-pending-signal
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class PendingSignalSuspendSupervisor < ReleaseSupervisor
+  attr_reader :suspensions
+
+  def initialize
+    super([])
+    @received_signal = "HUP"
+    @suspensions = 0
+  end
+
+  private
+
+  def with_default_tstp_handler
+    @suspensions += 1
+    raise "suspension loop re-entered with a pending signal" if @suspensions > 1
+
+    yield
+  end
+
+  def terminal_foreground_pgid(*)
+    nil
+  end
+
+  public :suspend_for_shell_job_control
+end
+
+handoff = ReleaseSupervisor::TerminalHandoff.new(fd: 0, supervisor_pgid: 123, release_pgid: 456)
+supervisor = PendingSignalSuspendSupervisor.new
+result = supervisor.suspend_for_shell_job_control(handoff)
+abort "pending signal did not interrupt job-control resume" unless result == :interrupted
+abort "pending signal caused repeated suspension" unless supervisor.suspensions == 1
+RUBY
+then
+  fail "job-control resume spun instead of honoring its pending signal"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "job-control resume returns immediately when a termination signal is pending"
+
+setup_case job-control-resume-with-lost-terminal
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class LostTerminalSuspendSupervisor < ReleaseSupervisor
+  attr_reader :suspensions
+
+  def initialize
+    super([])
+    @suspensions = 0
+  end
+
+  private
+
+  def with_default_tstp_handler
+    @suspensions += 1
+    raise "suspension loop re-entered after terminal loss" if @suspensions > 1
+
+    yield
+  end
+
+  def terminal_foreground_pgid(*)
+    nil
+  end
+
+  public :suspend_for_shell_job_control
+end
+
+handoff = ReleaseSupervisor::TerminalHandoff.new(fd: 0, supervisor_pgid: 123, release_pgid: 456)
+supervisor = LostTerminalSuspendSupervisor.new
+result = supervisor.suspend_for_shell_job_control(handoff)
+abort "terminal loss did not abort job-control resume" unless result == :terminal_lost
+abort "terminal loss caused repeated suspension" unless supervisor.suspensions == 1
+RUBY
+then
+  fail "job-control resume spun after losing its terminal"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "job-control resume returns immediately when its terminal is lost"
+
+setup_case non-tty-stop-preserves-fence-deadlines
+if ! TEST_RELEASE_SCRIPT="${release_script}" "${ruby_executable}" <<'RUBY'
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class NonTtyStoppedSupervisor < ReleaseSupervisor
+  private
+
+  def nonblocking_child_status(*)
+    Object.new.tap { |status| status.define_singleton_method(:stopped?) { true } }
+  end
+
+  def monotonic_time
+    1_000.0
+  end
+
+  public :supervise_cycle
+end
+
+scope = ReleaseSupervisor::ReleaseScope.new(
+  version: "17.1.0", base_version: "17.1.0", repo: "repo", target: "target", branch: "branch"
+)
+identity = ReleaseSupervisor::Identity.new(
+  agent_id: "agent", instance_id: "instance", machine_id: "machine", managed: true
+)
+state = ReleaseSupervisor::SupervisionState.new(next_heartbeat: 10.0, next_claim_renewal: 20.0)
+result = NonTtyStoppedSupervisor.new([]).supervise_cycle(
+  scope,
+  identity,
+  state:,
+  child_pid: 11,
+  pgid: 12,
+  liveness_writer: nil,
+  terminal_handoff: nil,
+  heartbeat_interval: 60.0,
+  claim_renewal_interval: 120.0,
+  termination_grace: 1.0,
+  coordination_timeout: 1.0
+)
+abort "non-TTY stop changed lease deadlines" unless result.equal?(state)
+RUBY
+then
+  fail "non-TTY stopped child postponed fencing without validation"
+fi
+assert_no_coordination_mutation
+assert_secret_absent
+pass "non-TTY stopped child preserves its existing fence deadlines"
+
 setup_case interactive-confirmation
 export FAKE_BUNDLE_MODE=interactive-confirm
 if ! run_release_in_pty $'y\n'; then
@@ -1710,6 +1865,33 @@ for exception_mode in after-spawn after-handshake; do
     pass "${exception_mode} supervisor exception terminates the release group"
   fi
 done
+
+if supervisor_case_enabled exception-initial-handoff; then
+  setup_case initial-terminal-handoff-failure
+  unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+  export FAKE_EXCEPTION_MODE=initial-handoff-failure
+  export FAKE_BUNDLE_MODE=hold
+  (
+    cd "${fake_repo}"
+    exec "${fake_bin}/release-exception-harness"
+  ) >"${output_log}" 2>&1 &
+  wrapper_pid=$!
+  if ! wait_for_process_exit "${wrapper_pid}"; then
+    cleanup_stalled_wrapper "${wrapper_pid}"
+    fail "failed initial terminal handoff left the release child supervised without a terminal"
+  fi
+  if wait "${wrapper_pid}"; then
+    fail "failed initial terminal handoff exited successfully"
+  fi
+  process_group="$(cat "${exception_group_log}")"
+  assert_group_dead "${process_group}"
+  assert_contains "${exception_liveness_log}" "closed"
+  assert_contains "${coord_log}" $'claim-atomic|'
+  assert_contains "${coord_log}" $'release|'
+  assert_contains "${output_log}" "initial terminal foreground transfer failed"
+  assert_secret_absent
+  pass "failed initial terminal handoff closes liveness and proves the child group dead"
+fi
 
 if supervisor_case_enabled exception-restore; then
   setup_case exception-restoration-during-unwind


### PR DESCRIPTION
## Why

The live release wrapper placed its Rake child in a dedicated background process group while the child still read confirmation from the controlling terminal. Terminal job control could therefore stop the child with `SIGTTIN` after the prompt, leaving the supervisor heartbeating indefinitely. Interrupting that stopped group could also race with cleanup proof.

## What changed

- Hand foreground terminal ownership to the verified release process group only when the wrapper owns the controlling terminal, then restore the prior group safely on every exit path.
- Preserve real shell job control: observe stopped children, return the terminal, stop the whole invoking job, refresh authoritative fencing after `fg`, and resume the release group.
- Refuse unsafe attached live invocations before coordination mutation unless stdin and stdout are the same direct foreground controlling terminal; retain supported headless automation.
- Resume stopped release groups before shutdown signals and prove the group dead before claim cleanup or handoff.
- Prevent `stty tostop`/`SIGTTOU` from stopping supervisor diagnostics while another process group owns the terminal.
- Make the post-spawn exception test seam inject only after the caller owns PID/PGID/pipes, so cleanup is deterministic and leak-free.

Existing release-line fencing, exact claim renewal, heartbeat/death-watch supervision, CI gates, OTP, redaction, recovery, and publication safeguards remain unchanged.

## Release-branch confidence

This is a focused RC release-operator fix limited to `script/release` and `script/release-test.bash`. The original prompt hang, TOSTOP supervisor stalls, and test-seam orphan race were reproduced on the exact release base. No live release, tag, GitHub release, gem push, npm publish, or other artifact publication was performed.

## Verification

- Base RED: PTY reached the confirmation prompt but never consumed `y`; supervisor heartbeats continued until timeout.
- TOSTOP RED: supervisor stopped with `SIGTTOU` while the release group or a foreign shell group owned the terminal.
- Test-seam RED: post-spawn injection reached cleanup without caller-owned PID/PGID/liveness resources.
- Focused final post-spawn cleanup suite: 81/81 on native macOS.
- Full final wrapper suite: 92/92 on native macOS.
- Same full suite in arm64 Linux with a read-only repository mount: 92/92.
- `./script/release --doctor` — PASS, read-only.
- Ruby/Bash syntax, focused RuboCop, `git diff --check`, workflow seam, coordination doctor, secrets/redaction, and helper/container leak checks — PASS.
- Independent QA Evidence v2 — PASS at exact head `e8aed9c5148634ae7ee0ba399856ba736984ebf8`.

## Review coverage

- Independent Codex QA reviewed and exercised the exact final head: PASS, no BLOCKING or DISCUSS items.
- Claude current-head review completed successfully with no new final-head finding.
- CodeRabbit check completed, but its public review path skips the non-default release branch.
- Greptile supplied earlier-head findings that were addressed; no new final-head artifact appeared after the test-only final push.
- Every inline review thread has an explicit disposition and is resolved; unresolved count is zero.

## Changelog

No entry: this changes contributor-only release orchestration, not shipped gem/npm user behavior, and should not appear in public release notes.

## Follow-up

The required `main` forward-port is intentionally outside this focused release-branch PR and must preserve the same exact safety evidence.
