### PR TITLE
Correct find_port_pids app-root claim in the #4937 breaking-change note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,9 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   case), `.print_kill_summary` takes `(status_symbol, blockers_array)` instead of a boolean,
   `.kill_port_processes` only signals listening sockets whose process working directory is inside
   the current app root, and `.find_port_pids` is now restricted to listening sockets (it returns
-  every listener on the port and does **not** filter by app root — attribution happens in the kill
-  path). Fixes [Issue 4846](https://github.com/shakacode/react_on_rails/issues/4846).
+  those listeners other than pid ≤ 1 and the calling process, and does **not** filter by app root —
+  attribution happens in the kill path). Fixes
+  [Issue 4846](https://github.com/shakacode/react_on_rails/issues/4846).
   [PR 4937](https://github.com/shakacode/react_on_rails/pull/4937) by
   [justin808](https://github.com/justin808).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,11 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   `ReactOnRails::Dev::ServerManager` directly: `.development_processes` and `.kill_running_processes`
   are removed, `.kill_processes` now returns a status symbol (and `bin/dev kill` exits non-zero when
   it refuses or cannot verify a shutdown, with `bin/dev clean` refusing to delete bundles in that
-  case), `.print_kill_summary` takes `(status_symbol, blockers_array)` instead of a boolean, and
-  `.kill_port_processes` / `.find_port_pids` only consider listening sockets attributable to the
-  current app root. Fixes [Issue 4846](https://github.com/shakacode/react_on_rails/issues/4846).
+  case), `.print_kill_summary` takes `(status_symbol, blockers_array)` instead of a boolean,
+  `.kill_port_processes` only signals listening sockets whose process working directory is inside
+  the current app root, and `.find_port_pids` is now restricted to listening sockets (it returns
+  every listener on the port and does **not** filter by app root — attribution happens in the kill
+  path). Fixes [Issue 4846](https://github.com/shakacode/react_on_rails/issues/4846).
   [PR 4937](https://github.com/shakacode/react_on_rails/pull/4937) by
   [justin808](https://github.com/justin808).
 


### PR DESCRIPTION
## Why

The `Unreleased` → `Fixed` entry for [PR 4937](https://github.com/shakacode/react_on_rails/pull/4937) made a **breaking API change** claim that does not match the merged code:

> …and `.kill_port_processes` / `.find_port_pids` only consider listening sockets attributable to the current app root.

That is accurate for `.kill_port_processes`. It is **not** accurate for `.find_port_pids`.

This sentence sits inside a "Breaking API changes for anyone calling `ReactOnRails::Dev::ServerManager` directly" paragraph — exactly what an integrator reads before adapting their code. Someone calling `ServerManager.find_port_pids(3000)` on the strength of it would believe the returned pids are pre-filtered to this app root, and could go on to signal every listener on that port including another checkout's. That is the precise harm [#4846](https://github.com/shakacode/react_on_rails/issues/4846) was about.

## What changed

`CHANGELOG.md` only. No code change.

The LISTEN-only narrowing **is** a real behavior change and is kept. Only the app-root-attribution half of the claim is corrected, and the entry now says where attribution actually happens.

```diff
-  `.kill_port_processes` / `.find_port_pids` only consider listening sockets attributable to the
-  current app root.
+  `.kill_port_processes` only signals listening sockets whose process working directory is inside
+  the current app root, and `.find_port_pids` is now restricted to listening sockets (it returns
+  those listeners other than pid ≤ 1 and the calling process, and does **not** filter by app root —
+  attribution happens in the kill path).
```

## Review path

One paragraph in `CHANGELOG.md`, lines ~57–66. The claim it corrects is verifiable from three places in the merged source:

1. **`find_port_pids` does no attribution** — `react_on_rails/lib/react_on_rails/dev/server_manager.rb:327`

   ```ruby
   def find_port_pids(port)
     probe_port_listeners(port).first
   end
   ```

   `probe_port_listeners` runs `lsof -nP -t -iTCP:PORT -sTCP:LISTEN` and rejects only `pid <= 1` and `Process.pid`. It never calls `attribute_pid`.

2. **`kill_port_processes` does** — `server_manager.rb:291` routes through `classify_port_listeners` → `attribute_pid` and signals only the `:owned` bucket.

3. **The existing specs assert the unfiltered behavior** — `react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb:2577` expects `find_port_pids(3000) == [1234, 5678]` with no app-root stubbing anywhere in the example.

`find_port_pids` has no callers in the kill path (only the spec and the RBS signature), so the corrected wording describes a public-API contract, not a live signalling risk in-tree.

Fixes #4945

<details>
<summary>Agent details</summary>

### Provenance

- Canonical launch target: `shakacode/react_on_rails:issue:4945` (`OWNER/REPO:issue:N`). Ad-hoc override: none.
- Issue authored by @justin808 (maintainer, and the requesting user for this batch); zero comments on the issue.
- Security preflight: `SECURITY_PREFLIGHT_OK` — no untrusted or hidden participants, no suspicious text, no changed files.
- Branched from freshly fetched `origin/main` @ `ad93f1b5e0d0085ceba99ab884f391e65bee5df3`.

### Decision log

- **Kept the LISTEN-only clause rather than deleting the whole sentence.** The issue is explicit that the narrowing to LISTEN sockets is a genuine behavior change worth keeping in a breaking-change note; only the attribution claim was false. Deleting both halves would have lost real information for integrators.
- **Adopted the issue's suggested wording nearly verbatim,** adjusted only for the file's ~100-char manual wrap. It already names where attribution does happen ("attribution happens in the kill path"), which is the fact a reader needs next.
- **Did not touch the source, the RBS signature, or the specs.** The code is correct as merged; the CHANGELOG was the only thing that misdescribed it. Changing `find_port_pids` to filter by app root would be a real breaking change to a public method with no in-tree caller demanding it — out of scope for a documentation defect, and not what the issue asks for.
- **Ran `pnpm install --frozen-lockfile` in the lane worktree.** The fresh worktree had an empty `node_modules/.bin`, so the lefthook `prettier` step failed with `Command "prettier" not found`. Installing deps was the root-cause fix; the commit was not made with `--no-verify`.

### Validation

- `npx prettier --check CHANGELOG.md` → clean
- `pnpm start format.listDifferent` (`prettier --check .`, whole repo) → "All matched files use Prettier code style!"
- lefthook pre-commit, all steps green: `trailing-newlines` ✔️, `markdown-links` (lychee offline, 8 OK / 0 errors) ✔️, `prettier` ✔️
- Ruby lint and test suites not run: no Ruby, JS, or config file is touched by this diff.

### Merge authority

`auto_merge_when_gates_pass`, per the batch instruction.

### Decision log (continued)

- **Took the Codex P2 thread as a fix, not a defer** (`c1a090ba0`). Codex correctly noted that `probe_port_listeners` rejects `pid <= 1` and the calling process (`server_manager.rb:346`), so the first draft's "every listener on the port" was itself an overstatement — in the exact sentence this PR exists to make precise. Fixed, replied in-thread, thread resolved.
- **Declined two `claude-review` nits as non-blocking, no push.** (a) "Split the dense parenthetical into two sentences" — style only; the current form is accurate and matches the entry's existing register. (b) "Use `<=` instead of `≤` for file consistency" — verified the premise is neutral: `≤` occurs 1× (this line) and `<=` occurs 0× in `CHANGELOG.md`, so there is no existing convention to match in either direction, and the reviewer called it purely cosmetic. Per the repo's review-loop convergence guidance, pushes are reserved for confirmed blockers.

### Merge qualification

- **Release phase: `beta`.** Target branch is `main`. `agent-coord doctor --json` reports `status: ok`, and `agent-coord status --repo shakacode/react_on_rails --target 4949 --json` exits 0 with no published phase entry for this line, so per `AGENTS.md` → *Reading the phase* the phase is derived from the target branch (`main` → `beta`). No published-phase/tracker conflict.
- **Release mode: `strict-rc`,** from the `Agent Release Mode` block of the single active tracker [#4842](https://github.com/shakacode/react_on_rails/issues/4842) (`Release gate: react_on_rails 17.1.0`). Per `AGENTS.md`, `strict-rc` applies the standard merge qualification; the accelerated-RC confidence block, independent finalizer, and 8/10 threshold do not apply.
- **Gate applied (beta row): confidence note + green required checks — satisfied.**
- **Standard merge qualification (`AGENTS.md`:765) — satisfied.** CI passing; all current review comments and threads addressed or explicitly triaged by tier; no question needing maintainer attention.
- `Labels: none` — docs-only change, so the `AGENTS.md` default (required gate + local validation, no CI expansion) applies. `Benchmarks: not applicable` — prose only, no runtime surface.

### Confidence note

- **Validated commands**: `npx prettier --check CHANGELOG.md` → clean; `pnpm start format.listDifferent` (`prettier --check .`, whole repo) → all files clean; lefthook pre-commit green on both commits (`trailing-newlines`, `markdown-links` lychee 8 OK / 0 errors, `prettier`).
- **Exact-head CI evidence**: `pr-ci-readiness` v2 → `verdict: READY` at head `c1a090ba0c141fd56b6629936267ebaf609ed2e5`; `required-pr-gate` SUCCESS; full `gh pr checks` list has zero non-green rows; `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`.
- **Independent review at current head**: `claude-review` check SUCCESS with a written review that independently re-derived the same source facts; CodeRabbit APPROVED with no actionable comments; Greptile 5/5; Codex review completed. Zero unresolved review threads (GraphQL, immediately before merge).
- **Remaining `UNKNOWN` facts**: none affecting merge safety. Ruby and JS test suites were correctly skipped by `script/ci-changes-detector` because no Ruby, JS, or config file is touched.
- **Residual risk**: negligible. Prose-only edit to one `CHANGELOG.md` paragraph; no code, no public API, no build or release surface changed. Worst case is another prose correction.

### Coordination

`coordination: unavailable — deliberately uncoordinated single-operator inline lane; the backend is healthy but no batch was registered at launch and no claim was held for target 4949.`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified development server port-management behavior.
  - Documented that port discovery excludes the system init process and the calling process.
  - Clarified that port discovery reports all listening processes on the specified port without application-root filtering.
  - Documented that process termination remains limited to listeners associated with the current application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
