### PR TITLE
Stamp CHANGELOG for 17.1.0.rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.1.0.rc.1] - 2026-08-28
+
 #### Fixed
 
 - **Fresh generated apps now preserve their resolved Shakapacker version**: The installer now pins
@@ -3198,7 +3200,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.0...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.1...main
+[17.1.0.rc.1]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.0...v17.1.0.rc.1
 [17.1.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v17.0.1...v17.1.0.rc.0
 [17.0.1]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...v17.0.1
 [17.0.0]: https://github.com/shakacode/react_on_rails/compare/v16.6.0...v17.0.0


### PR DESCRIPTION
## Why

PR #4950 fixes the fresh generated-app development-server proxy regression found by the 17.1.0 RC0 fleet. The fix is now on `release/17.1.0`, so the next candidate needs a dedicated changelog stamp before publication and downstream fleet validation.

## What changed

- Moves the existing Shakapacker 10.3.1/generated-app fix entry from `Unreleased` into `17.1.0.rc.1`.
- Advances the `Unreleased` compare link to `v17.1.0.rc.1...main`.
- Adds the `v17.1.0.rc.0...v17.1.0.rc.1` compare link.
- Leaves all React on Rails gem/npm version fields untouched; the supervised release task owns those generated updates.

## Classification and scope

`changelog-merged-prs v17.1.0.rc.0..origin/release/17.1.0` found exactly one post-RC0 PR: #4950. Its user-visible fix entry was already retained under `Unreleased`, so this PR only stamps that reviewed entry.

## Validation

- `bundle exec rake "update_changelog[rc]"` — selected `17.1.0.rc.1`.
- RC1 header, non-empty section, empty `Unreleased`, and both compare-link invariants — passed.
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/update_changelog_rake_helpers_spec.rb)` — 33 examples, 0 failures.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` — 249 files, 0 offenses.
- `pnpm run lint` — passed.
- `pnpm start format.listDifferent` — passed.
- `git diff --check` — passed.
- Pre-commit offline Markdown links and Prettier — passed.
- Pre-push online Markdown links and branch RuboCop — passed.

## CI and benchmark decision

- Hosted CI: release-target checks should run automatically; no manual force-full request yet.
- Benchmarks: not applicable to a deterministic `CHANGELOG.md`-only stamp.

## Churn notes

- Pre-push review gate: manual self-review; additional AI review/simplify skipped because this is deterministic five-line changelog-task output with explicit invariant checks.
- Post-push review churn: zero so far.

After this merges, the release coordinator will run the repository-owned `script/release` wrapper to publish `17.1.0.rc.1`, then generate a fresh downstream fleet-validation prompt against the immutable RC1 artifacts.
