### PR TITLE
Fix locale-dependent contributor tooling

### DIFF
--- a/bin/check-links
+++ b/bin/check-links
@@ -33,9 +33,13 @@ fi
 # Expand the same globs as CI, then byte-sort them so caller locale does not
 # change lychee's argument order.
 markdown_files=()
-sorted_markdown_files=$(printf '%s\n' *.md react_on_rails_pro/*.md | LC_ALL=C sort) || exit $?
-while IFS= read -r file; do
+sorted_markdown_files_file=$(mktemp)
+trap 'rm -f "$sorted_markdown_files_file"' EXIT
+printf '%s\0' *.md react_on_rails_pro/*.md | LC_ALL=C sort -z > "$sorted_markdown_files_file" || exit $?
+while IFS= read -r -d '' file; do
   markdown_files+=("$file")
-done <<< "$sorted_markdown_files"
+done < "$sorted_markdown_files_file"
+rm -f "$sorted_markdown_files_file"
+trap - EXIT
 
 exec lychee --config .lychee.toml docs/ "${markdown_files[@]}"

--- a/bin/check-links
+++ b/bin/check-links
@@ -30,6 +30,11 @@ if ! command -v lychee &> /dev/null; then
 fi
 
 # shellcheck disable=SC2035
-# Word-split the globs so *.md and react_on_rails_pro/*.md expand, matching
-# the workflow's `args: --config .lychee.toml docs/ *.md react_on_rails_pro/*.md`.
-exec lychee --config .lychee.toml docs/ *.md react_on_rails_pro/*.md
+# Expand the same globs as CI, then byte-sort them so caller locale does not
+# change lychee's argument order.
+markdown_files=()
+while IFS= read -r file; do
+  markdown_files+=("$file")
+done < <(printf '%s\n' *.md react_on_rails_pro/*.md | LC_ALL=C sort)
+
+exec lychee --config .lychee.toml docs/ "${markdown_files[@]}"

--- a/bin/check-links
+++ b/bin/check-links
@@ -33,8 +33,9 @@ fi
 # Expand the same globs as CI, then byte-sort them so caller locale does not
 # change lychee's argument order.
 markdown_files=()
+sorted_markdown_files=$(printf '%s\n' *.md react_on_rails_pro/*.md | LC_ALL=C sort) || exit $?
 while IFS= read -r file; do
   markdown_files+=("$file")
-done < <(printf '%s\n' *.md react_on_rails_pro/*.md | LC_ALL=C sort)
+done <<< "$sorted_markdown_files"
 
 exec lychee --config .lychee.toml docs/ "${markdown_files[@]}"

--- a/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
@@ -6,35 +6,75 @@ require "tmpdir"
 require_relative "spec_helper"
 
 RSpec.describe "bin/check-links" do
+  utf8_collation_locale = "en_US.UTF-8"
+
   let(:repo_root) { File.expand_path("../../..", __dir__) }
   let(:script_path) { File.join(repo_root, "bin/check-links") }
 
   it "invokes lychee with deterministically ordered CI inputs under UTF-8 collation" do
     Dir.mktmpdir do |tmpdir|
+      write_controlled_markdown_files(tmpdir)
       args_file = File.join(tmpdir, "lychee.args")
-      lychee_stub = File.join(tmpdir, "lychee")
-      File.write(
-        lychee_stub,
+      write_executable(
+        File.join(tmpdir, "lychee"),
         <<~BASH
-          #!/usr/bin/env bash
           printf '%s\\n' "$@" > "$LYCHEE_ARGS_FILE"
         BASH
       )
-      FileUtils.chmod("+x", lychee_stub)
+
+      c_order, c_stderr, c_status = markdown_glob_order(tmpdir, "C")
+      utf8_order, utf8_stderr, utf8_status = markdown_glob_order(tmpdir, utf8_collation_locale)
+
+      expect(c_status).to be_success, c_stderr
+      expect(c_order).to eq(["AGENTS.md", "AGENTS_USER_GUIDE.md"])
+      expect(utf8_status).to be_success, utf8_stderr
+      expect(utf8_stderr).to be_empty
+      expect(utf8_order).to eq(["AGENTS_USER_GUIDE.md", "AGENTS.md"])
 
       _stdout, stderr, status = Open3.capture3(
         {
-          "LANG" => "en_US.UTF-8",
-          "LC_ALL" => "en_US.UTF-8",
+          "LANG" => utf8_collation_locale,
+          "LC_ALL" => utf8_collation_locale,
           "LYCHEE_ARGS_FILE" => args_file,
           "PATH" => "#{tmpdir}:#{ENV.fetch('PATH')}"
         },
         script_path,
-        chdir: repo_root
+        chdir: tmpdir
       )
 
       expect(status).to be_success, stderr
-      expect(File.read(args_file).lines.map(&:chomp)).to eq(expected_lychee_args)
+      expect(File.read(args_file).lines.map(&:chomp)).to eq(
+        [
+          "--config",
+          ".lychee.toml",
+          "docs/",
+          "AGENTS.md",
+          "AGENTS_USER_GUIDE.md",
+          "react_on_rails_pro/README.md"
+        ]
+      )
+    end
+  end
+
+  it "does not invoke lychee when sorting the expanded inputs fails" do
+    Dir.mktmpdir do |tmpdir|
+      write_controlled_markdown_files(tmpdir)
+      lychee_invocation = File.join(tmpdir, "lychee.invoked")
+      write_executable(File.join(tmpdir, "sort"), "exit 42\n")
+      write_executable(File.join(tmpdir, "lychee"), "touch \"$LYCHEE_INVOCATION\"\n")
+
+      _stdout, stderr, status = Open3.capture3(
+        {
+          "LC_ALL" => "C",
+          "LYCHEE_INVOCATION" => lychee_invocation,
+          "PATH" => "#{tmpdir}:#{ENV.fetch('PATH')}"
+        },
+        script_path,
+        chdir: tmpdir
+      )
+
+      expect(status.exitstatus).to eq(42), stderr
+      expect(File).not_to exist(lychee_invocation)
     end
   end
 
@@ -47,9 +87,26 @@ RSpec.describe "bin/check-links" do
     expect(executable_lines).not_to include("--files-from")
   end
 
-  def expected_lychee_args
-    Dir.chdir(repo_root) do
-      ["--config", ".lychee.toml", "docs/"] + Dir["*.md"] + Dir["react_on_rails_pro/*.md"]
-    end
+  def write_controlled_markdown_files(directory)
+    File.write(File.join(directory, "AGENTS.md"), "")
+    File.write(File.join(directory, "AGENTS_USER_GUIDE.md"), "")
+    FileUtils.mkdir_p(File.join(directory, "react_on_rails_pro"))
+    File.write(File.join(directory, "react_on_rails_pro", "README.md"), "")
+  end
+
+  def write_executable(path, body)
+    File.write(path, "#!/usr/bin/env bash\n#{body}")
+    FileUtils.chmod("+x", path)
+  end
+
+  def markdown_glob_order(directory, locale)
+    stdout, stderr, status = Open3.capture3(
+      { "LANG" => locale, "LC_ALL" => locale },
+      "bash",
+      "-c",
+      "printf '%s\\n' *.md",
+      chdir: directory
+    )
+    [stdout.lines.map(&:chomp), stderr, status]
   end
 end

--- a/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
@@ -78,6 +78,44 @@ RSpec.describe "bin/check-links" do
     end
   end
 
+  it "passes a newline-bearing Markdown filename to lychee as one argument" do
+    Dir.mktmpdir do |tmpdir|
+      write_controlled_markdown_files(tmpdir)
+      newline_filename = "release\nnotes.md"
+      File.write(File.join(tmpdir, newline_filename), "")
+      args_file = File.join(tmpdir, "lychee.args")
+      write_executable(
+        File.join(tmpdir, "lychee"),
+        <<~'BASH'
+          printf '%s\0' "$@" > "$LYCHEE_ARGS_FILE"
+        BASH
+      )
+
+      _stdout, stderr, status = Open3.capture3(
+        {
+          "LC_ALL" => "C",
+          "LYCHEE_ARGS_FILE" => args_file,
+          "PATH" => "#{tmpdir}:#{ENV.fetch('PATH')}"
+        },
+        script_path,
+        chdir: tmpdir
+      )
+
+      expect(status).to be_success, stderr
+      expect(File.binread(args_file).split("\0")).to eq(
+        [
+          "--config",
+          ".lychee.toml",
+          "docs/",
+          "AGENTS.md",
+          "AGENTS_USER_GUIDE.md",
+          "react_on_rails_pro/README.md",
+          newline_filename
+        ]
+      )
+    end
+  end
+
   it "keeps the lychee invocation documented once" do
     script_content = File.read(script_path)
     executable_lines = script_content.lines.grep_v(/\A\s*(#|$)/).join

--- a/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
@@ -27,9 +27,13 @@ RSpec.describe "bin/check-links" do
 
       expect(c_status).to be_success, c_stderr
       expect(c_order).to eq(["AGENTS.md", "AGENTS_USER_GUIDE.md"])
-      expect(utf8_status).to be_success, utf8_stderr
-      expect(utf8_stderr).to be_empty
-      expect(utf8_order).to eq(["AGENTS_USER_GUIDE.md", "AGENTS.md"])
+      expected_utf8_order = ["AGENTS_USER_GUIDE.md", "AGENTS.md"]
+      unless utf8_status.success? && utf8_stderr.empty? && utf8_order == expected_utf8_order
+        skip(
+          "#{utf8_collation_locale} is unavailable or does not provide the expected collation " \
+          "for the controlled Markdown filenames"
+        )
+      end
 
       _stdout, stderr, status = Open3.capture3(
         {

--- a/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "bin/check-links" do
   let(:repo_root) { File.expand_path("../../..", __dir__) }
   let(:script_path) { File.join(repo_root, "bin/check-links") }
 
-  it "invokes lychee with the same inputs as the markdown link CI workflow" do
+  it "invokes lychee with deterministically ordered CI inputs under UTF-8 collation" do
     Dir.mktmpdir do |tmpdir|
       args_file = File.join(tmpdir, "lychee.args")
       lychee_stub = File.join(tmpdir, "lychee")
@@ -24,6 +24,8 @@ RSpec.describe "bin/check-links" do
 
       _stdout, stderr, status = Open3.capture3(
         {
+          "LANG" => "en_US.UTF-8",
+          "LC_ALL" => "en_US.UTF-8",
           "LYCHEE_ARGS_FILE" => args_file,
           "PATH" => "#{tmpdir}:#{ENV.fetch('PATH')}"
         },
@@ -40,7 +42,7 @@ RSpec.describe "bin/check-links" do
     script_content = File.read(script_path)
     executable_lines = script_content.lines.grep_v(/\A\s*(#|$)/).join
 
-    expect(script_content.scan(/^# Word-split the globs/).size).to eq(1)
+    expect(script_content.scan(/^# Expand the same globs/).size).to eq(1)
     expect(script_content.scan(/^exec lychee /).size).to eq(1)
     expect(executable_lines).not_to include("--files-from")
   end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe "script/release-forward-port" do
     git(repo, "rev-parse", "HEAD").strip
   end
 
-  def run_script(repo, *args)
-    Open3.capture3(git_env, RbConfig.ruby, script_path, *args, chdir: repo)
+  def run_script(repo, *args, env: {})
+    Open3.capture3(git_env.merge(env), RbConfig.ruby, script_path, *args, chdir: repo)
   end
 
   def run_script_from_repo_root(*args)
@@ -2143,8 +2143,15 @@ RSpec.describe "script/release-forward-port" do
       release_fix_sha = git(repo, "rev-parse", "HEAD").strip
       git(repo, "checkout", "main")
 
-      stdout, stderr, status =
-        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+      stdout, stderr, status = run_script(
+        repo,
+        "--source",
+        "release/1.0.1",
+        "--target",
+        "main",
+        "--dry-run",
+        env: { "LANG" => "C", "LC_ALL" => "C", "RUBYOPT" => "-EUS-ASCII" }
+      )
 
       expect(status).to be_success, stderr
       expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix separate release regression (#900)")

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1895,7 +1895,7 @@ class ReleaseForwardPort
     stdout, stderr, status = capture_git(*args)
     raise GitError, git_error(args, stdout, stderr, status) unless status.success?
 
-    stdout
+    stdout.force_encoding(Encoding::UTF_8)
   end
 
   def capture_git(*, stdin_data: "")

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1697,12 +1697,7 @@ class ReleaseForwardPort
   end
 
   def changelog_at(ref, label:)
-    # CHANGELOG.md is authored as UTF-8 (it contains characters like the ⚠️
-    # breaking-change marker). Open3 tags git's stdout with the process external
-    # encoding, which is US-ASCII under a C/POSIX-locale CI runner; matching a
-    # regex against those bytes then raises "invalid byte sequence in US-ASCII".
-    # Re-tag the bytes as UTF-8 so parsing is locale-independent.
-    git("show", "#{ref}:#{CHANGELOG_FILE}").dup.force_encoding(Encoding::UTF_8)
+    git("show", "#{ref}:#{CHANGELOG_FILE}")
   rescue GitError => e
     raise GitError, "unable to read #{CHANGELOG_FILE} at #{label} ref #{ref.inspect}: #{e.message}"
   end


### PR DESCRIPTION
## Why

Two focused gem specs depended on the caller's locale: release-forward-port could crash while parsing non-ASCII Git text under US-ASCII, while check-links could assert a different glob order under UTF-8. Together they left no locale in which the affected suite was reliably green.

Fixes #4941.

## What changed

- Normalize successful Git command output to UTF-8 at the release-forward-port script's shared text boundary.
- Expand check-links inputs once, NUL-sort them under `LC_ALL=C`, propagate sorter failures, and pass the resulting paths to lychee without losing newline-bearing filenames.
- Add regressions that reproduce the US-ASCII crash, prove locale-sensitive collation, verify deterministic ordering and arbitrary filename preservation, and ensure sorting fails closed.

## How to review and verify

1. Review `script/release-forward-port` and its focused spec together; the encoding change is intentionally at the shared Git-output boundary.
2. Review `bin/check-links` and its spec together; the input set stays the same, but ordering is explicit and sorter failure prevents lychee from running.
3. Replay both spec files under C/US-ASCII and UTF-8; the exact-head implementation replay reports 145 examples and 0 failures in each environment, and independent final-head review passed.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation — no user-facing workflow or API changed~
- [x] ~Update CHANGELOG file — contributor/release tooling determinism is not user-visible product behavior~

### Other Information

- Hosted CI: the CI detector selects the broad hosted suite for the changed release/tooling paths; a final-head run will be requested after the exact-head review wave is ready.
- Benchmarks: not applicable; no performance-sensitive runtime path changed.
- Process gap disposition: `script`. The fix and dual-locale replay mechanize the observed locale-dependent failure; broad repo-wide locale policy is a non-goal.

<details>
<summary>Agent details</summary>

### Commands and results

- `env LANG=C LC_ALL=C RUBYOPT=-EUS-ASCII bundle exec rspec spec/react_on_rails/release_forward_port_script_spec.rb spec/react_on_rails/check_links_script_spec.rb` — 145 examples, 0 failures.
- `env LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 RUBYOPT=-EUTF-8 bundle exec rspec spec/react_on_rails/release_forward_port_script_spec.rb spec/react_on_rails/check_links_script_spec.rb` — 145 examples, 0 failures.
- `shellcheck bin/check-links && bash -n bin/check-links && ruby -c script/release-forward-port` — passed.
- `git diff --check origin/main..HEAD` — passed.
- Full OSS RuboCop, package rake lint, pnpm lint, and focused Prettier checks — passed before the final commit.
- `script/ci-changes-detector origin/main` — selected lint, Ruby/JS tests, dummy/generator/E2E suites, release supervisor, and Pro suites; hosted CI requested after push.
- Local Claude `/code-review` — timed out after five minutes with no output or tracked changes.
- Local Claude `/simplify origin/main` — timed out after two and a half minutes with no output or tracked changes.

### Exact-head and replay evidence

- Base: `fde11341aa6d3883297cbb90b2ed02cddd233088`.
- Head: `268e53965048f6c82ef22c71b4b1e9061274aa29`.
- Scope: exactly `bin/check-links`, `script/release-forward-port`, and their two focused specs.
- `closeout-evidence-replay --expected-head-sha 268e53965048f6c82ef22c71b4b1e9061274aa29 --require-priority-dispositions` — replayed before merge submission.

### QA Evidence

- QA lane: `checker-ror-4941-20260828`; read-only full replay at `c5b4423a8`, followed by independent final-delta and whole-branch reviews at `268e53965`.
- Scope checked: The four changed tooling/spec paths for issue #4941 at the exact reviewed head.
- Tested at: repository head `268e53965048f6c82ef22c71b4b1e9061274aa29`.
- Automated checks: Both affected RSpec files under C/US-ASCII and UTF-8 (145 examples, 0 failures in each environment); `shellcheck bin/check-links`; `bash -n bin/check-links`; `ruby -c script/release-forward-port`; `git diff --check`.
- Manual checks: Not applicable; the real scripts are exercised by the focused regression suites.
- User-visible UI change: no.
- Visual evidence: Not applicable; no user-visible UI changed.
- Interaction change: no.
- Interaction evidence: Not applicable; no interaction behavior changed.
- Visual fix: no.
- Negative control: Not applicable; no visual fix.
- Performance evidence: Not applicable; no rendered-page, asset, bundle, or runtime-performance path changed.
- Findings: none.
- QA required: yes.
- QA required rationale: Release/contributor tooling behavior changed and both locale-dependent failures required exact-head replay.
- QA lane status: satisfied.
- Release-blocking status: clear.
- Process-gap disposition: script.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 268e53965048f6c82ef22c71b4b1e9061274aa29
tested_at: repository head 268e53965048f6c82ef22c71b4b1e9061274aa29
scope: issue 4941 release-forward-port and check-links tooling plus focused regression specs
automated_checks: dual-locale focused RSpec suites, shellcheck, bash syntax, and git diff check passed
manual_checks: not applicable: real scripts are exercised by focused regression suites
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no rendered UI target
interaction_change: no
interaction_evidence: not applicable: no interaction behavior changed
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: no rendered-page, asset, bundle, or runtime-performance impact
findings: none
release_blocking: clear
process_gap_disposition: script
-->

<!-- priority-finding-dispositions v1
head_sha: 268e53965048f6c82ef22c71b4b1e9061274aa29
finding: url=https://github.com/shakacode/react_on_rails/pull/4953#discussion_r3885881855 | severity=P2 | disposition=fixed | evidence=commit 268e53965 makes the locale regression conditional on an available distinct UTF-8 locale while retaining the real-locale assertion
finding: url=https://github.com/shakacode/react_on_rails/pull/4953#discussion_r3885882237 | severity=P2 | disposition=fixed | evidence=commit 268e53965 resolves the duplicate locale-portability finding
finding: url=https://github.com/shakacode/react_on_rails/pull/4953#discussion_r3885886547 | severity=Must-Fix | disposition=fixed | evidence=commit c5b4423a8 uses NUL-delimited sorting and adds an LF-bearing pathname regression
finding: url=https://github.com/shakacode/react_on_rails/pull/4953#discussion_r3885988758 | severity=P2 | disposition=false_positive | evidence=verified stock macOS /usr/bin/sort 2.3-Apple supports and documents -z; NUL-sort probe exits 0
-->

### Coordination and reviewer telemetry

- Batch: `ror-4941-20260828-194114`; canonical target `shakacode/react_on_rails:issue:4941`.
- Claim holder: `maker-lane-4941-locale-determinism`; branch `fix/issue-4941-locale-determinism`; coordination heartbeats remained live through implementation, review, and QA.
- Reviews: independent task review and hosted reviewers found locale portability, fail-closed sorting, and newline-path issues; the original implementer fixed all confirmed findings. Final-head independent review is in progress.
- Independent QA: `checker-ror-4941-20260828`, distinct from the maker, passed the full dual-locale suite at `c5b4423a8`; the final two-file delta and whole branch then received independent PASS verdicts at `268e53965`, while the full dual-locale suite was replayed at that exact head.
- Review findings addressed before the final wave: two duplicate locale-portability P2 findings, one newline-path Must-Fix finding, and one optional redundant-encoding cleanup. The final-wave macOS `sort -z` finding was disproved on stock Apple `sort 2.3`; an optional explanatory-comment nit was declined after final-candidate debounce.
- Human decision points: 0.

### Decision log

- **Non-blocking:** Where to normalize release-forward-port output encoding.
  - **Decision:** Normalize successful Git stdout in the shared wrapper before text parsing.
  - **Why:** This covers every text-parsing caller while binary patch paths retain byte semantics.
  - **Review later:** None.
- **Non-blocking:** How to preserve newline-bearing Markdown filenames while sorting deterministically.
  - **Decision:** Use a temporary NUL-delimited stream with `sort -z` and a NUL-aware Bash read loop.
  - **Why:** This preserves Git-valid filenames, keeps sorter failures visible, and avoids newline serialization ambiguity.
  - **Review later:** None.
- **Non-blocking:** Local Claude review and simplify availability.
  - **Decision:** Record both bounded timeouts and rely on the completed independent Codex review, fix re-review, whole-branch review, hosted review gate, and exact-head QA.
  - **Why:** Neither Claude invocation produced output or changed the branch; the repository policy permits exact timeout evidence.
  - **Review later:** Confirm the configured current-head hosted reviewer completes before merge.

### Merge confidence

- Target phase: `beta` (`main`); release tracker mode: `strict-rc`; standard merge qualification applies.
- Merge authority: `auto_merge_when_gates_pass`, explicitly supplied for issue #4941.
- Confidence: high after strict RED/GREEN reproduction, dual-locale exact-head QA, fail-closed regression coverage, and three independent review passes.
- Current-head hosted CI, required gate, CodeQL, Claude review, CodeRabbit review, independent reviews, and unresolved-thread sweep are clean. Remaining gate: strict merge ledger and exact-head merge-queue eligibility.

### Audit receipts

The completed-batch audit summary will be inserted here after terminal merge verification.

</details>
