### PR TITLE
Fix release failure recovery for strict RCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **Release failures now provide supervised, reason-specific recovery**: `script/release --evaluate-head`
+  supports strict exact-HEAD CI evaluation for both preview and live retries, foreign claims identify the available
+  holder/task/session metadata and targeted status command, and npm readiness distinguishes stale dependencies,
+  pnpm-version mismatches, and package-build failures without requiring `bin/setup`. Fixes
+  [Issue 4955](https://github.com/shakacode/react_on_rails/issues/4955).
+
 - **Fresh generated apps now preserve their resolved Shakapacker version**: The installer now pins
   `bundle add shakapacker --strict` to the version already selected through React on Rails instead
   of allowing an older globally installed gem to downgrade the app's lockfile. The tested

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -158,6 +158,14 @@ script/release --dry-run
 script/release
 ```
 
+Only when a CI-walkback failure proves exact HEAD has complete healthy evidence,
+use the exact modifier commands printed by that failure:
+
+```bash
+script/release --dry-run --evaluate-head
+script/release --evaluate-head
+```
+
 `script/release` derives `release-line:X.Y.Z` and `release/X.Y.Z` from that
 changelog version, creates a fresh UUID-backed identity, claims the exact line,
 heartbeats and authoritatively verifies it, supervises the Rake process group,
@@ -172,6 +180,18 @@ observed version in `If-Match`. Every active record is refused, including one
 whose holder appears dead, stale, or expired. A concurrent `409` is likewise a
 claim refusal. The preliminary status read is diagnostic only and never grants
 takeover authority.
+
+On a foreign-claim refusal, the wrapper prints available holder metadata,
+including task/thread and session fields when the claim recorded them, plus the
+targeted inspection command:
+
+```bash
+agent-coord status --repo shakacode/react_on_rails --target release-line:X.Y.Z --json
+```
+
+Inspect and coordinate with the recorded holder. Never infer takeover safety
+from lease expiry or heartbeat age alone; the wrapper does not provide or
+attempt an automatic takeover.
 
 #### Advanced automation compatibility
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -102,6 +102,20 @@ script/release --dry-run # no coordination and no release writes
 script/release           # live release after the preview and required gates
 ```
 
+`--evaluate-head` is a strict CI-evaluation modifier, not a waiver. Use it only
+when the release failure itself confirms that exact HEAD has complete healthy
+required-check evidence and prints both of these recovery commands:
+
+```bash
+script/release --dry-run --evaluate-head # no-write preview
+script/release --evaluate-head           # supervised live retry
+```
+
+Existing automation that already supplies `RELEASE_CI_EVALUATE_HEAD=true` to
+the wrapper remains supported for backward compatibility. New and interactive
+operator guidance must use `--evaluate-head`; the environment variable is an
+internal child contract, not the normal interface.
+
 Do not pass a positional version to the wrapper. The first valid, non-empty
 version section after `### [Unreleased]` is the source of truth. Internal Rake
 arguments remain available only for explicit no-write diagnostics and tightly
@@ -141,13 +155,21 @@ the clean-worktree check and verbosity setup. The root
 must byte-match the committed `pnpm-lock.yaml`, and every npm release package must pass its normal `build` script
 with lifecycle scripts enabled. This happens before release-checkout creation, `git pull`, npm or GitHub
 authentication, CI/tag/version-policy remote reads, registry probes, confirmation, version mutation, ShakaPerf
-dispatch, tagging, publication, or OTP prompting. A pnpm version mismatch must first be repaired by activating the
-exact pnpm version declared by the root `packageManager`. The release prints this frozen-install command for the
-installed-dependency repair:
+dispatch, tagging, publication, or OTP prompting. Recovery is reason-specific:
+
+- Missing or stale installed dependencies: run the frozen install the error prints.
+- Pnpm-version mismatch: activate the exact version declared by the root `packageManager`, verify `pnpm --version`,
+  and retry without treating dependency installation as the failure.
+- Package-build failure: fix and rerun the exact `pnpm --filter <package> run build` command the error prints.
+
+For only the stale-dependency case, the required repair is:
 
 ```bash
 pnpm install --frozen-lockfile
 ```
+
+`bin/setup` is never run automatically. The stale-dependency diagnostic may mention it only as an optional broader
+environment refresh; it is not required to retry the release.
 
 After the initial check succeeds, the task binds it to the exact current commit. A live release then runs
 `git pull --rebase` and immediately resolves `HEAD` again. If the pull advanced the checkout, all four release-package
@@ -205,7 +227,6 @@ VERBOSE=1                    # Enable verbose logging (shows all output)
 NPM_OTP=<code>               # Provide NPM one-time password (reused for all NPM publishes)
 RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for both gems)
 RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
-RELEASE_CI_EVALUATE_HEAD=true # Strictly evaluate the fetched exact release-source HEAD; not a waiver
 RELEASE_CI_STATUS_OVERRIDE=true # DANGEROUS last-resort waiver for the release CI-status gate
 RELEASE_ACCELERATED_RC=true # Explicit RC only: publish while named pending gates finish
 RELEASE_TRACKER=<issue> # Active release tracker for ShakaPerf evidence, accelerated RCs, and final promotion
@@ -323,25 +344,26 @@ the newest runtime-bearing commit. This is intentional: CI path filtering can at
 runtime suite to metadata-only commits, while the runtime-bearing commit is the one whose full
 suite establishes release health.
 
-`RELEASE_CI_EVALUATE_HEAD=true` disables only that walkback. It still queries and enforces the
-same CI gate at the exact fetched HEAD; it is a strict evaluation, not a waiver. It is appropriate
+`script/release --evaluate-head` disables only that walkback for its supervised child. It still queries and enforces
+the same CI gate at the exact fetched HEAD; it is a strict evaluation, not a waiver. It is appropriate
 only for the narrow topology where GitHub attached complete workflows to the final release tip,
 while the intermediate runtime SHA selected by normal walkback has zero usable runs.
 
-| Normal walkback / exact HEAD evidence                                                                                      | Required action                                                                                            |
-| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Walked-back SHA has usable CI evidence                                                                                     | Let the normal gate decide. Do not set either variable.                                                    |
-| Walked-back SHA has no usable runs; exact HEAD is pending                                                                  | Wait for the linked exact-HEAD checks. They remain blocking.                                               |
-| Walked-back SHA has no usable runs; exact HEAD has failed checks                                                           | Fix or otherwise resolve the failures. They remain blocking.                                               |
-| Walked-back SHA has no usable runs; exact HEAD is completely healthy under the same stable/prerelease required-check rules | Re-run with `RELEASE_CI_EVALUATE_HEAD=true`; it evaluates that exact HEAD and still blocks on any failure. |
-| Walked-back SHA has no usable runs; exact HEAD has no checks, unknown status, or an API failure                            | Fail closed. Wait for evidence or repair API/auth access; do not use strict HEAD without evidence.         |
-| Any case where a maintainer-approved waiver is truly required                                                              | `RELEASE_CI_STATUS_OVERRIDE=true` is the dangerous last resort, not a recovery default.                    |
+| Normal walkback / exact HEAD evidence                                                                                      | Required action                                                                                    |
+| -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Walked-back SHA has usable CI evidence                                                                                     | Let the normal gate decide. Do not add a recovery modifier or waiver.                              |
+| Walked-back SHA has no usable runs; exact HEAD is pending                                                                  | Wait for the linked exact-HEAD checks. They remain blocking.                                       |
+| Walked-back SHA has no usable runs; exact HEAD has failed checks                                                           | Fix or otherwise resolve the failures. They remain blocking.                                       |
+| Walked-back SHA has no usable runs; exact HEAD is completely healthy under the same stable/prerelease required-check rules | Use the printed `script/release --evaluate-head` recovery; it still blocks on any failure.         |
+| Walked-back SHA has no usable runs; exact HEAD has no checks, unknown status, or an API failure                            | Fail closed. Wait for evidence or repair API/auth access; do not use strict HEAD without evidence. |
+| Any case where a maintainer-approved waiver is truly required                                                              | `RELEASE_CI_STATUS_OVERRIDE=true` is the dangerous last resort, not a recovery default.            |
 
 Examples:
 
 ```bash
-# Only after the task reports complete healthy exact-HEAD evidence, retry the explicit target version:
-RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release[17.0.0.rc.10,true]"
+# Only after the task reports complete healthy exact-HEAD evidence:
+script/release --dry-run --evaluate-head
+script/release --evaluate-head
 ```
 
 Do not use `RELEASE_CI_STATUS_OVERRIDE=true` to substitute for pending, missing, failed, or
@@ -852,7 +874,7 @@ This task depends on the `gem-release` Ruby gem, which is installed via `bundle 
 Before releasing to production, always preview with a dry run:
 
 ```bash
-bundle exec rake "release[16.5.0,true]"
+script/release --dry-run
 ```
 
 This uses a temporary git worktree to show exactly what would be updated without making any changes.
@@ -864,7 +886,7 @@ This uses a temporary git worktree to show exactly what would be updated without
 Always test with a dry run before actually releasing:
 
 ```bash
-bundle exec rake "release[16.2.0,true]"
+script/release --dry-run
 ```
 
 This shows you exactly what would be updated without making any changes.
@@ -881,15 +903,24 @@ The release script now checks NPM authentication at the start and will automatic
 
 ### NPM Release Readiness Issues
 
-If the release reports a pnpm version mismatch, first activate the exact pnpm version declared by the root
-`packageManager`. Then run the exact frozen-install repair command it prints from the repository root for the
-installed dependency check:
+Follow the reason named by the release failure:
+
+- For missing or stale installed dependencies, run from the repository root:
 
 ```bash
 pnpm install --frozen-lockfile
 ```
 
-Then fix any remaining build error and rerun the same explicit release version. The release will not have reached
+- For a pnpm-version mismatch, activate the exact version declared by the root `packageManager`, verify it with
+  `pnpm --version`, and retry `script/release`. Do not reinstall dependencies unless a separate stale-dependency
+  failure requests it.
+- For a package-build failure, fix the reported error, rerun the exact printed
+  `pnpm --filter <package> run build` command, and retry `script/release`.
+
+`bin/setup` is only an optional broader environment refresh for a stale dependency state. The release script does
+not run it automatically, and neither a pnpm-version mismatch nor a package-build failure should recommend it.
+
+These readiness failures happen before
 release-checkout creation, pull/authentication, remote CI/tag/version reads, confirmation, version mutation,
 ShakaPerf dispatch, tagging, publication, or OTP prompting.
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -9377,6 +9377,18 @@ def abort_pnpm_release_version_mismatch!(installed_version:, declared_version:)
   )
 end
 
+def abort_pnpm_release_version_probe_failure!(output:)
+  abort_npm_release_readiness!(
+    "pnpm --version failed\n\n#{output.to_s.strip}",
+    recovery: <<~RECOVERY.strip
+      Restore the repository-declared pnpm command on PATH, then verify:
+        pnpm --version
+      Then retry:
+        script/release
+    RECOVERY
+  )
+end
+
 def abort_npm_release_package_build!(package_name:, output:)
   abort_npm_release_readiness!(
     "#{package_name} build failed\n\n#{output.to_s.strip}",
@@ -9399,7 +9411,9 @@ def validate_npm_release_readiness!(monorepo_root:)
 
   version_output, version_status = capture_npm_release_readiness_command(monorepo_root, "pnpm", "--version")
   installed_pnpm_version = version_output.to_s.strip
-  unless version_status.success? && installed_pnpm_version == declared_pnpm_version
+  abort_pnpm_release_version_probe_failure!(output: version_output) unless version_status.success?
+
+  unless installed_pnpm_version == declared_pnpm_version
     abort_pnpm_release_version_mismatch!(
       installed_version: installed_pnpm_version,
       declared_version: declared_pnpm_version

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -3120,6 +3120,18 @@ rescue Errno::ENOENT, Errno::EACCES
   nil
 end
 
+def prepared_release_version_from_changelog_at_revision(monorepo_root:, revision:)
+  changelog, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "show", "#{revision}:CHANGELOG.md"
+  )
+  return nil unless status.success?
+
+  ReleaseChangelogSelector.prepared_version(
+    changelog.lines,
+    version_pattern: ReleaseLeaseGuard::RELEASE_VERSION_PATTERN
+  )
+end
+
 def current_gem_version(monorepo_root)
   version_file = File.join(monorepo_root, "react_on_rails", "lib", "react_on_rails", "version.rb")
   content = File.read(version_file)
@@ -3148,6 +3160,16 @@ end
 # allowed, but `release/X.Y.Z` branches cannot cut another release line.
 def stable_release_branch_allowed?(current_branch:, target_gem_version:)
   ["main", "release/#{target_gem_version}"].include?(current_branch)
+end
+
+def supervised_release_branch_allowed?(current_branch:, target_gem_version:)
+  return false if current_branch.to_s.empty? || target_gem_version.to_s.empty?
+
+  if release_prerelease_version?(target_gem_version)
+    current_branch == "release/#{release_base_version(target_gem_version)}"
+  else
+    stable_release_branch_allowed?(current_branch:, target_gem_version:)
+  end
 end
 
 def release_base_version(gem_version)
@@ -8527,7 +8549,8 @@ def fetch_accelerated_rc_ci_snapshot!(repo_slug:, sha:, monorepo_root: nil, ci_b
 end
 
 def exact_head_recovery_guidance(repo_slug:, monorepo_root:, head_sha:, evaluated_sha:, required_names:,
-                                 is_prerelease:, ci_branch:, required_checks_known: true, target_gem_version: nil)
+                                 is_prerelease:, ci_branch:, required_checks_known: true, current_branch: nil,
+                                 target_gem_version: nil)
   return nil if head_sha.nil? || head_sha == evaluated_sha
   unless required_checks_known
     return exact_head_unknown_guidance("❌ Required CI check discovery is unknown; release remains blocked.")
@@ -8595,14 +8618,32 @@ def exact_head_recovery_guidance(repo_slug:, monorepo_root:, head_sha:, evaluate
         "❌ Exact HEAD is healthy, but the resolved release version is unavailable; release remains blocked."
       )
     end
-    prepared_version = prepared_release_version_from_changelog(monorepo_root:)
-    if prepared_version.to_s.empty?
+    unless supervised_release_branch_allowed?(current_branch:, target_gem_version:)
+      branch_label = current_branch.to_s.empty? ? "unknown" : current_branch
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but current branch #{branch_label} is not supported by " \
+             "script/release for #{target_gem_version}; wrapper recovery remains blocked."
+    end
+    prepared_head_version = prepared_release_version_from_changelog_at_revision(
+      monorepo_root:,
+      revision: head_sha
+    )
+    if prepared_head_version.to_s.empty?
       return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but script/release cannot resolve a prepared " \
              "CHANGELOG.md version; wrapper recovery remains blocked."
     end
-    unless prepared_version == target_gem_version
-      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but script/release would select #{prepared_version} " \
+    unless prepared_head_version == target_gem_version
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but script/release would select #{prepared_head_version} " \
              "while the diagnostic target is #{target_gem_version}; wrapper recovery remains blocked."
+    end
+    prepared_checkout_version = prepared_release_version_from_changelog(monorepo_root:)
+    if prepared_checkout_version.to_s.empty?
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but the current checkout has no prepared " \
+             "CHANGELOG.md version; wrapper recovery remains blocked."
+    end
+    unless prepared_checkout_version == target_gem_version
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but the current checkout would select " \
+             "#{prepared_checkout_version} while the diagnostic target is #{target_gem_version}; " \
+             "wrapper recovery remains blocked."
     end
 
     <<~GUIDANCE.strip
@@ -8627,7 +8668,7 @@ def exact_head_recovery_guidance(repo_slug:, monorepo_root:, head_sha:, evaluate
 end
 
 def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dry_run:, ci_branch: "main",
-                             target_gem_version: nil, defer_pending: false)
+                             target_gem_version: nil, defer_pending: false, current_branch: nil)
   ensure_ci_status_override_is_prerelease!(allow_override:, is_prerelease:)
   puts "\nChecking CI status on origin/#{ci_branch}..."
 
@@ -8748,6 +8789,7 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
         is_prerelease:,
         ci_branch:,
         required_checks_known:,
+        current_branch:,
         target_gem_version:
       )
       message += "\n\n#{guidance}" if guidance
@@ -10367,6 +10409,7 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       allow_override: allow_ci_status_override,
       dry_run: is_dry_run,
       ci_branch:,
+      current_branch:,
       target_gem_version: resolved_target_gem_version,
       defer_pending: !accelerated_rc_options.nil?
     )

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -8599,7 +8599,10 @@ def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required
     <<~GUIDANCE.strip
       ✓ Exact HEAD #{head_sha[0, 8]} has complete healthy CI evidence.
       Preview a re-evaluation of that exact HEAD (strict evaluation, not a waiver):
-        RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release[#{target_gem_version},true]"
+        script/release --dry-run --evaluate-head
+
+      Live retry through the supervised release path:
+        script/release --evaluate-head
 
       #{release_compound_live_boundary_guidance}
     GUIDANCE
@@ -9291,11 +9294,11 @@ def fetch_rubygems_versions(gem_name, api_url: RUBYGEMS_VERSIONS_API_URL)
   [response.body, response]
 end
 
-def abort_npm_release_readiness!(reason)
+def abort_npm_release_readiness!(reason, recovery:)
   abort <<~ERROR
     ❌ npm release readiness failed: #{reason}.
 
-    pnpm install --frozen-lockfile
+    #{recovery}
   ERROR
 end
 
@@ -9305,15 +9308,75 @@ def declared_pnpm_release_version!(monorepo_root:)
   match = package_manager.to_s.match(/\Apnpm@(?<version>\d+\.\d+\.\d+)(?:\+sha512\.[0-9a-f]+)?\z/i)
   return match[:version] if match
 
-  abort_npm_release_readiness!("root packageManager must declare an exact pnpm version")
+  abort_npm_release_readiness!(
+    "root packageManager must declare an exact pnpm version",
+    recovery: <<~RECOVERY.strip
+      Restore an exact pnpm@X.Y.Z pin in the root packageManager field.
+      Then retry:
+        script/release
+    RECOVERY
+  )
 rescue Errno::ENOENT, JSON::ParserError => e
-  abort_npm_release_readiness!("root packageManager cannot be verified (#{e.class}: #{e.message})")
+  abort_npm_release_readiness!(
+    "root packageManager cannot be verified (#{e.class}: #{e.message})",
+    recovery: <<~RECOVERY.strip
+      Restore a readable root package.json with a valid exact packageManager pin.
+      Then retry:
+        script/release
+    RECOVERY
+  )
 end
 
 def capture_npm_release_readiness_command(monorepo_root, *command)
   Open3.capture2e(*command, chdir: monorepo_root)
 rescue StandardError => e
-  abort_npm_release_readiness!("npm toolchain command failed to start (#{e.class}: #{e.message})")
+  abort_npm_release_readiness!(
+    "npm toolchain command failed to start (#{e.class}: #{e.message})",
+    recovery: <<~RECOVERY.strip
+      Restore the repository-declared pnpm command on PATH.
+      Then retry:
+        script/release
+    RECOVERY
+  )
+end
+
+def abort_stale_npm_release_dependencies!
+  abort_npm_release_readiness!(
+    "installed dependency state is missing or stale",
+    recovery: <<~RECOVERY.strip
+      Required recovery:
+        pnpm install --frozen-lockfile
+      Then retry:
+        script/release
+
+      Optional broader environment refresh (not required for this failure):
+        bin/setup
+    RECOVERY
+  )
+end
+
+def abort_pnpm_release_version_mismatch!(installed_version:, declared_version:)
+  abort_npm_release_readiness!(
+    "installed pnpm version #{installed_version.inspect} does not match packageManager #{declared_version.inspect}",
+    recovery: <<~RECOVERY.strip
+      Activate pnpm #{declared_version} declared by the root packageManager, then verify:
+        pnpm --version
+      Then retry:
+        script/release
+    RECOVERY
+  )
+end
+
+def abort_npm_release_package_build!(package_name:, output:)
+  abort_npm_release_readiness!(
+    "#{package_name} build failed\n\n#{output.to_s.strip}",
+    recovery: <<~RECOVERY.strip
+      Fix the package build failure, then verify:
+        pnpm --filter #{package_name} run build
+      Then retry:
+        script/release
+    RECOVERY
+  )
 end
 
 def validate_npm_release_readiness!(monorepo_root:)
@@ -9322,14 +9385,14 @@ def validate_npm_release_readiness!(monorepo_root:)
   installed_lock = File.join(monorepo_root, "node_modules", ".pnpm", "lock.yaml")
   dependency_state_ready = File.file?(workspace_lock) && File.file?(installed_lock) &&
                            File.binread(workspace_lock) == File.binread(installed_lock)
-  abort_npm_release_readiness!("installed dependency state is missing or stale") unless dependency_state_ready
+  abort_stale_npm_release_dependencies! unless dependency_state_ready
 
   version_output, version_status = capture_npm_release_readiness_command(monorepo_root, "pnpm", "--version")
   installed_pnpm_version = version_output.to_s.strip
   unless version_status.success? && installed_pnpm_version == declared_pnpm_version
-    abort_npm_release_readiness!(
-      "installed pnpm version #{installed_pnpm_version.inspect} does not match packageManager " \
-      "#{declared_pnpm_version.inspect}"
+    abort_pnpm_release_version_mismatch!(
+      installed_version: installed_pnpm_version,
+      declared_version: declared_pnpm_version
     )
   end
 
@@ -9339,7 +9402,7 @@ def validate_npm_release_readiness!(monorepo_root:)
     )
     next if status.success?
 
-    abort_npm_release_readiness!("#{package_name} build failed\n\n#{output.to_s.strip}")
+    abort_npm_release_package_build!(package_name:, output:)
   end
 
   puts "✓ npm release packages are ready to publish"

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -8526,8 +8526,8 @@ def fetch_accelerated_rc_ci_snapshot!(repo_slug:, sha:, monorepo_root: nil, ci_b
   )
 end
 
-def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required_names:, is_prerelease:, ci_branch:,
-                                 required_checks_known: true, target_gem_version: nil)
+def exact_head_recovery_guidance(repo_slug:, monorepo_root:, head_sha:, evaluated_sha:, required_names:,
+                                 is_prerelease:, ci_branch:, required_checks_known: true, target_gem_version: nil)
   return nil if head_sha.nil? || head_sha == evaluated_sha
   unless required_checks_known
     return exact_head_unknown_guidance("❌ Required CI check discovery is unknown; release remains blocked.")
@@ -8594,6 +8594,15 @@ def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required
       return exact_head_unknown_guidance(
         "❌ Exact HEAD is healthy, but the resolved release version is unavailable; release remains blocked."
       )
+    end
+    prepared_version = prepared_release_version_from_changelog(monorepo_root:)
+    if prepared_version.to_s.empty?
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but script/release cannot resolve a prepared " \
+             "CHANGELOG.md version; wrapper recovery remains blocked."
+    end
+    unless prepared_version == target_gem_version
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but script/release would select #{prepared_version} " \
+             "while the diagnostic target is #{target_gem_version}; wrapper recovery remains blocked."
     end
 
     <<~GUIDANCE.strip
@@ -8732,6 +8741,7 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
     if recovery_eligible && %i[no_checks no_required_checks].include?(evaluation[:kind])
       guidance = exact_head_recovery_guidance(
         repo_slug:,
+        monorepo_root:,
         head_sha: data[:head_sha],
         evaluated_sha: sha,
         required_names:,

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7243,6 +7243,42 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    it "reports a failed pnpm version probe without claiming a version mismatch" do
+      failure_status = instance_double(Process::Status, success?: false)
+
+      Dir.mktmpdir do |monorepo_root|
+        File.write(
+          File.join(monorepo_root, "package.json"),
+          JSON.generate("packageManager" => "pnpm@10.33.4+sha512.abc123")
+        )
+        workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
+        installed_store = File.join(monorepo_root, "node_modules", ".pnpm")
+        FileUtils.mkdir_p(installed_store)
+        File.write(workspace_lock, "lockfileVersion: '9.0'\n")
+        File.write(File.join(installed_store, "lock.yaml"), File.read(workspace_lock))
+        allow(Open3).to receive(:capture2e)
+          .with("pnpm", "--version", chdir: monorepo_root)
+          .and_return(["corepack failed to activate pnpm\n", failure_status])
+
+        failure = begin
+          validate_npm_release_readiness!(monorepo_root:)
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include("pnpm --version failed")
+          expect(failure&.message).to include("corepack failed to activate pnpm")
+          expect(failure&.message).to include("Restore the repository-declared pnpm command")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).not_to include("does not match packageManager")
+          expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).not_to include("bin/setup")
+        end
+      end
+    end
+
     it "reports the exact failed package build command without prescribing setup or install" do
       stub_const("NPM_RELEASE_PACKAGE_NAMES", ["react-on-rails"])
       success_status = instance_double(Process::Status, success?: true)

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7190,12 +7190,97 @@ RSpec.describe "release.rake helper methods" do
         File.write(File.join(monorepo_root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
         expect(Open3).not_to receive(:capture2e)
 
-        expect do
+        failure = begin
           validate_npm_release_readiness!(monorepo_root:)
-        end.to raise_error(
-          SystemExit,
-          /installed dependency state is missing or stale.*\npnpm install --frozen-lockfile\n?\z/m
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include("installed dependency state is missing or stale")
+          expect(failure&.message).to include("Required recovery:")
+          expect(failure&.message).to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Optional broader environment refresh")
+          expect(failure&.message).to include("bin/setup")
+        end
+      end
+    end
+
+    it "reports pnpm-version recovery without prescribing a dependency reinstall" do
+      success_status = instance_double(Process::Status, success?: true)
+
+      Dir.mktmpdir do |monorepo_root|
+        File.write(
+          File.join(monorepo_root, "package.json"),
+          JSON.generate("packageManager" => "pnpm@10.33.4+sha512.abc123")
         )
+        workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
+        installed_store = File.join(monorepo_root, "node_modules", ".pnpm")
+        FileUtils.mkdir_p(installed_store)
+        File.write(workspace_lock, "lockfileVersion: '9.0'\n")
+        File.write(File.join(installed_store, "lock.yaml"), File.read(workspace_lock))
+        allow(Open3).to receive(:capture2e)
+          .with("pnpm", "--version", chdir: monorepo_root)
+          .and_return(["9.15.0\n", success_status])
+
+        failure = begin
+          validate_npm_release_readiness!(monorepo_root:)
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include('installed pnpm version "9.15.0" does not match packageManager "10.33.4"')
+          expect(failure&.message).to include("Activate pnpm 10.33.4")
+          expect(failure&.message).to include("pnpm --version")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).not_to include("bin/setup")
+        end
+      end
+    end
+
+    it "reports the exact failed package build command without prescribing setup or install" do
+      stub_const("NPM_RELEASE_PACKAGE_NAMES", ["react-on-rails"])
+      success_status = instance_double(Process::Status, success?: true)
+      failure_status = instance_double(Process::Status, success?: false)
+
+      Dir.mktmpdir do |monorepo_root|
+        File.write(
+          File.join(monorepo_root, "package.json"),
+          JSON.generate("packageManager" => "pnpm@10.33.4+sha512.abc123")
+        )
+        workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
+        installed_store = File.join(monorepo_root, "node_modules", ".pnpm")
+        FileUtils.mkdir_p(installed_store)
+        File.write(workspace_lock, "lockfileVersion: '9.0'\n")
+        File.write(File.join(installed_store, "lock.yaml"), File.read(workspace_lock))
+        expect(Open3).to receive(:capture2e)
+          .with("pnpm", "--version", chdir: monorepo_root)
+          .ordered.and_return(["10.33.4\n", success_status])
+        expect(Open3).to receive(:capture2e)
+          .with("pnpm", "--filter", "react-on-rails", "run", "build", chdir: monorepo_root)
+          .ordered.and_return(["TypeScript compilation failed\n", failure_status])
+
+        failure = begin
+          validate_npm_release_readiness!(monorepo_root:)
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include("react-on-rails build failed")
+          expect(failure&.message).to include("TypeScript compilation failed")
+          expect(failure&.message).to include("Fix the package build failure, then verify:")
+          expect(failure&.message).to include("pnpm --filter react-on-rails run build")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).not_to include("bin/setup")
+        end
       end
     end
 
@@ -15945,7 +16030,7 @@ RSpec.describe "release.rake helper methods" do
       rakefile = File.read(File.expand_path("../../../rakelib/release.rake", __dir__))
       help = rakefile.match(/desc\("(.*?)"\)\ntask :release/m)[1]
 
-      expect(help).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+      expect(help).not_to include("--evaluate-head")
       expect(help).to include("only after it has found complete healthy\n    CI evidence")
       expect(help).to include("Override prerelease CI gates only")
     end
@@ -19114,7 +19199,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).to have_received(:fetch_main_commit_statuses).once
       end
@@ -19345,7 +19430,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Required CI check discovery is unknown")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
     end
@@ -19718,7 +19803,7 @@ RSpec.describe "release.rake helper methods" do
           end
 
           expect(error).to be_a(SystemExit), "#{kind} exact-HEAD evidence should block the release"
-          expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true"),
+          expect(output).not_to include("--evaluate-head"),
                                 "#{kind} exact-HEAD evidence must not receive strict guidance"
         end
       end
@@ -19726,7 +19811,8 @@ RSpec.describe "release.rake helper methods" do
       it "offers strict exact-HEAD evaluation only after exact HEAD is healthy" do
         strict_head_guidance = [
           "strict evaluation, not a waiver",
-          'RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\\[17\\.0\\.0\\.rc\\.10,true\\]"',
+          "script/release --dry-run --evaluate-head",
+          "script/release --evaluate-head",
           "DANGEROUS",
           "RELEASE_CI_STATUS_OVERRIDE=true"
         ].join(".*")
@@ -19753,6 +19839,40 @@ RSpec.describe "release.rake helper methods" do
         )
       end
 
+      it "replays the observed RC.1 walkback stop with supervised preview and live recovery" do
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("required-pr-gate")]))
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("required-pr-gate")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        failure = begin
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.1.0.rc.1"
+          )
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        message = failure&.message.to_s
+        aggregate_failures do
+          expect(message).to include("script/release --dry-run --evaluate-head")
+          expect(message).to include("script/release --evaluate-head")
+          expect(message).not_to include("RELEASE_CI_EVALUATE_HEAD")
+          expect(message.index("script/release --evaluate-head"))
+            .to be < message.index("RELEASE_CI_STATUS_OVERRIDE")
+        end
+      end
+
       it "offers strict guidance when a successful exact-HEAD check rerun supersedes an earlier failure" do
         check_suite = { "id" => 77 }
         allow(self).to receive(:fetch_ci_check_runs_for_sha)
@@ -19777,7 +19897,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
 
@@ -19809,7 +19929,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
 
@@ -19837,7 +19957,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
       end
@@ -19875,7 +19995,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
         expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
@@ -19905,7 +20025,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
         expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
@@ -19941,7 +20061,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -19972,7 +20092,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20004,7 +20124,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20038,7 +20158,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20078,7 +20198,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20124,7 +20244,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD #{exact_head_sha} has failing CI evidence")
           expect(error.message).to include("Legacy CI")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20167,7 +20287,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("Statuses API")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(statuses_query).to eq(expected_statuses_query)
       end
@@ -20347,7 +20467,8 @@ RSpec.describe "release.rake helper methods" do
 
         expected_output = [
           "⚠️ DRY RUN: CI evidence below would block a real release:",
-          '^  RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\\[17\\.0\\.0\\.rc\\.10,true\\]"$',
+          "^  script/release --dry-run --evaluate-head$",
+          "^  script/release --evaluate-head$",
           "⚠️ DRY RUN: Real release remains blocked.",
           "⚠️ DRY RUN: DANGEROUS PRERELEASE-ONLY LAST RESORT",
           "RELEASE_CI_STATUS_OVERRIDE=true"
@@ -20381,7 +20502,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("resolved release version is unavailable")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20401,7 +20522,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Required CI check discovery is unknown")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20429,7 +20550,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
 
@@ -20450,7 +20571,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(%r{Exact HEAD.*pending.*Wait.*Slow test.*https://github\.com}m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20471,7 +20592,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(%r{Exact HEAD.*failing.*JS unit tests.*https://github\.com}m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20494,7 +20615,7 @@ RSpec.describe "release.rake helper methods" do
           expect(error.message).to match(
             /Exact HEAD.*does not provide complete healthy CI evidence.*No CI check runs visible/m
           )
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20512,7 +20633,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD evidence is unknown.*Unable to query GitHub Checks API/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20540,7 +20661,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD.*failing CI evidence.*Advisory benchmark/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20565,7 +20686,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD.*pending CI evidence.*Benchmark/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20596,7 +20717,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).to have_received(:fetch_main_commit_statuses)
       end
@@ -20631,7 +20752,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD.*failing CI evidence.*Advisory/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).to have_received(:fetch_ci_statuses_for_sha)
       end
@@ -20666,7 +20787,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
     end
@@ -21121,7 +21242,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end
 
-        expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        expect(output).not_to include("--evaluate-head")
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
         expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
       end
@@ -21837,7 +21958,7 @@ RSpec.describe "release.rake helper methods" do
         main_ci_evaluation_sha(monorepo_root:, head_sha: "head")
       end
 
-      expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+      expect(output).not_to include("--evaluate-head")
       expect(output).to include(
         "Strict exact-HEAD recovery is offered only after exact-HEAD CI evidence is complete and healthy."
       )

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -19796,6 +19796,9 @@ RSpec.describe "release.rake helper methods" do
         allow(self).to receive(:prepared_release_version_from_changelog)
           .with(monorepo_root:)
           .and_return("17.0.0.rc.10")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.0.0.rc.10")
       end
 
       it "keeps the complete walkback output free of strict guidance for incomplete exact-HEAD evidence" do
@@ -19870,6 +19873,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: false,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
@@ -19879,8 +19883,8 @@ RSpec.describe "release.rake helper methods" do
       end
 
       it "withholds wrapper recovery when the changelog-selected version differs from an explicit diagnostic target" do
-        allow(self).to receive(:prepared_release_version_from_changelog)
-          .with(monorepo_root:)
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
           .and_return("17.1.0.rc.1")
         allow(self).to receive(:fetch_ci_check_runs_for_sha)
           .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
@@ -19895,6 +19899,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.1.0",
             target_gem_version: "17.1.0.rc.2"
           )
         end.to raise_error(SystemExit) { |error|
@@ -19904,9 +19909,100 @@ RSpec.describe "release.rake helper methods" do
         }
       end
 
+      it "binds wrapper recovery to the changelog version at the diagnosed exact HEAD" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "release/17.1.0",
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(
+          SystemExit,
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
+        )
+      end
+
+      it "withholds wrapper recovery when the current branch is not supported by script/release" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "main",
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("current branch main is not supported by script/release")
+          expect(error.message).not_to include("--evaluate-head")
+        }
+      end
+
+      it "withholds wrapper recovery when the current checkout selects a different version" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.1")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "release/17.1.0",
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("current checkout would select 17.1.0.rc.1")
+          expect(error.message).to include("diagnostic target is 17.1.0.rc.2")
+          expect(error.message).not_to include("--evaluate-head")
+        }
+      end
+
       it "replays the observed RC.1 walkback stop with supervised preview and live recovery" do
         allow(self).to receive(:prepared_release_version_from_changelog)
           .with(monorepo_root:)
+          .and_return("17.1.0.rc.1")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
           .and_return("17.1.0.rc.1")
         allow(self).to receive(:required_check_names_for_branch)
           .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
@@ -19924,6 +20020,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.1.0",
             target_gem_version: "17.1.0.rc.1"
           )
           nil
@@ -19961,6 +20058,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: false,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
@@ -19993,6 +20091,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
@@ -20548,6 +20647,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: false,
             allow_override: false,
             dry_run: true,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to output(Regexp.new(expected_output, Regexp::MULTILINE)).to_stdout
@@ -20614,6 +20714,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
@@ -20851,6 +20952,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -19757,6 +19757,9 @@ RSpec.describe "release.rake helper methods" do
         allow(self).to receive(:fetch_main_ci_checks)
           .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
           .and_return(walkback_without_ci_runs)
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.0.0.rc.10")
       end
 
       it "keeps the complete walkback output free of strict guidance for incomplete exact-HEAD evidence" do
@@ -19839,7 +19842,36 @@ RSpec.describe "release.rake helper methods" do
         )
       end
 
+      it "withholds wrapper recovery when the changelog-selected version differs from an explicit diagnostic target" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.1")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("script/release would select 17.1.0.rc.1")
+          expect(error.message).to include("diagnostic target is 17.1.0.rc.2")
+          expect(error.message).not_to include("--evaluate-head")
+        }
+      end
+
       it "replays the observed RC.1 walkback stop with supervised preview and live recovery" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.1")
         allow(self).to receive(:required_check_names_for_branch)
           .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
           .and_return(required_checks(checks: [required_check("required-pr-gate")]))

--- a/script/release
+++ b/script/release
@@ -29,6 +29,10 @@ class ReleaseSupervisor
   SIGNALS = %w[INT TERM HUP].freeze
   RELEASE_START = "S"
   CLAIM_STATUSES = %w[active released].freeze
+  FOREIGN_CLAIM_METADATA_FIELDS = %w[
+    agent_id instance_id branch phase operator host machine_id thread_handle chat_handle session_id session_source
+    expires_at
+  ].freeze
   PR_SET_CHILD_SUBREAPER = 36
 
   Identity = Data.define(:agent_id, :instance_id, :machine_id, :managed)
@@ -53,7 +57,7 @@ class ReleaseSupervisor
     @env = env
     @stdout = stdout
     @stderr = stderr
-    @options = { dry_run: false, reconcile_accelerated_rc: false, doctor: false }
+    @options = { dry_run: false, reconcile_accelerated_rc: false, doctor: false, evaluate_head: false }
     @parser = build_parser
     @received_signal = nil
     @managed_claim_release_safe = true
@@ -130,7 +134,8 @@ class ReleaseSupervisor
           acquire_release_lease!(scope, identity, coordination_timeout:, termination_grace:)
         rescue ClaimRefusedError
           managed_claim_cleanup_required = false
-          raise
+          guidance = atomic_claim_refusal_guidance(scope, identity, coordination_timeout:, termination_grace:)
+          raise ClaimRefusedError, guidance
         end
       else
         verify_existing_lease!(scope, identity, coordination_timeout:, termination_grace:)
@@ -163,7 +168,7 @@ class ReleaseSupervisor
 
   def build_parser
     OptionParser.new do |parser|
-      parser.banner = "Usage: script/release [--doctor | --dry-run | --reconcile-accelerated-rc]"
+      parser.banner = "Usage: script/release [--doctor | --dry-run | --reconcile-accelerated-rc] [--evaluate-head]"
       parser.on("--doctor", "Validate read-only release-machine setup") do
         @options[:doctor] = true
       end
@@ -176,6 +181,9 @@ class ReleaseSupervisor
       ) do
         @options[:reconcile_accelerated_rc] = true
       end
+      parser.on("--evaluate-head", "Strictly evaluate exact release-source HEAD instead of CI walkback") do
+        @options[:evaluate_head] = true
+      end
       parser.on("-h", "--help", "Show this help") do
         @stdout.puts parser
         exit 0
@@ -187,7 +195,17 @@ class ReleaseSupervisor
     @remaining_args = @argv.dup
     @parser.parse!(@remaining_args)
     selected_modes = @options.values_at(:doctor, :dry_run, :reconcile_accelerated_rc).count(true)
-    raise UsageError, "choose only one of --doctor, --dry-run, or --reconcile-accelerated-rc" if selected_modes > 1
+    incompatible_head_evaluation_mode = if @options.fetch(:doctor)
+                                          "--doctor"
+                                        elsif @options.fetch(:reconcile_accelerated_rc)
+                                          "--reconcile-accelerated-rc"
+                                        end
+    option_error = if selected_modes > 1
+                     "choose only one of --doctor, --dry-run, or --reconcile-accelerated-rc"
+                   elsif @options.fetch(:evaluate_head) && incompatible_head_evaluation_mode
+                     "--evaluate-head does not apply to #{incompatible_head_evaluation_mode}"
+                   end
+    raise UsageError, option_error if option_error
   end
 
   def parse_scope!
@@ -418,7 +436,7 @@ class ReleaseSupervisor
 
   def run_dry(version)
     child_pid = Process.spawn(
-      { ReleaseLeaseGuard::CONTRACT_ENV => nil },
+      release_child_environment(contract: nil),
       "bundle", "exec", "rake", "release[#{version},true]"
     )
     _pid, status = Process.wait2(child_pid)
@@ -533,10 +551,10 @@ class ReleaseSupervisor
     end
 
     claims = parse_pre_acquisition_claims!(stdout, scope)
-    return unless claims.any? { |claim| active_foreign_claim?(claim, identity) }
+    foreign_claims = claims.select { |claim| active_foreign_claim?(claim, identity) }
+    return if foreign_claims.empty?
 
-    raise ReleaseLeaseGuard::LeaseError,
-          "release line already has an active foreign claim; do not infer takeover safety from lease or heartbeat age"
+    raise ReleaseLeaseGuard::LeaseError, foreign_claim_failure_guidance(scope, foreign_claims)
   rescue JSON::ParserError, TypeError
     raise ReleaseLeaseGuard::LeaseError, "release-line pre-acquisition status is malformed or UNKNOWN"
   end
@@ -566,6 +584,52 @@ class ReleaseSupervisor
   def active_foreign_claim?(claim, identity)
     claim["status"] == "active" &&
       (claim["agent_id"] != identity.agent_id || claim["instance_id"] != identity.instance_id)
+  end
+
+  def foreign_claim_failure_guidance(scope, claims)
+    lines = ["release line already has an active foreign claim:"]
+    claims.each_with_index do |claim, index|
+      lines << "  Claim #{index + 1}:"
+      FOREIGN_CLAIM_METADATA_FIELDS.each do |field|
+        next unless claim.key?(field) && !claim[field].to_s.empty?
+
+        lines << "    #{field}: #{JSON.generate(claim[field])}"
+      end
+    end
+    lines.concat(
+      foreign_claim_inspection_guidance(scope)
+    )
+    lines.join("\n")
+  end
+
+  def atomic_claim_refusal_guidance(scope, identity, coordination_timeout:, termination_grace:)
+    stdout, status = run_agent_coord(
+      "status", "--repo", scope.repo, "--target", scope.target, "--json",
+      timeout: coordination_timeout,
+      termination_grace:
+    )
+    if status&.success?
+      claims = parse_pre_acquisition_claims!(stdout, scope)
+      foreign_claims = claims.select { |claim| active_foreign_claim?(claim, identity) }
+      unless foreign_claims.empty?
+        refusal = ["release-line lease claim was refused.", foreign_claim_failure_guidance(scope, foreign_claims)]
+        return refusal.join("\n")
+      end
+    end
+
+    (["release-line lease claim was refused; current holder metadata is unavailable."] +
+      foreign_claim_inspection_guidance(scope)).join("\n")
+  rescue StandardError
+    (["release-line lease claim was refused; current holder metadata is unavailable or malformed."] +
+      foreign_claim_inspection_guidance(scope)).join("\n")
+  end
+
+  def foreign_claim_inspection_guidance(scope)
+    [
+      "Inspect authoritative coordination state:",
+      "  agent-coord status --repo #{scope.repo} --target #{scope.target} --json",
+      "Do not infer takeover safety from lease or heartbeat age alone."
+    ]
   end
 
   def release_managed_lease!(scope, identity, coordination_timeout:, termination_grace:)
@@ -821,7 +885,7 @@ class ReleaseSupervisor
       wait_for_release_start(pipes.start_reader)
       pipes.start_reader.close
       exec(
-        { ReleaseLeaseGuard::CONTRACT_ENV => JSON.generate(contract) },
+        release_child_environment(contract: JSON.generate(contract)),
         "bundle", "exec", "rake", supervised_rake_task(scope.version)
       )
     rescue StandardError
@@ -878,6 +942,12 @@ class ReleaseSupervisor
     return "release:reconcile_accelerated_rc[#{version}]" if @options.fetch(:reconcile_accelerated_rc)
 
     "release[#{version}]"
+  end
+
+  def release_child_environment(contract:)
+    child_environment = { ReleaseLeaseGuard::CONTRACT_ENV => contract }
+    child_environment["RELEASE_CI_EVALUATE_HEAD"] = "true" if @options.fetch(:evaluate_head)
+    child_environment
   end
 
   def reset_child_signal_handlers

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -283,8 +283,9 @@ case "${command_name}" in
       "${claim_status}" "${TEST_REPO}" "${TEST_TARGET}"
     printf '"branch":"%s","agent_id":"%s","instance_id":"%s",' \
       "${TEST_BRANCH}" "${claim_agent_id}" "${claim_instance_id}"
-    printf '"machine_id":"%s","expires_at":"%s"}],' \
-      "${claim_machine_id}" "${claim_expiry}"
+    printf '"machine_id":"%s","expires_at":"%s",' "${claim_machine_id}" "${claim_expiry}"
+    printf '"host":"codex","operator":"release-operator","phase":"publishing",'
+    printf '"thread_handle":"release-task-123","session_id":"release-session-456"}],'
     if test "${include_heartbeat}" = 1; then
       printf '"heartbeats":[{"agent_id":"%s","instance_id":"%s",' \
         "${claim_agent_id}" "${claim_instance_id}"
@@ -366,6 +367,7 @@ process_group="$(ps -o pgid= -p "$$" | tr -d ' ')"
     printf '|%s' "${argument}"
   done
   printf '\ncontract:%s\n' "${REACT_ON_RAILS_RELEASE_LEASE_CONTRACT:-}"
+  printf 'evaluate-head:%s\n' "${RELEASE_CI_EVALUATE_HEAD:-}"
 } >>"${TEST_BUNDLE_LOG}"
 
 record_liveness() {
@@ -484,6 +486,28 @@ end
 
 exit ExceptionTestSupervisor.new(ARGV).run
 EXCEPTION_HARNESS
+
+  cat >"${fake_bin}/release-claim-refusal-diagnostic-failure-harness" <<'CLAIM_REFUSAL_HARNESS'
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class ClaimRefusalDiagnosticFailureSupervisor < ReleaseSupervisor
+  private
+
+  def run_agent_coord(*command, **)
+    if command.first == "status"
+      @status_reads = @status_reads.to_i + 1
+      raise SupervisorError, "injected claim-refusal diagnostic failure" if @status_reads > 1
+    end
+
+    super
+  end
+end
+
+exit ClaimRefusalDiagnosticFailureSupervisor.new(ARGV).run
+CLAIM_REFUSAL_HARNESS
 
   cat >"${fake_bin}/release-echild-harness" <<'ECHILD_HARNESS'
 #!/usr/bin/env ruby
@@ -605,7 +629,8 @@ UNVERIFIED_CHILD_HARNESS
   chmod +x "${fake_bin}/agent-coord" "${fake_bin}/bundle" "${fake_bin}/pnpm" \
     "${fake_bin}/release-handshake-harness" \
     "${fake_bin}/release-death-watch-startup-failure-harness" \
-    "${fake_bin}/release-exception-harness" "${fake_bin}/release-subreaper-failure-harness" \
+    "${fake_bin}/release-exception-harness" "${fake_bin}/release-claim-refusal-diagnostic-failure-harness" \
+    "${fake_bin}/release-subreaper-failure-harness" \
     "${fake_bin}/release-unverified-child-harness" "${fake_bin}/release-echild-harness"
 
   export PATH="${fake_bin}:${PATH}"
@@ -645,6 +670,7 @@ UNVERIFIED_CHILD_HARNESS
   unset FAKE_HANDSHAKE_IGNORE_TERM
   unset REACT_ON_RAILS_RELEASE_COORDINATION_TIMEOUT
   unset REACT_ON_RAILS_RELEASE_CLAIM_RENEWAL_INTERVAL
+  unset RELEASE_CI_EVALUATE_HEAD
 }
 
 run_release() {
@@ -665,6 +691,13 @@ run_exception_release() {
   (
     cd "${fake_repo}"
     "${fake_bin}/release-exception-harness" "$@"
+  ) >"${output_log}" 2>&1
+}
+
+run_claim_refusal_diagnostic_failure_release() {
+  (
+    cd "${fake_repo}"
+    "${fake_bin}/release-claim-refusal-diagnostic-failure-harness" "$@"
   ) >"${output_log}" 2>&1
 }
 
@@ -872,6 +905,32 @@ assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0,true]'
 assert_contains "${bundle_log}" 'contract:'
 pass "dry-run selects the first prepared changelog version"
 
+setup_case evaluate-head-dry-run
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID AGENT_COORD_MACHINE_ID AGENT_COORD_API_TOKEN
+run_release --dry-run --evaluate-head || fail "evaluate-head dry-run failed"
+assert_empty "${coord_log}"
+assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0,true]'
+assert_contains "${bundle_log}" 'evaluate-head:true'
+pass "evaluate-head modifies the dry-run child without enabling coordination"
+
+setup_case evaluate-head-environment-backward-compatibility
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID AGENT_COORD_MACHINE_ID AGENT_COORD_API_TOKEN
+export RELEASE_CI_EVALUATE_HEAD=true
+run_release --dry-run || fail "legacy evaluate-head environment contract failed"
+assert_empty "${coord_log}"
+assert_contains "${bundle_log}" 'evaluate-head:true'
+pass "evaluate-head preserves the existing environment contract for automation compatibility"
+
+setup_case evaluate-head-reconciliation-rejected
+if run_release --reconcile-accelerated-rc --evaluate-head; then
+  fail "evaluate-head was accepted for accelerated RC reconciliation"
+fi
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_contains "${output_log}" "--evaluate-head does not apply to --reconcile-accelerated-rc"
+assert_secret_absent
+pass "evaluate-head rejects accelerated RC reconciliation where it would be inert"
+
 setup_case missing-changelog-version
 cat >"${fake_repo}/CHANGELOG.md" <<'CHANGELOG'
 ### [Unreleased]
@@ -982,6 +1041,16 @@ assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
 assert_secret_absent
 pass "live mode acquires and cleans up a process-owned release lease"
 
+setup_case evaluate-head-live
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+FAKE_BUNDLE_MODE=success run_release --evaluate-head || fail "evaluate-head live release failed"
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
+assert_contains "${bundle_log}" 'evaluate-head:true'
+assert_secret_absent
+pass "evaluate-head modifies the supervised live child without bypassing coordination"
+
 setup_case managed-acquisition-empty-status
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 export FAKE_PREFLIGHT_STATUS_MODE=empty-first
@@ -1004,8 +1073,29 @@ assert_contains "${coord_log}" $'claim-atomic|'
 assert_not_contains "${coord_log}" $'claim|'
 assert_not_contains "${coord_log}" $'release|'
 assert_empty "${bundle_log}"
+assert_contains "${output_log}" "release line already has an active foreign claim"
+assert_contains "${output_log}" 'agent_id: "foreign-agent"'
+assert_contains "${output_log}" 'thread_handle: "release-task-123"'
+assert_contains "${output_log}" 'session_id: "release-session-456"'
+assert_contains "${output_log}" \
+  "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
 assert_secret_absent
 pass "managed acquisition atomically refuses an intervening foreign claim"
+
+setup_case managed-atomic-claim-race-diagnostic-failure
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_ATOMIC_CLAIM_MODE=foreign-race
+if run_claim_refusal_diagnostic_failure_release; then
+  fail "managed release ignored a claim-refusal diagnostic failure"
+fi
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_not_contains "${coord_log}" $'release|'
+assert_empty "${bundle_log}"
+assert_contains "${output_log}" "current holder metadata is unavailable or malformed"
+assert_contains "${output_log}" \
+  "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
+assert_secret_absent
+pass "claim-refusal diagnostic failures never release a foreign lease"
 
 for foreign_mode in dead expired missing-heartbeat; do
   setup_case "managed-acquisition-foreign-${foreign_mode}"
@@ -1019,6 +1109,11 @@ for foreign_mode in dead expired missing-heartbeat; do
   assert_not_contains "${coord_log}" $'release|'
   assert_empty "${bundle_log}"
   assert_contains "${output_log}" "release line already has an active foreign claim"
+  assert_contains "${output_log}" 'agent_id: "foreign-agent"'
+  assert_contains "${output_log}" 'thread_handle: "release-task-123"'
+  assert_contains "${output_log}" 'session_id: "release-session-456"'
+  assert_contains "${output_log}" \
+    "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
   assert_secret_absent
   pass "foreign ${foreign_mode} claims block managed acquisition without takeover"
 done

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -931,6 +931,16 @@ assert_contains "${output_log}" "--evaluate-head does not apply to --reconcile-a
 assert_secret_absent
 pass "evaluate-head rejects accelerated RC reconciliation where it would be inert"
 
+setup_case evaluate-head-doctor-rejected
+if run_release --doctor --evaluate-head; then
+  fail "evaluate-head was accepted for release doctor"
+fi
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_contains "${output_log}" "--evaluate-head does not apply to --doctor"
+assert_secret_absent
+pass "evaluate-head rejects release doctor where it would be inert"
+
 setup_case missing-changelog-version
 cat >"${fake_repo}/CHANGELOG.md" <<'CHANGELOG'
 ### [Unreleased]


### PR DESCRIPTION
Fixes #4955.

## Why

The strict 17.1.0 RC release path could fail with technically correct but operationally poor recovery guidance. In particular, the exact-HEAD recovery path exposed an obscure environment variable, foreign-claim failures omitted actionable ownership details, and npm readiness failures collapsed distinct causes into one generic install instruction.

This change makes those failures recoverable through the supervised `script/release` interface while preserving the existing release fences. It does not publish, tag, release, retry automatically, waive CI, take over a claim, or run `bin/setup`.

## What changed

- Add first-class `script/release --evaluate-head` support for both live and `--dry-run` operation, while retaining inherited `RELEASE_CI_EVALUATE_HEAD` compatibility for automation.
- Print the preview and live `--evaluate-head` commands only when exact HEAD has complete healthy required-check evidence, the diagnosed exact-HEAD changelog and current checkout select the same target version, and the current branch is supported by the wrapper. Pending, failed, missing, malformed, incomplete, unavailable, version-mismatched, and unsupported-branch evidence continues to fail closed without recommending the modifier.
- Keep `RELEASE_CI_STATUS_OVERRIDE` as the final, prerelease-only, visibly dangerous waiver.
- Enrich foreign-claim failures with available holder/task/session metadata and the targeted `agent-coord status` inspection command, without inferring takeover safety from lease or heartbeat age.
- Give separate recovery for stale dependencies, pnpm-version mismatches, failed pnpm probes, and package-build failures. `bin/setup` appears only as an optional broader refresh for stale dependencies.
- Update release documentation and the changelog.

## TDD and regression coverage

The implementation was driven through public wrapper/helper behavior:

- RED: `--evaluate-head` was rejected as unknown; GREEN: dry-run and live child propagation work.
- RED: healthy exact-HEAD guidance exposed the environment variable; GREEN: it prints the supervised preview/live commands only after complete healthy evidence.
- RED: the retry could be bound to a different changelog revision, local target, or unsupported branch; GREEN: all three cases fail closed without advertising an unusable wrapper command.
- RED: foreign-claim failures lacked metadata and a targeted inspection command; GREEN: both preliminary and atomic-race refusal paths provide them.
- RED: an atomic refusal diagnostic failure could reach claim cleanup; GREEN: regression coverage proves no foreign release command is issued.
- RED: npm readiness used generic recovery; GREEN: stale dependency, pnpm mismatch, failed pnpm probe, and package build failures are reason-specific.
- RED: `--reconcile-accelerated-rc --evaluate-head` was silently accepted; GREEN: the inert combination is rejected.
- The observed RC.1 walkback/exact-HEAD sequence has explicit replay coverage.

## Verification

- `script/release-test.bash` — 70 cases passed.
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb)` — 945 examples, 0 failures.
- Focused RuboCop on `script/release`, `rakelib/release.rake`, and the helper spec — no offenses.
- `pnpm exec prettier --check CHANGELOG.md internal/contributor-info/release-train-runbook.md internal/contributor-info/releasing.md` — all matched.
- Ruby and Bash syntax checks plus `git diff --check origin/main...HEAD` — passed.
- Pre-commit/pre-push hooks — Markdown links, trailing newlines, Prettier, branch RuboCop, and online link checks passed.
- `.agents/bin/validate --changed` — dependency install, docs sidebar, release supervisor, RuboCop, package build, ESLint, Prettier, and TypeScript checks passed. Its broad gem-unit phase could not start examples under local Ruby 4.0.5 because the process preactivated `json` 2.21.2 while the lock requires `json` 2.7.2; the focused 945-example release helper suite passes through the normal Bundler invocation.

## Review and churn

- Manual full-diff self-review completed.
- CodeRabbit and local Codex findings were independently reproduced and fixed: exact-target selection, failed pnpm-probe classification, immutable exact-HEAD changelog binding, current-checkout target binding, and wrapper branch compatibility.
- Final `codex review --base origin/main` closeout, including its immutable-base replay: no actionable findings.
- Configured `/simplify origin/main` pass produced no output within a bounded two-minute run and was stopped; no edits resulted.
- Post-push fix rounds before this head: 3. The final round is limited to exact-HEAD target/branch binding and its regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added supervised exact-HEAD evaluation for preview and live release recovery.
  * Release claim conflicts now show holder details and a targeted status-check command.
* **Bug Fixes**
  * Improved npm readiness checks for stale dependencies, package-manager version issues, version-probe failures, and package build failures.
  * Recovery guidance now identifies the specific issue and recommended next steps.
* **Documentation**
  * Updated release guides and runbooks with recovery commands, dry-run workflows, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
