### PR TITLE
Preserve release retry modifiers in readiness recovery

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -9354,7 +9354,14 @@ def abort_npm_release_readiness!(reason, recovery:)
   ERROR
 end
 
-def declared_pnpm_release_version!(monorepo_root:)
+def supervised_release_retry_command(dry_run:, evaluate_head:)
+  command = ["script/release"]
+  command << "--dry-run" if dry_run
+  command << "--evaluate-head" if evaluate_head
+  command.join(" ")
+end
+
+def declared_pnpm_release_version!(monorepo_root:, retry_command: "script/release")
   package_json = JSON.parse(File.read(File.join(monorepo_root, "package.json")))
   package_manager = package_json["packageManager"]
   match = package_manager.to_s.match(/\Apnpm@(?<version>\d+\.\d+\.\d+)(?:\+sha512\.[0-9a-f]+)?\z/i)
@@ -9365,7 +9372,7 @@ def declared_pnpm_release_version!(monorepo_root:)
     recovery: <<~RECOVERY.strip
       Restore an exact pnpm@X.Y.Z pin in the root packageManager field.
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 rescue Errno::ENOENT, JSON::ParserError => e
@@ -9374,12 +9381,12 @@ rescue Errno::ENOENT, JSON::ParserError => e
     recovery: <<~RECOVERY.strip
       Restore a readable root package.json with a valid exact packageManager pin.
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def capture_npm_release_readiness_command(monorepo_root, *command)
+def capture_npm_release_readiness_command(monorepo_root, *command, retry_command: "script/release")
   Open3.capture2e(*command, chdir: monorepo_root)
 rescue StandardError => e
   abort_npm_release_readiness!(
@@ -9387,19 +9394,19 @@ rescue StandardError => e
     recovery: <<~RECOVERY.strip
       Restore the repository-declared pnpm command on PATH.
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def abort_stale_npm_release_dependencies!
+def abort_stale_npm_release_dependencies!(retry_command: "script/release")
   abort_npm_release_readiness!(
     "installed dependency state is missing or stale",
     recovery: <<~RECOVERY.strip
       Required recovery:
         pnpm install --frozen-lockfile
       Then retry:
-        script/release
+        #{retry_command}
 
       Optional broader environment refresh (not required for this failure):
         bin/setup
@@ -9407,68 +9414,71 @@ def abort_stale_npm_release_dependencies!
   )
 end
 
-def abort_pnpm_release_version_mismatch!(installed_version:, declared_version:)
+def abort_pnpm_release_version_mismatch!(installed_version:, declared_version:, retry_command: "script/release")
   abort_npm_release_readiness!(
     "installed pnpm version #{installed_version.inspect} does not match packageManager #{declared_version.inspect}",
     recovery: <<~RECOVERY.strip
       Activate pnpm #{declared_version} declared by the root packageManager, then verify:
         pnpm --version
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def abort_pnpm_release_version_probe_failure!(output:)
+def abort_pnpm_release_version_probe_failure!(output:, retry_command: "script/release")
   abort_npm_release_readiness!(
     "pnpm --version failed\n\n#{output.to_s.strip}",
     recovery: <<~RECOVERY.strip
       Restore the repository-declared pnpm command on PATH, then verify:
         pnpm --version
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def abort_npm_release_package_build!(package_name:, output:)
+def abort_npm_release_package_build!(package_name:, output:, retry_command: "script/release")
   abort_npm_release_readiness!(
     "#{package_name} build failed\n\n#{output.to_s.strip}",
     recovery: <<~RECOVERY.strip
       Fix the package build failure, then verify:
         pnpm --filter #{package_name} run build
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def validate_npm_release_readiness!(monorepo_root:)
-  declared_pnpm_version = declared_pnpm_release_version!(monorepo_root:)
+def validate_npm_release_readiness!(monorepo_root:, retry_command: "script/release")
+  declared_pnpm_version = declared_pnpm_release_version!(monorepo_root:, retry_command:)
   workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
   installed_lock = File.join(monorepo_root, "node_modules", ".pnpm", "lock.yaml")
   dependency_state_ready = File.file?(workspace_lock) && File.file?(installed_lock) &&
                            File.binread(workspace_lock) == File.binread(installed_lock)
-  abort_stale_npm_release_dependencies! unless dependency_state_ready
+  abort_stale_npm_release_dependencies!(retry_command:) unless dependency_state_ready
 
-  version_output, version_status = capture_npm_release_readiness_command(monorepo_root, "pnpm", "--version")
+  version_output, version_status = capture_npm_release_readiness_command(
+    monorepo_root, "pnpm", "--version", retry_command:
+  )
   installed_pnpm_version = version_output.to_s.strip
-  abort_pnpm_release_version_probe_failure!(output: version_output) unless version_status.success?
+  abort_pnpm_release_version_probe_failure!(output: version_output, retry_command:) unless version_status.success?
 
   unless installed_pnpm_version == declared_pnpm_version
     abort_pnpm_release_version_mismatch!(
       installed_version: installed_pnpm_version,
-      declared_version: declared_pnpm_version
+      declared_version: declared_pnpm_version,
+      retry_command:
     )
   end
 
   NPM_RELEASE_PACKAGE_NAMES.each do |package_name|
     output, status = capture_npm_release_readiness_command(
-      monorepo_root, "pnpm", "--filter", package_name, "run", "build"
+      monorepo_root, "pnpm", "--filter", package_name, "run", "build", retry_command:
     )
     next if status.success?
 
-    abort_npm_release_package_build!(package_name:, output:)
+    abort_npm_release_package_build!(package_name:, output:, retry_command:)
   end
 
   puts "✓ npm release packages are ready to publish"
@@ -9481,14 +9491,14 @@ def current_npm_release_readiness_sha!(monorepo_root:, context:)
   abort "❌ Unable to bind npm release readiness to an exact git SHA before #{context}."
 end
 
-def refresh_npm_release_readiness_after_pull!(monorepo_root:, readiness_sha:)
+def refresh_npm_release_readiness_after_pull!(monorepo_root:, readiness_sha:, retry_command: "script/release")
   post_pull_sha = current_npm_release_readiness_sha!(
     monorepo_root:,
     context: "post-pull npm release readiness verification"
   )
   return readiness_sha if post_pull_sha == readiness_sha
 
-  validate_npm_release_readiness!(monorepo_root:)
+  validate_npm_release_readiness!(monorepo_root:, retry_command:)
   validated_sha = current_npm_release_readiness_sha!(
     monorepo_root:,
     context: "post-pull npm release readiness binding"
@@ -10158,6 +10168,10 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   args_hash = args.to_hash
 
   is_dry_run = release_truthy?(args_hash[:dry_run])
+  release_retry_command = supervised_release_retry_command(
+    dry_run: is_dry_run,
+    evaluate_head: ci_evaluate_head_only?
+  )
   activate_release_lease_guard!(dry_run: is_dry_run)
   is_verbose = ENV["VERBOSE"] == "1"
   allow_version_policy_override = version_policy_override_enabled?(args_hash[:override_version_policy])
@@ -10183,7 +10197,7 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
     monorepo_root:,
     context: "initial npm release readiness verification"
   )
-  validate_npm_release_readiness!(monorepo_root:)
+  validate_npm_release_readiness!(monorepo_root:, retry_command: release_retry_command)
   validated_readiness_sha = current_npm_release_readiness_sha!(
     monorepo_root:,
     context: "initial npm release readiness binding"
@@ -10210,7 +10224,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       sh_in_dir_for_release(release_root, "git pull --rebase")
       npm_readiness_sha = refresh_npm_release_readiness_after_pull!(
         monorepo_root: release_root,
-        readiness_sha: npm_readiness_sha
+        readiness_sha: npm_readiness_sha,
+        retry_command: release_retry_command
       )
     end
 

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7180,6 +7180,20 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#supervised_release_retry_command" do
+    it "preserves dry-run and exact-HEAD modifiers" do
+      aggregate_failures do
+        expect(supervised_release_retry_command(dry_run: false, evaluate_head: false)).to eq("script/release")
+        expect(supervised_release_retry_command(dry_run: true, evaluate_head: false))
+          .to eq("script/release --dry-run")
+        expect(supervised_release_retry_command(dry_run: false, evaluate_head: true))
+          .to eq("script/release --evaluate-head")
+        expect(supervised_release_retry_command(dry_run: true, evaluate_head: true))
+          .to eq("script/release --dry-run --evaluate-head")
+      end
+    end
+  end
+
   describe "#validate_npm_release_readiness!" do
     it "fails closed on a clean clone without installed dependencies and prints the exact repair command" do
       Dir.mktmpdir do |monorepo_root|
@@ -7191,7 +7205,10 @@ RSpec.describe "release.rake helper methods" do
         expect(Open3).not_to receive(:capture2e)
 
         failure = begin
-          validate_npm_release_readiness!(monorepo_root:)
+          validate_npm_release_readiness!(
+            monorepo_root:,
+            retry_command: "script/release --dry-run --evaluate-head"
+          )
           nil
         rescue SystemExit => error
           error
@@ -7201,7 +7218,7 @@ RSpec.describe "release.rake helper methods" do
           expect(failure&.message).to include("installed dependency state is missing or stale")
           expect(failure&.message).to include("Required recovery:")
           expect(failure&.message).to include("pnpm install --frozen-lockfile")
-          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Then retry:\n  script/release --dry-run --evaluate-head")
           expect(failure&.message).to include("Optional broader environment refresh")
           expect(failure&.message).to include("bin/setup")
         end
@@ -7226,7 +7243,7 @@ RSpec.describe "release.rake helper methods" do
           .and_return(["9.15.0\n", success_status])
 
         failure = begin
-          validate_npm_release_readiness!(monorepo_root:)
+          validate_npm_release_readiness!(monorepo_root:, retry_command: "script/release --evaluate-head")
           nil
         rescue SystemExit => error
           error
@@ -7236,7 +7253,7 @@ RSpec.describe "release.rake helper methods" do
           expect(failure&.message).to include('installed pnpm version "9.15.0" does not match packageManager "10.33.4"')
           expect(failure&.message).to include("Activate pnpm 10.33.4")
           expect(failure&.message).to include("pnpm --version")
-          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Then retry:\n  script/release --evaluate-head")
           expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
           expect(failure&.message).not_to include("bin/setup")
         end
@@ -7261,7 +7278,7 @@ RSpec.describe "release.rake helper methods" do
           .and_return(["corepack failed to activate pnpm\n", failure_status])
 
         failure = begin
-          validate_npm_release_readiness!(monorepo_root:)
+          validate_npm_release_readiness!(monorepo_root:, retry_command: "script/release --dry-run")
           nil
         rescue SystemExit => error
           error
@@ -7271,7 +7288,7 @@ RSpec.describe "release.rake helper methods" do
           expect(failure&.message).to include("pnpm --version failed")
           expect(failure&.message).to include("corepack failed to activate pnpm")
           expect(failure&.message).to include("Restore the repository-declared pnpm command")
-          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Then retry:\n  script/release --dry-run")
           expect(failure&.message).not_to include("does not match packageManager")
           expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
           expect(failure&.message).not_to include("bin/setup")
@@ -16271,6 +16288,7 @@ RSpec.describe "release.rake helper methods" do
       allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RELEASE_CI_EVALUATE_HEAD", nil).and_return(nil)
     end
 
     after { release_task.reenable }
@@ -16279,9 +16297,11 @@ RSpec.describe "release.rake helper methods" do
       mode = dry_run ? "dry run" : "live run"
 
       it "blocks a #{mode} from the original workspace before any release side effect" do
+        expected_retry_command = dry_run ? "script/release --dry-run" : "script/release"
         allow(task_receiver).to receive(:current_git_sha!).and_return("a" * 40)
-        allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+        allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
           expect(monorepo_root).to eq(self.monorepo_root)
+          expect(retry_command).to eq(expected_retry_command)
           abort "npm readiness stopped the release"
         end
 
@@ -16296,7 +16316,7 @@ RSpec.describe "release.rake helper methods" do
         aggregate_failures do
           expect(failure&.message).to eq("npm readiness stopped the release")
           expect(task_receiver).to have_received(:validate_npm_release_readiness!)
-            .with(monorepo_root:).once
+            .with(monorepo_root:, retry_command: expected_retry_command).once
           expect(task_receiver).not_to have_received(:with_release_checkout)
           expect(task_receiver).not_to have_received(:resolve_release_version_before_auth!)
           expect(task_receiver).not_to have_received(:verify_npm_auth)
@@ -16319,6 +16339,26 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    it "preserves dry-run and exact-HEAD modifiers in initial readiness recovery" do
+      allow(ENV).to receive(:fetch).with("RELEASE_CI_EVALUATE_HEAD", nil).and_return("true")
+      allow(task_receiver).to receive(:current_git_sha!).and_return("a" * 40)
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
+        expect(monorepo_root).to eq(self.monorepo_root)
+        expect(retry_command).to eq("script/release --dry-run --evaluate-head")
+        abort "modifier-preserving readiness stopped the release"
+      end
+
+      failure = begin
+        release_task.reenable
+        release_task.invoke("17.0.0.rc.10", true, true, false)
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      expect(failure&.message).to eq("modifier-preserving readiness stopped the release")
+    end
+
     it "hard-fails when HEAD changes during the initial readiness check before any later release action" do
       initial_sha = "a" * 40
       moved_sha = "b" * 40
@@ -16337,7 +16377,8 @@ RSpec.describe "release.rake helper methods" do
 
       aggregate_failures do
         expect(failure&.message).to match(/HEAD changed while npm release readiness was running/i)
-        expect(task_receiver).to have_received(:validate_npm_release_readiness!).with(monorepo_root:).once
+        expect(task_receiver).to have_received(:validate_npm_release_readiness!)
+          .with(monorepo_root:, retry_command: "script/release --dry-run").once
         expect(task_receiver).not_to have_received(:with_release_checkout)
         expect(task_receiver).not_to have_received(:resolve_release_version_before_auth!)
         expect(task_receiver).not_to have_received(:verify_npm_auth)
@@ -16360,9 +16401,11 @@ RSpec.describe "release.rake helper methods" do
       initial_sha = "a" * 40
       pulled_sha = "b" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(initial_sha, initial_sha, pulled_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
         abort "post-pull npm readiness stopped the release" if readiness_roots.length == 2
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
@@ -16380,6 +16423,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to eq("post-pull npm readiness stopped the release")
         expect(readiness_roots).to eq([monorepo_root, release_root])
+        expect(retry_commands).to eq(["script/release", "script/release"])
         expect(task_receiver).not_to have_received(:verify_npm_auth)
         expect(task_receiver).not_to have_received(:verify_gh_auth)
         expect(task_receiver).not_to have_received(:validate_main_ci_status!)
@@ -16398,9 +16442,11 @@ RSpec.describe "release.rake helper methods" do
       pulled_sha = "b" * 40
       moved_sha = "c" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(initial_sha, initial_sha, pulled_sha, moved_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
         abort "version resolution reached with stale readiness"
@@ -16417,6 +16463,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to match(/HEAD changed while npm release readiness was running/i)
         expect(readiness_roots).to eq([monorepo_root, release_root])
+        expect(retry_commands).to eq(["script/release", "script/release"])
         expect(task_receiver).not_to have_received(:verify_npm_auth)
         expect(task_receiver).not_to have_received(:verify_gh_auth)
         expect(task_receiver).not_to have_received(:validate_main_ci_status!)
@@ -16430,8 +16477,8 @@ RSpec.describe "release.rake helper methods" do
     it "keeps one readiness check when a live pull leaves HEAD unchanged" do
       head_sha = "a" * 40
       events = []
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
-        events << [:readiness, monorepo_root]
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
+        events << [:readiness, monorepo_root, retry_command]
       end
       allow(task_receiver).to receive(:current_git_sha!) do |root, context:|
         events << [:sha, root, context]
@@ -16458,7 +16505,7 @@ RSpec.describe "release.rake helper methods" do
         expect(events).to eq(
           [
             [:sha, monorepo_root, "initial npm release readiness verification"],
-            [:readiness, monorepo_root],
+            [:readiness, monorepo_root, "script/release"],
             [:sha, monorepo_root, "initial npm release readiness binding"],
             [:command, release_root, "git pull --rebase"],
             [:sha, release_root, "post-pull npm release readiness verification"],
@@ -16472,9 +16519,11 @@ RSpec.describe "release.rake helper methods" do
       initial_sha = "a" * 40
       pulled_sha = "b" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(initial_sha, initial_sha, pulled_sha, pulled_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
         abort "refreshed readiness reached version resolution"
@@ -16491,6 +16540,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to eq("refreshed readiness reached version resolution")
         expect(readiness_roots).to eq([monorepo_root, release_root])
+        expect(retry_commands).to eq(["script/release", "script/release"])
         expect(task_receiver).to have_received(:current_git_sha!).exactly(4).times
       end
     end
@@ -16498,9 +16548,11 @@ RSpec.describe "release.rake helper methods" do
     it "keeps a dry run bound to one original-workspace readiness check without pulling" do
       head_sha = "a" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(head_sha, head_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
         abort "dry readiness reached version resolution"
@@ -16517,6 +16569,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to eq("dry readiness reached version resolution")
         expect(readiness_roots).to eq([monorepo_root])
+        expect(retry_commands).to eq(["script/release --dry-run"])
         expect(task_receiver).to have_received(:current_git_sha!)
           .with(monorepo_root, context: "initial npm release readiness verification").once
         expect(task_receiver).to have_received(:current_git_sha!)


### PR DESCRIPTION
## Why

PR #4957 introduced `script/release --evaluate-head`, but dependency-readiness recovery rebuilt its retry text as plain `script/release`. Copying that guidance could silently discard `--dry-run` or `--evaluate-head`.

## What changed

- Centralized retry-command construction and pass the active modifiers through every npm-readiness recovery path.
- Added regression coverage for dry-run, exact-HEAD, and the observed ambient-environment replay.

## How to review and verify

1. Inspect `supervised_release_retry_command` and its callers in `rakelib/release.rake`; every recovery path now receives the command originally selected by the release task.
2. Run the focused RSpec file and `bash script/release-test.bash` to exercise the helper and release-supervisor paths.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation (the operator-facing option and guidance landed in #4957; this follow-up preserves it during recovery)~
- [x] ~Update CHANGELOG file (internal release-process correction; no user-visible product behavior)~

### Other Information

Follow-up to #4955 and #4957. This PR does not publish, tag, or change a release branch.

Labels: `ready-for-hosted-ci` — release-process behavior needs current-head hosted confirmation.

Benchmarks: not applicable.

<details>
<summary>Agent details</summary>

### Commands and results

- `RELEASE_CI_EVALUATE_HEAD=true bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb:16242` — 10 examples, 0 failures after the isolation fix (the preceding RED replay produced 8 failures when the ambient value leaked into default-mode examples).
- `bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb` — 947 examples, 0 failures.
- `bash script/release-test.bash` — 70/70 passing.
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop ../rakelib/release.rake spec/react_on_rails/release_rake_helpers_spec.rb` — 2 files inspected, no offenses.
- `env DISABLE_RBS_RUNTIME_CHECKING=true .agents/bin/validate` — all checks passed; gem suite: 2,600 examples, 0 failures, 5 pending.
- Pre-push branch lint — 2 files inspected, no offenses.

The plain root validator's RBS runtime check fails under local Ruby 4.0.5 in unchanged toolchain coverage. This commit changes only `rakelib/release.rake` and its RSpec file, so it cannot affect that RBS path; the successful validator above isolates the unrelated local baseline while retaining all applicable release/test checks.

### Exact-head and replay evidence

- Base: `649247f31b82593eef9e7269dfc5fd720105669e` (`origin/main`)
- Head: `ba53a449959fdaadc4ae23b7b70cfb6abb466d7e`
- `script/ci-changes-detector origin/main` selected Ruby lint, gem RSpec, and release-supervisor integration coverage.
- Independent exact-commit Codex review: zero findings; `patch is correct` (confidence 0.97).

### Coordination and reviewer telemetry

- #4955 private claim is active and owned by `ror-4955-release-modifier-followup` on this branch.
- The `release-line:17.1.0` lease remains active but blocked on this source PR; no release-branch write has occurred.

### Decision log

- **Non-blocking:** preserve the existing environment variable internally rather than replace it.
  - **Decision:** carry the selected script modifiers into recovery text.
  - **Why:** keeps backward compatibility while making the documented CLI option the normal operator interface.
  - **Review later:** None.

### Merge confidence

Confidence note:
- Validated: focused helper/replay specs, release supervisor tests, RuboCop, full validator with the known local RBS toolchain baseline isolated, and independent exact-head review.
- Evidence: commands above; current-head hosted CI requested after PR creation.
- UNKNOWN: hosted current-head checks and configured GitHub review artifacts are pending.
- Residual risk: recovery text covers multiple readiness branches; hosted confirmation remains required.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release readiness recovery messages now provide the appropriate retry command for the current run mode.
  * Retry instructions preserve dry-run and exact-HEAD options, making recovery steps easier to follow.

* **Tests**
  * Added coverage to verify retry commands and their run-mode options are correctly included in readiness and recovery messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->