### PR TITLE
Backport strict RC release recovery to 17.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **Release failures now provide supervised, reason-specific recovery**: `script/release --evaluate-head`
+  supports strict exact-HEAD CI evaluation for both preview and live retries, foreign claims identify the available
+  holder/task/session metadata and targeted status command, and npm readiness distinguishes stale dependencies,
+  pnpm-version mismatches, and package-build failures without requiring `bin/setup`. Fixes
+  [Issue 4955](https://github.com/shakacode/react_on_rails/issues/4955).
+
 - **Fresh generated apps now preserve their resolved Shakapacker version**: The installer now pins
   `bundle add shakapacker --strict` to the version already selected through React on Rails instead
   of allowing an older globally installed gem to downgrade the app's lockfile. The tested

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -158,6 +158,14 @@ script/release --dry-run
 script/release
 ```
 
+Only when a CI-walkback failure proves exact HEAD has complete healthy evidence,
+use the exact modifier commands printed by that failure:
+
+```bash
+script/release --dry-run --evaluate-head
+script/release --evaluate-head
+```
+
 `script/release` derives `release-line:X.Y.Z` and `release/X.Y.Z` from that
 changelog version, creates a fresh UUID-backed identity, claims the exact line,
 heartbeats and authoritatively verifies it, supervises the Rake process group,
@@ -172,6 +180,18 @@ observed version in `If-Match`. Every active record is refused, including one
 whose holder appears dead, stale, or expired. A concurrent `409` is likewise a
 claim refusal. The preliminary status read is diagnostic only and never grants
 takeover authority.
+
+On a foreign-claim refusal, the wrapper prints available holder metadata,
+including task/thread and session fields when the claim recorded them, plus the
+targeted inspection command:
+
+```bash
+agent-coord status --repo shakacode/react_on_rails --target release-line:X.Y.Z --json
+```
+
+Inspect and coordinate with the recorded holder. Never infer takeover safety
+from lease expiry or heartbeat age alone; the wrapper does not provide or
+attempt an automatic takeover.
 
 #### Advanced automation compatibility
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -102,6 +102,20 @@ script/release --dry-run # no coordination and no release writes
 script/release           # live release after the preview and required gates
 ```
 
+`--evaluate-head` is a strict CI-evaluation modifier, not a waiver. Use it only
+when the release failure itself confirms that exact HEAD has complete healthy
+required-check evidence and prints both of these recovery commands:
+
+```bash
+script/release --dry-run --evaluate-head # no-write preview
+script/release --evaluate-head           # supervised live retry
+```
+
+Existing automation that already supplies `RELEASE_CI_EVALUATE_HEAD=true` to
+the wrapper remains supported for backward compatibility. New and interactive
+operator guidance must use `--evaluate-head`; the environment variable is an
+internal child contract, not the normal interface.
+
 Do not pass a positional version to the wrapper. The first valid, non-empty
 version section after `### [Unreleased]` is the source of truth. Internal Rake
 arguments remain available only for explicit no-write diagnostics and tightly
@@ -141,13 +155,21 @@ the clean-worktree check and verbosity setup. The root
 must byte-match the committed `pnpm-lock.yaml`, and every npm release package must pass its normal `build` script
 with lifecycle scripts enabled. This happens before release-checkout creation, `git pull`, npm or GitHub
 authentication, CI/tag/version-policy remote reads, registry probes, confirmation, version mutation, ShakaPerf
-dispatch, tagging, publication, or OTP prompting. A pnpm version mismatch must first be repaired by activating the
-exact pnpm version declared by the root `packageManager`. The release prints this frozen-install command for the
-installed-dependency repair:
+dispatch, tagging, publication, or OTP prompting. Recovery is reason-specific:
+
+- Missing or stale installed dependencies: run the frozen install the error prints.
+- Pnpm-version mismatch: activate the exact version declared by the root `packageManager`, verify `pnpm --version`,
+  and retry without treating dependency installation as the failure.
+- Package-build failure: fix and rerun the exact `pnpm --filter <package> run build` command the error prints.
+
+For only the stale-dependency case, the required repair is:
 
 ```bash
 pnpm install --frozen-lockfile
 ```
+
+`bin/setup` is never run automatically. The stale-dependency diagnostic may mention it only as an optional broader
+environment refresh; it is not required to retry the release.
 
 After the initial check succeeds, the task binds it to the exact current commit. A live release then runs
 `git pull --rebase` and immediately resolves `HEAD` again. If the pull advanced the checkout, all four release-package
@@ -205,7 +227,6 @@ VERBOSE=1                    # Enable verbose logging (shows all output)
 NPM_OTP=<code>               # Provide NPM one-time password (reused for all NPM publishes)
 RUBYGEMS_OTP=<code>          # Provide RubyGems one-time password (reused for both gems)
 RELEASE_VERSION_POLICY_OVERRIDE=true # Override release version policy checks
-RELEASE_CI_EVALUATE_HEAD=true # Strictly evaluate the fetched exact release-source HEAD; not a waiver
 RELEASE_CI_STATUS_OVERRIDE=true # DANGEROUS last-resort waiver for the release CI-status gate
 RELEASE_ACCELERATED_RC=true # Explicit RC only: publish while named pending gates finish
 RELEASE_TRACKER=<issue> # Active release tracker for ShakaPerf evidence, accelerated RCs, and final promotion
@@ -323,25 +344,26 @@ the newest runtime-bearing commit. This is intentional: CI path filtering can at
 runtime suite to metadata-only commits, while the runtime-bearing commit is the one whose full
 suite establishes release health.
 
-`RELEASE_CI_EVALUATE_HEAD=true` disables only that walkback. It still queries and enforces the
-same CI gate at the exact fetched HEAD; it is a strict evaluation, not a waiver. It is appropriate
+`script/release --evaluate-head` disables only that walkback for its supervised child. It still queries and enforces
+the same CI gate at the exact fetched HEAD; it is a strict evaluation, not a waiver. It is appropriate
 only for the narrow topology where GitHub attached complete workflows to the final release tip,
 while the intermediate runtime SHA selected by normal walkback has zero usable runs.
 
-| Normal walkback / exact HEAD evidence                                                                                      | Required action                                                                                            |
-| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Walked-back SHA has usable CI evidence                                                                                     | Let the normal gate decide. Do not set either variable.                                                    |
-| Walked-back SHA has no usable runs; exact HEAD is pending                                                                  | Wait for the linked exact-HEAD checks. They remain blocking.                                               |
-| Walked-back SHA has no usable runs; exact HEAD has failed checks                                                           | Fix or otherwise resolve the failures. They remain blocking.                                               |
-| Walked-back SHA has no usable runs; exact HEAD is completely healthy under the same stable/prerelease required-check rules | Re-run with `RELEASE_CI_EVALUATE_HEAD=true`; it evaluates that exact HEAD and still blocks on any failure. |
-| Walked-back SHA has no usable runs; exact HEAD has no checks, unknown status, or an API failure                            | Fail closed. Wait for evidence or repair API/auth access; do not use strict HEAD without evidence.         |
-| Any case where a maintainer-approved waiver is truly required                                                              | `RELEASE_CI_STATUS_OVERRIDE=true` is the dangerous last resort, not a recovery default.                    |
+| Normal walkback / exact HEAD evidence                                                                                      | Required action                                                                                    |
+| -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Walked-back SHA has usable CI evidence                                                                                     | Let the normal gate decide. Do not add a recovery modifier or waiver.                              |
+| Walked-back SHA has no usable runs; exact HEAD is pending                                                                  | Wait for the linked exact-HEAD checks. They remain blocking.                                       |
+| Walked-back SHA has no usable runs; exact HEAD has failed checks                                                           | Fix or otherwise resolve the failures. They remain blocking.                                       |
+| Walked-back SHA has no usable runs; exact HEAD is completely healthy under the same stable/prerelease required-check rules | Use the printed `script/release --evaluate-head` recovery; it still blocks on any failure.         |
+| Walked-back SHA has no usable runs; exact HEAD has no checks, unknown status, or an API failure                            | Fail closed. Wait for evidence or repair API/auth access; do not use strict HEAD without evidence. |
+| Any case where a maintainer-approved waiver is truly required                                                              | `RELEASE_CI_STATUS_OVERRIDE=true` is the dangerous last resort, not a recovery default.            |
 
 Examples:
 
 ```bash
-# Only after the task reports complete healthy exact-HEAD evidence, retry the explicit target version:
-RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release[17.0.0.rc.10,true]"
+# Only after the task reports complete healthy exact-HEAD evidence:
+script/release --dry-run --evaluate-head
+script/release --evaluate-head
 ```
 
 Do not use `RELEASE_CI_STATUS_OVERRIDE=true` to substitute for pending, missing, failed, or
@@ -852,7 +874,7 @@ This task depends on the `gem-release` Ruby gem, which is installed via `bundle 
 Before releasing to production, always preview with a dry run:
 
 ```bash
-bundle exec rake "release[16.5.0,true]"
+script/release --dry-run
 ```
 
 This uses a temporary git worktree to show exactly what would be updated without making any changes.
@@ -864,7 +886,7 @@ This uses a temporary git worktree to show exactly what would be updated without
 Always test with a dry run before actually releasing:
 
 ```bash
-bundle exec rake "release[16.2.0,true]"
+script/release --dry-run
 ```
 
 This shows you exactly what would be updated without making any changes.
@@ -881,15 +903,24 @@ The release script now checks NPM authentication at the start and will automatic
 
 ### NPM Release Readiness Issues
 
-If the release reports a pnpm version mismatch, first activate the exact pnpm version declared by the root
-`packageManager`. Then run the exact frozen-install repair command it prints from the repository root for the
-installed dependency check:
+Follow the reason named by the release failure:
+
+- For missing or stale installed dependencies, run from the repository root:
 
 ```bash
 pnpm install --frozen-lockfile
 ```
 
-Then fix any remaining build error and rerun the same explicit release version. The release will not have reached
+- For a pnpm-version mismatch, activate the exact version declared by the root `packageManager`, verify it with
+  `pnpm --version`, and retry `script/release`. Do not reinstall dependencies unless a separate stale-dependency
+  failure requests it.
+- For a package-build failure, fix the reported error, rerun the exact printed
+  `pnpm --filter <package> run build` command, and retry `script/release`.
+
+`bin/setup` is only an optional broader environment refresh for a stale dependency state. The release script does
+not run it automatically, and neither a pnpm-version mismatch nor a package-build failure should recommend it.
+
+These readiness failures happen before
 release-checkout creation, pull/authentication, remote CI/tag/version reads, confirmation, version mutation,
 ShakaPerf dispatch, tagging, publication, or OTP prompting.
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -9386,7 +9386,14 @@ def abort_npm_release_readiness!(reason, recovery:)
   ERROR
 end
 
-def declared_pnpm_release_version!(monorepo_root:)
+def supervised_release_retry_command(dry_run:, evaluate_head:)
+  command = ["script/release"]
+  command << "--dry-run" if dry_run
+  command << "--evaluate-head" if evaluate_head
+  command.join(" ")
+end
+
+def declared_pnpm_release_version!(monorepo_root:, retry_command: "script/release")
   package_json = JSON.parse(File.read(File.join(monorepo_root, "package.json")))
   package_manager = package_json["packageManager"]
   match = package_manager.to_s.match(/\Apnpm@(?<version>\d+\.\d+\.\d+)(?:\+sha512\.[0-9a-f]+)?\z/i)
@@ -9397,7 +9404,7 @@ def declared_pnpm_release_version!(monorepo_root:)
     recovery: <<~RECOVERY.strip
       Restore an exact pnpm@X.Y.Z pin in the root packageManager field.
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 rescue Errno::ENOENT, JSON::ParserError => e
@@ -9406,12 +9413,12 @@ rescue Errno::ENOENT, JSON::ParserError => e
     recovery: <<~RECOVERY.strip
       Restore a readable root package.json with a valid exact packageManager pin.
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def capture_npm_release_readiness_command(monorepo_root, *command)
+def capture_npm_release_readiness_command(monorepo_root, *command, retry_command: "script/release")
   Open3.capture2e(*command, chdir: monorepo_root)
 rescue StandardError => e
   abort_npm_release_readiness!(
@@ -9419,19 +9426,19 @@ rescue StandardError => e
     recovery: <<~RECOVERY.strip
       Restore the repository-declared pnpm command on PATH.
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def abort_stale_npm_release_dependencies!
+def abort_stale_npm_release_dependencies!(retry_command: "script/release")
   abort_npm_release_readiness!(
     "installed dependency state is missing or stale",
     recovery: <<~RECOVERY.strip
       Required recovery:
         pnpm install --frozen-lockfile
       Then retry:
-        script/release
+        #{retry_command}
 
       Optional broader environment refresh (not required for this failure):
         bin/setup
@@ -9439,68 +9446,71 @@ def abort_stale_npm_release_dependencies!
   )
 end
 
-def abort_pnpm_release_version_mismatch!(installed_version:, declared_version:)
+def abort_pnpm_release_version_mismatch!(installed_version:, declared_version:, retry_command: "script/release")
   abort_npm_release_readiness!(
     "installed pnpm version #{installed_version.inspect} does not match packageManager #{declared_version.inspect}",
     recovery: <<~RECOVERY.strip
       Activate pnpm #{declared_version} declared by the root packageManager, then verify:
         pnpm --version
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def abort_pnpm_release_version_probe_failure!(output:)
+def abort_pnpm_release_version_probe_failure!(output:, retry_command: "script/release")
   abort_npm_release_readiness!(
     "pnpm --version failed\n\n#{output.to_s.strip}",
     recovery: <<~RECOVERY.strip
       Restore the repository-declared pnpm command on PATH, then verify:
         pnpm --version
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def abort_npm_release_package_build!(package_name:, output:)
+def abort_npm_release_package_build!(package_name:, output:, retry_command: "script/release")
   abort_npm_release_readiness!(
     "#{package_name} build failed\n\n#{output.to_s.strip}",
     recovery: <<~RECOVERY.strip
       Fix the package build failure, then verify:
         pnpm --filter #{package_name} run build
       Then retry:
-        script/release
+        #{retry_command}
     RECOVERY
   )
 end
 
-def validate_npm_release_readiness!(monorepo_root:)
-  declared_pnpm_version = declared_pnpm_release_version!(monorepo_root:)
+def validate_npm_release_readiness!(monorepo_root:, retry_command: "script/release")
+  declared_pnpm_version = declared_pnpm_release_version!(monorepo_root:, retry_command:)
   workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
   installed_lock = File.join(monorepo_root, "node_modules", ".pnpm", "lock.yaml")
   dependency_state_ready = File.file?(workspace_lock) && File.file?(installed_lock) &&
                            File.binread(workspace_lock) == File.binread(installed_lock)
-  abort_stale_npm_release_dependencies! unless dependency_state_ready
+  abort_stale_npm_release_dependencies!(retry_command:) unless dependency_state_ready
 
-  version_output, version_status = capture_npm_release_readiness_command(monorepo_root, "pnpm", "--version")
+  version_output, version_status = capture_npm_release_readiness_command(
+    monorepo_root, "pnpm", "--version", retry_command:
+  )
   installed_pnpm_version = version_output.to_s.strip
-  abort_pnpm_release_version_probe_failure!(output: version_output) unless version_status.success?
+  abort_pnpm_release_version_probe_failure!(output: version_output, retry_command:) unless version_status.success?
 
   unless installed_pnpm_version == declared_pnpm_version
     abort_pnpm_release_version_mismatch!(
       installed_version: installed_pnpm_version,
-      declared_version: declared_pnpm_version
+      declared_version: declared_pnpm_version,
+      retry_command:
     )
   end
 
   NPM_RELEASE_PACKAGE_NAMES.each do |package_name|
     output, status = capture_npm_release_readiness_command(
-      monorepo_root, "pnpm", "--filter", package_name, "run", "build"
+      monorepo_root, "pnpm", "--filter", package_name, "run", "build", retry_command:
     )
     next if status.success?
 
-    abort_npm_release_package_build!(package_name:, output:)
+    abort_npm_release_package_build!(package_name:, output:, retry_command:)
   end
 
   puts "✓ npm release packages are ready to publish"
@@ -9513,14 +9523,14 @@ def current_npm_release_readiness_sha!(monorepo_root:, context:)
   abort "❌ Unable to bind npm release readiness to an exact git SHA before #{context}."
 end
 
-def refresh_npm_release_readiness_after_pull!(monorepo_root:, readiness_sha:)
+def refresh_npm_release_readiness_after_pull!(monorepo_root:, readiness_sha:, retry_command: "script/release")
   post_pull_sha = current_npm_release_readiness_sha!(
     monorepo_root:,
     context: "post-pull npm release readiness verification"
   )
   return readiness_sha if post_pull_sha == readiness_sha
 
-  validate_npm_release_readiness!(monorepo_root:)
+  validate_npm_release_readiness!(monorepo_root:, retry_command:)
   validated_sha = current_npm_release_readiness_sha!(
     monorepo_root:,
     context: "post-pull npm release readiness binding"
@@ -10190,6 +10200,10 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   args_hash = args.to_hash
 
   is_dry_run = release_truthy?(args_hash[:dry_run])
+  release_retry_command = supervised_release_retry_command(
+    dry_run: is_dry_run,
+    evaluate_head: ci_evaluate_head_only?
+  )
   activate_release_lease_guard!(dry_run: is_dry_run)
   is_verbose = ENV["VERBOSE"] == "1"
   allow_version_policy_override = version_policy_override_enabled?(args_hash[:override_version_policy])
@@ -10215,7 +10229,7 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
     monorepo_root:,
     context: "initial npm release readiness verification"
   )
-  validate_npm_release_readiness!(monorepo_root:)
+  validate_npm_release_readiness!(monorepo_root:, retry_command: release_retry_command)
   validated_readiness_sha = current_npm_release_readiness_sha!(
     monorepo_root:,
     context: "initial npm release readiness binding"
@@ -10242,7 +10256,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       sh_in_dir_for_release(release_root, "git pull --rebase")
       npm_readiness_sha = refresh_npm_release_readiness_after_pull!(
         monorepo_root: release_root,
-        readiness_sha: npm_readiness_sha
+        readiness_sha: npm_readiness_sha,
+        retry_command: release_retry_command
       )
     end
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -9393,6 +9393,21 @@ def supervised_release_retry_command(dry_run:, evaluate_head:)
   command.join(" ")
 end
 
+def direct_release_dry_run_retry_command(task_arguments, evaluate_head:)
+  rake_task = "release[#{task_arguments.to_a.map(&:to_s).join(',')}]"
+  command = Shellwords.join(["bundle", "exec", "rake", rake_task])
+  return command unless evaluate_head
+
+  "RELEASE_CI_EVALUATE_HEAD=true #{command}"
+end
+
+def release_readiness_retry_command(task_arguments:, dry_run:, evaluate_head:)
+  supervised = release_truthy?(ENV.fetch("REACT_ON_RAILS_RELEASE_SUPERVISED", nil))
+  return supervised_release_retry_command(dry_run:, evaluate_head:) if supervised || !dry_run
+
+  direct_release_dry_run_retry_command(task_arguments, evaluate_head:)
+end
+
 def declared_pnpm_release_version!(monorepo_root:, retry_command: "script/release")
   package_json = JSON.parse(File.read(File.join(monorepo_root, "package.json")))
   package_manager = package_json["packageManager"]
@@ -10200,7 +10215,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   args_hash = args.to_hash
 
   is_dry_run = release_truthy?(args_hash[:dry_run])
-  release_retry_command = supervised_release_retry_command(
+  release_retry_command = release_readiness_retry_command(
+    task_arguments: args,
     dry_run: is_dry_run,
     evaluate_head: ci_evaluate_head_only?
   )

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -3152,6 +3152,18 @@ rescue Errno::ENOENT, Errno::EACCES
   nil
 end
 
+def prepared_release_version_from_changelog_at_revision(monorepo_root:, revision:)
+  changelog, status = Open3.capture2e(
+    "git", "-C", monorepo_root, "show", "#{revision}:CHANGELOG.md"
+  )
+  return nil unless status.success?
+
+  ReleaseChangelogSelector.prepared_version(
+    changelog.lines,
+    version_pattern: ReleaseLeaseGuard::RELEASE_VERSION_PATTERN
+  )
+end
+
 def current_gem_version(monorepo_root)
   version_file = File.join(monorepo_root, "react_on_rails", "lib", "react_on_rails", "version.rb")
   content = File.read(version_file)
@@ -3180,6 +3192,16 @@ end
 # allowed, but `release/X.Y.Z` branches cannot cut another release line.
 def stable_release_branch_allowed?(current_branch:, target_gem_version:)
   ["main", "release/#{target_gem_version}"].include?(current_branch)
+end
+
+def supervised_release_branch_allowed?(current_branch:, target_gem_version:)
+  return false if current_branch.to_s.empty? || target_gem_version.to_s.empty?
+
+  if release_prerelease_version?(target_gem_version)
+    current_branch == "release/#{release_base_version(target_gem_version)}"
+  else
+    stable_release_branch_allowed?(current_branch:, target_gem_version:)
+  end
 end
 
 def release_base_version(gem_version)
@@ -8558,8 +8580,9 @@ def fetch_accelerated_rc_ci_snapshot!(repo_slug:, sha:, monorepo_root: nil, ci_b
   )
 end
 
-def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required_names:, is_prerelease:, ci_branch:,
-                                 required_checks_known: true, target_gem_version: nil)
+def exact_head_recovery_guidance(repo_slug:, monorepo_root:, head_sha:, evaluated_sha:, required_names:,
+                                 is_prerelease:, ci_branch:, required_checks_known: true, current_branch: nil,
+                                 target_gem_version: nil)
   return nil if head_sha.nil? || head_sha == evaluated_sha
   unless required_checks_known
     return exact_head_unknown_guidance("❌ Required CI check discovery is unknown; release remains blocked.")
@@ -8627,11 +8650,41 @@ def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required
         "❌ Exact HEAD is healthy, but the resolved release version is unavailable; release remains blocked."
       )
     end
+    unless supervised_release_branch_allowed?(current_branch:, target_gem_version:)
+      branch_label = current_branch.to_s.empty? ? "unknown" : current_branch
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but current branch #{branch_label} is not supported by " \
+             "script/release for #{target_gem_version}; wrapper recovery remains blocked."
+    end
+    prepared_head_version = prepared_release_version_from_changelog_at_revision(
+      monorepo_root:,
+      revision: head_sha
+    )
+    if prepared_head_version.to_s.empty?
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but script/release cannot resolve a prepared " \
+             "CHANGELOG.md version; wrapper recovery remains blocked."
+    end
+    unless prepared_head_version == target_gem_version
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but script/release would select #{prepared_head_version} " \
+             "while the diagnostic target is #{target_gem_version}; wrapper recovery remains blocked."
+    end
+    prepared_checkout_version = prepared_release_version_from_changelog(monorepo_root:)
+    if prepared_checkout_version.to_s.empty?
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but the current checkout has no prepared " \
+             "CHANGELOG.md version; wrapper recovery remains blocked."
+    end
+    unless prepared_checkout_version == target_gem_version
+      return "❌ Exact HEAD #{head_sha[0, 8]} is healthy, but the current checkout would select " \
+             "#{prepared_checkout_version} while the diagnostic target is #{target_gem_version}; " \
+             "wrapper recovery remains blocked."
+    end
 
     <<~GUIDANCE.strip
       ✓ Exact HEAD #{head_sha[0, 8]} has complete healthy CI evidence.
       Preview a re-evaluation of that exact HEAD (strict evaluation, not a waiver):
-        RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release[#{target_gem_version},true]"
+        script/release --dry-run --evaluate-head
+
+      Live retry through the supervised release path:
+        script/release --evaluate-head
 
       #{release_compound_live_boundary_guidance}
     GUIDANCE
@@ -8647,7 +8700,7 @@ def exact_head_recovery_guidance(repo_slug:, head_sha:, evaluated_sha:, required
 end
 
 def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dry_run:, ci_branch: "main",
-                             target_gem_version: nil, defer_pending: false)
+                             target_gem_version: nil, defer_pending: false, current_branch: nil)
   ensure_ci_status_override_is_prerelease!(allow_override:, is_prerelease:)
   puts "\nChecking CI status on origin/#{ci_branch}..."
 
@@ -8761,12 +8814,14 @@ def validate_main_ci_status!(monorepo_root:, is_prerelease:, allow_override:, dr
     if recovery_eligible && %i[no_checks no_required_checks].include?(evaluation[:kind])
       guidance = exact_head_recovery_guidance(
         repo_slug:,
+        monorepo_root:,
         head_sha: data[:head_sha],
         evaluated_sha: sha,
         required_names:,
         is_prerelease:,
         ci_branch:,
         required_checks_known:,
+        current_branch:,
         target_gem_version:
       )
       message += "\n\n#{guidance}" if guidance
@@ -9323,11 +9378,11 @@ def fetch_rubygems_versions(gem_name, api_url: RUBYGEMS_VERSIONS_API_URL)
   [response.body, response]
 end
 
-def abort_npm_release_readiness!(reason)
+def abort_npm_release_readiness!(reason, recovery:)
   abort <<~ERROR
     ❌ npm release readiness failed: #{reason}.
 
-    pnpm install --frozen-lockfile
+    #{recovery}
   ERROR
 end
 
@@ -9337,15 +9392,87 @@ def declared_pnpm_release_version!(monorepo_root:)
   match = package_manager.to_s.match(/\Apnpm@(?<version>\d+\.\d+\.\d+)(?:\+sha512\.[0-9a-f]+)?\z/i)
   return match[:version] if match
 
-  abort_npm_release_readiness!("root packageManager must declare an exact pnpm version")
+  abort_npm_release_readiness!(
+    "root packageManager must declare an exact pnpm version",
+    recovery: <<~RECOVERY.strip
+      Restore an exact pnpm@X.Y.Z pin in the root packageManager field.
+      Then retry:
+        script/release
+    RECOVERY
+  )
 rescue Errno::ENOENT, JSON::ParserError => e
-  abort_npm_release_readiness!("root packageManager cannot be verified (#{e.class}: #{e.message})")
+  abort_npm_release_readiness!(
+    "root packageManager cannot be verified (#{e.class}: #{e.message})",
+    recovery: <<~RECOVERY.strip
+      Restore a readable root package.json with a valid exact packageManager pin.
+      Then retry:
+        script/release
+    RECOVERY
+  )
 end
 
 def capture_npm_release_readiness_command(monorepo_root, *command)
   Open3.capture2e(*command, chdir: monorepo_root)
 rescue StandardError => e
-  abort_npm_release_readiness!("npm toolchain command failed to start (#{e.class}: #{e.message})")
+  abort_npm_release_readiness!(
+    "npm toolchain command failed to start (#{e.class}: #{e.message})",
+    recovery: <<~RECOVERY.strip
+      Restore the repository-declared pnpm command on PATH.
+      Then retry:
+        script/release
+    RECOVERY
+  )
+end
+
+def abort_stale_npm_release_dependencies!
+  abort_npm_release_readiness!(
+    "installed dependency state is missing or stale",
+    recovery: <<~RECOVERY.strip
+      Required recovery:
+        pnpm install --frozen-lockfile
+      Then retry:
+        script/release
+
+      Optional broader environment refresh (not required for this failure):
+        bin/setup
+    RECOVERY
+  )
+end
+
+def abort_pnpm_release_version_mismatch!(installed_version:, declared_version:)
+  abort_npm_release_readiness!(
+    "installed pnpm version #{installed_version.inspect} does not match packageManager #{declared_version.inspect}",
+    recovery: <<~RECOVERY.strip
+      Activate pnpm #{declared_version} declared by the root packageManager, then verify:
+        pnpm --version
+      Then retry:
+        script/release
+    RECOVERY
+  )
+end
+
+def abort_pnpm_release_version_probe_failure!(output:)
+  abort_npm_release_readiness!(
+    "pnpm --version failed\n\n#{output.to_s.strip}",
+    recovery: <<~RECOVERY.strip
+      Restore the repository-declared pnpm command on PATH, then verify:
+        pnpm --version
+      Then retry:
+        script/release
+    RECOVERY
+  )
+end
+
+def abort_npm_release_package_build!(package_name:, output:)
+  abort_npm_release_readiness!(
+    "#{package_name} build failed\n\n#{output.to_s.strip}",
+    recovery: <<~RECOVERY.strip
+      Fix the package build failure, then verify:
+        pnpm --filter #{package_name} run build
+      Then retry:
+        script/release
+    RECOVERY
+  )
 end
 
 def validate_npm_release_readiness!(monorepo_root:)
@@ -9354,14 +9481,16 @@ def validate_npm_release_readiness!(monorepo_root:)
   installed_lock = File.join(monorepo_root, "node_modules", ".pnpm", "lock.yaml")
   dependency_state_ready = File.file?(workspace_lock) && File.file?(installed_lock) &&
                            File.binread(workspace_lock) == File.binread(installed_lock)
-  abort_npm_release_readiness!("installed dependency state is missing or stale") unless dependency_state_ready
+  abort_stale_npm_release_dependencies! unless dependency_state_ready
 
   version_output, version_status = capture_npm_release_readiness_command(monorepo_root, "pnpm", "--version")
   installed_pnpm_version = version_output.to_s.strip
-  unless version_status.success? && installed_pnpm_version == declared_pnpm_version
-    abort_npm_release_readiness!(
-      "installed pnpm version #{installed_pnpm_version.inspect} does not match packageManager " \
-      "#{declared_pnpm_version.inspect}"
+  abort_pnpm_release_version_probe_failure!(output: version_output) unless version_status.success?
+
+  unless installed_pnpm_version == declared_pnpm_version
+    abort_pnpm_release_version_mismatch!(
+      installed_version: installed_pnpm_version,
+      declared_version: declared_pnpm_version
     )
   end
 
@@ -9371,7 +9500,7 @@ def validate_npm_release_readiness!(monorepo_root:)
     )
     next if status.success?
 
-    abort_npm_release_readiness!("#{package_name} build failed\n\n#{output.to_s.strip}")
+    abort_npm_release_package_build!(package_name:, output:)
   end
 
   puts "✓ npm release packages are ready to publish"
@@ -10312,6 +10441,7 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       allow_override: allow_ci_status_override,
       dry_run: is_dry_run,
       ci_branch:,
+      current_branch:,
       target_gem_version: resolved_target_gem_version,
       defer_pending: !accelerated_rc_options.nil?
     )

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7190,12 +7190,133 @@ RSpec.describe "release.rake helper methods" do
         File.write(File.join(monorepo_root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
         expect(Open3).not_to receive(:capture2e)
 
-        expect do
+        failure = begin
           validate_npm_release_readiness!(monorepo_root:)
-        end.to raise_error(
-          SystemExit,
-          /installed dependency state is missing or stale.*\npnpm install --frozen-lockfile\n?\z/m
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include("installed dependency state is missing or stale")
+          expect(failure&.message).to include("Required recovery:")
+          expect(failure&.message).to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Optional broader environment refresh")
+          expect(failure&.message).to include("bin/setup")
+        end
+      end
+    end
+
+    it "reports pnpm-version recovery without prescribing a dependency reinstall" do
+      success_status = instance_double(Process::Status, success?: true)
+
+      Dir.mktmpdir do |monorepo_root|
+        File.write(
+          File.join(monorepo_root, "package.json"),
+          JSON.generate("packageManager" => "pnpm@10.33.4+sha512.abc123")
         )
+        workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
+        installed_store = File.join(monorepo_root, "node_modules", ".pnpm")
+        FileUtils.mkdir_p(installed_store)
+        File.write(workspace_lock, "lockfileVersion: '9.0'\n")
+        File.write(File.join(installed_store, "lock.yaml"), File.read(workspace_lock))
+        allow(Open3).to receive(:capture2e)
+          .with("pnpm", "--version", chdir: monorepo_root)
+          .and_return(["9.15.0\n", success_status])
+
+        failure = begin
+          validate_npm_release_readiness!(monorepo_root:)
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include('installed pnpm version "9.15.0" does not match packageManager "10.33.4"')
+          expect(failure&.message).to include("Activate pnpm 10.33.4")
+          expect(failure&.message).to include("pnpm --version")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).not_to include("bin/setup")
+        end
+      end
+    end
+
+    it "reports a failed pnpm version probe without claiming a version mismatch" do
+      failure_status = instance_double(Process::Status, success?: false)
+
+      Dir.mktmpdir do |monorepo_root|
+        File.write(
+          File.join(monorepo_root, "package.json"),
+          JSON.generate("packageManager" => "pnpm@10.33.4+sha512.abc123")
+        )
+        workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
+        installed_store = File.join(monorepo_root, "node_modules", ".pnpm")
+        FileUtils.mkdir_p(installed_store)
+        File.write(workspace_lock, "lockfileVersion: '9.0'\n")
+        File.write(File.join(installed_store, "lock.yaml"), File.read(workspace_lock))
+        allow(Open3).to receive(:capture2e)
+          .with("pnpm", "--version", chdir: monorepo_root)
+          .and_return(["corepack failed to activate pnpm\n", failure_status])
+
+        failure = begin
+          validate_npm_release_readiness!(monorepo_root:)
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include("pnpm --version failed")
+          expect(failure&.message).to include("corepack failed to activate pnpm")
+          expect(failure&.message).to include("Restore the repository-declared pnpm command")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).not_to include("does not match packageManager")
+          expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).not_to include("bin/setup")
+        end
+      end
+    end
+
+    it "reports the exact failed package build command without prescribing setup or install" do
+      stub_const("NPM_RELEASE_PACKAGE_NAMES", ["react-on-rails"])
+      success_status = instance_double(Process::Status, success?: true)
+      failure_status = instance_double(Process::Status, success?: false)
+
+      Dir.mktmpdir do |monorepo_root|
+        File.write(
+          File.join(monorepo_root, "package.json"),
+          JSON.generate("packageManager" => "pnpm@10.33.4+sha512.abc123")
+        )
+        workspace_lock = File.join(monorepo_root, "pnpm-lock.yaml")
+        installed_store = File.join(monorepo_root, "node_modules", ".pnpm")
+        FileUtils.mkdir_p(installed_store)
+        File.write(workspace_lock, "lockfileVersion: '9.0'\n")
+        File.write(File.join(installed_store, "lock.yaml"), File.read(workspace_lock))
+        expect(Open3).to receive(:capture2e)
+          .with("pnpm", "--version", chdir: monorepo_root)
+          .ordered.and_return(["10.33.4\n", success_status])
+        expect(Open3).to receive(:capture2e)
+          .with("pnpm", "--filter", "react-on-rails", "run", "build", chdir: monorepo_root)
+          .ordered.and_return(["TypeScript compilation failed\n", failure_status])
+
+        failure = begin
+          validate_npm_release_readiness!(monorepo_root:)
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        aggregate_failures do
+          expect(failure&.message).to include("react-on-rails build failed")
+          expect(failure&.message).to include("TypeScript compilation failed")
+          expect(failure&.message).to include("Fix the package build failure, then verify:")
+          expect(failure&.message).to include("pnpm --filter react-on-rails run build")
+          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
+          expect(failure&.message).not_to include("bin/setup")
+        end
       end
     end
 
@@ -15924,7 +16045,7 @@ RSpec.describe "release.rake helper methods" do
       rakefile = File.read(File.expand_path("../../../rakelib/release.rake", __dir__))
       help = rakefile.match(/desc\("(.*?)"\)\ntask :release/m)[1]
 
-      expect(help).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+      expect(help).not_to include("--evaluate-head")
       expect(help).to include("only after it has found complete healthy\n    CI evidence")
       expect(help).to include("Override prerelease CI gates only")
     end
@@ -19093,7 +19214,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).to have_received(:fetch_main_commit_statuses).once
       end
@@ -19324,7 +19445,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Required CI check discovery is unknown")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
     end
@@ -19651,6 +19772,12 @@ RSpec.describe "release.rake helper methods" do
         allow(self).to receive(:fetch_main_ci_checks)
           .with(monorepo_root:, allow_override: false, dry_run: false, ci_branch: "main")
           .and_return(walkback_without_ci_runs)
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.0.0.rc.10")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.0.0.rc.10")
       end
 
       it "keeps the complete walkback output free of strict guidance for incomplete exact-HEAD evidence" do
@@ -19697,7 +19824,7 @@ RSpec.describe "release.rake helper methods" do
           end
 
           expect(error).to be_a(SystemExit), "#{kind} exact-HEAD evidence should block the release"
-          expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true"),
+          expect(output).not_to include("--evaluate-head"),
                                 "#{kind} exact-HEAD evidence must not receive strict guidance"
         end
       end
@@ -19705,7 +19832,8 @@ RSpec.describe "release.rake helper methods" do
       it "offers strict exact-HEAD evaluation only after exact HEAD is healthy" do
         strict_head_guidance = [
           "strict evaluation, not a waiver",
-          'RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\\[17\\.0\\.0\\.rc\\.10,true\\]"',
+          "script/release --dry-run --evaluate-head",
+          "script/release --evaluate-head",
           "DANGEROUS",
           "RELEASE_CI_STATUS_OVERRIDE=true"
         ].join(".*")
@@ -19724,12 +19852,169 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: false,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
           SystemExit,
           Regexp.new(strict_head_guidance, Regexp::MULTILINE)
         )
+      end
+
+      it "withholds wrapper recovery when the changelog-selected version differs from an explicit diagnostic target" do
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.1")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "release/17.1.0",
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("script/release would select 17.1.0.rc.1")
+          expect(error.message).to include("diagnostic target is 17.1.0.rc.2")
+          expect(error.message).not_to include("--evaluate-head")
+        }
+      end
+
+      it "binds wrapper recovery to the changelog version at the diagnosed exact HEAD" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "release/17.1.0",
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(
+          SystemExit,
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
+        )
+      end
+
+      it "withholds wrapper recovery when the current branch is not supported by script/release" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "main",
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("current branch main is not supported by script/release")
+          expect(error.message).not_to include("--evaluate-head")
+        }
+      end
+
+      it "withholds wrapper recovery when the current checkout selects a different version" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.1")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.2")
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("Lint")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        expect do
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "release/17.1.0",
+            target_gem_version: "17.1.0.rc.2"
+          )
+        end.to raise_error(SystemExit) { |error|
+          expect(error.message).to include("current checkout would select 17.1.0.rc.1")
+          expect(error.message).to include("diagnostic target is 17.1.0.rc.2")
+          expect(error.message).not_to include("--evaluate-head")
+        }
+      end
+
+      it "replays the observed RC.1 walkback stop with supervised preview and live recovery" do
+        allow(self).to receive(:prepared_release_version_from_changelog)
+          .with(monorepo_root:)
+          .and_return("17.1.0.rc.1")
+        allow(self).to receive(:prepared_release_version_from_changelog_at_revision)
+          .with(monorepo_root:, revision: exact_head_sha)
+          .and_return("17.1.0.rc.1")
+        allow(self).to receive(:required_check_names_for_branch)
+          .with(monorepo_root:, repo_slug: "shakacode/react_on_rails", ci_branch: "main")
+          .and_return(required_checks(checks: [required_check("required-pr-gate")]))
+        allow(self).to receive(:fetch_ci_check_runs_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(check_runs: [passing_run("required-pr-gate")])
+        allow(self).to receive(:fetch_ci_statuses_for_sha)
+          .with(repo_slug: "shakacode/react_on_rails", sha: exact_head_sha)
+          .and_return(statuses: [])
+
+        failure = begin
+          validate_main_ci_status!(
+            monorepo_root:,
+            is_prerelease: true,
+            allow_override: false,
+            dry_run: false,
+            current_branch: "release/17.1.0",
+            target_gem_version: "17.1.0.rc.1"
+          )
+          nil
+        rescue SystemExit => error
+          error
+        end
+
+        message = failure&.message.to_s
+        aggregate_failures do
+          expect(message).to include("script/release --dry-run --evaluate-head")
+          expect(message).to include("script/release --evaluate-head")
+          expect(message).not_to include("RELEASE_CI_EVALUATE_HEAD")
+          expect(message.index("script/release --evaluate-head"))
+            .to be < message.index("RELEASE_CI_STATUS_OVERRIDE")
+        end
       end
 
       it "offers strict guidance when a successful exact-HEAD check rerun supersedes an earlier failure" do
@@ -19752,11 +20037,12 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: false,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
 
@@ -19784,11 +20070,12 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
 
@@ -19816,7 +20103,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
       end
@@ -19854,7 +20141,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
         expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
@@ -19884,7 +20171,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
         expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
@@ -19920,7 +20207,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -19951,7 +20238,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -19983,7 +20270,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20017,7 +20304,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20057,7 +20344,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("malformed")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20103,7 +20390,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD #{exact_head_sha} has failing CI evidence")
           expect(error.message).to include("Legacy CI")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20146,7 +20433,7 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Exact HEAD evidence is unknown")
           expect(error.message).to include("Statuses API")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(statuses_query).to eq(expected_statuses_query)
       end
@@ -20326,7 +20613,8 @@ RSpec.describe "release.rake helper methods" do
 
         expected_output = [
           "⚠️ DRY RUN: CI evidence below would block a real release:",
-          '^  RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\\[17\\.0\\.0\\.rc\\.10,true\\]"$',
+          "^  script/release --dry-run --evaluate-head$",
+          "^  script/release --evaluate-head$",
           "⚠️ DRY RUN: Real release remains blocked.",
           "⚠️ DRY RUN: DANGEROUS PRERELEASE-ONLY LAST RESORT",
           "RELEASE_CI_STATUS_OVERRIDE=true"
@@ -20338,6 +20626,7 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: false,
             allow_override: false,
             dry_run: true,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to output(Regexp.new(expected_output, Regexp::MULTILINE)).to_stdout
@@ -20360,7 +20649,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("resolved release version is unavailable")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20380,7 +20669,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("Required CI check discovery is unknown")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20404,11 +20693,12 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
 
@@ -20429,7 +20719,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(%r{Exact HEAD.*pending.*Wait.*Slow test.*https://github\.com}m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20450,7 +20740,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(%r{Exact HEAD.*failing.*JS unit tests.*https://github\.com}m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20473,7 +20763,7 @@ RSpec.describe "release.rake helper methods" do
           expect(error.message).to match(
             /Exact HEAD.*does not provide complete healthy CI evidence.*No CI check runs visible/m
           )
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20491,7 +20781,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD evidence is unknown.*Unable to query GitHub Checks API/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20519,7 +20809,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD.*failing CI evidence.*Advisory benchmark/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20544,7 +20834,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD.*pending CI evidence.*Benchmark/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
       end
 
@@ -20575,7 +20865,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to include("No required CI check runs found")
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).to have_received(:fetch_main_commit_statuses)
       end
@@ -20610,7 +20900,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end.to raise_error(SystemExit) { |error|
           expect(error.message).to match(/Exact HEAD.*failing CI evidence.*Advisory/m)
-          expect(error.message).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+          expect(error.message).not_to include("--evaluate-head")
         }
         expect(self).to have_received(:fetch_ci_statuses_for_sha)
       end
@@ -20641,11 +20931,12 @@ RSpec.describe "release.rake helper methods" do
             is_prerelease: true,
             allow_override: false,
             dry_run: false,
+            current_branch: "release/17.0.0",
             target_gem_version: "17.0.0.rc.10"
           )
         end.to raise_error(
           SystemExit,
-          /RELEASE_CI_EVALUATE_HEAD=true bundle exec rake "release\[17\.0\.0\.rc\.10,true\]"/
+          %r{script/release --dry-run --evaluate-head.*script/release --evaluate-head}m
         )
       end
     end
@@ -21100,7 +21391,7 @@ RSpec.describe "release.rake helper methods" do
           )
         end
 
-        expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+        expect(output).not_to include("--evaluate-head")
         expect(self).not_to have_received(:fetch_ci_check_runs_for_sha)
         expect(self).not_to have_received(:fetch_ci_statuses_for_sha)
       end
@@ -21816,7 +22107,7 @@ RSpec.describe "release.rake helper methods" do
         main_ci_evaluation_sha(monorepo_root:, head_sha: "head")
       end
 
-      expect(output).not_to include("RELEASE_CI_EVALUATE_HEAD=true")
+      expect(output).not_to include("--evaluate-head")
       expect(output).to include(
         "Strict exact-HEAD recovery is offered only after exact-HEAD CI evidence is complete and healthy."
       )

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -16268,6 +16268,7 @@ RSpec.describe "release.rake helper methods" do
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_CI_EVALUATE_HEAD", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("REACT_ON_RAILS_RELEASE_SUPERVISED", nil).and_return("true")
     end
 
     after { release_task.reenable }
@@ -16315,6 +16316,32 @@ RSpec.describe "release.rake helper methods" do
             a_string_matching(/gem bump|git push|git tag/)
           )
         end
+      end
+    end
+
+    it "preserves every explicit Rake argument in direct dry-run readiness recovery" do
+      allow(ENV).to receive(:fetch).with("REACT_ON_RAILS_RELEASE_SUPERVISED", nil).and_return(nil)
+      allow(task_receiver).to receive(:current_git_sha!).and_return("a" * 40)
+      expected_retry_command = "bundle exec rake release\\[17.0.0.rc.10,true,true,false\\]"
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
+        expect(monorepo_root).to eq(self.monorepo_root)
+        expect(retry_command).to eq(expected_retry_command)
+        abort "direct dry-run readiness stopped the release"
+      end
+
+      failure = begin
+        release_task.reenable
+        release_task.invoke("17.0.0.rc.10", true, true, false)
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure&.message).to eq("direct dry-run readiness stopped the release")
+        expect(task_receiver).to have_received(:validate_npm_release_readiness!)
+          .with(monorepo_root:, retry_command: expected_retry_command).once
+        expect(task_receiver).not_to have_received(:with_release_checkout)
       end
     end
 

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -7180,6 +7180,20 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#supervised_release_retry_command" do
+    it "preserves dry-run and exact-HEAD modifiers" do
+      aggregate_failures do
+        expect(supervised_release_retry_command(dry_run: false, evaluate_head: false)).to eq("script/release")
+        expect(supervised_release_retry_command(dry_run: true, evaluate_head: false))
+          .to eq("script/release --dry-run")
+        expect(supervised_release_retry_command(dry_run: false, evaluate_head: true))
+          .to eq("script/release --evaluate-head")
+        expect(supervised_release_retry_command(dry_run: true, evaluate_head: true))
+          .to eq("script/release --dry-run --evaluate-head")
+      end
+    end
+  end
+
   describe "#validate_npm_release_readiness!" do
     it "fails closed on a clean clone without installed dependencies and prints the exact repair command" do
       Dir.mktmpdir do |monorepo_root|
@@ -7191,7 +7205,10 @@ RSpec.describe "release.rake helper methods" do
         expect(Open3).not_to receive(:capture2e)
 
         failure = begin
-          validate_npm_release_readiness!(monorepo_root:)
+          validate_npm_release_readiness!(
+            monorepo_root:,
+            retry_command: "script/release --dry-run --evaluate-head"
+          )
           nil
         rescue SystemExit => error
           error
@@ -7201,7 +7218,7 @@ RSpec.describe "release.rake helper methods" do
           expect(failure&.message).to include("installed dependency state is missing or stale")
           expect(failure&.message).to include("Required recovery:")
           expect(failure&.message).to include("pnpm install --frozen-lockfile")
-          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Then retry:\n  script/release --dry-run --evaluate-head")
           expect(failure&.message).to include("Optional broader environment refresh")
           expect(failure&.message).to include("bin/setup")
         end
@@ -7226,7 +7243,7 @@ RSpec.describe "release.rake helper methods" do
           .and_return(["9.15.0\n", success_status])
 
         failure = begin
-          validate_npm_release_readiness!(monorepo_root:)
+          validate_npm_release_readiness!(monorepo_root:, retry_command: "script/release --evaluate-head")
           nil
         rescue SystemExit => error
           error
@@ -7236,7 +7253,7 @@ RSpec.describe "release.rake helper methods" do
           expect(failure&.message).to include('installed pnpm version "9.15.0" does not match packageManager "10.33.4"')
           expect(failure&.message).to include("Activate pnpm 10.33.4")
           expect(failure&.message).to include("pnpm --version")
-          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Then retry:\n  script/release --evaluate-head")
           expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
           expect(failure&.message).not_to include("bin/setup")
         end
@@ -7261,7 +7278,7 @@ RSpec.describe "release.rake helper methods" do
           .and_return(["corepack failed to activate pnpm\n", failure_status])
 
         failure = begin
-          validate_npm_release_readiness!(monorepo_root:)
+          validate_npm_release_readiness!(monorepo_root:, retry_command: "script/release --dry-run")
           nil
         rescue SystemExit => error
           error
@@ -7271,7 +7288,7 @@ RSpec.describe "release.rake helper methods" do
           expect(failure&.message).to include("pnpm --version failed")
           expect(failure&.message).to include("corepack failed to activate pnpm")
           expect(failure&.message).to include("Restore the repository-declared pnpm command")
-          expect(failure&.message).to include("Then retry:\n  script/release")
+          expect(failure&.message).to include("Then retry:\n  script/release --dry-run")
           expect(failure&.message).not_to include("does not match packageManager")
           expect(failure&.message).not_to include("pnpm install --frozen-lockfile")
           expect(failure&.message).not_to include("bin/setup")
@@ -16250,6 +16267,7 @@ RSpec.describe "release.rake helper methods" do
       allow(ENV).to receive(:fetch).with("RELEASE_TRACKER", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("RELEASE_CI_EVALUATE_HEAD", nil).and_return(nil)
     end
 
     after { release_task.reenable }
@@ -16258,9 +16276,11 @@ RSpec.describe "release.rake helper methods" do
       mode = dry_run ? "dry run" : "live run"
 
       it "blocks a #{mode} from the original workspace before any release side effect" do
+        expected_retry_command = dry_run ? "script/release --dry-run" : "script/release"
         allow(task_receiver).to receive(:current_git_sha!).and_return("a" * 40)
-        allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+        allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
           expect(monorepo_root).to eq(self.monorepo_root)
+          expect(retry_command).to eq(expected_retry_command)
           abort "npm readiness stopped the release"
         end
 
@@ -16275,7 +16295,7 @@ RSpec.describe "release.rake helper methods" do
         aggregate_failures do
           expect(failure&.message).to eq("npm readiness stopped the release")
           expect(task_receiver).to have_received(:validate_npm_release_readiness!)
-            .with(monorepo_root:).once
+            .with(monorepo_root:, retry_command: expected_retry_command).once
           expect(task_receiver).not_to have_received(:with_release_checkout)
           expect(task_receiver).not_to have_received(:resolve_release_version_before_auth!)
           expect(task_receiver).not_to have_received(:verify_npm_auth)
@@ -16298,6 +16318,26 @@ RSpec.describe "release.rake helper methods" do
       end
     end
 
+    it "preserves dry-run and exact-HEAD modifiers in initial readiness recovery" do
+      allow(ENV).to receive(:fetch).with("RELEASE_CI_EVALUATE_HEAD", nil).and_return("true")
+      allow(task_receiver).to receive(:current_git_sha!).and_return("a" * 40)
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
+        expect(monorepo_root).to eq(self.monorepo_root)
+        expect(retry_command).to eq("script/release --dry-run --evaluate-head")
+        abort "modifier-preserving readiness stopped the release"
+      end
+
+      failure = begin
+        release_task.reenable
+        release_task.invoke("17.0.0.rc.10", true, true, false)
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      expect(failure&.message).to eq("modifier-preserving readiness stopped the release")
+    end
+
     it "hard-fails when HEAD changes during the initial readiness check before any later release action" do
       initial_sha = "a" * 40
       moved_sha = "b" * 40
@@ -16316,7 +16356,8 @@ RSpec.describe "release.rake helper methods" do
 
       aggregate_failures do
         expect(failure&.message).to match(/HEAD changed while npm release readiness was running/i)
-        expect(task_receiver).to have_received(:validate_npm_release_readiness!).with(monorepo_root:).once
+        expect(task_receiver).to have_received(:validate_npm_release_readiness!)
+          .with(monorepo_root:, retry_command: "script/release --dry-run").once
         expect(task_receiver).not_to have_received(:with_release_checkout)
         expect(task_receiver).not_to have_received(:resolve_release_version_before_auth!)
         expect(task_receiver).not_to have_received(:verify_npm_auth)
@@ -16339,9 +16380,11 @@ RSpec.describe "release.rake helper methods" do
       initial_sha = "a" * 40
       pulled_sha = "b" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(initial_sha, initial_sha, pulled_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
         abort "post-pull npm readiness stopped the release" if readiness_roots.length == 2
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
@@ -16359,6 +16402,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to eq("post-pull npm readiness stopped the release")
         expect(readiness_roots).to eq([monorepo_root, release_root])
+        expect(retry_commands).to eq(["script/release", "script/release"])
         expect(task_receiver).not_to have_received(:verify_npm_auth)
         expect(task_receiver).not_to have_received(:verify_gh_auth)
         expect(task_receiver).not_to have_received(:validate_main_ci_status!)
@@ -16377,9 +16421,11 @@ RSpec.describe "release.rake helper methods" do
       pulled_sha = "b" * 40
       moved_sha = "c" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(initial_sha, initial_sha, pulled_sha, moved_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
         abort "version resolution reached with stale readiness"
@@ -16396,6 +16442,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to match(/HEAD changed while npm release readiness was running/i)
         expect(readiness_roots).to eq([monorepo_root, release_root])
+        expect(retry_commands).to eq(["script/release", "script/release"])
         expect(task_receiver).not_to have_received(:verify_npm_auth)
         expect(task_receiver).not_to have_received(:verify_gh_auth)
         expect(task_receiver).not_to have_received(:validate_main_ci_status!)
@@ -16409,8 +16456,8 @@ RSpec.describe "release.rake helper methods" do
     it "keeps one readiness check when a live pull leaves HEAD unchanged" do
       head_sha = "a" * 40
       events = []
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
-        events << [:readiness, monorepo_root]
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
+        events << [:readiness, monorepo_root, retry_command]
       end
       allow(task_receiver).to receive(:current_git_sha!) do |root, context:|
         events << [:sha, root, context]
@@ -16437,7 +16484,7 @@ RSpec.describe "release.rake helper methods" do
         expect(events).to eq(
           [
             [:sha, monorepo_root, "initial npm release readiness verification"],
-            [:readiness, monorepo_root],
+            [:readiness, monorepo_root, "script/release"],
             [:sha, monorepo_root, "initial npm release readiness binding"],
             [:command, release_root, "git pull --rebase"],
             [:sha, release_root, "post-pull npm release readiness verification"],
@@ -16451,9 +16498,11 @@ RSpec.describe "release.rake helper methods" do
       initial_sha = "a" * 40
       pulled_sha = "b" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(initial_sha, initial_sha, pulled_sha, pulled_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
         abort "refreshed readiness reached version resolution"
@@ -16470,6 +16519,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to eq("refreshed readiness reached version resolution")
         expect(readiness_roots).to eq([monorepo_root, release_root])
+        expect(retry_commands).to eq(["script/release", "script/release"])
         expect(task_receiver).to have_received(:current_git_sha!).exactly(4).times
       end
     end
@@ -16477,9 +16527,11 @@ RSpec.describe "release.rake helper methods" do
     it "keeps a dry run bound to one original-workspace readiness check without pulling" do
       head_sha = "a" * 40
       readiness_roots = []
+      retry_commands = []
       allow(task_receiver).to receive(:current_git_sha!).and_return(head_sha, head_sha)
-      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:|
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
         readiness_roots << monorepo_root
+        retry_commands << retry_command
       end
       allow(task_receiver).to receive(:resolve_release_version_before_auth!) do
         abort "dry readiness reached version resolution"
@@ -16496,6 +16548,7 @@ RSpec.describe "release.rake helper methods" do
       aggregate_failures do
         expect(failure&.message).to eq("dry readiness reached version resolution")
         expect(readiness_roots).to eq([monorepo_root])
+        expect(retry_commands).to eq(["script/release --dry-run"])
         expect(task_receiver).to have_received(:current_git_sha!)
           .with(monorepo_root, context: "initial npm release readiness verification").once
         expect(task_receiver).to have_received(:current_git_sha!)

--- a/script/release
+++ b/script/release
@@ -29,6 +29,10 @@ class ReleaseSupervisor
   POLL_INTERVAL = 0.05
   SIGNALS = %w[INT TERM HUP].freeze
   CLAIM_STATUSES = %w[active released].freeze
+  FOREIGN_CLAIM_METADATA_FIELDS = %w[
+    agent_id instance_id branch phase operator host machine_id thread_handle chat_handle session_id session_source
+    expires_at
+  ].freeze
   PR_SET_CHILD_SUBREAPER = 36
   CLAIM_CLEANUP_FAILED_MESSAGE =
     "ERROR: release-line lease cleanup failed; verify coordination state before retrying"
@@ -57,7 +61,7 @@ class ReleaseSupervisor
     @env = env
     @stdout = stdout
     @stderr = stderr
-    @options = { dry_run: false, reconcile_accelerated_rc: false, doctor: false }
+    @options = { dry_run: false, reconcile_accelerated_rc: false, doctor: false, evaluate_head: false }
     @parser = build_parser
     @received_signal = nil
     @managed_claim_release_safe = true
@@ -135,7 +139,8 @@ class ReleaseSupervisor
           acquire_release_lease!(scope, identity, coordination_timeout:, termination_grace:)
         rescue ClaimRefusedError
           managed_claim_cleanup_required = false
-          raise
+          guidance = atomic_claim_refusal_guidance(scope, identity, coordination_timeout:, termination_grace:)
+          raise ClaimRefusedError, guidance
         end
       else
         verify_existing_lease!(scope, identity, coordination_timeout:, termination_grace:)
@@ -172,7 +177,7 @@ class ReleaseSupervisor
 
   def build_parser
     OptionParser.new do |parser|
-      parser.banner = "Usage: script/release [--doctor | --dry-run | --reconcile-accelerated-rc]"
+      parser.banner = "Usage: script/release [--doctor | --dry-run | --reconcile-accelerated-rc] [--evaluate-head]"
       parser.on("--doctor", "Validate read-only release-machine setup") do
         @options[:doctor] = true
       end
@@ -185,6 +190,9 @@ class ReleaseSupervisor
       ) do
         @options[:reconcile_accelerated_rc] = true
       end
+      parser.on("--evaluate-head", "Strictly evaluate exact release-source HEAD instead of CI walkback") do
+        @options[:evaluate_head] = true
+      end
       parser.on("-h", "--help", "Show this help") do
         @stdout.puts parser
         exit 0
@@ -196,7 +204,17 @@ class ReleaseSupervisor
     @remaining_args = @argv.dup
     @parser.parse!(@remaining_args)
     selected_modes = @options.values_at(:doctor, :dry_run, :reconcile_accelerated_rc).count(true)
-    raise UsageError, "choose only one of --doctor, --dry-run, or --reconcile-accelerated-rc" if selected_modes > 1
+    incompatible_head_evaluation_mode = if @options.fetch(:doctor)
+                                          "--doctor"
+                                        elsif @options.fetch(:reconcile_accelerated_rc)
+                                          "--reconcile-accelerated-rc"
+                                        end
+    option_error = if selected_modes > 1
+                     "choose only one of --doctor, --dry-run, or --reconcile-accelerated-rc"
+                   elsif @options.fetch(:evaluate_head) && incompatible_head_evaluation_mode
+                     "--evaluate-head does not apply to #{incompatible_head_evaluation_mode}"
+                   end
+    raise UsageError, option_error if option_error
   end
 
   def parse_scope!
@@ -427,7 +445,7 @@ class ReleaseSupervisor
 
   def run_dry(version)
     child_pid = Process.spawn(
-      { ReleaseLeaseGuard::CONTRACT_ENV => nil },
+      release_child_environment(contract: nil),
       "bundle", "exec", "rake", "release[#{version},true]"
     )
     _pid, status = Process.wait2(child_pid)
@@ -542,10 +560,10 @@ class ReleaseSupervisor
     end
 
     claims = parse_pre_acquisition_claims!(stdout, scope)
-    return unless claims.any? { |claim| active_foreign_claim?(claim, identity) }
+    foreign_claims = claims.select { |claim| active_foreign_claim?(claim, identity) }
+    return if foreign_claims.empty?
 
-    raise ReleaseLeaseGuard::LeaseError,
-          "release line already has an active foreign claim; do not infer takeover safety from lease or heartbeat age"
+    raise ReleaseLeaseGuard::LeaseError, foreign_claim_failure_guidance(scope, foreign_claims)
   rescue JSON::ParserError, TypeError
     raise ReleaseLeaseGuard::LeaseError, "release-line pre-acquisition status is malformed or UNKNOWN"
   end
@@ -575,6 +593,52 @@ class ReleaseSupervisor
   def active_foreign_claim?(claim, identity)
     claim["status"] == "active" &&
       (claim["agent_id"] != identity.agent_id || claim["instance_id"] != identity.instance_id)
+  end
+
+  def foreign_claim_failure_guidance(scope, claims)
+    lines = ["release line already has an active foreign claim:"]
+    claims.each_with_index do |claim, index|
+      lines << "  Claim #{index + 1}:"
+      FOREIGN_CLAIM_METADATA_FIELDS.each do |field|
+        next unless claim.key?(field) && !claim[field].to_s.empty?
+
+        lines << "    #{field}: #{JSON.generate(claim[field])}"
+      end
+    end
+    lines.concat(
+      foreign_claim_inspection_guidance(scope)
+    )
+    lines.join("\n")
+  end
+
+  def atomic_claim_refusal_guidance(scope, identity, coordination_timeout:, termination_grace:)
+    stdout, status = run_agent_coord(
+      "status", "--repo", scope.repo, "--target", scope.target, "--json",
+      timeout: coordination_timeout,
+      termination_grace:
+    )
+    if status&.success?
+      claims = parse_pre_acquisition_claims!(stdout, scope)
+      foreign_claims = claims.select { |claim| active_foreign_claim?(claim, identity) }
+      unless foreign_claims.empty?
+        refusal = ["release-line lease claim was refused.", foreign_claim_failure_guidance(scope, foreign_claims)]
+        return refusal.join("\n")
+      end
+    end
+
+    (["release-line lease claim was refused; current holder metadata is unavailable."] +
+      foreign_claim_inspection_guidance(scope)).join("\n")
+  rescue StandardError
+    (["release-line lease claim was refused; current holder metadata is unavailable or malformed."] +
+      foreign_claim_inspection_guidance(scope)).join("\n")
+  end
+
+  def foreign_claim_inspection_guidance(scope)
+    [
+      "Inspect authoritative coordination state:",
+      "  agent-coord status --repo #{scope.repo} --target #{scope.target} --json",
+      "Do not infer takeover safety from lease or heartbeat age alone."
+    ]
   end
 
   def release_managed_lease!(scope, identity, coordination_timeout:, termination_grace:)
@@ -952,14 +1016,7 @@ class ReleaseSupervisor
 
   def fork_release_child(scope, identity, pipes)
     Process.fork do
-      reset_child_signal_handlers
-      pipes.liveness_writer.close
-      pipes.death_writer.close
-      pipes.ready_reader.close
-      Process.setpgid(0, 0)
-      pgid = Process.getpgrp
-      fork_supervisor_death_watch(pipes, pgid)
-      pipes.death_reader.close
+      pgid = prepare_release_child(pipes)
       contract = contract_for(
         scope,
         identity,
@@ -970,13 +1027,25 @@ class ReleaseSupervisor
       announce_process_group(pipes.ready_writer, pgid)
       pipes.ready_writer.close
       exec(
-        { ReleaseLeaseGuard::CONTRACT_ENV => JSON.generate(contract) },
+        release_child_environment(contract: JSON.generate(contract)),
         "bundle", "exec", "rake", supervised_rake_task(scope.version)
       )
     rescue StandardError
       @stderr.puts "ERROR: unable to start the supervised release command"
       exit! 127
     end
+  end
+
+  def prepare_release_child(pipes)
+    reset_child_signal_handlers
+    pipes.liveness_writer.close
+    pipes.death_writer.close
+    pipes.ready_reader.close
+    Process.setpgid(0, 0)
+    pgid = Process.getpgrp
+    fork_supervisor_death_watch(pipes, pgid)
+    pipes.death_reader.close
+    pgid
   end
 
   def fork_supervisor_death_watch(pipes, pgid)
@@ -999,6 +1068,12 @@ class ReleaseSupervisor
     return "release:reconcile_accelerated_rc[#{version}]" if @options.fetch(:reconcile_accelerated_rc)
 
     "release[#{version}]"
+  end
+
+  def release_child_environment(contract:)
+    child_environment = { ReleaseLeaseGuard::CONTRACT_ENV => contract }
+    child_environment["RELEASE_CI_EVALUATE_HEAD"] = "true" if @options.fetch(:evaluate_head)
+    child_environment
   end
 
   def reset_child_signal_handlers

--- a/script/release
+++ b/script/release
@@ -1071,7 +1071,10 @@ class ReleaseSupervisor
   end
 
   def release_child_environment(contract:)
-    child_environment = { ReleaseLeaseGuard::CONTRACT_ENV => contract }
+    child_environment = {
+      ReleaseLeaseGuard::CONTRACT_ENV => contract,
+      "REACT_ON_RAILS_RELEASE_SUPERVISED" => "true"
+    }
     child_environment["RELEASE_CI_EVALUATE_HEAD"] = "true" if @options.fetch(:evaluate_head)
     child_environment
   end

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -378,6 +378,7 @@ process_group="$(ps -o pgid= -p "$$" | tr -d ' ')"
     printf '|%s' "${argument}"
   done
   printf '\ncontract:%s\n' "${REACT_ON_RAILS_RELEASE_LEASE_CONTRACT:-}"
+  printf 'supervised:%s\n' "${REACT_ON_RAILS_RELEASE_SUPERVISED:-}"
   printf 'evaluate-head:%s\n' "${RELEASE_CI_EVALUATE_HEAD:-}"
 } >>"${TEST_BUNDLE_LOG}"
 
@@ -1801,6 +1802,7 @@ run_release --dry-run || fail "argumentless dry-run failed"
 assert_empty "${coord_log}"
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0,true]'
 assert_contains "${bundle_log}" 'contract:'
+assert_contains "${bundle_log}" 'supervised:true'
 pass "dry-run selects the first prepared changelog version"
 
 setup_case evaluate-head-dry-run
@@ -1921,6 +1923,7 @@ assert_contains "${coord_log}" $'heartbeat|'
 assert_contains "${coord_log}" $'status|'
 assert_contains "${coord_log}" $'release|'
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
+assert_contains "${bundle_log}" 'supervised:true'
 assert_secret_absent
 pass "live mode acquires and cleans up a process-owned release lease"
 

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -286,8 +286,9 @@ case "${command_name}" in
       "${claim_status}" "${TEST_REPO}" "${TEST_TARGET}"
     printf '"branch":"%s","agent_id":"%s","instance_id":"%s",' \
       "${TEST_BRANCH}" "${claim_agent_id}" "${claim_instance_id}"
-    printf '"machine_id":"%s","expires_at":"%s"}],' \
-      "${claim_machine_id}" "${claim_expiry}"
+    printf '"machine_id":"%s","expires_at":"%s",' "${claim_machine_id}" "${claim_expiry}"
+    printf '"host":"codex","operator":"release-operator","phase":"publishing",'
+    printf '"thread_handle":"release-task-123","session_id":"release-session-456"}],'
     if test "${include_heartbeat}" = 1; then
       printf '"heartbeats":[{"agent_id":"%s","instance_id":"%s",' \
         "${claim_agent_id}" "${claim_instance_id}"
@@ -377,6 +378,7 @@ process_group="$(ps -o pgid= -p "$$" | tr -d ' ')"
     printf '|%s' "${argument}"
   done
   printf '\ncontract:%s\n' "${REACT_ON_RAILS_RELEASE_LEASE_CONTRACT:-}"
+  printf 'evaluate-head:%s\n' "${RELEASE_CI_EVALUATE_HEAD:-}"
 } >>"${TEST_BUNDLE_LOG}"
 
 record_liveness() {
@@ -550,6 +552,28 @@ end
 
 exit ExceptionTestSupervisor.new(ARGV).run
 EXCEPTION_HARNESS
+
+  cat >"${fake_bin}/release-claim-refusal-diagnostic-failure-harness" <<'CLAIM_REFUSAL_HARNESS'
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+load ENV.fetch("TEST_RELEASE_SCRIPT")
+
+class ClaimRefusalDiagnosticFailureSupervisor < ReleaseSupervisor
+  private
+
+  def run_agent_coord(*command, **)
+    if command.first == "status"
+      @status_reads = @status_reads.to_i + 1
+      raise SupervisorError, "injected claim-refusal diagnostic failure" if @status_reads > 1
+    end
+
+    super
+  end
+end
+
+exit ClaimRefusalDiagnosticFailureSupervisor.new(ARGV).run
+CLAIM_REFUSAL_HARNESS
 
   cat >"${fake_bin}/release-echild-harness" <<'ECHILD_HARNESS'
 #!/usr/bin/env ruby
@@ -1246,7 +1270,8 @@ CLEANUP_TOSTOP_HARNESS
 
   chmod +x "${fake_bin}/agent-coord" "${fake_bin}/bundle" "${fake_bin}/pnpm" \
     "${fake_bin}/release-handshake-harness" \
-    "${fake_bin}/release-exception-harness" "${fake_bin}/release-subreaper-failure-harness" \
+    "${fake_bin}/release-exception-harness" "${fake_bin}/release-claim-refusal-diagnostic-failure-harness" \
+    "${fake_bin}/release-subreaper-failure-harness" \
     "${fake_bin}/release-unverified-child-harness" "${fake_bin}/release-echild-harness"
 
   export PATH="${fake_bin}:${PATH}"
@@ -1290,6 +1315,7 @@ CLEANUP_TOSTOP_HARNESS
   unset FAKE_SIGNAL_STOPPED_WRAPPER
   unset REACT_ON_RAILS_RELEASE_COORDINATION_TIMEOUT
   unset REACT_ON_RAILS_RELEASE_CLAIM_RENEWAL_INTERVAL
+  unset RELEASE_CI_EVALUATE_HEAD
 }
 
 run_release() {
@@ -1564,6 +1590,13 @@ run_exception_release() {
   ) >"${output_log}" 2>&1
 }
 
+run_claim_refusal_diagnostic_failure_release() {
+  (
+    cd "${fake_repo}"
+    "${fake_bin}/release-claim-refusal-diagnostic-failure-harness" "$@"
+  ) >"${output_log}" 2>&1
+}
+
 run_echild_release() {
   (
     cd "${fake_repo}"
@@ -1770,6 +1803,42 @@ assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0,true]'
 assert_contains "${bundle_log}" 'contract:'
 pass "dry-run selects the first prepared changelog version"
 
+setup_case evaluate-head-dry-run
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID AGENT_COORD_MACHINE_ID AGENT_COORD_API_TOKEN
+run_release --dry-run --evaluate-head || fail "evaluate-head dry-run failed"
+assert_empty "${coord_log}"
+assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0,true]'
+assert_contains "${bundle_log}" 'evaluate-head:true'
+pass "evaluate-head modifies the dry-run child without enabling coordination"
+
+setup_case evaluate-head-environment-backward-compatibility
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID AGENT_COORD_MACHINE_ID AGENT_COORD_API_TOKEN
+export RELEASE_CI_EVALUATE_HEAD=true
+run_release --dry-run || fail "legacy evaluate-head environment contract failed"
+assert_empty "${coord_log}"
+assert_contains "${bundle_log}" 'evaluate-head:true'
+pass "evaluate-head preserves the existing environment contract for automation compatibility"
+
+setup_case evaluate-head-reconciliation-rejected
+if run_release --reconcile-accelerated-rc --evaluate-head; then
+  fail "evaluate-head was accepted for accelerated RC reconciliation"
+fi
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_contains "${output_log}" "--evaluate-head does not apply to --reconcile-accelerated-rc"
+assert_secret_absent
+pass "evaluate-head rejects accelerated RC reconciliation where it would be inert"
+
+setup_case evaluate-head-doctor-rejected
+if run_release --doctor --evaluate-head; then
+  fail "evaluate-head was accepted for release doctor"
+fi
+assert_empty "${coord_log}"
+assert_empty "${bundle_log}"
+assert_contains "${output_log}" "--evaluate-head does not apply to --doctor"
+assert_secret_absent
+pass "evaluate-head rejects release doctor where it would be inert"
+
 setup_case missing-changelog-version
 cat >"${fake_repo}/CHANGELOG.md" <<'CHANGELOG'
 ### [Unreleased]
@@ -1855,6 +1924,16 @@ assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
 assert_secret_absent
 pass "live mode acquires and cleans up a process-owned release lease"
 
+setup_case evaluate-head-live
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+FAKE_BUNDLE_MODE=success run_release --evaluate-head || fail "evaluate-head live release failed"
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_contains "${coord_log}" $'release|'
+assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
+assert_contains "${bundle_log}" 'evaluate-head:true'
+assert_secret_absent
+pass "evaluate-head modifies the supervised live child without bypassing coordination"
+
 setup_case managed-acquisition-empty-status
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 export FAKE_PREFLIGHT_STATUS_MODE=empty-first
@@ -1877,8 +1956,29 @@ assert_contains "${coord_log}" $'claim-atomic|'
 assert_not_contains "${coord_log}" $'claim|'
 assert_not_contains "${coord_log}" $'release|'
 assert_empty "${bundle_log}"
+assert_contains "${output_log}" "release line already has an active foreign claim"
+assert_contains "${output_log}" 'agent_id: "foreign-agent"'
+assert_contains "${output_log}" 'thread_handle: "release-task-123"'
+assert_contains "${output_log}" 'session_id: "release-session-456"'
+assert_contains "${output_log}" \
+  "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
 assert_secret_absent
 pass "managed acquisition atomically refuses an intervening foreign claim"
+
+setup_case managed-atomic-claim-race-diagnostic-failure
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_ATOMIC_CLAIM_MODE=foreign-race
+if run_claim_refusal_diagnostic_failure_release; then
+  fail "managed release ignored a claim-refusal diagnostic failure"
+fi
+assert_contains "${coord_log}" $'claim-atomic|'
+assert_not_contains "${coord_log}" $'release|'
+assert_empty "${bundle_log}"
+assert_contains "${output_log}" "current holder metadata is unavailable or malformed"
+assert_contains "${output_log}" \
+  "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
+assert_secret_absent
+pass "claim-refusal diagnostic failures never release a foreign lease"
 
 for foreign_mode in dead expired missing-heartbeat; do
   setup_case "managed-acquisition-foreign-${foreign_mode}"
@@ -1892,6 +1992,11 @@ for foreign_mode in dead expired missing-heartbeat; do
   assert_not_contains "${coord_log}" $'release|'
   assert_empty "${bundle_log}"
   assert_contains "${output_log}" "release line already has an active foreign claim"
+  assert_contains "${output_log}" 'agent_id: "foreign-agent"'
+  assert_contains "${output_log}" 'thread_handle: "release-task-123"'
+  assert_contains "${output_log}" 'session_id: "release-session-456"'
+  assert_contains "${output_log}" \
+    "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
   assert_secret_absent
   pass "foreign ${foreign_mode} claims block managed acquisition without takeover"
 done


### PR DESCRIPTION
## Why

The strict 17.1.0 RC release path needs #4955’s safe, reason-specific recovery before the next RC attempt. #4959 and #4961 are behaviorally inseparable follow-ups: #4959 preserves `--dry-run` and `--evaluate-head` in the readiness-retry guidance introduced by #4957, while #4961 preserves the exact version and override tuple for direct Rake dry-run recovery.

## Source provenance and current merge hold

This approved aggregate contains these three source changes:

- #4957, source commit `e9f2bd2a83ac41d446a9450b63f0e2104870e671` → release commit `18cf8b64581c4c258f10d36fa17595d25a551c08`
- #4959, merged source commit `3f7c933900cae69ed87ec4692887fe221011dd43` → release commit `e3154dcc2616ff4341f40efa4d34b0d60158d90e`
- #4961, merged source commit `c2c1b7adcb96534c4990e88d2b911e460bc477b5` → release commit `da1286101321549daab3a48ea179ff94c8742405`

All three sources are live on current `origin/main` (`c2c1b7adcb96534c4990e88d2b911e460bc477b5`), and none is already in current `origin/release/17.1.0` (`5d9beed4f4f7cfafa12b1f2fe8ddc589951ec3f2`). The #4959 and #4961 release commits have identical stable patch IDs to their sources and exactly one direct source footer. The older #4957 release commit is a release-branch adaptation, has a different stable patch ID, and currently lacks its required direct footer.

**Merge hold:** do not merge this aggregate as-is. Squashing would collapse three sources into one multi-footer commit; rebasing would preserve commits but leave changelog-sweep attribution unknown; merge commits are disabled. The runbook requires an explicit maintainer-approved repair/merge plan. The default safe repair is to replace this aggregate with three source-atomic backport PRs, each synchronously squash-merged with one direct source footer.

This PR does not publish, tag, or run `script/release`.

## What changed

- Add the operator-facing `script/release --evaluate-head` modifier for supervised live and dry-run exact-HEAD recovery.
- Keep legacy environment compatibility internal, while failure guidance uses the script modifier only when exact-HEAD evidence is complete and healthy.
- Make foreign-claim and npm-readiness recovery actionable and reason-specific without unsafe takeover, automatic retry, or mandatory `bin/setup`.
- Preserve selected release modifiers in all dependency-readiness recovery commands, including the exact version and override tuple for direct Rake dry-run recovery.

## Verification

- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb)` — 949 examples, 0 failures
- `bash script/release-test.bash` — 98/98 passing
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop ../rakelib/release.rake spec/react_on_rails/release_rake_helpers_spec.rb)` — 2 files, no offenses
- `git diff --check origin/release/17.1.0...HEAD` — clean
- Exact-head hosted release-full coverage — all required checks completed successfully, including the Ruby 3.3/4.0 unit and generator matrices
- Strict merge ledger — `complete_allowed: true`, with the GitHub Codex P2 bound to its source-first fix evidence
- Current-head Claude comments — triaged with rationale and all threads resolved
- CodeRabbit — configured but skipped this non-default release-branch target; degraded coverage is explicitly recorded

Labels: `ready-for-hosted-ci` — release-process behavior received exact-head hosted confirmation.

Benchmarks: not applicable.

## Merge confidence

Confidence note:
- Validated: focused release helper specs, release supervisor integration tests, focused RuboCop, diff check, full hosted release CI, source liveness, review disposition, and full-diff self-review.
- Evidence: commands and exact SHAs above; release-line lease `release-line:17.1.0` remains held for this lane.
- BLOCKED: aggregate merge shape and #4957 provenance normalization require the explicit repair/merge plan described above.
- Residual risk after repair: release recovery logic crosses wrapper, Rake, docs, and test seams; rerun exact-head evidence on any replacement PR head before merge.