### PR TITLE
Preserve direct Rake dry-run recovery arguments

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -9361,6 +9361,21 @@ def supervised_release_retry_command(dry_run:, evaluate_head:)
   command.join(" ")
 end
 
+def direct_release_dry_run_retry_command(task_arguments, evaluate_head:)
+  rake_task = "release[#{task_arguments.to_a.map(&:to_s).join(',')}]"
+  command = Shellwords.join(["bundle", "exec", "rake", rake_task])
+  return command unless evaluate_head
+
+  "RELEASE_CI_EVALUATE_HEAD=true #{command}"
+end
+
+def release_readiness_retry_command(task_arguments:, dry_run:, evaluate_head:)
+  supervised = release_truthy?(ENV.fetch("REACT_ON_RAILS_RELEASE_SUPERVISED", nil))
+  return supervised_release_retry_command(dry_run:, evaluate_head:) if supervised || !dry_run
+
+  direct_release_dry_run_retry_command(task_arguments, evaluate_head:)
+end
+
 def declared_pnpm_release_version!(monorepo_root:, retry_command: "script/release")
   package_json = JSON.parse(File.read(File.join(monorepo_root, "package.json")))
   package_manager = package_json["packageManager"]
@@ -10168,7 +10183,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   args_hash = args.to_hash
 
   is_dry_run = release_truthy?(args_hash[:dry_run])
-  release_retry_command = supervised_release_retry_command(
+  release_retry_command = release_readiness_retry_command(
+    task_arguments: args,
     dry_run: is_dry_run,
     evaluate_head: ci_evaluate_head_only?
   )

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -16289,6 +16289,7 @@ RSpec.describe "release.rake helper methods" do
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_CI_EVALUATE_HEAD", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("REACT_ON_RAILS_RELEASE_SUPERVISED", nil).and_return("true")
     end
 
     after { release_task.reenable }
@@ -16336,6 +16337,32 @@ RSpec.describe "release.rake helper methods" do
             a_string_matching(/gem bump|git push|git tag/)
           )
         end
+      end
+    end
+
+    it "preserves every explicit Rake argument in direct dry-run readiness recovery" do
+      allow(ENV).to receive(:fetch).with("REACT_ON_RAILS_RELEASE_SUPERVISED", nil).and_return(nil)
+      allow(task_receiver).to receive(:current_git_sha!).and_return("a" * 40)
+      expected_retry_command = "bundle exec rake release\\[17.0.0.rc.10,true,true,false\\]"
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
+        expect(monorepo_root).to eq(self.monorepo_root)
+        expect(retry_command).to eq(expected_retry_command)
+        abort "direct dry-run readiness stopped the release"
+      end
+
+      failure = begin
+        release_task.reenable
+        release_task.invoke("17.0.0.rc.10", true, true, false)
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure&.message).to eq("direct dry-run readiness stopped the release")
+        expect(task_receiver).to have_received(:validate_npm_release_readiness!)
+          .with(monorepo_root:, retry_command: expected_retry_command).once
+        expect(task_receiver).not_to have_received(:with_release_checkout)
       end
     end
 

--- a/script/release
+++ b/script/release
@@ -945,7 +945,10 @@ class ReleaseSupervisor
   end
 
   def release_child_environment(contract:)
-    child_environment = { ReleaseLeaseGuard::CONTRACT_ENV => contract }
+    child_environment = {
+      ReleaseLeaseGuard::CONTRACT_ENV => contract,
+      "REACT_ON_RAILS_RELEASE_SUPERVISED" => "true"
+    }
     child_environment["RELEASE_CI_EVALUATE_HEAD"] = "true" if @options.fetch(:evaluate_head)
     child_environment
   end

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -367,6 +367,7 @@ process_group="$(ps -o pgid= -p "$$" | tr -d ' ')"
     printf '|%s' "${argument}"
   done
   printf '\ncontract:%s\n' "${REACT_ON_RAILS_RELEASE_LEASE_CONTRACT:-}"
+  printf 'supervised:%s\n' "${REACT_ON_RAILS_RELEASE_SUPERVISED:-}"
   printf 'evaluate-head:%s\n' "${RELEASE_CI_EVALUATE_HEAD:-}"
 } >>"${TEST_BUNDLE_LOG}"
 
@@ -903,6 +904,7 @@ run_release --dry-run || fail "argumentless dry-run failed"
 assert_empty "${coord_log}"
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0,true]'
 assert_contains "${bundle_log}" 'contract:'
+assert_contains "${bundle_log}" 'supervised:true'
 pass "dry-run selects the first prepared changelog version"
 
 setup_case evaluate-head-dry-run
@@ -1048,6 +1050,7 @@ assert_contains "${coord_log}" $'heartbeat|'
 assert_contains "${coord_log}" $'status|'
 assert_contains "${coord_log}" $'release|'
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
+assert_contains "${bundle_log}" 'supervised:true'
 assert_secret_absent
 pass "live mode acquires and cleans up a process-owned release lease"
 


### PR DESCRIPTION
## Why

PR #4959 preserves release modifiers in normal `script/release` recovery, but the supported direct Rake dry-run path could still replace an explicit version and override tuple with `script/release --dry-run`. Copying that advice could preview a different prepared release and discard explicit positional arguments. This source-first follow-up addresses the concrete review finding raised on backport PR #4960 before the release branch is updated.

## What changed

- Mark Rake children launched by `script/release` as supervised, without exposing a new operator-facing option or requirement.
- Keep normal wrapper recovery on `script/release [--dry-run] [--evaluate-head]`.
- For direct Rake dry runs, reconstruct the exact original argument tuple with shell-safe escaping; retain the legacy exact-HEAD environment only for that advanced direct-Rake compatibility path.
- Add wrapper and Rake regression coverage for the supervised marker and a four-argument direct dry-run replay.

This PR does not publish, tag, release, run `script/release`, or change release coordination.

## Verification

- RED replay: direct `release[17.0.0.rc.10,true,true,false]` expected the same retry tuple but received `script/release --dry-run`.
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb)` — 948 examples, 0 failures.
- `bash script/release-test.bash` — 70/70 passing.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` — 249 files, no offenses.
- Focused RuboCop on `rakelib/release.rake`, the helper spec, and `script/release` — 3 files, no offenses.
- Ruby/Bash syntax checks, `git diff --check origin/main...HEAD`, pre-commit hooks, and pre-push hooks — passed.
- `.agents/bin/validate --changed --fast` passed setup, docs, release-supervisor, full Ruby lint, package build, ESLint, Prettier, and TypeScript phases. Its Ruby 4/RBS runtime gem-unit phase failed broadly across unrelated existing specs; the normal focused 948-example release helper suite is green.

## Review and churn notes

- Full-diff self-review: clean; `Shellwords.join` preserves copy-paste safety and the internal marker only distinguishes wrapper-launched children.
- Local `codex review --base origin/main` ran for 61 minutes through repeated stream resets but never returned a verdict; it was terminated and is recorded as degraded.
- Configured Claude `/simplify origin/main` produced no output within five minutes and was stopped; it made no edits.
- Post-push fix rounds: 0.

Labels: `ready-for-hosted-ci` — release-process behavior needs current-head hosted confirmation.

Benchmarks: not applicable.

Follow-up to #4955, #4959, and #4960.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release dry-run guidance by providing a direct preview command when readiness checks fail.
  * Preserved all specified release options in suggested retry commands.
  * Release subprocesses now clearly identify supervised execution mode.

* **Bug Fixes**
  * Prevented dry-run readiness failures from proceeding to release checkout or execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->