### PR TITLE
Document React 19.2 streaming reveals and guard stable invariants

### DIFF
--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -53,6 +53,26 @@ React on Rails detects whether the installed React DOM server provides `renderTo
 `stream_react_component` on the synchronous path for React 16 and 17 while selecting progressive streaming
 automatically on React 18 and 19. The React 16/17 path is suitable only when the rendered tree does not suspend.
 
+### React 19.2 Suspense reveal batching
+
+[React 19.2 briefly batches some server-rendered Suspense boundary reveals](https://react.dev/blog/2025/10/01/react-19-2#batching-suspense-boundaries-for-ssr)
+so boundaries that finish near one another can become visible together. React controls this with heuristics and backs
+off when batching could hurt Core Web Vitals. React on Rails Pro does not add or expose a batching-delay setting.
+
+Keep these two checkpoints separate when observing a streamed page:
+
+- **Server chunk delivery:** React decides when resolved boundary markup enters its server stream. React on Rails Pro
+  forwards those emitted chunks in order. For RSC streams, each combined flush preserves the required order: payload
+  initialization and stylesheet prerequisites, then the HTML, then the matching payload-push scripts.
+- **Browser-visible reveal:** Network buffering, compression, HTML parsing, and React's reveal batching can make DOM
+  updates appear later or in larger groups than the chunks observed by Rails or the Node Renderer. A server chunk is
+  therefore not a guaranteed paint boundary.
+
+Make streaming tests state-based rather than timer-based. Assert the shell and fallbacks while data is unresolved,
+then resolve one or more sources and use retrying assertions for the final DOM state, element order, and the rule that
+resolved content does not return to its fallback. Do not assume one resolved boundary equals one output chunk, use an
+arbitrary sleep, or depend on a fixed batching delay such as 300 ms; React's timing is deliberately heuristic.
+
 ## React 18 Streaming Without RSC
 
 React 18 applications can use progressive SSR before adopting React Server Components. Keep all Rails props

--- a/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
@@ -97,6 +97,21 @@ TestComponentForStreaming.propTypes = {
   throwAsyncError: PropTypes.bool,
 };
 
+const UseIdField = ({ label }) => {
+  const id = React.useId();
+
+  return (
+    <label htmlFor={id}>
+      {label}
+      <input id={id} />
+    </label>
+  );
+};
+
+UseIdField.propTypes = {
+  label: PropTypes.string.isRequired,
+};
+
 const ManifestStylesheetPreload = () => (
   <main>
     <link rel="preload" as="style" href="https://cdn.example.com/webpack/test/css/4092-98880bc1.css?body=1" />
@@ -1026,6 +1041,40 @@ describe('streamServerRenderedReactComponent', () => {
     expect(chunks[1].consoleReplayScript).toBe('');
     expect(chunks[1].hasErrors).toBe(false);
     expect(chunks[1].isShellReady).toBe(true);
+  });
+
+  it('keeps useId values isolated across streamed roots without assuming React private ID encoding', async () => {
+    ReactOnRails.register({ UseIdField });
+
+    const renderRoot = async (domNodeId, label) => {
+      const renderResult = streamServerRenderedReactComponent({
+        name: 'UseIdField',
+        domNodeId,
+        trace: false,
+        props: { label },
+        throwJsErrors: false,
+        railsContext: testingRailsContext,
+      });
+      const { chunks, errors } = await collectStreamResult(renderResult);
+      const html = chunks.map((chunk) => chunk.html).join('');
+      const labelId = html.match(/<label for="([^"]+)"/)?.[1];
+      const inputId = html.match(/<input id="([^"]+)"/)?.[1];
+
+      expect(errors).toHaveLength(0);
+      expect(labelId).toBeDefined();
+      expect(inputId).toBe(labelId);
+
+      return labelId;
+    };
+
+    const [firstRootId, secondRootId] = await Promise.all([
+      renderRoot('use-id-root-a', 'First field'),
+      renderRoot('use-id-root-b', 'Second field'),
+    ]);
+
+    expect(firstRootId).toContain('use-id-root-a');
+    expect(secondRootId).toContain('use-id-root-b');
+    expect(firstRootId).not.toBe(secondRootId);
   });
 
   it('does not mutate global manifest filenames during a streamed render', async () => {

--- a/react_on_rails_pro/spec/dummy/e2e-tests/streaming.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/streaming.spec.ts
@@ -92,6 +92,43 @@ import {
   });
 });
 
+redisReceiverPageTest(
+  'keeps close-together Suspense resolutions ordered without assuming reveal timing',
+  async ({ page, sendRedisItemValue }) => {
+    const itemContainers = page.locator('.redis-items-container > section');
+
+    await expect(itemContainers).toHaveText([
+      'Waiting for the key "Item1"',
+      'Waiting for the key "Item2"',
+      'Waiting for the key "Item3"',
+      'Waiting for the key "Item4"',
+      'Waiting for the key "Item5"',
+    ]);
+
+    await Promise.all([
+      sendRedisItemValue(0, 'Close Resolution Value1'),
+      sendRedisItemValue(1, 'Close Resolution Value2'),
+    ]);
+
+    await expect(itemContainers).toHaveText([
+      'Value of "Item1": Close Resolution Value1',
+      'Value of "Item2": Close Resolution Value2',
+      'Waiting for the key "Item3"',
+      'Waiting for the key "Item4"',
+      'Waiting for the key "Item5"',
+    ]);
+
+    await sendRedisItemValue(4, 'Later Resolution Value5');
+    await expect(itemContainers).toHaveText([
+      'Value of "Item1": Close Resolution Value1',
+      'Value of "Item2": Close Resolution Value2',
+      'Waiting for the key "Item3"',
+      'Waiting for the key "Item4"',
+      'Value of "Item5": Later Resolution Value5',
+    ]);
+  },
+);
+
 redisReceiverInsideRouterPageTest(
   'no RSC payload request is made when the page is server side rendered',
   async ({ getNetworkRequests }) => {


### PR DESCRIPTION
## Why

React 19.2 can briefly batch browser-visible Suspense boundary reveals even though React on Rails Pro continues to forward the server's streamed chunks in order. Without that distinction, application tests can accidentally treat a network chunk as an immediate paint boundary or encode React's private timing and `useId` formats.

This change documents the supported behavior and protects the stable identity and ordering contracts that React on Rails owns. It intentionally does not add a timing knob or change production runtime code.

Closes #3886.

## What changed

- Explain the difference between server chunk delivery and browser-visible reveal timing under React 19.2, including the ordered RSC flush invariants and the absence of a React on Rails batching-delay setting.
- Recommend retrying, state-based streaming assertions rather than fixed sleeps, exact chunk-to-paint assumptions, or a guaranteed 300 ms window.
- Exercise real React `useId()` through two Pro streaming roots and verify identifier-prefix isolation plus label/input reference parity without asserting React's private ID encoding.
- Add a Chromium regression that resolves two boundaries close together and verifies their eventual DOM order and that already revealed content does not fall back again.

## Verification

- `node scripts/run-react19-jest.mjs tests/streamServerRenderedReactComponent.test.jsx --runInBand`: 1 suite, 43 tests passed.
- `pnpm run test:streaming`: 7 suites, 158 tests passed.
- `bundle exec rake react_on_rails:generate_packs && pnpm run build:test`: passed with warnings only.
- Targeted Chromium `streaming.spec.ts` close-together test: 1 test passed in 2.7 seconds.
- `pnpm run type-check` in `packages/react-on-rails-pro`: passed.
- `.agents/bin/validate --fast`: passed, including ESLint, Prettier, OSS/Pro RuboCop, and RBS validation.
- Docs sidebar, changed-doc links, Pro license headers, and `git diff --check`: passed.
- Pre-commit and pre-push hooks: passed.

One force-full exact-head hosted validation completed successfully across all nine selected workflows, including the full browser matrix and hosted Pro/RSC suites. A separate full dummy-app `pnpm exec tsc --noEmit --noErrorTruncation` still reports four pre-existing errors in `tests/strict-mode-support.test.tsx`; the changed streaming E2E file is not implicated.

## Agent details

<details>
<summary>Batch coordination</summary>

- Batch: `ror-issue-3886-streaming-docs-20260831-v1`
- Canonical target: `shakacode/react_on_rails:issue:3886`
- Maker: `ror-issue3886-maker`
- Independent checker: `ror-issue3886-checker` — clean at `b666f096be5b5ee6d72f4e338d46ed2b423e8a31`; no MUST_FIX, DISCUSS, or OPTIONAL findings
- Merge authority: only after all ordinary and exact-head autonomous gates pass

### QA Evidence

- QA lane: `ror-issue3886-checker`; independent read-only checker; current-head verdict clean
- Scope checked: React 19.2 streaming docs, actual-React identifier-prefix isolation, and the close-resolution browser regression
- Tested at: PR #4962 head `b666f096be5b5ee6d72f4e338d46ed2b423e8a31`
- Automated checks: focused React 19 Jest 43/43; targeted Chromium 1/1 plus 10/10 repetitions; ESLint, Prettier, Pro license headers, suite-selection, docs-sidebar, and diff checks passed
- Manual checks: not applicable; browser behavior is exercised by the targeted Playwright test
- User-visible UI change: no
- Visual evidence: not applicable; no product UI or visual fix changed
- Interaction change: no; only test coverage and documentation changed
- Interaction evidence: not applicable; no product interaction changed
- Visual fix: no
- Negative control: not applicable; no visual fix
- Performance evidence: not applicable; no runtime or bundle change
- Findings: none
- QA required: yes
- QA required rationale: the change adds Pro streaming regression coverage and documents RSC flush ordering
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: not applicable; no recurring process gap identified

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: b666f096be5b5ee6d72f4e338d46ed2b423e8a31
tested_at: PR #4962 head b666f096be5b5ee6d72f4e338d46ed2b423e8a31
scope: React 19.2 streaming docs, actual-React identifier-prefix isolation, and close-resolution browser regression
automated_checks: focused React 19 Jest 43/43; targeted Chromium 1/1 and 10/10 repetitions; ESLint, Prettier, Pro license headers, suite-selection, docs-sidebar, and diff checks passed
manual_checks: not applicable; browser behavior is covered by Playwright
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no product UI or visual fix changed
paint_check: not applicable: no product UI or visual fix changed
interaction_change: no
interaction_evidence: not applicable: no product interaction changed
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: no runtime or bundle change
findings: none
release_blocking: clear
process_gap_disposition: not applicable
-->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on React 19.2 Suspense reveal batching, server streaming order, and reliable state-based streaming tests.

* **Tests**
  * Added coverage ensuring concurrent streamed roots generate correctly matched and distinct element IDs.
  * Added end-to-end coverage for ordered Redis updates, including initial loading states and subsequent rendered values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->