### PR TITLE
Backport #4961 direct dry-run recovery to 17.1.0

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -9393,6 +9393,21 @@ def supervised_release_retry_command(dry_run:, evaluate_head:)
   command.join(" ")
 end
 
+def direct_release_dry_run_retry_command(task_arguments, evaluate_head:)
+  rake_task = "release[#{task_arguments.to_a.map(&:to_s).join(',')}]"
+  command = Shellwords.join(["bundle", "exec", "rake", rake_task])
+  return command unless evaluate_head
+
+  "RELEASE_CI_EVALUATE_HEAD=true #{command}"
+end
+
+def release_readiness_retry_command(task_arguments:, dry_run:, evaluate_head:)
+  supervised = release_truthy?(ENV.fetch("REACT_ON_RAILS_RELEASE_SUPERVISED", nil))
+  return supervised_release_retry_command(dry_run:, evaluate_head:) if supervised || !dry_run
+
+  direct_release_dry_run_retry_command(task_arguments, evaluate_head:)
+end
+
 def declared_pnpm_release_version!(monorepo_root:, retry_command: "script/release")
   package_json = JSON.parse(File.read(File.join(monorepo_root, "package.json")))
   package_manager = package_json["packageManager"]
@@ -10200,7 +10215,8 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
   args_hash = args.to_hash
 
   is_dry_run = release_truthy?(args_hash[:dry_run])
-  release_retry_command = supervised_release_retry_command(
+  release_retry_command = release_readiness_retry_command(
+    task_arguments: args,
     dry_run: is_dry_run,
     evaluate_head: ci_evaluate_head_only?
   )

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -16268,6 +16268,7 @@ RSpec.describe "release.rake helper methods" do
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_ACCELERATED_RC_REASON", nil).and_return(nil)
       allow(ENV).to receive(:fetch).with("RELEASE_CI_EVALUATE_HEAD", nil).and_return(nil)
+      allow(ENV).to receive(:fetch).with("REACT_ON_RAILS_RELEASE_SUPERVISED", nil).and_return("true")
     end
 
     after { release_task.reenable }
@@ -16315,6 +16316,32 @@ RSpec.describe "release.rake helper methods" do
             a_string_matching(/gem bump|git push|git tag/)
           )
         end
+      end
+    end
+
+    it "preserves every explicit Rake argument in direct dry-run readiness recovery" do
+      allow(ENV).to receive(:fetch).with("REACT_ON_RAILS_RELEASE_SUPERVISED", nil).and_return(nil)
+      allow(task_receiver).to receive(:current_git_sha!).and_return("a" * 40)
+      expected_retry_command = "bundle exec rake release\\[17.0.0.rc.10,true,true,false\\]"
+      allow(task_receiver).to receive(:validate_npm_release_readiness!) do |monorepo_root:, retry_command:|
+        expect(monorepo_root).to eq(self.monorepo_root)
+        expect(retry_command).to eq(expected_retry_command)
+        abort "direct dry-run readiness stopped the release"
+      end
+
+      failure = begin
+        release_task.reenable
+        release_task.invoke("17.0.0.rc.10", true, true, false)
+        nil
+      rescue SystemExit => error
+        error
+      end
+
+      aggregate_failures do
+        expect(failure&.message).to eq("direct dry-run readiness stopped the release")
+        expect(task_receiver).to have_received(:validate_npm_release_readiness!)
+          .with(monorepo_root:, retry_command: expected_retry_command).once
+        expect(task_receiver).not_to have_received(:with_release_checkout)
       end
     end
 

--- a/script/release
+++ b/script/release
@@ -1066,7 +1066,10 @@ class ReleaseSupervisor
   end
 
   def release_child_environment(contract:)
-    child_environment = { ReleaseLeaseGuard::CONTRACT_ENV => contract }
+    child_environment = {
+      ReleaseLeaseGuard::CONTRACT_ENV => contract,
+      "REACT_ON_RAILS_RELEASE_SUPERVISED" => "true"
+    }
     child_environment["RELEASE_CI_EVALUATE_HEAD"] = "true" if @options.fetch(:evaluate_head)
     child_environment
   end

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -378,6 +378,7 @@ process_group="$(ps -o pgid= -p "$$" | tr -d ' ')"
     printf '|%s' "${argument}"
   done
   printf '\ncontract:%s\n' "${REACT_ON_RAILS_RELEASE_LEASE_CONTRACT:-}"
+  printf 'supervised:%s\n' "${REACT_ON_RAILS_RELEASE_SUPERVISED:-}"
   printf 'evaluate-head:%s\n' "${RELEASE_CI_EVALUATE_HEAD:-}"
 } >>"${TEST_BUNDLE_LOG}"
 
@@ -1801,6 +1802,7 @@ run_release --dry-run || fail "argumentless dry-run failed"
 assert_empty "${coord_log}"
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0,true]'
 assert_contains "${bundle_log}" 'contract:'
+assert_contains "${bundle_log}" 'supervised:true'
 pass "dry-run selects the first prepared changelog version"
 
 setup_case evaluate-head-dry-run
@@ -1921,6 +1923,7 @@ assert_contains "${coord_log}" $'heartbeat|'
 assert_contains "${coord_log}" $'status|'
 assert_contains "${coord_log}" $'release|'
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
+assert_contains "${bundle_log}" 'supervised:true'
 assert_secret_absent
 pass "live mode acquires and cleans up a process-owned release lease"
 


### PR DESCRIPTION
## Why

The strict 17.1.0 RC release line needs the source-first recovery correction from #4961 before RC.1 is published. The earlier recovery work preserved wrapper modifiers, while direct Rake dry-run guidance could still discard an explicit version and positional options.

## What changed

- Cherry-picks source commit `c2c1b7adcb96534c4990e88d2b911e460bc477b5` from merged PR #4961.
- Preserves the exact direct-Rake dry-run argument tuple with shell-safe escaping.
- Marks wrapper-spawned Rake children as supervised while keeping `script/release --evaluate-head` as the normal operator interface.
- Adds regression coverage for the observed modifier-preservation path.

This is one source-atomic backport with no release, tag, or publication action.

## Source and release evidence

- Source PR: #4961
- Source commit: `c2c1b7adcb96534c4990e88d2b911e460bc477b5`
- Backport head: `dcaafcfc04c51c0e5bbb9de97c0495c3debb77fb`
- Release base: `36b8d3e7f4ec99e43d728b00f1689193b1a84e99`
- Stable patch-id matches the source commit exactly: `a7ad253aad5ae890a6227edd84190a5772557e79`
- Source commit is reachable from current `origin/main`; no later main commit touches the four source files.
- The backport contains exactly one commit and one direct `(cherry picked from commit ...)` footer.

## Verification

- `bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb --format progress` — 950 examples, 0 failures.
- `bash script/release-test.bash` — 98/98 passing.
- Ruby and Bash syntax checks — passed.
- `git diff --check origin/release/17.1.0...HEAD` — passed.
- Pre-push branch lint — 21 Ruby files, no offenses.
- Pre-push Markdown link check — 524 checked, 0 errors.

The standalone focused RuboCop invocation reports an existing `Metrics/AbcSize` threshold miss in `script/release#fork_release_child`; this source commit does not touch that method, and the required pre-push branch lint is clean.

Closes the release-line backport portion of #4955 after #4957 and #4959.
