### PR TITLE
Test: verify release-supervisor CI routing

### DIFF
--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -5,6 +5,7 @@ set -euo pipefail
 repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 release_script="${repo_root}/script/release"
 ruby_executable="$(ruby -rrbconfig -e 'puts RbConfig.ruby')"
+# Fixture-only CI routing sentinel: this file exercises the release-supervisor latest/unit leg without a real release.
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/react-on-rails-release-test.XXXXXX")"
 fake_secret="coord-secret-must-never-appear"
 tests_run=0


### PR DESCRIPTION
## Verification-only CI exercise — do not merge

This short-lived draft PR verifies the release-supervisor CI routing added by #4928. It must be closed without merging after the required hosted-CI evidence is captured. It tracks #4929; source workflow change: #4928.

The only change is a behavior-preserving comment in `script/release-test.bash`. Its path makes the CI detector select the release-supervisor integration route without changing release, package, workflow, tag, or publication behavior.

### Local evidence

- Clean base `ed8c2cab546b208421c1d4736e668e2e541abaae` and this sentinel commit both reproduce the same inherited fixture failure: `not ok - stalled fence status process never started`.
- `bash -n script/release-test.bash` and `git diff --check` passed.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` passed: 252 files inspected, no offenses.
- `script/ci-changes-detector origin/release/17.1.0` selected Release supervisor integration tests.
- Self-review confirmed one added comment only.

### Hosted-CI plan and safety boundary

After exact-head security preflight, this PR receives exactly one `+ci-force-full` request. The acceptance proof is the gem-tests `latest` / `unit` job and its successful `bash script/release-test.bash` step.

No release, deployment, tag, registry publication, GitHub release, or OTP action is authorized. Cleanup is mandatory: record evidence on #4929, close this PR unmerged, and delete this branch.
