### PR TITLE
Docs: correct demo-fleet manifest from rc.1 fleet inspection

### DIFF
--- a/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
+++ b/.agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb
@@ -3193,7 +3193,7 @@ class FleetValidationGeneratorTest < Minitest::Test
     assert_includes pack, "fallback_claim_repo: shakacode/react_on_rails"
     assert_includes pack, "adhoc:fleet-snapshot-RESOLVED_TAG"
     assert_includes pack, "Search the open `Release gate: react_on_rails X.Y.Z`"
-    assert_includes pack, "workflow=cpflow-review-app.yml, status_check=cpflow/review-app"
+    assert_includes pack, "workflow=.github/workflows/cpflow-deploy-review-app.yml, status_check=deploy / deploy"
     assert_includes pack, "one execution subagent for the assigned monorepo generator/install gate"
     assert_includes pack, "(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators)"
     assert_includes pack, "create-react-on-rails-app@RESOLVED_NPM_VERSION fleet-standard --standard"

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -96,8 +96,13 @@ defaults:
   build: bin/shakapacker
   branch_prefix: chore/demo-fleet
   review_app:
-    workflow: cpflow-review-app.yml
-    status_check: cpflow/review-app
+    # Every public demo with a review-app pipeline uses the control-plane-flow
+    # reusable workflow; its check-run is named `deploy / deploy` (there is no
+    # `cpflow/review-app` commit status). The first deploy for a PR must be
+    # requested with a `+review-app-deploy` comment or `workflow_dispatch`;
+    # `pull_request` runs only skip until an app exists.
+    workflow: .github/workflows/cpflow-deploy-review-app.yml
+    status_check: deploy / deploy
     cpflow_app_name: null
   age_gate:
     npm_min_days: 7
@@ -159,15 +164,16 @@ repos:
       - { ecosystem: npm, name: shakapacker }
       # No cpflow package until a CPFlow review-app pipeline exists for this repo.
     needs_pro: true
-    package_manager: npm
+    package_manager: npm # packageManager npm@11.6.0; .npmrc legacy-peer-deps=true is part of the lock contract
     ruby_test: ALLOW_DEMO_RENDERER_PASSWORD=true bin/rails test
-    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
-    # Recorded for future review-app wiring; skipped while cpflow_app_name is null.
+    js_test: npm run typecheck
+    # bin/rails fails closed without the demo renderer password.
+    build: ALLOW_DEMO_RENDERER_PASSWORD=true bin/rails react_on_rails:generate_packs && ALLOW_DEMO_RENDERER_PASSWORD=true bin/shakapacker
+    # Recorded for future review-app wiring; unreachable while review_app is null.
     smoke: [/]
-    review_app:
-      workflow: cpflow-review-app.yml
-      status_check: cpflow/review-app
-      cpflow_app_name: null # Set after a CPFlow review-app pipeline exists.
+    # Staging-only Control Plane config (.controlplane/controlplane.yml); no review-app
+    # workflow has ever existed in this repo. Re-add the block if one is wired up.
+    review_app: null
     verify: true
 
   - name: shakacode/react-on-rails-demo-hacker-news-rsc
@@ -187,9 +193,17 @@ repos:
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
     needs_pro: true
-    ruby_test: bin/rails test && bin/rails test:system
+    package_manager: pnpm # packageManager pnpm@10.22.0
+    ruby_test: RAILS_ENV=test bin/rails db:prepare && bin/rails test && bin/rails test:system
+    js_test: pnpm exec tsc --noEmit
     build: bin/rails react_on_rails:generate_packs && bin/shakapacker
     smoke: [/, /news/1]
+    review_app:
+      workflow: .github/workflows/cpflow-deploy-review-app.yml
+      status_check: deploy / deploy
+      # Prefix is react-on-rails-demo-hacker-news-rsc-review, but no review app has ever
+      # deployed and the caller has no +review-app-deploy trigger (see that repo's issue #93).
+      cpflow_app_name: null
     verify: true
 
   - name: shakacode/react-on-rails-demo-marketplace-rsc
@@ -209,8 +223,15 @@ repos:
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
     needs_pro: true
-    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
+    package_manager: pnpm # packageManager pnpm@9.15.2; .npmrc node-linker=hoisted
+    ruby_test: bin/rails db:test:prepare && bundle exec rspec spec/requests spec/routing
+    # Wraps rake react_on_rails:generate_packs + bin/shakapacker (rspack) + artifact checks.
+    build: SECRET_KEY_BASE=dummy_secret_key_base_for_demo_fleet bin/build-production
     smoke: [/, /products]
+    review_app:
+      workflow: .github/workflows/cpflow-deploy-review-app.yml
+      status_check: deploy / deploy
+      cpflow_app_name: react-server-components-demo-review # per-PR app: <name>-<PR#>
     verify: true
 
   - name: shakacode/react-on-rails-demo-gumroad-rsc
@@ -229,8 +250,15 @@ repos:
       - { ecosystem: npm, name: react-on-rails-rsc }
       - { ecosystem: gem, name: shakapacker }
     needs_pro: true
-    package_manager: npm
-    smoke: [/]
+    package_manager: npm # packageManager npm@10.8.2; Node 20.19.0; no npm shakapacker (rspack)
+    # CI runs only the demo specs, not the full upstream Gumroad suite.
+    ruby_test: bundle exec rspec spec/controllers/dashboard_controller_spec.rb spec/controllers/dashboard_rsc_demo_controller_spec.rb spec/controllers/public_product_rsc_demo_controller_spec.rb spec/requests/dashboard_demo_smoke_spec.rb spec/requests/public_product_demo_smoke_spec.rb
+    build: npm run setup && RAILS_ENV=test NODE_ENV=test bin/shakapacker && npm run build:rsc-demo:test
+    smoke: [/, /rsc-demo]
+    review_app:
+      workflow: .github/workflows/cpflow-deploy-review-app.yml
+      status_check: deploy / deploy
+      cpflow_app_name: react-on-rails-demo-gumroad-rsc-review-pr # per-PR app: <name>-<PR#>
     verify: true
 
   - name: shakacode/react-webpack-rails-tutorial
@@ -251,9 +279,16 @@ repos:
       - { ecosystem: npm, name: shakapacker }
       - { ecosystem: gem, name: cpflow }
     needs_pro: true
-    package_manager: yarn_classic
-    build: bin/rails react_on_rails:generate_packs && bin/shakapacker
+    package_manager: yarn_classic # default branch is master; run tooling via bin/conductor-exec
+    ruby_test: bundle exec rake ci:rspec
+    js_test: bundle exec rake ci:js
+    # = rm -rf public/packs && yarn res:build && rails react_on_rails:locale && rake react_on_rails:generate_packs && bin/shakapacker
+    build: yarn build:dev
     smoke: [/]
+    review_app:
+      workflow: .github/workflows/cpflow-deploy-review-app.yml
+      status_check: deploy / deploy
+      cpflow_app_name: qa-react-webpack-rails-tutorial # per-PR app: <name>-<PR#>; broken since 2026-07-13 (that repo's issue #784)
     verify: true
 
   - name: shakacode/react-on-rails-starter-tanstack
@@ -274,7 +309,15 @@ repos:
       - { ecosystem: npm, name: shakapacker }
       - { ecosystem: npm, name: shakapacker-rspack }
     needs_pro: true
-    smoke: [/]
+    package_manager: pnpm # packageManager pnpm@11.2.2 via corepack
+    ruby_test: bin/test rspec
+    js_test: pnpm run test:router-shim
+    build: RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 REACT_ON_RAILS_STARTER_TANSTACK_DATABASE_PASSWORD=dummy bin/rails assets:precompile
+    smoke: [/, /rsc-showcase, /hello_server]
+    review_app:
+      workflow: .github/workflows/cpflow-deploy-review-app.yml
+      status_check: deploy / deploy
+      cpflow_app_name: react-on-rails-starter-tanstack-review-pr # per-PR app: <name>-<PR#>; rollout unproven (that repo's issue #194)
     verify: true
 
   # ---------- Shelved / non-gating ----------


### PR DESCRIPTION
## Why

The `17.1.0.rc.1` fleet validation (pack `fleet-20260901T061545Z-69bea0`, tracker #4842) ran a read-only inspection of every hard-gate demo repository before the release-wide preflight closed as BLOCKED on #4984. Those inspections proved several `verify: true` fields in `internal/contributor-info/demo-fleet.yml` wrong, so the next pack would again start from commands that fail closed or from a review-app status check that does not exist. This records the verified values as provisional data.

## What changed

- `defaults.review_app`: real workflow path `.github/workflows/cpflow-deploy-review-app.yml` and check-run name `deploy / deploy` (every demo uses the control-plane-flow reusable workflow; `cpflow-review-app.yml` / `cpflow/review-app` exist nowhere), with a comment that `pull_request` runs only skip until `+review-app-deploy` or `workflow_dispatch` creates the app.
- flagship: `ALLOW_DEMO_RENDERER_PASSWORD=true` on the build (bin/rails fails closed without it), `js_test: npm run typecheck`, and `review_app: null` (staging-only Control Plane config; no review-app workflow has ever existed).
- hacker-news: `package_manager: pnpm`, `ruby_test` with `db:prepare`, `js_test: pnpm exec tsc --noEmit`, review-app block with `cpflow_app_name: null` (never deployed; no comment trigger, see shakacode/react-on-rails-demo-hacker-news-rsc#93).
- marketplace: `package_manager: pnpm`, CI-equivalent `ruby_test`, `build: SECRET_KEY_BASE=… bin/build-production`, review-app name prefix `react-server-components-demo-review`.
- gumroad: CI demo-spec `ruby_test`, the fleet-smoke build command, `/rsc-demo` smoke path, review-app prefix `react-on-rails-demo-gumroad-rsc-review-pr`.
- tutorial: `ruby_test: bundle exec rake ci:rspec`, `js_test: bundle exec rake ci:js`, `build: yarn build:dev` (the manifest's generate_packs+shakapacker omitted locale and ReScript steps), review-app prefix `qa-react-webpack-rails-tutorial` (broken since 2026-07-13, shakacode/react-webpack-rails-tutorial#784).
- tanstack: `ruby_test: bin/test rspec`, `js_test: pnpm run test:router-shim`, the production `assets:precompile` build, RSC smoke paths, review-app prefix `react-on-rails-starter-tanstack-review-pr` (rollout unproven, shakacode/react-on-rails-starter-tanstack#194).
- `generate_prompts_test.rb`: the assertion that pinned the old placeholder review-app metadata now expects the corrected default.

Every entry keeps `verify: true`: the rc-testing-plan conditions for clearing it (dependency-review CI confirmation and a proven review-app name) are not all met. The added smoke paths change lane weights, so the generated machine allocation differs from the previous pack layout; that is expected.

## Validation

- `bundle exec ruby .agents/skills/run-fleet-validation/scripts/generate_prompts_test.rb` → 166 runs, 670 assertions, 0 failures
- `replay_rc12_lifecycle.rb`, `fleet_health_test.rb` (73 runs, 0 failures), `replay_rc12_fleet_health.rb` → pass
- `generate_prompts.rb --machines local,m1 --prompts 6` renders all six prompts with the corrected review-app lines and `review_app: none/unverified` for flagship

Evidence for each field is in the fleet evidence comments on #4842 and the follow-up issues linked above (also shakacode/react-on-rails-demo-marketplace-rsc#203, shakacode/react-on-rails-demo-flagship#51, shakacode/react-on-rails-demo-gumroad-rsc#118, shakacode/react-webpack-rails-tutorial#815).

Refs #4842. Part of the rc.1 fleet validation closeout; no changelog entry (internal contributor documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated demo environments to use the current review-app deployment workflow.
  * Added explicit review-app names and expanded build, test, and smoke-test settings for supported demos.
  * Updated package-manager version guidance and environment-specific build commands.
  * Removed dedicated review-app configuration from the flagship demo.

* **Validation**
  * Updated generated validation output to verify the full review-app workflow path and deployment status check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->