### PR TITLE
Stamp CHANGELOG for 17.1.0.rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.1.0.rc.2] - 2026-09-02
+
 #### Fixed
 
 - **[Pro]** **Prerender-cached streamed renders now hydrate on every request**: The automatic prerender cache key
@@ -3216,7 +3218,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.1...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.2...main
+[17.1.0.rc.2]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.1...v17.1.0.rc.2
 [17.1.0.rc.1]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.0...v17.1.0.rc.1
 [17.1.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v17.0.1...v17.1.0.rc.0
 [17.0.1]: https://github.com/shakacode/react_on_rails/compare/v17.0.0...v17.0.1


### PR DESCRIPTION
## Why

`release/17.1.0` now carries the #4987 fix for #4984 (the rc.1 generator-matrix blocker). Per the release-train runbook, the next candidate needs its changelog section stamped before `script/release` cuts `v17.1.0.rc.2` from the branch tip; pushing this prepared section also dispatches the ShakaPerf release gate pre-run for the branch.

## What changed

`bundle exec rake "update_changelog[rc]"` on the release tip: the Unreleased entry moves under `### [17.1.0.rc.2]`, and the compare links gain the rc.2 anchor. No entries were written by hand.

## Validation

Changelog-only; `git diff --check` clean. Follow-up to #4987 (tracker #4842).

🤖 Generated with [Claude Code](https://claude.com/claude-code)