### PR TITLE
Release: bump versions to 17.1.0.rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-workspace",
-  "version": "17.1.0-rc.1",
+  "version": "17.1.0-rc.2",
   "description": "react-on-rails monorepo workspace manager",
   "private": true,
   "type": "module",

--- a/packages/create-react-on-rails-app/package.json
+++ b/packages/create-react-on-rails-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-on-rails-app",
-  "version": "17.1.0-rc.1",
+  "version": "17.1.0-rc.2",
   "description": "Create React on Rails applications with a single command",
   "bin": {
     "create-react-on-rails-app": "./bin/create-react-on-rails-app.js"

--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-pro-node-renderer",
-  "version": "17.1.0-rc.1",
+  "version": "17.1.0-rc.2",
   "protocolVersion": "2.0.0",
   "description": "React on Rails Pro Node Renderer for server-side rendering",
   "engines": {

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-pro",
-  "version": "17.1.0-rc.1",
+  "version": "17.1.0-rc.2",
   "description": "React on Rails Pro package with React Server Components support",
   "main": "lib/ReactOnRails.full.js",
   "type": "module",

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails",
-  "version": "17.1.0-rc.1",
+  "version": "17.1.0-rc.2",
   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
   "main": "lib/ReactOnRails.full.js",
   "type": "module",

--- a/react_on_rails/Gemfile.lock
+++ b/react_on_rails/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    react_on_rails (17.1.0.rc.1)
+    react_on_rails (17.1.0.rc.2)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/react_on_rails/lib/react_on_rails/version.rb
+++ b/react_on_rails/lib/react_on_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReactOnRails
-  VERSION = "17.1.0.rc.1"
+  VERSION = "17.1.0.rc.2"
 end

--- a/react_on_rails/spec/dummy/Gemfile.lock
+++ b/react_on_rails/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    react_on_rails (17.1.0.rc.1)
+    react_on_rails (17.1.0.rc.2)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    react_on_rails (17.1.0.rc.1)
+    react_on_rails (17.1.0.rc.2)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -20,14 +20,14 @@ PATH
 PATH
   remote: .
   specs:
-    react_on_rails_pro (17.1.0.rc.1)
+    react_on_rails_pro (17.1.0.rc.2)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       nokogiri (>= 1.12, < 2)
-      react_on_rails (= 17.1.0.rc.1)
+      react_on_rails (= 17.1.0.rc.2)
 
 GEM
   remote: https://rubygems.org/

--- a/react_on_rails_pro/lib/react_on_rails_pro/version.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/version.rb
@@ -14,6 +14,6 @@
 # https://github.com/shakacode/react_on_rails/blob/main/REACT-ON-RAILS-PRO-LICENSE.md
 
 module ReactOnRailsPro
-  VERSION = "17.1.0.rc.1"
+  VERSION = "17.1.0.rc.2"
   PROTOCOL_VERSION = "2.0.0"
 end

--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ../../..
   specs:
-    react_on_rails (17.1.0.rc.1)
+    react_on_rails (17.1.0.rc.2)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -20,14 +20,14 @@ PATH
 PATH
   remote: ../..
   specs:
-    react_on_rails_pro (17.1.0.rc.1)
+    react_on_rails_pro (17.1.0.rc.2)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       nokogiri (>= 1.12, < 2)
-      react_on_rails (= 17.1.0.rc.1)
+      react_on_rails (= 17.1.0.rc.2)
 
 GEM
   remote: https://rubygems.org/

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    react_on_rails (17.1.0.rc.1)
+    react_on_rails (17.1.0.rc.2)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -12,14 +12,14 @@ PATH
 PATH
   remote: ../..
   specs:
-    react_on_rails_pro (17.1.0.rc.1)
+    react_on_rails_pro (17.1.0.rc.2)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       nokogiri (>= 1.12, < 2)
-      react_on_rails (= 17.1.0.rc.1)
+      react_on_rails (= 17.1.0.rc.2)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Why

The live `script/release` run generated the coordinated `17.1.0.rc.2` version commit, but GitHub rejected its direct push because `release/17.1.0` now requires changes to land through a pull request and merge queue.

This PR preserves the exact generated release candidate metadata and routes it through the protected release-branch gate so the fenced release can resume safely after merge.

Relates to #4842.

## Changes

- bump the OSS and Pro gem versions to `17.1.0.rc.2`
- bump all five workspace package versions to `17.1.0-rc.2`
- update the affected Ruby lockfiles consistently

No runtime source changes are included. The `17.1.0.rc.2` changelog was already stamped by #4994.

## Verification

- the original `script/release` run completed all version generation and lockfile updates before the protected-branch push was rejected
- `git diff --check origin/release/17.1.0..HEAD`
- focused consistency check confirmed all gem version files use `17.1.0.rc.2` and all package manifests use `17.1.0-rc.2`
- manual diff review confirmed the commit contains only coordinated version and lockfile substitutions

## Churn notes

This is the unchanged generated commit from the failed release run; no regenerated or unrelated files were added afterward.

## Changelog classification

Release metadata only; the user-visible changelog section was prepared separately in #4994.
