### PR TITLE
Treat nil component ids as omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **Explicit `id: nil` now uses the configured automatic DOM id behavior**: Component rendering no longer omits the
+  container id while still reporting that a random id is active. Fixes
+  [Issue 4993](https://github.com/shakacode/react_on_rails/issues/4993).
+
 - **[Pro]** **Prerender-cached streamed renders now hydrate on every request**: The automatic prerender cache key
   deliberately ignores random dom ids so one cached render serves every mount point, but the cached
   chunks still embedded the first request's dom id in their React Server Component payload keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **Explicit `id: nil` now uses the configured automatic DOM id behavior**: Component rendering no longer omits the
   container id while still reporting that a random id is active. Fixes
   [Issue 4993](https://github.com/shakacode/react_on_rails/issues/4993).
+  [PR 4998](https://github.com/shakacode/react_on_rails/pull/4998) by
+  [justin808](https://github.com/justin808).
 
 - **[Pro]** **Prerender-cached streamed renders now hydrate on every request**: The automatic prerender cache key
   deliberately ignores random dom ids so one cached render serves every mount point, but the cached

--- a/react_on_rails/lib/react_on_rails/react_component/render_options.rb
+++ b/react_on_rails/lib/react_on_rails/react_component/render_options.rb
@@ -105,13 +105,11 @@ module ReactOnRails
       end
 
       def dom_id
-        @dom_id ||= options.fetch(:id) do
-          if random_dom_id
-            generate_unique_dom_id
-          else
-            base_dom_id
-          end
-        end
+        @dom_id ||= if options[:id].nil?
+                      random_dom_id ? generate_unique_dom_id : base_dom_id
+                    else
+                      options[:id]
+                    end
       end
 
       def random_dom_id?

--- a/react_on_rails/spec/react_on_rails/react_component/render_options_spec.rb
+++ b/react_on_rails/spec/react_on_rails/react_component/render_options_spec.rb
@@ -124,6 +124,24 @@ describe ReactOnRails::ReactComponent::RenderOptions do
         expect(opts.dom_id).to eq "im-an-id"
         expect(opts.random_dom_id?).to be(false)
       end
+
+      it "treats nil as an omitted id" do
+        attrs = the_attrs(react_component_name: "SomeApp", options: { id: nil, random_dom_id: true })
+        opts = described_class.new(**attrs)
+
+        allow(SecureRandom).to receive(:uuid).and_return("123456789")
+
+        expect(opts.dom_id).to eq "SomeApp-react-component-123456789"
+        expect(opts.random_dom_id?).to be(true)
+      end
+
+      it "uses the base id for nil when random ids are disabled" do
+        attrs = the_attrs(react_component_name: "SomeApp", options: { id: nil, random_dom_id: false })
+        opts = described_class.new(**attrs)
+
+        expect(opts.dom_id).to eq "SomeApp-react-component"
+        expect(opts.random_dom_id?).to be(false)
+      end
     end
   end
 


### PR DESCRIPTION
## Why

`RenderOptions#dom_id` treated an explicit `id: nil` differently from an omitted id. It returned `nil`, even though `random_dom_id?` reported that automatic id generation was active. This contradicted the documented helper behavior and could leave the container without an id.

Fixes #4993.

## What changed

- Treat only `nil` as an omitted component id, while preserving existing behavior for other explicit values.
- Cover both random-id and fixed-id configurations.
- Document the user-visible correction in the changelog.

## Review path

Start with `RenderOptions#dom_id`, then check the two focused examples in `render_options_spec.rb`. The key compatibility boundary is that this does not broaden the change to blank strings or other explicit values.

## Test plan

- `bundle exec rspec spec/react_on_rails/react_component/render_options_spec.rb` — 34 examples, 0 failures
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop` — 249 files, 0 offenses
- `bundle exec rake rbs:validate` — passed
- pre-commit and pre-push hooks — passed, including changed-file RuboCop, formatting, and Markdown links
- `.agents/bin/validate --changed` — lint, formatting, TypeScript, and build stages passed; the broad gem-unit stage produced widespread failures in unrelated filesystem/dev-server/locales tests and was stopped after 214 failures. The focused changed spec remains green; hosted current-head validation is requested.

<details>
<summary>Agent details</summary>

### Decision log

- **Non-blocking:** Keep the fix narrower than the issue's `presence` example.
  - **Decision:** Only `nil` uses automatic id generation.
  - **Why:** Blank strings and other explicit values have separate compatibility semantics and are not needed to resolve the reported inconsistency.
  - **Review later:** None.

### TDD evidence

- RED: the new `id: nil` random-id example returned `nil` instead of `SomeApp-react-component-123456789`.
- GREEN: both `id: nil` examples now follow the configured random-id behavior.

### Review and churn

- Pre-push review gate: manual self-review completed. A local `codex review --base origin/main` attempt recursively invoked the same command, so it was terminated without a verdict; current-head hosted review remains required.
- Post-push review churn: 0 follow-up commits; 0 review-fix rounds at draft publication.
- Batch QA lane: not required. This is a focused Ruby branch correction with direct unit coverage and no UI, workflow, release, or security surface.
- Security preflight: `SECURITY_PREFLIGHT_OK`; no untrusted participants, suspicious text, or high-risk files.
- Stage dependency gate: eligible; no dependency edges; binding `sha256:45191ad3f9aeef26a3d3bfd4b0d1b8127838a53bbb5cc18070e07e44756229f6`.

</details>
