### PR TITLE
Docs: surface React on Rails 17.1 upgrade actions

### DIFF
--- a/docs/.sidebar-exclusions
+++ b/docs/.sidebar-exclusions
@@ -36,6 +36,7 @@ upgrading/release-notes/16.5.1
 upgrading/release-notes/16.6.0
 upgrading/release-notes/17.0.0
 upgrading/release-notes/17.0.1
+upgrading/release-notes/17.1.0
 
 # URL-compatibility stub that redirects to pro/react-on-rails-pro
 pro/home-pro

--- a/docs/oss/upgrading/release-notes/17.1.0.md
+++ b/docs/oss/upgrading/release-notes/17.1.0.md
@@ -4,7 +4,8 @@ The 17.1.0 release line is currently available as a release candidate. Use the e
 versions. For example, Ruby uses `17.1.0.rc.1`, while npm uses `17.1.0-rc.1`.
 
 For the complete list of changes, see the [CHANGELOG](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md).
-When you upgrade from an earlier release candidate, also compare the exact tags:
+When you upgrade from an earlier release candidate, also compare the exact tags. Both placeholders use Ruby/tag dot
+notation, such as `17.1.0.rc.1`:
 `https://github.com/shakacode/react_on_rails/compare/v<CURRENT_VERSION>...v<TARGET_VERSION>`.
 
 ## Action required for Pro applications
@@ -13,7 +14,8 @@ When you upgrade from an earlier release candidate, also compare the exact tags:
 
 Render requests now use a raw JavaScript request body. The upgraded Node Renderer accepts both the old form-encoded
 body and the new content type, but an older renderer rejects requests from an upgraded gem. Deploy the Node Renderer
-before or together with the Rails gem. Do not deploy the upgraded gem first. See
+before the Rails gem. A simultaneous deployment is safe only when an atomic rollout prevents upgraded gem requests
+from reaching an old renderer. See
 [PR 4579](https://github.com/shakacode/react_on_rails/pull/4579).
 
 ### Re-check Node Renderer memory limits
@@ -32,7 +34,6 @@ with the older signature raises `ArgumentError: unknown keyword: :on_chunk_error
 
 If your application prepends or overrides a Pro helper, compare the helper signatures between the exact tags. Update
 the override and run the application's streamed SSR and RSC tests before deployment. See
-[PR 4722](https://github.com/shakacode/react_on_rails/pull/4722) and
-[PR 4804](https://github.com/shakacode/react_on_rails/pull/4804).
+[PR 4722](https://github.com/shakacode/react_on_rails/pull/4722).
 
 For the coupled gem and npm upgrade procedure, see the [Pro upgrade guide](../../../pro/updating.md).

--- a/docs/oss/upgrading/release-notes/17.1.0.md
+++ b/docs/oss/upgrading/release-notes/17.1.0.md
@@ -1,0 +1,38 @@
+# React on Rails 17.1.0 Release Notes
+
+The 17.1.0 release line is currently available as a release candidate. Use the exact matching gem and npm prerelease
+versions. For example, Ruby uses `17.1.0.rc.1`, while npm uses `17.1.0-rc.1`.
+
+For the complete list of changes, see the [CHANGELOG](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md).
+When you upgrade from an earlier release candidate, also compare the exact tags:
+`https://github.com/shakacode/react_on_rails/compare/v<CURRENT_VERSION>...v<TARGET_VERSION>`.
+
+## Action required for Pro applications
+
+### Deploy the Node Renderer first
+
+Render requests now use a raw JavaScript request body. The upgraded Node Renderer accepts both the old form-encoded
+body and the new content type, but an older renderer rejects requests from an upgraded gem. Deploy the Node Renderer
+before or together with the Rails gem. Do not deploy the upgraded gem first. See
+[PR 4579](https://github.com/shakacode/react_on_rails/pull/4579).
+
+### Re-check Node Renderer memory limits
+
+The default `maxVMPoolSize` increased from 2 to 4 for each renderer worker. This prevents old and new RSC bundle
+generations from rebuilding repeatedly during rolling deploys, but it can retain twice as many VM contexts. Re-check
+memory requests and limits across every worker and replica. If you set `MAX_VM_POOL_SIZE`, it must be a positive
+integer; invalid values now stop renderer startup instead of falling back to the default. See
+[PR 4811](https://github.com/shakacode/react_on_rails/pull/4811).
+
+### Update custom Pro helper overrides
+
+`ReactOnRailsProHelper` methods are internal and are not stable extension points. The 17.1 release line added the
+`on_chunk_errors:` keyword to `build_react_component_result_for_server_streamed_content`. An application override
+with the older signature raises `ArgumentError: unknown keyword: :on_chunk_errors` during streamed rendering.
+
+If your application prepends or overrides a Pro helper, compare the helper signatures between the exact tags. Update
+the override and run the application's streamed SSR and RSC tests before deployment. See
+[PR 4722](https://github.com/shakacode/react_on_rails/pull/4722) and
+[PR 4804](https://github.com/shakacode/react_on_rails/pull/4804).
+
+For the coupled gem and npm upgrade procedure, see the [Pro upgrade guide](../../../pro/updating.md).

--- a/docs/oss/upgrading/release-notes/index.md
+++ b/docs/oss/upgrading/release-notes/index.md
@@ -9,6 +9,7 @@ This archive keeps the major React on Rails OSS release notes easy to browse wit
 
 ## Recent OSS Release Notes
 
+- [17.1.0](./17.1.0.md)
 - [17.0.1](./17.0.1.md)
 - [17.0.0](./17.0.0.md)
 - [16.6.0](./16.6.0.md)

--- a/docs/pro/updating.md
+++ b/docs/pro/updating.md
@@ -57,7 +57,10 @@ string directly into `Gemfile`), the install will fail because no package exists
 under that spelling. Substitute `.` for `-` (or `-` for `.`) when crossing the
 language boundary.
 
-When you upgrade between prereleases, review the changes between the exact tags. Use
+### Compare exact prerelease tags
+
+When you upgrade between prereleases, review the changes between the exact tags. Use Ruby/tag dot notation for both
+placeholders in
 `https://github.com/shakacode/react_on_rails/compare/v<CURRENT_VERSION>...v<TARGET_VERSION>`.
 The release notes summarize the release line, but the tag comparison shows the RC-to-RC changes that apply to your
 current pin.
@@ -66,9 +69,6 @@ current pin.
 
 Methods in `ReactOnRailsProHelper` are internal implementation details, not stable extension points. An application
 that uses `prepend` or otherwise overrides a Pro helper method must re-check the method signature for every upgrade.
-For example, React on Rails Pro 17.1 added the `on_chunk_errors:` keyword to
-`build_react_component_result_for_server_streamed_content`. An override with the older signature raises
-`ArgumentError: unknown keyword: :on_chunk_errors` during streamed rendering.
 
 Prefer documented configuration and helper APIs. If an internal override is unavoidable, compare the exact release
 tags, update the override signature, and run the application's streamed SSR and RSC tests before deployment.

--- a/docs/pro/updating.md
+++ b/docs/pro/updating.md
@@ -57,6 +57,22 @@ string directly into `Gemfile`), the install will fail because no package exists
 under that spelling. Substitute `.` for `-` (or `-` for `.`) when crossing the
 language boundary.
 
+When you upgrade between prereleases, review the changes between the exact tags. Use
+`https://github.com/shakacode/react_on_rails/compare/v<CURRENT_VERSION>...v<TARGET_VERSION>`.
+The release notes summarize the release line, but the tag comparison shows the RC-to-RC changes that apply to your
+current pin.
+
+### Custom overrides of Pro helpers
+
+Methods in `ReactOnRailsProHelper` are internal implementation details, not stable extension points. An application
+that uses `prepend` or otherwise overrides a Pro helper method must re-check the method signature for every upgrade.
+For example, React on Rails Pro 17.1 added the `on_chunk_errors:` keyword to
+`build_react_component_result_for_server_streamed_content`. An override with the older signature raises
+`ArgumentError: unknown keyword: :on_chunk_errors` during streamed rendering.
+
+Prefer documented configuration and helper APIs. If an internal override is unavoidable, compare the exact release
+tags, update the override signature, and run the application's streamed SSR and RSC tests before deployment.
+
 ### Strict version pinning
 
 Use exact version constraints on both sides — never `^`, `~`, or `*`. Semver

--- a/react_on_rails/docs/agent/install-and-upgrade.md
+++ b/react_on_rails/docs/agent/install-and-upgrade.md
@@ -89,6 +89,9 @@ Review the generated initializer, Shakapacker configuration, scripts, routes, an
    `https://github.com/shakacode/react_on_rails/tree/v<GEM_TARGET_VERSION>`. Compare the complete
    `CURRENT_VERSION..GEM_TARGET_VERSION` release range before changing dependencies:
    `https://github.com/shakacode/react_on_rails/compare/v<CURRENT_VERSION>...v<GEM_TARGET_VERSION>`.
+   For Pro apps, treat `ReactOnRailsProHelper` methods as internal rather than stable extension points. If the app
+   prepends or overrides a Pro helper, compare its method signature between the exact tags and update the override
+   before running streamed SSR or RSC tests.
 
 ## JavaScript target matrix
 


### PR DESCRIPTION
### Summary

React on Rails Pro 17.1 has several operational upgrade requirements that are easy to miss in the unified changelog. This adds one focused release-notes page and puts the two reusable upgrade rules in the human and bundled-agent guides.

- Warn applications that override internal `ReactOnRailsProHelper` methods to compare signatures between exact tags.
- Explain how to review RC-to-RC changes with GitHub's exact tag comparison.
- Call out renderer-first deployment and the `maxVMPoolSize` memory and validation changes for 17.1.

Closes #4995.

### Pull Request checklist

- [x] ~Add/update test to cover these changes — documentation only~
- [x] Update documentation
- [x] ~Update CHANGELOG file — the release notes summarize existing 17.1 changelog entries~

### Other Information

Review the new 17.1 action list first, then confirm that the shorter guidance in both upgrade guides remains version-independent.

<details>
<summary>Agent details</summary>

- Decision: target `main`, not `release/17.1.0`. This is upgrade guidance, not a release-branch stabilizing change.
- Evidence: the issue reports a maintainer-observed failure during the HiChee RC upgrade. The documented behavior was checked against the current helper signature, Node Renderer configuration, CHANGELOG, and published `v17.1.0.rc.1` tag.
- Focused checks:
  - Prettier 3.6.2 on all four changed Markdown files
  - `script/check-docs-sidebar`
  - `lychee --config .lychee.toml` on all four changed Markdown files
  - `script/check-pro-license-headers`
  - pre-commit Markdown links, trailing newlines, and Prettier hooks
- Churn: one new release-notes page and three small documentation additions; no runtime, dependency, lockfile, release-branch, or version changes.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 17.1.0, including upgrade guidance for Pro applications.
  - Documented raw JavaScript request bodies and required Node Renderer deployment sequencing.
  - Documented renderer pool sizing changes and invalid `MAX_VM_POOL_SIZE` behavior.
  - Added guidance for comparing exact prerelease tags and updating custom Pro helper overrides, including streamed SSR and RSC testing.
  - Added the 17.1.0 release notes to the documentation index and sidebar configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->