### PR TITLE
Make release lock recovery actionable

### DIFF
--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -90,6 +90,13 @@ During a managed live run, the wrapper also uses this helper to renew the same
 active identity at least hourly with the exact observed backend version. Any
 identity mismatch or conditional-write conflict stops the supervised release
 process group before the wrapper attempts exact-identity cleanup.
+Managed cleanup uses the same helper to release only the exact active agent and
+instance identity with a conditional write. A matching already-released record
+is a successful retry. A replacement identity or write conflict is refused.
+When cleanup cannot complete, the wrapper prints the exact guarded release
+command and the restart command. Follow
+[Recover a retained publication lease](release-train-runbook.md#recover-a-retained-publication-lease)
+before running them.
 
 Automation that already owns a broader release-line lease may supply both
 `RELEASE_COORDINATOR_ID` and `RELEASE_COORDINATOR_INSTANCE_ID` and pre-acquire

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -193,6 +193,41 @@ Inspect and coordinate with the recorded holder. Never infer takeover safety
 from lease expiry or heartbeat age alone; the wrapper does not provide or
 attempt an automatic takeover.
 
+#### Recover a retained publication lease
+
+If managed lease cleanup fails, `script/release` prints the exact recovery
+command for the lease that it acquired. A foreign-claim refusal prints the same
+command when the backend supplies a usable exact identity. Before running the
+command, prove that every process group reported by the failed release is dead.
+Do not use lease expiry or heartbeat age as that proof.
+
+Run the printed command from the repository root with the release-machine
+coordination environment loaded. Its shape is:
+
+```bash
+script/release-claim --release \
+  --agent-id <printed-agent-id> \
+  --instance-id <printed-instance-id> \
+  --repo shakacode/react_on_rails \
+  --target release-line:X.Y.Z
+```
+
+The helper releases only the exact active `agent_id` and `instance_id` at the
+observed backend version. It refuses a replacement lease, even if the new lease
+reuses the agent ID. Repeating the command is safe when the first release write
+succeeded but its response was lost. If the backend reports a missing,
+malformed, or `UNKNOWN` identity, the wrapper omits the release command. Inspect
+the authoritative status and coordinate with the holder instead of constructing
+a command manually.
+
+After the exact lease release succeeds, keep the interrupted version first
+after `### [Unreleased]` and run the printed restart command. It preserves
+applicable command modifiers such as `--evaluate-head` or
+`--reconcile-accelerated-rc`; reapply any required `RELEASE_TRACKER` value in
+the environment.
+The release task's registry, tag, and GitHub-release checks resume an interrupted
+publication without republishing artifacts that already exist.
+
 #### Advanced automation compatibility
 
 Automation that already coordinates a broader sequence of release-line writes

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -948,6 +948,16 @@ If the release fails partway through (e.g., during NPM publish):
    `script/release` after the supervisor has acquired the required claim and the artifact evidence is exact; if lease state
    or any remote/artifact identity is `UNKNOWN`, remain stopped.
 
+If the wrapper cannot clean up its managed release-line lease, it prints the
+exact `script/release-claim --release ...` command followed by the restart
+command. First prove that every process group reported by the failed release is
+dead. Then run the printed release command from the repository root with the
+release-machine coordination environment loaded. Do not edit or reconstruct its
+agent ID, instance ID, repository, or target arguments. The command is fenced to
+that exact lease and safely refuses a replacement lease. See
+[Recover a retained publication lease](release-train-runbook.md#recover-a-retained-publication-lease)
+for the complete procedure.
+
 ## Version History
 
 A dry-run preview with `bundle exec rake "release[X.Y.Z,true]"` shows the generated commit, which looks

--- a/rakelib/release_atomic_claim.rb
+++ b/rakelib/release_atomic_claim.rb
@@ -72,6 +72,33 @@ module ReleaseAtomicClaim
       raise Error, "coordination backend atomic claim renewal failed (HTTP #{response.code})"
     end
 
+    def release!(repo:, target:, agent_id:, instance_id:, now: Time.now.utc)
+      validate_release_inputs!(repo:, target:, agent_id:, instance_id:)
+      path = "claims/#{repo}/#{target}.json"
+      current = read_claim(path)
+      release_status = verify_release_identity!(current, repo:, target:, agent_id:, instance_id:)
+      return true if release_status == "released"
+
+      timestamp = now.utc.iso8601
+      payload = current.fetch(:data).merge(
+        "status" => "released",
+        "released_by" => agent_id,
+        "released_at" => timestamp,
+        "updated_at" => timestamp,
+        "expires_at" => timestamp
+      )
+      response = request(
+        method: Net::HTTP::Put,
+        path: state_path(path),
+        headers: { "If-Match" => current.fetch(:version) },
+        body: JSON.generate("data" => payload)
+      )
+      return true if SUCCESS_CODES.include?(response.code.to_s)
+      raise ClaimRefused, "release-line claim changed during atomic release" if response.code.to_s == "409"
+
+      raise Error, "coordination backend atomic claim release failed (HTTP #{response.code})"
+    end
+
     private
 
     def validated_base_uri(base_url)
@@ -101,6 +128,15 @@ module ReleaseAtomicClaim
         raise Error, "release claim #{label} is missing" if value.to_s.empty? || value.to_s.casecmp?("UNKNOWN")
       end
       raise Error, "release claim TTL must be positive" unless ttl.is_a?(Integer) && ttl.positive?
+    end
+
+    def validate_release_inputs!(repo:, target:, agent_id:, instance_id:)
+      raise Error, "release claim repository is invalid" unless repo.match?(REPOSITORY_PATTERN)
+      raise Error, "release claim target is invalid" unless target.match?(TARGET_PATTERN)
+
+      { "agent id" => agent_id, "instance id" => instance_id }.each do |label, value|
+        raise Error, "release claim #{label} is missing" if value.to_s.empty? || value.to_s.casecmp?("UNKNOWN")
+      end
     end
 
     def read_claim(path)
@@ -146,6 +182,21 @@ module ReleaseAtomicClaim
       return if expected.all? { |field, value| current.fetch(:data)[field] == value }
 
       raise ClaimRefused, "release-line claim identity changed during renewal"
+    end
+
+    def verify_release_identity!(current, repo:, target:, agent_id:, instance_id:)
+      raise ClaimRefused, "release-line claim is absent during release" unless current
+
+      expected = {
+        "repo" => repo,
+        "target" => target,
+        "agent_id" => agent_id,
+        "instance_id" => instance_id
+      }
+      data = current.fetch(:data)
+      return data.fetch("status") if expected.all? { |field, value| data[field] == value }
+
+      raise ClaimRefused, "release-line claim identity changed during release"
     end
 
     def claim_payload(repo:, target:, agent_id:, instance_id:, machine_id:, branch:, ttl:, now:)

--- a/react_on_rails/spec/react_on_rails/release_atomic_claim/client_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_atomic_claim/client_spec.rb
@@ -159,6 +159,91 @@ RSpec.describe ReleaseAtomicClaim::Client do
     expect { client.renew!(**claim_args) }.to raise_error(ReleaseAtomicClaim::ClaimRefused)
   end
 
+  it "releases only the exact active identity with an exact-version conditional write" do
+    claim_data = {
+      "status" => "active",
+      "repo" => "shakacode/react_on_rails",
+      "target" => "release-line:17.1.0",
+      "agent_id" => "release-17.1.0-uuid",
+      "instance_id" => "uuid",
+      "machine_id" => "release-machine",
+      "branch" => "release/17.1.0"
+    }
+    responses.push(
+      response_class.new(code: "200", body: JSON.generate("version" => 12, "data" => claim_data)),
+      response_class.new(code: "200", body: "{}")
+    )
+
+    expect(client.release!(**claim_args.slice(:repo, :target, :agent_id, :instance_id, :now))).to be(true)
+
+    put = requests.fetch(1)
+    expect(put.fetch(:headers)).to include("If-Match" => "12")
+    payload = JSON.parse(put.fetch(:body)).fetch("data")
+    expect(payload).to include(
+      "status" => "released",
+      "agent_id" => "release-17.1.0-uuid",
+      "instance_id" => "uuid",
+      "released_at" => "2026-08-25T06:30:00Z"
+    )
+  end
+
+  it "treats an already-released exact identity as a successful retry" do
+    responses << response_class.new(
+      code: "200",
+      body: JSON.generate(
+        "version" => 13,
+        "data" => {
+          "status" => "released",
+          "repo" => "shakacode/react_on_rails",
+          "target" => "release-line:17.1.0",
+          "agent_id" => "release-17.1.0-uuid",
+          "instance_id" => "uuid"
+        }
+      )
+    )
+
+    release_args = claim_args.slice(:repo, :target, :agent_id, :instance_id, :now)
+    expect(client.release!(**release_args)).to be(true)
+    expect(requests.length).to eq(1)
+  end
+
+  it "refuses to release a replacement claim with the same agent and a new instance" do
+    responses << response_class.new(
+      code: "200",
+      body: JSON.generate(
+        "version" => 13,
+        "data" => {
+          "status" => "active",
+          "repo" => "shakacode/react_on_rails",
+          "target" => "release-line:17.1.0",
+          "agent_id" => "release-17.1.0-uuid",
+          "instance_id" => "replacement-uuid"
+        }
+      )
+    )
+
+    release_args = claim_args.slice(:repo, :target, :agent_id, :instance_id, :now)
+    expect { client.release!(**release_args) }.to raise_error(ReleaseAtomicClaim::ClaimRefused)
+    expect(requests.length).to eq(1)
+  end
+
+  it "maps a release conditional-write conflict to claim refusal" do
+    claim_data = {
+      "status" => "active",
+      "repo" => "shakacode/react_on_rails",
+      "target" => "release-line:17.1.0",
+      "agent_id" => "release-17.1.0-uuid",
+      "instance_id" => "uuid"
+    }
+    responses.push(
+      response_class.new(code: "200", body: JSON.generate("version" => 14, "data" => claim_data)),
+      response_class.new(code: "409", body: '{"error":"conflict"}')
+    )
+
+    release_args = claim_args.slice(:repo, :target, :agent_id, :instance_id, :now)
+    expect { client.release!(**release_args) }.to raise_error(ReleaseAtomicClaim::ClaimRefused)
+  end
+
   it "rejects malformed backend records without exposing the token" do
     responses << response_class.new(code: "200", body: '["secret-token"]')
 

--- a/script/release
+++ b/script/release
@@ -6,6 +6,7 @@ require "io/wait"
 require "open3"
 require "optparse"
 require "securerandom"
+require "shellwords"
 require "tempfile"
 require "rubygems/version"
 require_relative "../rakelib/release_changelog_selector"
@@ -152,12 +153,11 @@ class ReleaseSupervisor
     ensure
       if managed_claim_cleanup_required && @managed_claim_release_safe
         cleanup_succeeded = release_managed_lease!(scope, identity, coordination_timeout:, termination_grace:)
-        unless cleanup_succeeded
-          @stderr.puts "ERROR: release-line lease cleanup failed; verify coordination state before retrying"
-        end
+        report_managed_lease_cleanup_failure(scope, identity) unless cleanup_succeeded
       elsif managed_claim_cleanup_required
         cleanup_succeeded = false
         @stderr.puts "ERROR: retaining release-line lease because process-group termination was not proven"
+        report_managed_lease_recovery(scope, identity)
       end
       restore_signal_handlers(previous_signal_handlers)
     end
@@ -595,6 +595,14 @@ class ReleaseSupervisor
 
         lines << "    #{field}: #{JSON.generate(claim[field])}"
       end
+      agent_id = claim["agent_id"].to_s
+      instance_id = claim["instance_id"].to_s
+      next if agent_id.empty? || instance_id.empty?
+
+      lines << "    After proving this claim's release process group is dead, release its exact lease with:"
+      lines << "      #{lease_release_shell_command(scope, agent_id:, instance_id:)}"
+      lines << "    Then restart the release with:"
+      lines << "      script/release"
     end
     lines.concat(
       foreign_claim_inspection_guidance(scope)
@@ -633,12 +641,10 @@ class ReleaseSupervisor
   end
 
   def release_managed_lease!(scope, identity, coordination_timeout:, termination_grace:)
-    _stdout, status = run_agent_coord(
-      "release",
-      "--agent-id", identity.agent_id,
-      "--instance-id", identity.instance_id,
-      "--repo", scope.repo,
-      "--target", scope.target,
+    _stdout, status = run_coordination_command(
+      release_claim_helper!,
+      "--release",
+      *lease_release_arguments(scope, agent_id: identity.agent_id, instance_id: identity.instance_id),
       timeout: coordination_timeout,
       termination_grace:,
       ignore_received_signal: true
@@ -646,6 +652,34 @@ class ReleaseSupervisor
     status&.success? || false
   rescue SystemCallError
     false
+  end
+
+  def report_managed_lease_cleanup_failure(scope, identity)
+    @stderr.puts "ERROR: release-line lease cleanup failed; verify coordination state before retrying"
+    report_managed_lease_recovery(scope, identity)
+  end
+
+  def report_managed_lease_recovery(scope, identity)
+    command = lease_release_shell_command(scope, agent_id: identity.agent_id, instance_id: identity.instance_id)
+    @stderr.puts "After proving every reported release process group is dead, release this exact lease with:"
+    @stderr.puts "  #{command}"
+    @stderr.puts "Then restart the release with:"
+    @stderr.puts "  script/release"
+  end
+
+  def lease_release_shell_command(scope, agent_id:, instance_id:)
+    Shellwords.join(
+      ["script/release-claim", "--release", *lease_release_arguments(scope, agent_id:, instance_id:)]
+    )
+  end
+
+  def lease_release_arguments(scope, agent_id:, instance_id:)
+    [
+      "--agent-id", agent_id,
+      "--instance-id", instance_id,
+      "--repo", scope.repo,
+      "--target", scope.target
+    ]
   end
 
   def supervise_release(scope, identity, heartbeat_interval:, claim_renewal_interval:, termination_grace:,

--- a/script/release
+++ b/script/release
@@ -595,19 +595,26 @@ class ReleaseSupervisor
 
         lines << "    #{field}: #{JSON.generate(claim[field])}"
       end
-      agent_id = claim["agent_id"].to_s
-      instance_id = claim["instance_id"].to_s
-      next if agent_id.empty? || instance_id.empty?
+      agent_id = claim["agent_id"]
+      instance_id = claim["instance_id"]
+      next unless usable_release_identity?(agent_id, instance_id)
 
       lines << "    After proving this claim's release process group is dead, release its exact lease with:"
       lines << "      #{lease_release_shell_command(scope, agent_id:, instance_id:)}"
       lines << "    Then restart the release with:"
-      lines << "      script/release"
+      lines << "      #{release_restart_shell_command}"
     end
     lines.concat(
       foreign_claim_inspection_guidance(scope)
     )
     lines.join("\n")
+  end
+
+  def usable_release_identity?(*values)
+    values.all? do |value|
+      value.is_a?(String) && !value.empty? && value.match?(/\A[\x20-\x7E]+\z/) && value == value.strip &&
+        !value.casecmp?("UNKNOWN")
+    end
   end
 
   def atomic_claim_refusal_guidance(scope, identity, coordination_timeout:, termination_grace:)
@@ -664,7 +671,14 @@ class ReleaseSupervisor
     @stderr.puts "After proving every reported release process group is dead, release this exact lease with:"
     @stderr.puts "  #{command}"
     @stderr.puts "Then restart the release with:"
-    @stderr.puts "  script/release"
+    @stderr.puts "  #{release_restart_shell_command}"
+  end
+
+  def release_restart_shell_command
+    command = ["script/release"]
+    command << "--reconcile-accelerated-rc" if @options.fetch(:reconcile_accelerated_rc)
+    command << "--evaluate-head" if @options.fetch(:evaluate_head)
+    Shellwords.join(command)
   end
 
   def lease_release_shell_command(scope, agent_id:, instance_id:)

--- a/script/release-claim
+++ b/script/release-claim
@@ -4,10 +4,10 @@
 require "optparse"
 require_relative "../rakelib/release_atomic_claim"
 
-options = { renew: false }
+options = { renew: false, release: false }
 parser = OptionParser.new do |config|
-  config.banner = "Usage: script/release-claim --repo OWNER/REPO --target TARGET --agent-id ID " \
-                  "--instance-id ID --machine-id ID --branch BRANCH --ttl SECONDS"
+  config.banner = "Usage: script/release-claim [--renew | --release] --repo OWNER/REPO --target TARGET " \
+                  "--agent-id ID --instance-id ID [--machine-id ID --branch BRANCH --ttl SECONDS]"
   config.on("--repo VALUE") { |value| options[:repo] = value }
   config.on("--target VALUE") { |value| options[:target] = value }
   config.on("--agent-id VALUE") { |value| options[:agent_id] = value }
@@ -16,13 +16,19 @@ parser = OptionParser.new do |config|
   config.on("--branch VALUE") { |value| options[:branch] = value }
   config.on("--ttl SECONDS", Integer) { |value| options[:ttl] = value }
   config.on("--renew", "Renew only the exact active claim identity") { options[:renew] = true }
+  config.on("--release", "Release only the exact active claim identity") { options[:release] = true }
 end
 
 begin
   parser.parse!(ARGV)
   raise OptionParser::InvalidArgument, "positional arguments are not supported" unless ARGV.empty?
 
-  required = %i[repo target agent_id instance_id machine_id branch ttl]
+  if options.values_at(:renew, :release).all?
+    raise OptionParser::InvalidArgument, "choose only one of --renew or --release"
+  end
+
+  required = %i[repo target agent_id instance_id]
+  required.push(:machine_id, :branch, :ttl) unless options[:release]
   missing = required.reject { |name| options.key?(name) }
   raise OptionParser::MissingArgument, missing.join(", ") unless missing.empty?
 
@@ -31,7 +37,11 @@ begin
     token: ENV.fetch("AGENT_COORD_API_TOKEN", "")
   )
   renew = options.delete(:renew)
-  if renew
+  release = options.delete(:release)
+  if release
+    client.release!(**options.slice(:repo, :target, :agent_id, :instance_id))
+    puts "atomic release-line claim released by #{options.fetch(:agent_id)}"
+  elsif renew
     client.renew!(**options)
     puts "atomic release-line claim renewed by #{options.fetch(:agent_id)}"
   else

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -110,8 +110,10 @@ set -euo pipefail
 } >>"${TEST_COORD_LOG}"
 
 renew_mode=0
+release_mode=0
 for argument in "$@"; do
   test "${argument}" != --renew || renew_mode=1
+  test "${argument}" != --release || release_mode=1
 done
 
 if test "${renew_mode}" = 1; then
@@ -126,6 +128,24 @@ if test "${renew_mode}" = 1; then
       ;;
     unavailable) exit 91 ;;
   esac
+fi
+
+if test "${release_mode}" = 1; then
+  test "${FAKE_RELEASE_FAIL:-0}" != 1 || exit 93
+  release_agent_id=""
+  release_instance_id=""
+  while test "$#" -gt 0; do
+    case "$1" in
+      --agent-id) release_agent_id="$2"; shift 2 ;;
+      --instance-id) release_instance_id="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  test -s "${TEST_CLAIM_STATE_FILE}" || exit 96
+  test "${release_agent_id}" = "$(sed -n '1p' "${TEST_CLAIM_STATE_FILE}")" || exit 3
+  test "${release_instance_id}" = "$(sed -n '2p' "${TEST_CLAIM_STATE_FILE}")" || exit 3
+  : >"${TEST_CLAIM_STATE_FILE}"
+  exit 0
 fi
 
 case "${FAKE_ATOMIC_CLAIM_MODE:-${FAKE_CLAIM_FAIL:-success}}" in
@@ -1048,17 +1068,32 @@ assert_contains "${coord_log}" $'claim-atomic|'
 assert_not_contains "${coord_log}" $'claim|'
 assert_contains "${coord_log}" $'heartbeat|'
 assert_contains "${coord_log}" $'status|'
-assert_contains "${coord_log}" $'release|'
+assert_contains "${coord_log}" $'claim-atomic|--release|'
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
 assert_contains "${bundle_log}" 'supervised:true'
 assert_secret_absent
 pass "live mode acquires and cleans up a process-owned release lease"
 
+setup_case managed-cleanup-failure-guidance
+unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+export FAKE_RELEASE_FAIL=1
+if FAKE_BUNDLE_MODE=success run_release; then
+  fail "managed release ignored lease cleanup failure"
+fi
+release_agent_id="$(sed -n '1p' "${claim_state_file}")"
+release_instance_id="$(sed -n '2p' "${claim_state_file}")"
+assert_contains "${output_log}" "release-line lease cleanup failed"
+assert_contains "${output_log}" \
+  "script/release-claim --release --agent-id ${release_agent_id} --instance-id ${release_instance_id} --repo shakacode/react_on_rails --target release-line:17.1.0"
+assert_contains "${output_log}" "script/release"
+assert_secret_absent
+pass "managed cleanup failure prints the exact lease release and restart commands"
+
 setup_case evaluate-head-live
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 FAKE_BUNDLE_MODE=success run_release --evaluate-head || fail "evaluate-head live release failed"
 assert_contains "${coord_log}" $'claim-atomic|'
-assert_contains "${coord_log}" $'release|'
+assert_contains "${coord_log}" $'claim-atomic|--release|'
 assert_contains "${bundle_log}" 'args|exec|rake|release[17.1.0.rc.0]'
 assert_contains "${bundle_log}" 'evaluate-head:true'
 assert_secret_absent
@@ -1092,6 +1127,9 @@ assert_contains "${output_log}" 'thread_handle: "release-task-123"'
 assert_contains "${output_log}" 'session_id: "release-session-456"'
 assert_contains "${output_log}" \
   "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
+assert_contains "${output_log}" \
+  "script/release-claim --release --agent-id foreign-agent --instance-id foreign-instance --repo shakacode/react_on_rails --target release-line:17.1.0"
+assert_contains "${output_log}" "script/release"
 assert_secret_absent
 pass "managed acquisition atomically refuses an intervening foreign claim"
 
@@ -1127,6 +1165,9 @@ for foreign_mode in dead expired missing-heartbeat; do
   assert_contains "${output_log}" 'session_id: "release-session-456"'
   assert_contains "${output_log}" \
     "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
+  assert_contains "${output_log}" \
+    "script/release-claim --release --agent-id foreign-agent --instance-id foreign-instance --repo shakacode/react_on_rails --target release-line:17.1.0"
+  assert_contains "${output_log}" "script/release"
   assert_secret_absent
   pass "foreign ${foreign_mode} claims block managed acquisition without takeover"
 done
@@ -1164,7 +1205,9 @@ unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 FAKE_BUNDLE_MODE=success run_release || fail "first automatically coordinated release failed"
 FAKE_BUNDLE_MODE=success run_release || fail "second automatically coordinated release failed"
 claim_instances="$(
-  awk -F'|' '$1 == "claim-atomic" { for (i = 1; i <= NF; i += 1) if ($i == "--instance-id") print $(i + 1) }' \
+  awk -F'|' '$1 == "claim-atomic" && $2 != "--release" && $2 != "--renew" {
+    for (i = 1; i <= NF; i += 1) if ($i == "--instance-id") print $(i + 1)
+  }' \
     "${coord_log}"
 )"
 test "$(printf '%s\n' "${claim_instances}" | sed '/^$/d' | wc -l | tr -d ' ')" = 2 || \
@@ -1228,7 +1271,7 @@ if wait "${wrapper_pid}"; then
   fail "release continued after an accepted claim response was lost"
 fi
 assert_contains "${coord_log}" $'claim-atomic|'
-assert_contains "${coord_log}" $'release|'
+assert_contains "${coord_log}" $'claim-atomic|--release|'
 assert_not_contains "${coord_log}" $'--force|'
 assert_empty "${bundle_log}"
 assert_contains "${output_log}" "release-line atomic claim is unavailable or UNKNOWN"
@@ -1258,7 +1301,7 @@ if wait "${wrapper_pid}"; then
   fail "signal during claim acquisition exited successfully"
 fi
 assert_contains "${coord_log}" $'claim-atomic|'
-assert_contains "${coord_log}" $'release|'
+assert_contains "${coord_log}" $'claim-atomic|--release|'
 assert_empty "${bundle_log}"
 assert_contains "${output_log}" "release-line atomic claim is unavailable or UNKNOWN"
 assert_secret_absent
@@ -1271,8 +1314,9 @@ if run_release; then
   fail "failed release command exited successfully"
 fi
 assert_contains "${coord_log}" $'claim-atomic|'
-assert_contains "${coord_log}" $'release|'
-test "$(tail -n 1 "${coord_log}" | cut -d'|' -f1)" = release || fail "failed release did not clean up last"
+assert_contains "${coord_log}" $'claim-atomic|--release|'
+test "$(tail -n 1 "${coord_log}" | cut -d'|' -f1-2)" = 'claim-atomic|--release' ||
+  fail "failed release did not clean up last"
 assert_secret_absent
 pass "failed release work cleans up its process-owned claim"
 
@@ -1540,7 +1584,7 @@ fi
 process_group="$(cat "${exception_group_log}")"
 assert_group_dead "${process_group}"
 assert_contains "${coord_log}" $'claim-atomic|'
-assert_contains "${coord_log}" $'release|'
+assert_contains "${coord_log}" $'claim-atomic|--release|'
 assert_contains "${output_log}" "lost child process ownership"
 assert_secret_absent
 pass "lost child ownership closes supervision channels and terminates the release group"
@@ -1656,8 +1700,8 @@ if supervisor_case_enabled death-watch-startup-failure; then
   ! kill -0 "${watcher_pid}" 2>/dev/null || fail "failed death watch was not reaped"
   assert_contains "${output_log}" "release death watch did not become ready"
   assert_contains "${coord_log}" $'claim-atomic|'
-  assert_contains "${coord_log}" $'release|'
-  test "$(tail -n 1 "${coord_log}" | cut -d'|' -f1)" = release ||
+  assert_contains "${coord_log}" $'claim-atomic|--release|'
+  test "$(tail -n 1 "${coord_log}" | cut -d'|' -f1-2)" = 'claim-atomic|--release' ||
     fail "death-watch startup failure did not finish with claim cleanup"
   assert_secret_absent
   pass "death-watch startup failure keeps the release child blocked and cleans up boundedly"
@@ -1683,7 +1727,7 @@ fi
 kill -TERM "${wrapper_pid}"
 wait_for_process_exit "${wrapper_pid}" || cleanup_stalled_wrapper "${wrapper_pid}"
 wait "${wrapper_pid}" || true
-assert_contains "${coord_log}" $'release|'
+assert_contains "${coord_log}" $'claim-atomic|--release|'
 assert_secret_absent
 pass "managed release renews its exact claim during long-running work"
 
@@ -1700,7 +1744,7 @@ process_group="$(awk -F: '/^bundle:/ { print $3; exit }' "${bundle_log}")"
 test -n "${process_group}" || fail "managed renewal-failure case never started the release group"
 assert_group_dead "${process_group}"
 assert_contains "${coord_log}" $'claim-atomic|--renew|'
-assert_contains "${coord_log}" $'release|'
+assert_contains "${coord_log}" $'claim-atomic|--release|'
 assert_contains "${output_log}" "Release lease refresh failed"
 assert_contains "${bundle_log}" "liveness:eof"
 assert_contains "${bundle_log}" "termination:signal"
@@ -1840,8 +1884,9 @@ assert_contains "${output_log}" "process group ${process_group}"
 assert_contains "${bundle_log}" "liveness:eof"
 assert_contains "${bundle_log}" "termination:signal"
 assert_contains "${coord_log}" $'claim-atomic|'
-assert_contains "${coord_log}" $'release|'
-test "$(tail -n 1 "${coord_log}" | cut -d'|' -f1)" = release || fail "signal cleanup was not last"
+assert_contains "${coord_log}" $'claim-atomic|--release|'
+test "$(tail -n 1 "${coord_log}" | cut -d'|' -f1-2)" = 'claim-atomic|--release' ||
+  fail "signal cleanup was not last"
 assert_secret_absent
 pass "signals terminate the release group and clean up the process-owned claim"
 

--- a/script/release-test.bash
+++ b/script/release-test.bash
@@ -275,6 +275,33 @@ case "${command_name}" in
           claim_instance_id="foreign-instance"
           claim_machine_id="foreign-machine"
           ;;
+        foreign-unknown)
+          claim_agent_id="UNKNOWN"
+          claim_instance_id="UNKNOWN"
+          claim_machine_id="foreign-machine"
+          ;;
+        foreign-empty)
+          claim_agent_id=""
+          claim_instance_id="foreign-instance"
+          claim_machine_id="foreign-machine"
+          ;;
+        foreign-padded-unknown)
+          claim_agent_id=" UNKNOWN "
+          claim_instance_id="foreign-instance"
+          claim_machine_id="foreign-machine"
+          ;;
+        foreign-non-string)
+          claim_agent_id="foreign-agent"
+          claim_instance_id="foreign-instance"
+          claim_machine_id="foreign-machine"
+          include_heartbeat=0
+          ;;
+        foreign-newline | foreign-control-character)
+          claim_agent_id="foreign-agent"
+          claim_instance_id="foreign-instance"
+          claim_machine_id="foreign-machine"
+          include_heartbeat=0
+          ;;
       esac
     fi
     if test "${count}" -gt "${FAKE_STATUS_CHANGE_AFTER:-1}" &&
@@ -301,8 +328,19 @@ case "${command_name}" in
     printf '"degraded":["not checked in target scope"],'
     printf '"claims":[{"status":"%s","repo":"%s","target":"%s",' \
       "${claim_status}" "${TEST_REPO}" "${TEST_TARGET}"
-    printf '"branch":"%s","agent_id":"%s","instance_id":"%s",' \
-      "${TEST_BRANCH}" "${claim_agent_id}" "${claim_instance_id}"
+    if test "${FAKE_PREFLIGHT_STATUS_MODE:-}" = foreign-non-string && test "${count}" = 1; then
+      printf '"branch":"%s","agent_id":["foreign-agent"],"instance_id":{"value":"foreign-instance"},' \
+        "${TEST_BRANCH}"
+    elif test "${FAKE_PREFLIGHT_STATUS_MODE:-}" = foreign-newline && test "${count}" = 1; then
+      printf '"branch":"%s","agent_id":"foreign\\nagent","instance_id":"foreign-instance",' \
+        "${TEST_BRANCH}"
+    elif test "${FAKE_PREFLIGHT_STATUS_MODE:-}" = foreign-control-character && test "${count}" = 1; then
+      printf '"branch":"%s","agent_id":"foreign\\u001b[2J","instance_id":"foreign-instance",' \
+        "${TEST_BRANCH}"
+    else
+      printf '"branch":"%s","agent_id":"%s","instance_id":"%s",' \
+        "${TEST_BRANCH}" "${claim_agent_id}" "${claim_instance_id}"
+    fi
     printf '"machine_id":"%s","expires_at":"%s",' "${claim_machine_id}" "${claim_expiry}"
     printf '"host":"codex","operator":"release-operator","phase":"publishing",'
     printf '"thread_handle":"release-task-123","session_id":"release-session-456"}],'
@@ -1077,7 +1115,7 @@ pass "live mode acquires and cleans up a process-owned release lease"
 setup_case managed-cleanup-failure-guidance
 unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
 export FAKE_RELEASE_FAIL=1
-if FAKE_BUNDLE_MODE=success run_release; then
+if FAKE_BUNDLE_MODE=success run_release --evaluate-head; then
   fail "managed release ignored lease cleanup failure"
 fi
 release_agent_id="$(sed -n '1p' "${claim_state_file}")"
@@ -1085,7 +1123,7 @@ release_instance_id="$(sed -n '2p' "${claim_state_file}")"
 assert_contains "${output_log}" "release-line lease cleanup failed"
 assert_contains "${output_log}" \
   "script/release-claim --release --agent-id ${release_agent_id} --instance-id ${release_instance_id} --repo shakacode/react_on_rails --target release-line:17.1.0"
-assert_contains "${output_log}" "script/release"
+assert_contains "${output_log}" "script/release --evaluate-head"
 assert_secret_absent
 pass "managed cleanup failure prints the exact lease release and restart commands"
 
@@ -1152,7 +1190,7 @@ for foreign_mode in dead expired missing-heartbeat; do
   setup_case "managed-acquisition-foreign-${foreign_mode}"
   unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
   export FAKE_PREFLIGHT_STATUS_MODE="foreign-${foreign_mode}"
-  if run_release; then
+  if run_release --reconcile-accelerated-rc; then
     fail "managed release acquired over a foreign ${foreign_mode} claim"
   fi
   assert_contains "${coord_log}" $'status|'
@@ -1167,9 +1205,24 @@ for foreign_mode in dead expired missing-heartbeat; do
     "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
   assert_contains "${output_log}" \
     "script/release-claim --release --agent-id foreign-agent --instance-id foreign-instance --repo shakacode/react_on_rails --target release-line:17.1.0"
-  assert_contains "${output_log}" "script/release"
+  assert_contains "${output_log}" "script/release --reconcile-accelerated-rc"
   assert_secret_absent
   pass "foreign ${foreign_mode} claims block managed acquisition without takeover"
+done
+
+for malformed_identity_mode in unknown empty padded-unknown non-string newline control-character; do
+  setup_case "managed-acquisition-foreign-${malformed_identity_mode}"
+  unset RELEASE_COORDINATOR_ID RELEASE_COORDINATOR_INSTANCE_ID
+  export FAKE_PREFLIGHT_STATUS_MODE="foreign-${malformed_identity_mode}"
+  if run_release; then
+    fail "managed release acquired over a foreign claim with a malformed identity"
+  fi
+  assert_contains "${output_log}" "release line already has an active foreign claim"
+  assert_contains "${output_log}" \
+    "agent-coord status --repo shakacode/react_on_rails --target release-line:17.1.0 --json"
+  assert_not_contains "${output_log}" "script/release-claim --release"
+  assert_secret_absent
+  pass "foreign ${malformed_identity_mode} identities omit unusable recovery commands"
 done
 
 setup_case managed-acquisition-status-unavailable


### PR DESCRIPTION
## Why

A failed or interrupted `script/release` can retain its release-line coordination lock. The failure output currently leaves the maintainer without a safe, exact command to release that lock before restarting.

## What changed

- Print a copy-paste `script/release-claim --release` command plus the restart command when managed cleanup fails or termination cannot be proven.
- Include the same guarded recovery guidance when a foreign release claim blocks acquisition.
- Add exact-identity atomic release support using the current record version (`If-Match`).
- Make exact release retries idempotent when the first write succeeded but its response was lost.
- Route normal managed cleanup through the same exact-instance atomic helper.

The recovery command still instructs maintainers to prove the reported release process group is dead before unlocking. A stale command cannot release a replacement lease with a different instance ID.

## Verification

- `TMPDIR=/tmp bundle exec rspec spec/react_on_rails/release_atomic_claim/client_spec.rb` (13 examples, 0 failures)
- `TMPDIR=/tmp script/release-test.bash` (71/71 passing)
- Targeted RuboCop on all changed Ruby files (no offenses)
- Ruby syntax, Bash syntax, and `git diff --check`
- Independent Codex review: clean after addressing exact-instance fencing and retry idempotency findings

## Review notes

The first review identified that the general `agent-coord release` path did not enforce `instance_id`; cleanup and recovery were moved to the repository-owned atomic helper. A subsequent review identified ambiguous-success retry behavior; exact already-released identities now succeed idempotently. The final independent review was clean. The optional Claude simplify pass was unavailable because its OAuth session had expired.

Changelog: not user-visible (release-maintainer tooling safety).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit release support for active claims using repository, target, agent, and instance identity.
  - Added `--release` mode to the claim management command with success reporting.
  - Release retries safely succeed when the exact claim is already released.

- **Bug Fixes**
  - Added safeguards against releasing replacement or mismatched claims and handles release conflicts.
  - Improved cleanup and restart guidance, including safer handling of unusable claim identities.

- **Documentation**
  - Added recovery instructions for retained publication leases and interrupted releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->