### PR TITLE
Docs: restore packaged upgrade guide parity

### DIFF
--- a/packages/react-on-rails/docs/agent/install-and-upgrade.md
+++ b/packages/react-on-rails/docs/agent/install-and-upgrade.md
@@ -89,6 +89,9 @@ Review the generated initializer, Shakapacker configuration, scripts, routes, an
    `https://github.com/shakacode/react_on_rails/tree/v<GEM_TARGET_VERSION>`. Compare the complete
    `CURRENT_VERSION..GEM_TARGET_VERSION` release range before changing dependencies:
    `https://github.com/shakacode/react_on_rails/compare/v<CURRENT_VERSION>...v<GEM_TARGET_VERSION>`.
+   For Pro apps, treat `ReactOnRailsProHelper` methods as internal rather than stable extension points. If the app
+   prepends or overrides a Pro helper, compare its method signature between the exact tags and update the override
+   before running streamed SSR or RSC tests.
 
 ## JavaScript target matrix
 


### PR DESCRIPTION
## Why

PR #5003 updated the gem copy of the packaged install-and-upgrade guide but missed the byte-identical npm-package mirror. That mismatch breaks `package_agent_content_spec.rb` and blocks PR #4983 hosted validation.

## Change

Copy the three Pro-helper upgrade-warning lines into the npm package mirror. No product code or release state changes.

## Verification

- `bundle exec rspec spec/react_on_rails/package_agent_content_spec.rb` (22 examples, 0 failures)
- byte-for-byte `cmp` of both packaged guides
- docs sidebar check
- Prettier
- offline and online Markdown link checks
- `git diff --check`

Follow-up to #5003.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added upgrade guidance for React on Rails Pro applications.
  - Clarified that `ReactOnRailsProHelper` methods are internal implementation details, not stable extension points.
  - Instructed users with customized or overridden helper methods to compare signatures between the relevant versions and update their customizations before running streamed SSR or RSC tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->