### PR TITLE
Docs: point Rspack links at the canonical v2 URLs

### DIFF
--- a/docs/oss/core-concepts/webpack-configuration.md
+++ b/docs/oss/core-concepts/webpack-configuration.md
@@ -13,7 +13,7 @@ To get a deeper understanding of Shakapacker, watch [RailsConf 2020 CE - Webpack
 
 ## Rspack vs. Webpack
 
-[Rspack](https://rspack.dev/) is a high-performance JavaScript bundler written in Rust that provides significantly faster builds than Webpack (~20x improvement). React on Rails supports both bundlers through unified configuration.
+[Rspack](https://rspack.rs/) is a high-performance JavaScript bundler written in Rust that provides significantly faster builds than Webpack (~20x improvement). React on Rails supports both bundlers through unified configuration.
 
 ### Using Rspack
 

--- a/docs/oss/getting-started/why-rspack.md
+++ b/docs/oss/getting-started/why-rspack.md
@@ -87,7 +87,7 @@ Our control-tier measurement could not confirm a winner: browser-observed HMR me
 
 ### "Vite's plugin ecosystem is bigger"
 
-For app-level tooling, both ecosystems are large. Rspack targets compatibility with the webpack plugin and loader API, which is the API the Rails/Shakapacker world has built against for years — so the relevant comparison for a React on Rails app is less "Vite plugins vs Rspack plugins" than "does the webpack-contract tooling you already use carry over" (check the [Rspack compatibility documentation](https://www.rspack.dev/plugins/community-plugin-compatibility) for specific plugins). The plugin that decides our architecture is the RSC manifest/loader tooling described above, and that exists for webpack and rspack only.
+For app-level tooling, both ecosystems are large. Rspack targets compatibility with the webpack plugin and loader API, which is the API the Rails/Shakapacker world has built against for years — so the relevant comparison for a React on Rails app is less "Vite plugins vs Rspack plugins" than "does the webpack-contract tooling you already use carry over" (check the [Rspack compatibility documentation](https://rspack.rs/plugins/community-plugin-compatibility) for specific plugins). The plugin that decides our architecture is the RSC manifest/loader tooling described above, and that exists for webpack and rspack only.
 
 ### "Everyone uses Vite — you're swimming upstream"
 

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -2,7 +2,7 @@
 
 > **Status**: Supported as of React on Rails Pro 17.0.0. Rspack is the default bundler for fresh installs, the generator scaffolds the native `RSCRspackPlugin`, and RSC-on-Rspack is covered end-to-end by a CI gate — the `dummy-app-rspack-rsc-runtime-gate` job in [`.github/workflows/pro-integration-tests.yml`](https://github.com/shakacode/react_on_rails/blob/main/.github/workflows/pro-integration-tests.yml), which builds the client/server/RSC bundles with Rspack, boots Rails plus the Pro Node renderer, and runs the RSC Playwright suite so RSC routes are proven to render and hydrate under Rspack. Further production hardening is tracked in [issue #3488](https://github.com/shakacode/react_on_rails/issues/3488). The remaining known limitations below (no official React endorsement of the `react-server-dom-webpack` runtime under Rspack; production-posture streamed-CSS coverage) are genuine and still apply.
 
-This page documents the compatibility status of [Rspack](https://rspack.dev/) with React on Rails Pro's React Server Components (RSC) implementation.
+This page documents the compatibility status of [Rspack](https://rspack.rs/) with React on Rails Pro's React Server Components (RSC) implementation.
 
 ## Overview
 
@@ -104,7 +104,7 @@ To test RSC with Rspack in your project:
 
 1. **React on Rails does not use Rspack's experimental native RSC system**:
    As of Rspack v2, Rspack ships its own [built-in RSC
-   support](https://rspack.rs/blog/announcing-2-0) (driven by `builtin:swc-loader` and
+   support](https://rspack.rs/guide/integrations/rsc) (driven by `builtin:swc-loader` and
    `rspackExperiments.reactServerComponents`). React on Rails Pro does **not** use that
    experimental path. Its RSC integration is built on the `react-on-rails-rsc` package:
    manifest generation uses the native **`RSCRspackPlugin`** (standard rspack public APIs,
@@ -154,6 +154,6 @@ builds; production-posture coverage is tracked in
 - [Issue #3488: Rspack RSC path to production-ready (native RSCRspackPlugin)](https://github.com/shakacode/react_on_rails/issues/3488)
 - [Issue #1828: Rspack support for RSC](https://github.com/shakacode/react_on_rails/issues/1828)
 - [PR #3385: Manifest-helper approach for Rspack builds (superseded by the native plugin)](https://github.com/shakacode/react_on_rails/pull/3385)
-- [Rspack 2.0 React Server Components announcement](https://rspack.rs/blog/announcing-2-0)
+- [Rspack React Server Components guide](https://rspack.rs/guide/integrations/rsc)
 - [Three-bundle architecture](./how-react-server-components-work.md)
 - [Upgrading an existing Pro app to RSC](./upgrading-existing-pro-app.md)

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -102,11 +102,14 @@ To test RSC with Rspack in your project:
 
 ## Known Limitations
 
-1. **React on Rails does not use Rspack's experimental native RSC system**:
+1. **React on Rails does not use Rspack's native RSC system**:
    As of Rspack v2, Rspack ships its own [built-in RSC
-   support](https://rspack.rs/guide/integrations/rsc) (driven by `builtin:swc-loader` and
-   `rspackExperiments.reactServerComponents`). React on Rails Pro does **not** use that
-   experimental path. Its RSC integration is built on the `react-on-rails-rsc` package:
+   support](https://rspack.rs/guide/integrations/rsc), which its docs describe as full
+   support rather than experimental (the API is still namespaced under `experiments.rsc`
+   and `rspackExperiments.reactServerComponents`, with `builtin:swc-loader` applying the
+   directive transform, and it renders through React's separate `react-server-dom-rspack`
+   bindings). React on Rails Pro does **not** use that path. Its RSC integration is built
+   on the `react-on-rails-rsc` package:
    manifest generation uses the native **`RSCRspackPlugin`** (standard rspack public APIs,
    not Rspack's webpack-compatibility layer), while the RSC bundle still uses the
    `react-server-dom-webpack` loader and runtime.
@@ -117,8 +120,9 @@ To test RSC with Rspack in your project:
    node loader) under both bundlers. This loader is compatible with rspack.
 
 3. **No official React Rspack support**: The React team has not officially tested or
-   endorsed the `react-server-dom-webpack` runtime with Rspack. The native
-   `RSCRspackPlugin` is maintained by ShakaCode in `react-on-rails-rsc`.
+   endorsed the `react-server-dom-webpack` runtime with Rspack; the React repo ships a
+   separate, still pre-1.0 `react-server-dom-rspack` binding for Rspack's own RSC path.
+   The native `RSCRspackPlugin` is maintained by ShakaCode in `react-on-rails-rsc`.
 
 ## CSS / FOUC Status
 

--- a/internal/analysis/nextjs-turbopack-rsc-vs-react-on-rails-pro.md
+++ b/internal/analysis/nextjs-turbopack-rsc-vs-react-on-rails-pro.md
@@ -96,7 +96,7 @@ Next's Turbopack docs say Turbopack is a Rust incremental bundler built into Nex
 
 Next's current Cache Components docs say caching can happen at the data or UI level, uncached dynamic data should stream behind Suspense, and the build can produce a static shell containing HTML plus serialized RSC payload for client navigation. See [Next Caching](https://nextjs.org/docs/app/getting-started/caching).
 
-Rspack's public model is different from Turbopack. Rspack is a high-performance Rust bundler with a webpack-compatible API and support for most webpack loaders and many plugin patterns. See [Rspack](https://www.rspack.dev/) and [Rspack loader compatibility](https://rspack.dev/guide/features/loader).
+Rspack's public model is different from Turbopack. Rspack is a high-performance Rust bundler with a webpack-compatible API and support for most webpack loaders and many plugin patterns. See [Rspack](https://rspack.rs/) and [Rspack loader compatibility](https://rspack.rs/guide/features/loader).
 
 ## Next.js First Request: Browser Hits a URL
 

--- a/internal/analysis/rsc-rspack-client-reference-inclusion-decision-record-2026-06-27.md
+++ b/internal/analysis/rsc-rspack-client-reference-inclusion-decision-record-2026-06-27.md
@@ -162,7 +162,7 @@ Rspack docs say web-target lazy compilation defaults to `{ entries: false, impor
 Sources:
 
 - <https://rspack.rs/config/lazy-compilation>
-- <https://rspack.rs/guide/features/lazy-compilation>
+- <https://rspack.rs/guide/advanced/lazy-compilation>
 
 [react_on_rails#4227](https://github.com/shakacode/react_on_rails/pull/4227) shipped the short-term fix:
 
@@ -472,7 +472,7 @@ RSC package:
 Rspack / Shakapacker:
 
 - [Rspack lazyCompilation config](https://rspack.rs/config/lazy-compilation)
-- [Rspack lazyCompilation guide](https://rspack.rs/guide/features/lazy-compilation)
+- [Rspack lazyCompilation guide](https://rspack.rs/guide/advanced/lazy-compilation)
 - [web-infra-dev/rspack#7174 — Module.addBlock API](https://github.com/web-infra-dev/rspack/issues/7174)
 - [web-infra-dev/rspack#8469 — missing RSC framework APIs](https://github.com/web-infra-dev/rspack/issues/8469)
 - [web-infra-dev/rspack#9661 — JS identity support for dependency blocks](https://github.com/web-infra-dev/rspack/pull/9661)


### PR DESCRIPTION
## Problem

Rspack v2 is the current release, so its docs live at the plain `rspack.rs` domain. The repo still carried a mix of the `v2.` preview subdomain, the legacy `rspack.dev` / `www.rspack.dev` domains, and two paths that have since moved.

[#4989](https://github.com/shakacode/react_on_rails/issues/4989) fixed the two links that were breaking the whole-repo Lychee sweep, but the RSC one was patched to the Rspack 2.0 announcement blog post rather than to the guide the surrounding prose is actually citing.

## Changes

| File | Before | After |
|---|---|---|
| `docs/pro/react-server-components/rspack-compatibility.md` | `rspack.rs/blog/announcing-2-0` (x2) | `rspack.rs/guide/integrations/rsc` |
| `docs/pro/react-server-components/rspack-compatibility.md` | `rspack.dev/` | `rspack.rs/` |
| `docs/oss/getting-started/why-rspack.md` | `www.rspack.dev/plugins/community-plugin-compatibility` | `rspack.rs/plugins/community-plugin-compatibility` |
| `docs/oss/core-concepts/webpack-configuration.md` | `rspack.dev/` | `rspack.rs/` |
| `internal/analysis/nextjs-turbopack-rsc-vs-react-on-rails-pro.md` | `www.rspack.dev/`, `rspack.dev/guide/features/loader` | `rspack.rs/` equivalents |
| `internal/analysis/rsc-rspack-client-reference-inclusion-decision-record-2026-06-27.md` | `rspack.rs/guide/features/lazy-compilation` (x2) | `rspack.rs/guide/advanced/lazy-compilation` |

Two of these were genuine rot, not just domain churn:

- **RSC guide** — canonical path is `guide/integrations/rsc`, confirmed against `rspack.rs/sitemap.xml`. The old `v2.rspack.rs/guide/tech/rsc` now resolves (the preview site has since been populated), but it is not the durable location.
- **Lazy compilation guide** — moved `guide/features/` → `guide/advanced/`; the old path is a hard 404. It lives under `internal/analysis/`, which Lychee does not scan (`args: --config .lychee.toml docs/ *.md react_on_rails_pro/*.md`), so it was rotting silently.

Text-only link swaps; no prose rewrites beyond one link label that named the blog post.

## Validation

Every distinct Rspack URL remaining in the repo, checked live — all HTTP 200, none redirecting:

```
https://rspack.rs/                                         200
https://rspack.rs/config/lazy-compilation                  200
https://rspack.rs/guide/advanced/lazy-compilation          200
https://rspack.rs/guide/features/loader                    200
https://rspack.rs/guide/integrations/rsc                   200
https://rspack.rs/plugins/community-plugin-compatibility   200
```

`grep -rn "rspack\.dev\|v2\.rspack" --include="*.md" .` → no matches.

- `pnpm exec prettier --check` on all 5 changed files → "All matched files use Prettier code style!" (matches the `markdown-format-check` job)
- `script/ci-changes-detector` → **Documentation-only changes**, recommended CI jobs: NONE

### Local Lychee hook

The `markdown-links` pre-commit/pre-push hook was bypassed with `--no-verify`. It fails to parse `.lychee.toml` before checking any link:

```
TOML parse error at line 184, column 21
    184 | include_fragments = false
                              ^^^^^ wanted string or table
```

Local Lychee is v0.24.2; CI pins v0.23.0, where `include_fragments` is still a boolean. Pre-existing on `origin/main` and unrelated to this change — and the hook runs `--offline`, so it would not have checked these external URLs regardless. Verified manually with `curl` instead (above). Filing this toolchain mismatch separately.

## Merge qualifications

- **Release-mode gate**: target `main` → phase `beta` (lowest tier: confidence note + green required checks). No open release tracker → `development` mode. Gate satisfied.
- **CI posture**: docs-only, so no CI-expansion label per `AGENTS.md` → "Default: no CI-expansion label" — relies on `ci-required / required-pr-gate` plus the local verification above.
- **Changelog**: intentionally none. `changelog-guidelines.md` → "Do NOT add entries for: linting, formatting, refactoring, tests, or documentation fixes."
- **Confidence note**: validated via live `curl` status on all 6 URLs, sitemap confirmation of the two moved paths, prettier check, and the CI detector. No unresolved threads.
- **Residual risk**: low, and bounded to link targets — external URLs can rot again, which is exactly what the scheduled Lychee sweep exists to catch. No code, config, or behavior touched.

Refs #4989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Rspack links throughout the documentation and internal reference materials to use current destinations.
  * Corrected links for plugin compatibility, React Server Components integration, loader features, and lazy compilation guidance.
  * Clarified Rspack v2’s native React Server Components support, available APIs, and bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Final merge qualifications (updated at merge time)

Head `0254ec4b3`. Checks at merge:

| Check | Result |
|---|---|
| `required-pr-gate` (the only required check) | ✅ pass, 50s |
| `markdown-link-check` | ✅ pass, 3m44s — the check that actually validates this change |
| `claude-review` | ✅ pass, 2m11s |
| CodeRabbit / Greptile | ✅ pass |
| `markdown-format-check` | ⏳ starved in queue since 03:40 UTC (>1h), never scheduled |

**On merging with `markdown-format-check` unscheduled.** It is not a required check, and it was never dispatched to a runner — the repo is in a broad Actions backlog (50 of the last 60 runs queued, across unrelated branches; `markdown-link-check` in the *same run* only got a runner at 04:38). Rather than treat "queued" as evidence of anything, I reproduced the job locally at its exact scope — the workflow's own `git ls-files -z -- '*.md' '*.mdx' '*.markdown'` selection, all 421 files, then `pnpm exec prettier --check`:

```
file count: 421
Checking formatting...
All matched files use Prettier code style!
```

So the job's assertion is verified, just not by CI.

**Second commit (`0254ec4b3`)** responds to review feedback on Known Limitations #1 — the "experimental" characterization of Rspack's native RSC was stale. Verification table in [this comment](https://github.com/shakacode/react_on_rails/pull/5011#issuecomment-5535319699); mechanism and "Pro doesn't use it" claims both re-verified as still true.

**Residual risk**: low, bounded to link targets and doc prose. No code, config, or behavior touched. External URLs can rot again — which is what the scheduled Lychee sweep is for.

**Out of scope, tracked separately**: #5012 (local Lychee hook cannot parse `.lychee.toml`; forces `--no-verify`, which also disarms `prettier`/`trailing-newlines`/`pro-license-headers`) and, noted within it, whether `internal/**/*.md` belongs in the scheduled sweep — that gap is what let the lazy-compilation 404 rot unnoticed. #4989's suggestion to scope Lychee off PRs is intentionally not done here; it is a CI-topology change deserving its own PR.
