### PR TITLE
[Pro] Forward-port production RSC diagnostic redaction

### DIFF
--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -96,6 +96,15 @@ function hasRenderingErrorSignal(renderingError: unknown) {
   return nonEmptyMetadataString(message) || nonEmptyMetadataString(stack);
 }
 
+function shouldEmitConsoleReplay(metadata: Record<string, unknown>, railsEnv?: string) {
+  // Console replay remains useful in development/test and for clean production chunks. On an
+  // error-bearing chunk, however, it can repeat the same server-only message or stack path that
+  // diagnostic metadata redacts, so unknown and production-like environments fail closed.
+  if (railsEnv === 'development' || railsEnv === 'test') return true;
+
+  return metadata.hasErrors !== true && !hasRenderingErrorSignal(metadata.renderingError);
+}
+
 function createRSCDiagnosticScript(
   metadata: Record<string, unknown>,
   cacheKey: string,
@@ -2082,7 +2091,7 @@ export default function injectRSCPayload(
 
               // Emit console replay as a separate <script> tag (not inside the payload)
               const consoleScript = metadata.consoleReplayScript as string;
-              if (consoleScript) {
+              if (consoleScript && shouldEmitConsoleReplay(metadata, railsEnv)) {
                 rscPayloadBuffers.push(Buffer.from(createScriptTag(consoleScript, sanitizedNonce)));
               }
               // Primary flush is handled by React's flush() callback (see above).

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -417,7 +417,7 @@ describe('injectRSCPayload', () => {
         message: 'useState is not a function',
         stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
       },
-      consoleReplayScript: '<script>console.log("replay")</script>',
+      consoleReplayScript: 'console.log("test diagnostic replay")',
       serializedProps: { token: 'do-not-serialize' },
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
@@ -439,6 +439,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('serializedProps');
     expect(resultStr).not.toContain('do-not-serialize');
     expect(resultStr).not.toContain('consoleReplayScript');
+    expect(resultStr).toContain('<script>console.log("test diagnostic replay")</script>');
   });
 
   it('keeps the first RSC diagnostic metadata for a payload key', async () => {
@@ -504,6 +505,8 @@ describe('injectRSCPayload', () => {
         message: 'User 48213 not authorized for org 77',
         stack: 'Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)',
       },
+      consoleReplayScript:
+        'console.error("RSC inline failed for User 48213 at /srv/private/Auth.server.tsx:12:5")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -519,6 +522,8 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('not authorized');
     expect(resultStr).not.toContain('Auth.server.tsx');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('RSC inline failed');
+    expect(resultStr).not.toContain('/srv/private/Auth.server.tsx');
   });
 
   it('redacts renderingError in non-development/test environments like staging', async () => {
@@ -528,6 +533,7 @@ describe('injectRSCPayload', () => {
         message: 'Internal server failure',
         stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
       },
+      consoleReplayScript: 'console.error("staging secret at /srv/private/server.ts:42:7")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -542,6 +548,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('Internal server failure');
     expect(resultStr).not.toContain('server.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('staging secret');
   });
 
   it('redacts renderingError when railsEnv is not provided (undefined)', async () => {
@@ -551,6 +558,7 @@ describe('injectRSCPayload', () => {
         message: 'Database connection refused at 10.0.3.42:5432',
         stack: 'Error: Database connection refused\n    at Pool (/app/lib/db.ts:18:11)',
       },
+      consoleReplayScript: 'console.error("unknown-env secret at /srv/private/db.ts:18:11")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -563,6 +571,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('10.0.3.42');
     expect(resultStr).not.toContain('db.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('unknown-env secret');
   });
 
   it('forces hasErrors:true in production even when metadata has hasErrors:false with renderingError signal', async () => {
@@ -572,6 +581,7 @@ describe('injectRSCPayload', () => {
         message: 'Internal server failure',
         stack: 'Error: Internal server failure\n    at Server (/app/lib/server.ts:42:7)',
       },
+      consoleReplayScript: 'console.error("secondary inline secret at /srv/private/server.ts:42:7")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -585,6 +595,24 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('Internal server failure');
     expect(resultStr).not.toContain('server.ts');
     expect(resultStr).not.toContain('renderingError');
+    expect(resultStr).not.toContain('secondary inline secret');
+    expect(resultStr).not.toContain('/srv/private/server.ts');
+  });
+
+  it('preserves console replay for clean production chunks', async () => {
+    const mockRSC = createMockRSCStreamWithMetadata('{"test": "data"}', {
+      hasErrors: false,
+      consoleReplayScript: 'console.log("clean production replay")',
+    });
+    const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId, undefined, {
+      railsEnv: 'production',
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('<script>console.log("clean production replay")</script>');
   });
 
   it('includes full renderingError in diagnostic metadata in development', async () => {
@@ -594,6 +622,7 @@ describe('injectRSCPayload', () => {
         message: 'useState is not a function',
         stack: 'TypeError: useState is not a function\n    at Broken (/app/components/Broken.server.tsx:7:3)',
       },
+      consoleReplayScript: 'console.error("development diagnostic replay")',
     });
     const mockHTML = createMockHTMLStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
@@ -607,6 +636,7 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain('useState is not a function');
     expect(resultStr).toContain('Broken.server.tsx');
     expect(resultStr).toContain('renderingError');
+    expect(resultStr).toContain('<script>console.error("development diagnostic replay")</script>');
   });
 
   it('promotes streamed RSC client chunk stylesheet preloads to gate reveal', async () => {

--- a/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
+++ b/react_on_rails_pro/app/helpers/react_on_rails_pro_helper.rb
@@ -1467,12 +1467,10 @@ module ReactOnRailsProHelper
     error_signal = rsc_payload_rendering_error_signal?(metadata)
     return metadata unless error_signal || metadata.key?("renderingError")
 
-    redacted = metadata.except("renderingError")
-    # Preserve a generic failure signal so client error boundaries still fire. `hasErrors` is
-    # forced true when only a non-blank message/stack indicated the failure, matching the
-    # inline path's redacted branch.
-    redacted["hasErrors"] = true if error_signal
-    redacted
+    # Match the inline path's production allowlist exactly. Error chunks may carry sensitive
+    # details in console replay or future metadata fields, so forwarding every field except the
+    # known renderingError key would fail open as the producer evolves.
+    { "hasErrors" => error_signal }
   end
 
   def rsc_payload_rendering_error_signal?(metadata)

--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -755,6 +755,9 @@ describe ReactOnRailsProHelper do
     let(:synthetic_stack) do
       "Error: User 48213 not authorized\n    at Auth (/app/components/Auth.server.tsx:12:5)"
     end
+    let(:synthetic_console_replay_script) do
+      'console.error("RSC fetch failed for User 48213 at /app/components/Auth.server.tsx:12:5")'
+    end
     let(:rendering_error) { { "message" => synthetic_message, "stack" => synthetic_stack } }
     let(:error_chunk) do
       { "hasErrors" => true, "renderingError" => rendering_error, "html" => "payload" }
@@ -803,6 +806,30 @@ describe ReactOnRailsProHelper do
       expect(wire).not_to include("Auth.server.tsx")
     end
 
+    it "allowlists only a generic error signal in production browser metadata" do
+      stub_rails_env("production")
+      server_metadata = error_chunk.merge(
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" }
+      )
+      seen_by_server = nil
+
+      wire = framed_wire_bytes(server_metadata) do |chunk|
+        seen_by_server = chunk
+        chunk
+      end
+
+      expect(wire).to eq("{\"hasErrors\":true}\t00000007\npayload")
+      expect(wire).not_to include(synthetic_message)
+      expect(wire).not_to include("/srv/private/Auth.server.tsx")
+      expect(wire).not_to include(synthetic_console_replay_script)
+      expect(seen_by_server).to include(
+        "renderingError" => rendering_error,
+        "consoleReplayScript" => synthetic_console_replay_script,
+        "diagnosticContext" => { "sourcePath" => "/srv/private/Auth.server.tsx" }
+      )
+    end
+
     it "redacts renderingError in non-development/test environments like staging" do
       stub_rails_env("staging")
 
@@ -843,14 +870,16 @@ describe ReactOnRailsProHelper do
       expect(wire).to eq("{\"hasErrors\":false}\t00000007\npayload")
     end
 
-    it "includes the full renderingError in development" do
+    it "includes full error and console diagnostics in development" do
       stub_rails_env("development")
 
-      wire = framed_wire_bytes(error_chunk)
+      wire = framed_wire_bytes(error_chunk.merge("consoleReplayScript" => synthetic_console_replay_script))
+      metadata = JSON.parse(wire.split("\t", 2).first)
 
       expect(wire).to include("renderingError")
       expect(wire).to include(synthetic_message)
       expect(wire).to include("Auth.server.tsx")
+      expect(metadata["consoleReplayScript"]).to eq(synthetic_console_replay_script)
     end
 
     it "includes the full renderingError in test" do


### PR DESCRIPTION
### Summary

#### Why

The production RSC browser boundary must not replay server error diagnostics. This forward-ports only the production diagnostic-redaction change from #4856 onto current `main`; it does not alter the 17.1 release branch or changelog.

#### What changed

- Suppress inline console replay for error-bearing RSC chunks outside development and test.
- Reduce fetched error metadata to the `hasErrors` signal before it reaches the browser.
- Preserve development/test diagnostics, clean production replay, server-side error reporting, escaping, nonce behavior, and request isolation.

The commit retains direct `-x` provenance to merged commit `7f51a87258d9681cc844baa160cf7bab8019a880` from #4856.

#### How to review and verify

- Review the four production/test boundary files as a direct, release-neutral forward-port.
- Focused React 19 Jest: 83 examples passed.
- Focused Pro helper RSpec: 11 examples passed.
- Pro type-check, full Pro RuboCop (255 files), license headers (915 files), targeted ESLint/Prettier, and `git diff --check` passed.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation (no documentation contract changed)~
- [x] ~Update CHANGELOG file (release entry already shipped through #4856; this PR is a main-only forward-port)~

### Other Information

This intentionally supersedes only the RSC portion of #4863. PRs #4857 and #4863 are references, not merge candidates.

<details>
<summary>Agent details</summary>

- Base/head: `7eeb577a338f7fd5fa02da503243c49889e8d94e` / `6442fd38ac970e25bfad782817351604666ad369`.
- Independent QA reproduced the candidate tests on the base: four console-replay assertions failed (79 passed, 4 failed). The exact head passed all 83 focused Jest cases.
- Independent QA also checked the fetched Ruby boundary, scope, ancestry, main-only telemetry preservation, lint/type/license surfaces, and cross-PR independence. Verdict: approved; no blocking, discuss, or follow-up findings.
- Process-gap disposition: `checklist+replay`; the focused browser-boundary negative controls are retained as tests.

### QA Evidence

- QA required: yes — production browser-facing security boundary.
- Tested at exact head: `6442fd38ac970e25bfad782817351604666ad369` against base `7eeb577a338f7fd5fa02da503243c49889e8d94e`.
- Automated checks: base negative control failed 4 leak assertions; exact-head Jest 83/83; focused helper RSpec 11/11; type-check; Pro RuboCop; ESLint/Prettier; license headers; diff check.
- Findings: none.
- Release-blocking status: clear.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 6442fd38ac970e25bfad782817351604666ad369
tested_at: PR #5016 head 6442fd38ac970e25bfad782817351604666ad369
scope: inline and fetched production RSC browser diagnostic redaction with development test clean-production and server-side preservation
automated_checks: base negative control failed 4 leak assertions; exact-head Jest 83/83; focused helper RSpec 11/11; type-check; Pro RuboCop; ESLint; Prettier; license headers; diff check
manual_checks: exact diff scope ancestry provenance main-only-change preservation and cross-PR independence
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no painted UI changed
paint_check: not applicable: no painted surface changed
interaction_change: no
interaction_evidence: not applicable: no user interaction changed
visual_fix: no
negative_control: not applicable: no visual fix; behavioral negative control is recorded in automated_checks
performance_impact: not_applicable
performance_evidence: not applicable: no performance-sensitive path or bundle dependency changed
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Console replay diagnostics are now preserved in development and test environments.
  - Production and staging responses remove sensitive diagnostic details from browser-visible metadata.
  - Clean production responses continue to include console replay information when no errors are present.
  - Error metadata is now limited to a simple error indicator, preventing unintended diagnostic data from being exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


