### PR TITLE
Fix credential redaction for passwords containing at signs

### DIFF
--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -418,7 +418,7 @@ module ReactOnRails
         # URL fallback and by the rescue blocks below, so there is exactly one definition of
         # "strip userinfo" rather than two regexes that can drift apart.
         def strip_userinfo(text)
-          text.to_s.gsub(%r{//[^/@]*@}, "//")
+          text.to_s.gsub(%r{//[^/?#]*@}, "//")
         end
 
         def file_url_to_string(url)

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -164,7 +164,7 @@ module ReactOnRails
           # in URI::InvalidURIError's own message.
           msg = "You specified server rendering JS file: #{sanitized_renderer_url(server_js_file)}, but it cannot " \
                 "be read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
-                "avoid this warning.\nError is: #{strip_userinfo(e.message)}\n\n" \
+                "avoid this warning.\nError is: #{strip_userinfo(e.message, configured_url: server_js_file)}\n\n" \
                 "#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
@@ -408,17 +408,38 @@ module ReactOnRails
           uri.to_s
         rescue URI::InvalidURIError
           # A URL malformed enough that URI rejects it still shouldn't leak credentials.
-          strip_userinfo(url)
+          strip_malformed_configured_url_userinfo(url)
         end
 
-        # Best-effort strip of the common user:pass@ form from arbitrary text — not just a URL
-        # value, but also free-form text that may quote one, such as the message of a
-        # URI::InvalidURIError raised from an unparseable credential-bearing URL (that message
-        # embeds the raw original string verbatim). Shared by sanitized_renderer_url's malformed-
-        # URL fallback and by the rescue blocks below, so there is exactly one definition of
-        # "strip userinfo" rather than two regexes that can drift apart.
-        def strip_userinfo(text)
-          text.to_s.gsub(%r{//[^/?#]*@}, "//")
+        # A configured URL is one value rather than arbitrary prose. Handle only the common
+        # user:password@ fallback shapes that URI.parse rejects, including raw ? or # password
+        # characters. Anchoring the substitutions leaves path/query @ characters alone and avoids
+        # turning this fallback into a general malformed-URL parser.
+        def strip_malformed_configured_url_userinfo(url)
+          url = url.lstrip
+          sanitized_url = url.sub(%r{\A(?<scheme>https?://)[^/:?#]*:[^/]*@}i, '\k<scheme>')
+          return sanitized_url unless sanitized_url == url
+
+          url.sub(%r{\A(?<scheme>https?://)[^/@]*@}i, '\k<scheme>')
+        end
+
+        # Best-effort strip of the common user:pass@ form from arbitrary error text. When the
+        # configured URL is known, replace that exact value with its sanitized form first so raw
+        # ?/# password characters are handled without treating unrelated prose as malformed URL
+        # syntax. The remaining substitution preserves ordinary path, query, and fragment @s.
+        def strip_userinfo(text, configured_url: nil)
+          sanitized_text = if configured_url
+                             text.to_s.gsub(configured_url) { sanitized_renderer_url(configured_url) }
+                           else
+                             text.to_s
+                           end
+          sanitized_text.gsub(%r{//[^/?#]*@}, "//")
+        end
+
+        def sanitized_url_error_message(error, configured_url:)
+          return strip_userinfo(error.message, configured_url:) unless error.is_a?(URI::InvalidURIError)
+
+          "bad URI (sanitized): #{sanitized_renderer_url(configured_url).inspect}"
         end
 
         def file_url_to_string(url)
@@ -462,7 +483,7 @@ module ReactOnRails
           # well as url itself: a URL malformed enough that URI.parse raises embeds the raw,
           # unsanitized URL verbatim in URI::InvalidURIError's own message.
           msg = "file_url_to_string #{sanitized_renderer_url(url)} failed\nError is: " \
-                "#{strip_userinfo(e.message)}\n\n#{Utils.default_troubleshooting_section}"
+                "#{sanitized_url_error_message(e, configured_url: url)}\n\n#{Utils.default_troubleshooting_section}"
           raise ReactOnRails::ServerBundleLoadError, msg
         end
 

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -437,6 +437,38 @@ module ReactOnRails
               expect(error.message).to include("bad host")
             }
           end
+
+          it "does not leak a password that contains an @" do
+            server_bundle_url = "http://bundle-user:s3cr3t@still-secret@bad host/webpack/development/server-bundle.js"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).not_to include("bundle-user")
+              expect(error.message).not_to include("s3cr3t")
+              expect(error.message).not_to include("still-secret")
+            }
+          end
+
+          it "preserves @ characters in the path and query string" do
+            server_bundle_url = "http://bad host/webpack/server@bundle.js?source=@config"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include("/webpack/server@bundle.js?source=@config")
+            }
+          end
         end
 
         # read_bundle_js_code also serves the local (non-HTTP) bundle path, where

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -413,6 +413,26 @@ module ReactOnRails
           end
         end
 
+        context "when a valid HTTP-served bundle URL contains query or fragment @ characters" do
+          it "preserves them in the raised diagnostic" do
+            server_bundle_url = "http://localhost:3035?source=@config#next=@fragment"
+
+            allow(ReactOnRails::Utils).to receive_messages(
+              server_bundle_js_file_path: server_bundle_url,
+              server_bundle_path_is_http?: true
+            )
+            allow(Net::HTTP).to receive(:get_response).and_raise(
+              Errno::ECONNREFUSED.new("connect(2) for localhost:3035")
+            )
+
+            expect do
+              described_class.read_bundle_js_code
+            end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+              expect(error.message).to include(server_bundle_url)
+            }
+          end
+        end
+
         # A URL malformed enough that URI.parse itself raises (e.g. a space in the host) fails
         # before sanitized_renderer_url is ever applied to the `url` variable at the raise site —
         # URI::InvalidURIError's own message embeds the original credential-bearing string
@@ -453,6 +473,50 @@ module ReactOnRails
               expect(error.message).not_to include("s3cr3t")
               expect(error.message).not_to include("still-secret")
             }
+          end
+
+          it "does not leak a password that contains a raw query or fragment delimiter" do
+            ["?", "#"].each do |delimiter|
+              server_bundle_url =
+                "http://bundle-user:s3cr3t#{delimiter}still-secret@bad host/webpack/development/server-bundle.js"
+
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                expect(error.message).not_to include("bundle-user")
+                expect(error.message).not_to include("s3cr3t")
+                expect(error.message).not_to include("still-secret")
+                expect(error.message).to include(
+                  "http://bad host/webpack/development/server-bundle.js"
+                )
+              }
+            end
+          end
+
+          it "does not leak credentials from an escaped invalid-URI error" do
+            [
+              'http://bundle-user:s3cr3t"?tail@bad host/webpack/development/server-bundle.js',
+              " http://bundle-user:s3cr3t@bad host/webpack/development/server-bundle.js",
+              "http://bundle-user:s3cr3t?tail word@bad host/webpack/development/server-bundle.js"
+            ].each do |server_bundle_url|
+              allow(ReactOnRails::Utils).to receive_messages(
+                server_bundle_js_file_path: server_bundle_url,
+                server_bundle_path_is_http?: true
+              )
+
+              expect do
+                described_class.read_bundle_js_code
+              end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+                expect(error.message).not_to include("bundle-user")
+                expect(error.message).not_to include("s3cr3t")
+                expect(error.message).to include("http://bad host/webpack/development/server-bundle.js")
+              }
+            end
           end
 
           it "preserves @ characters in the path and query string" do


### PR DESCRIPTION
### Summary

#### Why

The fallback redaction used after a server bundle read failure could stop at the first `@` in malformed configured URLs. A password containing additional `@` characters could therefore leak its suffix.

#### What changed

- Redact the complete credential portion of the configured HTTP(S) URL for #4825's original multi-`@` case.
- Cover the same narrow malformed-authority fallback when a password contains a raw `?` or `#`.
- Preserve legitimate `@` characters in valid URL paths, queries, and fragments byte-for-byte.
- Reconstruct invalid-URI diagnostics from the sanitized configured value so escaped exception text cannot reveal credentials.

This deliberately does not add a general malformed, encoded, or nested URL parser.

Fixes #4825.

#### Verification

- TDD negative control reproduced the original credential suffix leak before the fix.
- Focused spec: 40 examples, 0 failures.
- Targeted RuboCop: no offenses.
- `git diff --check origin/main...HEAD`: clean.
- Independent exact-head QA: approved with no in-scope blockers.
- Exact-head Codex review: no actionable findings.
- `.agents/bin/validate --changed`: lint, builds, type checks, and preceding suites passed; the generator sweep was stopped after a generated fixture's `pnpm install` stalled and raised a pnpm timeout `TypeError`. Hosted current-head CI is the final full-suite gate.

### Pull Request checklist

- [x] Add/update tests to cover these changes
- [x] ~Update documentation (no documentation contract changed)~
- [x] ~Update CHANGELOG file (deferred to normal mainline changelog reconciliation)~

### Other Information

This replaces #4857 and the #4825 portion of #4863. Those PRs are references only and must not be merged.

The 17.1 release branch is not modified.

<details>
<summary>QA evidence</summary>

- Base: `21651a356c7b6043f2686c02c811ee23888d639c`
- Candidate head: `6de97f2b96f4b227eb4fa33af46267eb3b1b9df6`
- Covered: original multi-`@` leak, standalone raw `?`/`#` malformed password cases, escaped invalid-URI diagnostics, leading/embedded whitespace, and preservation of legitimate path/query/fragment `@` characters.
- Scope boundary: ambiguous combined malformed delimiters are excluded because interpreting them as credentials conflicts with preserving valid root query/fragment behavior and would require the general parser explicitly excluded from this PR.
- Benchmarks: not applicable; this is bounded error-path string sanitization.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 6de97f2b96f4b227eb4fa33af46267eb3b1b9df6
tested_at: PR #5017 head 6de97f2b96f4b227eb4fa33af46267eb3b1b9df6
scope: original multi-at credential leak with narrow malformed-authority fallbacks and preservation of legitimate path query and fragment at signs
automated_checks: focused spec 40/40; targeted RuboCop; diff check; exact-head Codex review
manual_checks: independent inspection of delimiter behavior scope ancestry and fail-closed invalid-URI diagnostics
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no UI changed
paint_check: not applicable: no painted surface changed
interaction_change: no
interaction_evidence: not applicable: no user interaction changed
visual_fix: no
negative_control: not applicable: no visual fix; behavioral negative control is recorded in automated_checks
performance_impact: not_applicable
performance_evidence: not applicable: bounded error-path sanitization
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential redaction in server bundle loading errors, including malformed renderer URLs.
  - Added support for safely handling credentials containing special characters such as `@`, `?`, and `#`.
  - Prevented URL query strings and fragments from being incorrectly treated as credential data.
  - Preserved legitimate `@` characters in bundle paths, query parameters, and fragments while ensuring passwords remain fully hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


