### PR TITLE
Agents: reject ambiguous QA heads and mixed interaction units

### DIFF
--- a/.agents/agent-workflow-drift.yml
+++ b/.agents/agent-workflow-drift.yml
@@ -96,7 +96,7 @@ files:
     and retains its reviewed shared-workflow inventory boundary.
   consumer_mode: '100755'
   source_sha256: b2110347ace4cca5b39a03fddc054542b528aae8a6d45c37f445ee078a687d37
-  consumer_sha256: 6e03791b92e259d405df415dbb358f18e26c285431bb4711f0b9f122ac6f50ba
+  consumer_sha256: fc264880bc5cb4d6f6ee70507df040bf0c868eb3bc7b63030c4b3d7ed5b0401c
 - source: skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
   consumer: ".agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb"
   mode: overlay
@@ -104,7 +104,7 @@ files:
     and adds structured v3 forward-gate contract tests.
   consumer_mode: '100755'
   source_sha256: 35b3558bca3d49ac2032fc8b2a422877237e9f473f5d779f916e8ed8242bc60f
-  consumer_sha256: d911d98a09f23bc161b55b7859a227383587cca61652a07b5e5fe2bb09b17f85
+  consumer_sha256: 750cde0acd4fb9117319b8dfcc413692c96bd987e52d58442c97744b46b2f5cd
 - source: skills/post-merge-audit/bin/post-merge-audit-scope
   consumer: ".agents/skills/post-merge-audit/bin/post-merge-audit-scope"
   mode: identical

--- a/.agents/agent-workflow-drift.yml
+++ b/.agents/agent-workflow-drift.yml
@@ -96,7 +96,7 @@ files:
     and retains its reviewed shared-workflow inventory boundary.
   consumer_mode: '100755'
   source_sha256: b2110347ace4cca5b39a03fddc054542b528aae8a6d45c37f445ee078a687d37
-  consumer_sha256: e58625104f471490e0c2a4fa067512340724fbf7fc4f13fa4891987cd6528a37
+  consumer_sha256: 7987322a7fae8490fbc50217df87d41c653e7ac522a911804a7e5cead70a5d1e
 - source: skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
   consumer: ".agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb"
   mode: overlay
@@ -104,7 +104,7 @@ files:
     and adds structured v3 forward-gate contract tests.
   consumer_mode: '100755'
   source_sha256: 35b3558bca3d49ac2032fc8b2a422877237e9f473f5d779f916e8ed8242bc60f
-  consumer_sha256: 37ace0049a81533b1a38fc9d8c1f2be3a5ede617d87354fa3064e3f854266a39
+  consumer_sha256: 68838c8e6ee9ea79a1bfa3b6b9272125c4106fe1588e4571d7c2536d000f604c
 - source: skills/post-merge-audit/bin/post-merge-audit-scope
   consumer: ".agents/skills/post-merge-audit/bin/post-merge-audit-scope"
   mode: identical

--- a/.agents/agent-workflow-drift.yml
+++ b/.agents/agent-workflow-drift.yml
@@ -96,7 +96,7 @@ files:
     and retains its reviewed shared-workflow inventory boundary.
   consumer_mode: '100755'
   source_sha256: b2110347ace4cca5b39a03fddc054542b528aae8a6d45c37f445ee078a687d37
-  consumer_sha256: fc264880bc5cb4d6f6ee70507df040bf0c868eb3bc7b63030c4b3d7ed5b0401c
+  consumer_sha256: e58625104f471490e0c2a4fa067512340724fbf7fc4f13fa4891987cd6528a37
 - source: skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
   consumer: ".agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb"
   mode: overlay
@@ -104,7 +104,7 @@ files:
     and adds structured v3 forward-gate contract tests.
   consumer_mode: '100755'
   source_sha256: 35b3558bca3d49ac2032fc8b2a422877237e9f473f5d779f916e8ed8242bc60f
-  consumer_sha256: 750cde0acd4fb9117319b8dfcc413692c96bd987e52d58442c97744b46b2f5cd
+  consumer_sha256: 37ace0049a81533b1a38fc9d8c1f2be3a5ede617d87354fa3064e3f854266a39
 - source: skills/post-merge-audit/bin/post-merge-audit-scope
   consumer: ".agents/skills/post-merge-audit/bin/post-merge-audit-scope"
   mode: identical

--- a/.agents/skills/post-merge-audit/bin/closeout-evidence-replay
+++ b/.agents/skills/post-merge-audit/bin/closeout-evidence-replay
@@ -698,8 +698,11 @@ module CloseoutEvidenceReplay
     match = value.match(%r{\A([-+]?\d+(?:\.\d+)?)([A-Za-z%]+(?:/[A-Za-z]+)?)\z})
     return unless match
 
-    unit = match[2].downcase
-    unit[-1] = "B" if preserve_byte_case && match[2].end_with?("B")
+    unit = match[2].split("/").map do |component|
+      normalized = component.downcase
+      normalized[-1] = "B" if preserve_byte_case && component.end_with?("B")
+      normalized
+    end.join("/")
     [match[1], unit]
   end
 

--- a/.agents/skills/post-merge-audit/bin/closeout-evidence-replay
+++ b/.agents/skills/post-merge-audit/bin/closeout-evidence-replay
@@ -223,13 +223,20 @@ module CloseoutEvidenceReplay
     return true if duplicate_keys.include?("head_sha")
 
     head_sha = fields.fetch("head_sha", "").to_s.downcase
+    if expected_head_sha && !full_head_sha?(head_sha)
+      return tested_at_matches_head?(fields.fetch("tested_at", "").to_s, expected_head_sha)
+    end
+
     full_head_sha?(head_sha) && (!expected_head_sha || head_sha == expected_head_sha)
   end
 
   def replay_qa_markers(markers, expected_head_sha: nil, version: 1)
     return unknown("qa-evidence marker missing") if markers.empty?
 
-    markers = current_head_markers(markers, expected_head_sha) if expected_head_sha
+    if expected_head_sha
+      matching = markers.select { |marker| applicable_qa_marker?(marker, expected_head_sha) }
+      markers = matching unless matching.empty?
+    end
     aggregate_marker_results(
       markers.map do |marker|
         if version == 3
@@ -649,7 +656,7 @@ module CloseoutEvidenceReplay
   end
 
   def validate_measurement_triple(baseline, candidate, tolerance, field, missing)
-    measurements = [baseline, candidate, tolerance].map { |value| parse_measurement(value) }
+    measurements = [baseline, candidate, tolerance].map { |value| parse_measurement(value, preserve_byte_case: true) }
     valid = measurements.all? && measurements.map { |measurement| measurement.fetch(1) }.uniq.one?
     valid &&= !measurements.last.fetch(0).start_with?("-") if valid
     missing << field unless valid

--- a/.agents/skills/post-merge-audit/bin/closeout-evidence-replay
+++ b/.agents/skills/post-merge-audit/bin/closeout-evidence-replay
@@ -701,6 +701,7 @@ module CloseoutEvidenceReplay
     unit = match[2].split("/").map do |component|
       normalized = component.downcase
       normalized[-1] = "B" if preserve_byte_case && component.end_with?("B")
+      normalized[-3] = "B" if preserve_byte_case && normalized.end_with?("bps") && component[-3] == "B"
       normalized
     end.join("/")
     [match[1], unit]

--- a/.agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
+++ b/.agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
@@ -765,6 +765,39 @@ class CloseoutEvidenceReplayTest < Minitest::Test
     assert_includes qa.fetch("missing"), "interaction_evidence"
   end
 
+  [
+    %w[100MB 90Mb 1MB UNKNOWN],
+    %w[100Mb 90MB 1Mb UNKNOWN],
+    %w[100MB 90MB 1Mb UNKNOWN],
+    %w[100Mb 90Mb 1MB UNKNOWN],
+    %w[100MB 90MB 1MB SATISFIED],
+    %w[100Mb 90Mb 1Mb SATISFIED],
+    %w[52PX 0px 1Px SATISFIED],
+    %w[52MS 0ms 1Ms SATISFIED]
+  ].each do |baseline, candidate, tolerance, verdict|
+    define_method("test_v3_interaction_unit_case_#{baseline}_#{candidate}_#{tolerance}") do
+      body = v3_marker(
+        "interaction_change" => "yes",
+        "interaction_evidence_kind" => "measured_substitute",
+        "interaction_baseline_value" => baseline,
+        "interaction_candidate_value" => candidate,
+        "interaction_tolerance" => tolerance
+      )
+      qa = run_replay(
+        body,
+        expected_head_sha: "1111111111111111111111111111111111111111",
+        require_structured_visual_evidence_v3: true
+      ).fetch("qa_evidence")
+
+      assert_equal verdict, qa.fetch("verdict")
+      if verdict == "SATISFIED"
+        assert_empty qa.fetch("missing")
+      else
+        assert_includes qa.fetch("missing"), "interaction_evidence"
+      end
+    end
+  end
+
   def test_v3_interaction_tolerance_must_be_non_negative
     qa = run_replay(
       v3_marker(
@@ -2604,6 +2637,61 @@ class CloseoutEvidenceReplayTest < Minitest::Test
           end
         end
       end
+    end
+  end
+
+  [[2, 2], [3, 3], [2, 3], [1, 2]].product(%w[missing invalid]).each do |(valid_version, ambiguous_version), head_kind|
+    define_method("test_current_tested_at_retains_#{head_kind}_head_v#{valid_version}_v#{ambiguous_version}") do
+      head = "1111111111111111111111111111111111111111"
+      valid = valid_version == 1 ? v1_marker(head_sha: head) : public_send("v#{valid_version}_marker")
+      ambiguous = public_send(
+        "v#{ambiguous_version}_marker", "head_sha" => "invalid", "status" => "blocked", "release_blocking" => "blocked"
+      )
+      ambiguous = ambiguous.lines.reject { |line| line.start_with?("head_sha:") }.join if head_kind == "missing"
+      modes = [{}, { require_visual_evidence_v2: true }]
+      modes << { require_structured_visual_evidence_v3: true } if ambiguous_version == 3
+
+      modes.each do |mode|
+        [valid + ambiguous, ambiguous + valid, ambiguous].each do |body|
+          data = run_replay(body, expected_head_sha: head, **mode)
+          qa = data.fetch("qa_evidence")
+
+          assert_equal "UNKNOWN", data.fetch("overall_verdict"), mode.inspect
+          assert_equal ambiguous_version, qa.fetch("marker_version")
+          assert qa.fetch("missing").any? { |field| field.end_with?("head_sha") }, qa.inspect
+          expected_count = body != ambiguous && valid_version == ambiguous_version ? 2 : 1
+          assert_equal expected_count, qa.fetch("marker_count")
+        end
+      end
+    end
+  end
+
+  def test_current_tested_at_repair_preserves_stale_history_and_version_precedence
+    head = "1111111111111111111111111111111111111111"
+    stale = "2222222222222222222222222222222222222222"
+    [2, 3].each do |version|
+      current = public_send("v#{version}_marker")
+      history = public_send(
+        "v#{version}_marker", "head_sha" => stale, "tested_at" => "PR #123 head #{stale}",
+                              "status" => "blocked", "release_blocking" => "blocked"
+      )
+      strict = version == 3 ? { require_structured_visual_evidence_v3: true } : { require_visual_evidence_v2: true }
+      [{}, strict].each do |mode|
+        [history + current, current + history].each do |body|
+          qa = run_replay(body, expected_head_sha: head, **mode).fetch("qa_evidence")
+
+          assert_equal "SATISFIED", qa.fetch("verdict")
+          assert_equal 1, qa.fetch("marker_count")
+        end
+      end
+    end
+
+    malformed_v2 = v2_marker("head_sha" => "invalid", "status" => "blocked", "release_blocking" => "blocked")
+    [v3_marker + malformed_v2, malformed_v2 + v3_marker].each do |body|
+      qa = run_replay(body, expected_head_sha: head).fetch("qa_evidence")
+
+      assert_equal "SATISFIED", qa.fetch("verdict")
+      assert_equal 3, qa.fetch("marker_version")
     end
   end
 

--- a/.agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
+++ b/.agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
@@ -773,9 +773,22 @@ class CloseoutEvidenceReplayTest < Minitest::Test
     %w[100MB 90MB 1MB SATISFIED],
     %w[100Mb 90Mb 1Mb SATISFIED],
     %w[52PX 0px 1Px SATISFIED],
-    %w[52MS 0ms 1Ms SATISFIED]
+    %w[52MS 0ms 1Ms SATISFIED],
+    %w[100MB/s 90Mb/s 1MB/s UNKNOWN],
+    %w[100Mb/s 90MB/s 1MB/s UNKNOWN],
+    %w[100MB/s 90MB/s 1Mb/s UNKNOWN],
+    %w[100Mb/s 90Mb/s 1MB/s UNKNOWN],
+    %w[100MB/s 90MB/s 1MB/s SATISFIED],
+    %w[100Mb/s 90Mb/s 1Mb/s SATISFIED],
+    %w[100MB/S 90MB/s 1MB/s SATISFIED],
+    %w[100MB/MS 90MB/ms 1MB/Ms SATISFIED],
+    %w[52PX/S 0px/s 1Px/s SATISFIED],
+    %w[100ms/MB 90ms/Mb 1ms/MB UNKNOWN],
+    %w[100ms/MB 90ms/MB 1ms/Mb UNKNOWN],
+    %w[100ms/MB 90MS/MB 1Ms/MB SATISFIED],
+    %w[100ms/Mb 90MS/Mb 1Ms/Mb SATISFIED]
   ].each do |baseline, candidate, tolerance, verdict|
-    define_method("test_v3_interaction_unit_case_#{baseline}_#{candidate}_#{tolerance}") do
+    define_method("test_v3_interaction_unit_case_#{baseline}_#{candidate}_#{tolerance}".tr("/", "_")) do
       body = v3_marker(
         "interaction_change" => "yes",
         "interaction_evidence_kind" => "measured_substitute",

--- a/.agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
+++ b/.agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb
@@ -786,7 +786,21 @@ class CloseoutEvidenceReplayTest < Minitest::Test
     %w[100ms/MB 90ms/Mb 1ms/MB UNKNOWN],
     %w[100ms/MB 90ms/MB 1ms/Mb UNKNOWN],
     %w[100ms/MB 90MS/MB 1Ms/MB SATISFIED],
-    %w[100ms/Mb 90MS/Mb 1Ms/Mb SATISFIED]
+    %w[100ms/Mb 90MS/Mb 1Ms/Mb SATISFIED],
+    %w[100MBps 90Mbps 1MBps UNKNOWN],
+    %w[100Mbps 90MBps 1MBps UNKNOWN],
+    %w[100MBps 90MBps 1Mbps UNKNOWN],
+    %w[100MiBps 90Mibps 1MiBps UNKNOWN],
+    %w[100Mibps 90MiBps 1MiBps UNKNOWN],
+    %w[100MiBps 90MiBps 1Mibps UNKNOWN],
+    %w[100MBps 90MBps 1MBps SATISFIED],
+    %w[100Mbps 90Mbps 1Mbps SATISFIED],
+    %w[100MiBps 90MiBps 1MiBps SATISFIED],
+    %w[100Mibps 90Mibps 1Mibps SATISFIED],
+    %w[100MBPS 90MBps 1MBPs SATISFIED],
+    %w[100MibPS 90Mibps 1MibPs SATISFIED],
+    %w[100BYTES 90bytes 1Bytes SATISFIED],
+    %w[100BPM 90bpm 1Bpm SATISFIED]
   ].each do |baseline, candidate, tolerance, verdict|
     define_method("test_v3_interaction_unit_case_#{baseline}_#{candidate}_#{tolerance}".tr("/", "_")) do
       body = v3_marker(


### PR DESCRIPTION
### Summary

The closeout evidence replay command can currently report a passing QA result while dropping a malformed current-head receipt, or while treating byte and bit measurements as the same unit. This follow-up fixes the two confirmed defects left after #4980 merged. Refs #4939.

## What changed

- Keep a QA receipt with a missing or invalid `head_sha` in validation when its `tested_at` still names the expected current head. It now fails closed instead of disappearing beside valid evidence.
- Distinguish `MB` from `Mb` in structured interaction measurements, including tolerance and existing rate units such as `MB/s` and `MBps`. Same-unit values and ordinary unit case normalization keep working.
- Add regression coverage and refresh only the two corresponding consumer overlay hashes. No source pin, schema, priority-disposition policy, runtime package or CI workflow changes.

## How to review and verify

1. Inspect QA marker selection and the existing measurement parser option in `closeout-evidence-replay`.
2. Run `bundle exec ruby .agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb`.
3. Confirm malformed current evidence and mixed byte/bit triples are rejected while valid current evidence, genuinely stale history and same-unit measurements retain their prior outcomes.

### Pull Request checklist

- [x] Add/update tests to cover these changes.
- [x] ~Update documentation — internal replay corrections, no documented contract change.~
- [x] ~Update CHANGELOG — not user-visible product behavior.~

### Other Information

This is a focused internal-tooling follow-up, not a broader workflow upgrade. Justin retains merge control.

<details>
<summary>Agent details</summary>

### Commands and results

Accepted base: `a1721d4b85cf133fe8184ede2fea43cec2eca150`.
Candidate head: `2c938ce1c9e90fbf650aad346f96ce49b773486c`.

- Complete helper suite at clean committed head: **243 tests, 2,517 assertions; zero failures/errors/skips**.
- Suffix-rate regression: six mixed `MBps`/`Mbps` and `MiBps`/`Mibps` cases failed at `1535d51f792e1914248e99f3923b94d6c6e2fab4`; the same 35-case interaction matrix passes at this candidate (140 assertions), including ordinary BYTES/BPM and suffix-case controls.
- Hosted-review regression: four mixed rate-unit cases failed on prior head `1d2c3b75867eda6687d60d4f20d48e02ca05db1f`; the same 21-case interaction matrix passes at the candidate (84 assertions). Numerator and denominator byte/bit distinctions are preserved without changing grammar or adding conversion.
- Regression-only replay against exact base: **12 expected failures** (eight QA selection cases, four mixed byte/bit cases); four valid-unit controls pass.
- `bundle exec rubocop --config .agents/.rubocop.yml .agents/skills/post-merge-audit/bin/closeout-evidence-replay .agents/skills/post-merge-audit/bin/closeout-evidence-replay-test.rb`: two files, no offenses.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`: 250 files, no offenses.
- `bundle exec ruby .agents/bin/agent-workflow-drift-manifest-test.rb --source-root /tmp/ror-pr4980-pinned-source.CgYBGb`: 42 mapped, four excluded, pass.
- `/tmp/ror-pr4980-pinned-source.CgYBGb/bin/check-agent-workflow-drift --manifest .agents/agent-workflow-drift.yml --source-root /tmp/ror-pr4980-pinned-source.CgYBGb --consumer-root .`: 22 identical, 20 expected overlays, zero unexpected drift. Source checkout verified at `1958648b70a450aa67c15b833428485d17021045`.
- Prettier 3.6.2 check of `.agents/agent-workflow-drift.yml`: pass; existing runtime reused, no installation.
- `git diff --check a1721d4b85cf133fe8184ede2fea43cec2eca150 HEAD`: pass. Normal commit hooks pass; clean worktree.

### Review and validation scope

The coordinator checked the exact suffix repair against the accepted brief and confirmed finding; the task-review loop passed with prior rounds preserved and the second fix round recorded. Independent command QA passed **140/140 CLI invocations**: 26 prior-head suffix/control cases, 26 final-head cases, and all 88 prior preservation cases rerun at this final head. Whole-branch `codex review --base a1721d4b85cf133fe8184ede2fea43cec2eca150` at `2c938ce1c9e90fbf650aad346f96ce49b773486c` completed clean at 2026-09-06T06:41Z, observed gpt-6-astra/xhigh, read-only sandbox, exit0; independently ran all243 tests via stdin and verified syntax and hashes. No actionable regressions found. Old-head reviews are not proof of this head. Additional local Claude review and simplify remain unavailable from the recorded logged-out state; no credential or installation change attempted. Hosted reviews remain a separate final-head gate, and draft skips are not counted as working reviews.

CI selection reports this `.agents`-only diff as documentation-only with no package suites. No skip-CI marker or waiver is used. Local complete helper coverage is explicit; hosted required-gate drift checks remain required. Labels: ready-for-hosted-ci after final review convergence, for one optimized hosted confirmation of the stable head. Benchmarks: not applicable; no application runtime/performance change.

### Decision log

- Reuse open issue4939 for the residual work; no duplicate issue.
- Preserve genuine stale evidence and existing version precedence. Keep priority-marker selection unchanged.
- Reuse the existing byte-case parser option and preserve byte case in each existing slash-delimited component and before the existing `ps` suffix; no new units, conversions, grammar or marker-count limit.
- Preserve the existing `tested_at` last-full-SHA contract: ambiguous malformed-head current receipts fail closed, while genuine full stale heads remain excluded. The proposed new prose restriction was declined with independent v1/v2/v3 CLI evidence.
- Changelog classification: `not_user_visible`.
- Process-gap disposition: `script` — correct the two replay acceptance paths and replay their regressions; broader gate redesign is a non-goal.

### QA Evidence

- QA lane: `ror-4939-independent-qa`, read-only on the clean candidate worktree and branch; coordinator-owned issue4939 lease live. Independent of maker.
- Scope checked: receipt selection and structured interaction-unit validation; three changed internal-tooling paths.
- Tested at: head `2c938ce1c9e90fbf650aad346f96ce49b773486c`; original negative control at base `a1721d4b85cf133fe8184ede2fea43cec2eca150`, suffix regression compared against prior `1535d51f792e1914248e99f3923b94d6c6e2fab4`.
- Automated checks: complete helper suite, lint and drift checks above; independent synthetic CLI driver exercised **140 invocations**: 26 prior-head suffix/control cases, 26 final-head cases, and all 88 original/slash-rate cases rerun at final head. All expected verdicts matched.
- Manual checks: actual `bundle exec ruby <snapshot-helper> --expected-head-sha <exact-sha> [strict flags] -` calls with synthetic receipts; inspected JSON verdicts rather than relying on exit0. Missing/invalid current-head receipts, mixed MB/Mb and mixed MB/s/Mb/s triples return UNKNOWN. Genuine stale receipts, same-unit measurements, duplicate heads and priority behavior retain expected outcomes. Denominator, malformed-slash, negative-tolerance and unchanged typed-performance controls pass. Snapshot bytes were compared with their exact Git objects.
- User-visible UI change: no.
- Visual evidence: not applicable: internal CLI parser only; synthetic URLs exercise receipt parsing, not actual UI evidence.
- Interaction change: no; no browser interaction changed.
- Interaction evidence: not applicable: internal CLI parser only.
- Visual fix: no.
- Negative control: not applicable: no visual fix. CLI negative control separately reproduced both defects on exact base.
- Performance evidence: not applicable: no runtime, asset-delivery or bundle change.
- Findings: none outstanding within the accepted repair scope.
- QA required: yes.
- QA required rationale: developer-workflow command changes require observable CLI proof independent of maker tests.
- QA lane status: satisfied.
- Release-blocking status: clear for scoped QA; this is not release authorization.
- Process-gap disposition: script.

<!-- qa-evidence v3
required: yes
status: satisfied
head_sha: 2c938ce1c9e90fbf650aad346f96ce49b773486c
tested_at: head 2c938ce1c9e90fbf650aad346f96ce49b773486c
scope: issue4939 residual QA receipt and interaction-unit replay repairs
automated_checks: complete helper suite 243 tests 2517 assertions; independent CLI QA 140 prior/final invocations including prior88 at final; lint and drift pass
manual_checks: actual helper CLI receipt submissions and observed JSON verdicts at base and candidate
user_visible_ui_change: no
visual_evidence_status: not_applicable
visual_evidence_destination: not_applicable
visual_evidence_url: not_applicable
visual_baseline_status: not_applicable
visual_candidate_status: not_applicable
paint_check_status: not_applicable
interaction_change: no
interaction_evidence_kind: not_applicable
interaction_evidence_destination: not_applicable
interaction_evidence_url: not_applicable
interaction_baseline_value: not_applicable
interaction_candidate_value: not_applicable
interaction_tolerance: not_applicable
visual_fix: no
negative_control_status: not_applicable
performance_impact: not_applicable
performance_evidence_status: not_applicable
performance_source_kind: not_applicable
performance_source_ref: not_applicable
performance_metric_kind: not_applicable
performance_baseline_value: not_applicable
performance_candidate_value: not_applicable
findings: none
release_blocking: clear
process_gap_disposition: script
-->

<!-- priority-finding-dispositions v1
head_sha: 2c938ce1c9e90fbf650aad346f96ce49b773486c
finding: url=https://github.com/shakacode/react_on_rails/pull/5018#discussion_r3943168552 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/5018#discussion_r3943215672
-->

### Coordination and churn

Canonical launch identity: `shakacode/react_on_rails:issue:4939`.
Batch `ror-4939-followup-20260905`, lane `lane-4939-followup`; isolated branch `jg-codex/4939-evidence-followup`. One maker, independent review/QA. Prior stopped holder reconciled before claim acquisition. Merge authority: none; Justin merges. No other lane changes.

Two post-push correctness rounds address slash-rate and suffix-rate findings. No optional cleanup commits or force-push. The hosted cohort for1535 completed successfully but is superseded by the required suffix correction; iteration was restored before the new push. One optimized hosted confirmation will be requested for the verified stable repair head. Hosted CI has not been used as the first test pass.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved post-merge audit evidence replay when markers contain abbreviated or invalid commit identifiers.
  - Ensured current evidence takes precedence over stale history without allowing malformed markers to disrupt valid results.
  - Improved measurement-unit normalization across compound units and case variations, while continuing to reject mismatched units.

- **Tests**
  - Added coverage for measurement-unit matching and marker validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
