### PR TITLE
Docs: replace dead CodeRabbit sponsor logos with live brand assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ Thanks to the companies supporting ShakaCode's open-source work.
   </a>
   <a href="https://coderabbit.ai">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_7229870ac5.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg">
-      <img alt="CodeRabbit" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg" height="34">
+      <source media="(prefers-color-scheme: dark)" srcset="https://docs.coderabbit.ai/coderabbit-logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://docs.coderabbit.ai/coderabbit-logo-light.svg">
+      <img alt="CodeRabbit" src="https://docs.coderabbit.ai/coderabbit-logo-light.svg" height="34">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
## Problem

`markdown-link-check` is **red on `main`** ([run](https://github.com/shakacode/react_on_rails/actions/runs/34023643033/job/101460660264), commit `c4476352`). Both errors are the CodeRabbit typemarks in the README sponsors block:

```
### Errors in README.md
* [ERROR] <https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg>
* [ERROR] <https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_7229870ac5.svg>
  Network error: received fatal alert: HandshakeFailure
```

## This is decommissioning, not a blip

The Strapi Cloud host still resolves, but rejects the TLS handshake at every version:

```
$ dig +short victorious-bubble-f69a016683.media.strapiapp.com
162.159.140.98
172.66.0.96

$ curl https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg
curl: (35) LibreSSL/3.3.6: error:1404B410:SSL routines:ST_CONNECT:sslv3 alert handshake failure

$ openssl s_client -tls1_2 ...   -> tlsv1 alert protocol version
$ openssl s_client -tls1_3 ...   -> tlsv1 alert protocol version
```

Reproduced identically on the GitHub runner and locally, so it is server-side and permanent.

**This is not just a CI problem.** GitHub proxies README images through camo, which hits the same handshake failure — so the CodeRabbit sponsor logos are currently rendering broken for every reader of the README.

## Fix

Repointed at CodeRabbit's current published assets on their own docs domain (`coderabbit.ai` itself is healthy, HTTP 200).

The light/dark split is preserved, verified by inspecting the SVG fills rather than trusting the filenames:

| Slot | Was | Now | Dominant fill |
|---|---|---|---|
| `prefers-color-scheme: dark` | `White_Typemark` | `coderabbit-logo-dark.svg` | `#FEFEFE` — white, for dark backgrounds ✅ |
| `prefers-color-scheme: light` | `Orange_Typemark` | `coderabbit-logo-light.svg` | `#171717` + `#D75D2C` mark — dark, for light backgrounds ✅ |
| `<img>` fallback | `Orange_Typemark` | `coderabbit-logo-light.svg` | same as light, matching the original fallback choice ✅ |

Worth stating plainly since the naming inverts what you might assume: Mintlify names these by *the background they sit on*, so `-dark` is the white logo. Mapping them by filename would have silently swapped the two.

## Considered and rejected

Adding the host to `.lychee.toml` `exclude` (there is precedent in #4758 for the flaky gem badge). Rejected: that badge was a working asset that was intermittently unreachable, whereas this one is gone for good. Excluding it would turn the check green while leaving the images visibly broken on the page — hiding the symptom this check exists to surface.

## Validation

```
https://docs.coderabbit.ai/coderabbit-logo-dark.svg     200  image/svg+xml
https://docs.coderabbit.ai/coderabbit-logo-light.svg    200  image/svg+xml
```

- `grep -rn "strapiapp.com" --include="*.md" .` → no matches
- `pnpm exec prettier --check README.md` → clean
- Changed lines are 3 URL swaps inside one `<picture>` block; no other README content touched.

## Scope note

Found via the session-start `main` CI hook while finishing #5011 (Rspack doc links, #4989). Unrelated root cause, so it is a separate PR rather than a rider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CodeRabbit supporter logo in the README for improved dark/light theme display.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->