### PR TITLE
Pro cache: promote aged L2 entries into L1 with remaining lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   expiry and `l1MaxTtlSeconds` from promotion time, and entries with no remaining lifetime skip the L1 write.
   Served data was always correct; this is a performance fix. Fixes
   [Issue 5027](https://github.com/shakacode/react_on_rails/issues/5027).
+  [PR 5029](https://github.com/shakacode/react_on_rails/pull/5029) by
+  [AbanoubGhadban](https://github.com/AbanoubGhadban).
 
 - **[Pro]** **Standalone upgrades preserve customized bundler configurations**: The Pro generator automatically
   upgrades only complete, unchanged configuration pairs from supported current templates. Customized, historical,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   `l1MaxTtlSeconds` was written to L1 already expired — permanently bypassing L1 for that key and paying an L2
   (e.g. Redis) round trip on every request. Promoted entries now expire at the earlier of the original entry's
   expiry and `l1MaxTtlSeconds` from promotion time, and entries with no remaining lifetime skip the L1 write.
-  A non-positive `l1MaxTtlSeconds` now disables L1 writes entirely instead of storing permanent L1 entries.
-  Served data was always correct; this is a performance fix. Fixes
+  A non-positive `l1MaxTtlSeconds` now disables L1 entirely instead of storing permanent L1 entries.
+  With the default in-memory L1 this was purely a performance bug; a `RedisCacheHandler` L1 could
+  additionally serve entries past their intended expiry, because Redis applies TTLs at write time —
+  promoted entries now always encode exactly the remaining lifetime. Fixes
   [Issue 5027](https://github.com/shakacode/react_on_rails/issues/5027).
   [PR 5029](https://github.com/shakacode/react_on_rails/pull/5029) by
   [AbanoubGhadban](https://github.com/AbanoubGhadban).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   `l1MaxTtlSeconds` was written to L1 already expired — permanently bypassing L1 for that key and paying an L2
   (e.g. Redis) round trip on every request. Promoted entries now expire at the earlier of the original entry's
   expiry and `l1MaxTtlSeconds` from promotion time, and entries with no remaining lifetime skip the L1 write.
+  A non-positive `l1MaxTtlSeconds` now disables L1 writes entirely instead of storing permanent L1 entries.
   Served data was always correct; this is a performance fix. Fixes
   [Issue 5027](https://github.com/shakacode/react_on_rails/issues/5027).
   [PR 5029](https://github.com/shakacode/react_on_rails/pull/5029) by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   (e.g. Redis) round trip on every request. Promoted entries now expire at the earlier of the original entry's
   expiry and `l1MaxTtlSeconds` from promotion time, and entries with no remaining lifetime skip the L1 write.
   A non-positive `l1MaxTtlSeconds` now disables L1 entirely instead of storing permanent L1 entries.
+  **Action required for upgraders:** if you run a persistent L1 (e.g. `RedisCacheHandler`) with a
+  non-positive `l1MaxTtlSeconds`, the disabled L1 retains entries written before it was disabled —
+  flush that L1 store before re-enabling it with a positive cap, or retained stale/indefinite entries
+  become readable again.
   With the default in-memory L1 this was purely a performance bug; a `RedisCacheHandler` L1 could
   additionally serve entries past their intended expiry, because Redis applies TTLs at write time —
   promoted entries now always encode exactly the remaining lifetime. Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   runtime behavior. Fixes [Issue 5036](https://github.com/shakacode/react_on_rails/issues/5036)
   by [justin808](https://github.com/justin808).
 
+- **[Pro]** **`TieredCacheHandler` keeps serving L1 hits for entries older than `l1MaxTtlSeconds`**: Promoting an
+  L2 hit into L1 rewrote the entry's `revalidate` but kept its original `timestamp`, so any entry older than
+  `l1MaxTtlSeconds` was written to L1 already expired — permanently bypassing L1 for that key and paying an L2
+  (e.g. Redis) round trip on every request. Promoted entries now expire at the earlier of the original entry's
+  expiry and `l1MaxTtlSeconds` from promotion time, and entries with no remaining lifetime skip the L1 write.
+  Served data was always correct; this is a performance fix. Fixes
+  [Issue 5027](https://github.com/shakacode/react_on_rails/issues/5027).
+
 - **[Pro]** **Standalone upgrades preserve customized bundler configurations**: The Pro generator automatically
   upgrades only complete, unchanged configuration pairs from supported current templates. Customized, historical,
   missing, or ambiguous pairs remain unchanged with manual migration instructions, preventing helper redeclarations

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -19,8 +19,11 @@ export interface TieredCacheHandlerOptions {
   /**
    * Maximum TTL (in seconds) for entries promoted to L1.
    * Bounds how long a stale L1 entry can persist after L2 is updated by another worker.
-   * Defaults to undefined (use the entry's original revalidate value).
-   * A value <= 0 disables L1 writes entirely (all reads go to L2).
+   * Defaults to undefined (use the entry's original revalidate value); Infinity behaves
+   * the same as undefined.
+   * A non-positive or NaN value disables L1 entirely (all reads and writes go to L2).
+   * Note: a persistent L1 (e.g. Redis) disabled this way retains entries written
+   * before it was disabled; flush it before re-enabling.
    */
   l1MaxTtlSeconds?: number;
 }
@@ -121,15 +124,16 @@ export class TieredCacheHandler implements CacheHandler {
     if (this.l1Disabled()) return null;
 
     const now = Date.now();
+    const hasFiniteLifetime = entry.revalidate > 0;
 
-    // A future timestamp means the producer's clock is ahead of ours. Any
-    // lifetime computed from it overshoots the entry's true expiry (a Redis L2
-    // started its EX at the producer's write), so serve from L2 and skip the
-    // promotion rather than clamping.
-    if (entry.timestamp > now) return null;
+    // A future timestamp on a finite entry means the producer's clock is ahead
+    // of ours: any remaining lifetime computed from it overshoots the entry's
+    // true expiry (a Redis L2 started its EX at the producer's write), so serve
+    // from L2 and skip the promotion rather than clamping. Indefinite entries
+    // are unaffected — their expiry never depends on the timestamp.
+    if (hasFiniteLifetime && entry.timestamp > now) return null;
 
-    const remainingSeconds =
-      entry.revalidate > 0 ? entry.revalidate - (now - entry.timestamp) / 1000 : Infinity;
+    const remainingSeconds = hasFiniteLifetime ? entry.revalidate - (now - entry.timestamp) / 1000 : Infinity;
 
     // Already expired (possible via L2 TTL rounding or cross-worker clock skew):
     // writing it to L1 would only create an entry the next get deletes.

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -39,7 +39,9 @@ export class TieredCacheHandler implements CacheHandler {
   }
 
   async get(key: string): Promise<CacheEntry | null> {
-    const l1Entry = await this.l1.get(key);
+    // A disabled L1 is bypassed on reads too: a persistent L1 (e.g. shared
+    // Redis) may still hold entries written before the cap disabled it.
+    const l1Entry = this.l1Disabled() ? null : await this.l1.get(key);
     if (l1Entry) return l1Entry;
 
     let l2Entry: CacheEntry | null;
@@ -80,11 +82,12 @@ export class TieredCacheHandler implements CacheHandler {
     await Promise.all([l2Write, l1Write]);
   }
 
-  // A cap of 0 (or negative) cannot be expressed as a revalidate value —
-  // revalidate <= 0 means "never expires" in both L1 backends — so it disables
-  // L1 writes entirely instead of inverting into immortal entries.
+  // A cap of 0, negative, or NaN cannot be expressed as a revalidate value —
+  // revalidate <= 0 (and NaN via Math.min) means "never expires" in both L1
+  // backends — so any defined non-positive/non-finite cap disables L1 entirely
+  // instead of inverting into immortal entries. `!(x > 0)` is true for NaN.
   private l1Disabled(): boolean {
-    return this.l1MaxTtlSeconds !== undefined && this.l1MaxTtlSeconds <= 0;
+    return this.l1MaxTtlSeconds !== undefined && !(this.l1MaxTtlSeconds > 0);
   }
 
   // Caps revalidate on a freshly-written entry. Assumes timestamp ~= now, so
@@ -117,8 +120,10 @@ export class TieredCacheHandler implements CacheHandler {
     if (this.l1Disabled()) return null;
 
     const now = Date.now();
+    // Clamp elapsed at >= 0: a producer clock ahead of ours would otherwise
+    // make the remaining lifetime exceed the entry's own revalidate.
     const remainingSeconds =
-      entry.revalidate > 0 ? entry.revalidate - (now - entry.timestamp) / 1000 : Infinity;
+      entry.revalidate > 0 ? entry.revalidate - Math.max(0, now - entry.timestamp) / 1000 : Infinity;
 
     // Already expired (possible via L2 TTL rounding or cross-worker clock skew):
     // writing it to L1 would only create an entry the next get deletes.
@@ -132,6 +137,12 @@ export class TieredCacheHandler implements CacheHandler {
     // Indefinite entry with no cap: nothing to bound.
     if (!Number.isFinite(cappedSeconds)) return entry;
 
-    return { ...entry, timestamp: now, revalidate: cappedSeconds };
+    // Floor to whole seconds: a TTL-on-write L1 (Redis EX) rounds the TTL up
+    // with Math.ceil, so a fractional value could outlive the original expiry
+    // by up to a second. Under one whole second of life left, skip L1.
+    const flooredSeconds = Math.floor(cappedSeconds);
+    if (flooredSeconds <= 0) return null;
+
+    return { ...entry, timestamp: now, revalidate: flooredSeconds };
   }
 }

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -20,6 +20,7 @@ export interface TieredCacheHandlerOptions {
    * Maximum TTL (in seconds) for entries promoted to L1.
    * Bounds how long a stale L1 entry can persist after L2 is updated by another worker.
    * Defaults to undefined (use the entry's original revalidate value).
+   * A value <= 0 disables L1 writes entirely (all reads go to L2).
    */
   l1MaxTtlSeconds?: number;
 }
@@ -67,11 +68,23 @@ export class TieredCacheHandler implements CacheHandler {
       console.error('TieredCacheHandler: L2 set failed', err);
     });
 
+    if (this.l1Disabled()) {
+      await l2Write;
+      return;
+    }
+
     const l1Entry = this.applyL1TtlForFreshEntry(entry);
     const l1Write = this.l1.set(key, l1Entry).catch((err: unknown) => {
       console.error('TieredCacheHandler: L1 set failed', err);
     });
     await Promise.all([l2Write, l1Write]);
+  }
+
+  // A cap of 0 (or negative) cannot be expressed as a revalidate value —
+  // revalidate <= 0 means "never expires" in both L1 backends — so it disables
+  // L1 writes entirely instead of inverting into immortal entries.
+  private l1Disabled(): boolean {
+    return this.l1MaxTtlSeconds !== undefined && this.l1MaxTtlSeconds <= 0;
   }
 
   // Caps revalidate on a freshly-written entry. Assumes timestamp ~= now, so
@@ -101,6 +114,8 @@ export class TieredCacheHandler implements CacheHandler {
   // time and serve the entry past its L2 expiry.
   // Returns null when the entry has no remaining lifetime (skip the L1 write).
   private applyL1TtlForPromotion(entry: CacheEntry): CacheEntry | null {
+    if (this.l1Disabled()) return null;
+
     const now = Date.now();
     const remainingSeconds =
       entry.revalidate > 0 ? entry.revalidate - (now - entry.timestamp) / 1000 : Infinity;

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -38,7 +38,11 @@ export class TieredCacheHandler implements CacheHandler {
   constructor(l1: CacheHandler, l2: CacheHandler, opts: TieredCacheHandlerOptions = {}) {
     this.l1 = l1;
     this.l2 = l2;
-    this.l1MaxTtlSeconds = opts.l1MaxTtlSeconds;
+    // Normalize Infinity to undefined so the two spellings of "no cap" are
+    // truly equivalent — otherwise the fresh-write path would rewrite an
+    // indefinite entry's revalidate: 0 to Infinity, which a custom
+    // TTL-on-write L1 handler could reject as an invalid backend TTL.
+    this.l1MaxTtlSeconds = opts.l1MaxTtlSeconds === Infinity ? undefined : opts.l1MaxTtlSeconds;
   }
 
   async get(key: string): Promise<CacheEntry | null> {

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -92,21 +92,31 @@ export class TieredCacheHandler implements CacheHandler {
   // a promoted entry may be arbitrarily old, so the cap must bound the remaining
   // lifetime — rewriting revalidate alone would produce an L1 entry that is
   // already expired (issue #5027).
+  // Finite-lifetime entries are always re-stamped to
+  // { timestamp: now, revalidate: <remaining> }: timestamp-checking handlers
+  // (InMemoryLRUCacheHandler) and TTL-on-write handlers (RedisCacheHandler's EX,
+  // which ignores the entry timestamp) both interpret that as exactly the
+  // remaining lifetime, whereas passing the aged entry through unchanged would
+  // let a TTL-on-write L1 restart the full original revalidate from promotion
+  // time and serve the entry past its L2 expiry.
   // Returns null when the entry has no remaining lifetime (skip the L1 write).
   private applyL1TtlForPromotion(entry: CacheEntry): CacheEntry | null {
     const now = Date.now();
-    const entryExpiryMs = entry.revalidate > 0 ? entry.timestamp + entry.revalidate * 1000 : Infinity;
+    const remainingSeconds =
+      entry.revalidate > 0 ? entry.revalidate - (now - entry.timestamp) / 1000 : Infinity;
 
     // Already expired (possible via L2 TTL rounding or cross-worker clock skew):
     // writing it to L1 would only create an entry the next get deletes.
-    if (entryExpiryMs <= now) return null;
+    if (remainingSeconds <= 0) return null;
 
-    if (this.l1MaxTtlSeconds === undefined) return entry;
+    const cappedSeconds =
+      this.l1MaxTtlSeconds === undefined
+        ? remainingSeconds
+        : Math.min(remainingSeconds, this.l1MaxTtlSeconds);
 
-    // The entry's own expiry is sooner than the cap: keep it unchanged and L1
-    // will expire it at exactly that time.
-    if (entryExpiryMs <= now + this.l1MaxTtlSeconds * 1000) return entry;
+    // Indefinite entry with no cap: nothing to bound.
+    if (!Number.isFinite(cappedSeconds)) return entry;
 
-    return { ...entry, timestamp: now, revalidate: this.l1MaxTtlSeconds };
+    return { ...entry, timestamp: now, revalidate: cappedSeconds };
   }
 }

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -50,10 +50,12 @@ export class TieredCacheHandler implements CacheHandler {
     }
 
     if (l2Entry) {
-      const promoted = this.applyL1Ttl(l2Entry);
-      void this.l1.set(key, promoted).catch((err: unknown) => {
-        console.error('TieredCacheHandler: L1 promotion failed', err);
-      });
+      const promoted = this.applyL1TtlForPromotion(l2Entry);
+      if (promoted) {
+        void this.l1.set(key, promoted).catch((err: unknown) => {
+          console.error('TieredCacheHandler: L1 promotion failed', err);
+        });
+      }
       return l2Entry; // Return original entry (full TTL); only L1 gets the capped TTL
     }
 
@@ -65,14 +67,16 @@ export class TieredCacheHandler implements CacheHandler {
       console.error('TieredCacheHandler: L2 set failed', err);
     });
 
-    const l1Entry = this.applyL1Ttl(entry);
+    const l1Entry = this.applyL1TtlForFreshEntry(entry);
     const l1Write = this.l1.set(key, l1Entry).catch((err: unknown) => {
       console.error('TieredCacheHandler: L1 set failed', err);
     });
     await Promise.all([l2Write, l1Write]);
   }
 
-  private applyL1Ttl(entry: CacheEntry): CacheEntry {
+  // Caps revalidate on a freshly-written entry. Assumes timestamp ~= now, so
+  // capping revalidate alone bounds the entry's absolute expiry correctly.
+  private applyL1TtlForFreshEntry(entry: CacheEntry): CacheEntry {
     if (this.l1MaxTtlSeconds === undefined) return entry;
 
     const capped =
@@ -81,5 +85,28 @@ export class TieredCacheHandler implements CacheHandler {
     if (capped === entry.revalidate) return entry;
 
     return { ...entry, revalidate: capped };
+  }
+
+  // Caps an entry promoted from L2 so its absolute expiry is the earlier of the
+  // entry's own expiry and now + l1MaxTtlSeconds. Unlike applyL1TtlForFreshEntry,
+  // a promoted entry may be arbitrarily old, so the cap must bound the remaining
+  // lifetime — rewriting revalidate alone would produce an L1 entry that is
+  // already expired (issue #5027).
+  // Returns null when the entry has no remaining lifetime (skip the L1 write).
+  private applyL1TtlForPromotion(entry: CacheEntry): CacheEntry | null {
+    const now = Date.now();
+    const entryExpiryMs = entry.revalidate > 0 ? entry.timestamp + entry.revalidate * 1000 : Infinity;
+
+    // Already expired (possible via L2 TTL rounding or cross-worker clock skew):
+    // writing it to L1 would only create an entry the next get deletes.
+    if (entryExpiryMs <= now) return null;
+
+    if (this.l1MaxTtlSeconds === undefined) return entry;
+
+    // The entry's own expiry is sooner than the cap: keep it unchanged and L1
+    // will expire it at exactly that time.
+    if (entryExpiryMs <= now + this.l1MaxTtlSeconds * 1000) return entry;
+
+    return { ...entry, timestamp: now, revalidate: this.l1MaxTtlSeconds };
   }
 }

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -133,10 +133,18 @@ export class TieredCacheHandler implements CacheHandler {
     // are unaffected — their expiry never depends on the timestamp.
     if (hasFiniteLifetime && entry.timestamp > now) return null;
 
-    const remainingSeconds = hasFiniteLifetime ? entry.revalidate - (now - entry.timestamp) / 1000 : Infinity;
-
-    // Already expired (possible via L2 TTL rounding or cross-worker clock skew):
-    // writing it to L1 would only create an entry the next get deletes.
+    // Floor the remaining lifetime to whole seconds: a TTL-on-write L1 (Redis
+    // EX) rounds the TTL up with Math.ceil, so a fractional value could outlive
+    // the ORIGINAL expiry by up to a second. Only the remaining-lifetime term
+    // is floored — the cap below is applied unfloored, so sub-second caps keep
+    // working (exceeding the cap itself by Redis's <1s rounding never passes
+    // the entry's own expiry, because ceil(cap) <= floor(remaining) here).
+    // Expired or under one whole second of life left (also possible via L2 TTL
+    // rounding or cross-worker clock skew): skip L1 — writing the entry would
+    // only create one the next get deletes.
+    const remainingSeconds = hasFiniteLifetime
+      ? Math.floor(entry.revalidate - (now - entry.timestamp) / 1000)
+      : Infinity;
     if (remainingSeconds <= 0) return null;
 
     const cappedSeconds =
@@ -147,12 +155,6 @@ export class TieredCacheHandler implements CacheHandler {
     // Indefinite entry with no cap: nothing to bound.
     if (!Number.isFinite(cappedSeconds)) return entry;
 
-    // Floor to whole seconds: a TTL-on-write L1 (Redis EX) rounds the TTL up
-    // with Math.ceil, so a fractional value could outlive the original expiry
-    // by up to a second. Under one whole second of life left, skip L1.
-    const flooredSeconds = Math.floor(cappedSeconds);
-    if (flooredSeconds <= 0) return null;
-
-    return { ...entry, timestamp: now, revalidate: flooredSeconds };
+    return { ...entry, timestamp: now, revalidate: cappedSeconds };
   }
 }

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -128,7 +128,11 @@ export class TieredCacheHandler implements CacheHandler {
     if (this.l1Disabled()) return null;
 
     const now = Date.now();
-    const hasFiniteLifetime = entry.revalidate > 0;
+    // Infinity counts as indefinite, not finite: both supported backends treat
+    // it as "never expires" (RedisCacheHandler serializes any non-finite
+    // revalidate as 0 / no EX; InMemoryLRUCacheHandler's age check can never
+    // exceed it), so it must take the indefinite path below.
+    const hasFiniteLifetime = Number.isFinite(entry.revalidate) && entry.revalidate > 0;
 
     // A future timestamp on a finite entry means the producer's clock is ahead
     // of ours: any remaining lifetime computed from it overshoots the entry's

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -84,8 +84,9 @@ export class TieredCacheHandler implements CacheHandler {
 
   // A cap of 0, negative, or NaN cannot be expressed as a revalidate value —
   // revalidate <= 0 (and NaN via Math.min) means "never expires" in both L1
-  // backends — so any defined non-positive/non-finite cap disables L1 entirely
-  // instead of inverting into immortal entries. `!(x > 0)` is true for NaN.
+  // backends — so those caps disable L1 entirely instead of inverting into
+  // immortal entries. `!(x > 0)` is true for NaN. An Infinity cap is NOT
+  // disabled: it means "unbounded", the same as leaving the option undefined.
   private l1Disabled(): boolean {
     return this.l1MaxTtlSeconds !== undefined && !(this.l1MaxTtlSeconds > 0);
   }
@@ -120,10 +121,15 @@ export class TieredCacheHandler implements CacheHandler {
     if (this.l1Disabled()) return null;
 
     const now = Date.now();
-    // Clamp elapsed at >= 0: a producer clock ahead of ours would otherwise
-    // make the remaining lifetime exceed the entry's own revalidate.
+
+    // A future timestamp means the producer's clock is ahead of ours. Any
+    // lifetime computed from it overshoots the entry's true expiry (a Redis L2
+    // started its EX at the producer's write), so serve from L2 and skip the
+    // promotion rather than clamping.
+    if (entry.timestamp > now) return null;
+
     const remainingSeconds =
-      entry.revalidate > 0 ? entry.revalidate - Math.max(0, now - entry.timestamp) / 1000 : Infinity;
+      entry.revalidate > 0 ? entry.revalidate - (now - entry.timestamp) / 1000 : Infinity;
 
     // Already expired (possible via L2 TTL rounding or cross-worker clock skew):
     // writing it to L1 would only create an entry the next get deletes.

--- a/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
+++ b/packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts
@@ -24,6 +24,10 @@ export interface TieredCacheHandlerOptions {
    * A non-positive or NaN value disables L1 entirely (all reads and writes go to L2).
    * Note: a persistent L1 (e.g. Redis) disabled this way retains entries written
    * before it was disabled; flush it before re-enabling.
+   * Cross-worker promotion assumes roughly synchronized clocks: a finite-lifetime
+   * L2 entry stamped ahead of the local clock is served from L2 without being
+   * promoted, so a writer with a persistently fast clock keeps L1 unpopulated
+   * for the keys it writes until clocks converge.
    */
   l1MaxTtlSeconds?: number;
 }
@@ -137,9 +141,13 @@ export class TieredCacheHandler implements CacheHandler {
     // A future timestamp on a finite entry means the producer's clock is ahead
     // of ours: any remaining lifetime computed from it overshoots the entry's
     // true expiry (a Redis L2 started its EX at the producer's write), so serve
-    // from L2 and skip the promotion rather than clamping. Indefinite entries
-    // are unaffected — their expiry never depends on the timestamp.
-    if (hasFiniteLifetime && entry.timestamp > now) return null;
+    // from L2 and skip the promotion rather than clamping. A non-finite
+    // timestamp (corrupted or malformed data from a custom L2) is skipped for
+    // the same reason — no remaining lifetime can be derived from it, and NaN
+    // would otherwise slide through every comparison below and promote the
+    // entry unmodified, making it immortal in L1. Indefinite entries are
+    // unaffected — their expiry never depends on the timestamp.
+    if (hasFiniteLifetime && (!Number.isFinite(entry.timestamp) || entry.timestamp > now)) return null;
 
     // Floor the remaining lifetime to whole seconds: a TTL-on-write L1 (Redis
     // EX) rounds the TTL up with Math.ceil, so a fractional value could outlive

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -166,4 +166,103 @@ describe('TieredCacheHandler', () => {
       expect(l2Entry!.revalidate).toBe(600);
     });
   });
+
+  // Regression tests for https://github.com/shakacode/react_on_rails/issues/5027:
+  // promotion must account for the entry's age, not just rewrite `revalidate`.
+  describe('L2-to-L1 promotion of aged entries', () => {
+    test('promotes an indefinite entry aged past l1MaxTtlSeconds into a readable L1 entry', async () => {
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 30 });
+      // Written 60s ago with revalidate: 0 (indefinite) — L2 rightfully still holds it.
+      const entry = makeEntry({ revalidate: 0, timestamp: Date.now() - 60_000 });
+      await l2.set('key', entry);
+
+      await capped.get('key');
+
+      const l1Entry = await l1.get('key');
+      expect(l1Entry).not.toBeNull();
+      expect(l1Entry!.revalidate).toBe(30);
+      // Re-stamped at promotion time so the L1 copy gets a full cap window.
+      expect(Date.now() - l1Entry!.timestamp).toBeLessThan(5_000);
+    });
+
+    test('does not extend an aged finite entry past its original expiry', async () => {
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 60 });
+      // Written ~3595s ago with revalidate: 3600 — only ~5s of life left.
+      const originalTimestamp = Date.now() - 3_595_000;
+      const entry = makeEntry({ revalidate: 3600, timestamp: originalTimestamp });
+      await l2.set('key', entry);
+
+      await capped.get('key');
+
+      const l1Entry = await l1.get('key');
+      expect(l1Entry).not.toBeNull();
+      // The promoted copy must expire when the original would (~5s from now),
+      // not a full cap window (60s) later.
+      const promotedExpiry = l1Entry!.timestamp + l1Entry!.revalidate * 1000;
+      const originalExpiry = originalTimestamp + 3600 * 1000;
+      expect(promotedExpiry).toBeLessThanOrEqual(originalExpiry);
+      expect(promotedExpiry).toBeGreaterThan(Date.now());
+    });
+
+    test('skips the L1 write entirely for an entry already past its own revalidate', async () => {
+      // A real L2 would not return an expired entry, but Redis TTL rounding
+      // (Math.ceil) or cross-worker clock skew can hand back an entry with no
+      // remaining lifetime. Deliver it via a stub L2.
+      const expired = makeEntry({ revalidate: 5, timestamp: Date.now() - 10_000 });
+      const stubL2: InMemoryLRUCacheHandler = {
+        get: jest.fn().mockResolvedValue(expired),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as InMemoryLRUCacheHandler;
+      const capped = new TieredCacheHandler(l1, stubL2, { l1MaxTtlSeconds: 60 });
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.get('key');
+
+      expect(l1SetSpy).not.toHaveBeenCalled();
+      expect(await l1.get('key')).toBeNull();
+    });
+
+    test('skips the L1 write for an expired entry even without l1MaxTtlSeconds', async () => {
+      const expired = makeEntry({ revalidate: 5, timestamp: Date.now() - 10_000 });
+      const stubL2: InMemoryLRUCacheHandler = {
+        get: jest.fn().mockResolvedValue(expired),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as InMemoryLRUCacheHandler;
+      const uncapped = new TieredCacheHandler(l1, stubL2);
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await uncapped.get('key');
+
+      expect(l1SetSpy).not.toHaveBeenCalled();
+    });
+
+    test('aged entries hit L2 only once, then are served from L1', async () => {
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 30 });
+      await l2.set('key', makeEntry({ revalidate: 0, timestamp: Date.now() - 60_000 }));
+      const l2GetSpy = jest.spyOn(l2, 'get');
+
+      for (let i = 0; i < 5; i += 1) {
+        expect(await capped.get('key')).not.toBeNull(); // eslint-disable-line no-await-in-loop
+      }
+
+      // Before the fix, every get above fell through to L2 and re-promoted an
+      // already-expired entry, so this was 5.
+      expect(l2GetSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('without l1MaxTtlSeconds, promotes an aged entry unchanged (same absolute expiry)', async () => {
+      // No cap configured: the aged entry keeps its own timestamp/revalidate,
+      // so its absolute expiry in L1 matches L2 exactly.
+      const originalTimestamp = Date.now() - 60_000;
+      const entry = makeEntry({ revalidate: 3600, timestamp: originalTimestamp });
+      await l2.set('key', entry);
+
+      await tiered.get('key');
+
+      const l1Entry = await l1.get('key');
+      expect(l1Entry).not.toBeNull();
+      expect(l1Entry!.timestamp).toBe(originalTimestamp);
+      expect(l1Entry!.revalidate).toBe(3600);
+    });
+  });
 });

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -340,6 +340,26 @@ describe('TieredCacheHandler', () => {
       expect(l1SetSpy).not.toHaveBeenCalled();
     });
 
+    test('a future-stamped indefinite entry is still promoted (its expiry cannot depend on the timestamp)', async () => {
+      // The future-timestamp skip only makes sense for finite lifetimes; an
+      // indefinite entry (revalidate: 0 — the unstable_cache default) must keep
+      // populating L1 even during a clock-skew window.
+      const skewed = makeEntry({ revalidate: 0, timestamp: Date.now() + 5_000 });
+      const stubL2: InMemoryLRUCacheHandler = {
+        get: jest.fn().mockResolvedValue(skewed),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as InMemoryLRUCacheHandler;
+      const capped = new TieredCacheHandler(l1, stubL2, { l1MaxTtlSeconds: 30 });
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.get('key');
+
+      expect(l1SetSpy).toHaveBeenCalledTimes(1);
+      const promoted = l1SetSpy.mock.calls[0][1];
+      expect(promoted.revalidate).toBe(30);
+      expect(promoted.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+
     test('an Infinity cap behaves as "no cap", not as disabled L1', async () => {
       // Infinity means "unbounded", the same as leaving the option undefined:
       // L1 stays in use and promoted entries keep their own expiry.

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -360,6 +360,21 @@ describe('TieredCacheHandler', () => {
       expect(promoted.timestamp).toBeLessThanOrEqual(Date.now());
     });
 
+    test('a sub-second cap still promotes (flooring must not zero out the cap)', async () => {
+      // Flooring exists to stop Redis EX ceil from passing the ORIGINAL expiry,
+      // so only the remaining-lifetime term is floored; the cap itself is
+      // applied unfloored. A 0.5s cap must keep repopulating L1, not silently
+      // disable promotion forever.
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 0.5 });
+      await l2.set('key', makeEntry({ revalidate: 0, timestamp: Date.now() - 60_000 }));
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.get('key');
+
+      expect(l1SetSpy).toHaveBeenCalledTimes(1);
+      expect(l1SetSpy.mock.calls[0][1].revalidate).toBe(0.5);
+    });
+
     test('an Infinity cap behaves as "no cap", not as disabled L1', async () => {
       // Infinity means "unbounded", the same as leaving the option undefined:
       // L1 stays in use and promoted entries keep their own expiry.

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -136,10 +136,10 @@ describe('TieredCacheHandler', () => {
 
       const l1Entry = await l1.get('key');
       expect(l1Entry).not.toBeNull();
-      // Promotion computes the remaining lifetime, so allow for the few ms
-      // elapsed since the entry was stamped — but never more than the original.
+      // Promotion computes the remaining lifetime floored to whole seconds, so
+      // allow up to 1s of slack — but never more than the original.
       expect(l1Entry!.revalidate).toBeLessThanOrEqual(5);
-      expect(l1Entry!.revalidate).toBeGreaterThan(4.5);
+      expect(l1Entry!.revalidate).toBeGreaterThanOrEqual(4);
     });
 
     test('assigns l1MaxTtlSeconds when original revalidate is 0 (indefinite)', async () => {
@@ -294,6 +294,51 @@ describe('TieredCacheHandler', () => {
       expect(l1SetSpy).not.toHaveBeenCalled();
     });
 
+    test('a disabled L1 is also bypassed on reads, so pre-existing L1 data cannot be served', async () => {
+      // A persistent L1 (e.g. shared Redis) may still hold entries from before
+      // the cap disabled it; "all reads go to L2" must include those.
+      await l1.set('key', makeEntry({ value: [Buffer.from('stale-l1')], revalidate: 0 }));
+      await l2.set('key', makeEntry({ value: [Buffer.from('fresh-l2')], revalidate: 0 }));
+      const disabled = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 0 });
+      const l1GetSpy = jest.spyOn(l1, 'get');
+
+      const result = await disabled.get('key');
+
+      expect(result!.value[0].toString()).toBe('fresh-l2');
+      expect(l1GetSpy).not.toHaveBeenCalled();
+    });
+
+    test('a NaN l1MaxTtlSeconds disables L1 instead of writing immortal entries', async () => {
+      // e.g. Number(process.env.UNSET_VAR): NaN passes a `<= 0` check and turns
+      // Math.min into NaN, which both backends treat as "never expires".
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: Number.NaN });
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.set('key', makeEntry({ revalidate: 600 }));
+      await l2.set('key2', makeEntry({ revalidate: 600 }));
+      await capped.get('key2'); // promotion path
+
+      expect(l1SetSpy).not.toHaveBeenCalled();
+      expect(await l2.get('key')).not.toBeNull();
+    });
+
+    test('a producer clock ahead of ours cannot inflate the promoted lifetime past the original revalidate', async () => {
+      // Cross-worker skew: the L2 writer's clock is 5s fast, so elapsed looks
+      // negative here. The promoted entry must never outlive the original TTL.
+      const skewed = makeEntry({ revalidate: 10, timestamp: Date.now() + 5_000 });
+      const stubL2: InMemoryLRUCacheHandler = {
+        get: jest.fn().mockResolvedValue(skewed),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as InMemoryLRUCacheHandler;
+      const capped = new TieredCacheHandler(l1, stubL2, { l1MaxTtlSeconds: 60 });
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.get('key');
+
+      expect(l1SetSpy).toHaveBeenCalledTimes(1);
+      expect(l1SetSpy.mock.calls[0][1].revalidate).toBeLessThanOrEqual(10);
+    });
+
     test('promoted entries are re-stamped so TTL-on-write L1 handlers apply only the remaining lifetime', async () => {
       // RedisCacheHandler.set starts EX ceil(revalidate) at write time and its
       // get never checks entry.timestamp, so a promoted entry carrying an old
@@ -301,8 +346,9 @@ describe('TieredCacheHandler', () => {
       // it long past the L2 expiry. The promoted copy must always encode the
       // remaining lifetime relative to a fresh timestamp.
       const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 60 });
-      // ~5s of life left out of 3600s.
-      const entry = makeEntry({ revalidate: 3600, timestamp: Date.now() - 3_595_000 });
+      // ~4.5s of life left out of 3600s (deliberately not a whole second, so a
+      // rounded-up TTL would provably pass the original expiry).
+      const entry = makeEntry({ revalidate: 3600, timestamp: Date.now() - 3_595_500 });
       await l2.set('key', entry);
       const l1SetSpy = jest.spyOn(l1, 'set');
 
@@ -312,7 +358,11 @@ describe('TieredCacheHandler', () => {
       const promoted = l1SetSpy.mock.calls[0][1];
       expect(Date.now() - promoted.timestamp).toBeLessThan(2_000); // fresh timestamp
       expect(promoted.revalidate).toBeGreaterThan(0);
-      expect(promoted.revalidate).toBeLessThanOrEqual(6); // remaining ~5s, never the original 3600
+      // A TTL-on-write handler applies EX ceil(revalidate) from the promoted
+      // timestamp, so even the rounded-up TTL must not pass the original expiry.
+      const originalExpiry = entry.timestamp + 3600 * 1000;
+      const trueRemainingSeconds = (originalExpiry - promoted.timestamp) / 1000;
+      expect(Math.ceil(promoted.revalidate)).toBeLessThanOrEqual(trueRemainingSeconds);
     });
   });
 });

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -322,9 +322,10 @@ describe('TieredCacheHandler', () => {
       expect(await l2.get('key')).not.toBeNull();
     });
 
-    test('a producer clock ahead of ours cannot inflate the promoted lifetime past the original revalidate', async () => {
-      // Cross-worker skew: the L2 writer's clock is 5s fast, so elapsed looks
-      // negative here. The promoted entry must never outlive the original TTL.
+    test('a future-stamped entry (producer clock ahead) is served from L2 but not promoted', async () => {
+      // Cross-worker skew: any lifetime computed from a future timestamp
+      // overshoots a Redis L2's EX (which started at the producer's write), so
+      // promotion is skipped entirely instead of clamped.
       const skewed = makeEntry({ revalidate: 10, timestamp: Date.now() + 5_000 });
       const stubL2: InMemoryLRUCacheHandler = {
         get: jest.fn().mockResolvedValue(skewed),
@@ -333,10 +334,26 @@ describe('TieredCacheHandler', () => {
       const capped = new TieredCacheHandler(l1, stubL2, { l1MaxTtlSeconds: 60 });
       const l1SetSpy = jest.spyOn(l1, 'set');
 
-      await capped.get('key');
+      const result = await capped.get('key');
 
-      expect(l1SetSpy).toHaveBeenCalledTimes(1);
-      expect(l1SetSpy.mock.calls[0][1].revalidate).toBeLessThanOrEqual(10);
+      expect(result).not.toBeNull(); // L2 value still served
+      expect(l1SetSpy).not.toHaveBeenCalled();
+    });
+
+    test('an Infinity cap behaves as "no cap", not as disabled L1', async () => {
+      // Infinity means "unbounded", the same as leaving the option undefined:
+      // L1 stays in use and promoted entries keep their own expiry.
+      const uncapped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: Infinity });
+      const originalTimestamp = Date.now() - 60_000;
+      await l2.set('key', makeEntry({ revalidate: 3600, timestamp: originalTimestamp }));
+
+      await uncapped.get('key');
+
+      const l1Entry = await l1.get('key');
+      expect(l1Entry).not.toBeNull();
+      const promotedExpiry = l1Entry!.timestamp + l1Entry!.revalidate * 1000;
+      expect(promotedExpiry).toBeLessThanOrEqual(originalTimestamp + 3600 * 1000 + 1);
+      expect(promotedExpiry).toBeGreaterThan(Date.now());
     });
 
     test('promoted entries are re-stamped so TTL-on-write L1 handlers apply only the remaining lifetime', async () => {

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -375,6 +375,18 @@ describe('TieredCacheHandler', () => {
       expect(l1SetSpy.mock.calls[0][1].revalidate).toBe(0.5);
     });
 
+    test('an Infinity cap preserves indefinite revalidate on fresh writes, exactly like undefined', async () => {
+      // Without normalization, min/ternary logic would rewrite revalidate: 0 to
+      // Infinity — a value a custom TTL-on-write L1 handler could reject.
+      const uncapped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: Infinity });
+
+      await uncapped.set('key', makeEntry({ revalidate: 0 }));
+
+      const l1Entry = await l1.get('key');
+      expect(l1Entry).not.toBeNull();
+      expect(l1Entry!.revalidate).toBe(0);
+    });
+
     test('an Infinity cap behaves as "no cap", not as disabled L1', async () => {
       // Infinity means "unbounded", the same as leaving the option undefined:
       // L1 stays in use and promoted entries keep their own expiry.

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -360,6 +360,28 @@ describe('TieredCacheHandler', () => {
       expect(promoted.timestamp).toBeLessThanOrEqual(Date.now());
     });
 
+    test('a future-stamped Infinity entry is also promoted (Infinity is the other indefinite spelling)', async () => {
+      // RedisCacheHandler maps every non-finite revalidate to the non-expiring
+      // representation (serialized as 0, stored without EX), and the in-memory
+      // handler's age check can never exceed Infinity — so like revalidate: 0,
+      // an Infinity entry's expiry cannot depend on its timestamp and clock
+      // skew must not block promotion.
+      const skewed = makeEntry({ revalidate: Infinity, timestamp: Date.now() + 5_000 });
+      const stubL2: InMemoryLRUCacheHandler = {
+        get: jest.fn().mockResolvedValue(skewed),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as InMemoryLRUCacheHandler;
+      const capped = new TieredCacheHandler(l1, stubL2, { l1MaxTtlSeconds: 30 });
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.get('key');
+
+      expect(l1SetSpy).toHaveBeenCalledTimes(1);
+      const promoted = l1SetSpy.mock.calls[0][1];
+      expect(promoted.revalidate).toBe(30);
+      expect(promoted.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+
     test('a sub-second cap still promotes (flooring must not zero out the cap)', async () => {
       // Flooring exists to stop Redis EX ceil from passing the ORIGINAL expiry,
       // so only the remaining-lifetime term is floored; the cap itself is

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -270,6 +270,30 @@ describe('TieredCacheHandler', () => {
       expect(promotedExpiry).toBeGreaterThan(Date.now());
     });
 
+    test('l1MaxTtlSeconds of 0 disables L1 writes on set instead of writing immortal entries', async () => {
+      // revalidate <= 0 means "never expires" in both L1 backends, so capping
+      // to 0 must not fall through to Math.min — it would make entries
+      // permanent, the opposite of a stricter cap.
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 0 });
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.set('key', makeEntry({ revalidate: 600 }));
+
+      expect(l1SetSpy).not.toHaveBeenCalled();
+      expect(await l2.get('key')).not.toBeNull(); // L2 still written normally
+    });
+
+    test('a non-positive l1MaxTtlSeconds disables L1 promotion writes', async () => {
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: -5 });
+      await l2.set('key', makeEntry({ revalidate: 600 }));
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      const result = await capped.get('key');
+
+      expect(result).not.toBeNull(); // L2 value still served
+      expect(l1SetSpy).not.toHaveBeenCalled();
+    });
+
     test('promoted entries are re-stamped so TTL-on-write L1 handlers apply only the remaining lifetime', async () => {
       // RedisCacheHandler.set starts EX ceil(revalidate) at write time and its
       // get never checks entry.timestamp, so a promoted entry carrying an old

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -360,6 +360,24 @@ describe('TieredCacheHandler', () => {
       expect(promoted.timestamp).toBeLessThanOrEqual(Date.now());
     });
 
+    test('a NaN-stamped finite entry is served from L2 but never promoted (would be immortal in L1)', async () => {
+      // A malformed timestamp from a custom L2 yields NaN remaining lifetime,
+      // which passes every <=/> comparison unchecked and would previously fall
+      // through to promoting the entry unmodified — never expiring in L1.
+      const malformed = makeEntry({ revalidate: 600, timestamp: Number.NaN });
+      const stubL2: InMemoryLRUCacheHandler = {
+        get: jest.fn().mockResolvedValue(malformed),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as InMemoryLRUCacheHandler;
+      const capped = new TieredCacheHandler(l1, stubL2, { l1MaxTtlSeconds: 60 });
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      const result = await capped.get('key');
+
+      expect(result).not.toBeNull(); // L2 value still served
+      expect(l1SetSpy).not.toHaveBeenCalled();
+    });
+
     test('a future-stamped Infinity entry is also promoted (Infinity is the other indefinite spelling)', async () => {
       // RedisCacheHandler maps every non-finite revalidate to the non-expiring
       // representation (serialized as 0, stored without EX), and the in-memory

--- a/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
+++ b/packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts
@@ -136,7 +136,10 @@ describe('TieredCacheHandler', () => {
 
       const l1Entry = await l1.get('key');
       expect(l1Entry).not.toBeNull();
-      expect(l1Entry!.revalidate).toBe(5);
+      // Promotion computes the remaining lifetime, so allow for the few ms
+      // elapsed since the entry was stamped — but never more than the original.
+      expect(l1Entry!.revalidate).toBeLessThanOrEqual(5);
+      expect(l1Entry!.revalidate).toBeGreaterThan(4.5);
     });
 
     test('assigns l1MaxTtlSeconds when original revalidate is 0 (indefinite)', async () => {
@@ -250,9 +253,10 @@ describe('TieredCacheHandler', () => {
       expect(l2GetSpy).toHaveBeenCalledTimes(1);
     });
 
-    test('without l1MaxTtlSeconds, promotes an aged entry unchanged (same absolute expiry)', async () => {
-      // No cap configured: the aged entry keeps its own timestamp/revalidate,
-      // so its absolute expiry in L1 matches L2 exactly.
+    test('without l1MaxTtlSeconds, promotes an aged entry with its absolute expiry preserved', async () => {
+      // No cap configured: the promoted copy must still expire exactly when the
+      // original would, re-stamped so TTL-on-write L1 handlers apply only the
+      // remaining lifetime.
       const originalTimestamp = Date.now() - 60_000;
       const entry = makeEntry({ revalidate: 3600, timestamp: originalTimestamp });
       await l2.set('key', entry);
@@ -261,8 +265,30 @@ describe('TieredCacheHandler', () => {
 
       const l1Entry = await l1.get('key');
       expect(l1Entry).not.toBeNull();
-      expect(l1Entry!.timestamp).toBe(originalTimestamp);
-      expect(l1Entry!.revalidate).toBe(3600);
+      const promotedExpiry = l1Entry!.timestamp + l1Entry!.revalidate * 1000;
+      expect(promotedExpiry).toBeLessThanOrEqual(originalTimestamp + 3600 * 1000 + 1);
+      expect(promotedExpiry).toBeGreaterThan(Date.now());
+    });
+
+    test('promoted entries are re-stamped so TTL-on-write L1 handlers apply only the remaining lifetime', async () => {
+      // RedisCacheHandler.set starts EX ceil(revalidate) at write time and its
+      // get never checks entry.timestamp, so a promoted entry carrying an old
+      // timestamp with its full original revalidate would let a Redis L1 serve
+      // it long past the L2 expiry. The promoted copy must always encode the
+      // remaining lifetime relative to a fresh timestamp.
+      const capped = new TieredCacheHandler(l1, l2, { l1MaxTtlSeconds: 60 });
+      // ~5s of life left out of 3600s.
+      const entry = makeEntry({ revalidate: 3600, timestamp: Date.now() - 3_595_000 });
+      await l2.set('key', entry);
+      const l1SetSpy = jest.spyOn(l1, 'set');
+
+      await capped.get('key');
+
+      expect(l1SetSpy).toHaveBeenCalledTimes(1);
+      const promoted = l1SetSpy.mock.calls[0][1];
+      expect(Date.now() - promoted.timestamp).toBeLessThan(2_000); // fresh timestamp
+      expect(promoted.revalidate).toBeGreaterThan(0);
+      expect(promoted.revalidate).toBeLessThanOrEqual(6); // remaining ~5s, never the original 3600
     });
   });
 });


### PR DESCRIPTION
Fixes #5027.

## Why

`TieredCacheHandler.get` promoted an L2 (e.g. Redis) hit into L1 by rewriting `revalidate` while keeping the L2 entry's original `timestamp`. Any entry older than `l1MaxTtlSeconds` was therefore written into L1 **already expired**: the next `l1.get` deleted it and fell through to L2 again — permanently disabling L1 for that key and paying an L2 round trip plus a wasted L1 write on every request. The dominant case is `unstable_cache`'s default `revalidate: 0` (indefinite), where every entry older than the cap hits this path forever. Served data was always correct; this is a performance fix.

## What changed

- `packages/react-on-rails-pro/src/cache/TieredCacheHandler.ts`: split the single `applyL1Ttl` helper into two paths:
  - `applyL1TtlForFreshEntry` — `set()` path, behavior unchanged (fresh entries have `timestamp ≈ now`, so capping `revalidate` alone is correct).
  - `applyL1TtlForPromotion` — `get()` promotion path: always re-stamps finite-lifetime entries to `{ timestamp: now, revalidate: min(remaining, l1MaxTtlSeconds) }`, bounding the promoted entry's absolute expiry to the **earlier of** the entry's own expiry and `now + l1MaxTtlSeconds`. Re-stamping (rather than passing an aged entry through) is required so **TTL-on-write** L1 handlers (`RedisCacheHandler`'s `EX`, which never checks `entry.timestamp` on `get`) apply exactly the remaining lifetime — review finding by Greptile/Codex. When no lifetime remains, the L1 write is skipped entirely (no corpse writes — also protects against Redis `EX`/`Math.ceil` rounding and cross-worker clock skew edge cases).
  - A defined non-positive or non-finite `l1MaxTtlSeconds` (0, negative, `NaN`) now disables L1 entirely — writes **and reads**, so pre-existing data in a persistent L1 can't be served either — instead of inverting into permanent L1 entries (`revalidate <= 0` means "never expires" in both backends). Review findings by claude-review, Codex, and CodeRabbit.
  - Promotion hardening from review: future-stamped entries (producer clock ahead of ours) skip promotion entirely and are served from L2 — any computed lifetime would overshoot a Redis L2's `EX` — and the remaining lifetime is floored to whole seconds (cap applied unfloored) so Redis's `EX Math.ceil` can never round past the original expiry — under 1s of life left skips L1.
- `packages/react-on-rails-pro/tests/TieredCacheHandler.test.ts`: 15 new tests — 12 regression tests (each watched failing first: the 3 issue behaviors, the TTL-on-write re-stamp/ceil contract, cap≤0 on both paths, disabled-L1 read bypass, NaN cap, future-timestamp handling for finite and indefinite entries, and the sub-second-cap dead zone) + 3 characterization guards for cap-unset semantics and the "aged entries hit L2 only once" contract.
- `CHANGELOG.md`: entry under Unreleased → Fixed (`[Pro]` scope).

## How to review

1. `applyL1TtlForPromotion` — the invariant: promoted absolute expiry never exceeds the original entry's expiry and never exceeds `now + cap`; `null` return skips the L1 write.
2. The `get` promotion call site — guarded write; the caller still receives the original `l2Entry` (unchanged contract).
3. The three regression tests — they mirror the exact failure modes documented in #5027.

<details><summary>Agent details</summary>

### Decision log (non-blocking decisions)

1. **Implementation shape (revised after review):** the first push promoted entries **unchanged** when their own expiry beat the cap (byte-identical optimization). Greptile P1 + Codex P2 correctly flagged that this is wrong for TTL-on-write L1 handlers (`RedisCacheHandler.set` starts `EX ceil(revalidate)` at write time and its `get` never checks `timestamp`), which would restart the full original TTL at promotion. Reverted to the issue's proposed shape: always re-stamp with the remaining lifetime. Fractional `revalidate` values are fine in both backends (in-memory does ms math; Redis ceils by <1s).
2. **Cap-unset corpse guard:** an already-expired entry is never written to L1 even without a cap configured. Semantics-preserving (that write was deleted on next read anyway); pinned by a characterization test.
3. **`l1MaxTtlSeconds <= 0` (claude-review finding, first declined as pre-existing, then reclassified to fix):** previously inverted into "immortal L1 entries" on both the fresh-write and promotion paths (pre-existing on `main` for `set`). Now treated as "L1 disabled": `set` writes only L2, promotion skips the L1 write. Documented in the option's JSDoc and CHANGELOG.
4. **Wave-3 review hardening (all confirmed against code, fixed):** disabled-L1 read bypass (Codex P2 + CodeRabbit Major), clock-ahead clamp (Codex P2 + claude-review), NaN cap guard (claude-review), whole-second flooring vs. Redis `EX ceil` (CodeRabbit Major), and the CHANGELOG "always correct" claim narrowed to the in-memory-L1 case (Codex P2).
5. **Wave-4:** future-stamped promotion skip (Codex P2 — supersedes the earlier elapsed-clamp: clamping still let a promoted entry outlive a Redis L2's `EX` in the delayed-promotion case). **Declined:** CodeRabbit's "disable L1 for `Infinity` caps" — `Infinity` correctly behaves as "no cap" (same as `undefined`) in every path; the confusion came from an over-broad code comment, now corrected, with a test pinning `Infinity` = no-cap.
6. **Wave-5:** the future-timestamp skip now applies only to **finite** entries — an indefinite entry's expiry can't depend on its timestamp, so skipping it needlessly degraded the default `unstable_cache` case during skew (Codex P2). Public JSDoc now names NaN as disabling and carries the persistent-L1 caveat (claude nit + Codex P2 — doc-only: `CacheHandler` has no delete method, so a disabled persistent L1 cannot be actively retired). **Declined:** "Action required: flush Redis L1 on upgrade" (Codex P2) — every old-path Redis-L1 entry carries a TTL bounded by its cap/original TTL and self-expires within the tier's already-documented staleness budget; upgrading never extends staleness.
7. **Wave-6/7:** sub-second caps had become a silent promotion dead zone (flooring zeroed them — a regression this PR introduced; claude-review). Fixed by flooring only the remaining-lifetime term and applying the cap unfloored: `revalidate = min(floor(remaining), cap)`, preserving `ceil(revalidate) ≤ remaining`. **Declined:** Codex's "account for Redis EX install delay" — every TTL-on-write store installs every TTL late by its queue/network delay (including L2's own original `EX`); the ms-scale overshoot is inherent to the backend class and fully solvable only by the deferred `expiresAt` model. Wave-7: `Infinity` caps are normalized to `undefined` at construction so the documented equivalence is exact on the fresh-write path too (a custom TTL-on-write L1 could reject `revalidate: Infinity`; built-ins already handled it) — Codex P2.
8. **Declined (deferred as future durable fix):** claude-review's altitude note that `CacheEntry` should store an absolute `expiresAt` instead of `timestamp + revalidate` — correct observation, but a wire-format change to the Redis serialization and `CacheHandler` contract, out of scope for this fix.
9. **Local Pro RSpec step:** failed in the fresh worktree with 34 load-time errors (`cannot load such file -- rails_helper`, 0 examples ran) — environment-only; the diff touches no Ruby files. Hosted CI is authoritative for the Ruby suite.

### QA Evidence

QA lane: not required — no UI, rendered-page, asset-delivery, or bundle-shape impact; deterministic unit oracle. Replayable `qa-evidence v2` marker not applicable (no QA lane ran).

- TDD red→green: 3 regression tests each confirmed failing against unfixed code before the fix (born-dead promotion `l1.get → null`; expiry extended 55s past original; corpse `l1.set` called).
- Verified repro on unfixed `main` (2026-09-07): 5 consecutive `tiered.get` calls → 5 L2 round trips + 5 corpse promotions, `l1.get` null throughout; after fix: 1 L2 round trip, L1 readable (pinned as the "aged entries hit L2 only once" test).
- Local validation: jest `TieredCacheHandler.test.ts` 25/25 (after review fixes); neighboring cache suites (`InMemoryLRUCacheHandler`, `RedisCacheHandler`, `buildCacheKey`) 57/57; full Pro JS suites 501 + 159 streaming + 20 RSC (incl. `unstable_cacheRSC`) + packed-React compatibility all green at the initial head; `tsc --noEmit` clean; ESLint + Prettier clean. Hosted CI green at every head so far (24 pass / 0 fail at a1fb23ef).

**Benchmarks: not applicable (local M1 A/B not run — decision recorded per AGENTS.md).** This is a correctness
fix to promotion TTL bookkeeping, not a throughput change with a hypothesis to measure: the steady-state L1-hit and
L2-hit paths are unchanged, and the promotion path adds only scalar comparisons plus one object re-stamp — executed
once per key per L1 lifetime, not per request. The "L2 round trip on every request" claim describes the bug being
fixed, and its mechanism is verified directly by the unit oracle above ("aged entries hit L2 only once"; L1 readable
after promotion). No render-path, Node-renderer, bundle, or concurrency behavior is touched. The dedicated quiet
M1 A/B runner is not available in this session; if a maintainer wants trend confirmation, the existing cache
benchmarks can be run there post-merge.

### Confidence note

High confidence: single-file behavioral change with an explicit invariant, red-first regression coverage, full-package JS suites green, and no Ruby/API surface touched. Main risk considered: extending L1 freshness past L2 expiry — excluded by the invariant test ("does not extend an aged finite entry past its original expiry").

</details>

