### PR TITLE
[Pro] RSCRoute: migrate forwardRef to ref-as-prop, then adopt useEffectEvent for onRefetchError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -522,6 +522,16 @@ pair`, returns invalid UTF-8, or silently mis-decodes the value. The parser now 
 
 #### Changed
 
+- **[Pro]** **`RSCRoute` now uses React 19.2's `useEffectEvent` for `onRefetchError` and takes `ref` as a
+  regular prop instead of `forwardRef`**: The public `<RSCRoute ref={…}>` handle API and `onRefetchError`
+  behavior are unchanged, but the RSC client path now requires React >= 19.2 at runtime (matching the
+  documented Pro 17 RSC requirement of React 19.2.x; React below 19.2 fails with
+  `useEffectEvent is not a function`). Calling `useEffectEvent` in a server component without
+  `'use client'` now gets the branded missing-directive diagnostic. Implements
+  [Issue 5030](https://github.com/shakacode/react_on_rails/issues/5030).
+  [PR 5031](https://github.com/shakacode/react_on_rails/pull/5031) by
+  [AbanoubGhadban](https://github.com/AbanoubGhadban).
+
 - **[Pro] Render requests now send raw JavaScript bodies to the Node renderer**: Non-bundle render
   requests use a raw `application/vnd.react-on-rails.render-request+javascript` body with metadata in
   `X-React-On-Rails-Pro-*` headers instead of `application/x-www-form-urlencoded`, removing

--- a/packages/react-on-rails-pro/src/RSCRoute.tsx
+++ b/packages/react-on-rails-pro/src/RSCRoute.tsx
@@ -21,7 +21,6 @@ import * as React from 'react';
 import {
   Component,
   createContext,
-  forwardRef,
   use,
   useCallback,
   useContext,
@@ -32,6 +31,7 @@ import {
   useRef,
   useState,
   type ReactNode,
+  type Ref,
 } from 'react';
 import { useRSC } from './RSCProvider.tsx';
 import { shouldClearRefetchErrorOnSuccessfulVersionChange } from './RSCRouteSuccessfulVersion.ts';
@@ -179,113 +179,123 @@ const toServerComponentFetchError = (
 
 type RefetchErrorState = [string, ServerComponentFetchError];
 type RSCContextValue = ReturnType<typeof useRSC>;
-type RSCRouteContentProps = Omit<RSCRouteProps, 'ssr'> & { rscContext: RSCContextValue };
+// React 19 ref-as-prop: `ref` is a regular prop on function components, so no
+// forwardRef wrapper is needed. Keep these three components plain named
+// functions — do NOT reintroduce forwardRef or wrap them in React.memo:
+// useEffectEvent is silently frozen at its mount-time closure inside
+// ForwardRef/SimpleMemoComponent fibers (React never swaps their impl), which
+// would break the freshness of the refetch-error path with no error or
+// warning. Guarded by imperativeRefetch test 2c.
+type RouteHandleRef = { ref?: Ref<RSCRouteHandle> };
+type RSCRouteContentProps = Omit<RSCRouteProps, 'ssr'> & { rscContext: RSCContextValue } & RouteHandleRef;
 
-const RSCRouteContent = forwardRef<RSCRouteHandle, RSCRouteContentProps>(
-  ({ componentName, componentProps, onRefetchError, rscContext }, ref) => {
-    const { getComponent, refetchComponent, getRefetchVersion, retainComponent, successfulVersions } =
-      rscContext;
-    const currentRouteKey = useMemo(
-      () => createRSCPayloadKey(componentName, componentProps),
-      [componentName, componentProps],
-    );
-    const successfulVersion = successfulVersions[currentRouteKey] ?? 0;
-    const [refetchErrorState, setRefetchErrorState] = useState<RefetchErrorState | null>(null);
-    const refetchError = refetchErrorState?.[0] === currentRouteKey ? refetchErrorState[1] : null;
+function RSCRouteContent({
+  componentName,
+  componentProps,
+  onRefetchError,
+  rscContext,
+  ref,
+}: RSCRouteContentProps) {
+  const { getComponent, refetchComponent, getRefetchVersion, retainComponent, successfulVersions } =
+    rscContext;
+  const currentRouteKey = useMemo(
+    () => createRSCPayloadKey(componentName, componentProps),
+    [componentName, componentProps],
+  );
+  const successfulVersion = successfulVersions[currentRouteKey] ?? 0;
+  const [refetchErrorState, setRefetchErrorState] = useState<RefetchErrorState | null>(null);
+  const refetchError = refetchErrorState?.[0] === currentRouteKey ? refetchErrorState[1] : null;
 
-    // Read the latest committed props in `refetch`, even when a descendant
-    // captured the handle at an earlier render.
-    const latestPropsRef = useRef<[string, unknown]>([componentName, componentProps]);
-    const onRefetchErrorRef = useRef(onRefetchError);
-    const latestRefetchRequestRef = useRef(0);
-    // Version 0 means "evicted or not yet seen"; it lets a later monotonic
-    // success token clear a stale refetch error after the key reloads.
-    const previousSuccessfulVersionRef = useRef({ key: currentRouteKey, version: successfulVersion });
-    const isMountedRef = useRef(false);
-    useLayoutEffect(() => {
-      isMountedRef.current = true;
-      return () => {
-        isMountedRef.current = false;
-      };
-    }, []);
-    useLayoutEffect(() => {
-      latestPropsRef.current = [componentName, componentProps];
-    }, [componentName, componentProps]);
-    useLayoutEffect(() => {
-      onRefetchErrorRef.current = onRefetchError;
-    }, [onRefetchError]);
-    useLayoutEffect(
-      () => retainComponent(componentName, componentProps),
-      [componentName, componentProps, retainComponent],
-    );
-    useLayoutEffect(() => {
-      const previous = previousSuccessfulVersionRef.current;
-      const current = { key: currentRouteKey, version: successfulVersion };
-      previousSuccessfulVersionRef.current = current;
+  // Read the latest committed props in `refetch`, even when a descendant
+  // captured the handle at an earlier render.
+  const latestPropsRef = useRef<[string, unknown]>([componentName, componentProps]);
+  const onRefetchErrorRef = useRef(onRefetchError);
+  const latestRefetchRequestRef = useRef(0);
+  // Version 0 means "evicted or not yet seen"; it lets a later monotonic
+  // success token clear a stale refetch error after the key reloads.
+  const previousSuccessfulVersionRef = useRef({ key: currentRouteKey, version: successfulVersion });
+  const isMountedRef = useRef(false);
+  useLayoutEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+  useLayoutEffect(() => {
+    latestPropsRef.current = [componentName, componentProps];
+  }, [componentName, componentProps]);
+  useLayoutEffect(() => {
+    onRefetchErrorRef.current = onRefetchError;
+  }, [onRefetchError]);
+  useLayoutEffect(
+    () => retainComponent(componentName, componentProps),
+    [componentName, componentProps, retainComponent],
+  );
+  useLayoutEffect(() => {
+    const previous = previousSuccessfulVersionRef.current;
+    const current = { key: currentRouteKey, version: successfulVersion };
+    previousSuccessfulVersionRef.current = current;
 
-      if (shouldClearRefetchErrorOnSuccessfulVersionChange(previous, current)) {
-        setRefetchErrorState(null);
+    if (shouldClearRefetchErrorOnSuccessfulVersionChange(previous, current)) {
+      setRefetchErrorState(null);
+    }
+  }, [currentRouteKey, successfulVersion]);
+
+  const refetch = useCallback((): Promise<ReactNode> => {
+    const [n, p] = latestPropsRef.current;
+    const requestKey = createRSCPayloadKey(n, p);
+    // eslint-disable-next-line no-multi-assign
+    const requestId = (latestRefetchRequestRef.current += 1);
+    const recoverOnError = process.env.NODE_ENV === 'production';
+    // refetchComponent swaps the cache promise and bumps the provider's
+    // version inside startTransition. That re-renders every <RSCRoute>
+    // (including this one) as a transition commit, so old content stays
+    // visible while the new promise streams in.
+    const refetchPromise = refetchComponent(n, p, recoverOnError);
+    const sharedRefetchVersion = getRefetchVersion(n, p);
+    const handledRefetchPromise = rejectErrorPayload(refetchPromise).catch((error: unknown) => {
+      const serverComponentFetchError = toServerComponentFetchError(error, n, p);
+      if (
+        recoverOnError &&
+        isMountedRef.current &&
+        latestRefetchRequestRef.current === requestId &&
+        getRefetchVersion(n, p) === sharedRefetchVersion &&
+        createRSCPayloadKey(...latestPropsRef.current) === requestKey
+      ) {
+        setRefetchErrorState([requestKey, serverComponentFetchError]);
       }
-    }, [currentRouteKey, successfulVersion]);
+      throw serverComponentFetchError;
+    });
+    if (recoverOnError) {
+      void handledRefetchPromise.catch(() => undefined);
+    }
+    return handledRefetchPromise;
+  }, [getRefetchVersion, refetchComponent]);
 
-    const refetch = useCallback((): Promise<ReactNode> => {
-      const [n, p] = latestPropsRef.current;
-      const requestKey = createRSCPayloadKey(n, p);
-      // eslint-disable-next-line no-multi-assign
-      const requestId = (latestRefetchRequestRef.current += 1);
-      const recoverOnError = process.env.NODE_ENV === 'production';
-      // refetchComponent swaps the cache promise and bumps the provider's
-      // version inside startTransition. That re-renders every <RSCRoute>
-      // (including this one) as a transition commit, so old content stays
-      // visible while the new promise streams in.
-      const refetchPromise = refetchComponent(n, p, recoverOnError);
-      const sharedRefetchVersion = getRefetchVersion(n, p);
-      const handledRefetchPromise = rejectErrorPayload(refetchPromise).catch((error: unknown) => {
-        const serverComponentFetchError = toServerComponentFetchError(error, n, p);
-        if (
-          recoverOnError &&
-          isMountedRef.current &&
-          latestRefetchRequestRef.current === requestId &&
-          getRefetchVersion(n, p) === sharedRefetchVersion &&
-          createRSCPayloadKey(...latestPropsRef.current) === requestKey
-        ) {
-          setRefetchErrorState([requestKey, serverComponentFetchError]);
-        }
-        throw serverComponentFetchError;
-      });
-      if (recoverOnError) {
-        void handledRefetchPromise.catch(() => undefined);
-      }
-      return handledRefetchPromise;
-    }, [getRefetchVersion, refetchComponent]);
+  const clearRefetchError = useCallback(() => {
+    if (isMountedRef.current) {
+      setRefetchErrorState((state) => (state?.[0] === currentRouteKey ? null : state));
+    }
+  }, [currentRouteKey]);
 
-    const clearRefetchError = useCallback(() => {
-      if (isMountedRef.current) {
-        setRefetchErrorState((state) => (state?.[0] === currentRouteKey ? null : state));
-      }
-    }, [currentRouteKey]);
+  const handle = useMemo<RSCRouteHandle>(
+    () => ({ refetch, retry: refetch, refetchError, clearRefetchError }),
+    [clearRefetchError, refetch, refetchError],
+  );
+  useImperativeHandle(ref, () => handle, [handle]);
+  useEffect(() => {
+    if (refetchError) {
+      onRefetchErrorRef.current?.(refetchError);
+    }
+  }, [refetchError]);
 
-    const handle = useMemo<RSCRouteHandle>(
-      () => ({ refetch, retry: refetch, refetchError, clearRefetchError }),
-      [clearRefetchError, refetch, refetchError],
-    );
-    useImperativeHandle(ref, () => handle, [handle]);
-    useEffect(() => {
-      if (refetchError) {
-        onRefetchErrorRef.current?.(refetchError);
-      }
-    }, [refetchError]);
-
-    const componentPromise = getComponent(componentName, componentProps);
-    return (
-      <CurrentRSCRouteContext.Provider value={handle}>
-        <PromiseWrapper promise={componentPromise} />
-      </CurrentRSCRouteContext.Provider>
-    );
-  },
-);
-
-RSCRouteContent.displayName = 'RSCRouteContent';
+  const componentPromise = getComponent(componentName, componentProps);
+  return (
+    <CurrentRSCRouteContext.Provider value={handle}>
+      <PromiseWrapper promise={componentPromise} />
+    </CurrentRSCRouteContext.Provider>
+  );
+}
 
 /**
  * Reads the RSC context above the error boundary (so a missing provider still
@@ -295,24 +305,25 @@ RSCRouteContent.displayName = 'RSCRouteContent';
  * the boundary and surface as `ServerComponentFetchError`, matching async
  * fetch failures (#4372).
  */
-const RSCRouteContentWithErrorBoundary = forwardRef<RSCRouteHandle, Omit<RSCRouteProps, 'ssr'>>(
-  ({ componentName, componentProps, onRefetchError }, ref) => {
-    const rscContext = useRSC();
-    return (
-      <RSCRouteErrorBoundary componentName={componentName} componentProps={componentProps}>
-        <RSCRouteContent
-          ref={ref}
-          componentName={componentName}
-          componentProps={componentProps}
-          onRefetchError={onRefetchError}
-          rscContext={rscContext}
-        />
-      </RSCRouteErrorBoundary>
-    );
-  },
-);
-
-RSCRouteContentWithErrorBoundary.displayName = 'RSCRouteContentWithErrorBoundary';
+function RSCRouteContentWithErrorBoundary({
+  componentName,
+  componentProps,
+  onRefetchError,
+  ref,
+}: Omit<RSCRouteProps, 'ssr'> & RouteHandleRef) {
+  const rscContext = useRSC();
+  return (
+    <RSCRouteErrorBoundary componentName={componentName} componentProps={componentProps}>
+      <RSCRouteContent
+        ref={ref}
+        componentName={componentName}
+        componentProps={componentProps}
+        onRefetchError={onRefetchError}
+        rscContext={rscContext}
+      />
+    </RSCRouteErrorBoundary>
+  );
+}
 
 /**
  * Renders a React Server Component inside a React Client Component.
@@ -340,23 +351,25 @@ RSCRouteContentWithErrorBoundary.displayName = 'RSCRouteContentWithErrorBoundary
  * wrapServerComponentRenderer from 'react-on-rails/wrapServerComponentRenderer/client' for client-side
  * rendering or 'react-on-rails/wrapServerComponentRenderer/server' for server-side rendering.
  */
-const RSCRoute = forwardRef<RSCRouteHandle, RSCRouteProps>(
-  ({ componentName, componentProps, ssr = true, onRefetchError }, ref): ReactNode => {
-    if (!ssr && typeof window === 'undefined') {
-      throw new RSCRouteSSRFalseBailoutError(componentName);
-    }
+function RSCRoute({
+  componentName,
+  componentProps,
+  ssr = true,
+  onRefetchError,
+  ref,
+}: RSCRouteProps & RouteHandleRef): ReactNode {
+  if (!ssr && typeof window === 'undefined') {
+    throw new RSCRouteSSRFalseBailoutError(componentName);
+  }
 
-    return (
-      <RSCRouteContentWithErrorBoundary
-        ref={ref}
-        componentName={componentName}
-        componentProps={componentProps}
-        onRefetchError={onRefetchError}
-      />
-    );
-  },
-);
-
-RSCRoute.displayName = 'RSCRoute';
+  return (
+    <RSCRouteContentWithErrorBoundary
+      ref={ref}
+      componentName={componentName}
+      componentProps={componentProps}
+      onRefetchError={onRefetchError}
+    />
+  );
+}
 
 export default RSCRoute;

--- a/packages/react-on-rails-pro/src/RSCRoute.tsx
+++ b/packages/react-on-rails-pro/src/RSCRoute.tsx
@@ -25,6 +25,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useEffectEvent,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
@@ -207,9 +208,12 @@ function RSCRouteContent({
   const refetchError = refetchErrorState?.[0] === currentRouteKey ? refetchErrorState[1] : null;
 
   // Read the latest committed props in `refetch`, even when a descendant
-  // captured the handle at an earlier render.
+  // captured the handle at an earlier render. Deliberately a ref, NOT a
+  // useEffectEvent: an effect event has a new identity every render, which
+  // would destabilize `refetch` → `handle` → the context provider value and
+  // re-render every useCurrentRSCRoute consumer on every route render.
+  // Guarded by imperativeRefetch test 2d.
   const latestPropsRef = useRef<[string, unknown]>([componentName, componentProps]);
-  const onRefetchErrorRef = useRef(onRefetchError);
   const latestRefetchRequestRef = useRef(0);
   // Version 0 means "evicted or not yet seen"; it lets a later monotonic
   // success token clear a stale refetch error after the key reloads.
@@ -224,9 +228,6 @@ function RSCRouteContent({
   useLayoutEffect(() => {
     latestPropsRef.current = [componentName, componentProps];
   }, [componentName, componentProps]);
-  useLayoutEffect(() => {
-    onRefetchErrorRef.current = onRefetchError;
-  }, [onRefetchError]);
   useLayoutEffect(
     () => retainComponent(componentName, componentProps),
     [componentName, componentProps, retainComponent],
@@ -283,9 +284,16 @@ function RSCRouteContent({
     [clearRefetchError, refetch, refetchError],
   );
   useImperativeHandle(ref, () => handle, [handle]);
+  // Always sees the latest committed onRefetchError prop without making the
+  // effect below re-run on callback identity changes. Safe only because these
+  // components are plain function components — see the ordering note above
+  // RouteHandleRef (useEffectEvent freezes inside forwardRef/memo).
+  const emitRefetchError = useEffectEvent((error: ServerComponentFetchError) => {
+    onRefetchError?.(error);
+  });
   useEffect(() => {
     if (refetchError) {
-      onRefetchErrorRef.current?.(refetchError);
+      emitRefetchError(refetchError);
     }
   }, [refetchError]);
 

--- a/packages/react-on-rails-pro/src/capabilities/proRSC.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proRSC.ts
@@ -54,6 +54,8 @@ const CLIENT_HOOK_NAMES = [
   'useInsertionEffect',
   'useOptimistic',
   'useActionState',
+  // `use` must NOT be listed: it is legal in Server Components.
+  'useEffectEvent',
 ].join('|');
 const CLIENT_HOOK_RUNTIME_ERROR_REGEX = new RegExp(
   `(?:(?:React\\.)|\\(0\\s*,\\s*[\\w$]+\\.)?(${CLIENT_HOOK_NAMES})\\)? is not a function\\b`,

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -1099,6 +1099,81 @@ class CapturingErrorBoundary extends React.Component<
     result.unmount();
   });
 
+  it('2c. onRefetchError observes the latest callback prop after a re-render', async () => {
+    process.env.NODE_ENV = 'production';
+    const refetchFailure = new Error('refetch failed after callback swap');
+    setupSequencedFetcher([<div data-testid="card">v1</div>, rejectWith(refetchFailure)]);
+    const ref = React.createRef<RSCRouteHandle>();
+    const staleCallback = jest.fn();
+    const freshCallback = jest.fn();
+
+    const Root: React.FC<{ onRefetchError: (error: unknown) => void }> = ({ onRefetchError }) => (
+      <TestHarness>
+        <RSCRoute
+          ref={ref}
+          componentName="UserCard"
+          componentProps={{ id: 1 }}
+          onRefetchError={onRefetchError}
+        />
+      </TestHarness>
+    );
+
+    const result = await renderInAct(<Root onRefetchError={staleCallback} />);
+    expect(screen.getByTestId('card')).toHaveTextContent('v1');
+
+    // Swap the callback prop without changing the route key. The error path
+    // must observe the swapped-in callback, not the one captured at mount.
+    // Guards the effect-event freshness that forwardRef/memo would silently
+    // freeze (see the ordering note in RSCRoute.tsx and issue #5030).
+    await rerenderInAct(result, <Root onRefetchError={freshCallback} />);
+
+    await act(async () => {
+      await ref.current!.refetch().catch(() => undefined);
+    });
+
+    await waitFor(() => expect(freshCallback).toHaveBeenCalledTimes(1));
+    expect(freshCallback.mock.calls[0][0]).toBe(ref.current!.refetchError);
+    expect(staleCallback).not.toHaveBeenCalled();
+  });
+
+  it('2d. handle identity is stable across re-renders with unchanged route props', async () => {
+    let consumerRenders = 0;
+    const HandleConsumer: React.FC = () => {
+      useCurrentRSCRoute();
+      consumerRenders += 1;
+      return null;
+    };
+    setupSequencedFetcher([
+      <div data-testid="card">
+        v1
+        <HandleConsumer />
+      </div>,
+    ]);
+    const ref = React.createRef<RSCRouteHandle>();
+
+    // componentProps is a fresh object every render (the common JSX inline
+    // shape); only the derived route key must matter for handle stability.
+    const Root: React.FC = () => (
+      <TestHarness>
+        <RSCRoute ref={ref} componentName="UserCard" componentProps={{ id: 1 }} />
+      </TestHarness>
+    );
+
+    const result = await renderInAct(<Root />);
+    expect(screen.getByTestId('card')).toHaveTextContent('v1');
+
+    const firstHandle = ref.current!;
+    const rendersAfterMount = consumerRenders;
+
+    await rerenderInAct(result, <Root />);
+
+    // Guards the `latestPropsRef` exclusion (issue #5030): if `refetch` ever
+    // gained a per-render identity (e.g. via useEffectEvent), `handle` would
+    // recompute each render and re-render every useCurrentRSCRoute consumer.
+    expect(ref.current).toBe(firstHandle);
+    expect(consumerRenders).toBe(rendersAfterMount);
+  });
+
   it('3. useCurrentRSCRoute() from a descendant calls refetch with the parent route name and props', async () => {
     const InlineButton: React.FC = () => {
       const { refetch } = useCurrentRSCRoute();

--- a/packages/react-on-rails-pro/tests/serverRenderRSCReactComponent.rsc.test.tsx
+++ b/packages/react-on-rails-pro/tests/serverRenderRSCReactComponent.rsc.test.tsx
@@ -20,7 +20,7 @@
 /// <reference types="react/experimental" />
 
 import * as React from 'react';
-import { Suspense, useInsertionEffect, useState } from 'react';
+import { Suspense, useEffectEvent, useInsertionEffect, useState } from 'react';
 import * as mock from 'mock-fs';
 import * as path from 'path';
 import { finished } from 'stream/promises';
@@ -70,7 +70,14 @@ const InsertionEffectWithoutClientDirective = () => {
   return <p>Client insertion effect in RSC runtime</p>;
 };
 
+const EffectEventWithoutClientDirective = () => {
+  useEffectEvent(() => undefined);
+
+  return <p>Client effect event in RSC runtime</p>;
+};
+
 ReactOnRails.register({
+  EffectEventWithoutClientDirective,
   HooksWithoutClientDirective,
   InsertionEffectWithoutClientDirective,
   PromiseContainer,
@@ -258,6 +265,18 @@ test('explains likely missing use client directive for newer client hooks', asyn
   expect((error as Error).message).toContain('"use client";');
   expect((error as Error).message).toContain('Original error:');
   expect((error as Error).message).toContain('useInsertionEffect');
+  expect((error as Error).message).toContain('is not a function');
+});
+
+test('explains likely missing use client directive when a server component calls useEffectEvent', async () => {
+  const error = await captureRenderedError('EffectEventWithoutClientDirective');
+
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toContain('EffectEventWithoutClientDirective');
+  expect((error as Error).message).toContain('client hook "useEffectEvent"');
+  expect((error as Error).message).toContain('"use client";');
+  expect((error as Error).message).toContain('Original error:');
+  expect((error as Error).message).toContain('useEffectEvent');
   expect((error as Error).message).toContain('is not a function');
 });
 


### PR DESCRIPTION
## Summary

Implements #5030 in the mandated order:

1. **Part 1 (34bdc6c):** `RSCRouteContent`, `RSCRouteContentWithErrorBoundary`, and `RSCRoute` migrate from `forwardRef` wrappers to plain named function components taking React 19's `ref` as a regular prop. The three `displayName` assignments are dropped (named declarations self-name in DevTools). `useImperativeHandle` is unchanged. Public API (`<RSCRoute ref={…}>`, `RSCRouteHandle`, `RSCRouteProps`) is unchanged.
2. **Part 2 (f634edf):** the `onRefetchErrorRef` mutable box + `useLayoutEffect` sync collapse into a single `useEffectEvent`, which always sees the latest committed `onRefetchError` prop without the error-emitting effect re-running on callback identity changes.
3. **Ride-along (1fe5475):** `useEffectEvent` joins `CLIENT_HOOK_NAMES` in `capabilities/proRSC.ts`, so calling it in a server component without `'use client'` gets the branded RSC diagnostic instead of a raw `(0 , react.useEffectEvent) is not a function`. `use` stays deliberately unlisted (legal in Server Components) — now recorded in a comment.

## Why the ordering is mandatory (empirically re-verified here)

React never swaps an effect event's implementation inside `ForwardRef`/`SimpleMemoComponent` fibers (`react-dom-client.development.js:13888` in the repo's own react-dom 19.2.7: `case 11: case 15: break;`). Adopting `useEffectEvent` before dropping `forwardRef` pins `onRefetchError` to its mount-time closure with no error or warning.

**Test-first evidence:** new test `2c` was applied to the *wrong-order* combination (useEffectEvent inside the still-forwardRef component) before landing Part 1, and failed exactly as the issue predicts — the *stale* mount-time callback fired and the fresh one never did. A probe assertion confirmed the stale callback was invoked (frozen closure), not merely a broken error path. A source comment above `RouteHandleRef` now documents the trap for future `React.memo` attempts.

## New regression tests (both verified to have teeth)

- **`2c. onRefetchError observes the latest callback prop after a re-render`** — fails under the wrong-order change (stale mount-time callback fires); passes before and after this PR's ordered migration.
- **`2d. handle identity is stable across re-renders with unchanged route props`** — guards the `latestPropsRef` exclusion: converting it to `useEffectEvent` would give `refetch` a per-render identity, destabilizing `handle` → context value → re-rendering every `useCurrentRSCRoute()` consumer per route render. Verified to fail when `refetch` is given a per-render identity. `latestPropsRef` stays a ref, with a source comment saying why.
- **`explains likely missing use client directive when a server component calls useEffectEvent`** — written first; failed with the raw unbranded TypeError until `CLIENT_HOOK_NAMES` gained the hook.

## React version floor

Adopting `useEffectEvent` requires React ≥ 19.2 on the RSC client path. This is **within already-documented policy**: `docs/pro/react-server-components/create-without-ssr.md` states "React on Rails Pro 17 RSC requires React 19.2.x with patch >= 19.2.7. React 19.0.x is no longer a supported Pro RSC runtime line in v17." The React 16/17/18 packed-compatibility matrix is unaffected — it exercises the main entry, and `RSCRoute.tsx` is reachable only via `registerServerComponent/{client,server}` and the `./RSCRoute` subpath.

## Validation

- `npx tsc --noEmit` — clean
- `npx eslint src/RSCRoute.tsx src/capabilities/proRSC.ts` — clean
- `npx prettier --check` on all touched files — clean
- `jest tests/imperativeRefetch.client.test.tsx tests/boundedCacheProvider.client.test.tsx` — 67/67 (includes the 2 new tests)
- RSC suite file `serverRenderRSCReactComponent.rsc.test.tsx` — 7/7 (includes the new diagnostic test)
- `pnpm run test` (all 5 pro sub-suites incl. packed React 16/17/18 compatibility) — exit 0
- `.agents/bin/validate --changed` — all steps green except its "React on Rails Pro RSpec" step, which fails identically on an unchanged tree: `bin/ci-local` runs bare `bundle exec rspec`, which loads `spec/load/spec_helper.rb` (calls `config.disable_monkey_patching!`) and breaks the 34 alphabetically-later spec files with `undefined method 'describe' for main`. Hosted CI runs the scoped `bundle exec rspec spec/react_on_rails_pro`, which I ran directly: **898 examples, 0 failures, 1 pending**. Pre-existing local-tooling discrepancy (this PR contains no Ruby changes).

Confidence note:
- Validated: commands above; each new test additionally verified RED under its target regression before the guarded change landed.
- Evidence: commit messages record the RED observations; CI on this PR.
- UNKNOWN: none.
- Residual risk: none identified — behavior-preserving migration guarded by new regression tests; public API unchanged.

Closes #5030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Updated `RSCRoute` ref handling for React 19.2.
  * Refetch error callbacks now use the latest callback provided during re-renders.
  * Route handle identity remains stable when route settings are unchanged.
  * React 19.2 or later is now required at runtime.

* **Bug Fixes**
  * Improved diagnostics for client-only hooks used without the required client directive.
  * Prevented unrelated errors from being incorrectly labeled as client-hook issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->