### PR TITLE
ci-local: scope Pro RSpec step to spec/react_on_rails_pro (match hosted CI)

### DIFF
--- a/bin/ci-local
+++ b/bin/ci-local
@@ -502,7 +502,7 @@ if [ "$RUN_PRO_TESTS" = true ]; then
     if [ "$RUN_JS" != true ]; then
       run_job_argv "React on Rails Pro JS Tests" run_pro_js_tests
     fi
-    run_job "React on Rails Pro RSpec" "cd react_on_rails_pro && bundle_command \"$PRO_GEMFILE\" bundle exec rspec spec/react_on_rails_pro"
+    run_job "React on Rails Pro RSpec" "cd react_on_rails_pro && bundle_command \"$PRO_GEMFILE\" bundle exec rspec spec/react_on_rails_pro spec/async"
   fi
 fi
 

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -502,7 +502,7 @@ if [ "$RUN_PRO_TESTS" = true ]; then
     if [ "$RUN_JS" != true ]; then
       run_job_argv "React on Rails Pro JS Tests" run_pro_js_tests
     fi
-    run_job "React on Rails Pro RSpec" "cd react_on_rails_pro && bundle_command \"$PRO_GEMFILE\" bundle exec rspec"
+    run_job "React on Rails Pro RSpec" "cd react_on_rails_pro && bundle_command \"$PRO_GEMFILE\" bundle exec rspec spec/react_on_rails_pro"
   fi
 fi
 


### PR DESCRIPTION
## Why

`bin/ci-local`'s "React on Rails Pro RSpec" step runs bare `bundle exec rspec` in `react_on_rails_pro/`, which sweeps in every spec directory — including `spec/load/` (whose `spec_helper.rb` calls `config.disable_monkey_patching!`, poisoning later-loaded spec files) and `spec/dummy/spec/` (which needs the dummy app's own bundle). The local gate false-fails with `0 examples, 0 failures, 34 errors occurred outside of examples` while hosted CI is green, because hosted CI runs the scoped suite.

## What changed

One line: the "React on Rails Pro RSpec" `run_job` invocation now runs `bundle exec rspec spec/react_on_rails_pro`, matching hosted CI.

## How to review

Compare with hosted CI's invocation at `.github/workflows/pro-test-package-and-gem.yml:461` (`bundle exec rspec spec/react_on_rails_pro`). The `bundle_command "$PRO_GEMFILE"` wrapper, env scrubbing, and job name are unchanged — only the rspec target scope changed.

<details><summary>Agent details</summary>

- Thread handle: ror-cilocal-fresco
- Lane: l2-cilocal-fix
- Branch: `ci-local-scope-pro-rspec` from origin/main (f8e0be41088aa8576c9a5d5b23f93c6d8236c090)

### BEFORE (bare invocation, exactly as ci-local line 505 runs it)

```
$ cd react_on_rails_pro && env -u GEM_HOME -u GEM_PATH -u RUBYOPT -u BUNDLE_GEMFILE BUNDLE_GEMFILE="$PWD/Gemfile" bundle exec rspec 2>&1 | tail -8
# ./spec/react_on_rails_pro/rolling_deploy_adapters/http_spec.rb:21:in `<top (required)>'
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Finished in 0.00005 seconds (files took 33.07 seconds to load)
0 examples, 0 failures, 34 errors occurred outside of examples
```

Error breakdown of the 34 (observed): 9 × `NoMethodError: undefined method 'describe' for main` (the `spec/load/spec_helper.rb:21` `config.disable_monkey_patching!` poisoning), 25 × `LoadError: cannot load such file -- rails_helper` (`spec/dummy/spec/*` files swept in by the bare glob; they belong to the dummy app's own bundle). Both symptom classes are consequences of the same unscoped invocation and both disappear with the scoped run.

Sample:

```
NoMethodError:
  undefined method `describe' for main
# ./spec/react_on_rails_pro/assets_precompile_spec.rb:19:in `<top (required)>'
```

### AFTER (scoped invocation, matching hosted CI)

```
$ cd react_on_rails_pro && env -u GEM_HOME -u GEM_PATH -u RUBYOPT -u BUNDLE_GEMFILE BUNDLE_GEMFILE="$PWD/Gemfile" bundle exec rspec spec/react_on_rails_pro 2>&1 | tail -4
Finished in 31.25 seconds (files took 1.34 seconds to load)
898 examples, 0 failures, 1 pending
```

### Diff stat

```
 bin/ci-local | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

### Decision log

- No CHANGELOG entry — dev tooling change, per repo changelog policy.
- `spec/load` remains runnable separately by design; its own `spec_helper.rb` uses `disable_monkey_patching!` intentionally for that suite.
- Lint: repo lint entrypoint (`.agents/bin/lint`) could not run in this environment (broken rvm default gemset — native extensions linked against a different libruby; the entrypoint does not scrub `GEM_HOME`/`GEM_PATH`); shellcheck is not installed on this host. `bash -n bin/ci-local` passes.
- Mechanism nuance vs. the lane diagnosis: the headline (34 errors outside examples) reproduced exactly, but only 9 of the 34 are the `disable_monkey_patching!` `describe`-for-main errors; the other 25 are `spec/dummy` `rails_helper` LoadErrors. Same root cause (unscoped glob), same fix.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the local CI command to run both React on Rails Pro and asynchronous specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->