### PR TITLE
Pin json < 3 in generated example apps (json 3.0.0 x Rails < 8.1 quirks_mode crash)

### DIFF
--- a/react_on_rails/rakelib/shakapacker_examples.rake
+++ b/react_on_rails/rakelib/shakapacker_examples.rake
@@ -196,6 +196,12 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
       sh_in_dir(example_type.dir, "touch .gitignore")
       sh_in_dir(example_type.dir,
                 "echo \"gem 'react_on_rails', path: '#{relative_gem_root}'\" >> #{example_type.gemfile}")
+      # json 3.0.0 (2026-09-07) raises ArgumentError on unknown keywords, and Rails < 8.1
+      # ActiveSupport still passes the removed quirks_mode: option to JSON.generate
+      # (fixed upstream in rails/rails#55534; released only in Rails >= 8.1.0).
+      # Remove this pin when example apps generate on Rails >= 8.1.
+      sh_in_dir(example_type.dir,
+                "echo \"gem 'json', '< 3'\" >> #{example_type.gemfile}")
       # Shakapacker is automatically included as a dependency via react_on_rails.gemspec (>= 6.0)
       bundle_install_in(example_type.dir)
       # Use unbundled_sh_in_dir to ensure we're using the generated app's Gemfile

--- a/react_on_rails/rakelib/shakapacker_examples.rake
+++ b/react_on_rails/rakelib/shakapacker_examples.rake
@@ -199,9 +199,11 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
       # json 3.0.0 (2026-09-07) raises ArgumentError on unknown keywords, and Rails < 8.1
       # ActiveSupport still passes the removed quirks_mode: option to JSON.generate
       # (fixed upstream in rails/rails#55534; released only in Rails >= 8.1.0).
-      # Remove this pin when example apps generate on Rails >= 8.1.
-      sh_in_dir(example_type.dir,
-                "echo \"gem 'json', '< 3'\" >> #{example_type.gemfile}")
+      # Self-retires when example apps generate on Rails >= 8.1; also removable if a
+      # json 3.x release restores tolerance for removed keywords.
+      if Gem::Version.new(Rails.version) < Gem::Version.new("8.1")
+        File.write(example_type.gemfile, "gem 'json', '>= 2', '< 3'\n", mode: "a")
+      end
       # Shakapacker is automatically included as a dependency via react_on_rails.gemspec (>= 6.0)
       bundle_install_in(example_type.dir)
       # Use unbundled_sh_in_dir to ensure we're using the generated app's Gemfile

--- a/react_on_rails/spec/react_on_rails/shakapacker_examples_rake_spec.rb
+++ b/react_on_rails/spec/react_on_rails/shakapacker_examples_rake_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe "shakapacker_examples rake helpers" do
   end
 
   describe "pinned React example generation" do
-    let(:example_dir) { "/tmp/example-app" }
+    let(:example_dir) { Dir.mktmpdir("ror-example-app-") }
+    let(:generated_gemfile) { "source 'https://rubygems.org'\ngem 'rails'\n" }
     let(:example_type) do
       instance_double(
         ReactOnRails::TaskHelpers::ExampleType,
@@ -94,6 +95,7 @@ RSpec.describe "shakapacker_examples rake helpers" do
     end
 
     before do
+      File.write(example_type.gemfile, generated_gemfile)
       Rake::Task.clear
       allow(ReactOnRails::TaskHelpers::ExampleType).to receive(:all).and_return(
         { shakapacker_examples: [example_type] }
@@ -106,7 +108,10 @@ RSpec.describe "shakapacker_examples rake helpers" do
       allow(task_context).to receive(:sh_in_dir)
       allow(task_context).to receive(:unbundled_sh_in_dir)
       allow(task_context).to receive(:apply_react_version)
+      allow(Rails).to receive(:version).and_return("8.0.4")
     end
+
+    after { FileUtils.remove_entry(example_dir) }
 
     it "pins shakapacker after the pinned React branch bundle install and before npm install" do
       bundle_install_calls = 0
@@ -123,6 +128,22 @@ RSpec.describe "shakapacker_examples rake helpers" do
         .ordered
 
       Rake::Task["shakapacker_examples:gen_example_app"].invoke
+    end
+
+    ["8.0.4", "8.1.0", "8.2.0"].each do |rails_version|
+      it "writes the appropriate JSON pin before bundling on Rails #{rails_version}" do
+        allow(Rails).to receive(:version).and_return(rails_version)
+        expected_gemfile = generated_gemfile.dup
+        expected_gemfile << "gem 'json', '>= 2', '< 3'\n" if rails_version == "8.0.4"
+
+        expect(task_context).to receive(:bundle_install_in).with(example_dir).exactly(3).times do
+          expect(File.read(example_type.gemfile)).to eq(expected_gemfile)
+        end
+
+        Rake::Task["shakapacker_examples:gen_example_app"].invoke
+
+        expect(File.read(example_type.gemfile)).to eq(expected_gemfile)
+      end
     end
   end
 end


### PR DESCRIPTION
## Why

json 3.0.0 (released 2026-09-07) raises `ArgumentError: unknown keyword` for unknown options that json 2.x silently ignored. ActiveSupport < 8.1 still passes the removed `quirks_mode:` option to `JSON.generate` (activesupport-7.2.3.2 `lib/active_support/json/encoding.rb:110`), so every `.to_json` call in the generated example apps crashes on the latest-gems CI cell with `ArgumentError: unknown keyword: quirks_mode` (run 34144394924, job 101813224745, "examples (4.0, latest)"). Upstream fix (rails/rails#55534) shipped only in Rails >= 8.1.0; 7-2-stable is not getting a release.

## What changed

One append in the `shakapacker_examples:gen_*` rake task: after the `react_on_rails` gem line is added to the generated example app's Gemfile and before the first `bundle install`, the task now also appends `gem 'json', '>= 2', '< 3'` behind a Rails < 8.1 version guard. This is a CI-only surface in effect — the generated example apps exist only for CI. (Precisely: rakelib/ is packaged into the published gem by the gemspec’s git-ls-files rule, so this file does ship, but it is inert for consumers — apps never load the gem’s rakelib.)

## How to review

- `react_on_rails/rakelib/shakapacker_examples.rake`: a Rails-version-guarded Gemfile append (plus a comment explaining the pin and its removal trigger).
- Removal trigger: drop the pin when example apps generate on Rails >= 8.1 (the Gemfile.development_dependencies Rails constraint moves past 8.1).

<details><summary>Agent details</summary>

### Audit receipts

<!-- completed-batch-audit-summary:start -->
#### Completed-batch audit

**Status:** Clean — no outstanding findings or follow-ups. [Durable receipt](https://github.com/shakacode/react_on_rails/pull/5033#issuecomment-5594700886).
<!-- completed-batch-audit-summary:end -->

- Thread handle: ror-jsonpin-fresco
- Lane: l4-json-pin-fix (PR batch "ROR 09-07 19:16 - 5031 closeout + ci-local rspec scope")

### Root-cause matrix

| Component | Version | Behavior |
|---|---|---|
| json | 3.0.0 (2026-09-07) | raises `ArgumentError: unknown keyword` for unknown options |
| json | 2.21.2 | silently ignores unknown options — works |
| activesupport | 7.2.3.2 | passes `quirks_mode: true, max_nesting: false` to `::JSON.generate` at `lib/active_support/json/encoding.rb:110` |
| Rails fix | rails/rails#55534 (merged 2025-08-22) | released only in >= 8.1.0; 8-0-stable backport unreleased as of v8.0.5.1; 7-2-stable not fixed |

### Original JSON-pin validation (historical, before fixture repair)

1. `bundle exec rake shakapacker_examples:gen_basic` — exit 0 (full generation incl. shakapacker install, generators, npm install, rspack build: "Rspack compiled successfully").
2. Generated `gen-examples/examples/basic/Gemfile` line 48: `gem 'json', '>= 2', '< 3'`.
3. Generated `Gemfile.lock`: GEM specs resolve `json (2.21.2)` (checksum `1f1d3b7c…`), `json (< 3)` under DEPENDENCIES, alongside `rails (7.2.3.2)` / `activesupport (7.2.3.2)` — the exact crashing combination, now on json 2.x.
4. Runtime proof inside the generated app: `bundle exec ruby -e '… {a: 1, t: Time.now}.to_json'` → `json 2.21.2, activesupport 7.2.3.2` and successful JSON output (this is the call path that raises `unknown keyword: quirks_mode` under json 3.0.0).
5. `bundle exec rake run_rspec:shakapacker_examples_basic` — exit 0, `1 example, 0 failures`.
6. RuboCop on the changed file: `1 file inspected, no offenses detected`.
7. `git diff --stat`: only `react_on_rails/rakelib/shakapacker_examples.rake` (+6). Generated `gen-examples/` output is gitignored (root `.gitignore` line 42) and not committed.

### Fixture repair and current-head verification

Fixture repair head: `a941646c7de0823d65d8c5e6920ac4c1ff82a47b`.

The prior focused spec stubbed application generation but did not create the Gemfile used by the real append. It failed with `Errno::ENOENT`. The spec now creates a unique temporary application directory and Gemfile, then removes only that fixture.

- Before repair: 4 examples, 1 failure (the missing Gemfile).
- After repair: 7 examples, 0 failures, both ordinary and with the unchanged normal Rake-derived RBS hook.
- Rails 8.0.4 asserts the actual JSON pin before all three bundle calls; Rails 8.1.0 and 8.2.0 assert no pin. Existing React/Shakapacker/npm ordering remains covered.
- Independent fixture QA: 4 examples, 0 failures; zero leaked temporary directories.
- Mandatory full lint and normal commit hooks passed. Initial local lint dependency-path failures were corrected with existing byte-matched dependencies; no package installation or source workaround.
- The fixture-only repair changes no production task behavior, package versions, lockfiles, or other PR code.
- Local validation uses the focused task/spec path plus full lint; no repeated broad local suite is claimed. Current-head hosted validation remains required.
- Actual whole-PR Codex review completed clean at this head and replayed 7 passing tests plus both-file lint. Required read-only Claude review and same-session simplify also completed; no actionable changes remained. Optional private-helper extraction and unrelated app-generator work were declined without changing the candidate.
- Next: validate this commit on GitHub and obtain separate merge approval. After this PR lands, #5038 can bring in the JSON compatibility fix and finish its checks; that clears a prerequisite for the already-approved #4700 and #4986 merges.

### Churn

One fixture-repair commit updates the existing PR. All required pre-push reviews completed before publication; no optional cleanup commit or validation waiver. Existing hosted-CI selection will be checked for the new head before requesting any missing run.

### QA Evidence

- QA lane: independent fixture reviewer.
- Scope checked: real temporary Gemfile creation, JSON pin content before bundling at Rails 8.0.4/8.1.0/8.2.0, and cleanup.
- Tested at: `a941646c7de0823d65d8c5e6920ac4c1ff82a47b`.
- Automated checks: focused 7/0 ordinary and normal RBS; full lint and hooks passed.
- Manual checks: independent CLI fixture replay ran all four generation cases; actual Gemfile reads passed and zero new fixture directories remained. Expensive generation/install shell commands were mocked; this is not a fresh whole-app build claim.
- User-visible UI change: no.
- Visual evidence: not applicable — CI test-fixture/dependency-tooling scope.
- Interaction change: no.
- Interaction evidence: not applicable — no UI interaction change.
- Visual fix: no.
- Negative control: not applicable to visuals; missing-Gemfile baseline failure was reproduced.
- Performance evidence: not applicable — no performance-sensitive production runtime change.
- Findings: no actionable issue in independent QA.
- QA required: yes.
- QA required rationale: the fixture fix must exercise real filesystem behavior, not merely suppress the production append.
- QA lane status: satisfied for the bounded fixture behavior; hosted generated-app tests remain separate.
- Release-blocking status: clear for scoped QA only; no release or merge is authorized by this evidence.
- Process-gap disposition: not applicable.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: a941646c7de0823d65d8c5e6920ac4c1ff82a47b
tested_at: a941646c7de0823d65d8c5e6920ac4c1ff82a47b
scope: real temporary Gemfile JSON pin before bundling at Rails8.0.4/8.1.0/8.2.0 and cleanup
automated_checks: focused7/0 ordinary and normalRBS; full lint and hooks PASS
manual_checks: independent CLI fixture replay4/0; actual Gemfile content at each bundling boundary and zero new temp directories; expensive generation shell calls mocked
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: CI fixture and dependency tooling only
paint_check: not applicable: no UI changes
interaction_change: no
interaction_evidence: not applicable: no UI changes
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: no performance-sensitive runtime change
findings: none
release_blocking: clear
process_gap_disposition: not applicable
-->

<!-- priority-finding-dispositions v1
head_sha: a941646c7de0823d65d8c5e6920ac4c1ff82a47b
finding: url=https://github.com/shakacode/react_on_rails/pull/5033#discussion_r3955513851 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/5033#discussion_r3963640921
finding: url=https://github.com/shakacode/react_on_rails/pull/5033#discussion_r3955525559 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/react_on_rails/pull/5033#discussion_r3963641073
-->

### Decision log

- No CHANGELOG entry: CI-only dev tooling; the shipped rakelib copy is inert for consumers (never loaded by apps).
- Pin applied at example-generation time (rake task) rather than in the gem or Gemfile.development_dependencies, keeping the workaround scoped to the CI-only example apps.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated example applications to use a compatible JSON gem version with Rails releases before 8.1, preventing related errors.
  * Applications using Rails 8.1 or later no longer receive the unnecessary version restriction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


