### PR TITLE
CI: pin Claude action to repaired binary release

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,13 +15,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ccc3a35a6367cdb8e6fbd0728287467540ecfe2 # v1.0.219
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -110,13 +110,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ccc3a35a6367cdb8e6fbd0728287467540ecfe2 # v1.0.219
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -51,8 +51,6 @@ rules:
       - bundle-size.yml:23
       - check-markdown-links.yml:34
       - check-markdown-links.yml:70
-      - claude-code-review.yml:17
-      - claude.yml:25
       - codeql.yml:24
       - playwright.yml:79
   dependabot-cooldown:
@@ -109,8 +107,6 @@ rules:
       - bundle-size.yml:129
       - check-markdown-links.yml:37
       - check-markdown-links.yml:80
-      - claude-code-review.yml:24
-      - claude.yml:32
       - dummy-app-bundler-tests.yml:46
       - dummy-app-bundler-tests.yml:160
       - examples.yml:154


### PR DESCRIPTION
## Why

Claude review on PR #5038 failed before review execution because the moving `anthropics/claude-code-action@v1` tag resolved to v1.0.218, which installed Claude Code 2.1.265 and Agent SDK 0.3.265. The installer reported success but did not create `/home/runner/.local/bin/claude`, and the SDK then failed with `ENOENT`.

Anthropic released v1.0.219 minutes later, updating both components to 2.1.266/0.3.266. A rerun of the same workflow on the unchanged PR #5038 head passed with that repaired release. Pinning the exact release commit prevents a future moving-tag update from silently reintroducing this class of outage.

## What changed

- Pin both Claude workflows to `anthropics/claude-code-action` v1.0.219 commit `5ccc3a35a6367cdb8e6fbd0728287467540ecfe2`.
- Pin each existing `actions/checkout` major to its current release commit and disable persisted checkout credentials.
- Remove the four now-resolved `artipacked` and `unpinned-uses` entries from the zizmor baseline.

No workflow triggers, permissions, prompts, or allowed Claude tools changed.

## Verification

- `node .github/workflows/hosted-ci-safety.test.cjs`
- `actionlint .github/workflows/claude-code-review.yml .github/workflows/claude.yml`
- `pnpm exec prettier --check .github/workflows/claude-code-review.yml .github/workflows/claude.yml .github/zizmor.yml`
- Pinned zizmor 1.16.3 container against both edited workflows: no findings
- Upstream v1.0.219 action commit checks: all green
- Original PR #5038 Claude review run 34292651466, attempt 2, unchanged head `295704febaac149f2010b2aeaa29c1186a6e9097`: success

`yamllint` is unavailable locally. The trusted secure-actions scanner confirms the touched action references are immutable and version-commented; its repo-wide run remains nonzero on the pre-existing repository baseline, including the absent global `trusted_actions` allowlist.

## Review and churn

- Local Codex autoreview found one actionable issue: obsolete zizmor suppressions. Fixed, then the rerun was clean.
- Independent local Claude review found no correctness issue; declined an optional repo-wide checkout-pin consolidation nit as out of scope.
- `/simplify origin/main` made no changes.
- Post-push review-fix commits: 0.

## Changelog

Not user-visible; no changelog entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved workflow security by pinning third-party automation to specific versions.
  - Disabled persistent checkout credentials to reduce the risk of token exposure.
  - Added validation to detect failed automated review authentication.

- **Chores**
  - Removed obsolete workflow security warnings and suppressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->