### PR TITLE
Docs: restore sponsor and Rspack links on release/17.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ Thanks to the companies supporting ShakaCode's open-source work.
   </a>
   <a href="https://coderabbit.ai">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_7229870ac5.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg">
-      <img alt="CodeRabbit" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_7958cfa790.svg" height="34">
+      <source media="(prefers-color-scheme: dark)" srcset="https://docs.coderabbit.ai/coderabbit-logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://docs.coderabbit.ai/coderabbit-logo-light.svg">
+      <img alt="CodeRabbit" src="https://docs.coderabbit.ai/coderabbit-logo-light.svg" height="34">
     </picture>
   </a>
 </p>

--- a/docs/oss/getting-started/why-rspack.md
+++ b/docs/oss/getting-started/why-rspack.md
@@ -87,7 +87,7 @@ Our control-tier measurement could not confirm a winner: browser-observed HMR me
 
 ### "Vite's plugin ecosystem is bigger"
 
-For app-level tooling, both ecosystems are large. Rspack targets compatibility with the webpack plugin and loader API, which is the API the Rails/Shakapacker world has built against for years — so the relevant comparison for a React on Rails app is less "Vite plugins vs Rspack plugins" than "does the webpack-contract tooling you already use carry over" (check the [Rspack compatibility documentation](https://rspack.dev/guide/compatibility/plugin) for specific plugins). The plugin that decides our architecture is the RSC manifest/loader tooling described above, and that exists for webpack and rspack only.
+For app-level tooling, both ecosystems are large. Rspack targets compatibility with the webpack plugin and loader API, which is the API the Rails/Shakapacker world has built against for years — so the relevant comparison for a React on Rails app is less "Vite plugins vs Rspack plugins" than "does the webpack-contract tooling you already use carry over" (check the [Rspack compatibility documentation](https://rspack.dev/plugins/community-plugin-compatibility) for specific plugins). The plugin that decides our architecture is the RSC manifest/loader tooling described above, and that exists for webpack and rspack only.
 
 ### "Everyone uses Vite — you're swimming upstream"
 

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -104,7 +104,7 @@ To test RSC with Rspack in your project:
 
 1. **React on Rails does not use Rspack's experimental native RSC system**:
    As of Rspack v2, Rspack ships its own [built-in RSC
-   support](https://v2.rspack.rs/guide/tech/rsc) (driven by `builtin:swc-loader` and
+   support](https://rspack.rs/guide/integrations/rsc) (driven by `builtin:swc-loader` and
    `rspackExperiments.reactServerComponents`). React on Rails Pro does **not** use that
    experimental path. Its RSC integration is built on the `react-on-rails-rsc` package:
    manifest generation uses the native **`RSCRspackPlugin`** (standard rspack public APIs,
@@ -154,6 +154,6 @@ builds; production-posture coverage is tracked in
 - [Issue #3488: Rspack RSC path to production-ready (native RSCRspackPlugin)](https://github.com/shakacode/react_on_rails/issues/3488)
 - [Issue #1828: Rspack support for RSC](https://github.com/shakacode/react_on_rails/issues/1828)
 - [PR #3385: Manifest-helper approach for Rspack builds (superseded by the native plugin)](https://github.com/shakacode/react_on_rails/pull/3385)
-- [Rspack v2 React Server Components guide](https://v2.rspack.rs/guide/tech/rsc)
+- [Rspack v2 React Server Components guide](https://rspack.rs/guide/integrations/rsc)
 - [Three-bundle architecture](./how-react-server-components-work.md)
 - [Upgrading an existing Pro app to RSC](./upgrading-existing-pro-app.md)


### PR DESCRIPTION
### Summary

Restore working sponsor assets and Rspack documentation links on `release/17.1.0`. These documentation failures block the full link check needed by #5026. This is the first prerequisite in #5042.

### What changed

The README sponsor repair is backported from #5022. Two obsolete Rspack URLs are also corrected in two documentation pages (three occurrences), using the same targets already in #5026. The maintainer approved this one-time docs-only exception to source-atomic backporting. No runtime code, package versions, layout, or CI policy changes.

### How to review and verify

Inspect the URL-only diff in all three files. Verification includes the full hosted Lychee scope, direct checks of the replacement URLs, formatting, and independent review. The unchanged README theme mapping was previously checked in Chrome.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~ — no executable behavior changes; link checks cover the replacement assets.
- [x] Update documentation.
- [x] ~Update CHANGELOG file~ — URL-only documentation repair; no product behavior or package versions change.

### Other Information

This PR is deliberately separate from the JSON compatibility backport. That backport will start from the fresh release tip after this one merges. No tag or package publication is part of this PR.

<details>
<summary>Agent details</summary>

### Commands and results

- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop`: 252 files, zero offenses.
- Prettier check of all three changed documentation files: passed, using the existing installed package binary.
- Current-head `lychee --config .lychee.toml docs/ *.md react_on_rails_pro/*.md` with Lychee 0.23.0: 3,571 URLs, 2,393 OK, zero errors, 1,102 existing exclusions, 76 redirects (1m13s). Independent replay of the full scope also passed; it used the configured cache. Fresh direct requests separately verified both old Rspack URLs return 404 and replacements return 200 with the correct titles.
- `curl --fail --location` for both new SVG URLs: HTTP 200, `image/svg+xml`.
- `git diff --check`: passed. Normal commit and pre-push hooks passed.
- [Hosted Lychee](https://github.com/shakacode/react_on_rails/actions/runs/34448689688/job/102779131772): 3,571 URLs, zero errors on this exact head. Formatting, sidebar, generated-doc validation, required gate, and applicable checks passed; runtime suites were skipped by the normal docs-only selectors.
- README-only source/backport patch IDs match: `f2d17424a31f4b5a4afb2a7104ca50edf0a16d3d`. The additional Rspack URL repair is a distinct commit, not attributed to #5022.

### Exact-head and replay evidence

- Base: `168f2714c6a80718b9feaeb94040856fcbf801f1`.
- Head: `6fc16a46d70a039dba7c9d73b85124bcda626b0f`.
- Canonical launch target: issue #5042. [Approved two-link exception](https://github.com/shakacode/react_on_rails/pull/5043#issuecomment-5614532398); JSON remains a separate backport.
- Source #5022 remains live on fetched `main`; no later README changes at the validation snapshot.
- Changelog classification: `not_user_visible` (product behavior unchanged).
- Local pre-push engine panel and simplify: not applicable to this URL-only documentation repair. Separate maker-distinct task/adversarial QA and current-head hosted review are required.

### QA Evidence

- QA lane: `/root/review_backports`, isolated review of the complete committed three-file diff; coordinator owns the release lease.
- Scope checked: Three-file URL-only release repair; README source provenance, all changed URL targets, full markdown link-scan coverage.
- Tested at: `6fc16a46d70a039dba7c9d73b85124bcda626b0f`.
- Automated checks: worker checks above; independent fresh HTTP checks, SVG theme-fill inspection, source patch parity, diff check, Prettier and full hosted-scope Lychee passed (3,571 URLs, zero errors; independent replay used configured cache). Fresh Rspack old404/new200 checks passed.
- Manual checks: source README sponsor block painted correctly in Chrome dark theme; light asset painted correctly when opened directly.
- User-visible UI change: no — no application UI change; restores documentation image URLs without changing layout or interaction.
- Visual evidence: [rendered source README](https://github.com/shakacode/react_on_rails/blob/f8e0be41088aa8576c9a5d5b23f93c6d8236c090/README.md#supporters), supplementary painted check.
- Interaction change: no — same sponsor navigation target and layout.
- Interaction evidence: not applicable; navigation behavior unchanged.
- Visual fix: no application visual fix; documentation asset reachability repaired.
- Negative control: source link failures recorded in #5022 and current release CI on #5026.
- Performance evidence: not applicable; no application runtime or asset-bundling change.
- Findings: none. Independent full-diff adversarial/task review is clean; task reducer reports `task_complete` with canonical diff byte equality.
- QA required: yes.
- QA required rationale: release-targeted backport requires maker-distinct verification.
- QA lane status: satisfied.
- Release-blocking status: local QA and hosted CI/reviews clear; final merge-assurance replay remains required.
- Process-gap disposition: checklist+replay — the earlier README-only scan missed failures in the full hosted scope; replay the full workflow command here. Non-goal: new CI policy or generic process machinery.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 6fc16a46d70a039dba7c9d73b85124bcda626b0f
tested_at: 6fc16a46d70a039dba7c9d73b85124bcda626b0f
scope: README source-identical backport of PR5022 plus approved two-URL Rspack repair
automated_checks: independent live URL and SVG fill checks, Prettier, diff-check, source patch-id and single-footer verification; full hosted-scope Lychee3571 URLs0errors; fresh Rspack old404/new200 negative controls
manual_checks: coordinator Chrome source README paint check; independent old URL failure reproduction
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: documentation URL repair, no application UI or layout change
paint_check: not applicable: no application UI change; supplementary documentation paint inspection is recorded above
interaction_change: no
interaction_evidence: not applicable: sponsor navigation target unchanged
visual_fix: no
negative_control: not applicable: no application visual fix; original asset TLS failures independently reproduced
performance_impact: not_applicable
performance_evidence: not applicable: no runtime or bundling changes
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

<!-- priority-finding-dispositions v1
head_sha: 6fc16a46d70a039dba7c9d73b85124bcda626b0f
status: not_applicable
-->

### Coordination and reviewer telemetry

One release coordinator serializes writes under `release-line:17.1.0`. Maker `/root/backport_5042`; checker `/root/review_backports`. Host Codex; observed model/effort UNKNOWN. One explicit maintainer-approved two-URL scope exception; no runtime adaptation. Current-head [Claude review](https://github.com/shakacode/react_on_rails/pull/5043#issuecomment-5614621009) and [CodeRabbit review](https://github.com/shakacode/react_on_rails/pull/5043#issuecomment-5614059941) are clean. [Review dispositions](https://github.com/shakacode/react_on_rails/pull/5043#issuecomment-5614671477) retain the accurate Rspack v2 label without a polish commit. No unresolved review threads. The skipped automatic Claude workflow is not counted; the completed comment-triggered review provides actual coverage.

### Merge confidence

Phase `rc`, mode `strict-rc`. High implementation confidence for this exact URL-only diff; merge remains subject to current-head gates and source-liveness recheck.

</details>

(cherry picked from commit f8e0be41088aa8576c9a5d5b23f93c6d8236c090)
