### PR TITLE
Fix: backport JSON compatibility for release/17.1.0

### DIFF
--- a/react_on_rails/rakelib/shakapacker_examples.rake
+++ b/react_on_rails/rakelib/shakapacker_examples.rake
@@ -196,6 +196,14 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
       sh_in_dir(example_type.dir, "touch .gitignore")
       sh_in_dir(example_type.dir,
                 "echo \"gem 'react_on_rails', path: '#{relative_gem_root}'\" >> #{example_type.gemfile}")
+      # json 3.0.0 (2026-09-07) raises ArgumentError on unknown keywords, and Rails < 8.1
+      # ActiveSupport still passes the removed quirks_mode: option to JSON.generate
+      # (fixed upstream in rails/rails#55534; released only in Rails >= 8.1.0).
+      # Self-retires when example apps generate on Rails >= 8.1; also removable if a
+      # json 3.x release restores tolerance for removed keywords.
+      if Gem::Version.new(Rails.version) < Gem::Version.new("8.1")
+        File.write(example_type.gemfile, "gem 'json', '>= 2', '< 3'\n", mode: "a")
+      end
       # Shakapacker is automatically included as a dependency via react_on_rails.gemspec (>= 6.0)
       bundle_install_in(example_type.dir)
       # Use unbundled_sh_in_dir to ensure we're using the generated app's Gemfile

--- a/react_on_rails/spec/react_on_rails/shakapacker_examples_rake_spec.rb
+++ b/react_on_rails/spec/react_on_rails/shakapacker_examples_rake_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe "shakapacker_examples rake helpers" do
   end
 
   describe "pinned React example generation" do
-    let(:example_dir) { "/tmp/example-app" }
+    let(:example_dir) { Dir.mktmpdir("ror-example-app-") }
+    let(:generated_gemfile) { "source 'https://rubygems.org'\ngem 'rails'\n" }
     let(:example_type) do
       instance_double(
         ReactOnRails::TaskHelpers::ExampleType,
@@ -94,6 +95,7 @@ RSpec.describe "shakapacker_examples rake helpers" do
     end
 
     before do
+      File.write(example_type.gemfile, generated_gemfile)
       Rake::Task.clear
       allow(ReactOnRails::TaskHelpers::ExampleType).to receive(:all).and_return(
         { shakapacker_examples: [example_type] }
@@ -106,7 +108,10 @@ RSpec.describe "shakapacker_examples rake helpers" do
       allow(task_context).to receive(:sh_in_dir)
       allow(task_context).to receive(:unbundled_sh_in_dir)
       allow(task_context).to receive(:apply_react_version)
+      allow(Rails).to receive(:version).and_return("8.0.4")
     end
+
+    after { FileUtils.remove_entry(example_dir) }
 
     it "pins shakapacker after the pinned React branch bundle install and before npm install" do
       bundle_install_calls = 0
@@ -123,6 +128,22 @@ RSpec.describe "shakapacker_examples rake helpers" do
         .ordered
 
       Rake::Task["shakapacker_examples:gen_example_app"].invoke
+    end
+
+    ["8.0.4", "8.1.0", "8.2.0"].each do |rails_version|
+      it "writes the appropriate JSON pin before bundling on Rails #{rails_version}" do
+        allow(Rails).to receive(:version).and_return(rails_version)
+        expected_gemfile = generated_gemfile.dup
+        expected_gemfile << "gem 'json', '>= 2', '< 3'\n" if rails_version == "8.0.4"
+
+        expect(task_context).to receive(:bundle_install_in).with(example_dir).exactly(3).times do
+          expect(File.read(example_type.gemfile)).to eq(expected_gemfile)
+        end
+
+        Rake::Task["shakapacker_examples:gen_example_app"].invoke
+
+        expect(File.read(example_type.gemfile)).to eq(expected_gemfile)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Restore generated-example CI on `release/17.1.0` by backporting #5033. JSON 3 removes an option that Rails versions below 8.1 still pass, causing `unknown keyword: quirks_mode`. This is the second prerequisite in #5042, after merged #5043, and unblocks validation of #5026.

### What changed

Generated CI example apps use `json >= 2, < 3` when Rails is below 8.1. Rails 8.1 and later keep their existing dependency resolution. This is a source-identical backport; it does not change the public app generator, product versions, lockfiles, or GitHub Actions definitions.

### How to review and verify

Check that the pin is added before Bundler runs and applies only to older Rails. The focused test matrix covers Rails 8.0.4, 8.1.0, and 8.2.0 in isolated temporary directories. Source and backport patch IDs must match.

### Pull Request checklist

- [x] Add/update test to cover these changes.
- [x] ~Update documentation~ — no public API or installation change.
- [x] ~Update CHANGELOG file~ — internal CI example-generation repair, no product behavior change.

### Other Information

Tracks #5042. #5026 will refresh onto the release branch only after this prerequisite merges. No tag, package publication, or deployment is part of this PR.

<details>
<summary>Agent details</summary>

### Commands and results

- `cd react_on_rails && bundle exec rspec spec/react_on_rails/shakapacker_examples_rake_spec.rb`: 7 examples, zero failures on committed head. Removing only the implementation pin makes the new Rails 8.0.4 assertion fail (7 examples, one expected failure); restoring it returns to green. Rails 8.1/8.2 no-pin cases remain green.
- Real CLI negative control: ActiveSupport 7.2.3.2 with JSON 3.0.1 raises `unknown keyword: quirks_mode`. The same serialization with the exact `>= 2, < 3` constraint selects JSON 2.21.2 and succeeds. No package installations or lockfile changes were needed. This is a library-level reproduction, not a full app test.
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop`: 252 files, zero offenses. Normal commit hooks passed.
- `git diff --check`: passed. Two complete file blobs are source-identical; stable source/backport patch ID is `6695b2a114918018f490bfcfda03fcf50934b4e3`. Exactly one direct source footer is retained.
- The broad generated-app matrix was not run locally (estimated 20–40+ minutes with package installation). It passed in hosted CI on this exact head: [latest dependencies, Ruby 4.0](https://github.com/shakacode/react_on_rails/actions/runs/34452145875/job/102790307174) and [minimum dependencies / React 16, 17, 18, Ruby 3.3](https://github.com/shakacode/react_on_rails/actions/runs/34452145875/job/102790307286).
- Final hosted snapshot: 45 successful checks and one normal docs-format skip. All nine release-hosted workflow groups passed, including generated examples, all six package-generator shards, Webpack/Rspack integrations, Pro tests, Node renderer, Playwright, lint, and precompilation. Marking ready superseded the earlier draft-event runs on the same head; their cancelled jobs are not used as evidence.
- Normal pre-push branch lint and link hooks passed. No CI waiver or force-full override was used; the release-target policy selected the full hosted matrix automatically.

### Local review

- `codex review --base 08089e9883171e19331599c122addfb781fa19f4`: no actionable findings; the reviewer also ran the focused seven-example suite successfully.
- Report-only local Claude review of the complete committed two-file diff: no blocker. Its access was limited to supplied diff text. Source inspection answers its verification questions: the rake file explicitly requires `rails/version`; the spec already requires `tmpdir`; generated Gemfile paths are absolute; normal `rails new` runs within the active bundle with no Rails-version rewrite; this task is the source patch's complete intended CI surface.
- `/simplify origin/release/17.1.0...HEAD`, requested repository default `claude-opus-4-8`, $20 cap: keep as-is; no worthwhile behavior-preserving simplification. The first no-tool attempt stopped without a verdict and was not counted. A bounded read-only retry inspected both files and completed all simplification lenses inline; no Agent-tool fan-out was available. No code or plan files changed.
- Optional suggestions about fixture naming, additional version cases, and install-count style were declined as unnecessary backport churn. The duplicate-append concern does not apply to the normal task, which clobbers before generation. No code changed during review.
- Risk coverage: correctness, security, compatibility, test isolation, and release scope checked. No persistent-data, application performance, UI, or GitHub Actions definition change. These local reviews do not replace current-head hosted review.

### Exact-head and replay evidence

- Base: `08089e9883171e19331599c122addfb781fa19f4`.
- Head: `3ea45483f0ed168cb08046d56e27c593cb93cfb5`.
- Source: #5033, `1898ef51b15e677f5d965f799e5e52a6f7e798aa`.
- Source liveness rechecked against fetched `main` at `e560acddc87d03e239a1fe4c813a238ea5024f8c`: the source commit is retained, with no later changes to either backported path.
- Changelog classification: `not_user_visible`.

### QA Evidence

Independent reviewer `/root/review_backports` checked the complete two-file diff, source provenance, actual task-loading path, mocked version matrix, and real JSON serialization failure. The reviewer independently ran the focused suite (7 passed), reproduced JSON 3 failure / JSON 2 success, and confirmed normal Rake loading plus matching Rails library/CLI versions. Maker-only negative-control source mutation is identified separately above.

The exact task review is complete with no findings. Raw canonical diff equality was verified with the same explicit Git 2.54.0 binary; Apple Git 2.50.1 abbreviates object IDs differently. This was a capture-format difference, not a code change. Local application, browser, full generated-app, and Linux-parity tests were not run. The hosted generator matrix and the remaining selected release suites now passed as recorded above.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 3ea45483f0ed168cb08046d56e27c593cb93cfb5
tested_at: 3ea45483f0ed168cb08046d56e27c593cb93cfb5
scope: source-identical two-file CI example generation JSON compatibility backport
automated_checks: independent focused RSpec7passed; normal rake taskload; source blobs and patch-id parity; clean diff; maker Ruby lint252files0offenses; full hosted latest/minimum generated-app matrix and all selected release suites passed at this head
manual_checks: independent installed ActiveSupport7.2.3.2 JSON3.0.1 serialization failure and same process recipe with JSON2.21.2 success; observed Rails library and CLI versions agree
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: internal CI fixture dependency selection only
paint_check: not applicable: no rendered application UI change
interaction_change: no
interaction_evidence: not applicable: no user interaction change
visual_fix: no
negative_control: not applicable: no visual fix; library failure reproduced separately above
performance_impact: not_applicable
performance_evidence: not applicable: no product runtime or asset performance change
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

<!-- priority-finding-dispositions v1
head_sha: 3ea45483f0ed168cb08046d56e27c593cb93cfb5
status: not_applicable
-->

### Coordination and confidence

One coordinator serializes release writes; maker and checker are separate. Observed model/effort are UNKNOWN where the host does not expose them. Phase `rc`, mode `strict-rc`; no CI or review waiver. Strong local implementation evidence does not imply merge readiness. Process-gap disposition: `checklist+replay` — use the existing exact-head QA record validator before merge after the earlier docs PR exposed invalid metadata syntax; no new process mechanism.

### Current-head hosted review

[Claude](https://github.com/shakacode/react_on_rails/pull/5044#issuecomment-5615037838), [CodeRabbit](https://github.com/shakacode/react_on_rails/pull/5044#issuecomment-5615001340), [Greptile](https://github.com/shakacode/react_on_rails/pull/5044#issuecomment-5615120933), and [Codex](https://github.com/shakacode/react_on_rails/pull/5044#issuecomment-5615092684) completed reviews of `3ea45483f0ed168cb08046d56e27c593cb93cfb5` with no actionable findings. Consolidated full-PR review inventory: zero inline comments, zero review threads, zero formal review objects. AI summaries are review evidence, not human approvals. Hosted validation is complete; exact-head merge-assurance replay remains required immediately before queue submission.

</details>

(cherry picked from commit 1898ef51b15e677f5d965f799e5e52a6f7e798aa)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated example applications now use a compatible JSON dependency with Rails versions older than 8.1, preventing setup and runtime errors related to JSON generation.
* **Tests**
  * Added coverage across supported Rails versions to verify dependency configuration before and after bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
