### PR TITLE
Docs: exercise Rails DX benchmark workflow

### DIFF
--- a/benchmarks/rspack-vite-rails-dx/README.md
+++ b/benchmarks/rspack-vite-rails-dx/README.md
@@ -7,6 +7,8 @@ This package supplies the Rails-level evidence requested by issue #4695 and the 
 
 Both starters use React 19.0.4 and the same minimal stateful component. Their committed Ruby and pnpm lockfiles make the package replayable. [PROVENANCE.md](PROVENANCE.md) records the generation commands and the small alignment edits made after generation.
 
+The committed checks validate the recorded artifact without running a new benchmark.
+
 ## What it measures
 
 The harness records at least five samples per stack for:


### PR DESCRIPTION
## Why

This draft verification PR exercises the post-merge workflow follow-up for #5013. It changes only benchmark documentation so the Benchmark workflow runs on a pull request.

## What changed

- Adds one nonfunctional sentence to the Rails DX benchmark README.

## Validation

- `pnpm exec prettier --check README.md`
- `pnpm run check` in `benchmarks/rspack-vite-rails-dx` — six tests and deterministic report replay pass.
- `git diff --check`
- Pre-push branch lint and online Markdown link check.