### PR TITLE
Fix local Lychee version mismatch guard

### DIFF
--- a/bin/lefthook/markdown-link-lint
+++ b/bin/lefthook/markdown-link-lint
@@ -28,6 +28,17 @@ if ! command -v lychee &> /dev/null; then
   exit 0
 fi
 
+required_lychee_version="0.23.0"
+lychee_version="$(lychee --version 2>&1 || true)"
+if [ "$lychee_version" != "lychee ${required_lychee_version}" ]; then
+  echo "⚠️  lychee version mismatch; skipping ${mode_label} Markdown link check." >&2
+  echo "   Found: ${lychee_version:-unable to determine}" >&2
+  echo "   Required: lychee ${required_lychee_version} (matches CI)" >&2
+  echo "   Install with: cargo install lychee --version ${required_lychee_version}" >&2
+  echo "   Or run bin/check-links manually with lychee ${required_lychee_version}." >&2
+  exit 0
+fi
+
 files_arr=()
 while IFS= read -r file; do
   [ -n "$file" ] && files_arr+=("$file")

--- a/react_on_rails/spec/react_on_rails/markdown_link_lint_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/markdown_link_lint_script_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tmpdir"
+require_relative "spec_helper"
+
+RSpec.describe "bin/lefthook/markdown-link-lint" do
+  let(:repo_root) { File.expand_path("../../..", __dir__) }
+  let(:hook_path) { File.join(repo_root, "bin/lefthook/markdown-link-lint") }
+
+  it "skips an incompatible lychee version with an actionable warning" do
+    _stdout, stderr, status = run_hook("lychee 0.24.2")
+
+    expect(status).to be_success
+    expect(stderr).to include("lychee version mismatch; skipping offline Markdown link check.")
+    expect(stderr).to include("Found: lychee 0.24.2")
+    expect(stderr).to include("Required: lychee 0.23.0 (matches CI)")
+  end
+
+  it "keeps the missing lychee skip behavior" do
+    _stdout, stderr, status = run_hook(nil)
+
+    expect(status).to be_success
+    expect(stderr).to include("lychee is not installed; skipping offline Markdown link check.")
+  end
+
+  it "runs the CI-compatible lychee version" do
+    Dir.mktmpdir do |tmpdir|
+      args_file = File.join(tmpdir, "lychee.args")
+      _stdout, stderr, status = run_hook("lychee 0.23.0", args_file:)
+
+      expect(status).to be_success, stderr
+      expect(File.read(args_file).lines.map(&:chomp)).to eq(["--config", ".lychee.toml", "--offline", "README.md"])
+    end
+  end
+
+  def run_hook(version, args_file: nil)
+    Dir.mktmpdir do |tmpdir|
+      write_hook_fixture(tmpdir, version)
+      path = [File.join(tmpdir, "fake-bin"), version ? ENV.fetch("PATH") : "/usr/bin:/bin"].join(":")
+      environment = { "PATH" => path }
+      environment["LYCHEE_ARGS_FILE"] = args_file if args_file
+
+      return Open3.capture3(
+        environment,
+        "bin/lefthook/markdown-link-lint",
+        "all-changed",
+        "--offline",
+        chdir: tmpdir
+      )
+    end
+  end
+
+  def write_hook_fixture(directory, version)
+    hook_directory = File.join(directory, "bin/lefthook")
+    fake_bin = File.join(directory, "fake-bin")
+    FileUtils.mkdir_p([hook_directory, fake_bin])
+    File.symlink(hook_path, File.join(hook_directory, "markdown-link-lint"))
+    File.write(File.join(hook_directory, "ensure-mise"), ":\n")
+    write_executable(File.join(hook_directory, "get-changed-files"), "printf 'README.md\\n'\n")
+    File.write(File.join(directory, "README.md"), "# fixture\n")
+    return unless version
+
+    write_executable(
+      File.join(fake_bin, "lychee"),
+      <<~BASH
+        if [ "${1:-}" = "--version" ]; then
+          echo "#{version}"
+        elif [ -n "${LYCHEE_ARGS_FILE:-}" ]; then
+          printf '%s\\n' "$@" > "$LYCHEE_ARGS_FILE"
+        fi
+      BASH
+    )
+  end
+
+  def write_executable(path, body)
+    File.write(path, "#!/usr/bin/env bash\n#{body}")
+    FileUtils.chmod("+x", path)
+  end
+end


### PR DESCRIPTION
## Why

The local Markdown-link lefthook ran any installed Lychee while CI remains pinned to v0.23.0. Lychee 0.24.x rejects the current include_fragments setting, causing a raw TOML parse error and encouraging contributors to use --no-verify.

## What changed

- Skip the local link check with an actionable warning unless lychee --version is exactly 0.23.0, matching CI.
- Preserve the missing-binary skip and run the existing link-check command for the compatible version.
- Add focused hook-level regression coverage for incompatible, missing, and compatible binaries.

## Scope

CI remains pinned to Lychee v0.23.0 and its existing link-check inputs are unchanged. This deliberately does not expand internal Markdown coverage.

Fixes #5012

## Verification

- cd react_on_rails && bundle exec rspec spec/react_on_rails/markdown_link_lint_script_spec.rb
- cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop spec/react_on_rails/markdown_link_lint_script_spec.rb
- bash -n bin/lefthook/markdown-link-lint
- shellcheck -x bin/lefthook/markdown-link-lint (only the existing dynamic-source SC1091 informational notice)
- Local pre-commit and pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect local git-hook link linting; CI behavior is unchanged and failures are avoided via skip-with-warning rather than blocking commits incorrectly.
> 
> **Overview**
> The local lefthook Markdown link check now **requires Lychee `0.23.0`**, aligned with CI, instead of running whatever version is on `PATH`. If `lychee --version` is not exactly `lychee 0.23.0`, the hook **exits successfully** and prints install/run guidance—same pattern as when Lychee is missing—so newer releases (e.g. 0.24.x) no longer fail the hook with config parse errors.
> 
> **Tests** add hook-level coverage for incompatible versions, missing binary, and the compatible case (including expected `lychee` CLI args).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299a5e8ed8ce628e63b3236c7e4c21e35d4131f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown link checking now verifies that the supported Lychee version is installed before running.
  * Incompatible or unavailable versions are reported with a clear warning, and link checking is skipped instead of running with unexpected behavior.
* **Tests**
  * Added coverage for supported versions, incompatible versions, missing installations, warning messages, and link-checking arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->