### PR TITLE
Fix docs-only CI guard after descendant workflow success

### DIFF
--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -404,7 +404,7 @@ async function checkPreviousMainCommitStatus({
 
   const guardOnlyTrail = [];
   const noRunsTrail = [];
-  const successfulDescendantJobsByWorkflow = new Map();
+  const successfulDescendantJobSetsByWorkflow = new Map();
 
   async function checkSha(shaToCheck, remainingGuardOnlyHops, remainingNoRunsHops) {
     if (remainingGuardOnlyHops <= 0 || remainingNoRunsHops <= 0) {
@@ -518,18 +518,20 @@ async function checkPreviousMainCommitStatus({
     }
 
     const isSupersededByDescendant = ({ run, failedJobNames, ambiguousJobNames }) => {
-      const successfulJobNames = successfulDescendantJobsByWorkflow.get(run.workflow_id);
+      const successfulJobNameSets = successfulDescendantJobSetsByWorkflow.get(run.workflow_id);
 
       return (
         isValidWorkflowId(run.workflow_id) &&
-        successfulJobNames !== undefined &&
+        successfulJobNameSets !== undefined &&
         failedJobNames.length > 0 &&
-        failedJobNames.every(
-          (jobName) =>
-            typeof jobName === 'string' &&
-            jobName.length > 0 &&
-            !ambiguousJobNames.has(jobName) &&
-            successfulJobNames.has(jobName),
+        successfulJobNameSets.some((successfulJobNames) =>
+          failedJobNames.every(
+            (jobName) =>
+              typeof jobName === 'string' &&
+              jobName.length > 0 &&
+              !ambiguousJobNames.has(jobName) &&
+              successfulJobNames.has(jobName),
+          ),
         )
       );
     };
@@ -585,11 +587,9 @@ async function checkPreviousMainCommitStatus({
       `Main commit ${shaToCheck} only has docs-only guard failures. Checking first parent ${parentSha} for the underlying CI state.`,
     );
     for (const [workflowId, jobNames] of result.successfulJobsByWorkflow) {
-      const accumulatedJobNames = successfulDescendantJobsByWorkflow.get(workflowId) || new Set();
-      for (const jobName of jobNames) {
-        accumulatedJobNames.add(jobName);
-      }
-      successfulDescendantJobsByWorkflow.set(workflowId, accumulatedJobNames);
+      const successfulJobNameSets = successfulDescendantJobSetsByWorkflow.get(workflowId) || [];
+      successfulJobNameSets.push(jobNames);
+      successfulDescendantJobSetsByWorkflow.set(workflowId, successfulJobNameSets);
     }
     guardOnlyTrail.push({ sha: shaToCheck, runs: result.guardOnlyRuns });
     await checkSha(parentSha, remainingGuardOnlyHops - 1, remainingNoRunsHops);

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -235,7 +235,11 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
       const failed = failedJobs(latestJobs);
 
       if (failed.length === 0) {
-        return { kind: 'passing' };
+        const hasSuccessfulJob = latestJobs.some((job) => job.conclusion === 'success');
+        return {
+          kind: 'passing',
+          successfulWorkflowId: run.conclusion === 'success' && hasSuccessfulJob ? run.workflow_id : null,
+        };
       }
 
       warnForMissingGuardSteps({ core, run, jobs: latestJobs });
@@ -248,12 +252,15 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
   );
   const failingRuns = [];
   const guardOnlyRuns = [];
+  const successfulWorkflowIds = [];
 
   for (const runResult of completedRunResults) {
     if (runResult.kind === 'failing') {
       failingRuns.push(runResult.run);
     } else if (runResult.kind === 'guard-only') {
       guardOnlyRuns.push(runResult.run);
+    } else if (runResult.successfulWorkflowId !== null) {
+      successfulWorkflowIds.push(runResult.successfulWorkflowId);
     }
   }
 
@@ -263,6 +270,7 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
     incompleteRuns,
     failingRuns,
     guardOnlyRuns,
+    successfulWorkflowIds,
   };
 }
 
@@ -349,6 +357,7 @@ async function checkPreviousMainCommitStatus({
 
   const guardOnlyTrail = [];
   const noRunsTrail = [];
+  const successfulDescendantWorkflowIds = new Set();
 
   async function checkSha(shaToCheck, remainingGuardOnlyHops, remainingNoRunsHops) {
     if (remainingGuardOnlyHops <= 0 || remainingNoRunsHops <= 0) {
@@ -461,8 +470,15 @@ async function checkPreviousMainCommitStatus({
       );
     }
 
-    if (result.failingRuns.length > 0) {
-      const details = result.failingRuns.map(summarizeRun).join('\n');
+    const supersededFailingRuns = result.failingRuns.filter((run) =>
+      successfulDescendantWorkflowIds.has(run.workflow_id),
+    );
+    const unresolvedFailingRuns = result.failingRuns.filter(
+      (run) => !successfulDescendantWorkflowIds.has(run.workflow_id),
+    );
+
+    if (unresolvedFailingRuns.length > 0) {
+      const details = unresolvedFailingRuns.map(summarizeRun).join('\n');
 
       core.setFailed(
         [
@@ -480,7 +496,11 @@ async function checkPreviousMainCommitStatus({
     }
 
     if (result.guardOnlyRuns.length === 0) {
-      if (result.incompleteRuns.length > 0) {
+      if (supersededFailingRuns.length > 0) {
+        core.info(
+          `Main commit ${shaToCheck} has ${supersededFailingRuns.length} failure(s) superseded by a successful descendant run for the same workflow. Docs-only skip allowed.`,
+        );
+      } else if (result.incompleteRuns.length > 0) {
         core.info(
           `Main commit ${shaToCheck} has ${result.incompleteRuns.length} running workflow(s) but no completed failures. Docs-only skip allowed.`,
         );
@@ -501,6 +521,9 @@ async function checkPreviousMainCommitStatus({
     core.info(
       `Main commit ${shaToCheck} only has docs-only guard failures. Checking first parent ${parentSha} for the underlying CI state.`,
     );
+    for (const workflowId of result.successfulWorkflowIds) {
+      successfulDescendantWorkflowIds.add(workflowId);
+    }
     guardOnlyTrail.push({ sha: shaToCheck, runs: result.guardOnlyRuns });
     await checkSha(parentSha, remainingGuardOnlyHops - 1, remainingNoRunsHops);
   }

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -1,6 +1,7 @@
 const FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'action_required']);
 const GUARD_JOB_NAME = 'detect-changes';
 const GUARD_STEP_NAME = 'Guard docs-only main pushes';
+const ORCHESTRATION_JOB_NAMES = new Set([GUARD_JOB_NAME, 'setup-integration-matrix', 'setup-matrix']);
 const TRUSTED_RUN_EVENTS = new Set(['push', 'merge_group']);
 const MAX_GUARD_ONLY_HOPS = 10;
 const MAX_NO_RUNS_HOPS = 50;
@@ -16,10 +17,22 @@ function summarizeRun(run) {
   return `- [${run.name} #${run.run_number}](${run.html_url}) concluded ${run.conclusion}`;
 }
 
+function isValidWorkflowId(workflowId) {
+  return Number.isSafeInteger(workflowId) && workflowId > 0;
+}
+
 function latestRunsByWorkflow(workflowRuns) {
   const latestByWorkflow = new Map();
 
   for (const run of workflowRuns) {
+    if (!isValidWorkflowId(run.workflow_id)) {
+      const error = new TypeError(
+        `Expected workflow run ${run.id ?? 'UNKNOWN'} to have a positive safe integer workflow_id.`,
+      );
+      error.unexpectedGithubApiResponse = true;
+      throw error;
+    }
+
     const existing = latestByWorkflow.get(run.workflow_id);
     if (
       !existing ||
@@ -31,10 +44,6 @@ function latestRunsByWorkflow(workflowRuns) {
   }
 
   return latestByWorkflow;
-}
-
-function isValidWorkflowId(workflowId) {
-  return Number.isSafeInteger(workflowId) && workflowId > 0;
 }
 
 function latestAttemptJobs(jobs) {
@@ -63,6 +72,10 @@ function isGuardOnlyFailure(jobs) {
       return failedSteps.length > 0 && failedSteps.every((step) => step.name === GUARD_STEP_NAME);
     })
   );
+}
+
+function isSuccessfulQualityGateJob(job) {
+  return job.conclusion === 'success' && !ORCHESTRATION_JOB_NAMES.has(job.name);
 }
 
 function githubApiErrorStatus(error) {
@@ -239,9 +252,7 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
       const failed = failedJobs(latestJobs);
 
       if (failed.length === 0) {
-        const hasSuccessfulSubstantiveJob = latestJobs.some(
-          (job) => job.name !== GUARD_JOB_NAME && job.conclusion === 'success',
-        );
+        const hasSuccessfulSubstantiveJob = latestJobs.some(isSuccessfulQualityGateJob);
         return {
           kind: 'passing',
           successfulWorkflowId:

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -33,6 +33,10 @@ function latestRunsByWorkflow(workflowRuns) {
   return latestByWorkflow;
 }
 
+function isValidWorkflowId(workflowId) {
+  return Number.isSafeInteger(workflowId) && workflowId > 0;
+}
+
 function latestAttemptJobs(jobs) {
   const latestAttempt = Math.max(...jobs.map((job) => job.run_attempt));
   return jobs.filter((job) => job.run_attempt === latestAttempt);
@@ -235,10 +239,15 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
       const failed = failedJobs(latestJobs);
 
       if (failed.length === 0) {
-        const hasSuccessfulJob = latestJobs.some((job) => job.conclusion === 'success');
+        const hasSuccessfulSubstantiveJob = latestJobs.some(
+          (job) => job.name !== GUARD_JOB_NAME && job.conclusion === 'success',
+        );
         return {
           kind: 'passing',
-          successfulWorkflowId: run.conclusion === 'success' && hasSuccessfulJob ? run.workflow_id : null,
+          successfulWorkflowId:
+            run.conclusion === 'success' && isValidWorkflowId(run.workflow_id) && hasSuccessfulSubstantiveJob
+              ? run.workflow_id
+              : null,
         };
       }
 
@@ -470,11 +479,11 @@ async function checkPreviousMainCommitStatus({
       );
     }
 
-    const supersededFailingRuns = result.failingRuns.filter((run) =>
-      successfulDescendantWorkflowIds.has(run.workflow_id),
+    const supersededFailingRuns = result.failingRuns.filter(
+      (run) => isValidWorkflowId(run.workflow_id) && successfulDescendantWorkflowIds.has(run.workflow_id),
     );
     const unresolvedFailingRuns = result.failingRuns.filter(
-      (run) => !successfulDescendantWorkflowIds.has(run.workflow_id),
+      (run) => !isValidWorkflowId(run.workflow_id) || !successfulDescendantWorkflowIds.has(run.workflow_id),
     );
 
     if (unresolvedFailingRuns.length > 0) {

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -75,7 +75,24 @@ function isGuardOnlyFailure(jobs) {
 }
 
 function isSuccessfulQualityGateJob(job) {
-  return job.conclusion === 'success' && !ORCHESTRATION_JOB_NAMES.has(job.name);
+  return (
+    job.conclusion === 'success' &&
+    typeof job.name === 'string' &&
+    job.name.length > 0 &&
+    !ORCHESTRATION_JOB_NAMES.has(job.name)
+  );
+}
+
+function jobNameCounts(jobs) {
+  const counts = new Map();
+
+  for (const job of jobs) {
+    if (typeof job.name === 'string' && job.name.length > 0) {
+      counts.set(job.name, (counts.get(job.name) || 0) + 1);
+    }
+  }
+
+  return counts;
 }
 
 function githubApiErrorStatus(error) {
@@ -250,15 +267,21 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
 
       const latestJobs = latestAttemptJobs(jobs);
       const failed = failedJobs(latestJobs);
+      const nameCounts = jobNameCounts(latestJobs);
 
       if (failed.length === 0) {
-        const hasSuccessfulSubstantiveJob = latestJobs.some(isSuccessfulQualityGateJob);
+        const successfulJobNames = latestJobs
+          .filter((job) => isSuccessfulQualityGateJob(job) && nameCounts.get(job.name) === 1)
+          .map((job) => job.name);
         return {
           kind: 'passing',
           successfulWorkflowId:
-            run.conclusion === 'success' && isValidWorkflowId(run.workflow_id) && hasSuccessfulSubstantiveJob
+            run.conclusion === 'success' &&
+            isValidWorkflowId(run.workflow_id) &&
+            successfulJobNames.length > 0
               ? run.workflow_id
               : null,
+          successfulJobNames,
         };
       }
 
@@ -267,20 +290,24 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
       return {
         kind: isGuardOnlyFailure(latestJobs) ? 'guard-only' : 'failing',
         run,
+        failedJobNames: failed.map((job) => job.name),
+        ambiguousJobNames: new Set(
+          Array.from(nameCounts, ([jobName, count]) => (count > 1 ? jobName : null)).filter(Boolean),
+        ),
       };
     }),
   );
-  const failingRuns = [];
+  const failingRunResults = [];
   const guardOnlyRuns = [];
-  const successfulWorkflowIds = [];
+  const successfulJobsByWorkflow = new Map();
 
   for (const runResult of completedRunResults) {
     if (runResult.kind === 'failing') {
-      failingRuns.push(runResult.run);
+      failingRunResults.push(runResult);
     } else if (runResult.kind === 'guard-only') {
       guardOnlyRuns.push(runResult.run);
     } else if (runResult.successfulWorkflowId !== null) {
-      successfulWorkflowIds.push(runResult.successfulWorkflowId);
+      successfulJobsByWorkflow.set(runResult.successfulWorkflowId, new Set(runResult.successfulJobNames));
     }
   }
 
@@ -288,9 +315,9 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
     status: 'runs-found',
     workflowRuns,
     incompleteRuns,
-    failingRuns,
+    failingRunResults,
     guardOnlyRuns,
-    successfulWorkflowIds,
+    successfulJobsByWorkflow,
   };
 }
 
@@ -377,7 +404,7 @@ async function checkPreviousMainCommitStatus({
 
   const guardOnlyTrail = [];
   const noRunsTrail = [];
-  const successfulDescendantWorkflowIds = new Set();
+  const successfulDescendantJobsByWorkflow = new Map();
 
   async function checkSha(shaToCheck, remainingGuardOnlyHops, remainingNoRunsHops) {
     if (remainingGuardOnlyHops <= 0 || remainingNoRunsHops <= 0) {
@@ -490,12 +517,28 @@ async function checkPreviousMainCommitStatus({
       );
     }
 
-    const supersededFailingRuns = result.failingRuns.filter(
-      (run) => isValidWorkflowId(run.workflow_id) && successfulDescendantWorkflowIds.has(run.workflow_id),
-    );
-    const unresolvedFailingRuns = result.failingRuns.filter(
-      (run) => !isValidWorkflowId(run.workflow_id) || !successfulDescendantWorkflowIds.has(run.workflow_id),
-    );
+    const isSupersededByDescendant = ({ run, failedJobNames, ambiguousJobNames }) => {
+      const successfulJobNames = successfulDescendantJobsByWorkflow.get(run.workflow_id);
+
+      return (
+        isValidWorkflowId(run.workflow_id) &&
+        successfulJobNames !== undefined &&
+        failedJobNames.length > 0 &&
+        failedJobNames.every(
+          (jobName) =>
+            typeof jobName === 'string' &&
+            jobName.length > 0 &&
+            !ambiguousJobNames.has(jobName) &&
+            successfulJobNames.has(jobName),
+        )
+      );
+    };
+    const supersededFailingRuns = result.failingRunResults
+      .filter(isSupersededByDescendant)
+      .map(({ run }) => run);
+    const unresolvedFailingRuns = result.failingRunResults
+      .filter((runResult) => !isSupersededByDescendant(runResult))
+      .map(({ run }) => run);
 
     if (unresolvedFailingRuns.length > 0) {
       const details = unresolvedFailingRuns.map(summarizeRun).join('\n');
@@ -541,8 +584,12 @@ async function checkPreviousMainCommitStatus({
     core.info(
       `Main commit ${shaToCheck} only has docs-only guard failures. Checking first parent ${parentSha} for the underlying CI state.`,
     );
-    for (const workflowId of result.successfulWorkflowIds) {
-      successfulDescendantWorkflowIds.add(workflowId);
+    for (const [workflowId, jobNames] of result.successfulJobsByWorkflow) {
+      const accumulatedJobNames = successfulDescendantJobsByWorkflow.get(workflowId) || new Set();
+      for (const jobName of jobNames) {
+        accumulatedJobNames.add(jobName);
+      }
+      successfulDescendantJobsByWorkflow.set(workflowId, accumulatedJobNames);
     }
     guardOnlyTrail.push({ sha: shaToCheck, runs: result.guardOnlyRuns });
     await checkSha(parentSha, remainingGuardOnlyHops - 1, remainingNoRunsHops);

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.cjs
@@ -306,7 +306,7 @@ async function evaluateCommitRuns({ github, context, core, sha, createdAfter, ex
       failingRunResults.push(runResult);
     } else if (runResult.kind === 'guard-only') {
       guardOnlyRuns.push(runResult.run);
-    } else if (runResult.successfulWorkflowId !== null) {
+    } else if (runResult.kind === 'passing' && runResult.successfulWorkflowId !== null) {
       successfulJobsByWorkflow.set(runResult.successfulWorkflowId, new Set(runResult.successfulJobNames));
     }
   }

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -701,6 +701,76 @@ async function testDuplicateSuccessfulAndSkippedJobNamesDoNotSupersedeFailure() 
   assert.match(core.failed[0], /Integration Tests #68/);
 }
 
+async function testPartialSuccessAcrossDescendantsDoesNotSupersedeCombinedFailure() {
+  // Production break: separate descendant runs each pass only one job, but
+  // unioning their evidence incorrectly suggests that one run passed both jobs.
+  const newestDescendant = 'docs-fix-newest';
+  const olderDescendant = 'docs-fix-older';
+  const ancestor = 'broken-integration';
+  const newestGuardRun = run({
+    id: 69,
+    workflowId: 690,
+    sha: newestDescendant,
+    name: 'Docs Guard',
+    conclusion: 'failure',
+  });
+  const newestPartialRun = run({
+    id: 70,
+    workflowId: 700,
+    sha: newestDescendant,
+    name: 'Integration Tests',
+  });
+  const olderGuardRun = run({
+    id: 71,
+    workflowId: 710,
+    sha: olderDescendant,
+    name: 'Docs Guard',
+    conclusion: 'failure',
+  });
+  const olderPartialRun = run({
+    id: 72,
+    workflowId: 700,
+    sha: olderDescendant,
+    name: 'Integration Tests',
+  });
+  const staleFailure = run({
+    id: 73,
+    workflowId: 700,
+    sha: ancestor,
+    name: 'Integration Tests',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[newestGuardRun, newestPartialRun, olderGuardRun, olderPartialRun, staleFailure]],
+    jobsByRunId: {
+      69: [guardOnlyJob()],
+      70: [successJob('rspack-dummy-app-tests'), skippedJob('webpack-dummy-app-tests')],
+      71: [guardOnlyJob()],
+      72: [skippedJob('rspack-dummy-app-tests'), successJob('webpack-dummy-app-tests')],
+      73: [
+        { ...buildFailureJob(), name: 'rspack-dummy-app-tests' },
+        { ...buildFailureJob(), name: 'webpack-dummy-app-tests' },
+      ],
+    },
+    parentsBySha: {
+      [newestDescendant]: olderDescendant,
+      [olderDescendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: newestDescendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Integration Tests #73/);
+}
+
 async function testMissingWorkflowIdsDoNotSupersedeOlderFailure() {
   const descendant = 'docs-fix';
   const ancestor = 'broken-docs';
@@ -1543,6 +1613,7 @@ async function main() {
   await testSuccessfulMatrixSetupDoesNotSupersedeSkippedQualityGates();
   await testSuccessfulJobDoesNotSupersedeDifferentSkippedJobFailure();
   await testDuplicateSuccessfulAndSkippedJobNamesDoNotSupersedeFailure();
+  await testPartialSuccessAcrossDescendantsDoesNotSupersedeCombinedFailure();
   await testMissingWorkflowIdsDoNotSupersedeOlderFailure();
   await testMalformedWorkflowIdsDoNotSupersedeOlderFailure();
   await testMissingWorkflowIdCollisionFailsClosed();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -611,6 +611,96 @@ async function testSuccessfulMatrixSetupDoesNotSupersedeSkippedQualityGates() {
   assert.match(core.failed[0], /Integration Tests #62/);
 }
 
+async function testSuccessfulJobDoesNotSupersedeDifferentSkippedJobFailure() {
+  // Production break: a narrower descendant matrix passes one job and skips the
+  // ancestor's failing job, but workflow-level success incorrectly hides that failure.
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-integration';
+  const guardRun = run({
+    id: 63,
+    workflowId: 630,
+    sha: descendant,
+    name: 'Docs Guard',
+    conclusion: 'failure',
+  });
+  const narrowerRun = run({ id: 64, workflowId: 640, sha: descendant, name: 'Integration Tests' });
+  const staleFailure = run({
+    id: 65,
+    workflowId: 640,
+    sha: ancestor,
+    name: 'Integration Tests',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, narrowerRun, staleFailure]],
+    jobsByRunId: {
+      63: [guardOnlyJob()],
+      64: [successJob('webpack-dummy-app-tests'), skippedJob('rspack-dummy-app-tests')],
+      65: [{ ...buildFailureJob(), name: 'rspack-dummy-app-tests' }],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Integration Tests #65/);
+}
+
+async function testDuplicateSuccessfulAndSkippedJobNamesDoNotSupersedeFailure() {
+  // Production break: duplicate display names collapse into one Set entry, so
+  // one success can hide that another same-named job was skipped.
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-integration';
+  const guardRun = run({
+    id: 66,
+    workflowId: 660,
+    sha: descendant,
+    name: 'Docs Guard',
+    conclusion: 'failure',
+  });
+  const ambiguousRun = run({ id: 67, workflowId: 670, sha: descendant, name: 'Integration Tests' });
+  const staleFailure = run({
+    id: 68,
+    workflowId: 670,
+    sha: ancestor,
+    name: 'Integration Tests',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, ambiguousRun, staleFailure]],
+    jobsByRunId: {
+      66: [guardOnlyJob()],
+      67: [successJob('integration'), skippedJob('integration')],
+      68: [{ ...buildFailureJob(), name: 'integration' }],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Integration Tests #68/);
+}
+
 async function testMissingWorkflowIdsDoNotSupersedeOlderFailure() {
   const descendant = 'docs-fix';
   const ancestor = 'broken-docs';
@@ -1451,6 +1541,8 @@ async function main() {
   await testAllSkippedJobsDoNotSupersedeOlderFailure();
   await testSuccessfulGuardJobDoesNotSupersedeSkippedSubstantiveWork();
   await testSuccessfulMatrixSetupDoesNotSupersedeSkippedQualityGates();
+  await testSuccessfulJobDoesNotSupersedeDifferentSkippedJobFailure();
+  await testDuplicateSuccessfulAndSkippedJobNamesDoNotSupersedeFailure();
   await testMissingWorkflowIdsDoNotSupersedeOlderFailure();
   await testMalformedWorkflowIdsDoNotSupersedeOlderFailure();
   await testMissingWorkflowIdCollisionFailsClosed();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -3,6 +3,7 @@ const {
   GUARD_JOB_NAME,
   GUARD_STEP_NAME,
   checkPreviousMainCommitStatus,
+  evaluateCommitRuns,
   isGuardOnlyFailure,
   latestRunsByWorkflow,
   parseExcludeWorkflows,
@@ -301,6 +302,29 @@ async function testUnexpectedJobIteratorShapeFailsClearly() {
   assert.equal(core.failed.length, 1);
   assert.match(core.failed[0], /GitHub API returned an unexpected response/);
   assert.match(core.failed[0], /Expected jobs array while listing workflow run 15 \(Main push lint\)\./);
+}
+
+async function testNoJobsRunDoesNotCreateSuccessfulWorkflowEvidence() {
+  const previous = 'previous';
+  const emptyRun = run({ id: 16, sha: previous, name: 'Empty workflow' });
+  const github = makeGithub({
+    pages: [[emptyRun]],
+    jobsByRunId: {},
+    parentsBySha: {},
+  });
+  const core = makeCore();
+
+  const result = await evaluateCommitRuns({
+    github,
+    context,
+    core,
+    sha: previous,
+    createdAfter: '2026-01-01T00:00:00.000Z',
+    excludeWorkflows: [],
+  });
+
+  assert.deepEqual(Array.from(result.successfulJobsByWorkflow), []);
+  assert.match(core.warnings[0], /No jobs found for workflow run 16/);
 }
 
 async function testGuardOnlyHopLimitStopsAtConfiguredLimit() {
@@ -1644,6 +1668,7 @@ async function main() {
   await testPaginatedJobsAreChecked();
   await testOctokitJobIteratorArrayPagesAreChecked();
   await testUnexpectedJobIteratorShapeFailsClearly();
+  await testNoJobsRunDoesNotCreateSuccessfulWorkflowEvidence();
   await testGuardOnlyHopLimitStopsAtConfiguredLimit();
 }
 

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -563,6 +563,54 @@ async function testSuccessfulGuardJobDoesNotSupersedeSkippedSubstantiveWork() {
   assert.match(core.failed[0], /Lint #49/);
 }
 
+async function testSuccessfulMatrixSetupDoesNotSupersedeSkippedQualityGates() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-integration';
+  const guardRun = run({
+    id: 60,
+    workflowId: 600,
+    sha: descendant,
+    name: 'Docs Guard',
+    conclusion: 'failure',
+  });
+  const orchestrationOnlyRun = run({ id: 61, workflowId: 610, sha: descendant, name: 'Integration Tests' });
+  const staleFailure = run({
+    id: 62,
+    workflowId: 610,
+    sha: ancestor,
+    name: 'Integration Tests',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, orchestrationOnlyRun, staleFailure]],
+    jobsByRunId: {
+      60: [guardOnlyJob()],
+      61: [
+        successJob(GUARD_JOB_NAME),
+        successJob('setup-integration-matrix'),
+        skippedJob('webpack-dummy-app-tests'),
+        skippedJob('rspack-dummy-app-tests'),
+      ],
+      62: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Integration Tests #62/);
+}
+
 async function testMissingWorkflowIdsDoNotSupersedeOlderFailure() {
   const descendant = 'docs-fix';
   const ancestor = 'broken-docs';
@@ -595,7 +643,8 @@ async function testMissingWorkflowIdsDoNotSupersedeOlderFailure() {
   });
 
   assert.equal(core.failed.length, 1);
-  assert.match(core.failed[0], /Check Markdown Links #52/);
+  assert.match(core.failed[0], /GitHub API returned an unexpected response/);
+  assert.match(core.failed[0], /workflow run 51 to have a positive safe integer workflow_id/);
 }
 
 async function testMalformedWorkflowIdsDoNotSupersedeOlderFailure() {
@@ -632,7 +681,70 @@ async function testMalformedWorkflowIdsDoNotSupersedeOlderFailure() {
   });
 
   assert.equal(core.failed.length, 1);
-  assert.match(core.failed[0], /Check Markdown Links #55/);
+  assert.match(core.failed[0], /GitHub API returned an unexpected response/);
+  assert.match(core.failed[0], /workflow run 54 to have a positive safe integer workflow_id/);
+}
+
+async function testMissingWorkflowIdCollisionFailsClosed() {
+  const previous = 'docs-fix';
+  const failingRun = run({ id: 56, sha: previous, name: 'Check Markdown Links', conclusion: 'failure' });
+  const successfulRun = run({ id: 57, sha: previous, name: 'Check Markdown Links' });
+  delete failingRun.workflow_id;
+  delete successfulRun.workflow_id;
+  const github = makeGithub({
+    pages: [[failingRun, successfulRun]],
+    jobsByRunId: {
+      56: [buildFailureJob()],
+      57: [successJob()],
+    },
+    parentsBySha: {},
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: previous,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /GitHub API returned an unexpected response/);
+  assert.match(core.failed[0], /workflow run 56 to have a positive safe integer workflow_id/);
+}
+
+async function testMalformedWorkflowIdCollisionFailsClosed() {
+  const previous = 'docs-fix';
+  const failingRun = {
+    ...run({ id: 58, sha: previous, name: 'Check Markdown Links', conclusion: 'failure' }),
+    workflow_id: 'invalid',
+  };
+  const successfulRun = {
+    ...run({ id: 59, sha: previous, name: 'Check Markdown Links' }),
+    workflow_id: 'invalid',
+  };
+  const github = makeGithub({
+    pages: [[failingRun, successfulRun]],
+    jobsByRunId: {
+      58: [buildFailureJob()],
+      59: [successJob()],
+    },
+    parentsBySha: {},
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: previous,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /GitHub API returned an unexpected response/);
+  assert.match(core.failed[0], /workflow run 58 to have a positive safe integer workflow_id/);
 }
 
 async function testIncompleteRunDoesNotSupersedeOlderFailure() {
@@ -1338,8 +1450,11 @@ async function main() {
   await testEmptyJobsDoNotSupersedeOlderFailure();
   await testAllSkippedJobsDoNotSupersedeOlderFailure();
   await testSuccessfulGuardJobDoesNotSupersedeSkippedSubstantiveWork();
+  await testSuccessfulMatrixSetupDoesNotSupersedeSkippedQualityGates();
   await testMissingWorkflowIdsDoNotSupersedeOlderFailure();
   await testMalformedWorkflowIdsDoNotSupersedeOlderFailure();
+  await testMissingWorkflowIdCollisionFailsClosed();
+  await testMalformedWorkflowIdCollisionFailsClosed();
   await testIncompleteRunDoesNotSupersedeOlderFailure();
   await testGuardOnlyRunDoesNotSupersedeOlderSameWorkflowFailure();
   await testNoRunSyntheticBaseLooksThroughToParentFailure();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -520,6 +520,121 @@ async function testAllSkippedJobsDoNotSupersedeOlderFailure() {
   assert.match(core.failed[0], /Check Markdown Links/);
 }
 
+async function testSuccessfulGuardJobDoesNotSupersedeSkippedSubstantiveWork() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-lint';
+  const guardRun = run({
+    id: 47,
+    workflowId: 470,
+    sha: descendant,
+    name: 'Docs Guard',
+    conclusion: 'failure',
+  });
+  const orchestrationOnlyRun = run({ id: 48, workflowId: 480, sha: descendant, name: 'Lint' });
+  const staleFailure = run({
+    id: 49,
+    workflowId: 480,
+    sha: ancestor,
+    name: 'Lint',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, orchestrationOnlyRun, staleFailure]],
+    jobsByRunId: {
+      47: [guardOnlyJob()],
+      48: [successJob(GUARD_JOB_NAME), skippedJob('lint')],
+      49: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Lint #49/);
+}
+
+async function testMissingWorkflowIdsDoNotSupersedeOlderFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-docs';
+  const guardRun = run({ id: 50, workflowId: 500, sha: descendant, name: 'Lint', conclusion: 'failure' });
+  const successfulRun = { ...run({ id: 51, sha: descendant, name: 'Check Markdown Links' }) };
+  const staleFailure = {
+    ...run({ id: 52, sha: ancestor, name: 'Check Markdown Links', conclusion: 'failure' }),
+  };
+  delete successfulRun.workflow_id;
+  delete staleFailure.workflow_id;
+  const github = makeGithub({
+    pages: [[guardRun, successfulRun, staleFailure]],
+    jobsByRunId: {
+      50: [guardOnlyJob()],
+      51: [successJob()],
+      52: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Check Markdown Links #52/);
+}
+
+async function testMalformedWorkflowIdsDoNotSupersedeOlderFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-docs';
+  const guardRun = run({ id: 53, workflowId: 530, sha: descendant, name: 'Lint', conclusion: 'failure' });
+  const successfulRun = {
+    ...run({ id: 54, sha: descendant, name: 'Check Markdown Links' }),
+    workflow_id: 'not-a-workflow-id',
+  };
+  const staleFailure = {
+    ...run({ id: 55, sha: ancestor, name: 'Check Markdown Links', conclusion: 'failure' }),
+    workflow_id: 'not-a-workflow-id',
+  };
+  const github = makeGithub({
+    pages: [[guardRun, successfulRun, staleFailure]],
+    jobsByRunId: {
+      53: [guardOnlyJob()],
+      54: [successJob()],
+      55: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Check Markdown Links #55/);
+}
+
 async function testIncompleteRunDoesNotSupersedeOlderFailure() {
   const descendant = 'docs-fix';
   const ancestor = 'broken-docs';
@@ -1222,6 +1337,9 @@ async function main() {
   await testDescendantSuccessDoesNotSupersedeDifferentWorkflowFailure();
   await testEmptyJobsDoNotSupersedeOlderFailure();
   await testAllSkippedJobsDoNotSupersedeOlderFailure();
+  await testSuccessfulGuardJobDoesNotSupersedeSkippedSubstantiveWork();
+  await testMissingWorkflowIdsDoNotSupersedeOlderFailure();
+  await testMalformedWorkflowIdsDoNotSupersedeOlderFailure();
   await testIncompleteRunDoesNotSupersedeOlderFailure();
   await testGuardOnlyRunDoesNotSupersedeOlderSameWorkflowFailure();
   await testNoRunSyntheticBaseLooksThroughToParentFailure();

--- a/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
+++ b/.github/actions/ensure-main-docs-safety/check-previous-main.test.cjs
@@ -71,6 +71,15 @@ function successJob(name = 'build') {
   };
 }
 
+function skippedJob(name = 'build') {
+  return {
+    name,
+    run_attempt: 1,
+    conclusion: 'skipped',
+    steps: [{ name: 'Run tests', conclusion: 'skipped' }],
+  };
+}
+
 function makeGithub({
   pages,
   jobsByRunId,
@@ -361,6 +370,235 @@ async function testGuardOnlyFailuresLookThroughToParentFailure() {
   assert.equal(core.failed.length, 1);
   assert.match(core.failed[0], /main commit real-failure still has failing workflows/);
   assert.match(core.failed[0], /Ignored docs-only guard-only failures/);
+}
+
+async function testDescendantSuccessSupersedesOlderSameWorkflowFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-docs';
+  const guardRun = run({ id: 30, workflowId: 300, sha: descendant, name: 'Lint', conclusion: 'failure' });
+  const fixedRun = run({ id: 31, workflowId: 310, sha: descendant, name: 'Check Markdown Links' });
+  const staleFailure = run({
+    id: 32,
+    workflowId: 310,
+    sha: ancestor,
+    name: 'Renamed Markdown Link Check',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, fixedRun, staleFailure]],
+    jobsByRunId: {
+      30: [guardOnlyJob()],
+      31: [successJob()],
+      32: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.deepEqual(core.failed, []);
+  assert.match(core.infoMessages.at(-1), /superseded by a successful descendant run/);
+}
+
+async function testDescendantSuccessDoesNotSupersedeDifferentWorkflowFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-build';
+  const guardRun = run({ id: 33, workflowId: 330, sha: descendant, name: 'Lint', conclusion: 'failure' });
+  const fixedRun = run({ id: 34, workflowId: 340, sha: descendant, name: 'Check Markdown Links' });
+  const unrelatedFailure = run({
+    id: 35,
+    workflowId: 350,
+    sha: ancestor,
+    name: 'Check Markdown Links',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, fixedRun, unrelatedFailure]],
+    jobsByRunId: {
+      33: [guardOnlyJob()],
+      34: [successJob()],
+      35: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Check Markdown Links #35/);
+}
+
+async function testEmptyJobsDoNotSupersedeOlderFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-docs';
+  const guardRun = run({ id: 36, workflowId: 360, sha: descendant, name: 'Lint', conclusion: 'failure' });
+  const emptyRun = run({ id: 37, workflowId: 370, sha: descendant, name: 'Check Markdown Links' });
+  const staleFailure = run({
+    id: 38,
+    workflowId: 370,
+    sha: ancestor,
+    name: 'Check Markdown Links',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, emptyRun, staleFailure]],
+    jobsByRunId: {
+      36: [guardOnlyJob()],
+      37: [],
+      38: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Check Markdown Links/);
+}
+
+async function testAllSkippedJobsDoNotSupersedeOlderFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-docs';
+  const guardRun = run({ id: 39, workflowId: 390, sha: descendant, name: 'Lint', conclusion: 'failure' });
+  const skippedRun = run({ id: 40, workflowId: 400, sha: descendant, name: 'Check Markdown Links' });
+  const staleFailure = run({
+    id: 41,
+    workflowId: 400,
+    sha: ancestor,
+    name: 'Check Markdown Links',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, skippedRun, staleFailure]],
+    jobsByRunId: {
+      39: [guardOnlyJob()],
+      40: [skippedJob()],
+      41: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Check Markdown Links/);
+}
+
+async function testIncompleteRunDoesNotSupersedeOlderFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-docs';
+  const guardRun = run({ id: 42, workflowId: 420, sha: descendant, name: 'Lint', conclusion: 'failure' });
+  const incompleteRun = {
+    ...run({ id: 43, workflowId: 430, sha: descendant, name: 'Check Markdown Links' }),
+    status: 'in_progress',
+    conclusion: null,
+  };
+  const staleFailure = run({
+    id: 44,
+    workflowId: 430,
+    sha: ancestor,
+    name: 'Check Markdown Links',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, incompleteRun, staleFailure]],
+    jobsByRunId: {
+      42: [guardOnlyJob()],
+      44: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Check Markdown Links/);
+}
+
+async function testGuardOnlyRunDoesNotSupersedeOlderSameWorkflowFailure() {
+  const descendant = 'docs-fix';
+  const ancestor = 'broken-docs';
+  const guardRun = run({
+    id: 45,
+    workflowId: 450,
+    sha: descendant,
+    name: 'Check Markdown Links',
+    conclusion: 'failure',
+  });
+  const staleFailure = run({
+    id: 46,
+    workflowId: 450,
+    sha: ancestor,
+    name: 'Check Markdown Links',
+    conclusion: 'failure',
+  });
+  const github = makeGithub({
+    pages: [[guardRun, staleFailure]],
+    jobsByRunId: {
+      45: [guardOnlyJob()],
+      46: [buildFailureJob()],
+    },
+    parentsBySha: {
+      [descendant]: ancestor,
+    },
+  });
+  const core = makeCore();
+
+  await checkPreviousMainCommitStatus({
+    github,
+    context,
+    core,
+    previousSha: descendant,
+    excludeWorkflowsInput: '',
+  });
+
+  assert.equal(core.failed.length, 1);
+  assert.match(core.failed[0], /Check Markdown Links/);
 }
 
 async function testNoRunSyntheticBaseLooksThroughToParentFailure() {
@@ -980,6 +1218,12 @@ async function main() {
   );
 
   await testGuardOnlyFailuresLookThroughToParentFailure();
+  await testDescendantSuccessSupersedesOlderSameWorkflowFailure();
+  await testDescendantSuccessDoesNotSupersedeDifferentWorkflowFailure();
+  await testEmptyJobsDoNotSupersedeOlderFailure();
+  await testAllSkippedJobsDoNotSupersedeOlderFailure();
+  await testIncompleteRunDoesNotSupersedeOlderFailure();
+  await testGuardOnlyRunDoesNotSupersedeOlderSameWorkflowFailure();
   await testNoRunSyntheticBaseLooksThroughToParentFailure();
   await testNoRunPushBaseLooksThroughToParentFailure();
   await testNoRunPushBaseLooksThroughToParentSuccess();


### PR DESCRIPTION
## Why

The docs-only CI safety guard walks first-parent history past guard-only failures. A real workflow failure on an older tree could remain a permanent blocker even after the same workflow and failed job passed on a descendant that fixed the defect.

Fixes #5024.

## What changed

- Carry successful workflow-and-job evidence per individual descendant run while walking toward older first parents.
- Match a newer success to an older failure only by immutable numeric `workflow_id` and the exact failed job display name.
- Require a completed trusted run and at least one successful quality-gate job.
- Exclude CI-routing jobs (`detect-changes`, `setup-matrix`, and `setup-integration-matrix`) from success evidence.
- Reject ambiguous duplicate job display names rather than allowing one successful job to hide another skipped or failing job.
- Fail closed before grouping when the API returns a missing or malformed `workflow_id`.
- Keep unrelated failures, guard-only runs, incomplete runs, empty jobs, all-skipped jobs, manual runs, and traversal-limit failures blocking as before.

## How to review and verify

Review the success-evidence predicate in `.github/actions/ensure-main-docs-safety/check-previous-main.cjs`. Then review the same-workflow, cross-job, duplicate-name, and negative regressions in `check-previous-main.test.cjs`.

### Commands and results

- `node .github/actions/ensure-main-docs-safety/check-previous-main.test.cjs` — passed.
- `node --check` for both changed `.cjs` files — passed.
- targeted ESLint and Prettier checks for the changed action files — passed.
- `pnpm run lint` — passed.
- `actionlint` — passed.
- mandatory OSS RuboCop — 252 files inspected, no offenses.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/bin/validate --changed` — all changed-surface checks passed; its expanded local full suite reached 43/45 suites and 665/673 tests before two unrelated Redis-dependent Pro suites failed because local Redis was unavailable.

### Exact-head and replay evidence

- Base: `7cce8e068e43e91e544866254ed2bb06b9b221d7`
- Head: `c40dd303ea2ca17b19ffc0fc638c1be0aa42ad48`
- Red replay: a successful job in a narrower descendant matrix previously suppressed a different skipped/failing ancestor job; a duplicate successful job name could hide a same-named skipped job; and partial successes from two descendant runs could be pooled to hide a combined ancestor failure.
- Green replay: all three regressions now remain blocking, while the intended same-workflow, same-unambiguous-job success from one actual descendant run retires the older failure.

### Workflow Change Audit

- Secret references: unchanged.
- `permissions:`: unchanged.
- `on:` triggers: unchanged.
- Third-party actions: none added or changed.
- Behavior: the local composite action now retires an older failure only when one trusted descendant run completed successfully and the same workflow ID plus every exact, unambiguous failed job name succeeded together in that run.
- Fail-closed controls: invalid IDs and ambiguous job names cannot suppress failures; non-quality evidence, unrelated failures, and traversal exhaustion remain blocking.
- Post-merge exercise: #5054 tracks the required real `push` exercise from a later valuable docs-only PR.

### Review

Independent read-only review of the current repair returned clean after verifying job-specific matching, duplicate-name fail-closed behavior, and per-run evidence grouping. The current-head hosted review is still in progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes main-branch docs-only CI gating logic with nuanced job/workflow matching; incorrect supersession could allow skips when CI is still red, though new fail-closed rules and tests target that risk.
> 
> **Overview**
> Updates the **ensure-main-docs-safety** composite action so docs-only skips are not blocked forever by an ancestor workflow failure that was already fixed on a newer commit.
> 
> While walking first-parent history, the guard now **records per-descendant-run success evidence** (numeric `workflow_id` plus unambiguous successful quality-gate job names) and **retires matching older failures** only when every failed job name succeeded in the **same** descendant run. Orchestration jobs (`detect-changes`, `setup-matrix`, `setup-integration-matrix`) no longer count as proof of green CI; empty/all-skipped runs, duplicate job display names, partial successes split across runs, and invalid/missing `workflow_id` values **fail closed** and keep blocking.
> 
> **Tests** in `check-previous-main.test.cjs` add broad regression coverage for supersession, matrix/skipped-job edge cases, and API shape validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb2604a07732f3a6bed520a1bd6cc285a344069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of documentation-only updates when an earlier failed check is superseded by a successful follow-up run.
  * Added safeguards so incomplete, ambiguous, invalid, or jobless workflow results are not treated as successful.
  * Improved validation and evaluation of workflow checks, including complex job and matrix scenarios.

* **Tests**
  * Expanded automated coverage for superseded checks, partial successes, skipped jobs, invalid workflow identifiers, and in-progress runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->