### PR TITLE
Test generated Claude hook execution contract

### DIFF
--- a/packages/react-on-rails/docs/agent/rsc-adoption.md
+++ b/packages/react-on-rails/docs/agent/rsc-adoption.md
@@ -25,6 +25,9 @@ bundle exec rake react_on_rails:install_rsc_agent_guardrails
 bin/rails react_on_rails:doctor FORMAT=json
 ```
 
+The generated advisory hook requires Claude Code 2.1.139 or newer. That release added the exec-form
+`args` field that keeps project paths with spaces or special characters intact.
+
 Before completion, protect any RSC payload route, keep the Node renderer private, avoid sensitive
 logged props or URLs, build all three bundles, and exercise navigation and hydration in a browser.
 

--- a/react_on_rails/docs/agent/rsc-adoption.md
+++ b/react_on_rails/docs/agent/rsc-adoption.md
@@ -25,6 +25,9 @@ bundle exec rake react_on_rails:install_rsc_agent_guardrails
 bin/rails react_on_rails:doctor FORMAT=json
 ```
 
+The generated advisory hook requires Claude Code 2.1.139 or newer. That release added the exec-form
+`args` field that keeps project paths with spaces or special characters intact.
+
 Before completion, protect any RSC payload route, keep the Node renderer private, avoid sensitive
 logged props or URLs, build all three bundles, and exercise navigation and hydration in a browser.
 

--- a/react_on_rails/spec/react_on_rails/agent_guardrails_spec.rb
+++ b/react_on_rails/spec/react_on_rails/agent_guardrails_spec.rb
@@ -36,6 +36,26 @@ module ReactOnRails
       Dir.chdir(@app_root) { Open3.capture3(env, RbConfig.ruby, hook_path, *args, stdin_data:) }
     end
 
+    def run_registered_hook(app_root, stdin_data:)
+      settings_path = File.join(app_root, ".claude/settings.json")
+      settings = JSON.parse(File.read(settings_path))
+      hook = settings.dig("hooks", "PostToolUse")
+                     .find { |entry| entry.fetch("matcher").split("|").include?("Write") }
+                     .fetch("hooks")
+                     .find { |entry| entry.fetch("type") == "command" }
+      environment = { "CLAUDE_PROJECT_DIR" => app_root }
+      command = hook.fetch("command").gsub("${CLAUDE_PROJECT_DIR}", app_root)
+
+      Dir.chdir(app_root) do
+        if hook.key?("args")
+          args = hook.fetch("args").map { |arg| arg.gsub("${CLAUDE_PROJECT_DIR}", app_root) }
+          Open3.capture3(environment, [command, command], *args, stdin_data:)
+        else
+          Open3.capture3(environment, command, stdin_data:)
+        end
+      end
+    end
+
     def additional_context(stdout)
       JSON.parse(stdout).dig("hookSpecificOutput", "additionalContext")
     end
@@ -997,6 +1017,21 @@ module ReactOnRails
       expect(hook).to include(
         "type" => "command", "command" => described_class::HOOK_COMMAND, "args" => described_class::HOOK_ARGS
       )
+    end
+
+    it "executes the registered project hook when the generated app path contains spaces" do
+      app_root = File.join(@app_root, "generated app")
+      routes_path = File.join(app_root, "config/routes.rb")
+      described_class.install(app_root)
+      FileUtils.mkdir_p(File.dirname(routes_path))
+      File.write(routes_path, "rsc_payload_route\n")
+      hook_input = JSON.generate("tool_name" => "Write", "tool_input" => { "file_path" => routes_path })
+
+      stdout, stderr, status = run_registered_hook(app_root, stdin_data: hook_input)
+
+      expect(status).to be_success
+      expect(stderr).to be_empty
+      expect(additional_context(stdout)).to include("rsc-app-safety: config/routes.rb")
     end
 
     it "removes the legacy shell hook file and upgrades its settings registration" do


### PR DESCRIPTION
## Why

Claude Code 2.1.139 added exec-form hook arguments, and React on Rails now generates that form. The existing tests verified the generated JSON shape and exercised the Ruby hook directly, but did not prove that the generated `settings.json` registration itself executes correctly when the project path contains spaces.

## What changed

- Execute the command selected from the generated `.claude/settings.json` in a project path containing a space.
- Verify the generated hook returns the expected `PostToolUse` advisory context.
- Document Claude Code 2.1.139 as the minimum version for the generated exec-form hook in both mirrored adoption guides.
- Leave production code unchanged.

## Regression evidence

- Red replay: replacing the generated exec form with the historical shell-form command from #4816 makes the new focused example fail with `Errno::ENOENT` at the first space-delimited path segment.
- Green replay: the current generated `command` plus `args` form passes the same example.

## Validation

- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/agent_guardrails_spec.rb)` — 78 examples, 0 failures
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop spec/react_on_rails/agent_guardrails_spec.rb)` — no offenses
- `pnpm exec prettier --check react_on_rails/docs/agent/rsc-adoption.md packages/react-on-rails/docs/agent/rsc-adoption.md` — passed
- mirrored adoption guides compare byte-for-byte equal
- `script/check-docs-sidebar` — passed
- `git diff --check` — passed

## Process gap disposition

- Mechanism: `checklist+replay`
- Motivating miss: shape-only generator coverage did not execute the registration contract that Claude consumes.
- Replay evidence: the prior shell form fails deterministically in an explicit spaced path; the current exec form passes without network access or mutable external behavior.
- Non-goal: emulate every Claude Code hook feature or support Claude Code versions older than 2.1.139.

Addresses #4753.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a note that the generated advisory hook requires Claude Code 2.1.139 or later.
  - Clarified compatibility with project paths containing spaces or special characters.

- **Tests**
  - Added coverage confirming the registered advisory hook runs successfully when the project path contains spaces and provides the expected advisory context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->