### PR TITLE
Test real Shakapacker RSC asset shapes

### DIFF
--- a/packages/react-on-rails-pro/tests/fixtures/rsc-css-gating/shakapacker-asset-shapes.json
+++ b/packages/react-on-rails-pro/tests/fixtures/rsc-css-gating/shakapacker-asset-shapes.json
@@ -1,0 +1,22 @@
+{
+  "provenance": {
+    "productionSource": "shakacode/react_on_rails#4560 production QA and #4570",
+    "developmentSource": "shakacode/react_on_rails#4561 verified Shakapacker development shape",
+    "bundler": "Rspack 2.0.5 through Shakapacker",
+    "note": "Sanitized excerpt. Paths and hashes preserve the captured asset-name shapes."
+  },
+  "production": {
+    "flightRow": "2:I[\"./client/app/components/FoucProbe/RscFoucProbeClient.jsx\",[635,\"js/client0-ddfe2f4e010169bd.chunk.js\"],\"default\"]\n",
+    "manifestEntry": {
+      "id": "./client/app/components/FoucProbe/RscFoucProbeClient.jsx",
+      "chunks": [635, "js/client0-ddfe2f4e010169bd.chunk.js"],
+      "css": ["/packs/css/635-166421e0.css"],
+      "name": "default"
+    }
+  },
+  "development": {
+    "flightRow": "2:I[\"./client/app/components/FoucProbe/RscFoucProbeClient.jsx\",[\"client0\",\"js/client0.chunk.js\"],\"default\"]\n",
+    "chunkName": "client0",
+    "stylesheetHref": "/packs/css/client0.css"
+  }
+}

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -14,6 +14,8 @@
  */
 
 import { Readable, PassThrough } from 'stream';
+import { readFileSync } from 'fs';
+import { resolve as resolvePath } from 'path';
 import { RailsContextWithServerStreamingCapabilities } from 'react-on-rails/types';
 import injectRSCPayload from '../src/injectRSCPayload.ts';
 import RSCRequestTracker from '../src/RSCRequestTracker.ts';
@@ -39,6 +41,25 @@ const expectedPayloadPushScript = (chunk: string) =>
   `<script ${rscPayloadScriptMarker}>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]).push(${JSON.stringify(
     chunk,
   )})</script>`;
+
+type ShakapackerAssetShapes = {
+  production: {
+    flightRow: string;
+    manifestEntry: {
+      chunks: Array<number | string>;
+      css: string[];
+    };
+  };
+  development: {
+    flightRow: string;
+    chunkName: string;
+    stylesheetHref: string;
+  };
+};
+
+const shakapackerAssetShapes = JSON.parse(
+  readFileSync(resolvePath(__dirname, 'fixtures/rsc-css-gating/shakapacker-asset-shapes.json'), 'utf8'),
+) as ShakapackerAssetShapes;
 
 // Shared utilities — createMockRSCStream wraps content in length-prefixed format,
 // createMockHTMLStream passes HTML through as-is.
@@ -656,17 +677,21 @@ describe('injectRSCPayload', () => {
   });
 
   it('promotes only manifest-listed production RSC stylesheet preloads', async () => {
-    const flightData =
-      '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",[4092,"js/client1-570df890c7aa791c.chunk.js"],"default"]\n' +
-      '0:["$","$L2",null,{},null]\n';
+    const { flightRow: flightData, manifestEntry } = shakapackerAssetShapes.production;
     const mockRSC = createMockRSCStream([flightData]);
-    const manifestStylesheetHref = '/webpack/test/css/4092-98880bc1.css';
+    const [manifestStylesheetHref] = manifestEntry.css;
     const unrelatedPreload =
       '<link rel="preload" as="style" href="https://cdn.example.com/assets/next-route-theme.css">';
+    const revealHTML =
+      '<div hidden id="RscFoucProbe-react-component-0S:0">styled boundary</div>' +
+      '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>';
     const mockHTML = createMockHTMLStream([
-      `<link rel="preload" as="style" href="https://cdn.example.com${manifestStylesheetHref}?body=1">${unrelatedPreload}`,
+      `<link rel="preload" as="style" href="https://cdn.example.com${manifestStylesheetHref}?body=1">${unrelatedPreload}${revealHTML}`,
     ]);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    expect(manifestEntry.chunks).toEqual([635, 'js/client0-ddfe2f4e010169bd.chunk.js']);
+    expect(manifestStylesheetHref).toBe('/packs/css/635-166421e0.css');
 
     const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
       rscClientManifestStylesheetHrefs: new Set([manifestStylesheetHref]),
@@ -676,9 +701,31 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain(
       `<link rel="stylesheet" href="https://cdn.example.com${manifestStylesheetHref}?body=1" data-precedence="rsc-css">`,
     );
+    expect(resultStr.indexOf(manifestStylesheetHref)).toBeLessThan(
+      resultStr.indexOf('<div hidden id="RscFoucProbe-react-component-0S:0">'),
+    );
     expect(resultStr.split(manifestStylesheetHref)).toHaveLength(2);
     expect(resultStr).toContain(unrelatedPreload);
     expect(resultStr).toContain(expectedPayloadPushScript(flightData));
+  });
+
+  it('does not infer a stylesheet from the real unhashed development asset shape', async () => {
+    const { flightRow, chunkName, stylesheetHref } = shakapackerAssetShapes.development;
+    const mockRSC = createMockRSCStream([flightRow]);
+    const mockHTML = createMockHTMLStream(['<main>ready</main>']);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    expect(flightRow).toContain(`["${chunkName}","js/${chunkName}.chunk.js"]`);
+    expect(stylesheetHref).toBe(`/packs/css/${chunkName}.css`);
+
+    const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
+      rscClientChunkStylesheetHrefsByChunkName: new Map([[chunkName, [stylesheetHref]]]),
+    });
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain('<main>ready</main>');
+    expect(resultStr).not.toContain(`<link rel="stylesheet" href="${stylesheetHref}"`);
+    expect(resultStr).toContain(expectedPayloadPushScript(flightRow));
   });
 
   it('injects inferred RSC client chunk stylesheets before streamed reveal HTML', async () => {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -163,6 +163,31 @@ const createFlushingHTMLStream = (html: string) =>
     },
   }) as Readable;
 
+const createFlushingHTMLChunkStream = (chunks: string[]) =>
+  ({
+    pipe(destination: PassThrough & { flush?: () => void }) {
+      if (chunks.length === 0) {
+        destination.end();
+        return destination;
+      }
+
+      const writeChunk = (index: number) => {
+        setTimeout(() => {
+          destination.write(new TextEncoder().encode(chunks[index]));
+          destination.flush?.();
+          if (index === chunks.length - 1) {
+            destination.end();
+          } else {
+            writeChunk(index + 1);
+          }
+        }, 0);
+      };
+
+      writeChunk(0);
+      return destination;
+    },
+  }) as Readable;
+
 const collectStreamData = async (stream: Readable) => {
   const chunks: string[] = [];
   for await (const chunk of stream) {
@@ -685,8 +710,9 @@ describe('injectRSCPayload', () => {
     const revealHTML =
       '<div hidden id="RscFoucProbe-react-component-0S:0">styled boundary</div>' +
       '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>';
-    const mockHTML = createMockHTMLStream([
-      `<link rel="preload" as="style" href="https://cdn.example.com${manifestStylesheetHref}?body=1">${unrelatedPreload}${revealHTML}`,
+    const mockHTML = createFlushingHTMLChunkStream([
+      `<link rel="preload" as="style" href="https://cdn.example.com${manifestStylesheetHref}?body=1">${unrelatedPreload}`,
+      revealHTML,
     ]);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
@@ -696,14 +722,20 @@ describe('injectRSCPayload', () => {
     const result = injectWithOptions(mockHTML, rscRequestTracker, domNodeId, {
       rscClientManifestStylesheetHrefs: new Set([manifestStylesheetHref]),
     });
-    const resultStr = await collectStreamData(result);
+    const { allData, chunks } = collectStreamDataByChunk(result);
+    const resultStr = await allData;
+    const stylesheetChunkIndex = chunks.findIndex(
+      (chunk) => chunk.includes('rel="stylesheet"') && chunk.includes(manifestStylesheetHref),
+    );
+    const revealChunkIndex = chunks.findIndex((chunk) =>
+      chunk.includes('<div hidden id="RscFoucProbe-react-component-0S:0">'),
+    );
 
     expect(resultStr).toContain(
       `<link rel="stylesheet" href="https://cdn.example.com${manifestStylesheetHref}?body=1" data-precedence="rsc-css">`,
     );
-    expect(resultStr.indexOf(manifestStylesheetHref)).toBeLessThan(
-      resultStr.indexOf('<div hidden id="RscFoucProbe-react-component-0S:0">'),
-    );
+    expect(stylesheetChunkIndex).toBeGreaterThanOrEqual(0);
+    expect(revealChunkIndex).toBeGreaterThan(stylesheetChunkIndex);
     expect(resultStr.split(manifestStylesheetHref)).toHaveLength(2);
     expect(resultStr).toContain(unrelatedPreload);
     expect(resultStr).toContain(expectedPayloadPushScript(flightData));


### PR DESCRIPTION
## Why

The RSC stylesheet-gating tests relied on synthetic hashed `clientN` asset names that stock Shakapacker builds do not produce. This could let tests pass without exercising the real production and development shapes.

Addresses #4561.

## What changed

- Adds a sanitized fixture based on the production Rspack/Shakapacker evidence from #4560 and #4570, plus the verified development shape from #4561.
- Uses the numeric production chunk ID and ID-named CSS asset to verify manifest-backed preload promotion before a streamed reveal.
- Records that the real unhashed development shape does not engage the legacy hashed-name inference path.
- Changes tests only. Runtime behavior is unchanged.

## Process-gap replay

- Mechanism: checklist + replay.
- Motivating miss: synthetic fixtures passed while real Shakapacker asset names did not engage the same paths.
- Replay evidence: the captured production asset names and Flight row from #4560/#4570, plus the development shape in #4561.
- Non-goal: no RSC CSS architecture cleanup or runtime change.

## Validation

- RED replay: retaining the old single-chunk stream with the new flush-order oracle failed because the reveal and promoted stylesheet occupied output chunk `0` (`Expected: > 0`, `Received: 0`).
- GREEN replay: the production fixture now writes and flushes the preload before scheduling the reveal; the targeted production promotion test passed with strict output-chunk ordering.
- `pnpm --filter react-on-rails-pro exec node scripts/run-react19-jest.mjs tests/injectRSCPayload.test.ts --runInBand` — 84 tests passed.
- `pnpm --filter react-on-rails-pro run type-check` — passed.
- `pnpm run lint` — passed.
- `pnpm start format.listDifferent` — passed.
- `script/check-pro-license-headers` — all 915 in-scope Pro files passed.
- Pre-commit and pre-push hooks — passed. The test file remains excluded by the repository ESLint path configuration, reported as a non-failing warning.

## Review state

Claude's old-head finding about the same-chunk ordering oracle was repaired at `1cd97ebde40dd4c01d11bcba3aa872a3ae0ec3e0`. Independent exact-head re-review specifically scrutinized the split-flush oracle and reported CLEAN with no MUST_FIX, DISCUSS, or OPTIONAL findings. The automatic current-head Claude review completed successfully; its two non-blocking observations were answered and resolved without another code change. Hosted full validation has not been requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RSC stylesheet preloads for production assets.
  * Prevented stylesheets from being incorrectly inferred from development asset names.

* **Tests**
  * Added coverage for production and development Shakapacker asset naming patterns.
  * Added streaming scenarios to verify stylesheet preload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->