### PR TITLE
Docs: choose E2E topology for multi-process RSC tests

### DIFF
--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -47,6 +47,12 @@ React Server Components add one more moving part to the standard test setup: sys
 
 Use this recipe for Capybara, system, and end-to-end tests that exercise `stream_react_component`, `RSCRoute`, or the `rsc_payload_route`.
 
+This recipe fits a Rails-managed system-test topology: the normal Rails test server can reach a renderer that is
+started once for the suite or worker. If the browser test needs a separately launched Rails origin and renderer,
+cross-process data setup, or detailed streaming, network, and trace assertions, use E2E on Rails + Playwright
+instead. See [System Specs for Streamed RSC Payloads](../../pro/react-server-components/system-spec-streaming-rsc.md#choose-the-test-topology)
+for the decision rule and the multi-process lifecycle boundary.
+
 This recipe uses the React on Rails TestHelper with `build_test_command`: Rails checks whether generated bundles are stale, runs your test build command when needed, and fails fast if compilation fails.
 
 The Step 3 renderer-lifecycle helper is **RSpec-focused** because it uses `before(:suite)` and `after(:suite)` hooks; for Minitest, see [Minitest Equivalent](#minitest-equivalent) for a parallel adaptation that reuses the same safety points from a `test/test_helper.rb` harness plus `Minitest.after_run`.
@@ -363,7 +369,7 @@ Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 
-### 4. Write A Capybara RSC Smoke Test
+### 4. Write A Capybara RSC Smoke Test for a Rails-managed Runtime
 
 Keep the first system test boring: visit a route that streams one Server Component and assert on visible HTML plus one hydrated Client Component interaction.
 

--- a/docs/pro/react-server-components/system-spec-streaming-rsc.md
+++ b/docs/pro/react-server-components/system-spec-streaming-rsc.md
@@ -32,8 +32,8 @@ Choose the owner of the application runtime before you choose the browser assert
 | The test needs a separately launched Rails server or node renderer                                                                                            | E2E on Rails + Playwright                                       |
 | Test data must be visible across process or database connections                                                                                              | E2E on Rails app commands or scenarios                          |
 | Streaming HTTP, Action Cable, exact network counts, failed-resource checks, or traces are central assertions                                                  | Playwright                                                      |
-| The app already uses Playwright for ShakaPerf, visual regression, or other browser verification                                                               | Reuse Playwright instead of adding a custom Capybara runtime    |
-| Puffing Billy or another external proxy is needed for unrelated APIs                                                                                          | Keep those tests separate; do not proxy or cache the RSC stream |
+| The app already uses Playwright for ShakaPerf, visual regression, or other browser verification                                                               | Playwright; reuse the existing browser runtime                  |
+| Puffing Billy or another external proxy is needed for unrelated APIs                                                                                          | A separate Capybara suite; keep the RSC stream out of the proxy |
 
 Capybara is not generally incompatible with RSC. It is a good fit when Rails manages the system-test server and
 that server can reach the renderer. If you would need to start a separate Rails origin or renderer around each
@@ -106,7 +106,9 @@ Keep these responsibilities separate:
 
 > **Lifecycle rule:** Do not start and stop the Rails server or RSC renderer around individual examples or
 > retries. Keep one application topology alive for the focused E2E run. Reset browser contexts and application
-> data between tests, and stop application processes only after the run.
+> data between tests, and stop application processes only after the run. When workers or browser projects share a
+> Rails database, run them serially; parallel runs require an isolated database and external-state namespace for
+> each worker or shard.
 
 Streamed chunks and browser resource requests can outlive the assertion that appears to finish a test. Killing the
 origin during reset can create late chunk errors, attribute a failure to the next test, and make retries look more
@@ -162,8 +164,8 @@ For app-specific system specs:
 
 For a multi-process Playwright test, also:
 
-1. Fail on unexpected `console.error` messages, page errors or unhandled rejections, failed RSC chunks, and failed
-   resources.
+1. Fail on unexpected `console.error` messages, page errors or unhandled rejections, failed RSC chunks, failed
+   network requests, and non-2xx responses from the RSC route.
 2. Capture a Playwright trace, screenshot or video, Rails logs, and renderer logs when a test fails.
 3. Verify that one stable Rails origin and one stable renderer origin serve the focused run.
 4. Run the same source tests in each required desktop and mobile project.

--- a/docs/pro/react-server-components/system-spec-streaming-rsc.md
+++ b/docs/pro/react-server-components/system-spec-streaming-rsc.md
@@ -22,7 +22,24 @@ Common symptoms:
 - browser console logs show a pending Flight decode or missing client reference after the payload route returned
   successfully on the server.
 
-## Recommended Capybara Shape
+## Choose the Test Topology
+
+Choose the owner of the application runtime before you choose the browser assertions:
+
+| Situation                                                                                                                                                     | Recommended owner                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Rails' normal system-test server can reach the renderer, no custom application processes run inside examples, and the test needs a simple hydration assertion | Capybara with a non-buffering driver is acceptable              |
+| The test needs a separately launched Rails server or node renderer                                                                                            | E2E on Rails + Playwright                                       |
+| Test data must be visible across process or database connections                                                                                              | E2E on Rails app commands or scenarios                          |
+| Streaming HTTP, Action Cable, exact network counts, failed-resource checks, or traces are central assertions                                                  | Playwright                                                      |
+| The app already uses Playwright for ShakaPerf, visual regression, or other browser verification                                                               | Reuse Playwright instead of adding a custom Capybara runtime    |
+| Puffing Billy or another external proxy is needed for unrelated APIs                                                                                          | Keep those tests separate; do not proxy or cache the RSC stream |
+
+Capybara is not generally incompatible with RSC. It is a good fit when Rails manages the system-test server and
+that server can reach the renderer. If you would need to start a separate Rails origin or renderer around each
+example, stop extending the Capybara harness and use the multi-process path below.
+
+## Capybara Shape for a Rails-managed Runtime
 
 Use a non-Billy browser driver for specs that assert streamed RSC behavior. If your suite's default JavaScript
 driver is already a plain Selenium driver, you can use it directly. Otherwise, register a dedicated driver for
@@ -61,6 +78,50 @@ Good assertions include:
 - an app-owned hydration marker appears after the client boundary finishes;
 - a Suspense fallback is replaced by streamed content and the related client control works.
 
+## E2E on Rails + Playwright for a Multi-process Runtime
+
+Use [E2E on Rails](https://e2eonrails.com/) with Playwright when a test needs an external Rails server, a node
+renderer, cross-process Rails data setup, or detailed streaming and network evidence. Follow the canonical
+[Streamed and Multi-process Applications](https://e2eonrails.com/docs/STREAMING_AND_MULTI_PROCESS_APPS/) guide for
+the full setup. Keep this React on Rails guide focused on the RSC transport boundary.
+
+```text
+focused RSC E2E run
+  -> start and wait for the node renderer
+  -> start and wait for one Rails test server
+  -> run the configured Playwright desktop and mobile projects
+       -> E2E on Rails command resets and creates Rails data
+       -> fresh browser context exercises the real RSC stream
+       -> assert hydration, interaction, console, failed resources, and network
+  -> stop Rails
+  -> stop the renderer
+```
+
+Keep these responsibilities separate:
+
+- React on Rails owns the RSC route, renderer configuration, and streaming contract.
+- The consuming app owns process commands, dependency ordering, readiness checks, logs, and cleanup.
+- E2E on Rails owns Rails-side app commands and state setup.
+- Playwright owns browser contexts, traces, console and page errors, failed resources, and network assertions.
+
+> **Lifecycle rule:** Do not start and stop the Rails server or RSC renderer around individual examples or
+> retries. Keep one application topology alive for the focused E2E run. Reset browser contexts and application
+> data between tests, and stop application processes only after the run.
+
+Streamed chunks and browser resource requests can outlive the assertion that appears to finish a test. Killing the
+origin during reset can create late chunk errors, attribute a failure to the next test, and make retries look more
+stable than the underlying system.
+
+### Make Test Data Visible to Rails
+
+A separate Rails server uses another process and database connection. It normally cannot see records inside an
+RSpec example's uncommitted transaction. Do not use committed `before(:all)` fixtures as the default workaround.
+
+Create and reset data inside the serving Rails process through E2E on Rails
+[app commands](https://e2eonrails.com/docs/app-commands/) or
+[scenarios](https://e2eonrails.com/docs/scenarios/). Transaction-sharing modes require every participating
+process, thread, and connection to support the same assumptions; they are not a general multi-process solution.
+
 ## Puffing Billy Compatibility
 
 Puffing Billy is an HTTP proxy for browser requests. Its
@@ -98,6 +159,17 @@ For app-specific system specs:
 2. Wait for an app-owned hydrated marker, visible client-island behavior, or streamed content replacement.
 3. Confirm the RSC payload route was served by the app under test, not by a Billy stub or cache.
 4. Keep external API stubbing separate from the RSC payload transport check.
+
+For a multi-process Playwright test, also:
+
+1. Fail on unexpected `console.error` messages, page errors or unhandled rejections, failed RSC chunks, and failed
+   resources.
+2. Capture a Playwright trace, screenshot or video, Rails logs, and renderer logs when a test fails.
+3. Verify that one stable Rails origin and one stable renderer origin serve the focused run.
+4. Run the same source tests in each required desktop and mobile project.
+5. Treat retries as diagnostic evidence, not proof of stability.
+6. After migration parity, delete superseded browser specs and custom runtime helpers instead of maintaining two
+   sources of truth.
 
 Request specs for `/rsc_payload/:component_name` are still useful for status codes, content type, and payload
 shape, but they do not prove browser streaming. Pair request specs with at least one browser assertion when the

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -9646,8 +9646,8 @@ Choose the owner of the application runtime before you choose the browser assert
 | The test needs a separately launched Rails server or node renderer                                                                                            | E2E on Rails + Playwright                                       |
 | Test data must be visible across process or database connections                                                                                              | E2E on Rails app commands or scenarios                          |
 | Streaming HTTP, Action Cable, exact network counts, failed-resource checks, or traces are central assertions                                                  | Playwright                                                      |
-| The app already uses Playwright for ShakaPerf, visual regression, or other browser verification                                                               | Reuse Playwright instead of adding a custom Capybara runtime    |
-| Puffing Billy or another external proxy is needed for unrelated APIs                                                                                          | Keep those tests separate; do not proxy or cache the RSC stream |
+| The app already uses Playwright for ShakaPerf, visual regression, or other browser verification                                                               | Playwright; reuse the existing browser runtime                  |
+| Puffing Billy or another external proxy is needed for unrelated APIs                                                                                          | A separate Capybara suite; keep the RSC stream out of the proxy |
 
 Capybara is not generally incompatible with RSC. It is a good fit when Rails manages the system-test server and
 that server can reach the renderer. If you would need to start a separate Rails origin or renderer around each
@@ -9720,7 +9720,9 @@ Keep these responsibilities separate:
 
 > **Lifecycle rule:** Do not start and stop the Rails server or RSC renderer around individual examples or
 > retries. Keep one application topology alive for the focused E2E run. Reset browser contexts and application
-> data between tests, and stop application processes only after the run.
+> data between tests, and stop application processes only after the run. When workers or browser projects share a
+> Rails database, run them serially; parallel runs require an isolated database and external-state namespace for
+> each worker or shard.
 
 Streamed chunks and browser resource requests can outlive the assertion that appears to finish a test. Killing the
 origin during reset can create late chunk errors, attribute a failure to the next test, and make retries look more
@@ -9776,8 +9778,8 @@ For app-specific system specs:
 
 For a multi-process Playwright test, also:
 
-1. Fail on unexpected `console.error` messages, page errors or unhandled rejections, failed RSC chunks, and failed
-   resources.
+1. Fail on unexpected `console.error` messages, page errors or unhandled rejections, failed RSC chunks, failed
+   network requests, and non-2xx responses from the RSC route.
 2. Capture a Playwright trace, screenshot or video, Rails logs, and renderer logs when a test fails.
 3. Verify that one stable Rails origin and one stable renderer origin serve the focused run.
 4. Run the same source tests in each required desktop and mobile project.

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -933,6 +933,8 @@ SOURCE: docs/pro/react-on-rails-pro.md
 
 React on Rails Pro is the advanced rendering and performance tier for React on Rails. Start with the open-source integration, then add Pro when you need higher SSR throughput, React Server Components, streaming SSR, fragment caching, or dedicated Node renderer tooling.
 
+> **Stable GA:** React Server Components are supported in React on Rails Pro 17. The stable RSC stack uses React and React DOM 19.2.x (patch 19.2.7 or newer) with `react-on-rails-rsc` 19.2.x (patch 19.2.1 or newer).
+
 > [!NOTE]
 > **Summary for AI agents:** This is the canonical Pro hub after the docs IA cleanup. Use it for installation, upgrades, streaming SSR, Node renderer, fragment caching, profiling, and troubleshooting. Route RSC-specific requests to the nested [React Server Components index](./react-server-components/index.md).
 
@@ -1061,7 +1063,9 @@ bundle add react_on_rails_pro --version="<gem_version>" --strict
 bundle exec rails generate react_on_rails:pro
 ```
 
-The standalone generator adds Pro-specific files and modifies your existing webpack configs (`serverWebpackConfig.js` and `ServerClientOrBoth.js`) to enable Pro features like `libraryTarget: 'commonjs2'` and `target = 'node'`.
+The standalone generator adds Pro-specific files. It automatically upgrades existing webpack/Rspack configs (`serverWebpackConfig.js` and `ServerClientOrBoth.js`) only when both files exactly match a supported current generated pair, enabling settings such as `libraryTarget: 'commonjs2'` and `target = 'node'`. A supported pair using the legacy companion filename `generateWebpackConfigs.js` keeps that filename.
+
+Customized, unknown, unsupported historical, incomplete, or ambiguous pairs are left unchanged, including their paths. If the generator skips the pair, complete the [manual webpack/Rspack migration](./upgrading-to-pro.md#complete-a-skipped-webpackrspack-migration-manually) before validation; rerunning it does not migrate these files.
 
 ## After Running the Generator
 
@@ -1906,9 +1910,72 @@ The Pro package re-exports everything from core, so no other import changes are 
 bundle exec rails generate react_on_rails:pro
 ```
 
-This adds the Pro initializer, configures webpack for Pro features, and sets up the Node renderer entry point and configuration.
+This adds the Pro initializer and sets up the Node renderer entry point and configuration. It automatically upgrades webpack/Rspack configuration only when both files exactly match a supported current generated pair. If it reports that the pair was left unchanged, complete the manual edits below; rerunning the generator does not migrate customized or unsupported files.
 
-After the generator runs, verify everything works:
+#### Complete a skipped webpack/Rspack migration manually
+
+Start with a commit or backup of your configuration. Locate `serverWebpackConfig.js` and its companion `ServerClientOrBoth.js` in your app's active `config/webpack/` or `config/rspack/` directory. Older apps may use `generateWebpackConfigs.js` as the companion. Follow the file imported by your environment configs; if both names exist, resolve which is active before editing. Keep existing filenames and application customizations.
+
+Use the installed templates as references: run `bundle show react_on_rails`, then inspect `lib/generators/react_on_rails/templates/base/base/config/webpack/{serverWebpackConfig,ServerClientOrBoth}.js.tt` under that directory. Their Pro branches show the intended configuration; retain your app's Shakapacker output-path choices and any RSC plugin setup. Do not replace customized files wholesale with the templates.
+
+1. In `serverWebpackConfig.js`, inside `configureServer`, set these values after the existing output configuration and before returning it. Preserve the other output settings, including its filename and path:
+
+   ```javascript
+   serverWebpackConfig.output.libraryTarget = 'commonjs2';
+   serverWebpackConfig.target = 'node';
+   serverWebpackConfig.node = false;
+   ```
+
+2. Ensure these helpers are available at module scope. Add only missing helpers; do not paste a second declaration over an existing `const`, `let`, `var`, or function. Existing helpers must be synchronous: `getLoaderPath` returns a string, and `extractLoader` returns a matching `rule.use` entry or no match, never a Promise or iterator. Adapt customized helpers and their callers deliberately:
+
+   ```javascript
+   function getLoaderPath(item) {
+     if (typeof item === 'string') return item;
+     if (item && typeof item.loader === 'string') return item.loader;
+     return '';
+   }
+
+   function extractLoader(rule, loaderName) {
+     if (!Array.isArray(rule.use)) return null;
+     return rule.use.find((item) => getLoaderPath(item).includes(loaderName));
+   }
+   ```
+
+3. If the server bundle uses Babel, set its SSR caller inside the existing `rules.forEach((rule) => { ... })` loop and `Array.isArray(rule.use)` guard, alongside the CSS loader handling. Give the Babel loader entry an `options` object first if it currently uses a bare string or omits options. Preserve existing caller metadata while setting `ssr: true`. Apps using SWC do not need this Babel block:
+
+   ```javascript
+   const babelLoader = extractLoader(rule, 'babel-loader');
+   if (babelLoader && babelLoader.options) {
+     babelLoader.options.caller = { ...babelLoader.options.caller, ssr: true };
+   }
+   ```
+
+4. Update the server export and companion import together. At module scope, export the server configuration function as `default` and expose `extractLoader`, retaining any additional exports your app uses:
+
+   ```javascript
+   module.exports = {
+     default: configureServer,
+     extractLoader,
+   };
+   ```
+
+   In the active `ServerClientOrBoth.js` or `generateWebpackConfigs.js`, replace the old direct function import with:
+
+   ```javascript
+   const { default: serverWebpackConfig } = require('./serverWebpackConfig');
+   ```
+
+   Keep its existing `serverWebpackConfig()` invocation and client/RSC bundle handling. Update any other direct consumers of the old function export to use `.default` too.
+
+After an automatic or manual migration, check both files and build the bundles. Adjust the two paths below for Rspack or the legacy companion filename:
+
+```bash
+node --check config/webpack/serverWebpackConfig.js
+node --check config/webpack/ServerClientOrBoth.js
+RAILS_ENV=production bin/shakapacker
+```
+
+Syntax checks alone do not execute the configuration. Confirm the build completes, then start the app and request a page that uses server rendering (`prerender: true`). Check that the response contains server-rendered markup and that the Node renderer logs contain no loader or export errors:
 
 ```bash
 bundle exec rails react_on_rails:doctor
@@ -5155,8 +5222,10 @@ SOURCE: docs/pro/react-server-components/index.md
 > **Pro Feature** — React Server Components require [React on Rails Pro](../react-on-rails-pro.md) with the node renderer.
 > Free or very low cost for startups and small companies. [Upgrade or licensing details →](../upgrading-to-pro.md#try-pro-risk-free)
 
+> **Stable GA:** React Server Components are supported in React on Rails Pro 17. The stable RSC stack uses React and React DOM 19.2.x (patch 19.2.7 or newer) with `react-on-rails-rsc` 19.2.x (patch 19.2.1 or newer).
+
 > [!NOTE]
-> **Summary for AI agents:** Use this page when the user explicitly wants React Server Components or an RSC migration path. It routes to the tutorial, deep dives, and migration guides. Treat RSC as a Pro-only feature that runs with the Node renderer.
+> **Summary for AI agents:** Use this page when the user explicitly wants React Server Components or an RSC migration path. It routes to the tutorial, deep dives, and migration guides. Treat RSC as a supported GA feature of React on Rails Pro 17 that runs with the Node renderer.
 
 ## What Are React Server Components?
 
@@ -5228,9 +5297,9 @@ Current React on Rails Pro releases provide full RSC support with:
 
 ### Requirements
 
-- React on Rails Pro v16.4.0 or higher
-- React on Rails v16.4.0 or higher
-- React 19 with a compatible `react-on-rails-rsc` version
+- React on Rails Pro 17, installed at the same version as React on Rails 17
+- React and React DOM 19.2.x with patch 19.2.7 or newer
+- Stable `react-on-rails-rsc` 19.2.x with patch 19.2.1 or newer
 - Node renderer — installed separately via `react-on-rails-pro-node-renderer` npm package (see [Pro Installation](../installation.md#install-react-on-rails-pro-node-renderer))
 - Shakapacker or Rspack for bundling
 
@@ -5249,7 +5318,7 @@ See the full [RSC tutorial](./tutorial.md) for the complete learning path.
 
 ### Upgrading an Existing Pro App?
 
-See [Upgrading an Existing Pro App to RSC](./upgrading-existing-pro-app.md) for the generator-based runbook: prerequisites, `rails g react_on_rails:rsc` usage, legacy webpack compatibility, and a verification checklist.
+See [Upgrading an Existing Pro App to RSC](./upgrading-existing-pro-app.md) for the generator-based runbook: prerequisites, `rails g react_on_rails:rsc` usage, legacy webpack compatibility, and a verification checklist. Its Pro 16.4+ prerequisite is only the minimum starting point for an existing app; upgrade the app to Pro 17 for the supported GA destination documented here.
 
 ### Migrating Your React Components?
 
@@ -7533,7 +7602,121 @@ SOURCE: docs/pro/react-server-components/tutorial.md
 
 # React Server Components Tutorial
 
-This tutorial will guide you through learning [React Server Components (RSC)](https://react.dev/reference/rsc/server-components) with React on Rails Pro, from basic concepts to advanced features. The tutorial is divided into several parts that build upon each other:
+This tutorial will guide you through learning [React Server Components (RSC)](https://react.dev/reference/rsc/server-components) with React on Rails Pro, from creating and verifying a new application to advanced features.
+
+## Build and Verify a New Pro RSC App
+
+This exercise starts from the public app generator, adds a small Rails-backed
+feature beside the generated RSC example, and verifies the result with automated
+tests and a production asset build.
+
+> [!NOTE]
+> React on Rails Pro needs no license token for development, test, CI, or asset
+> builds. Production use requires a paid license. See [Pro Installation](../installation.md)
+> for the licensing and production configuration details.
+
+### 1. Prepare the prerequisites
+
+Install the prerequisites listed in the
+[`create-react-on-rails-app` quick start](../../oss/getting-started/create-react-on-rails-app.md#prerequisites),
+including Ruby, Rails, Node.js, Git, your JavaScript package manager, and the
+database used by your app.
+
+The generator defaults to PostgreSQL. If your development environment uses a
+different database, make that an intentional application change and rerun the
+database setup and the complete test suite afterward.
+
+### 2. Generate the Pro RSC app
+
+From the directory that will contain the new app, run:
+
+```bash
+npx create-react-on-rails-app my-app --rsc
+cd my-app
+bin/rails db:prepare
+```
+
+The `--rsc` mode installs React on Rails Pro, configures the Node renderer, and
+generates the HelloServer RSC example. Start the generated development process
+and visit its linked HelloServer route before changing the example.
+
+Keep Rails responsible for database access, authorization, and caching. Prepare
+the page data in the Rails controller and pass it as props to the server
+component instead of querying the database from the RSC process. See
+[RSC Data Fetching Patterns](../../oss/migrating/rsc-data-fetching.md) for the
+supported patterns.
+
+### 3. Add one Rails-backed vertical slice
+
+Add a small form feature that proves both server-side outcomes:
+
+1. Put the data rules in an Active Record model.
+2. Handle the form display and submission in a Rails controller.
+3. On invalid input, render the form again with validation errors and an
+   unsuccessful response status such as `422 Unprocessable Content`.
+4. On valid input, persist the record and redirect to a success page or message.
+
+Then add automated coverage for:
+
+- the RSC page route, including content derived from data supplied by Rails;
+- the form's invalid submission and rendered error feedback; and
+- the form's valid submission, persistence, and redirect or success message.
+
+RSC route tests need the Pro Node renderer to be running. The generated
+development process starts it for local use; for an isolated test process or CI,
+use the readiness and cleanup pattern in
+[Testing with the Node renderer](../node-renderer.md#running-rails-tests-against-the-node-renderer-in-ci).
+
+### 4. Verify tests and the production build
+
+Run the relevant tests and then the full Rails test suite:
+
+```bash
+bin/rails test
+```
+
+Build the production assets through the generated package script:
+
+```bash
+npm run build
+```
+
+Treat only observed zero exit statuses as success. Resolve test failures,
+renderer startup errors, database errors, and build errors rather than inferring
+success from generated files.
+
+### Point-in-time agent evidence
+
+On August 13, 2026, Codex and Claude each attempted this exercise from an empty
+repository at React on Rails revision
+`06d962d089f34dc1ec2963a50c233508ecbc7103`. Their immutable evidence bundles
+remain available as diagnostic records:
+
+| Run                                                                                                                                                                                        | Agent and model             | Review result                                                 | Recorded environment                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Claude evidence bundle](https://github.com/shakacode/react_on_rails/tree/deee3f55bebb7ffeebf24219fe9fd6751db54c73/internal/agent-evals/pro-app-buildability/runs/final-claude-06d962d0-1) | Claude Code 2.1.210, Sonnet | Protocol-noncompliant diagnostic; not counted as a completion | Linux 7.0.0-28-generic aarch64; Ruby 3.4.10; Node 22.23.2; npm 10.9.8; pnpm 10.33.4 |
+| [Codex evidence bundle](https://github.com/shakacode/react_on_rails/tree/deee3f55bebb7ffeebf24219fe9fd6751db54c73/internal/agent-evals/pro-app-buildability/runs/final-codex-06d962d0-1)   | Codex CLI 0.144.4, GPT-5.4  | Protocol-noncompliant diagnostic; not counted as a completion | Linux 7.0.0-28-generic aarch64; Ruby 3.4.10; Node 22.23.2; npm 10.9.8; pnpm 10.33.4 |
+
+Both bundles passed structural and security validation, but later manual review
+found protocol violations. Neither counts as a completion. New harness results
+therefore require explicit semantic review; bounded command and artifact facts
+do not receive an automatic pass or fail. See the
+[internal eval README on GitHub](https://github.com/shakacode/react_on_rails/blob/main/internal/agent-evals/pro-app-buildability/README.md#diagnostic-history)
+for the diagnostic history and review rules. Fresh compliant Codex and Claude
+runs are required before making either a single-agent or two-agent completion
+claim.
+
+These bundles are point-in-time observations, not a compatibility guarantee for
+other versions, platforms, databases, or network conditions. In particular,
+package resolution through `npx` and the public network may change. The run
+schema deliberately records `tutorial_claims_supported: false`: both retained
+bundles supply diagnostic context after manual protocol review, and neither
+supports a completion claim or automatically attests to this tutorial or to
+broader product claims.
+
+## Continue the RSC Tutorial
+
+The remaining parts build upon each other:
 
 1. [Create React Server Component without SSR](create-without-ssr.md) - Learn the fundamentals of React Server Components by creating a basic RSC page without server-side rendering.
 
@@ -9453,7 +9636,24 @@ Common symptoms:
 - browser console logs show a pending Flight decode or missing client reference after the payload route returned
   successfully on the server.
 
-## Recommended Capybara Shape
+## Choose the Test Topology
+
+Choose the owner of the application runtime before you choose the browser assertions:
+
+| Situation                                                                                                                                                     | Recommended owner                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Rails' normal system-test server can reach the renderer, no custom application processes run inside examples, and the test needs a simple hydration assertion | Capybara with a non-buffering driver is acceptable              |
+| The test needs a separately launched Rails server or node renderer                                                                                            | E2E on Rails + Playwright                                       |
+| Test data must be visible across process or database connections                                                                                              | E2E on Rails app commands or scenarios                          |
+| Streaming HTTP, Action Cable, exact network counts, failed-resource checks, or traces are central assertions                                                  | Playwright                                                      |
+| The app already uses Playwright for ShakaPerf, visual regression, or other browser verification                                                               | Reuse Playwright instead of adding a custom Capybara runtime    |
+| Puffing Billy or another external proxy is needed for unrelated APIs                                                                                          | Keep those tests separate; do not proxy or cache the RSC stream |
+
+Capybara is not generally incompatible with RSC. It is a good fit when Rails manages the system-test server and
+that server can reach the renderer. If you would need to start a separate Rails origin or renderer around each
+example, stop extending the Capybara harness and use the multi-process path below.
+
+## Capybara Shape for a Rails-managed Runtime
 
 Use a non-Billy browser driver for specs that assert streamed RSC behavior. If your suite's default JavaScript
 driver is already a plain Selenium driver, you can use it directly. Otherwise, register a dedicated driver for
@@ -9492,6 +9692,50 @@ Good assertions include:
 - an app-owned hydration marker appears after the client boundary finishes;
 - a Suspense fallback is replaced by streamed content and the related client control works.
 
+## E2E on Rails + Playwright for a Multi-process Runtime
+
+Use [E2E on Rails](https://e2eonrails.com/) with Playwright when a test needs an external Rails server, a node
+renderer, cross-process Rails data setup, or detailed streaming and network evidence. Follow the canonical
+[Streamed and Multi-process Applications](https://e2eonrails.com/docs/STREAMING_AND_MULTI_PROCESS_APPS/) guide for
+the full setup. Keep this React on Rails guide focused on the RSC transport boundary.
+
+```text
+focused RSC E2E run
+  -> start and wait for the node renderer
+  -> start and wait for one Rails test server
+  -> run the configured Playwright desktop and mobile projects
+       -> E2E on Rails command resets and creates Rails data
+       -> fresh browser context exercises the real RSC stream
+       -> assert hydration, interaction, console, failed resources, and network
+  -> stop Rails
+  -> stop the renderer
+```
+
+Keep these responsibilities separate:
+
+- React on Rails owns the RSC route, renderer configuration, and streaming contract.
+- The consuming app owns process commands, dependency ordering, readiness checks, logs, and cleanup.
+- E2E on Rails owns Rails-side app commands and state setup.
+- Playwright owns browser contexts, traces, console and page errors, failed resources, and network assertions.
+
+> **Lifecycle rule:** Do not start and stop the Rails server or RSC renderer around individual examples or
+> retries. Keep one application topology alive for the focused E2E run. Reset browser contexts and application
+> data between tests, and stop application processes only after the run.
+
+Streamed chunks and browser resource requests can outlive the assertion that appears to finish a test. Killing the
+origin during reset can create late chunk errors, attribute a failure to the next test, and make retries look more
+stable than the underlying system.
+
+### Make Test Data Visible to Rails
+
+A separate Rails server uses another process and database connection. It normally cannot see records inside an
+RSpec example's uncommitted transaction. Do not use committed `before(:all)` fixtures as the default workaround.
+
+Create and reset data inside the serving Rails process through E2E on Rails
+[app commands](https://e2eonrails.com/docs/app-commands/) or
+[scenarios](https://e2eonrails.com/docs/scenarios/). Transaction-sharing modes require every participating
+process, thread, and connection to support the same assumptions; they are not a general multi-process solution.
+
 ## Puffing Billy Compatibility
 
 Puffing Billy is an HTTP proxy for browser requests. Its
@@ -9529,6 +9773,17 @@ For app-specific system specs:
 2. Wait for an app-owned hydrated marker, visible client-island behavior, or streamed content replacement.
 3. Confirm the RSC payload route was served by the app under test, not by a Billy stub or cache.
 4. Keep external API stubbing separate from the RSC payload transport check.
+
+For a multi-process Playwright test, also:
+
+1. Fail on unexpected `console.error` messages, page errors or unhandled rejections, failed RSC chunks, and failed
+   resources.
+2. Capture a Playwright trace, screenshot or video, Rails logs, and renderer logs when a test fails.
+3. Verify that one stable Rails origin and one stable renderer origin serve the focused run.
+4. Run the same source tests in each required desktop and mobile project.
+5. Treat retries as diagnostic evidence, not proof of stability.
+6. After migration parity, delete superseded browser specs and custom runtime helpers instead of maintaining two
+   sources of truth.
 
 Request specs for `/rsc_payload/:component_name` are still useful for status codes, content type, and payload
 shape, but they do not prove browser streaming. Pair request specs with at least one browser assertion when the
@@ -11011,7 +11266,7 @@ SOURCE: docs/pro/react-server-components/rspack-compatibility.md
 
 # Rspack Compatibility with React Server Components
 
-> **Status**: Supported as of React on Rails Pro 17.0.0. Rspack is the default bundler for fresh installs, the generator scaffolds the native `RSCRspackPlugin`, and RSC-on-Rspack is covered end-to-end by a CI gate — the `dummy-app-rspack-rsc-runtime-gate` job in [`.github/workflows/pro-integration-tests.yml`](https://github.com/shakacode/react_on_rails/blob/main/.github/workflows/pro-integration-tests.yml), which builds the client/server/RSC bundles with Rspack, boots Rails plus the Pro Node renderer, and runs the RSC Playwright suite so RSC routes are proven to render and hydrate under Rspack. Further production hardening is tracked in [issue #3488](https://github.com/shakacode/react_on_rails/issues/3488). The remaining known limitations below (no official React endorsement of the `react-server-dom-webpack` runtime under Rspack; production-posture streamed-CSS coverage) are genuine and still apply.
+> **Status**: Supported as a GA path as of React on Rails Pro 17.0.0. Rspack is the default bundler for fresh installs, the generator scaffolds the native `RSCRspackPlugin`, and RSC-on-Rspack is covered end-to-end by a CI gate — the `dummy-app-rspack-rsc-runtime-gate` job in [`.github/workflows/pro-integration-tests.yml`](https://github.com/shakacode/react_on_rails/blob/main/.github/workflows/pro-integration-tests.yml), which builds the client/server/RSC bundles with Rspack, boots Rails plus the Pro Node renderer, and runs the RSC Playwright suite so RSC routes are proven to render and hydrate under Rspack. The native plugin delivery tracked in [issue #3488](https://github.com/shakacode/react_on_rails/issues/3488) is complete. The remaining production CSS/FOUC simplification follow-up is tracked in [issue #4557](https://github.com/shakacode/react_on_rails/issues/4557). The remaining known limitations below (no official React endorsement of the `react-server-dom-webpack` runtime under Rspack; production-posture streamed-CSS coverage) are genuine and still apply.
 
 This page documents the compatibility status of [Rspack](https://rspack.rs/) with React on Rails Pro's React Server Components (RSC) implementation.
 
@@ -11082,9 +11337,11 @@ two plugins share the same `{ isServer, clientReferences }` options.
 > path. That route-hydration coverage is now wired into this repo's CI as the
 > `dummy-app-rspack-rsc-runtime-gate` job (it builds the three bundles with Rspack, boots
 > Rails plus the Pro Node renderer, and runs the RSC Playwright suite on every qualifying
-> change). Further production hardening is tracked in [issue #3488](https://github.com/shakacode/react_on_rails/issues/3488)
-> (which superseded the abandoned manifest-helper approach in
-> [PR #3385](https://github.com/shakacode/react_on_rails/pull/3385)).
+> change). The native-plugin delivery completed in [issue #3488](https://github.com/shakacode/react_on_rails/issues/3488),
+> which superseded the abandoned manifest-helper approach in
+> [PR #3385](https://github.com/shakacode/react_on_rails/pull/3385).
+> The live production CSS/FOUC simplification follow-up is
+> [issue #4557](https://github.com/shakacode/react_on_rails/issues/4557).
 
 ## How the RSC Bundle Avoids the Plugin
 
@@ -11166,7 +11423,7 @@ builds; production-posture coverage is tracked in
 
 ## Related Resources
 
-- [Issue #3488: Rspack RSC path to production-ready (native RSCRspackPlugin)](https://github.com/shakacode/react_on_rails/issues/3488)
+- [Issue #3488: Completed native RSCRspackPlugin delivery](https://github.com/shakacode/react_on_rails/issues/3488)
 - [Issue #1828: Rspack support for RSC](https://github.com/shakacode/react_on_rails/issues/1828)
 - [PR #3385: Manifest-helper approach for Rspack builds (superseded by the native plugin)](https://github.com/shakacode/react_on_rails/pull/3385)
 - [Rspack React Server Components guide](https://rspack.rs/guide/integrations/rsc)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -312,7 +312,7 @@ Read the full **[React on Rails Doctrine](./misc/doctrine.md)** for our design p
 
 ## System Requirements
 
-- **Rails 7.0+** (Ruby 3.3+ is incompatible with Rails < 7.0; CI tests against Rails 7.1)
+- **Rails 7.0+** (Ruby 3.3+ is incompatible with Rails < 7.0; CI tests against Rails 7.2)
 - **Ruby 3.3+**
 - **Node.js 18+** (React on Rails Pro's Node renderer defaults to Fastify 5 and requires **Node.js 20+** at startup;
   its **Node.js 18.19.0+** `engines.node` floor applies with the documented Fastify 4-compatible dependency overrides)
@@ -6820,8 +6820,8 @@ Use this matrix to decide which approach to use:
 ## Prerequisites
 
 - **React 19** — native metadata hoisting is a React 19 feature
-- **React on Rails 16.2.0+** — for basic `react_component` usage (16.2.0+ is the currently supported, version-aligned line)
-- **React on Rails Pro** — for `stream_react_component` and RSC support. Current public releases (16.2.0+) are version-aligned: install Pro at the same version as `react_on_rails`.
+- **React on Rails 16.2.0+** — the minimum for basic `react_component` usage; the current stable documentation targets React on Rails 17
+- **React on Rails Pro 17 with React on Rails 17** — for `stream_react_component` and supported GA RSC. Install Pro at the same version as `react_on_rails`; the stable RSC stack uses React and React DOM 19.2.x with patch 19.2.7 or newer and `react-on-rails-rsc` 19.2.x with patch 19.2.1 or newer.
 
 ## References
 
@@ -12326,6 +12326,12 @@ React Server Components add one more moving part to the standard test setup: sys
 
 Use this recipe for Capybara, system, and end-to-end tests that exercise `stream_react_component`, `RSCRoute`, or the `rsc_payload_route`.
 
+This recipe fits a Rails-managed system-test topology: the normal Rails test server can reach a renderer that is
+started once for the suite or worker. If the browser test needs a separately launched Rails origin and renderer,
+cross-process data setup, or detailed streaming, network, and trace assertions, use E2E on Rails + Playwright
+instead. See [System Specs for Streamed RSC Payloads](../../pro/react-server-components/system-spec-streaming-rsc.md#choose-the-test-topology)
+for the decision rule and the multi-process lifecycle boundary.
+
 This recipe uses the React on Rails TestHelper with `build_test_command`: Rails checks whether generated bundles are stale, runs your test build command when needed, and fails fast if compilation fails.
 
 The Step 3 renderer-lifecycle helper is **RSpec-focused** because it uses `before(:suite)` and `after(:suite)` hooks; for Minitest, see [Minitest Equivalent](#minitest-equivalent) for a parallel adaptation that reuses the same safety points from a `test/test_helper.rb` harness plus `Minitest.after_run`.
@@ -12642,7 +12648,7 @@ Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 
-### 4. Write A Capybara RSC Smoke Test
+### 4. Write A Capybara RSC Smoke Test for a Rails-managed Runtime
 
 Keep the first system test boring: visit a route that streams one Server Component and assert on visible HTML plus one hydrated Client Component interaction.
 
@@ -14419,14 +14425,21 @@ REACT_RENDERER_URL=http://localhost:3801
 The renderer port must match on both sides: `RENDERER_PORT` is read by the Node process and
 `REACT_RENDERER_URL` is read by the Rails-side Pro initializer.
 
-> **Note:** `bin/dev kill` scopes cleanup to the current app directory. It first uses the running
-> session's recorded ports. For a manual default-port setup, export `RENDERER_PORT` (or a local
-> `REACT_RENDERER_URL`) in a fresh shell so the renderer port is scanned; base-port setups also
-> derive the renderer's `base + 2` port. A port candidate is signalled only when `lsof` finds a
+> **Note:** `bin/dev kill` scopes cleanup to the current app directory. It combines the running
+> session's recorded ports with the current port configuration. It can also derive a renderer fallback from an
+> active generated `node-renderer:` command in `Procfile.dev`, `Procfile.dev-static-assets`, or
+> `Procfile.dev-prod-assets` that uses `${RENDERER_PORT:-PORT}`. For a manual setup without that
+> generated command, export `RENDERER_PORT` (or a local `REACT_RENDERER_URL`) in a fresh shell so
+> the renderer port is scanned. Base-port setups also derive the renderer's `base + 2` port.
+> A port candidate is signalled only when `lsof` finds a
 > `LISTEN` socket and the process working directory is inside this app root. Foreign listeners that
 > are visible to the invoking user are reported and left running; a listener owned by another OS user
 > may be invisible to `lsof` and therefore go unreported. If ownership or shutdown cannot be verified,
 > the command exits nonzero instead of reporting success.
+
+`bin/dev kill` cannot verify Overmind shutdown if `tmp/sockets` resolves outside the app directory.
+Inspect the symlink and configure an app-local socket directory before retrying. Removing a stale
+`tmp/react_on_rails/dev-session.json` file alone does not resolve this directory blocker.
 
 ## See Also
 
@@ -20921,7 +20934,9 @@ rails generate react_on_rails:install --pro --typescript
 rails generate react_on_rails:install --pro --rspack
 ```
 
-The standalone Pro generator also modifies `config/webpack/serverWebpackConfig.js` (enables `libraryTarget: 'commonjs2'`, adds `extractLoader`, sets `target = 'node'`, changes exports to object style) and updates the import in `config/webpack/ServerClientOrBoth.js`. If your webpack configs use the legacy filename `generateWebpackConfigs.js`, the generator will rename it automatically.
+The standalone Pro generator upgrades `serverWebpackConfig.js` and its companion `ServerClientOrBoth.js` in the active `config/webpack/` or `config/rspack/` directory only when both files exactly match a supported current generated pair. It enables Pro server settings and updates the paired export/import shape. A supported pair can use the legacy companion filename `generateWebpackConfigs.js`; the generator keeps that filename without renaming it.
+
+Customized, unknown, unsupported historical, incomplete, or ambiguous pairs are left unchanged, including their paths. If the generator skips the pair, follow the [manual webpack/Rspack migration instructions](../../pro/upgrading-to-pro.md#complete-a-skipped-webpackrspack-migration-manually); rerunning it does not migrate these files.
 
 **Upgrading an existing React on Rails app to Pro:**
 
@@ -25938,7 +25953,7 @@ This guide covers the React-side challenges of migrating an existing React on Ra
 > [!NOTE]
 > **Summary for AI agents:** Use this page when the user has an existing React on Rails app and wants to adopt RSC. This covers the React-side migration (component restructuring, state, data fetching). For the initial RSC setup, see the [RSC tutorial](../../pro/react-server-components/tutorial.md). RSC requires Pro with the Node renderer.
 
-> **React on Rails Pro required:** RSC support requires [React on Rails Pro](../../pro/react-on-rails-pro.md) with the node renderer. Current public releases (16.2.0+) are version-aligned: install Pro at the same version as `react_on_rails`. The Pro gem provides the streaming view helpers (`stream_react_component`, `stream_react_component_with_async_props`, `rsc_payload_react_component`, and `rsc_payload_react_component_with_async_props`), the RSC webpack plugin and loader, and the `registerServerComponent` API. For setup, see the [RSC tutorial](../../pro/react-server-components/tutorial.md). For upgrade steps, see the [performance breakthroughs guide](../../pro/major-performance-breakthroughs-upgrade-guide.md).
+> **React on Rails Pro required:** RSC is a supported GA feature of [React on Rails Pro 17](../../pro/react-on-rails-pro.md) with the node renderer. Install Pro at the same version as `react_on_rails`. The stable v17 RSC stack uses React and React DOM 19.2.x with patch 19.2.7 or newer and `react-on-rails-rsc` 19.2.x with patch 19.2.1 or newer. The Pro gem provides the streaming view helpers (`stream_react_component`, `stream_react_component_with_async_props`, `rsc_payload_react_component`, and `rsc_payload_react_component_with_async_props`), the RSC webpack plugin and loader, and the `registerServerComponent` API. For setup, see the [RSC tutorial](../../pro/react-server-components/tutorial.md). For upgrade steps, see [Upgrading an Existing React on Rails Pro App to RSC](../../pro/react-server-components/upgrading-existing-pro-app.md). That guide's Pro 16.4+ prerequisite is only the minimum starting point for an existing app; Pro 17 is the supported GA destination and current documentation baseline.
 
 ## Why Migrate?
 
@@ -26145,8 +26160,9 @@ These mistakes account for the majority of setup failures:
 
 ## Prerequisites
 
-- React 19+
-- [React on Rails Pro](../../pro/react-on-rails-pro.md) installed at the same version as React on Rails (current public releases, 16.2.0+, are version-aligned)
+- React and React DOM 19.2.x with patch 19.2.7 or newer
+- [React on Rails Pro 17](../../pro/react-on-rails-pro.md) installed at the same version as React on Rails 17
+- Stable `react-on-rails-rsc` 19.2.x with patch 19.2.1 or newer
 - Node renderer configured (RSC requires server-side JavaScript execution)
 - RSC webpack bundle configured (see [RSC tutorial](../../pro/react-server-components/tutorial.md))
 - Node.js 20+
@@ -26196,7 +26212,7 @@ After these steps, every component is still a Client Component (because of the `
 
 Before starting, ensure you have:
 
-- **React on Rails Pro** and **React on Rails** installed at the same version — current public releases (16.2.0+) are version-aligned, and the Pro gem depends on the exact matching `react_on_rails` release
+- **React on Rails Pro 17** and **React on Rails 17** installed at the same version — these stable v17 releases are version-aligned, and the Pro gem depends on the exact matching `react_on_rails` release
 - **React 19.2.x** (`react` and `react-dom` both at 19.2.x with patch `>= 19.2.7` for the React on Rails Pro 17 RSC path)
 - **Node renderer** configured and running (RSC requires server-side JavaScript execution via the node renderer, not ExecJS). If you're still using ExecJS, migrate to the node renderer first -- see [Node Renderer Basics](../building-features/node-renderer/basics.md).
 - **Shakapacker** (or webpack configured via Shakapacker)

--- a/react_on_rails/spec/dummy/e2e/README.md
+++ b/react_on_rails/spec/dummy/e2e/README.md
@@ -2,6 +2,17 @@
 
 This directory contains end-to-end tests using Playwright integrated with Rails via the `cypress-on-rails` gem.
 
+This is the repository's runnable reference for Rails-side app commands, scenarios, database reset, and Playwright
+browser contexts. Applications that need a separate Rails server plus an RSC node renderer should keep that runtime
+alive for the focused run and reuse these E2E on Rails responsibilities. See
+[System Specs for Streamed RSC Payloads](../../../../docs/pro/react-server-components/system-spec-streaming-rsc.md#choose-the-test-topology)
+for the Capybara-versus-Playwright decision and
+[E2E on Rails: Streamed and Multi-process Applications](https://e2eonrails.com/docs/STREAMING_AND_MULTI_PROCESS_APPS/)
+for the full external-runtime setup.
+
+The dummy app does not currently expose a streamed RSC route. Its examples demonstrate the test harness, not an
+RSC runtime. Use an application's existing RSC route and renderer commands when adapting the public guide.
+
 ## Quick Start
 
 ```bash
@@ -194,9 +205,11 @@ pnpm test:e2e:report
 5. **Test Hydration**: Ensure client-side hydration works correctly
 6. **Monitor Console**: Listen for console errors during tests
 7. **Scenarios for Complex Setup**: Create reusable scenarios for complex application states
+8. **Stable Multi-process Runtime**: Start Rails and auxiliary renderers once for a focused run, not around each
+   test or retry
 
 ## More Information
 
 - [Playwright Documentation](https://playwright.dev/)
 - [cypress-on-rails Gem](https://github.com/shakacode/cypress-on-rails)
-- [React on Rails Testing Guide](../../CLAUDE.md#playwright-e2e-testing)
+- [React on Rails Playwright E2E Testing Guide](../../../../.claude/docs/playwright-e2e-testing.md)


### PR DESCRIPTION
## Why

The streamed-RSC system-spec guide presented a Capybara example without defining when a consuming application should stop extending a Rails system-test harness and use a stable external runtime. Applications that need a separate Rails server, node renderer, or cross-process test data can otherwise create per-example process churn that causes late chunk failures and misleading retry results.

This change gives readers an explicit topology decision while preserving Capybara as a supported choice for Rails-managed system tests.

Fixes #4757.

## What changed

- Add a Capybara-versus-E2E-on-Rails decision table to the streamed-RSC guide.
- Document the one-runtime-per-focused-run lifecycle rule, Rails-side data setup, responsibility boundaries, and Playwright failure evidence.
- Keep all Puffing Billy transport warnings intact and label the Capybara example as Rails-managed only.
- Point the OSS testing guide and dummy Playwright README to the same decision.
- Record that the current dummy harness has no streamed RSC route, so this PR does not invent a new runtime or test.
- Regenerate `llms-full.txt` and `llms-full-pro.txt`. This also catches up generated references with source-doc changes already present on `main`.

The dependency evidence is now concrete: the HiChee migration landed in `shakacode/hichee#9902`, and the canonical E2E on Rails multi-process guide landed in `shakacode/cypress-playwright-on-rails#264` and is published at https://e2eonrails.com/docs/STREAMING_AND_MULTI_PROCESS_APPS/.

## Validation

- `pnpm exec prettier --check docs/pro/react-server-components/system-spec-streaming-rsc.md docs/oss/building-features/testing-configuration.md react_on_rails/spec/dummy/e2e/README.md`
- `node script/generate-llms-full.mjs --check`
- `node script/generate-llms-full.mjs --validate`
- `script/check-docs-sidebar origin/main HEAD`
- `bin/check-links` — 3,608 links checked, 0 errors
- `lychee --no-progress react_on_rails/spec/dummy/e2e/README.md` — 0 errors after fixing its stale local testing-guide link
- `codex review --base origin/main` — no actionable findings
- pre-commit and pre-push hooks passed

## Issue evaluation

- **Disposition:** fix later / P2, now unblocked by landed reference documentation and implementation evidence
- **Impact:** prevents fragile per-example Rails/renderer orchestration without requiring every app to adopt Playwright
- **Complexity:** documentation-only; three source pages and two generated reference artifacts
- **Process-gap disposition:** not applicable

## Codex decision log

- **Non-blocking:** The dummy app does not expose an existing streamed RSC route.
  - **Decision:** Keep the change documentation-only and describe the existing harness accurately.
  - **Why:** The issue explicitly prohibits inventing an unverified runtime.
  - **Review later:** None.

## Review and QA notes

- Manual self-review and local Codex review found no actionable defect. Current-head review feedback was triaged and resolved with one focused repair commit.
- Post-push review churn: 1 focused review-fix commit after the current-head reviewer wave.
- GitHub Rich Diff was inspected for all three source Markdown files at the exact head. Baseline deletions and candidate additions painted correctly, including the topology table, links, callouts, headings, and code blocks.

<!-- qa-evidence v3
required: yes
status: satisfied
head_sha: 386bad83ba87c05b7f2dc85a620d9af333cd4d50
tested_at: PR head 386bad83ba87c05b7f2dc85a620d9af333cd4d50
scope: Three documentation source pages and regenerated llms-full artifacts
automated_checks: Prettier, llms generation check and validation, sidebar guard, full link check, and focused link check passed
manual_checks: GitHub Rich Diff inspected for all three source Markdown files at the exact head; baseline and candidate rendered with no blank or broken sections
user_visible_ui_change: yes
visual_evidence_status: complete
visual_evidence_destination: github_pr
visual_evidence_url: https://github.com/shakacode/react_on_rails/pull/5059/files
visual_baseline_status: captured
visual_candidate_status: captured
paint_check_status: passed
interaction_change: no
interaction_evidence_kind: not_applicable
interaction_evidence_destination: not_applicable
interaction_evidence_url: not_applicable
interaction_baseline_value: not_applicable
interaction_candidate_value: not_applicable
interaction_tolerance: not_applicable
visual_fix: no
negative_control_status: not_applicable
performance_impact: not_applicable
performance_evidence_status: not_applicable
performance_source_kind: not_applicable
performance_source_ref: not_applicable
performance_metric_kind: not_applicable
performance_baseline_value: not_applicable
performance_candidate_value: not_applicable
findings: none
release_blocking: clear
process_gap_disposition: not applicable
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or test harness code modifications.
> 
> **Overview**
> Documentation now steers teams toward **Capybara only when Rails owns the system-test server and renderer**, and toward **E2E on Rails + Playwright** when tests need a separate Rails origin, node renderer, cross-process DB setup, or rich streaming/network/trace assertions.
> 
> The streamed-RSC guide adds a **topology decision table**, renames the Capybara section for Rails-managed runtimes, and documents multi-process lifecycle (one stable topology per run), responsibility splits, E2E data setup via app commands/scenarios, and an expanded Playwright verification checklist. The OSS testing-configuration guide and dummy Playwright README **cross-link** that decision and note the dummy app has no streamed RSC route.
> 
> Regenerated **`llms-full.txt` / `llms-full-pro.txt`** also reflect related doc updates (Pro 17 RSC GA/version pins, Pro generator webpack/Rspack skip behavior and manual migration, tutorial build-and-verify exercise, `bin/dev kill` port discovery, Rspack GA status).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386bad83ba87c05b7f2dc85a620d9af333cd4d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated React on Rails Pro 17 and React 19.2.x RSC requirements, upgrade guidance, and stable GA references.
  * Clarified when to use Rails-managed Capybara system tests versus Playwright E2E tests, including external runtimes, proxies, multi-process databases, and streaming verification.
  * Documented supported Pro generator migration behavior and added a tutorial exercise for building and verifying a Pro RSC application.
  * Clarified `bin/dev kill` port discovery and updated Playwright E2E links and best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->