### PR TITLE
Update changelog for 17.1.0.rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.1.0.rc.3] - 2026-09-11
+
 #### Fixed
 
 - **[Pro] RSC 19.3 release-candidate compatibility and generated defaults**: Generated RSC apps now pin
@@ -3236,7 +3238,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.2...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.3...main
+[17.1.0.rc.3]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.2...v17.1.0.rc.3
 [17.1.0.rc.2]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.1...v17.1.0.rc.2
 [17.1.0.rc.1]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.0...v17.1.0.rc.1
 [17.1.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v17.0.1...v17.1.0.rc.0


### PR DESCRIPTION
### Why

React on Rails 17.1.0 RC3 cannot be published while its qualified RSC RC3 notes remain under `Unreleased`. The release wrapper selects the first non-empty stamped changelog section as its publication target.

### Change

- Stamp the existing RSC 19.3 RC3 qualification notes as `17.1.0.rc.3` dated 2026-09-11.
- Add the RC2-to-RC3 comparison link and advance the `unreleased` anchor.

No product version fields are changed here; the supervised release task owns the generated version-bump commit.

### Validation

- `bundle exec rake update_changelog[17.1.0.rc.3]`
- Prettier passed.
- Offline and online Markdown link checks passed.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog stamping and compare-link updates with no application or dependency version changes in this PR.
> 
> **Overview**
> Prepares **17.1.0.rc.3** for publication by moving the existing **[Pro] RSC 19.3 RC3** *Fixed* notes out of `Unreleased` into a stamped section dated **2026-09-11**, leaving `Unreleased` empty for follow-on work.
> 
> Updates the changelog footer so `[unreleased]` compares **v17.1.0.rc.3…main** and adds **`[17.1.0.rc.3]`** linking **v17.1.0.rc.2…v17.1.0.rc.3**. No runtime or version-bump files are touched here—the supervised release task still owns gem/npm version commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5244ae7210c5590f074c38178ea091a9b34d1af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->