### PR TITLE
Expose public process execution API

### DIFF
--- a/react_on_rails/lib/react_on_rails/dev/process_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/process_manager.rb
@@ -84,6 +84,20 @@ module ReactOnRails
           exit 1
         end
 
+        # Replace this process with an available executable using the same
+        # Bundler-aware lookup strategy as development-process startup.
+        def exec_process_if_available(process, args)
+          return exec(process, *args) if installed?(process)
+          return false unless process_available_in_system?(process)
+
+          env_overrides = preserve_runtime_env_vars
+          with_unbundled_context do
+            exec(env_overrides, process, *args)
+          end
+        rescue Errno::ENOENT
+          false
+        end
+
         private
 
         # Check if a process is actually usable in the current execution context

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -1751,15 +1751,7 @@ module ReactOnRails
         end
 
         def execute_overmind_command(args)
-          return exec("overmind", *args) if ProcessManager.installed?("overmind")
-          return false unless ProcessManager.send(:process_available_in_system?, "overmind")
-
-          env_overrides = ProcessManager.send(:preserve_runtime_env_vars)
-          ProcessManager.send(:with_unbundled_context) do
-            exec(env_overrides, "overmind", *args)
-          end
-        rescue Errno::ENOENT
-          false
+          ProcessManager.exec_process_if_available("overmind", args)
         end
 
         def wait_for_overmind_command(pid, timeout_secs)

--- a/react_on_rails/sig/react_on_rails/dev/process_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/process_manager.rbs
@@ -7,6 +7,7 @@ module ReactOnRails
       def self.installed?: (String) -> bool
       def self.ensure_procfile: (String) -> void
       def self.run_with_process_manager: (String) -> void
+      def self.exec_process_if_available: (String, Array[String]) -> bool
 
       private
 

--- a/react_on_rails/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/process_manager_spec.rb
@@ -178,6 +178,31 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
     end
   end
 
+  describe ".exec_process_if_available" do
+    it "exposes a public API that execs a process available in the current context" do
+      allow(described_class).to receive(:installed?).with("overmind").and_return(true)
+      expect(described_class).to receive(:exec).with("overmind", "quit", "-s", "/tmp/overmind.sock").and_return(true)
+
+      result = described_class.exec_process_if_available("overmind", ["quit", "-s", "/tmp/overmind.sock"])
+
+      expect(result).to be true
+    end
+
+    it "preserves runtime environment when execing outside Bundler" do
+      env_overrides = { "PORT" => "4321" }
+      allow(described_class).to receive(:installed?).with("overmind").and_return(false)
+      allow(described_class).to receive(:process_available_in_system?).with("overmind").and_return(true)
+      allow(described_class).to receive(:preserve_runtime_env_vars).and_return(env_overrides)
+      allow(described_class).to receive(:with_unbundled_context).and_yield
+      expect(described_class).to receive(:exec)
+        .with(env_overrides, "overmind", "kill", "-s", "/tmp/overmind.sock").and_return(true)
+
+      result = described_class.exec_process_if_available("overmind", ["kill", "-s", "/tmp/overmind.sock"])
+
+      expect(result).to be true
+    end
+  end
+
   describe ".run_process_outside_bundle" do
     it "uses with_unbundled_context when Bundler is available" do
       expect(described_class).to receive(:with_unbundled_context).and_yield

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -3027,26 +3027,9 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       # project. A bare `system("overmind", ...)` here repeats the context that
       # already failed, and the process-group fallback cannot reach an Overmind
       # session because its tmux server daemonizes to PPID 1.
-      it "executes Overmind in the bundled context when startup finds it there" do
-        root = app_root("runner")
-        socket_path = File.join(root, "r.sock")
-        servers << UNIXServer.new(socket_path)
-
-        allow(ReactOnRails::Dev::ProcessManager).to receive(:installed?).with("overmind").and_return(true)
-        expect(described_class).to receive(:exec).with("overmind", "quit", "-s", socket_path).and_return(true)
-
-        expect(described_class.send(:execute_overmind_command, ["quit", "-s", socket_path])).to be true
-      end
-
-      it "executes Overmind outside Bundler when startup finds it only there" do
-        env_overrides = { "PORT" => "4321" }
-        allow(ReactOnRails::Dev::ProcessManager).to receive(:installed?).with("overmind").and_return(false)
-        allow(ReactOnRails::Dev::ProcessManager)
-          .to receive(:process_available_in_system?).with("overmind").and_return(true)
-        allow(ReactOnRails::Dev::ProcessManager).to receive(:preserve_runtime_env_vars).and_return(env_overrides)
-        allow(ReactOnRails::Dev::ProcessManager).to receive(:with_unbundled_context).and_yield
-        expect(described_class).to receive(:exec)
-          .with(env_overrides, "overmind", "kill", "-s", "/tmp/overmind.sock").and_return(true)
+      it "uses ProcessManager's public execution API for Overmind control" do
+        expect(ReactOnRails::Dev::ProcessManager).to receive(:exec_process_if_available)
+          .with("overmind", ["kill", "-s", "/tmp/overmind.sock"]).and_return(true)
 
         result = described_class.send(:execute_overmind_command, ["kill", "-s", "/tmp/overmind.sock"])
 


### PR DESCRIPTION
## Why

Issue #4942's comment and dead-code cleanup landed in #4983, but its remaining process-runner item did not. Later shutdown hardening in #4986 expanded that private coupling: `ServerManager` now reaches three private `ProcessManager` methods to preserve the same Bundler-compatible lookup while using `exec` for a bounded control subprocess.

## What changed

- Add a public `ProcessManager.exec_process_if_available` API for process-replacing callers.
- Keep the current-context lookup, system-context lookup, runtime environment preservation, and legacy/new Bundler compatibility path in `ProcessManager`.
- Route Overmind shutdown control through that public API instead of cross-class private `send` calls.
- Pin the public method and both execution contexts with focused specs and an RBS signature.

This is a narrow maintainability repair; it does not change shutdown containment, timeout, escalation, or release behavior.

## Validation

- `bundle exec rspec spec/react_on_rails/dev/process_manager_spec.rb spec/react_on_rails/dev/server_manager_spec.rb` — 403 examples, 0 failures
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop` — 253 files, no offenses
- `bundle exec rake rbs:validate` — passed
- pre-commit hooks — passed (Ruby autofix/lint and trailing-newline checks; JS/Markdown checks skipped as not applicable)
- TDD red: the ServerManager delegation spec failed because the public API did not exist
- bounded mutation: removing preserved runtime environment from the Bundler-free exec path failed the focused expectation
- `codex review --base origin/main` — clean, no actionable findings

Claude `/code-review` and `/simplify` were attempted as the high-risk secondary gate but were unavailable because the account weekly limit is exhausted until September 14. No edits resulted.

Addresses the remaining item 3 in #4942.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API extraction with tests and RBS; Overmind shutdown behavior is intended to stay the same.
> 
> **Overview**
> **Refactors how Overmind control commands are launched** so `ServerManager` no longer reaches into private `ProcessManager` helpers via `send`.
> 
> A new public **`ProcessManager.exec_process_if_available`** wraps the same Bundler-aware lookup used when starting dev (`installed?` → system-wide fallback with `preserve_runtime_env_vars` and `with_unbundled_context`) but uses **`exec`** for process-replacing callers. **`execute_overmind_command`** now delegates to that API in one line.
> 
> Specs move the bundled-vs-unbundled exec behavior to `process_manager_spec`; `server_manager_spec` only asserts delegation. An RBS signature documents the new method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e59856993bc20de4496088cf3f38938627bc5f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development command execution when tools are available through either the project environment or the system.
  - Preserved runtime environment settings when launching development processes.
  - Improved reliability of Overmind control commands across different setup configurations.

- **Tests**
  - Added coverage for process execution in project and system environments, including environment-variable preservation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->