### PR TITLE
Add Rails overlay parity evidence harness

### DIFF
--- a/benchmarks/rspack-vite-rails-dx/.gitignore
+++ b/benchmarks/rspack-vite-rails-dx/.gitignore
@@ -2,4 +2,5 @@
 results/latest.json
 results/local*.json
 RESULTS.local.md
+OVERLAY_RESULTS.local.md
 node_modules/

--- a/benchmarks/rspack-vite-rails-dx/OVERLAY_RESULTS.md
+++ b/benchmarks/rspack-vite-rails-dx/OVERLAY_RESULTS.md
@@ -1,0 +1,25 @@
+# Recorded Rails-tier overlay evidence
+
+Generated from `results/overlay-recorded.json`. Do not edit the matrix by hand.
+
+| Stack                   | Compile overlay | Runtime overlay with original source frame | Compile-error click-to-editor | Source restoration |
+| ----------------------- | --------------- | ------------------------------------------ | ----------------------------- | ------------------ |
+| React on Rails + Rspack | PASS            | FAIL                                       | FAIL                          | PASS               |
+| Inertia Rails + Vite    | PASS            | FAIL                                       | FAIL                          | PASS               |
+
+Each overlay result requires the deterministic marker and the original TSX file and line. Click-to-editor uses a temporary `LAUNCH_EDITOR` recorder and requires the copied workspace's exact source path, line, and column. The harness restores each mutation, waits for the overlay to clear, and removes its process group, workspace, and ports.
+
+## Environment
+
+- Recorded: 2026-09-12T00:52:09.890Z
+- Harness commit: `aff9a6a2a83fa85bebce13e91b7d3882b500404c`
+- Worktree clean at start: true
+- OS: Darwin 25.6.0 arm64
+- CPU: Apple M5 Max (18 logical CPUs)
+- Node: v22.12.0; pnpm: 10.33.4; Ruby: ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [arm64-darwin23]
+- Rspack stack: react_on_rails 17.0.1; shakapacker 10.3.0; rspack/2.2.2 darwin-arm64 node-v22.12.0
+- Vite stack: inertia_rails 3.22.0; vite_rails 3.11.1; vite/8.2.2 darwin-arm64 node-v22.12.0
+
+## Interpretation boundary
+
+This is a same-machine browser verification of the two pinned generated Rails starters. A FAIL records observed behavior; it is not by itself a product defect. Product fixes require separate issue evaluation. See [issue #4696](https://github.com/shakacode/react_on_rails/issues/4696).

--- a/benchmarks/rspack-vite-rails-dx/OVERLAY_RESULTS.md
+++ b/benchmarks/rspack-vite-rails-dx/OVERLAY_RESULTS.md
@@ -4,15 +4,15 @@ Generated from `results/overlay-recorded.json`. Do not edit the matrix by hand.
 
 | Stack                   | Compile overlay | Runtime overlay with original source frame | Compile-error click-to-editor | Source restoration |
 | ----------------------- | --------------- | ------------------------------------------ | ----------------------------- | ------------------ |
-| React on Rails + Rspack | PASS            | FAIL                                       | FAIL                          | PASS               |
+| React on Rails + Rspack | PASS            | FAIL                                       | FAIL                          | FAIL               |
 | Inertia Rails + Vite    | PASS            | FAIL                                       | FAIL                          | PASS               |
 
 Each overlay result requires the deterministic marker and the original TSX file and line. Click-to-editor uses a temporary `LAUNCH_EDITOR` recorder and requires the copied workspace's exact source path, line, and column. The harness restores each mutation, waits for the overlay to clear, and removes its process group, workspace, and ports.
 
 ## Environment
 
-- Recorded: 2026-09-12T00:52:09.890Z
-- Harness commit: `aff9a6a2a83fa85bebce13e91b7d3882b500404c`
+- Recorded: 2026-09-12T01:10:38.530Z
+- Harness commit: `caaa27bc232393836bb71c2f8c94ec656bed49c2`
 - Worktree clean at start: true
 - OS: Darwin 25.6.0 arm64
 - CPU: Apple M5 Max (18 logical CPUs)

--- a/benchmarks/rspack-vite-rails-dx/README.md
+++ b/benchmarks/rspack-vite-rails-dx/README.md
@@ -38,3 +38,15 @@ Run on an otherwise quiet machine and compare both stacks within the same run. D
 The report uses medians and min-to-max spread. It labels a metric `ambiguous` when either spread exceeds 50% of its median. Otherwise, a difference inside the larger observed spread is a `wash`; only a difference outside that local noise band is called an improvement or regression for Vite relative to Rspack.
 
 The generated-configuration audit is descriptive. File and line counts do not measure how difficult the concepts are to learn. This package also does not test production performance, runtime-error overlay quality, or click-to-editor behavior; issue #4696 owns the overlay follow-up.
+
+## Overlay verification
+
+The issue #4696 verifier uses the same pinned starter pair and isolated workspace lifecycle. It injects deterministic compile and runtime errors, checks each overlay for the marker and original TSX source line, and verifies compile-error click-to-editor through a temporary `LAUNCH_EDITOR` recorder. It does not open a local editor or modify the committed starters.
+
+After installing the replay prerequisites above, run:
+
+```bash
+pnpm run verify:overlays
+```
+
+The local JSON and Markdown outputs are ignored. A recorded result must come from a clean committed harness, redact local paths, and be replayed twice on a quiet machine before replacing `results/overlay-recorded.json` and `OVERLAY_RESULTS.md`. A failed matrix cell records observed behavior; evaluate product changes separately.

--- a/benchmarks/rspack-vite-rails-dx/README.md
+++ b/benchmarks/rspack-vite-rails-dx/README.md
@@ -37,7 +37,7 @@ Run on an otherwise quiet machine and compare both stacks within the same run. D
 
 The report uses medians and min-to-max spread. It labels a metric `ambiguous` when either spread exceeds 50% of its median. Otherwise, a difference inside the larger observed spread is a `wash`; only a difference outside that local noise band is called an improvement or regression for Vite relative to Rspack.
 
-The generated-configuration audit is descriptive. File and line counts do not measure how difficult the concepts are to learn. This package also does not test production performance, runtime-error overlay quality, or click-to-editor behavior; issue #4696 owns the overlay follow-up.
+The generated-configuration audit is descriptive. File and line counts do not measure how difficult the concepts are to learn. The timing benchmark does not test production performance or overlay behavior; the verifier below owns the overlay evidence requested by issue #4696.
 
 ## Overlay verification
 

--- a/benchmarks/rspack-vite-rails-dx/package.json
+++ b/benchmarks/rspack-vite-rails-dx/package.json
@@ -10,6 +10,7 @@
     "benchmark": "node scripts/run.mjs",
     "check": "prettier --check . --ignore-path .prettierignore && node --test scripts/*.test.mjs && node scripts/report.mjs --check",
     "format": "prettier --write . --ignore-path .prettierignore",
+    "verify:overlays": "node scripts/overlay.mjs",
     "prepare:starters": "pnpm --dir starters/rspack install --ignore-workspace --frozen-lockfile && pnpm --dir starters/vite install --ignore-workspace --frozen-lockfile"
   },
   "devDependencies": {

--- a/benchmarks/rspack-vite-rails-dx/results/overlay-recorded.json
+++ b/benchmarks/rspack-vite-rails-dx/results/overlay-recorded.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "created_at": "2026-09-12T00:52:09.890Z",
+  "environment": {
+    "harness_git_head": "aff9a6a2a83fa85bebce13e91b7d3882b500404c",
+    "harness_git_clean": true,
+    "operating_system": "Darwin 25.6.0 arm64",
+    "cpu": "Apple M5 Max",
+    "logical_cpu_count": 18,
+    "total_memory_bytes": 137438953472,
+    "node": "v22.12.0",
+    "pnpm": "10.33.4",
+    "ruby": "ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [arm64-darwin23]",
+    "rails": { "rspack": "Rails 8.1.3", "vite": "Rails 8.1.3" },
+    "dependencies": {
+      "rspack_ruby": "react_on_rails 17.0.1; shakapacker 10.3.0",
+      "rspack_javascript": "rspack/2.2.2 darwin-arm64 node-v22.12.0",
+      "vite_ruby": "inertia_rails 3.22.0; vite_rails 3.11.1",
+      "vite_javascript": "vite/8.2.2 darwin-arm64 node-v22.12.0"
+    },
+    "commands": {
+      "rspack": "REACT_ON_RAILS_BASE_PORT=<PORT> bin/dev --no-open-browser",
+      "vite": "PORT=<PORT> VITE_RUBY_PORT=<PORT+1> bin/dev"
+    }
+  },
+  "methodology": {
+    "compile_overlay": "append a deterministic syntax error and require the overlay marker plus original TSX file and line",
+    "runtime_overlay": "insert a deterministic render-time throw and require the overlay marker plus original TSX file and line",
+    "click_to_editor": "click the compile-error source link with LAUNCH_EDITOR set to a recorder; require exact copied source path, line, and column",
+    "cleanup": "restore each source mutation, wait for the overlay to clear, then remove the process group, workspace, and ports"
+  },
+  "results": {
+    "rspack": {
+      "compile_overlay": {
+        "status": "PASS",
+        "marker_visible": true,
+        "source_location_visible": true,
+        "expected_source": "app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx:26",
+        "evidence": "Compiled with problems:×ERROR in ./app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx × Module build failed (from builtin:swc-loader): ╰─▶ × Syntax Error: Expression expected ╭─[26:36] 24 │ 25 │ export default HelloWorld; 26 │ const ROR_DX_COMPILE_ERROR_MARKER = ; · ─ ╰────"
+      },
+      "runtime_overlay": {
+        "status": "FAIL",
+        "marker_visible": true,
+        "source_location_visible": false,
+        "expected_source": "app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx:6",
+        "evidence": "Uncaught runtime errors:×ERRORROR_DX_RUNTIME_ERROR_MARKER at HelloWorld (http://127.0.0.1:39228/packs/js/generated/HelloWorld.bae9e906ef250676.hot-update.js:15:11) at react-stack-bottom-frame (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:22430:20) at renderWithHooks (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:5759:22) at updateFunctionComponent (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:8020:19) at beginWork (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:9685:18) at runWithFiberInDEV (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:546:16"
+      },
+      "click_to_editor": {
+        "status": "FAIL",
+        "expected_source": "app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx:26:<column>",
+        "evidence": "timed out waiting for the LAUNCH_EDITOR recorder",
+        "available_targets": [],
+        "responses": [
+          {
+            "status": 404,
+            "url": "http://127.0.0.1:41455/rspack-dev-server/open-editor?fileName=builtin:react-refresh-loader!builtin:react-refresh-loader!builtin:swc-loader??ruleSet[1].rules[3].use[0]!<LOCAL_PATH>/.work/rspack-oc-96928-1789174330086-75b1660d59a97/app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx",
+            "body": "<!DOCTYPE html> <html lang=\"en\"> <head> <meta charset=\"utf-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"> <meta name=\"turbo-visit-control\" content=\"reload\"> <title>Action Controller: Exception caught</title> <style> body { background-color: #FAFAFA; color: #333; color-scheme: light dark; supported-color-schemes: light dark; margin: 0px; } body, p, ol, ul, td { font-family: helvetica, verdana, arial, sans-serif; font-size: 13px; line-height: 18px; } pre { font-size: 11px; white-space: pre-wrap; } pre.box { border: 1px solid #EEE; padding: 10px; margin: 0px; width: 958px; } header { color: #F0F0F0; background: #C00; padding: 0.5em 1.5em; } header button { appearance: none; background-color: hsl(0 0% 0% / 0.2); border: 0; border-radius: 14px; color: white; float: right; font-weight: 500; height: 28px; padding-inline: 14px; margin: 0.35em 0; } header button:active { background-color: hsl(0 0% 0% / 0.25); } h1 { overflow-wrap: break-word; margin: 0.2em 0; line-he"
+          }
+        ]
+      },
+      "source_restoration": {
+        "status": "PASS",
+        "compile": { "status": "PASS" },
+        "runtime": { "status": "PASS" }
+      },
+      "browser_error_excerpt": "Error: ROR_DX_RUNTIME_ERROR_MARKER at HelloWorld (http://127.0.0.1:39228/packs/js/generated/HelloWorld.bae9e906ef250676.hot-update.js:15:11) at react-stack-bottom-frame (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:22430:20) at renderWithHooks (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:5759:22) at updateFunctionComponent (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:8020:19) at beginWork (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:9685:18) at runWithFiberInDEV (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:546:16) at performUnitOfWork ",
+      "cleanup": "PASS"
+    },
+    "vite": {
+      "compile_overlay": {
+        "status": "PASS",
+        "marker_visible": true,
+        "source_location_visible": true,
+        "expected_source": "app/frontend/pages/inertia_example/index.tsx:26",
+        "evidence": "[plugin:vite:oxc] Transform failed with 1 error: [PARSE_ERROR] Unexpected token ╭─[ app/frontend/pages/inertia_example/index.tsx:26:37 ] │ 26 │ const ROR_DX_COMPILE_ERROR_MARKER = ; │ ┬ │ ╰── ────╯<LOCAL_PATH>/.work/vite-oc-96928-1789174356059-c6052f115b692/app/frontend/pages/inertia_example/index.tsx at transformWithOxc (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4103:19) at TransformPluginContext.transform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4174:26) at EnvironmentPluginContainer.transform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:30932:51) at async loadAndTransform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:20671:26) at async viteTransformMiddleware (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_mo"
+      },
+      "runtime_overlay": {
+        "status": "FAIL",
+        "marker_visible": false,
+        "source_location_visible": false,
+        "expected_source": "app/frontend/pages/inertia_example/index.tsx:7",
+        "evidence": "No matching overlay appeared before the bounded timeout."
+      },
+      "click_to_editor": {
+        "status": "FAIL",
+        "expected_source": "app/frontend/pages/inertia_example/index.tsx:26:<column>",
+        "evidence": "locator.waitFor: Timeout 5000ms exceeded. Call log: \u001b[2m - waiting for locator('vite-error-overlay').locator('.file-link').filter({ hasText: 'index.tsx' }).first() to be visible\u001b[22m",
+        "available_targets": [
+          "file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4103:19",
+          "file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4174:26",
+          "file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:30932:51",
+          "file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:20671:26",
+          "file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:25205:20"
+        ],
+        "responses": []
+      },
+      "source_restoration": {
+        "status": "PASS",
+        "compile": { "status": "PASS" },
+        "runtime": { "status": "PASS" }
+      },
+      "browser_error_excerpt": "Error: ROR_DX_RUNTIME_ERROR_MARKER at InertiaExample (http://127.0.0.1:41862/vite-dev/pages/inertia_example/index.tsx?t=1789174370157:9:8) at react-stack-bottom-frame (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:18325:12) at renderWithHooks (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:9993:19) at updateFunctionComponent (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:11226:16) at beginWork (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:11847:20) at runWithFiberInDEV (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modu",
+      "cleanup": "PASS"
+    }
+  }
+}

--- a/benchmarks/rspack-vite-rails-dx/results/overlay-recorded.json
+++ b/benchmarks/rspack-vite-rails-dx/results/overlay-recorded.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "created_at": "2026-09-12T00:52:09.890Z",
+  "created_at": "2026-09-12T01:10:38.530Z",
   "environment": {
-    "harness_git_head": "aff9a6a2a83fa85bebce13e91b7d3882b500404c",
+    "harness_git_head": "caaa27bc232393836bb71c2f8c94ec656bed49c2",
     "harness_git_clean": true,
     "operating_system": "Darwin 25.6.0 arm64",
     "cpu": "Apple M5 Max",
@@ -43,7 +43,7 @@
         "marker_visible": true,
         "source_location_visible": false,
         "expected_source": "app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx:6",
-        "evidence": "Uncaught runtime errors:×ERRORROR_DX_RUNTIME_ERROR_MARKER at HelloWorld (http://127.0.0.1:39228/packs/js/generated/HelloWorld.bae9e906ef250676.hot-update.js:15:11) at react-stack-bottom-frame (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:22430:20) at renderWithHooks (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:5759:22) at updateFunctionComponent (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:8020:19) at beginWork (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:9685:18) at runWithFiberInDEV (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:546:16"
+        "evidence": "Uncaught runtime errors:×ERRORROR_DX_RUNTIME_ERROR_MARKER at HelloWorld (http://127.0.0.1:47876/packs/js/generated/HelloWorld.1c2173974ac152c1.hot-update.js:15:11) at react-stack-bottom-frame (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:22430:20) at renderWithHooks (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:5759:22) at updateFunctionComponent (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:8020:19) at beginWork (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:9685:18) at runWithFiberInDEV (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:546:16"
       },
       "click_to_editor": {
         "status": "FAIL",
@@ -53,17 +53,21 @@
         "responses": [
           {
             "status": 404,
-            "url": "http://127.0.0.1:41455/rspack-dev-server/open-editor?fileName=builtin:react-refresh-loader!builtin:react-refresh-loader!builtin:swc-loader??ruleSet[1].rules[3].use[0]!<LOCAL_PATH>/.work/rspack-oc-96928-1789174330086-75b1660d59a97/app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx",
+            "url": "http://127.0.0.1:46556/rspack-dev-server/open-editor?fileName=builtin:react-refresh-loader!builtin:react-refresh-loader!builtin:swc-loader??ruleSet[1].rules[3].use[0]!<LOCAL_PATH>/.work/rspack-oc-14145-1789175438692-ca39148008b1f/app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx",
             "body": "<!DOCTYPE html> <html lang=\"en\"> <head> <meta charset=\"utf-8\" /> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"> <meta name=\"turbo-visit-control\" content=\"reload\"> <title>Action Controller: Exception caught</title> <style> body { background-color: #FAFAFA; color: #333; color-scheme: light dark; supported-color-schemes: light dark; margin: 0px; } body, p, ol, ul, td { font-family: helvetica, verdana, arial, sans-serif; font-size: 13px; line-height: 18px; } pre { font-size: 11px; white-space: pre-wrap; } pre.box { border: 1px solid #EEE; padding: 10px; margin: 0px; width: 958px; } header { color: #F0F0F0; background: #C00; padding: 0.5em 1.5em; } header button { appearance: none; background-color: hsl(0 0% 0% / 0.2); border: 0; border-radius: 14px; color: white; float: right; font-weight: 500; height: 28px; padding-inline: 14px; margin: 0.35em 0; } header button:active { background-color: hsl(0 0% 0% / 0.25); } h1 { overflow-wrap: break-word; margin: 0.2em 0; line-he"
           }
         ]
       },
       "source_restoration": {
-        "status": "PASS",
-        "compile": { "status": "PASS" },
-        "runtime": { "status": "PASS" }
+        "status": "FAIL",
+        "compile": {
+          "status": "FAIL",
+          "health_marker_observed": false,
+          "evidence": "ready=false; overlay=undefined"
+        },
+        "runtime": { "status": "PASS", "health_marker_observed": true }
       },
-      "browser_error_excerpt": "Error: ROR_DX_RUNTIME_ERROR_MARKER at HelloWorld (http://127.0.0.1:39228/packs/js/generated/HelloWorld.bae9e906ef250676.hot-update.js:15:11) at react-stack-bottom-frame (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:22430:20) at renderWithHooks (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:5759:22) at updateFunctionComponent (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:8020:19) at beginWork (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:9685:18) at runWithFiberInDEV (http://127.0.0.1:39228/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--944726.js:546:16) at performUnitOfWork ",
+      "browser_error_excerpt": "Error: ROR_DX_RUNTIME_ERROR_MARKER at HelloWorld (http://127.0.0.1:47876/packs/js/generated/HelloWorld.1c2173974ac152c1.hot-update.js:15:11) at react-stack-bottom-frame (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:22430:20) at renderWithHooks (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:5759:22) at updateFunctionComponent (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:8020:19) at beginWork (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:9685:18) at runWithFiberInDEV (http://127.0.0.1:47876/packs/js/vendors-starters_rspack_node_modules_pnpm_react_19_0_4_node_modules_react_jsx-dev-runtime_js--39f23b.js:546:16) at performUnitOfWork ",
       "cleanup": "PASS"
     },
     "vite": {
@@ -72,7 +76,7 @@
         "marker_visible": true,
         "source_location_visible": true,
         "expected_source": "app/frontend/pages/inertia_example/index.tsx:26",
-        "evidence": "[plugin:vite:oxc] Transform failed with 1 error: [PARSE_ERROR] Unexpected token ╭─[ app/frontend/pages/inertia_example/index.tsx:26:37 ] │ 26 │ const ROR_DX_COMPILE_ERROR_MARKER = ; │ ┬ │ ╰── ────╯<LOCAL_PATH>/.work/vite-oc-96928-1789174356059-c6052f115b692/app/frontend/pages/inertia_example/index.tsx at transformWithOxc (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4103:19) at TransformPluginContext.transform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4174:26) at EnvironmentPluginContainer.transform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:30932:51) at async loadAndTransform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:20671:26) at async viteTransformMiddleware (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_mo"
+        "evidence": "[plugin:vite:oxc] Transform failed with 1 error: [PARSE_ERROR] Unexpected token ╭─[ app/frontend/pages/inertia_example/index.tsx:26:37 ] │ 26 │ const ROR_DX_COMPILE_ERROR_MARKER = ; │ ┬ │ ╰── ────╯<LOCAL_PATH>/.work/vite-oc-14145-1789175496734-eb4cb61914712/app/frontend/pages/inertia_example/index.tsx at transformWithOxc (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4103:19) at TransformPluginContext.transform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:4174:26) at EnvironmentPluginContainer.transform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:30932:51) at async loadAndTransform (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_modules/vite/dist/node/chunks/node.js:20671:26) at async viteTransformMiddleware (file://<LOCAL_PATH>/starters/vite/node_modules/.pnpm/vite@8.2.2/node_mo"
       },
       "runtime_overlay": {
         "status": "FAIL",
@@ -96,10 +100,10 @@
       },
       "source_restoration": {
         "status": "PASS",
-        "compile": { "status": "PASS" },
-        "runtime": { "status": "PASS" }
+        "compile": { "status": "PASS", "health_marker_observed": true },
+        "runtime": { "status": "PASS", "health_marker_observed": true }
       },
-      "browser_error_excerpt": "Error: ROR_DX_RUNTIME_ERROR_MARKER at InertiaExample (http://127.0.0.1:41862/vite-dev/pages/inertia_example/index.tsx?t=1789174370157:9:8) at react-stack-bottom-frame (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:18325:12) at renderWithHooks (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:9993:19) at updateFunctionComponent (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:11226:16) at beginWork (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modules/.vite/deps/@inertiajs_react.js?v=cbc08bae:11847:20) at runWithFiberInDEV (http://127.0.0.1:41862/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-96928-1789174365839-faa698f4ea3d4/node_modu",
+      "browser_error_excerpt": "Error: ROR_DX_RUNTIME_ERROR_MARKER at InertiaExample (http://127.0.0.1:45297/vite-dev/pages/inertia_example/index.tsx?t=1789175514442:9:8) at react-stack-bottom-frame (http://127.0.0.1:45297/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-14145-1789175507463-a6f4299da1a83/node_modules/.vite/deps/@inertiajs_react.js?v=1deaec1a:18325:12) at renderWithHooks (http://127.0.0.1:45297/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-14145-1789175507463-a6f4299da1a83/node_modules/.vite/deps/@inertiajs_react.js?v=1deaec1a:9993:19) at updateFunctionComponent (http://127.0.0.1:45297/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-14145-1789175507463-a6f4299da1a83/node_modules/.vite/deps/@inertiajs_react.js?v=1deaec1a:11226:16) at beginWork (http://127.0.0.1:45297/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-14145-1789175507463-a6f4299da1a83/node_modules/.vite/deps/@inertiajs_react.js?v=1deaec1a:11847:20) at runWithFiberInDEV (http://127.0.0.1:45297/vite-dev/@fs<LOCAL_PATH>/.work/vite-or-14145-1789175507463-a6f4299da1a83/node_modu",
       "cleanup": "PASS"
     }
   }

--- a/benchmarks/rspack-vite-rails-dx/scripts/app-session.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/app-session.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { readFile, realpath, rm } from 'node:fs/promises';
+import { realpath, rm } from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';

--- a/benchmarks/rspack-vite-rails-dx/scripts/app-session.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/app-session.mjs
@@ -1,0 +1,248 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { readFile, realpath, rm } from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { redactLocalPaths } from './local-paths.mjs';
+import { createWorkspace } from './starter-workspace.mjs';
+
+const maxLogCharacters = 8_000;
+
+export async function startApp({ browser, label, root, tool, extraEnv = {} }) {
+  const repositoryRoot = path.resolve(root, '../..');
+  const rootAliases = [
+    ...new Set([root, await realpath(root), repositoryRoot, await realpath(repositoryRoot)]),
+  ];
+  const nonce = `${label}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const workspace = await createWorkspace(root, tool, nonce);
+  const marker = `ready-${tool}-${nonce}`;
+  await workspace.setMarker(marker);
+  await clearSharedToolCache(root, tool);
+  const basePort = await reservePortRange();
+  const webPort = tool === 'rspack' ? basePort : basePort + 100;
+  const assetPort = basePort + 1;
+  const command = tool === 'rspack' ? ['bin/dev', '--no-open-browser'] : ['bin/dev'];
+  const env = {
+    ...process.env,
+    FORCE_COLOR: '0',
+    NO_COLOR: '1',
+    PORT: String(basePort),
+    REACT_ON_RAILS_BASE_PORT: String(basePort),
+    SHAKAPACKER_DEV_SERVER_HOST: '127.0.0.1',
+    VITE_RUBY_HOST: '127.0.0.1',
+    VITE_RUBY_PORT: String(assetPort),
+    ...extraEnv,
+  };
+  let logTail = '';
+  const capture = (chunk) => {
+    logTail = `${logTail}${chunk}`.slice(-maxLogCharacters);
+  };
+  const startedAt = performance.now();
+  const child = spawn(command[0], command.slice(1), {
+    cwd: workspace.directory,
+    detached: process.platform !== 'win32',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', capture);
+  child.stderr.on('data', capture);
+  let page;
+  let stopPromise;
+  const stop = async () => {
+    stopPromise ??= (async () => {
+      try {
+        await page?.close();
+        await stopProcess(child);
+        await waitForClosedPorts([webPort, assetPort]);
+      } finally {
+        await workspace.remove();
+      }
+    })();
+    await stopPromise;
+  };
+
+  try {
+    const url = `http://127.0.0.1:${webPort}${tool === 'rspack' ? '/hello_world' : '/'}`;
+    await waitForHttp(url, child, () => logTail);
+    const assetUrl =
+      tool === 'rspack'
+        ? `http://127.0.0.1:${assetPort}/packs/js/runtime.js`
+        : `http://127.0.0.1:${assetPort}/vite-dev/@vite/client`;
+    await waitForHttp(assetUrl, child, () => logTail);
+    page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    await page.locator('[data-benchmark-marker]').filter({ hasText: marker }).waitFor({ timeout: 30_000 });
+    return {
+      assetPort,
+      basePort,
+      log: () => redactLocalPaths(logTail, rootAliases),
+      marker,
+      page,
+      readyMs: round(performance.now() - startedAt),
+      stop,
+      webPort,
+      workspace,
+    };
+  } catch (error) {
+    await stop();
+    throw new Error(
+      `${tool} failed to become browser-ready: ${error.message}\n${redactLocalPaths(logTail, rootAliases)}`,
+    );
+  }
+}
+
+export function captureEnvironment(root) {
+  const repositoryRoot = path.resolve(root, '../..');
+  const gitHead = commandOutput('git', ['rev-parse', 'HEAD'], repositoryRoot);
+  return {
+    harness_git_head: gitHead,
+    harness_git_clean:
+      commandOutput('git', ['status', '--porcelain', '--untracked-files=all'], repositoryRoot) === '',
+    operating_system: `${os.type()} ${os.release()} ${os.arch()}`,
+    cpu: os.cpus()[0]?.model ?? 'unknown',
+    logical_cpu_count: os.cpus().length,
+    total_memory_bytes: os.totalmem(),
+    node: process.version,
+    pnpm: commandOutput('pnpm', ['--version'], root),
+    ruby: commandOutput('ruby', ['--version'], root),
+    rails: {
+      rspack: commandOutput('bundle', ['exec', 'rails', '--version'], path.join(root, 'starters/rspack')),
+      vite: commandOutput('bundle', ['exec', 'rails', '--version'], path.join(root, 'starters/vite')),
+    },
+    dependencies: {
+      rspack_ruby: gemVersions(['react_on_rails', 'shakapacker'], path.join(root, 'starters/rspack')),
+      rspack_javascript: commandOutput(
+        'pnpm',
+        ['exec', 'rspack', '--version'],
+        path.join(root, 'starters/rspack'),
+      ),
+      vite_ruby: gemVersions(['inertia_rails', 'vite_rails'], path.join(root, 'starters/vite')),
+      vite_javascript: commandOutput('pnpm', ['exec', 'vite', '--version'], path.join(root, 'starters/vite')),
+    },
+    commands: {
+      rspack: 'REACT_ON_RAILS_BASE_PORT=<PORT> bin/dev --no-open-browser',
+      vite: 'PORT=<PORT> VITE_RUBY_PORT=<PORT+1> bin/dev',
+    },
+  };
+}
+
+async function clearSharedToolCache(root, tool) {
+  const candidates =
+    tool === 'rspack' ? ['starters/rspack/node_modules/.cache'] : ['starters/vite/node_modules/.vite'];
+  await Promise.all(
+    candidates.map((candidate) => rm(path.join(root, candidate), { recursive: true, force: true })),
+  );
+}
+
+async function reservePortRange() {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const base = 38_000 + Math.floor(Math.random() * 10_000);
+    if (await portsAvailable([base, base + 1, base + 100])) return base;
+  }
+  throw new Error('could not reserve an available benchmark port range');
+}
+
+async function portsAvailable(ports) {
+  const servers = [];
+  try {
+    for (const port of ports) {
+      const server = net.createServer();
+      await new Promise((resolve, reject) => server.once('error', reject).listen(port, '127.0.0.1', resolve));
+      servers.push(server);
+    }
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+  }
+}
+
+async function waitForHttp(url, child, readLog) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      const result = child.exitCode === null ? `after ${child.signalCode}` : child.exitCode;
+      throw new Error(`process exited ${result}: ${readLog().slice(-2_000)}`);
+    }
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok) return;
+    } catch {
+      // Connection refusal is expected until Rails is ready.
+    }
+    await delay(50);
+  }
+  throw new Error(`timed out waiting for ${url}`);
+}
+
+async function stopProcess(child) {
+  const alreadyExited = child.exitCode !== null || child.signalCode !== null;
+  if (process.platform === 'win32' && alreadyExited) return;
+
+  const exited = alreadyExited ? Promise.resolve() : new Promise((resolve) => child.once('exit', resolve));
+  const target = process.platform === 'win32' ? child.pid : -child.pid;
+  signalProcess(target, 'SIGTERM');
+
+  if (process.platform !== 'win32') {
+    if (!(await waitForProcessGroupExit(child.pid, 10_000))) {
+      signalProcess(target, 'SIGKILL');
+      if (!(await waitForProcessGroupExit(child.pid, 10_000)))
+        throw new Error(`process group ${child.pid} did not exit`);
+    }
+    await exited;
+    return;
+  }
+
+  if (await Promise.race([exited.then(() => true), delay(10_000).then(() => false)])) return;
+  signalProcess(target, 'SIGKILL');
+  await exited;
+}
+
+function signalProcess(target, signal) {
+  try {
+    process.kill(target, signal);
+  } catch (error) {
+    if (error.code !== 'ESRCH') throw error;
+  }
+}
+
+async function waitForProcessGroupExit(pid, timeout) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(-pid, 0);
+    } catch (error) {
+      if (error.code === 'ESRCH') return true;
+      throw error;
+    }
+    await delay(50);
+  }
+  return false;
+}
+
+async function waitForClosedPorts(ports) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (await portsAvailable(ports)) return;
+    await delay(100);
+  }
+  throw new Error(`benchmark ports did not close: ${ports.join(', ')}`);
+}
+
+function gemVersions(names, cwd) {
+  const expression = `puts ${JSON.stringify(names)}.map { |name| "#{name} #{Gem.loaded_specs.fetch(name).version}" }.join("; ")`;
+  return commandOutput('bundle', ['exec', 'ruby', '-e', expression], cwd);
+}
+
+function commandOutput(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function round(value) {
+  return Math.round(value * 10) / 10;
+}

--- a/benchmarks/rspack-vite-rails-dx/scripts/app-session.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/app-session.mjs
@@ -55,6 +55,7 @@ export async function startApp({ browser, label, root, tool, extraEnv = {} }) {
       try {
         await page?.close();
         await stopProcess(child);
+        await stopResidualProcesses(nonce);
         await waitForClosedPorts([webPort, assetPort]);
       } finally {
         await workspace.remove();
@@ -91,6 +92,19 @@ export async function startApp({ browser, label, root, tool, extraEnv = {} }) {
       `${tool} failed to become browser-ready: ${error.message}\n${redactLocalPaths(logTail, rootAliases)}`,
     );
   }
+}
+
+export function residualProcessGroups(processList, nonce, ownPid = process.pid) {
+  const groups = new Set();
+  for (const line of processList.split('\n')) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/);
+    if (!match) continue;
+    const [, pidText, groupText, command] = match;
+    const pid = Number(pidText);
+    const group = Number(groupText);
+    if (pid !== ownPid && group > 1 && command.includes(nonce)) groups.add(group);
+  }
+  return [...groups];
 }
 
 export function captureEnvironment(root) {
@@ -199,6 +213,30 @@ async function stopProcess(child) {
   if (await Promise.race([exited.then(() => true), delay(10_000).then(() => false)])) return;
   signalProcess(target, 'SIGKILL');
   await exited;
+}
+
+async function stopResidualProcesses(nonce) {
+  if (process.platform === 'win32') return;
+  let groups = currentResidualProcessGroups(nonce);
+  for (const group of groups) signalProcess(-group, 'SIGTERM');
+  const deadline = Date.now() + 5_000;
+  while (groups.length > 0 && Date.now() < deadline) {
+    await delay(50);
+    groups = currentResidualProcessGroups(nonce);
+  }
+  for (const group of groups) signalProcess(-group, 'SIGKILL');
+  if (groups.length > 0) {
+    await delay(50);
+    const survivors = currentResidualProcessGroups(nonce);
+    if (survivors.length > 0)
+      throw new Error(`benchmark session processes did not exit: ${survivors.join(', ')}`);
+  }
+}
+
+function currentResidualProcessGroups(nonce) {
+  const result = spawnSync('ps', ['-axo', 'pid=,pgid=,command='], { encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`could not inspect benchmark session processes: ${result.stderr}`);
+  return residualProcessGroups(result.stdout, nonce);
 }
 
 function signalProcess(target, signal) {

--- a/benchmarks/rspack-vite-rails-dx/scripts/app-session.test.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/app-session.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { residualProcessGroups } from './app-session.mjs';
+
+test('finds only process groups owned by the unique benchmark session', () => {
+  const processList = `
+  100 100 tmux -L overmind-rspack-session-abc
+  101 100 ruby app from rspack-session-abc
+  200 200 tmux -L unrelated-session
+  300 300 node harness rspack-session-abc
+`;
+  assert.deepEqual(residualProcessGroups(processList, 'rspack-session-abc', 300), [100]);
+});

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
@@ -24,13 +24,20 @@ export function addRuntimeError(source, tool) {
 
 export function sourceLocationVisible(text, relativePath, line) {
   const normalized = text.replaceAll('\\', '/');
-  const basename = path.posix.basename(relativePath);
-  const hasPath = normalized.includes(relativePath) || normalized.includes(basename);
+  const normalizedPath = relativePath.replaceAll('\\', '/');
+  const pathIndex = normalized.indexOf(normalizedPath);
+  if (pathIndex === -1) return false;
+  const escapedPath = normalizedPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const escapedLine = String(line).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const hasLine = new RegExp(`(?::|\\(|\\[|line\\s+)${escapedLine}(?::\\d+|\\)|\\]|\\s)`, 'i').test(
-    normalized,
+  if (new RegExp(`${escapedPath}:${escapedLine}:\\d+`).test(normalized)) return true;
+
+  // Rspack renders the source path in the error heading and its line/column in
+  // the immediately following SWC code frame instead of one contiguous token.
+  const errorTail = normalized.slice(
+    pathIndex + normalizedPath.length,
+    pathIndex + normalizedPath.length + 400,
   );
-  return hasPath && hasLine;
+  return new RegExp(`(?:╭─)?\\[${escapedLine}:\\d+\\]`).test(errorTail);
 }
 
 export function parseEditorInvocation(invocation, workspaceDirectory, expectedSourcePath) {

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
@@ -48,15 +48,20 @@ export function parseEditorInvocation(invocation, workspaceDirectory, expectedSo
 export function buildOverlayReport(raw) {
   const cells = (tool) => {
     const result = raw.results[tool];
-    return [result.compile_overlay.status, result.runtime_overlay.status, result.click_to_editor.status];
+    return [
+      result.compile_overlay.status,
+      result.runtime_overlay.status,
+      result.click_to_editor.status,
+      result.source_restoration.status,
+    ];
   };
   const row = (label, tool) => `| ${label} | ${cells(tool).join(' | ')} |`;
   return `# Recorded Rails-tier overlay evidence
 
 Generated from \`results/overlay-recorded.json\`. Do not edit the matrix by hand.
 
-| Stack | Compile overlay | Runtime overlay with original source frame | Compile-error click-to-editor |
-| --- | --- | --- | --- |
+| Stack | Compile overlay | Runtime overlay with original source frame | Compile-error click-to-editor | Source restoration |
+| --- | --- | --- | --- | --- |
 ${row('React on Rails + Rspack', 'rspack')}
 ${row('Inertia Rails + Vite', 'vite')}
 

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
@@ -27,7 +27,9 @@ export function sourceLocationVisible(text, relativePath, line) {
   const basename = path.posix.basename(relativePath);
   const hasPath = normalized.includes(relativePath) || normalized.includes(basename);
   const escapedLine = String(line).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const hasLine = new RegExp(`(?:[:(]|line\\s+)${escapedLine}(?::\\d+|[):\\s])`, 'i').test(normalized);
+  const hasLine = new RegExp(`(?::|\\(|\\[|line\\s+)${escapedLine}(?::\\d+|\\)|\\]|\\s)`, 'i').test(
+    normalized,
+  );
   return hasPath && hasLine;
 }
 

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
@@ -54,6 +54,12 @@ export function parseEditorInvocation(invocation, workspaceDirectory, expectedSo
   };
 }
 
+export function replaceBenchmarkMarker(source, marker) {
+  const updated = source.replace(/const BENCHMARK_MARKER = '[^']+'/, `const BENCHMARK_MARKER = '${marker}'`);
+  if (updated === source) throw new Error('benchmark marker was not found in probe source');
+  return updated;
+}
+
 export function buildOverlayReport(raw) {
   const cells = (tool) => {
     const result = raw.results[tool];

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
@@ -1,0 +1,80 @@
+import path from 'node:path';
+
+export const compileErrorMarker = 'ROR_DX_COMPILE_ERROR_MARKER';
+export const runtimeErrorMarker = 'ROR_DX_RUNTIME_ERROR_MARKER';
+
+export function addCompileError(source) {
+  const prefix = source.endsWith('\n') ? source : `${source}\n`;
+  return {
+    source: `${prefix}const ${compileErrorMarker} = ;\n`,
+    line: prefix.split('\n').length,
+  };
+}
+
+export function addRuntimeError(source, tool) {
+  const anchor =
+    tool === 'rspack' ? 'const HelloWorld = () => {' : 'export default function InertiaExample() {';
+  const line = source.slice(0, source.indexOf(anchor)).split('\n').length + 1;
+  if (!source.includes(anchor)) throw new Error(`runtime probe anchor was not found for ${tool}`);
+  return {
+    source: source.replace(anchor, `${anchor}\n  throw new Error('${runtimeErrorMarker}');`),
+    line,
+  };
+}
+
+export function sourceLocationVisible(text, relativePath, line) {
+  const normalized = text.replaceAll('\\', '/');
+  const basename = path.posix.basename(relativePath);
+  const hasPath = normalized.includes(relativePath) || normalized.includes(basename);
+  const escapedLine = String(line).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const hasLine = new RegExp(`(?:[:(]|line\\s+)${escapedLine}(?::\\d+|[):\\s])`, 'i').test(normalized);
+  return hasPath && hasLine;
+}
+
+export function parseEditorInvocation(invocation, workspaceDirectory, expectedSourcePath) {
+  const combined = invocation.join(' ');
+  const escaped = expectedSourcePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = combined.match(new RegExp(`${escaped}:(\\d+):(\\d+)`));
+  const splitArguments =
+    invocation[0] === expectedSourcePath && /^\d+$/.test(invocation[1]) && /^\d+$/.test(invocation[2]);
+  if (!match && !splitArguments) return undefined;
+  return {
+    file: path.relative(workspaceDirectory, expectedSourcePath).split(path.sep).join('/'),
+    line: Number(match?.[1] ?? invocation[1]),
+    column: Number(match?.[2] ?? invocation[2]),
+  };
+}
+
+export function buildOverlayReport(raw) {
+  const cells = (tool) => {
+    const result = raw.results[tool];
+    return [result.compile_overlay.status, result.runtime_overlay.status, result.click_to_editor.status];
+  };
+  const row = (label, tool) => `| ${label} | ${cells(tool).join(' | ')} |`;
+  return `# Recorded Rails-tier overlay evidence
+
+Generated from \`results/overlay-recorded.json\`. Do not edit the matrix by hand.
+
+| Stack | Compile overlay | Runtime overlay with original source frame | Compile-error click-to-editor |
+| --- | --- | --- | --- |
+${row('React on Rails + Rspack', 'rspack')}
+${row('Inertia Rails + Vite', 'vite')}
+
+Each overlay result requires the deterministic marker and the original TSX file and line. Click-to-editor uses a temporary \`LAUNCH_EDITOR\` recorder and requires the copied workspace's exact source path, line, and column. The harness restores each mutation, waits for the overlay to clear, and removes its process group, workspace, and ports.
+
+## Environment
+
+- Recorded: ${raw.created_at}
+- Harness commit: \`${raw.environment.harness_git_head}\`
+- Worktree clean at start: ${raw.environment.harness_git_clean}
+- OS: ${raw.environment.operating_system}
+- CPU: ${raw.environment.cpu} (${raw.environment.logical_cpu_count} logical CPUs)
+- Node: ${raw.environment.node}; pnpm: ${raw.environment.pnpm}; Ruby: ${raw.environment.ruby}
+- Rspack stack: ${raw.environment.dependencies.rspack_ruby}; ${raw.environment.dependencies.rspack_javascript}
+- Vite stack: ${raw.environment.dependencies.vite_ruby}; ${raw.environment.dependencies.vite_javascript}
+
+## Interpretation boundary
+
+This is a same-machine browser verification of the two pinned generated Rails starters. A FAIL records observed behavior; it is not by itself a product defect. Product fixes require separate issue evaluation. See [issue #4696](https://github.com/shakacode/react_on_rails/issues/4696).
+`;
+}

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.mjs
@@ -14,8 +14,8 @@ export function addCompileError(source) {
 export function addRuntimeError(source, tool) {
   const anchor =
     tool === 'rspack' ? 'const HelloWorld = () => {' : 'export default function InertiaExample() {';
-  const line = source.slice(0, source.indexOf(anchor)).split('\n').length + 1;
   if (!source.includes(anchor)) throw new Error(`runtime probe anchor was not found for ${tool}`);
+  const line = source.slice(0, source.indexOf(anchor)).split('\n').length + 1;
   return {
     source: source.replace(anchor, `${anchor}\n  throw new Error('${runtimeErrorMarker}');`),
     line,

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
@@ -69,13 +69,15 @@ test('report renders all measured matrix cells', () => {
         compile_overlay: { status: 'PASS' },
         runtime_overlay: { status: 'PASS' },
         click_to_editor: { status: 'PASS' },
+        source_restoration: { status: 'PASS' },
       },
       vite: {
         compile_overlay: { status: 'PASS' },
         runtime_overlay: { status: 'FAIL' },
         click_to_editor: { status: 'PASS' },
+        source_restoration: { status: 'PASS' },
       },
     },
   };
-  assert.match(buildOverlayReport(raw), /Inertia Rails \+ Vite \| PASS \| FAIL \| PASS/);
+  assert.match(buildOverlayReport(raw), /Inertia Rails \+ Vite \| PASS \| FAIL \| PASS \| PASS/);
 });

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
@@ -6,6 +6,7 @@ import {
   buildOverlayReport,
   compileErrorMarker,
   parseEditorInvocation,
+  replaceBenchmarkMarker,
   runtimeErrorMarker,
   sourceLocationVisible,
 } from './overlay-helpers.mjs';
@@ -46,6 +47,14 @@ test('editor invocation must contain the exact workspace source, line, and colum
     column: 7,
   });
   assert.equal(parseEditorInvocation(['/other/index.tsx:12:7'], workspace, source), undefined);
+});
+
+test('restoration health marker must replace an existing benchmark marker', () => {
+  assert.equal(
+    replaceBenchmarkMarker("const BENCHMARK_MARKER = 'old';\n", 'recovered'),
+    "const BENCHMARK_MARKER = 'recovered';\n",
+  );
+  assert.throws(() => replaceBenchmarkMarker('const other = true;\n', 'recovered'), /was not found/);
 });
 
 test('report renders all measured matrix cells', () => {

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
@@ -27,6 +27,8 @@ test('source location accepts an original path and line but rejects a generated 
   assert.equal(sourceLocationVisible(`${relativePath}:17:9`, relativePath, 17), true);
   assert.equal(sourceLocationVisible(`${relativePath} ╭─[17:9]`, relativePath, 17), true);
   assert.equal(sourceLocationVisible('assets/application.js:17:9', relativePath, 17), false);
+  assert.equal(sourceLocationVisible('/tmp/other/index.tsx:17:9', relativePath, 17), false);
+  assert.equal(sourceLocationVisible(`${relativePath} mentioned; node.js:17:9`, relativePath, 17), false);
   assert.equal(sourceLocationVisible(`${relativePath}:18:9`, relativePath, 17), false);
 });
 

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
@@ -25,6 +25,7 @@ test('runtime probe inserts a deterministic throw and reports its line', () => {
 test('source location accepts an original path and line but rejects a generated frame', () => {
   const relativePath = 'app/frontend/pages/inertia_example/index.tsx';
   assert.equal(sourceLocationVisible(`${relativePath}:17:9`, relativePath, 17), true);
+  assert.equal(sourceLocationVisible(`${relativePath} ╭─[17:9]`, relativePath, 17), true);
   assert.equal(sourceLocationVisible('assets/application.js:17:9', relativePath, 17), false);
   assert.equal(sourceLocationVisible(`${relativePath}:18:9`, relativePath, 17), false);
 });

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay-helpers.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  addCompileError,
+  addRuntimeError,
+  buildOverlayReport,
+  compileErrorMarker,
+  parseEditorInvocation,
+  runtimeErrorMarker,
+  sourceLocationVisible,
+} from './overlay-helpers.mjs';
+
+test('compile probe reports the appended source line', () => {
+  const probe = addCompileError('const valid = true;\n');
+  assert.equal(probe.line, 2);
+  assert.match(probe.source, new RegExp(compileErrorMarker));
+});
+
+test('runtime probe inserts a deterministic throw and reports its line', () => {
+  const probe = addRuntimeError('header\nconst HelloWorld = () => {\n  return null;\n};\n', 'rspack');
+  assert.equal(probe.line, 3);
+  assert.match(probe.source, new RegExp(runtimeErrorMarker));
+});
+
+test('source location accepts an original path and line but rejects a generated frame', () => {
+  const relativePath = 'app/frontend/pages/inertia_example/index.tsx';
+  assert.equal(sourceLocationVisible(`${relativePath}:17:9`, relativePath, 17), true);
+  assert.equal(sourceLocationVisible('assets/application.js:17:9', relativePath, 17), false);
+  assert.equal(sourceLocationVisible(`${relativePath}:18:9`, relativePath, 17), false);
+});
+
+test('editor invocation must contain the exact workspace source, line, and column', () => {
+  const workspace = '/tmp/overlay/vite';
+  const source = `${workspace}/app/frontend/pages/index.tsx`;
+  assert.deepEqual(parseEditorInvocation([`${source}:12:7`], workspace, source), {
+    file: 'app/frontend/pages/index.tsx',
+    line: 12,
+    column: 7,
+  });
+  assert.deepEqual(parseEditorInvocation([source, '12', '7'], workspace, source), {
+    file: 'app/frontend/pages/index.tsx',
+    line: 12,
+    column: 7,
+  });
+  assert.equal(parseEditorInvocation(['/other/index.tsx:12:7'], workspace, source), undefined);
+});
+
+test('report renders all measured matrix cells', () => {
+  const raw = {
+    created_at: '2026-09-11T00:00:00.000Z',
+    environment: {
+      harness_git_head: 'abc',
+      harness_git_clean: true,
+      operating_system: 'test',
+      cpu: 'test',
+      logical_cpu_count: 1,
+      node: 'v22',
+      pnpm: '10',
+      ruby: 'ruby',
+      dependencies: {
+        rspack_ruby: 'react_on_rails 17',
+        rspack_javascript: 'rspack 2',
+        vite_ruby: 'vite_rails 3',
+        vite_javascript: 'vite 8',
+      },
+    },
+    results: {
+      rspack: {
+        compile_overlay: { status: 'PASS' },
+        runtime_overlay: { status: 'PASS' },
+        click_to_editor: { status: 'PASS' },
+      },
+      vite: {
+        compile_overlay: { status: 'PASS' },
+        runtime_overlay: { status: 'FAIL' },
+        click_to_editor: { status: 'PASS' },
+      },
+    },
+  };
+  assert.match(buildOverlayReport(raw), /Inertia Rails \+ Vite \| PASS \| FAIL \| PASS/);
+});

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -12,6 +12,7 @@ import {
   buildOverlayReport,
   compileErrorMarker,
   parseEditorInvocation,
+  replaceBenchmarkMarker,
   runtimeErrorMarker,
   sourceLocationVisible,
 } from './overlay-helpers.mjs';
@@ -227,7 +228,8 @@ async function verifyClickToEditor(session, tool, expectedLine) {
 }
 
 async function restoreHealthy(session, tool, healthySource, marker) {
-  await session.workspace.writeSource(healthySource);
+  const recoveryMarker = `recovered-${tool}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  await session.workspace.writeSource(replaceBenchmarkMarker(healthySource, recoveryMarker));
   const deadline = Date.now() + 30_000;
   let lastOverlay = '';
   let lastReady = false;
@@ -235,14 +237,15 @@ async function restoreHealthy(session, tool, healthySource, marker) {
     lastOverlay = await currentOverlayText(session.page, tool);
     lastReady = await session.page
       .locator('[data-benchmark-marker]')
-      .filter({ hasText: session.marker })
+      .filter({ hasText: recoveryMarker })
       .isVisible()
       .catch(() => false);
-    if (!lastOverlay.includes(marker) && lastReady) return { status: 'PASS' };
+    if (!lastOverlay.includes(marker) && lastReady) return { status: 'PASS', health_marker_observed: true };
     await delay(100);
   }
   return {
     status: 'FAIL',
+    health_marker_observed: false,
     evidence: `ready=${lastReady}; overlay=${excerpt(redactEvidence(lastOverlay, session))}`,
   };
 }

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -159,6 +159,16 @@ async function observeOverlay(session, tool, marker, line, timeout = 30_000) {
 }
 
 async function verifyClickToEditor(session, tool, expectedLine) {
+  const responses = [];
+  const recordResponse = async (response) => {
+    if (!response.url().includes('open-editor')) return;
+    responses.push({
+      status: response.status(),
+      url: redactEvidence(response.url(), session),
+      body: excerpt(redactEvidence(await response.text().catch(() => ''), session)),
+    });
+  };
+  session.page.on('response', recordResponse);
   const target =
     tool === 'rspack'
       ? session.page
@@ -167,7 +177,8 @@ async function verifyClickToEditor(session, tool, expectedLine) {
           .first()
       : session.page.locator('vite-error-overlay').locator('.file-link').first();
   try {
-    await target.click({ timeout: 5_000 });
+    await target.waitFor({ state: 'visible', timeout: 5_000 });
+    await target.evaluate((element) => element.click());
     const invocation = await waitForEditorInvocation();
     const parsed = parseEditorInvocation(
       invocation,
@@ -180,6 +191,10 @@ async function verifyClickToEditor(session, tool, expectedLine) {
       status: positionMatches ? 'PASS' : 'FAIL',
       expected_source: `${session.workspace.relativeMessagePath}:${expectedLine}:<column>`,
       recorded_source: parsed ? `${parsed.file}:${parsed.line}:${parsed.column}` : undefined,
+      recorded_invocation: invocation.map((argument) =>
+        redactEvidence(argument.replaceAll(session.workspace.directory, '<WORKSPACE>'), session),
+      ),
+      responses,
       evidence: positionMatches
         ? 'The temporary editor recorder received the exact copied source path, line, and column.'
         : 'The editor recorder did not receive the expected copied source location.',
@@ -189,7 +204,10 @@ async function verifyClickToEditor(session, tool, expectedLine) {
       status: 'FAIL',
       expected_source: `${session.workspace.relativeMessagePath}:${expectedLine}:<column>`,
       evidence: excerpt(redactEvidence(error.message, session)),
+      responses,
     };
+  } finally {
+    session.page.off('response', recordResponse);
   }
 }
 

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -116,7 +116,8 @@ async function withProbeSession(tool, label, browserErrors, probe) {
     browser,
     root,
     tool,
-    label: `overlay-${label}`,
+    // Overmind includes this value in a tmux socket path with a strict length limit.
+    label: label === 'compile' ? 'oc' : 'or',
     extraEnv: {
       LAUNCH_EDITOR: recorderPath,
       OVERLAY_EDITOR_RECORD: recorderOutput,

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -74,11 +74,49 @@ console.log(JSON.stringify(matrixSummary(safeRaw), null, 2));
 async function verifyTool(tool) {
   await rm(recorderOutput, { force: true });
   const browserErrors = [];
+  const compileResult = await withProbeSession(tool, 'compile', browserErrors, async (session) => {
+    const healthySource = await session.workspace.readSource();
+    const compile = addCompileError(healthySource);
+    await session.workspace.writeSource(compile.source);
+    const compileEvidence = await observeOverlay(session, tool, compileErrorMarker, compile.line);
+    const clickEvidence =
+      compileEvidence.status === 'PASS'
+        ? await verifyClickToEditor(session, tool, compile.line)
+        : { status: 'FAIL', reason: 'compile overlay did not expose verified source evidence' };
+    const restoration = await restoreHealthy(session, tool, healthySource, compileErrorMarker);
+    return { compileEvidence, clickEvidence, restoration };
+  });
+
+  const runtimeResult = await withProbeSession(tool, 'runtime', browserErrors, async (session) => {
+    const healthySource = await session.workspace.readSource();
+    const runtime = addRuntimeError(healthySource, tool);
+    await session.workspace.writeSource(runtime.source);
+    const runtimeEvidence = await observeOverlay(session, tool, runtimeErrorMarker, runtime.line, 12_000);
+    const restoration = await restoreHealthy(session, tool, healthySource, runtimeErrorMarker);
+    return { runtimeEvidence, restoration };
+  });
+
+  const restorations = [compileResult.restoration, runtimeResult.restoration];
+  return {
+    compile_overlay: compileResult.compileEvidence,
+    runtime_overlay: runtimeResult.runtimeEvidence,
+    click_to_editor: compileResult.clickEvidence,
+    source_restoration: {
+      status: restorations.every((result) => result.status === 'PASS') ? 'PASS' : 'FAIL',
+      compile: compileResult.restoration,
+      runtime: runtimeResult.restoration,
+    },
+    browser_error_excerpt: excerpt(browserErrors.join('\n')),
+    cleanup: 'PASS',
+  };
+}
+
+async function withProbeSession(tool, label, browserErrors, probe) {
   const session = await startApp({
     browser,
     root,
     tool,
-    label: 'overlay',
+    label: `overlay-${label}`,
     extraEnv: {
       LAUNCH_EDITOR: recorderPath,
       OVERLAY_EDITOR_RECORD: recorderOutput,
@@ -89,29 +127,8 @@ async function verifyTool(tool) {
     browserErrors.push(redactEvidence(error.stack ?? error.message, session)),
   );
   const healthySource = await session.workspace.readSource();
-
   try {
-    const compile = addCompileError(healthySource);
-    await session.workspace.writeSource(compile.source);
-    const compileEvidence = await observeOverlay(session, tool, compileErrorMarker, compile.line);
-    const clickEvidence =
-      compileEvidence.status === 'PASS'
-        ? await verifyClickToEditor(session, tool, compile.line)
-        : { status: 'FAIL', reason: 'compile overlay did not expose verified source evidence' };
-    await restoreHealthy(session, tool, healthySource, compileErrorMarker);
-
-    const runtime = addRuntimeError(healthySource, tool);
-    await session.workspace.writeSource(runtime.source);
-    const runtimeEvidence = await observeOverlay(session, tool, runtimeErrorMarker, runtime.line, 12_000);
-    await restoreHealthy(session, tool, healthySource, runtimeErrorMarker);
-
-    return {
-      compile_overlay: compileEvidence,
-      runtime_overlay: runtimeEvidence,
-      click_to_editor: clickEvidence,
-      browser_error_excerpt: excerpt(browserErrors.join('\n')),
-      cleanup: 'PASS',
-    };
+    return await probe(session);
   } finally {
     await session.workspace.writeSource(healthySource).catch(() => {});
     await session.stop();
@@ -187,12 +204,13 @@ async function restoreHealthy(session, tool, healthySource, marker) {
       .filter({ hasText: session.marker })
       .isVisible()
       .catch(() => false);
-    if (!lastOverlay.includes(marker) && lastReady) return;
+    if (!lastOverlay.includes(marker) && lastReady) return { status: 'PASS' };
     await delay(100);
   }
-  throw new Error(
-    `${tool} overlay did not clear after restoring the source: ready=${lastReady}; overlay=${excerpt(redactEvidence(lastOverlay, session))}`,
-  );
+  return {
+    status: 'FAIL',
+    evidence: `ready=${lastReady}; overlay=${excerpt(redactEvidence(lastOverlay, session))}`,
+  };
 }
 
 async function waitForOverlayText(page, tool, marker, timeout) {
@@ -255,6 +273,7 @@ function matrixSummary(result) {
         compile_overlay: result.results[tool].compile_overlay.status,
         runtime_overlay: result.results[tool].runtime_overlay.status,
         click_to_editor: result.results[tool].click_to_editor.status,
+        source_restoration: result.results[tool].source_restoration.status,
       },
     ]),
   );

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -202,10 +202,13 @@ async function waitForOverlayText(page, tool, marker, timeout) {
 }
 
 async function currentOverlayText(page, tool) {
-  const locator =
+  const host =
     tool === 'rspack'
-      ? page.frameLocator('#rspack-dev-server-client-overlay').locator('body')
+      ? page.locator('#rspack-dev-server-client-overlay')
       : page.locator('vite-error-overlay');
+  if (!(await host.isVisible().catch(() => false))) return '';
+  const locator =
+    tool === 'rspack' ? page.frameLocator('#rspack-dev-server-client-overlay').locator('body') : host;
   return (await locator.textContent({ timeout: 500 }).catch(() => '')) ?? '';
 }
 

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -178,17 +178,21 @@ async function verifyClickToEditor(session, tool, expectedLine) {
 async function restoreHealthy(session, tool, healthySource, marker) {
   await session.workspace.writeSource(healthySource);
   const deadline = Date.now() + 30_000;
+  let lastOverlay = '';
+  let lastReady = false;
   while (Date.now() < deadline) {
-    const overlay = await currentOverlayText(session.page, tool);
-    const ready = await session.page
+    lastOverlay = await currentOverlayText(session.page, tool);
+    lastReady = await session.page
       .locator('[data-benchmark-marker]')
       .filter({ hasText: session.marker })
       .isVisible()
       .catch(() => false);
-    if (!overlay.includes(marker) && ready) return;
+    if (!lastOverlay.includes(marker) && lastReady) return;
     await delay(100);
   }
-  throw new Error(`${tool} overlay did not clear after restoring the source`);
+  throw new Error(
+    `${tool} overlay did not clear after restoring the source: ready=${lastReady}; overlay=${excerpt(redactEvidence(lastOverlay, session))}`,
+  );
 }
 
 async function waitForOverlayText(page, tool, marker, timeout) {

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -204,10 +204,21 @@ async function verifyClickToEditor(session, tool, expectedLine) {
         : 'The editor recorder did not receive the expected copied source location.',
     };
   } catch (error) {
+    const availableTargets =
+      tool === 'vite'
+        ? await session.page
+            .locator('vite-error-overlay')
+            .locator('.file-link')
+            .allTextContents()
+            .catch(() => [])
+        : [];
     return {
       status: 'FAIL',
       expected_source: `${session.workspace.relativeMessagePath}:${expectedLine}:<column>`,
       evidence: excerpt(redactEvidence(error.message, session)),
+      available_targets: availableTargets.map((targetText) =>
+        redactEvidence(targetText.replaceAll(session.workspace.directory, '<WORKSPACE>'), session),
+      ),
       responses,
     };
   } finally {

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -19,7 +19,7 @@ import { prepareWorkspaces, removeWorkspaces } from './starter-workspace.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repositoryRoot = path.resolve(root, '../..');
-const output = path.resolve(root, readArgument('--output') ?? 'results/overlay-local.json');
+const output = path.resolve(root, readArgument('--output') ?? 'results/local-overlay.json');
 const report = path.resolve(root, readArgument('--report') ?? 'OVERLAY_RESULTS.local.md');
 const tools = ['rspack', 'vite'];
 const rootAliases = [
@@ -231,7 +231,9 @@ async function currentOverlayText(page, tool) {
       : page.locator('vite-error-overlay');
   if (!(await host.isVisible().catch(() => false))) return '';
   const locator =
-    tool === 'rspack' ? page.frameLocator('#rspack-dev-server-client-overlay').locator('body') : host;
+    tool === 'rspack'
+      ? page.frameLocator('#rspack-dev-server-client-overlay').locator('body')
+      : host.locator('.window');
   return (await locator.textContent({ timeout: 500 }).catch(() => '')) ?? '';
 }
 

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -175,7 +175,11 @@ async function verifyClickToEditor(session, tool, expectedLine) {
           .frameLocator('#rspack-dev-server-client-overlay')
           .locator('[data-can-open="true"]')
           .first()
-      : session.page.locator('vite-error-overlay').locator('.file-link').first();
+      : session.page
+          .locator('vite-error-overlay')
+          .locator('.file-link')
+          .filter({ hasText: path.basename(session.workspace.messagePath) })
+          .first();
   try {
     await target.waitFor({ state: 'visible', timeout: 5_000 });
     await target.evaluate((element) => element.click());

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -1,0 +1,259 @@
+import { chmod, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { format as formatOutput } from 'prettier';
+import { captureEnvironment, startApp } from './app-session.mjs';
+import { assertNoLocalPaths, redactLocalPaths } from './local-paths.mjs';
+import {
+  addCompileError,
+  addRuntimeError,
+  buildOverlayReport,
+  compileErrorMarker,
+  parseEditorInvocation,
+  runtimeErrorMarker,
+  sourceLocationVisible,
+} from './overlay-helpers.mjs';
+import { prepareWorkspaces, removeWorkspaces } from './starter-workspace.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repositoryRoot = path.resolve(root, '../..');
+const output = path.resolve(root, readArgument('--output') ?? 'results/overlay-local.json');
+const report = path.resolve(root, readArgument('--report') ?? 'OVERLAY_RESULTS.local.md');
+const tools = ['rspack', 'vite'];
+const rootAliases = [
+  ...new Set([root, await realpath(root), repositoryRoot, await realpath(repositoryRoot)]),
+];
+let browser;
+let activeSession;
+
+const environment = captureEnvironment(root);
+if (!environment.harness_git_clean)
+  throw new Error('overlay verification must start from a clean committed worktree');
+
+await prepareWorkspaces(root);
+const recorderPath = path.join(root, '.work/editor-recorder.mjs');
+const recorderOutput = path.join(root, '.work/editor-invocations.jsonl');
+await writeEditorRecorder(recorderPath);
+
+const raw = {
+  schema_version: 1,
+  created_at: new Date().toISOString(),
+  environment,
+  methodology: {
+    compile_overlay:
+      'append a deterministic syntax error and require the overlay marker plus original TSX file and line',
+    runtime_overlay:
+      'insert a deterministic render-time throw and require the overlay marker plus original TSX file and line',
+    click_to_editor:
+      'click the compile-error source link with LAUNCH_EDITOR set to a recorder; require exact copied source path, line, and column',
+    cleanup:
+      'restore each source mutation, wait for the overlay to clear, then remove the process group, workspace, and ports',
+  },
+  results: {},
+};
+
+try {
+  browser = await chromium.launch({ headless: true });
+  for (const tool of tools) raw.results[tool] = await verifyTool(tool);
+} finally {
+  await activeSession?.stop();
+  await browser?.close();
+  await removeWorkspaces(root);
+}
+
+const safeRaw = JSON.parse(redactLocalPaths(JSON.stringify(raw), rootAliases));
+assertNoLocalPaths(safeRaw, rootAliases);
+await mkdir(path.dirname(output), { recursive: true });
+await writeFile(output, await formatOutput(JSON.stringify(safeRaw), { parser: 'json' }));
+await writeFile(report, await formatOutput(buildOverlayReport(safeRaw), { parser: 'markdown' }));
+console.log(`Wrote ${path.relative(root, output)} and ${path.relative(root, report)}`);
+console.log(JSON.stringify(matrixSummary(safeRaw), null, 2));
+
+async function verifyTool(tool) {
+  await rm(recorderOutput, { force: true });
+  const browserErrors = [];
+  const session = await startApp({
+    browser,
+    root,
+    tool,
+    label: 'overlay',
+    extraEnv: {
+      LAUNCH_EDITOR: recorderPath,
+      OVERLAY_EDITOR_RECORD: recorderOutput,
+    },
+  });
+  activeSession = session;
+  session.page.on('pageerror', (error) =>
+    browserErrors.push(redactEvidence(error.stack ?? error.message, session)),
+  );
+  const healthySource = await session.workspace.readSource();
+
+  try {
+    const compile = addCompileError(healthySource);
+    await session.workspace.writeSource(compile.source);
+    const compileEvidence = await observeOverlay(session, tool, compileErrorMarker, compile.line);
+    const clickEvidence =
+      compileEvidence.status === 'PASS'
+        ? await verifyClickToEditor(session, tool, compile.line)
+        : { status: 'FAIL', reason: 'compile overlay did not expose verified source evidence' };
+    await restoreHealthy(session, tool, healthySource, compileErrorMarker);
+
+    const runtime = addRuntimeError(healthySource, tool);
+    await session.workspace.writeSource(runtime.source);
+    const runtimeEvidence = await observeOverlay(session, tool, runtimeErrorMarker, runtime.line, 12_000);
+    await restoreHealthy(session, tool, healthySource, runtimeErrorMarker);
+
+    return {
+      compile_overlay: compileEvidence,
+      runtime_overlay: runtimeEvidence,
+      click_to_editor: clickEvidence,
+      browser_error_excerpt: excerpt(browserErrors.join('\n')),
+      cleanup: 'PASS',
+    };
+  } finally {
+    await session.workspace.writeSource(healthySource).catch(() => {});
+    await session.stop();
+    activeSession = undefined;
+  }
+}
+
+async function observeOverlay(session, tool, marker, line, timeout = 30_000) {
+  const text = await waitForOverlayText(session.page, tool, marker, timeout);
+  if (text === undefined) {
+    return {
+      status: 'FAIL',
+      marker_visible: false,
+      source_location_visible: false,
+      expected_source: `${session.workspace.relativeMessagePath}:${line}`,
+      evidence: 'No matching overlay appeared before the bounded timeout.',
+    };
+  }
+  const locationVisible = sourceLocationVisible(text, session.workspace.relativeMessagePath, line);
+  return {
+    status: locationVisible ? 'PASS' : 'FAIL',
+    marker_visible: true,
+    source_location_visible: locationVisible,
+    expected_source: `${session.workspace.relativeMessagePath}:${line}`,
+    evidence: excerpt(redactEvidence(text, session)),
+  };
+}
+
+async function verifyClickToEditor(session, tool, expectedLine) {
+  const target =
+    tool === 'rspack'
+      ? session.page
+          .frameLocator('#rspack-dev-server-client-overlay')
+          .locator('[data-can-open="true"]')
+          .first()
+      : session.page.locator('vite-error-overlay').locator('.file-link').first();
+  try {
+    await target.click({ timeout: 5_000 });
+    const invocation = await waitForEditorInvocation();
+    const parsed = parseEditorInvocation(
+      invocation,
+      session.workspace.directory,
+      session.workspace.messagePath,
+    );
+    const positionMatches =
+      parsed?.line === expectedLine && Number.isInteger(parsed.column) && parsed.column > 0;
+    return {
+      status: positionMatches ? 'PASS' : 'FAIL',
+      expected_source: `${session.workspace.relativeMessagePath}:${expectedLine}:<column>`,
+      recorded_source: parsed ? `${parsed.file}:${parsed.line}:${parsed.column}` : undefined,
+      evidence: positionMatches
+        ? 'The temporary editor recorder received the exact copied source path, line, and column.'
+        : 'The editor recorder did not receive the expected copied source location.',
+    };
+  } catch (error) {
+    return {
+      status: 'FAIL',
+      expected_source: `${session.workspace.relativeMessagePath}:${expectedLine}:<column>`,
+      evidence: excerpt(redactEvidence(error.message, session)),
+    };
+  }
+}
+
+async function restoreHealthy(session, tool, healthySource, marker) {
+  await session.workspace.writeSource(healthySource);
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const overlay = await currentOverlayText(session.page, tool);
+    const ready = await session.page
+      .locator('[data-benchmark-marker]')
+      .filter({ hasText: session.marker })
+      .isVisible()
+      .catch(() => false);
+    if (!overlay.includes(marker) && ready) return;
+    await delay(100);
+  }
+  throw new Error(`${tool} overlay did not clear after restoring the source`);
+}
+
+async function waitForOverlayText(page, tool, marker, timeout) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const text = await currentOverlayText(page, tool);
+    if (text.includes(marker)) return text;
+    await delay(100);
+  }
+  return undefined;
+}
+
+async function currentOverlayText(page, tool) {
+  const locator =
+    tool === 'rspack'
+      ? page.frameLocator('#rspack-dev-server-client-overlay').locator('body')
+      : page.locator('vite-error-overlay');
+  return (await locator.textContent({ timeout: 500 }).catch(() => '')) ?? '';
+}
+
+async function waitForEditorInvocation() {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const lines = (await readFile(recorderOutput, 'utf8')).trim().split('\n');
+      if (lines[0]) return JSON.parse(lines.at(-1));
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+    await delay(100);
+  }
+  throw new Error('timed out waiting for the LAUNCH_EDITOR recorder');
+}
+
+async function writeEditorRecorder(filename) {
+  await writeFile(
+    filename,
+    `#!/usr/bin/env node\nimport { appendFile } from 'node:fs/promises';\nawait appendFile(process.env.OVERLAY_EDITOR_RECORD, JSON.stringify(process.argv.slice(2)) + '\\n');\n`,
+  );
+  await chmod(filename, 0o755);
+}
+
+function redactEvidence(value, session) {
+  return redactLocalPaths(value, [...rootAliases, session.workspace.directory]);
+}
+
+function excerpt(value) {
+  if (!value) return undefined;
+  return value.replace(/\s+/g, ' ').trim().slice(0, 1_000);
+}
+
+function matrixSummary(result) {
+  return Object.fromEntries(
+    tools.map((tool) => [
+      tool,
+      {
+        compile_overlay: result.results[tool].compile_overlay.status,
+        runtime_overlay: result.results[tool].runtime_overlay.status,
+        click_to_editor: result.results[tool].click_to_editor.status,
+      },
+    ]),
+  );
+}
+
+function readArgument(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}

--- a/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/overlay.mjs
@@ -128,11 +128,9 @@ async function withProbeSession(tool, label, browserErrors, probe) {
   session.page.on('pageerror', (error) =>
     browserErrors.push(redactEvidence(error.stack ?? error.message, session)),
   );
-  const healthySource = await session.workspace.readSource();
   try {
     return await probe(session);
   } finally {
-    await session.workspace.writeSource(healthySource).catch(() => {});
     await session.stop();
     activeSession = undefined;
   }

--- a/benchmarks/rspack-vite-rails-dx/scripts/run.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/run.mjs
@@ -1,33 +1,23 @@
-import { spawn, spawnSync } from 'node:child_process';
-import { readFile, realpath, rm, writeFile, mkdir } from 'node:fs/promises';
-import net from 'node:net';
-import os from 'node:os';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
-import process from 'node:process';
-import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
 import { format as formatOutput } from 'prettier';
-import { redactLocalPaths } from './local-paths.mjs';
-import { createWorkspace, prepareWorkspaces, removeWorkspaces } from './starter-workspace.mjs';
+import { captureEnvironment, startApp } from './app-session.mjs';
+import { prepareWorkspaces, removeWorkspaces } from './starter-workspace.mjs';
 import { buildSummary } from './stats.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const repositoryRoot = path.resolve(root, '../..');
-const rootAliases = [
-  ...new Set([root, await realpath(root), repositoryRoot, await realpath(repositoryRoot)]),
-];
 const sampleCount = Number(readArgument('--samples') ?? 5);
 const output = path.resolve(root, readArgument('--output') ?? 'results/latest.json');
 const tools = ['rspack', 'vite'];
-const maxLogCharacters = 8_000;
 let browser;
 let activeSession;
 
 if (!Number.isInteger(sampleCount) || sampleCount < 5)
   throw new Error('--samples must be an integer of at least 5');
 
-const environment = captureEnvironment();
+const environment = captureEnvironment(root);
 if (!environment.harness_git_clean) throw new Error('benchmark must start from a clean committed worktree');
 
 await prepareWorkspaces(root);
@@ -61,14 +51,17 @@ try {
   for (let iteration = 0; iteration < sampleCount; iteration += 1) {
     const order = iteration % 2 === 0 ? tools : [...tools].reverse();
     for (const tool of order) {
-      const session = await startApp(tool, `cold-${iteration}`);
+      const session = await startApp({ browser, root, tool, label: `cold-${iteration}` });
+      activeSession = session;
       raw.raw_samples_ms.cold_start[tool].push(session.readyMs);
       await session.stop();
+      activeSession = undefined;
     }
   }
 
   for (const tool of tools) {
-    const session = await startApp(tool, 'refresh');
+    const session = await startApp({ browser, root, tool, label: 'refresh' });
+    activeSession = session;
     try {
       const input = session.page.locator('[data-benchmark-input]');
       await input.fill(`state-${tool}`);
@@ -87,6 +80,7 @@ try {
       }
     } finally {
       await session.stop();
+      activeSession = undefined;
     }
     raw.generated_config_audit[tool] = await inspectConfig(tool);
   }
@@ -101,84 +95,6 @@ await mkdir(path.dirname(output), { recursive: true });
 await writeFile(output, await formatOutput(JSON.stringify(raw), { parser: 'json' }));
 console.log(`Wrote ${path.relative(root, output)}`);
 console.log(JSON.stringify(raw.summary, null, 2));
-
-async function startApp(tool, label) {
-  const nonce = `${label}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const workspace = await createWorkspace(root, tool, nonce);
-  const marker = `ready-${tool}-${nonce}`;
-  await workspace.setMarker(marker);
-  await clearSharedToolCache(tool);
-  const basePort = await reservePortRange();
-  const webPort = tool === 'rspack' ? basePort : basePort + 100;
-  const assetPort = basePort + 1;
-  const command = tool === 'rspack' ? ['bin/dev', '--no-open-browser'] : ['bin/dev'];
-  const env = {
-    ...process.env,
-    FORCE_COLOR: '0',
-    NO_COLOR: '1',
-    PORT: String(basePort),
-    REACT_ON_RAILS_BASE_PORT: String(basePort),
-    SHAKAPACKER_DEV_SERVER_HOST: '127.0.0.1',
-    VITE_RUBY_HOST: '127.0.0.1',
-    VITE_RUBY_PORT: String(assetPort),
-  };
-  let logTail = '';
-  const capture = (chunk) => {
-    logTail = `${logTail}${chunk}`.slice(-maxLogCharacters);
-  };
-  const startedAt = performance.now();
-  const child = spawn(command[0], command.slice(1), {
-    cwd: workspace.directory,
-    detached: process.platform !== 'win32',
-    env,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  child.stdout.on('data', capture);
-  child.stderr.on('data', capture);
-  let page;
-  let stopPromise;
-  const stop = async () => {
-    stopPromise ??= (async () => {
-      try {
-        await page?.close();
-        await stopProcess(child);
-        await waitForClosedPorts([webPort, assetPort]);
-      } finally {
-        await workspace.remove();
-      }
-    })();
-    await stopPromise;
-    if (activeSession?.stop === stop) activeSession = undefined;
-  };
-  activeSession = { stop };
-
-  try {
-    const url = `http://127.0.0.1:${webPort}${tool === 'rspack' ? '/hello_world' : '/'}`;
-    await waitForHttp(url, child, () => logTail);
-    const assetUrl =
-      tool === 'rspack'
-        ? `http://127.0.0.1:${assetPort}/packs/js/runtime.js`
-        : `http://127.0.0.1:${assetPort}/vite-dev/@vite/client`;
-    await waitForHttp(assetUrl, child, () => logTail);
-    page = await browser.newPage();
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
-    await page.locator('[data-benchmark-marker]').filter({ hasText: marker }).waitFor({ timeout: 30_000 });
-    return { page, readyMs: round(performance.now() - startedAt), stop, workspace };
-  } catch (error) {
-    await stop();
-    throw new Error(
-      `${tool} failed to become browser-ready: ${error.message}\n${redactLocalPaths(logTail, rootAliases)}`,
-    );
-  }
-}
-
-async function clearSharedToolCache(tool) {
-  const candidates =
-    tool === 'rspack' ? ['starters/rspack/node_modules/.cache'] : ['starters/vite/node_modules/.vite'];
-  await Promise.all(
-    candidates.map((candidate) => rm(path.join(root, candidate), { recursive: true, force: true })),
-  );
-}
 
 async function inspectConfig(tool) {
   const files =
@@ -216,152 +132,7 @@ async function inspectConfig(tool) {
   };
 }
 
-async function reservePortRange() {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    const base = 38_000 + Math.floor(Math.random() * 10_000);
-    if (await portsAvailable([base, base + 1, base + 100])) return base;
-  }
-  throw new Error('could not reserve an available benchmark port range');
-}
-
-async function portsAvailable(ports) {
-  const servers = [];
-  try {
-    for (const port of ports) {
-      const server = net.createServer();
-      await new Promise((resolve, reject) => server.once('error', reject).listen(port, '127.0.0.1', resolve));
-      servers.push(server);
-    }
-    return true;
-  } catch {
-    return false;
-  } finally {
-    await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
-  }
-}
-
-async function waitForHttp(url, child, readLog) {
-  const deadline = Date.now() + 60_000;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null || child.signalCode !== null) {
-      const result = child.exitCode === null ? `after ${child.signalCode}` : child.exitCode;
-      throw new Error(`process exited ${result}: ${readLog().slice(-2_000)}`);
-    }
-    try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
-      if (response.ok) return;
-    } catch {
-      // Connection refusal is expected until Rails is ready.
-    }
-    await delay(50);
-  }
-  throw new Error(`timed out waiting for ${url}`);
-}
-
-async function stopProcess(child) {
-  const alreadyExited = child.exitCode !== null || child.signalCode !== null;
-  if (process.platform === 'win32' && alreadyExited) return;
-
-  const exited = alreadyExited ? Promise.resolve() : new Promise((resolve) => child.once('exit', resolve));
-  const target = process.platform === 'win32' ? child.pid : -child.pid;
-  signalProcess(target, 'SIGTERM');
-
-  if (process.platform !== 'win32') {
-    if (!(await waitForProcessGroupExit(child.pid, 10_000))) {
-      signalProcess(target, 'SIGKILL');
-      if (!(await waitForProcessGroupExit(child.pid, 10_000)))
-        throw new Error(`process group ${child.pid} did not exit`);
-    }
-    await exited;
-    return;
-  }
-
-  if (await Promise.race([exited.then(() => true), delay(10_000).then(() => false)])) return;
-  signalProcess(target, 'SIGKILL');
-  await exited;
-}
-
-function signalProcess(target, signal) {
-  try {
-    process.kill(target, signal);
-  } catch (error) {
-    if (error.code !== 'ESRCH') throw error;
-  }
-}
-
-async function waitForProcessGroupExit(pid, timeout) {
-  const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(-pid, 0);
-    } catch (error) {
-      if (error.code === 'ESRCH') return true;
-      throw error;
-    }
-    await delay(50);
-  }
-  return false;
-}
-
-async function waitForClosedPorts(ports) {
-  const deadline = Date.now() + 10_000;
-  while (Date.now() < deadline) {
-    if (await portsAvailable(ports)) return;
-    await delay(100);
-  }
-  throw new Error(`benchmark ports did not close: ${ports.join(', ')}`);
-}
-
-function captureEnvironment() {
-  const gitHead = commandOutput('git', ['rev-parse', 'HEAD'], repositoryRoot);
-  return {
-    harness_git_head: gitHead,
-    harness_git_clean:
-      commandOutput('git', ['status', '--porcelain', '--untracked-files=all'], repositoryRoot) === '',
-    operating_system: `${os.type()} ${os.release()} ${os.arch()}`,
-    cpu: os.cpus()[0]?.model ?? 'unknown',
-    logical_cpu_count: os.cpus().length,
-    total_memory_bytes: os.totalmem(),
-    node: process.version,
-    pnpm: commandOutput('pnpm', ['--version'], root),
-    ruby: commandOutput('ruby', ['--version'], root),
-    rails: {
-      rspack: commandOutput('bundle', ['exec', 'rails', '--version'], path.join(root, 'starters/rspack')),
-      vite: commandOutput('bundle', ['exec', 'rails', '--version'], path.join(root, 'starters/vite')),
-    },
-    dependencies: {
-      rspack_ruby: gemVersions(['react_on_rails', 'shakapacker'], path.join(root, 'starters/rspack')),
-      rspack_javascript: commandOutput(
-        'pnpm',
-        ['exec', 'rspack', '--version'],
-        path.join(root, 'starters/rspack'),
-      ),
-      vite_ruby: gemVersions(['inertia_rails', 'vite_rails'], path.join(root, 'starters/vite')),
-      vite_javascript: commandOutput('pnpm', ['exec', 'vite', '--version'], path.join(root, 'starters/vite')),
-    },
-    commands: {
-      rspack: 'REACT_ON_RAILS_BASE_PORT=<PORT> bin/dev --no-open-browser',
-      vite: 'PORT=<PORT> VITE_RUBY_PORT=<PORT+1> bin/dev',
-    },
-  };
-}
-
-function gemVersions(names, cwd) {
-  const expression = `puts ${JSON.stringify(names)}.map { |name| "#{name} #{Gem.loaded_specs.fetch(name).version}" }.join("; ")`;
-  return commandOutput('bundle', ['exec', 'ruby', '-e', expression], cwd);
-}
-
-function commandOutput(command, args, cwd) {
-  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
-  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed: ${result.stderr}`);
-  return result.stdout.trim();
-}
-
 function readArgument(name) {
   const index = process.argv.indexOf(name);
   return index === -1 ? undefined : process.argv[index + 1];
-}
-
-function round(value) {
-  return Math.round(value * 10) / 10;
 }

--- a/benchmarks/rspack-vite-rails-dx/scripts/run.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/run.mjs
@@ -136,3 +136,7 @@ function readArgument(name) {
   const index = process.argv.indexOf(name);
   return index === -1 ? undefined : process.argv[index + 1];
 }
+
+function round(value) {
+  return Math.round(value * 10) / 10;
+}

--- a/benchmarks/rspack-vite-rails-dx/scripts/starter-workspace.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/starter-workspace.mjs
@@ -29,20 +29,32 @@ export async function createWorkspace(root, tool, nonce) {
   await symlink(dependencyPath, path.join(destination, 'node_modules'), 'dir');
   await mkdir(path.join(destination, 'log'), { recursive: true });
   await mkdir(path.join(destination, 'tmp'), { recursive: true });
+  const messagePath =
+    tool === 'rspack'
+      ? path.join(destination, 'app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx')
+      : path.join(destination, 'app/frontend/pages/inertia_example/index.tsx');
+  const originalSource = await readFile(messagePath, 'utf8');
   return {
     directory: destination,
-    messagePath:
-      tool === 'rspack'
-        ? path.join(destination, 'app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx')
-        : path.join(destination, 'app/frontend/pages/inertia_example/index.tsx'),
+    messagePath,
+    relativeMessagePath: path.relative(destination, messagePath).split(path.sep).join('/'),
+    async readSource() {
+      return readFile(messagePath, 'utf8');
+    },
+    async restoreSource() {
+      await writeFile(messagePath, originalSource);
+    },
     async setMarker(marker) {
-      const contents = await readFile(this.messagePath, 'utf8');
+      const contents = await readFile(messagePath, 'utf8');
       const updated = contents.replace(
         /const BENCHMARK_MARKER = '[^']+'/,
         `const BENCHMARK_MARKER = '${marker}'`,
       );
       if (updated === contents) throw new Error(`benchmark marker was not found in ${tool} starter`);
-      await writeFile(this.messagePath, updated);
+      await writeFile(messagePath, updated);
+    },
+    async writeSource(contents) {
+      await writeFile(messagePath, contents);
     },
     async remove() {
       await rm(destination, { recursive: true, force: true });

--- a/benchmarks/rspack-vite-rails-dx/scripts/starter-workspace.mjs
+++ b/benchmarks/rspack-vite-rails-dx/scripts/starter-workspace.mjs
@@ -33,16 +33,12 @@ export async function createWorkspace(root, tool, nonce) {
     tool === 'rspack'
       ? path.join(destination, 'app/javascript/src/HelloWorld/ror_components/HelloWorld.client.tsx')
       : path.join(destination, 'app/frontend/pages/inertia_example/index.tsx');
-  const originalSource = await readFile(messagePath, 'utf8');
   return {
     directory: destination,
     messagePath,
     relativeMessagePath: path.relative(destination, messagePath).split(path.sep).join('/'),
     async readSource() {
       return readFile(messagePath, 'utf8');
-    },
-    async restoreSource() {
-      await writeFile(messagePath, originalSource);
     },
     async setMarker(marker) {
       const contents = await readFile(messagePath, 'utf8');


### PR DESCRIPTION
## Why

Issue #4696 needs reproducible Rails-level evidence for compile-error overlays, runtime-error source mapping, and click-to-editor on the pinned Rspack and Vite starters. The existing benchmark measures startup and Fast Refresh but intentionally leaves these checks out.

## What changed

- extract the existing app/session lifecycle into a shared benchmark helper
- add deterministic compile-error and render-time runtime-error probes for both starters
- require each observed overlay to show the marker and the exact original TSX path and line
- verify compile-error click-to-editor with a temporary `LAUNCH_EDITOR` recorder, without opening a GUI
- verify restoration with a newly rendered marker, not stale pre-error DOM
- restore source mutations and retain process-group, workspace, and port cleanup
- render redacted JSON and Markdown evidence from a clean committed harness

## Recorded result

| Capability | Rspack | Vite |
| --- | --- | --- |
| Compile overlay, original source | PASS | PASS |
| Runtime overlay, original source | FAIL: generated hot-update frame | FAIL: no matching overlay |
| Compile click-to-editor | FAIL: Rails-origin request returns 404; recorder not invoked | FAIL: no app-source file link |
| Source restoration | FAIL for compile recovery; PASS for runtime recovery | PASS |
| Cleanup | PASS | PASS |

The two final live replays produced the same status matrix. The committed artifacts are redacted and contain no local-user paths.

## Validation

- [x] `pnpm run check` (13 tests)
- [x] existing timing benchmark: `pnpm run benchmark -- --samples 5 --output results/local-refactor.json`
- [x] installed both pinned starter dependency sets
- [x] ran `pnpm run verify:overlays` twice after final oracle and cleanup hardening
- [x] verified no session-nonce processes remained after either replay
- [x] `git diff --check`
- [x] pre-commit hooks
- [x] pre-push hooks
- [x] primary Codex review clean
- [x] independent checker review clean

## Process-gap disposition

- Mechanism: checklist+replay
- Motivating miss: the earlier DX run could observe a compile overlay but had no repeatable runtime, recovery, or click-to-editor oracle.
- Replay: the live verifier passes its cleanup contract twice and records each unsupported capability as a fail-closed `FAIL`, not an inferred success.
- Non-goal: this PR does not change Rspack, Vite, React on Rails, or starter runtime behavior. The measured Rspack product gaps require separate follow-up scope.

Addresses #4696.
