### PR TITLE
Bump version to 17.1.0.rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-workspace",
-  "version": "17.1.0-rc.2",
+  "version": "17.1.0-rc.3",
   "description": "react-on-rails monorepo workspace manager",
   "private": true,
   "type": "module",

--- a/packages/create-react-on-rails-app/package.json
+++ b/packages/create-react-on-rails-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-on-rails-app",
-  "version": "17.1.0-rc.2",
+  "version": "17.1.0-rc.3",
   "description": "Create React on Rails applications with a single command",
   "bin": {
     "create-react-on-rails-app": "./bin/create-react-on-rails-app.js"

--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-pro-node-renderer",
-  "version": "17.1.0-rc.2",
+  "version": "17.1.0-rc.3",
   "protocolVersion": "2.0.0",
   "description": "React on Rails Pro Node Renderer for server-side rendering",
   "engines": {

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails-pro",
-  "version": "17.1.0-rc.2",
+  "version": "17.1.0-rc.3",
   "description": "React on Rails Pro package with React Server Components support",
   "main": "lib/ReactOnRails.full.js",
   "type": "module",

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails",
-  "version": "17.1.0-rc.2",
+  "version": "17.1.0-rc.3",
   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
   "main": "lib/ReactOnRails.full.js",
   "type": "module",

--- a/react_on_rails/Gemfile.lock
+++ b/react_on_rails/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    react_on_rails (17.1.0.rc.2)
+    react_on_rails (17.1.0.rc.3)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/react_on_rails/lib/react_on_rails/version.rb
+++ b/react_on_rails/lib/react_on_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReactOnRails
-  VERSION = "17.1.0.rc.2"
+  VERSION = "17.1.0.rc.3"
 end

--- a/react_on_rails/spec/dummy/Gemfile.lock
+++ b/react_on_rails/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    react_on_rails (17.1.0.rc.2)
+    react_on_rails (17.1.0.rc.3)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    react_on_rails (17.1.0.rc.2)
+    react_on_rails (17.1.0.rc.3)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -20,14 +20,14 @@ PATH
 PATH
   remote: .
   specs:
-    react_on_rails_pro (17.1.0.rc.2)
+    react_on_rails_pro (17.1.0.rc.3)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       nokogiri (>= 1.12, < 2)
-      react_on_rails (= 17.1.0.rc.2)
+      react_on_rails (= 17.1.0.rc.3)
 
 GEM
   remote: https://rubygems.org/

--- a/react_on_rails_pro/lib/react_on_rails_pro/version.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/version.rb
@@ -14,6 +14,6 @@
 # https://github.com/shakacode/react_on_rails/blob/main/REACT-ON-RAILS-PRO-LICENSE.md
 
 module ReactOnRailsPro
-  VERSION = "17.1.0.rc.2"
+  VERSION = "17.1.0.rc.3"
   PROTOCOL_VERSION = "2.0.0"
 end

--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ../../..
   specs:
-    react_on_rails (17.1.0.rc.2)
+    react_on_rails (17.1.0.rc.3)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -20,14 +20,14 @@ PATH
 PATH
   remote: ../..
   specs:
-    react_on_rails_pro (17.1.0.rc.2)
+    react_on_rails_pro (17.1.0.rc.3)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       nokogiri (>= 1.12, < 2)
-      react_on_rails (= 17.1.0.rc.2)
+      react_on_rails (= 17.1.0.rc.3)
 
 GEM
   remote: https://rubygems.org/

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    react_on_rails (17.1.0.rc.2)
+    react_on_rails (17.1.0.rc.3)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -12,14 +12,14 @@ PATH
 PATH
   remote: ../..
   specs:
-    react_on_rails_pro (17.1.0.rc.2)
+    react_on_rails_pro (17.1.0.rc.3)
       async (>= 2.29)
       async-http (~> 0.95)
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
       jwt (>= 2.5, < 4)
       nokogiri (>= 1.12, < 2)
-      react_on_rails (= 17.1.0.rc.2)
+      react_on_rails (= 17.1.0.rc.3)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Why: The release supervisor generated the canonical RC3 version bump, but the protected release branch requires a squash-merged PR through its merge queue. This PR delivers that unchanged release artifact through the required path.

Implementation:
- Set the OSS and Pro gem versions to `17.1.0.rc.3`.
- Set all published npm package versions to `17.1.0-rc.3`.
- Update Ruby lockfiles owned by the release task.

Validation:
- `RELEASE_TRACKER=4842 script/release --dry-run`
- `git diff --check origin/release/17.1.0...HEAD`

Release tracker: #4842

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile-only changes with no runtime, security, or behavioral code modifications.
> 
> **Overview**
> Bumps the **17.1.0** release candidate from **rc.2** to **rc.3** across the monorepo so OSS, Pro, and published npm artifacts stay aligned for the protected release branch merge path.
> 
> Ruby `react_on_rails` and `react_on_rails_pro` now report **`17.1.0.rc.3`** in their version constants, with related **`Gemfile.lock`** files updated for the gem and dummy apps. npm packages (`react-on-rails`, `react-on-rails-pro`, `react-on-rails-pro-node-renderer`, `create-react-on-rails-app`) and the workspace root use **`17.1.0-rc.3`**. No application or library logic changes—only version metadata and lockfile pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4afe68fe0a9309447817a33317340bcdf8131b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->