### PR TITLE
Fix npm release visibility checks

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -9708,7 +9708,11 @@ def fetch_npm_package_metadata(package_ref, registry_url:)
     "peerDependencies",
     "--json",
     "--registry",
-    registry_url
+    registry_url,
+    # A package version can be available at the registry while npm's local cache
+    # still serves the pre-publish 404. Release verification must consult npm
+    # online so that a successful publish is not treated as a failed release.
+    "--prefer-online"
   )
   [output, status]
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -38,7 +38,10 @@ RUBYGEMS_VERSIONS_API_URL = "https://rubygems.org/api/v1/versions"
 RUBYGEMS_VERSIONS_OPEN_TIMEOUT_SECONDS = 10
 RUBYGEMS_VERSIONS_READ_TIMEOUT_SECONDS = 15
 GITHUB_RELEASE_BODY_MAX_LENGTH = 125_000
-NPM_PUBLISH_VERIFY_ATTEMPTS = 6
+# npm can take longer than the former 25-second window to serve a just-published
+# exact version, even when cache reads are bypassed. Keep the recovery bounded
+# while allowing the registry's eventual-consistency window to settle.
+NPM_PUBLISH_VERIFY_ATTEMPTS = 24
 NPM_PUBLISH_VERIFY_RETRY_DELAY_SECONDS = 5
 NPM_PUBLISH_MAX_BACKOFF_SECONDS = 30
 NPM_PUBLISH_HARD_FAILURE_CATEGORIES = %i[

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -8215,7 +8215,8 @@ RSpec.describe "release.rake helper methods" do
           "peerDependencies",
           "--json",
           "--registry",
-          "https://registry.npmjs.org/"
+          "https://registry.npmjs.org/",
+          "--prefer-online"
         )
         .and_return(
           ["npm ERR! 404 Not Found", failed_status],
@@ -8243,7 +8244,8 @@ RSpec.describe "release.rake helper methods" do
           "peerDependencies",
           "--json",
           "--registry",
-          "https://registry.npmjs.org/"
+          "https://registry.npmjs.org/",
+          "--prefer-online"
         )
         .and_return([
                       JSON.generate(

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -8027,7 +8027,8 @@ RSpec.describe "release.rake helper methods" do
             "peerDependencies",
             "--json",
             "--registry",
-            "https://registry.npmjs.org/"
+            "https://registry.npmjs.org/",
+            "--prefer-online"
           )
           .and_return(["npm ERR! 404 Not Found", instance_double(Process::Status, success?: false)])
         allow(self).to receive(:sleep)


### PR DESCRIPTION
## Why

npm can cache an exact-version 404 after a successful publish, causing the release supervisor to stop even though the registry has the package.

## What

- force npm metadata reads used by release publication to prefer the online registry
- cover the release helper command arguments

## Verification

- `bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb:8000`
- verified `npm_config_prefer_online=true npm view react-on-rails-pro@17.1.0-rc.3 ...` against the published RC artifact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only tooling changes with no runtime app impact; slightly longer worst-case wait during npm verify retries.
> 
> **Overview**
> Fixes false release failures when npm’s local cache still returns a 404 for a version that was just published.
> 
> Release verification now runs `npm view` with **`--prefer-online`** so metadata reads hit the registry instead of stale cache. **`NPM_PUBLISH_VERIFY_ATTEMPTS`** is raised from 6 to 24 (still 5s between tries) to give npm’s eventual-consistency window more time while keeping recovery bounded.
> 
> Specs for the release rake helpers were updated to expect the new `npm view` arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1341291a83570edac00df66f57875a054a3ed253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release verification now checks the npm registry directly, preventing successful package publishes from being incorrectly reported as failures due to stale cached responses.
  * Verification retries for longer after publishing to accommodate registry availability delays.

* **Tests**
  * Updated release verification coverage to reflect direct registry lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->