### PR TITLE
Qualify react-on-rails-rsc 19.3.0-rc.4 for React on Rails 17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
-- **[Pro] Side-effect-only RSC client modules work in generated apps again**: Generated RSC apps now pin
+- **[Pro]** **Side-effect-only RSC client modules work in generated apps again**: Generated RSC apps now pin
   `react-on-rails-rsc@19.3.0-rc.4` with React/React DOM `~19.2.8`. RC4 accepts `"use client"` browser
   registration modules that intentionally perform runtime side effects without exporting a client reference,
   while continuing to reject inert, type-only, and CommonJS-style modules that may have lost their exports.
@@ -34,6 +34,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   outside the qualified prerelease window because it rejected valid side-effect-only registration entrypoints.
   See [Tutorial Issue 823](https://github.com/shakacode/react-webpack-rails-tutorial/issues/823) and the
   [RSC RC4 release](https://github.com/shakacode/react_on_rails_rsc/releases/tag/19.3.0-rc.4).
+  [PR 5066](https://github.com/shakacode/react_on_rails/pull/5066) by
+  [justin808](https://github.com/justin808).
 
 ### [17.1.0.rc.3] - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Fixed
+
+- **[Pro] Side-effect-only RSC client modules work in generated apps again**: Generated RSC apps now pin
+  `react-on-rails-rsc@19.3.0-rc.4` with React/React DOM `~19.2.8`. RC4 accepts `"use client"` browser
+  registration modules that intentionally perform runtime side effects without exporting a client reference,
+  while continuing to reject inert, type-only, and CommonJS-style modules that may have lost their exports.
+  It also preserves CSS-wrapper side effects through production Webpack and Rspack tree shaking. RC3 remains
+  outside the qualified prerelease window because it rejected valid side-effect-only registration entrypoints.
+  See [Tutorial Issue 823](https://github.com/shakacode/react-webpack-rails-tutorial/issues/823) and the
+  [RSC RC4 release](https://github.com/shakacode/react_on_rails_rsc/releases/tag/19.3.0-rc.4).
+
 ### [17.1.0.rc.3] - 2026-09-11
 
 #### Fixed

--- a/docs/pro/react-server-components/create-without-ssr.md
+++ b/docs/pro/react-server-components/create-without-ssr.md
@@ -37,7 +37,7 @@ yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 > React on Rails Pro 17 RSC requires React 19.2.x with patch >= 19.2.7. React 19.0.x is no longer a supported Pro RSC runtime line in v17. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
 >
 > The Pro 17.0 generator pins stable `react-on-rails-rsc@19.2.1`; the 17.1 RC soak pins
-> `19.3.0-rc.3` with React/React DOM `~19.2.8`. Keep the Pro gem/npm packages, React,
+> `19.3.0-rc.4` with React/React DOM `~19.2.8`. Keep the Pro gem/npm packages, React,
 > React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
 
 2. Enable support for Server Components in React on Rails Pro configuration:

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -17,7 +17,7 @@ The RSC implementation depends on the `react-on-rails-rsc` npm package, which pr
 
 ## React and Package Version Policy
 
-During the 17.1 RC soak, generated RSC apps pin `react-on-rails-rsc@19.3.0-rc.3`
+During the 17.1 RC soak, generated RSC apps pin `react-on-rails-rsc@19.3.0-rc.4`
 with `react@~19.2.8` and `react-dom@~19.2.8` for both webpack and rspack projects.
 RSC 19.3 still uses the React 19.2 runtime. Existing apps using stable RSC 19.2.1+
 and matching React/React DOM 19.2.7+ remain supported. React 19.0.x and 19.3.x
@@ -25,8 +25,9 @@ are outside the supported runtime line.
 
 The RSC RC honors application `splitChunks` settings for generated client-reference
 chunks and preserves their complete sibling chunk metadata for hydration. Its shared
-loader parses raw JSX/TSX, and modules marked `"use client"` without a runtime ES-module
-export fail the build with a file-specific error.
+loader parses raw JSX/TSX, and modules marked `"use client"` may omit exports when they
+perform observable runtime side effects. Inert, type-only, and CommonJS-style client modules
+still fail the build with a file-specific error.
 
 Upgrade the Pro gem/npm packages, React, React DOM, and `react-on-rails-rsc` as a
 coordinated set; see the [17.1 candidate upgrade guidance](upgrading-existing-pro-app.md).

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -4,7 +4,7 @@ This guide walks you through adding React Server Components to an existing React
 
 > **For React-side migration patterns** (restructuring components, Context, data fetching, etc.), see the [RSC Migration Guide series](../../oss/migrating/migrating-to-rsc.md). This page covers only the infrastructure upgrade.
 
-> **17.1 RC soak:** the generator now pins `react-on-rails-rsc@19.3.0-rc.3` with matching
+> **17.1 RC soak:** the generator now pins `react-on-rails-rsc@19.3.0-rc.4` with matching
 > React/React DOM 19.2.8. Upgrade the Pro gem and npm packages together to a 17.1 candidate that
 > includes this support before changing RSC; earlier Pro releases reject it at startup.
 > The stable 19.2.1 / React 19.2.7 combination below remains supported for existing apps.
@@ -18,13 +18,14 @@ startup with the new RSC pin until this required upgrade is complete.
 For that 17.1 candidate's generated defaults:
 
 ```bash
-pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.3
+pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.4
 ```
 
 The RC loader accepts raw JSX/TSX and supports `parserPlugins` for proposal syntax already
 handled by your application transpiler. A `"use client"` module must expose at least one runtime
-ES-module export; type-only modules and CommonJS-style exports now produce a file-specific build
-error. Add an ES-module export or remove the directive. Rspack builds now honor application
+ES-module export unless it performs observable runtime side effects; inert, type-only, and
+CommonJS-style modules produce a file-specific build error. Add an ES-module export, add the
+intended runtime registration side effect, or remove the directive. Rspack builds now honor application
 `splitChunks` settings while retaining the sibling chunk metadata needed for hydration.
 RC3 also restores stylesheet hints when Webpack or Rspack scope-hoists a client reference and its
 CSS-bearing children into concatenated modules in production builds.
@@ -40,7 +41,7 @@ Before running the generator, verify your environment:
 | React on Rails Pro npm   | `npm ls react-on-rails-pro` / `yarn why react-on-rails-pro` / `pnpm list react-on-rails-pro` / `bun pm why react-on-rails-pro` | Matches gem version                                           |
 | React version            | `npm ls react` / `yarn why react` / `pnpm list react` / `bun pm why react`                                                     | Stable 19.2.x: >=19.2.8 for 17.1 RC; >=19.2.7 for 17.0 stable |
 | React DOM version        | `npm ls react-dom` / `yarn why react-dom` / `pnpm list react-dom` / `bun pm why react-dom`                                     | Must match `react` version                                    |
-| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | 17.1 RC pin: 19.3.0-rc.3; 17.0 stable: stable 19.2.x >=19.2.1 |
+| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | 17.1 RC pin: 19.3.0-rc.4; 17.0 stable: stable 19.2.x >=19.2.1 |
 | Node.js                  | `node --version`                                                                                                               | 18+                                                           |
 | Pro initializer exists   | `ls config/initializers/react_on_rails_pro.rb`                                                                                 | File exists                                                   |
 | Node renderer configured | Check `react_on_rails_pro.rb` for `server_renderer = "NodeRenderer"`                                                           | NodeRenderer enabled                                          |
@@ -48,9 +49,9 @@ Before running the generator, verify your environment:
 For the **17.1 RC standalone generator**, upgrade React and React DOM together before running it:
 
 ```bash
-pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.3
-# or: yarn add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.3
-# or: npm install react@~19.2.8 react-dom@~19.2.8 && npm install --save-exact react-on-rails-rsc@19.3.0-rc.3
+pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.4
+# or: yarn add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.4
+# or: npm install react@~19.2.8 react-dom@~19.2.8 && npm install --save-exact react-on-rails-rsc@19.3.0-rc.4
 ```
 
 For apps staying on the **supported 17.0 stable path**, use this coordinated set instead:
@@ -73,13 +74,13 @@ The generator-managed RSC version is what goes in your app's `package.json`. Sep
 
 > [!NOTE]
 > During the 17.1 soak, the Pro package's optional `react-on-rails-rsc` peer range is
-> `>=19.2.1 <19.4.0 || ~19.3.0-rc.3`. Only the 19.3.0 prerelease tuple from rc.3 onward is
+> `>=19.2.1 <19.4.0 || ~19.3.0-rc.4`. Only the 19.3.0 prerelease tuple from rc.4 onward is
 > admitted. Doctor and the Node Renderer enforce React/React DOM 19.2.7+ for RSC 19.2, and
 > 19.2.8+ for RSC 19.3, with matching stable React/DOM 19.2.x versions. Set
 > `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency diagnostic escape hatch;
 > it downgrades startup errors to warnings and does not make an unsupported tuple supported.
 >
-> This qualification installs exactly `19.3.0-rc.3`; the compatibility range does not
+> This qualification installs exactly `19.3.0-rc.4`; the compatibility range does not
 > mean that every later satisfying version has been tested.
 
 ## Pre-Migration: Audit Components for Client API Usage

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -7734,7 +7734,7 @@ yarn add react@~19.2.7 react-dom@~19.2.7 react-on-rails-rsc@19.2.1
 > React on Rails Pro 17 RSC requires React 19.2.x with patch >= 19.2.7. React 19.0.x is no longer a supported Pro RSC runtime line in v17. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
 >
 > The Pro 17.0 generator pins stable `react-on-rails-rsc@19.2.1`; the 17.1 RC soak pins
-> `19.3.0-rc.3` with React/React DOM `~19.2.8`. Keep the Pro gem/npm packages, React,
+> `19.3.0-rc.4` with React/React DOM `~19.2.8`. Keep the Pro gem/npm packages, React,
 > React DOM, and `react-on-rails-rsc` upgraded as a coordinated set.
 
 2. Enable support for Server Components in React on Rails Pro configuration:
@@ -9728,7 +9728,7 @@ This guide walks you through adding React Server Components to an existing React
 
 > **For React-side migration patterns** (restructuring components, Context, data fetching, etc.), see the [RSC Migration Guide series](../../oss/migrating/migrating-to-rsc.md). This page covers only the infrastructure upgrade.
 
-> **17.1 RC soak:** the generator now pins `react-on-rails-rsc@19.3.0-rc.3` with matching
+> **17.1 RC soak:** the generator now pins `react-on-rails-rsc@19.3.0-rc.4` with matching
 > React/React DOM 19.2.8. Upgrade the Pro gem and npm packages together to a 17.1 candidate that
 > includes this support before changing RSC; earlier Pro releases reject it at startup.
 > The stable 19.2.1 / React 19.2.7 combination below remains supported for existing apps.
@@ -9742,13 +9742,14 @@ startup with the new RSC pin until this required upgrade is complete.
 For that 17.1 candidate's generated defaults:
 
 ```bash
-pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.3
+pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.4
 ```
 
 The RC loader accepts raw JSX/TSX and supports `parserPlugins` for proposal syntax already
 handled by your application transpiler. A `"use client"` module must expose at least one runtime
-ES-module export; type-only modules and CommonJS-style exports now produce a file-specific build
-error. Add an ES-module export or remove the directive. Rspack builds now honor application
+ES-module export unless it performs observable runtime side effects; inert, type-only, and
+CommonJS-style modules produce a file-specific build error. Add an ES-module export, add the
+intended runtime registration side effect, or remove the directive. Rspack builds now honor application
 `splitChunks` settings while retaining the sibling chunk metadata needed for hydration.
 RC3 also restores stylesheet hints when Webpack or Rspack scope-hoists a client reference and its
 CSS-bearing children into concatenated modules in production builds.
@@ -9764,7 +9765,7 @@ Before running the generator, verify your environment:
 | React on Rails Pro npm   | `npm ls react-on-rails-pro` / `yarn why react-on-rails-pro` / `pnpm list react-on-rails-pro` / `bun pm why react-on-rails-pro` | Matches gem version                                           |
 | React version            | `npm ls react` / `yarn why react` / `pnpm list react` / `bun pm why react`                                                     | Stable 19.2.x: >=19.2.8 for 17.1 RC; >=19.2.7 for 17.0 stable |
 | React DOM version        | `npm ls react-dom` / `yarn why react-dom` / `pnpm list react-dom` / `bun pm why react-dom`                                     | Must match `react` version                                    |
-| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | 17.1 RC pin: 19.3.0-rc.3; 17.0 stable: stable 19.2.x >=19.2.1 |
+| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | 17.1 RC pin: 19.3.0-rc.4; 17.0 stable: stable 19.2.x >=19.2.1 |
 | Node.js                  | `node --version`                                                                                                               | 18+                                                           |
 | Pro initializer exists   | `ls config/initializers/react_on_rails_pro.rb`                                                                                 | File exists                                                   |
 | Node renderer configured | Check `react_on_rails_pro.rb` for `server_renderer = "NodeRenderer"`                                                           | NodeRenderer enabled                                          |
@@ -9772,9 +9773,9 @@ Before running the generator, verify your environment:
 For the **17.1 RC standalone generator**, upgrade React and React DOM together before running it:
 
 ```bash
-pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.3
-# or: yarn add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.3
-# or: npm install react@~19.2.8 react-dom@~19.2.8 && npm install --save-exact react-on-rails-rsc@19.3.0-rc.3
+pnpm add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.4
+# or: yarn add react@~19.2.8 react-dom@~19.2.8 react-on-rails-rsc@19.3.0-rc.4
+# or: npm install react@~19.2.8 react-dom@~19.2.8 && npm install --save-exact react-on-rails-rsc@19.3.0-rc.4
 ```
 
 For apps staying on the **supported 17.0 stable path**, use this coordinated set instead:
@@ -9797,13 +9798,13 @@ The generator-managed RSC version is what goes in your app's `package.json`. Sep
 
 > [!NOTE]
 > During the 17.1 soak, the Pro package's optional `react-on-rails-rsc` peer range is
-> `>=19.2.1 <19.4.0 || ~19.3.0-rc.3`. Only the 19.3.0 prerelease tuple from rc.3 onward is
+> `>=19.2.1 <19.4.0 || ~19.3.0-rc.4`. Only the 19.3.0 prerelease tuple from rc.4 onward is
 > admitted. Doctor and the Node Renderer enforce React/React DOM 19.2.7+ for RSC 19.2, and
 > 19.2.8+ for RSC 19.3, with matching stable React/DOM 19.2.x versions. Set
 > `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` only as an emergency diagnostic escape hatch;
 > it downgrades startup errors to warnings and does not make an unsupported tuple supported.
 >
-> This qualification installs exactly `19.3.0-rc.3`; the compatibility range does not
+> This qualification installs exactly `19.3.0-rc.4`; the compatibility range does not
 > mean that every later satisfying version has been tested.
 
 ## Pre-Migration: Audit Components for Client API Usage
@@ -10898,7 +10899,7 @@ The RSC implementation depends on the `react-on-rails-rsc` npm package, which pr
 
 ## React and Package Version Policy
 
-During the 17.1 RC soak, generated RSC apps pin `react-on-rails-rsc@19.3.0-rc.3`
+During the 17.1 RC soak, generated RSC apps pin `react-on-rails-rsc@19.3.0-rc.4`
 with `react@~19.2.8` and `react-dom@~19.2.8` for both webpack and rspack projects.
 RSC 19.3 still uses the React 19.2 runtime. Existing apps using stable RSC 19.2.1+
 and matching React/React DOM 19.2.7+ remain supported. React 19.0.x and 19.3.x
@@ -10906,8 +10907,9 @@ are outside the supported runtime line.
 
 The RSC RC honors application `splitChunks` settings for generated client-reference
 chunks and preserves their complete sibling chunk metadata for hydration. Its shared
-loader parses raw JSX/TSX, and modules marked `"use client"` without a runtime ES-module
-export fail the build with a file-specific error.
+loader parses raw JSX/TSX, and modules marked `"use client"` may omit exports when they
+perform observable runtime side effects. Inert, type-only, and CommonJS-style client modules
+still fail the build with a file-specific error.
 
 Upgrade the Pro gem/npm packages, React, React DOM, and `react-on-rails-rsc` as a
 coordinated set; see the [17.1 candidate upgrade guidance](upgrading-existing-pro-app.md).

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
       "These force patched versions of transitive dev dependencies. Remove when upstream packages update.",
       "ajv overrides were intentionally excluded: ajv v8 breaks webpack's schema-utils/ajv-keywords.",
       "The 2 moderate ajv alerts (ReDoS in $data option) are tolerable — ajv only validates our own config files.",
-      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react-on-rails-pro-node-renderer>react(-dom)/react-on-rails-rsc, react-on-rails-pro>react(-dom)/react-on-rails-rsc, and react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scope Pro RSC package tests and dummy validation to the React 19.2.8 + react-on-rails-rsc 19.3.0-rc.3 pair, the React on Rails 17 RSC floor (#3865; gate landed in #4026). The root workspace pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 only for legacy non-Pro fixture coverage."
+      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react-on-rails-pro-node-renderer>react(-dom)/react-on-rails-rsc, react-on-rails-pro>react(-dom)/react-on-rails-rsc, and react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scope Pro RSC package tests and dummy validation to the React 19.2.8 + react-on-rails-rsc 19.3.0-rc.4 pair, the React on Rails 17 RSC floor (#3865; gate landed in #4026). The root workspace pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 only for legacy non-Pro fixture coverage."
     ],
     "overrides": {
       "react": "$react",
@@ -141,13 +141,13 @@
       "react_on_rails>react-dom": "^19.2.0",
       "react-on-rails-pro-node-renderer>react": "~19.2.8",
       "react-on-rails-pro-node-renderer>react-dom": "~19.2.8",
-      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.3.0-rc.3",
+      "react-on-rails-pro-node-renderer>react-on-rails-rsc": "19.3.0-rc.4",
       "react-on-rails-pro>react": "~19.2.8",
       "react-on-rails-pro>react-dom": "~19.2.8",
-      "react-on-rails-pro>react-on-rails-rsc": "19.3.0-rc.3",
+      "react-on-rails-pro>react-on-rails-rsc": "19.3.0-rc.4",
       "react_on_rails_pro_dummy>react": "~19.2.8",
       "react_on_rails_pro_dummy>react-dom": "~19.2.8",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.3.0-rc.3",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.3.0-rc.4",
       "sentry-testkit>body-parser": "npm:empty-npm-package@1.0.0",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0",
       "lodash@>=4.0.0 <=4.17.22": ">=4.17.23 <5",

--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -74,7 +74,7 @@
     "react": "~19.2.8",
     "react-dom": "~19.2.8",
     "react-on-rails": "workspace:*",
-    "react-on-rails-rsc": "19.3.0-rc.3",
+    "react-on-rails-rsc": "19.3.0-rc.4",
     "redis": "^5.0.1",
     "sentry-testkit": "^5.0.6",
     "touch": "^3.1.0",

--- a/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
@@ -20,10 +20,10 @@
 // Ruby Doctor/generator constants that install and diagnose the same Pro RSC
 // package line. The 19.2.1 line pairs with React/React DOM 19.2.7 and carries
 // the coordinated RSC fixes required by the Pro RSC renderer path.
-// The 19.3.0 RC soak admits only the qualified prerelease tuple, from rc.3 onward.
+// The 19.3.0 RC soak admits only the qualified prerelease tuple, from rc.4 onward.
 // RSC package minors and React runtime minors are independent: RSC 19.3 still uses React 19.2.
 export const RSC_PEER_SUPPORT = {
-  reactOnRailsRsc: { minimumVersion: '19.2.1', minimumPrereleaseVersion: '19.3.0-rc.3', supportedMajor: 19 },
+  reactOnRailsRsc: { minimumVersion: '19.2.1', minimumPrereleaseVersion: '19.3.0-rc.4', supportedMajor: 19 },
   react: {
     supportedMajor: 19,
     supportedRanges: [

--- a/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
@@ -28,20 +28,25 @@ const versionBelowMinimumVersion = (version: string) => {
 const belowMinimumVersion = versionBelowMinimumVersion(minimumVersion);
 
 describe('checkRscPeerCompatibility', () => {
-  it.each(['19.3.0-rc.3', '19.3.0'])('accepts %s with the coordinated React 19.2.8 runtime', (rscVersion) => {
+  it.each(['19.3.0-rc.4', '19.3.0'])('accepts %s with the coordinated React 19.2.8 runtime', (rscVersion) => {
     expect(
       checkRscPeerCompatibility({ rscVersion, reactVersion: '19.2.8', reactDomVersion: '19.2.8' }),
     ).toEqual({ level: 'ok' });
   });
 
-  it.each(['19.3.0-rc.0', '19.3.0-rc.1', '19.3.0-rc.2', '19.3.1-rc.0', '19.4.0-rc.0', '19.4.0'])(
-    'rejects unqualified RSC version %s',
-    (rscVersion) => {
-      expect(
-        checkRscPeerCompatibility({ rscVersion, reactVersion: '19.2.8', reactDomVersion: '19.2.8' }).level,
-      ).toBe('error');
-    },
-  );
+  it.each([
+    '19.3.0-rc.0',
+    '19.3.0-rc.1',
+    '19.3.0-rc.2',
+    '19.3.0-rc.3',
+    '19.3.1-rc.0',
+    '19.4.0-rc.0',
+    '19.4.0',
+  ])('rejects unqualified RSC version %s', (rscVersion) => {
+    expect(
+      checkRscPeerCompatibility({ rscVersion, reactVersion: '19.2.8', reactDomVersion: '19.2.8' }).level,
+    ).toBe('error');
+  });
 
   it.each([
     ['19.2.7', '19.2.7'],
@@ -53,15 +58,15 @@ describe('checkRscPeerCompatibility', () => {
     ['19.2.9-canary.0', '19.2.9-canary.0'],
   ])('rejects RSC 19.3 with React %s and React DOM %s', (reactVersion, reactDomVersion) => {
     expect(
-      checkRscPeerCompatibility({ rscVersion: '19.3.0-rc.3', reactVersion, reactDomVersion }).level,
+      checkRscPeerCompatibility({ rscVersion: '19.3.0-rc.4', reactVersion, reactDomVersion }).level,
     ).toBe('error');
   });
 
   it('configures the qualified 19.3.0 prerelease tuple', () => {
-    expect(minimumPrereleaseVersion).toBe('19.3.0-rc.3');
+    expect(minimumPrereleaseVersion).toBe('19.3.0-rc.4');
   });
 
-  it.each(['19.2.1', '19.3.0-rc.3'])(
+  it.each(['19.2.1', '19.3.0-rc.4'])(
     'explains stable-only React and React DOM support for RSC %s',
     (rscVersion) => {
       for (const versions of [
@@ -100,7 +105,7 @@ describe('checkRscPeerCompatibility', () => {
       expect(r.level).toBe('error');
       expect(r.message).toContain(prerelease);
       expect(r.message).toContain(`>= ${minimumVersion}`);
-      expect(r.message).toContain('19.3.0-rc.3 during the RC soak');
+      expect(r.message).toContain('19.3.0-rc.4 during the RC soak');
       expect(r.message).not.toContain('undefined');
     },
   );
@@ -109,7 +114,7 @@ describe('checkRscPeerCompatibility', () => {
     const r = checkRscPeerCompatibility({ rscVersion: belowMinimumVersion, reactVersion: '19.2.7' });
     expect(r.level).toBe('error');
     expect(r.message).toContain(`>= ${minimumVersion}`);
-    expect(r.message).toContain('19.3.0-rc.3 during the RC soak');
+    expect(r.message).toContain('19.3.0-rc.4 during the RC soak');
     expect(r.message).not.toContain('undefined');
   });
 

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "react": ">= 16",
     "react-dom": ">= 16",
-    "react-on-rails-rsc": ">=19.2.1 <19.4.0 || ~19.3.0-rc.3",
+    "react-on-rails-rsc": ">=19.2.1 <19.4.0 || ~19.3.0-rc.4",
     "@tanstack/react-router": ">=1.139.0 <2.0.0",
     "ioredis": ">= 5"
   },
@@ -118,7 +118,7 @@
     "mock-fs": "^5.5.0",
     "react": "~19.2.8",
     "react-dom": "~19.2.8",
-    "react-on-rails-rsc": "19.3.0-rc.3",
+    "react-on-rails-rsc": "19.3.0-rc.4",
     "ioredis": "5.11.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ overrides:
   react_on_rails>react-dom: ^19.2.0
   react-on-rails-pro-node-renderer>react: ~19.2.8
   react-on-rails-pro-node-renderer>react-dom: ~19.2.8
-  react-on-rails-pro-node-renderer>react-on-rails-rsc: 19.3.0-rc.3
+  react-on-rails-pro-node-renderer>react-on-rails-rsc: 19.3.0-rc.4
   react-on-rails-pro>react: ~19.2.8
   react-on-rails-pro>react-dom: ~19.2.8
-  react-on-rails-pro>react-on-rails-rsc: 19.3.0-rc.3
+  react-on-rails-pro>react-on-rails-rsc: 19.3.0-rc.4
   react_on_rails_pro_dummy>react: ~19.2.8
   react_on_rails_pro_dummy>react-dom: ~19.2.8
-  react_on_rails_pro_dummy>react-on-rails-rsc: 19.3.0-rc.3
+  react_on_rails_pro_dummy>react-on-rails-rsc: 19.3.0-rc.4
   sentry-testkit>body-parser: npm:empty-npm-package@1.0.0
   sentry-testkit>express: npm:empty-npm-package@1.0.0
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23 <5'
@@ -286,8 +286,8 @@ importers:
         specifier: ~19.2.8
         version: 19.2.8(react@19.2.8)
       react-on-rails-rsc:
-        specifier: 19.3.0-rc.3
-        version: 19.3.0-rc.3(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.3.0-rc.4
+        version: 19.3.0-rc.4(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(@swc/core@1.15.3))
 
   packages/react-on-rails-pro-node-renderer:
     dependencies:
@@ -401,8 +401,8 @@ importers:
         specifier: workspace:*
         version: link:../react-on-rails
       react-on-rails-rsc:
-        specifier: 19.3.0-rc.3
-        version: 19.3.0-rc.3(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.3.0-rc.4
+        version: 19.3.0-rc.4(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(@swc/core@1.15.3))
       redis:
         specifier: ^5.0.1
         version: 5.10.0
@@ -765,8 +765,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.3.0-rc.3
-        version: 19.3.0-rc.3(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.104.1)
+        specifier: 19.3.0-rc.4
+        version: 19.3.0-rc.4(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8578,8 +8578,8 @@ packages:
       react-dom: ~19.0.4
       webpack: ^5.59.0
 
-  react-on-rails-rsc@19.3.0-rc.3:
-    resolution: {integrity: sha512-u8rIEzHOZPvD6ZILc0jbUH3m0UPF6I+Vt5D6mKgRxgxWrIuVFGsbEUaLnxtPCvP/pBgiGiZ8g6PNgv6LMEE2vA==}
+  react-on-rails-rsc@19.3.0-rc.4:
+    resolution: {integrity: sha512-+oJbP947a1e8Pg8GzhsWJxXmtiEyNJCGlX9oxmOGFonVxS9znet8sPpq8imaSi5ak6heNd4SlY6cX4cbgAbVhw==}
     peerDependencies:
       '@rspack/core': ^1.0.0 || ^2.0.0
       react: ~19.0.4
@@ -19330,7 +19330,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.3.0-rc.3(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.104.1):
+  react-on-rails-rsc@19.3.0-rc.4(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.104.1):
     dependencies:
       '@babel/parser': 7.29.7
       acorn-loose: 8.5.2
@@ -19343,7 +19343,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.2.1
 
-  react-on-rails-rsc@19.3.0-rc.3(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(@swc/core@1.15.3)):
+  react-on-rails-rsc@19.3.0-rc.4(@rspack/core@2.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(@swc/core@1.15.3)):
     dependencies:
       '@babel/parser': 7.29.7
       acorn-loose: 8.5.2

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -159,9 +159,9 @@ module ReactOnRails
       # `react-on-rails-rsc`. Coordination note for #3609: Pro package metadata and generated apps
       # use the tested React 19.2.x range with the exact RSC package pin.
       RSC_REACT_VERSION_RANGE = "~19.2.8"
-      # Qualify the JSX/TSX loader and Rspack chunk fixes during the 19.3.0 RC soak.
+      # Qualify the side-effect-only client module and CSS wrapper fixes during the 19.3.0 RC soak.
       # Keep the React 19.2 runtime line independent from the RSC package minor.
-      RSC_PACKAGE_VERSION_PIN = "19.3.0-rc.3"
+      RSC_PACKAGE_VERSION_PIN = "19.3.0-rc.4"
 
       private
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -8948,13 +8948,14 @@ RSpec.describe ReactOnRails::Doctor do
     let(:doctor) { described_class.new(verbose: false, fix: false) }
     let(:checker) { doctor.instance_variable_get(:@checker) }
 
-    ["19.3.0-rc.3", "19.3.0"].each do |version|
+    ["19.3.0-rc.4", "19.3.0"].each do |version|
       it "accepts qualified RSC #{version}" do
         expect(doctor.send(:rsc_package_version_at_or_above_minimum?, version)).to be true
       end
     end
 
-    ["19.3.0-rc.0", "19.3.0-rc.1", "19.3.0-rc.2", "19.3.1-rc.0", "19.4.0-rc.0", "19.4.0"].each do |version|
+    ["19.3.0-rc.0", "19.3.0-rc.1", "19.3.0-rc.2", "19.3.0-rc.3", "19.3.1-rc.0", "19.4.0-rc.0",
+     "19.4.0"].each do |version|
       it "rejects unqualified RSC #{version}" do
         expect(doctor.send(:rsc_package_version_at_or_above_minimum?, version)).to be false
       end
@@ -8966,7 +8967,7 @@ RSpec.describe ReactOnRails::Doctor do
     end
 
     it "enforces the RSC 19.3 React floor even when package peers are overly broad" do
-      package = { "version" => "19.3.0-rc.3" }
+      package = { "version" => "19.3.0-rc.4" }
       expect(doctor.send(:check_rsc_supported_react_version_for_package, package, "react", "19.2.7"))
         .to be false
       expect(doctor.send(:check_rsc_supported_react_version_for_package, package, "react-dom", "19.2.7"))
@@ -8990,7 +8991,7 @@ RSpec.describe ReactOnRails::Doctor do
       errors = checker.messages.select { |message| message[:type] == :error }.pluck(:content)
       expect(errors).to include(a_string_including(
                                   "npm install react@~19.2.8 react-dom@~19.2.8 && " \
-                                  "npm install react-on-rails-rsc@19.3.0-rc.3 --save-exact"
+                                  "npm install react-on-rails-rsc@19.3.0-rc.4 --save-exact"
                                 ))
       expect(errors).to include(a_string_including(
                                   "RSC 19.2.x requires stable React/React DOM ~19.2.7",
@@ -9000,15 +9001,15 @@ RSpec.describe ReactOnRails::Doctor do
 
     [
       ["19.2.1", "19.2.6", "19.2.6", "unsupported React 19.2.6"],
-      ["19.3.0-rc.3", "19.2.7", "19.2.7", "unsupported React 19.2.7"],
-      ["19.3.0-rc.3", "19.2.8", "19.2.7", "unsupported React DOM 19.2.7"],
-      ["19.3.0-rc.3", "19.2.8", "19.2.9", "requires react and react-dom to resolve to the same version"],
+      ["19.3.0-rc.4", "19.2.7", "19.2.7", "unsupported React 19.2.7"],
+      ["19.3.0-rc.4", "19.2.8", "19.2.7", "unsupported React DOM 19.2.7"],
+      ["19.3.0-rc.4", "19.2.8", "19.2.9", "requires react and react-dom to resolve to the same version"],
       ["19.2.1", "19.2.8-rc.1", "19.2.8-rc.1", "unsupported React 19.2.8-rc.1"],
       ["19.2.1", "19.2.8", "19.2.8-rc.1", "unsupported React DOM 19.2.8-rc.1"],
-      ["19.3.0-rc.3", "19.2.9-rc.1", "19.2.9-rc.1", "unsupported React 19.2.9-rc.1"],
-      ["19.3.0-rc.3", "19.2.9", "19.2.9-rc.1", "unsupported React DOM 19.2.9-rc.1"],
+      ["19.3.0-rc.4", "19.2.9-rc.1", "19.2.9-rc.1", "unsupported React 19.2.9-rc.1"],
+      ["19.3.0-rc.4", "19.2.9", "19.2.9-rc.1", "unsupported React DOM 19.2.9-rc.1"],
       ["19.2.1", "19.2.7", "19.2.7", nil],
-      ["19.3.0-rc.3", "19.2.8", "19.2.8", nil]
+      ["19.3.0-rc.4", "19.2.8", "19.2.8", nil]
     ].each do |rsc_version, react_version, react_dom_version, expected_error|
       it "checks RSC #{rsc_version} with React #{react_version}/DOM #{react_dom_version} without peer metadata" do
         allow(doctor).to receive(:detect_react_version_from_deps).and_return(react_version)
@@ -9696,7 +9697,7 @@ RSpec.describe ReactOnRails::Doctor do
           .with(Dir.pwd)
           .and_return(
             [
-              JSON.generate("latest" => "19.2.1", "next" => "19.3.0-rc.3"),
+              JSON.generate("latest" => "19.2.1", "next" => "19.3.0-rc.4"),
               instance_double(Process::Status, success?: true)
             ]
           )
@@ -9707,10 +9708,10 @@ RSpec.describe ReactOnRails::Doctor do
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(warning_msgs).to include(
           a_string_including(
-            "react-on-rails-rsc 19.2.1 is behind the npm next dist-tag 19.3.0-rc.3",
+            "react-on-rails-rsc 19.2.1 is behind the npm next dist-tag 19.3.0-rc.4",
             "React peer requirements",
             "React runtime versions supported by this React on Rails Pro release",
-            "npm view react-on-rails-rsc@19.3.0-rc.3 peerDependencies"
+            "npm view react-on-rails-rsc@19.3.0-rc.4 peerDependencies"
           )
         )
         expect(warning_msgs.join("\n")).not_to include(

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -809,7 +809,7 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
   describe "#rsc_packages_with_version" do
     it "defines an explicit RSC package version pin independent from the React semver range prefix" do
       expect(ReactOnRails::Generators::JsDependencyManager::RSC_REACT_VERSION_RANGE).to eq("~19.2.8")
-      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.3.0-rc.3")
+      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.3.0-rc.4")
     end
 
     it "keeps the generated RSC React policy on the 19.2.x patch track" do
@@ -889,11 +889,11 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.3.0-rc.3")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.3.0-rc.4")
       expect(warning_text).to include("left the version pin in package.json")
       expect(warning_text).to include("client-export parsing")
       expect(warning_text).to include("react-on-rails-rsc/RspackPlugin")
-      manual_command = "npm install --save-exact react-on-rails-rsc@19.3.0-rc.3"
+      manual_command = "npm install --save-exact react-on-rails-rsc@19.3.0-rc.4"
       expect(warning_text).to include(manual_command)
       expect(warning_text.scan(manual_command).size).to eq(1)
     end
@@ -901,9 +901,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
     it "keeps the pinned manual install instruction when the pinned install raises" do
       allow(instance)
         .to receive(:rsc_packages_with_version)
-        .and_return([["react-on-rails-rsc@19.3.0-rc.3"], true])
+        .and_return([["react-on-rails-rsc@19.3.0-rc.4"], true])
 
-      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.3.0-rc.3"]).and_raise("network down")
+      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.3.0-rc.4"]).and_raise("network down")
       allow(instance).to receive(:add_packages).with(["react-on-rails-rsc"]).and_return(true)
 
       instance.send(:add_rsc_dependencies)
@@ -912,9 +912,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.3.0-rc.3")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.3.0-rc.4")
       expect(warning_text).to include("Error adding React Server Components dependencies: network down")
-      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.3.0-rc.3")
+      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.3.0-rc.4")
     end
 
     it "uses computed rsc packages for manual recovery when installation raises" do

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -12,7 +12,7 @@ describe RscGenerator, type: :generator do
   describe "React version preflight" do
     let(:generator) { described_class.new([], {}, destination_root: Dir.pwd) }
     let(:react_version) { "19.2.8-rc.0" }
-    let(:rsc_version) { "19.3.0-rc.3" }
+    let(:rsc_version) { "19.3.0-rc.4" }
 
     around do |example|
       Dir.mktmpdir("rsc-version-preflight") do |dir|
@@ -42,7 +42,7 @@ describe RscGenerator, type: :generator do
         generator.run_generator
 
         messages = GeneratorMessages.messages.join("\n")
-        expect(messages).to include("required minimum", "react-on-rails-rsc 19.3.0-rc.3",
+        expect(messages).to include("required minimum", "react-on-rails-rsc 19.3.0-rc.4",
                                     "matching stable React/React DOM 19.2.8+ on 19.2.x",
                                     "Node Renderer refuses startup until", "react@~19.2.8", "react-dom@~19.2.8")
         expect(messages).not_to include("recommended minimum")
@@ -64,7 +64,7 @@ describe RscGenerator, type: :generator do
 
     prerelease_versions = ["19.2.8-rc.0", "^19.2.9-canary.1", "19.2.8.beta.1", "19.2.0-canary-abc123-20260101"]
     stable_versions = ["~19.2.8", "19.2.9", "19.2.8+build.1"]
-    ["19.2.1", "19.3.0-rc.3"].each do |package_version|
+    ["19.2.1", "19.3.0-rc.4"].each do |package_version|
       context "with RSC #{package_version}" do
         let(:rsc_version) { package_version }
 

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -56,7 +56,7 @@
     "react-intl": "^10",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "19.3.0-rc.3",
+    "react-on-rails-rsc": "19.3.0-rc.4",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",


### PR DESCRIPTION
## Summary

- pin React on Rails Pro RSC surfaces and generated apps to `react-on-rails-rsc@19.3.0-rc.4`
- raise the Ruby Doctor and Node Renderer qualified prerelease floor to RC4, explicitly rejecting RC0-RC3 while retaining supported stable releases
- refresh the lockfile, Pro RSC documentation, generated `llms-full-pro.txt`, and the Unreleased changelog

## Qualification evidence

- npm RC4 provenance was verified at RSC commit `78f78ce`: version, `next` dist-tag, package `gitHead`, git tag, and GitHub release agree
- the [published downstream E2E run](https://github.com/shakacode/react_on_rails_rsc/actions/runs/34723889111) passed against `v17.1.0.rc.3`
- [tutorial PR #824](https://github.com/shakacode/react-webpack-rails-tutorial/pull/824) registry replay passed: the RC3 negative control reproduced [#823](https://github.com/shakacode/react-webpack-rails-tutorial/issues/823); RC4 passed frozen install/build, JavaScript tests, live Node Renderer + Rails + RSC payload testing, 10/10 targeted RSpec examples, and 80/80 canonical RSpec examples
- coordinated under release tracker [#4842](https://github.com/shakacode/react_on_rails/issues/4842)

## Local validation

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run type-check`
- Node Renderer compatibility suite: 42/42 passed
- RSC generator preflight specs: 17/17 passed
- JavaScript dependency manager specs: 96/96 passed
- focused Doctor specs: 63/63 passed
- `script/check-pro-license-headers`: 907/907 files passed
- `.agents/bin/docs`: 3,578 links checked, 0 errors
- `pnpm start format.listDifferent`
- `node script/generate-llms-full.mjs --check`
- `git diff --check`
- pre-commit and pre-push hooks passed

The canonical local `.agents/bin/validate --changed` run additionally passed its release supervisor (98/98), full RuboCop, benchmark RuboCop, package builds, ESLint, Prettier, typecheck, Pro dummy pack/test-bundle generation, non-RSC JavaScript suite (494/494), and streaming suite (158/158). It stopped at 19/20 Pro RSC tests because the unchanged `serverRenderRSCReactComponent.rsc.test.tsx` log-isolation assertion captured `Outside The Component`. A serial rerun failed identically on this PR and on a detached, frozen-lockfile control at exact base SHA `46becf414`, establishing it as a pre-existing local/toolchain failure rather than an RC4 regression. Hosted current-head CI remains the merge gate.

## Scope

This PR only qualifies and pins the RSC RC4 dependency. It does not bump the React on Rails product version, stamp a release changelog heading, tag, publish, or merge the release.
