### PR TITLE
Prepare changelog for React on Rails 17.1.0.rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.1.0.rc.4] - 2026-09-12
+
 #### Fixed
 
 - **[Pro]** **Side-effect-only RSC client modules work in generated apps again**: Generated RSC apps now pin
@@ -3251,7 +3253,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.3...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.4...main
+[17.1.0.rc.4]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.3...v17.1.0.rc.4
 [17.1.0.rc.3]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.2...v17.1.0.rc.3
 [17.1.0.rc.2]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.1...v17.1.0.rc.2
 [17.1.0.rc.1]: https://github.com/shakacode/react_on_rails/compare/v17.1.0.rc.0...v17.1.0.rc.1


### PR DESCRIPTION
## Summary

- stamp the existing Unreleased RC4 qualification entry as `17.1.0.rc.4`
- update the Unreleased and RC4 compare links
- keep this PR changelog-only; it does not bump product versions, tag, publish, or run the release

## Classification sweep

| PR | Title | Result | Category | Reason |
| --- | --- | --- | --- | --- |
| #5066 | Qualify react-on-rails-rsc 19.3.0-rc.4 for React on Rails 17.1 | entry-needed | Pro runtime | Changes generated Pro/RSC dependency pins and the qualified compatibility floor for users. |

The #5066 entry was already present under Unreleased. The sweep from `v17.1.0.rc.3` through release tip `730a86dc990a9c37e7dedf322644d44c0bd7a69f` found no unknown commits or missing entries.

## Validation

- `bundle exec rake 'update_changelog[17.1.0.rc.4]'`
- `bundle exec rspec spec/react_on_rails/update_changelog_rake_helpers_spec.rb` (33 examples, 0 failures)
- `pnpm exec prettier --check -- CHANGELOG.md`
- `git diff --check`
- verified trailing newline, unique/newest-first version headings, and exact compare-link endpoints
- verified the committed diff contains only `CHANGELOG.md`

## Release coordination

This prepares the changelog under release tracker #4842. The release coordinator retains merge and publication authority.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CHANGELOG and compare-link updates with no product or runtime changes.
> 
> **Overview**
> **Changelog-only release prep** for `17.1.0.rc.4` (2026-09-12): the existing Unreleased **Pro/RSC** fix (qualifying `react-on-rails-rsc@19.3.0-rc.4` for generated apps) is moved under a new `### [17.1.0.rc.4]` section, leaving `[Unreleased]` empty.
> 
> Footer compare links are updated so `[unreleased]` points at `v17.1.0.rc.4...main` and a new `[17.1.0.rc.4]` link covers `v17.1.0.rc.3...v17.1.0.rc.4`. No gem/npm version bumps or runtime code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f926bd95c1979de769428989c2524301018342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->