### PR TITLE
Backport npm release visibility checks to 17.1

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -32,7 +32,10 @@ RUBYGEMS_VERSIONS_API_URL = "https://rubygems.org/api/v1/versions"
 RUBYGEMS_VERSIONS_OPEN_TIMEOUT_SECONDS = 10
 RUBYGEMS_VERSIONS_READ_TIMEOUT_SECONDS = 15
 GITHUB_RELEASE_BODY_MAX_LENGTH = 125_000
-NPM_PUBLISH_VERIFY_ATTEMPTS = 6
+# npm can take longer than the former 25-second window to serve a just-published
+# exact version, even when cache reads are bypassed. Keep the recovery bounded
+# while allowing the registry's eventual-consistency window to settle.
+NPM_PUBLISH_VERIFY_ATTEMPTS = 24
 NPM_PUBLISH_VERIFY_RETRY_DELAY_SECONDS = 5
 NPM_PUBLISH_MAX_BACKOFF_SECONDS = 30
 NPM_PUBLISH_HARD_FAILURE_CATEGORIES = %i[
@@ -9871,7 +9874,11 @@ def fetch_npm_package_metadata(package_ref, registry_url:)
     "peerDependencies",
     "--json",
     "--registry",
-    registry_url
+    registry_url,
+    # A package version can be available at the registry while npm's local cache
+    # still serves the pre-publish 404. Release verification must consult npm
+    # online so that a successful publish is not treated as a failed release.
+    "--prefer-online"
   )
   [output, status]
 end

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -8027,7 +8027,8 @@ RSpec.describe "release.rake helper methods" do
             "peerDependencies",
             "--json",
             "--registry",
-            "https://registry.npmjs.org/"
+            "https://registry.npmjs.org/",
+            "--prefer-online"
           )
           .and_return(["npm ERR! 404 Not Found", instance_double(Process::Status, success?: false)])
         allow(self).to receive(:sleep)
@@ -8214,7 +8215,8 @@ RSpec.describe "release.rake helper methods" do
           "peerDependencies",
           "--json",
           "--registry",
-          "https://registry.npmjs.org/"
+          "https://registry.npmjs.org/",
+          "--prefer-online"
         )
         .and_return(
           ["npm ERR! 404 Not Found", failed_status],
@@ -8242,7 +8244,8 @@ RSpec.describe "release.rake helper methods" do
           "peerDependencies",
           "--json",
           "--registry",
-          "https://registry.npmjs.org/"
+          "https://registry.npmjs.org/",
+          "--prefer-online"
         )
         .and_return([
                       JSON.generate(


### PR DESCRIPTION
## Why

The RC4 release published `react-on-rails@17.1.0-rc.4`, but the release process stopped before the registry exposed that version. The release branch still used the former six-attempt (~25 second) npm visibility window, while npm recorded the package roughly 69 seconds after the final failed lookup.

This backports the already-merged mainline fix from #5064 so the release branch uses online registry reads and waits up to roughly 115 seconds before declaring publication unverified.

## What changed

- Increased npm publication verification from 6 to 24 attempts at five-second intervals.
- Added `--prefer-online` to exact-version metadata reads.
- Updated the release helper expectations for the online lookup.

## Provenance

- Source PR: #5064
- Source merge commit: `31e7b46b042f34c582cddddc07f270a81d2a717b`
- The backport commit contains the required direct `cherry-pick -x` footer.

## Validation

- Real red-side evidence: RC4's six-attempt verification ended at 2026-09-13 10:07:30Z; npm reports `react-on-rails@17.1.0-rc.4` published at 10:08:39Z with the exact tarball shasum `ef1a7565bb8bbe4a186351f55d29cb454ce56c85`.
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb)` — 950 examples, 0 failures.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile RUBYOPT=-W0 bundle exec rubocop ../rakelib/release.rake spec/react_on_rails/release_rake_helpers_spec.rb --format simple)` — 2 files inspected, no offenses.
- `git diff --check` — passed.
- Independent high-risk adversarial review of exact head `43c2161f9ddd1dac895ba10d9f5e850eafef1ac6` — no `BLOCKING` or `DISCUSS` code finding; source/backport patches are byte-equivalent after normalizing hunk offsets.

## Release recovery state

- `v17.1.0.rc.4` points to release commit `bd8706ad4ffe7428eb995ea2efc3df9175e71989`.
- `react-on-rails@17.1.0-rc.4` is visible on npm with the expected shasum.
- The other three npm packages and both RubyGems remain unpublished.
- The existing remote tag makes the next supervised `script/release` run an idempotent retry; it should skip the already-visible npm package and continue with the remaining artifacts.

Changelog classification: not user-visible (release tooling only).

Merge-gate note: current-head hosted checks pass. Review coverage is degraded on exact head `43c2161f9ddd1dac895ba10d9f5e850eafef1ac6`: Codex completed with no findings; Claude skipped because release-branch workflow validation requires the default-branch workflow; CodeRabbit is disabled for non-default base branches; Cursor Bugbot hit its usage limit. The maintainer explicitly waived the two-working-review-systems floor in the active release session on 2026-09-13 so this release-recovery backport may merge.

Tracks #4842.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only rake/spec changes; no runtime app or auth behavior.
> 
> **Overview**
> Backports npm post-publish verification fixes so release automation does not fail when the registry is slow to expose a new exact version.
> 
> **Release rake** extends the bounded verify window by raising `NPM_PUBLISH_VERIFY_ATTEMPTS` from 6 to 24 (still 5s between tries, ~115s total) and passes **`--prefer-online`** on `npm view` metadata reads so stale local cache 404s are not mistaken for a failed publish.
> 
> **Specs** update mocked `npm view` invocations to expect the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c2161f9ddd1dac895ba10d9f5e850eafef1ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->